### PR TITLE
test(field): verify FieldSet renders as a fieldset element

### DIFF
--- a/hushh-webapp/__tests__/ui/field.test.tsx
+++ b/hushh-webapp/__tests__/ui/field.test.tsx
@@ -85,4 +85,13 @@ describe("Field", () => {
       container.querySelector('[data-slot="field-description"]'),
     ).toBeTruthy();
   });
+
+  it("renders FieldSet as a fieldset element", () => {
+    const { container } = render(<FieldSet>content</FieldSet>);
+
+    const fieldSet = container.querySelector('[data-slot="field-set"]');
+
+    expect(fieldSet?.tagName).toBe("FIELDSET");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a single contract test to the existing Field test suite verifying that `FieldSet` renders as a native `<fieldset>` element.

## Why

`FieldSet` is implemented as a semantic HTML `<fieldset>` and is used to group related form controls. Existing tests verify the presence of the `field-set` data-slot but do not verify the underlying rendered HTML element type.

Adding this assertion helps protect the component contract and detects unintended changes to the semantic element used by the component.

## Changes

* Added 1 new `it()` block to `__tests__/ui/field.test.tsx`
* Verifies `FieldSet` renders as a `<fieldset>` element
* No production code changes
* No existing tests modified
* No import changes
* No snapshots or mocks added

## Test Plan

```bash
npx vitest run __tests__/ui/field.test.tsx
```

All tests pass locally.

## Risk

Low.

This is a test-only change that adds a single assertion to an existing test suite and does not affect runtime behavior.
