### PR TITLE
test(radio-group): verify RadioGroupItem has role='radio'

### DIFF
--- a/hushh-webapp/__tests__/ui/radio-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/radio-group.test.tsx
@@ -54,4 +54,19 @@ describe("RadioGroup", () => {
     expect(checkedOptions).toHaveLength(1);
     expect(checkedOptions[0].getAttribute("value")).toBe("b");
   });
+
+  it("renders RadioGroupItem with role='radio'", () => {
+    const { container } = render(
+      <RadioGroup defaultValue="a">
+        <RadioGroupItem value="a" />
+      </RadioGroup>,
+    );
+
+    const item = container.querySelector(
+      '[data-slot="radio-group-item"]',
+    );
+
+    expect(item?.getAttribute("role")).toBe("radio");
+  });
+
 });


### PR DESCRIPTION
## Summary

Adds a single contract test to the existing RadioGroup test suite verifying that `RadioGroupItem` renders with `role="radio"`.

## Why

`RadioGroupItem` is expected to expose the ARIA `radio` role so assistive technologies can correctly identify and announce radio button options.

Existing tests verify checked-state behavior using radio-role queries, but do not explicitly assert that the rendered item exposes the expected role attribute. Adding a dedicated assertion documents and protects this accessibility contract.

## Changes

* Added 1 new `it()` block to `__tests__/ui/radio-group.test.tsx`
* Verifies `RadioGroupItem` renders with `role="radio"`
* No production code changes
* No existing tests modified
* No import changes
* No snapshots or mocks added

## Test Plan

```bash
npx vitest run __tests__/ui/radio-group.test.tsx
```

All tests pass locally.

## Risk

Low.

This is a test-only change that adds a single assertion to an existing test suite and does not affect runtime behavior.
