### PR TITLE
fix(one-location): public location link viewable without login

### DIFF
--- a/hushh-webapp/__tests__/app/one/one-auth-gate.test.tsx
+++ b/hushh-webapp/__tests__/app/one/one-auth-gate.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  pathname: "/one/location",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+}));
+
+vi.mock("@/components/vault/vault-lock-guard", () => ({
+  VaultLockGuard: ({ children }: { children: ReactNode }) => (
+    <div data-testid="vault-lock-guard">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/auth/phone-mandate-guard", () => ({
+  PhoneMandateGuard: ({ children }: { children: ReactNode }) => (
+    <div data-testid="phone-mandate-guard">{children}</div>
+  ),
+}));
+
+import { OneAuthGate } from "@/app/one/one-auth-gate";
+
+describe("OneAuthGate", () => {
+  beforeEach(() => {
+    mocks.pathname = "/one/location";
+  });
+
+  it("renders public temporary location links without the login guards", () => {
+    mocks.pathname = "/one/location/request/public-token";
+
+    render(
+      <OneAuthGate>
+        <div>shared location</div>
+      </OneAuthGate>,
+    );
+
+    expect(screen.getByText("shared location")).toBeTruthy();
+    expect(screen.queryByTestId("vault-lock-guard")).toBeNull();
+    expect(screen.queryByTestId("phone-mandate-guard")).toBeNull();
+  });
+
+  it("keeps private One routes behind the vault + phone login guards", () => {
+    mocks.pathname = "/one/location";
+
+    render(
+      <OneAuthGate>
+        <div>private one surface</div>
+      </OneAuthGate>,
+    );
+
+    expect(screen.getByTestId("vault-lock-guard")).toBeTruthy();
+    expect(screen.getByTestId("phone-mandate-guard")).toBeTruthy();
+    expect(screen.getByText("private one surface")).toBeTruthy();
+  });
+
+  it("keeps circle-invite claim links guarded because claiming needs an account", () => {
+    mocks.pathname = "/one/location/invite/circle-token";
+
+    render(
+      <OneAuthGate>
+        <div>circle invite</div>
+      </OneAuthGate>,
+    );
+
+    expect(screen.getByTestId("vault-lock-guard")).toBeTruthy();
+    expect(screen.getByTestId("phone-mandate-guard")).toBeTruthy();
+  });
+});

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -405,7 +405,7 @@ async function openAskFlow() {
 async function openTemporaryLinkFlow() {
   await switchLocationTab("Links", "Links");
   fireEvent.click(
-    screen.getByRole("button", { name: /Create temporary link/i }),
+    screen.getByRole("button", { name: /Create public location link/i }),
   );
   expect(
     await screen.findByRole("heading", { name: "Share outside your Circle" }),
@@ -773,8 +773,8 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Share to contacts/i })).toBeTruthy();
     await switchLocationTab("Links", "Links");
-    expect(screen.getByRole("button", { name: /Create temporary link/i })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Active temporary link" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Create public location link/i })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Active public location link" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Invite link" })).toBeTruthy();
     expect(screen.queryByText("Public link responses")).toBeNull();
     expect(screen.queryByText(/Share a public location link/i)).toBeNull();
@@ -897,7 +897,7 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openTemporaryLinkFlow();
-    fireEvent.click(screen.getByRole("button", { name: /Review temporary link/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Review public location link/i }));
 
     await waitFor(() => expect(mockCreatePublicInvite).toHaveBeenCalledTimes(1));
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
@@ -921,7 +921,7 @@ describe("OneLocationAgentPage", () => {
     );
     expect(screen.queryByText(longPublicUrl)).toBeNull();
     expect(
-      await screen.findByRole("heading", { name: "Temporary link active" }),
+      await screen.findByRole("heading", { name: "Public location link active" }),
     ).toBeTruthy();
     expect(JSON.stringify(mockTrackEvent.mock.calls)).not.toMatch(
       /8012|9911|latitude|longitude|28\.6139|77\.209/u,
@@ -1470,7 +1470,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText(/No setup blockers/)).toBeNull();
     await switchLocationTab("Links", "Links");
     expect(
-      screen.getByRole("button", { name: /Create temporary link/i }),
+      screen.getByRole("button", { name: /Create public location link/i }),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/app/one/layout.tsx
+++ b/hushh-webapp/app/one/layout.tsx
@@ -1,12 +1,7 @@
 import type { ReactNode } from "react";
 
-import { PhoneMandateGuard } from "@/components/auth/phone-mandate-guard";
-import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
+import { OneAuthGate } from "./one-auth-gate";
 
 export default function OneLayout({ children }: { children: ReactNode }) {
-  return (
-    <VaultLockGuard>
-      <PhoneMandateGuard>{children}</PhoneMandateGuard>
-    </VaultLockGuard>
-  );
+  return <OneAuthGate>{children}</OneAuthGate>;
 }

--- a/hushh-webapp/app/one/one-auth-gate.tsx
+++ b/hushh-webapp/app/one/one-auth-gate.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+import { PhoneMandateGuard } from "@/components/auth/phone-mandate-guard";
+import { VaultLockGuard } from "@/components/vault/vault-lock-guard";
+import { isPublicRoute } from "@/lib/navigation/routes";
+
+/**
+ * OneAuthGate - conditionally applies the vault + phone login guards to
+ * `/one/*` routes.
+ *
+ * Most One surfaces are private and must stay behind VaultLockGuard +
+ * PhoneMandateGuard. However, a small set of One routes are intentionally
+ * public - notably shared temporary location links at
+ * `/one/location/request/[token]`. Anyone who receives such a link must be
+ * able to open it and view the shared live location WITHOUT signing in or
+ * having a Hushh account.
+ *
+ * The source of truth for "which One routes are public" is `isPublicRoute()`
+ * in lib/navigation/routes.ts, which the server-side middleware (proxy.ts)
+ * already honors. This gate mirrors that contract on the client so the layout
+ * does not redirect anonymous visitors of public links to /login.
+ */
+export function OneAuthGate({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  if (isPublicRoute(pathname ?? "")) {
+    return <>{children}</>;
+  }
+
+  return (
+    <VaultLockGuard>
+      <PhoneMandateGuard>{children}</PhoneMandateGuard>
+    </VaultLockGuard>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -5,7 +5,7 @@
  *
  * Figma source of truth: one_location_final_fixed_clean_navigation (node 10:1054),
  * 16 mobile screens organised as four hub tabs (Now | People | Links | Inbox)
- * plus focused, full-screen task flows (Share / Ask / Invite / Temporary link).
+ * plus focused, full-screen task flows (Share / Ask / Invite / Public location link).
  *
  * STRICTLY PRESENTATION + LOCAL VIEW-ROUTING.
  * - All data and every action handler are passed in via `vm` from the existing
@@ -262,7 +262,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       : tab === "people"
         ? "Circle, contacts and invites"
         : tab === "links"
-          ? "Temporary and invite links"
+          ? "Public location and invite links"
           : "Requests and shared locations";
 
   return (
@@ -447,7 +447,7 @@ function NowHub({
           <QuickPathRow
             icon={<LinkIcon className="h-4 w-4" />}
             title="Links"
-            description="Temporary public sharing"
+            description="Public location sharing"
             onClick={() => onGoTab("links")}
           />
           <QuickPathRow
@@ -591,17 +591,17 @@ function LinksHub({
           className="h-11 w-full rounded-full bg-[#0a84ff] text-sm font-semibold text-white hover:bg-[#0a84ff]/90"
         >
           <Plus className="mr-2 h-4 w-4" />
-          Create temporary link
+          Create public location link
         </Button>
         <p className="mt-2 text-xs text-muted-foreground">
           Anyone with the link can view until expiry.
         </p>
       </SectionCard>
 
-      <SectionCard title="Active temporary link">
+      <SectionCard title="Active public location link">
         {temp ? (
           <TemporaryLinkCard
-            title="Temporary link active"
+            title="Public location link active"
             statusLine="Anyone with this link can view you"
             expiryLabel={vm.expiresCountdownLabel(temp.expiresAt)}
             onCopy={vm.onCopyPublicInvite}
@@ -611,7 +611,7 @@ function LinksHub({
           />
         ) : (
           <EmptyState
-            title="No active temporary link"
+            title="No active public location link"
             description="Create one above when you need to share outside your Circle."
           />
         )}
@@ -1213,7 +1213,7 @@ function TemporaryLinkFlow({
       <div className="space-y-5">
         <TaskFlowHeader
           eyebrow="Copy, share or revoke"
-          title="Temporary link active"
+          title="Public location link active"
           onBack={onClose}
         />
         <WarningCard
@@ -1222,7 +1222,7 @@ function TemporaryLinkFlow({
         />
         {invite ? (
           <TemporaryLinkCard
-            title="Temporary link active"
+            title="Public location link active"
             statusLine="Anyone with this link can view you"
             expiryLabel={vm.expiresCountdownLabel(invite.expiresAt)}
             onCopy={vm.onCopyPublicInvite}
@@ -1275,14 +1275,14 @@ function TemporaryLinkFlow({
       </SectionCard>
       <TrustNoteCard
         title="Expires automatically"
-        description="Temporary links are safer when they expire quickly."
+        description="Public location links are safer when they expire quickly."
       />
       <Button
         onClick={vm.onCreatePublicInvite}
         isLoading={vm.busy === "publicInvite"}
         className="h-12 w-full rounded-2xl bg-[#0a84ff] text-base font-semibold text-white hover:bg-[#0a84ff]/90"
       >
-        Review temporary link
+        Review public location link
       </Button>
     </div>
   );


### PR DESCRIPTION
## Problem

When a user creates a temporary **public location link** and shares it, the recipient should be able to open the link and view the live/shared location **without logging in or having a Hushh account**. Instead, opening the link bounced the visitor to `/login`.

## Root cause

The whole stack was already designed to be public:

- Backend `GET /api/one/location/public-invites/{token}` has no auth dependency.
- Frontend `OneLocationService.resolvePublicInvite` sends no `Authorization` header.
- `proxy.ts` middleware already whitelists `/one/location/request/` via `isPublicRoute()`.

The single regression: `app/one/layout.tsx` wrapped **every** `/one/*` route — including the public viewer `/one/location/request/[token]` — in `VaultLockGuard` (which redirects anonymous users to `/login`) plus `PhoneMandateGuard`. That contradicted the `isPublicRoute()` contract.

## Fix

- Added `app/one/one-auth-gate.tsx`: a small client gate that mirrors the same `isPublicRoute()` contract the middleware uses. Public routes render guard-free, so anyone with the link can view the shared location without an account; private One surfaces stay behind vault + phone login.
- Circle-invite **claim** links (`/one/location/invite/...`) intentionally stay guarded since claiming needs an account.
- Renamed user-visible **"temporary link"** copy to **"public location link"** across the Links hub for consistency with the page-level wording.

## Tests

- New `__tests__/app/one/one-auth-gate.test.tsx` locks the contract (public link guard-free, private routes guarded, circle-invite guarded).
- Updated One Location suite assertions for the renamed copy.
- All 30 tests pass across `one-location-agent-page`, `one-auth-gate`, and `public-request-page`.
