### PR TITLE
test(agent-history-sidebar): cover empty chat history fallback

### DIFF
--- a/hushh-webapp/__tests__/components/agent-history-sidebar.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-history-sidebar.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
+
+describe("AgentHistorySidebar", () => {
+  it("renders the empty chat history fallback", () => {
+    render(
+      <AgentHistorySidebar
+        conversations={[]}
+        activeConversationId={null}
+        onCreateNew={vi.fn()}
+        onSelectConversation={vi.fn()}
+        onRenameConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No chats yet")).toBeTruthy();
+    expect(screen.getByRole("list", { name: "Conversation history" })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an AgentHistorySidebar component test for the empty chat history fallback.
- Verifies the empty state copy renders alongside the conversation history list landmark.

## Why
- Protects the sidebar's empty-state behavior when no Agent chat conversations are available.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/agent-history-sidebar-empty-fallback-test`.
- Scope: one new component test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/components/agent-history-sidebar.test.tsx`.
- The PR does not modify `components/agent/agent-history-sidebar.tsx` or any Agent chat runtime code.
- The claim is limited to the empty chat history fallback for an empty `conversations` prop.
- No existing tests or production files were moved, rewritten, or deleted.

## Validation
- `git diff --check --cached`
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
