### PR TITLE
test(agent-screen): cover native route marker contract

### DIFF
--- a/hushh-webapp/__tests__/components/agent-screen.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-screen.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentScreen } from "@/components/agent/agent-screen";
+
+vi.mock("@/components/agent/agent-chat-workspace", () => ({
+  AgentChatWorkspace: () => <div data-testid="agent-chat-workspace" />,
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { uid: "agent-user" },
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/testing/native-test", () => ({
+  useNativeTestBeacon: vi.fn(),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    isVaultUnlocked: true,
+    vaultOwnerToken: "vault-owner-token",
+  }),
+}));
+
+describe("AgentScreen", () => {
+  it("renders the native route marker contract", () => {
+    const { container } = render(<AgentScreen />);
+
+    const marker = container.querySelector('[data-native-route-marker="true"]');
+
+    expect(marker).toBeTruthy();
+    expect(marker?.getAttribute("aria-hidden")).toBe("true");
+    expect(marker?.getAttribute("data-testid")).toBe("native-route-agent");
+    expect(marker?.getAttribute("data-native-route-id")).toBe("/agent");
+    expect(marker?.getAttribute("data-native-auth-default")).toBe("authenticated");
+    expect(marker?.getAttribute("data-native-data-default")).toBe("loaded");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an AgentScreen render test for the native route marker contract.
- Verifies the `/agent` marker exposes the expected hidden marker attributes, auth state, and data state.

## Why
- Protects the native route audit contract for the Agent screen without changing runtime behavior.

## PR Base Policy
- Base branch: `integration/pr-train`.
- Head branch: `codex/agent-screen-native-route-marker-test`.
- Scope: one new component test file only.

## No Overlap Proof
- Only file changed: `hushh-webapp/__tests__/components/agent-screen.test.tsx`.
- The PR does not modify `components/agent/agent-screen.tsx`, `NativeRouteMarker`, `AppPageShell`, or Agent chat runtime code.
- The claim is limited to the Agent screen native route marker contract for `/agent` and `native-route-agent`.
- No existing tests or production files were moved, rewritten, or deleted.

## Validation
- `git diff --check --cached`
- Not run locally: this isolated worktree does not have `node_modules`, so `vitest` is not available.

## DCO
- Commit includes Signed-off-by footer.
