### PR TITLE
test(consent-center-page): cover loading consent entries copy

### DIFF
--- a/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
@@ -405,4 +405,13 @@ describe("ConsentCenterPage requestId deep links", () => {
     }) as HTMLButtonElement;
     expect(revokeButton.disabled).toBe(true);
   });
+
+  it("shows loading consent entries copy while the list is loading", async () => {
+    mocks.search = "tab=pending";
+    mocks.listEntries.mockReturnValue(new Promise(() => {}));
+
+    render(<ConsentCenterPage />);
+
+    expect(await screen.findByText("Loading consent entries…")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a focused test for consent center loading entries copy.

## Reviewer Proof
- Surface: consent center page loading path; file: `consent-center-page-deeplink.test.tsx`.
- No overlap: only loading copy; no active grants, inbox, dialog, audit, or sheet coverage.
- Test-only; base: `integration/pr-train`.
