### PR TITLE
test(route-scope): characterize route scope classification boundaries

### DIFF
--- a/hushh-webapp/__tests__/navigation/route-scope.test.ts
+++ b/hushh-webapp/__tests__/navigation/route-scope.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getRouteScope,
+  isPersonaScopedRoute,
+  routePersonaForScope,
+} from "@/lib/navigation/route-scope";
+
+describe("route-scope", () => {
+  it("classifies investor routes via exact and prefix match", () => {
+    expect(getRouteScope("/one/kai")).toBe("investor");
+    expect(getRouteScope("/one/kai/portfolio")).toBe("investor");
+    expect(getRouteScope("/kai")).toBe("investor");
+  });
+
+  it("classifies ria routes via exact and prefix match", () => {
+    expect(getRouteScope("/ria")).toBe("ria");
+    expect(getRouteScope("/ria/clients/user-1")).toBe("ria");
+  });
+
+  it("classifies onboarding routes ahead of persona routes", () => {
+    expect(getRouteScope("/one/onboarding")).toBe("onboarding");
+    expect(getRouteScope("/kai/onboarding")).toBe("onboarding");
+    expect(getRouteScope("/ria/onboarding")).toBe("onboarding");
+  });
+
+  it("classifies shared routes", () => {
+    expect(getRouteScope("/")).toBe("shared");
+    expect(getRouteScope("/one")).toBe("shared");
+    expect(getRouteScope("/agent")).toBe("shared");
+    expect(getRouteScope("/consents")).toBe("shared");
+    expect(getRouteScope("/marketplace")).toBe("shared");
+    expect(getRouteScope("/profile")).toBe("shared");
+    expect(getRouteScope("/one/location")).toBe("shared");
+  });
+
+  it("classifies public routes", () => {
+    expect(getRouteScope("/login")).toBe("public");
+    expect(getRouteScope("/logout")).toBe("public");
+  });
+
+  it("returns unknown for empty and unrecognized paths", () => {
+    expect(getRouteScope("")).toBe("unknown");
+    expect(getRouteScope("/some-random-path")).toBe("unknown");
+  });
+
+  it("flags only investor and ria routes as persona scoped", () => {
+    expect(isPersonaScopedRoute("/one/kai")).toBe(true);
+    expect(isPersonaScopedRoute("/ria")).toBe(true);
+    expect(isPersonaScopedRoute("/")).toBe(false);
+  });
+
+  it("maps persona scopes correctly", () => {
+    expect(routePersonaForScope("investor")).toBe("investor");
+    expect(routePersonaForScope("ria")).toBe("ria");
+  });
+});


### PR DESCRIPTION
## What

Adds characterization tests for route scope classification utilities in `lib/navigation/route-scope.ts`.

## Why

The module exports pure deterministic routing helpers but currently lacks direct test coverage.

These tests document and lock the current classification behavior for:

* investor routes
* ria routes
* onboarding route precedence
* shared routes
* public routes
* unknown route fallback
* persona-scoped route detection
* persona mapping

## Scope

Test-only change.

No production code modified.

## Validation

```bash
npx vitest run __tests__/navigation/route-scope.test.ts
```

## Notes

The tests characterize the current implementation without changing behavior and use only public exports from the module.
