### PR TITLE
test(routes): characterize buildConnectedSystemRoute String/trim/encodeURIComponent boundaries

### DIFF
--- a/hushh-webapp/__tests__/navigation/build-connected-system-route.test.ts
+++ b/hushh-webapp/__tests__/navigation/build-connected-system-route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConnectedSystemRoute } from "@/lib/navigation/routes";
+
+describe("buildConnectedSystemRoute", () => {
+  it("returns the base route for missing or empty values", () => {
+    expect(buildConnectedSystemRoute()).toBe("/one/connected-systems");
+    expect(buildConnectedSystemRoute(null)).toBe("/one/connected-systems");
+    expect(buildConnectedSystemRoute("")).toBe("/one/connected-systems");
+  });
+
+  it("returns the base route for whitespace-only values", () => {
+    expect(buildConnectedSystemRoute("  ")).toBe(
+      "/one/connected-systems"
+    );
+  });
+
+  it("appends a system id when provided", () => {
+    expect(buildConnectedSystemRoute("plaid")).toBe(
+      "/one/connected-systems/plaid"
+    );
+  });
+
+  it("encodes route segments using encodeURIComponent", () => {
+    expect(buildConnectedSystemRoute("my system")).toBe(
+      "/one/connected-systems/my%20system"
+    );
+
+    expect(buildConnectedSystemRoute("a/b")).toBe(
+      "/one/connected-systems/a%2Fb"
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds characterization tests for `buildConnectedSystemRoute` in `lib/navigation/routes.ts`.

## Why

The helper is a pure deterministic function and currently lacks direct test coverage.

These tests document and lock the current behavior for:

* null and undefined inputs
* empty and whitespace-only inputs
* normal system identifiers
* URL encoding via `encodeURIComponent`

## Scope

Test-only change.

No production code modified.

## Validation

```bash
npx vitest run __tests__/navigation/build-connected-system-route.test.ts
```

## Notes

The tests use only the public function interface and characterize existing behavior without changing implementation.
