### PR TITLE
test(consent-dialog): cover busy state aria contract

### DIFF
--- a/hushh-webapp/__tests__/components/consent-dialog.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-dialog.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConsentDialog } from "@/components/consent/consent-dialog";
+
+describe("ConsentDialog", () => {
+  it("sets the busy aria contract while loading", () => {
+    render(
+      <ConsentDialog
+        open
+        loading
+        request={{
+          agentId: "agent-1",
+          agentName: "Shopping Agent",
+          scope: "attr.shopping.receipts.*",
+          scopeDescription: "Read shopping receipt history",
+        }}
+        onGrant={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Shopping Agent" });
+
+    expect(dialog.getAttribute("aria-busy")).toBe("true");
+    expect((screen.getByRole("button", { name: "Deny" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByRole("button", { name: "Allow" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for `ConsentDialog` busy-state ARIA behavior.

## Reviewer Proof
- Surface: `ConsentDialog`; file: `__tests__/components/consent-dialog.test.tsx`.
- No overlap: only dialog busy ARIA; no center, inbox, audit, or sheet coverage.
- Test-only; base: `integration/pr-train`.
