### PR TITLE
test(routes): characterize buildMarketplaceRiaProfileRoute query omission behavior

### DIFF
--- a/hushh-webapp/__tests__/navigation/build-marketplace-ria-profile-route.test.ts
+++ b/hushh-webapp/__tests__/navigation/build-marketplace-ria-profile-route.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMarketplaceRiaProfileRoute } from "@/lib/navigation/routes";
+
+describe("buildMarketplaceRiaProfileRoute", () => {
+  it("returns the base route when riaId is missing", () => {
+    expect(buildMarketplaceRiaProfileRoute()).toBe("/marketplace/ria");
+    expect(buildMarketplaceRiaProfileRoute(null)).toBe("/marketplace/ria");
+  });
+
+  it("returns the base route for whitespace-only riaId", () => {
+    expect(buildMarketplaceRiaProfileRoute("  ")).toBe(
+      "/marketplace/ria"
+    );
+  });
+
+  it("adds riaId when provided", () => {
+    expect(buildMarketplaceRiaProfileRoute("ria-123")).toBe(
+      "/marketplace/ria?riaId=ria-123"
+    );
+  });
+
+  it("serializes spaces using URLSearchParams behavior", () => {
+    expect(buildMarketplaceRiaProfileRoute("has space")).toBe(
+      "/marketplace/ria?riaId=has+space"
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds characterization tests for `buildMarketplaceRiaProfileRoute` in `lib/navigation/routes.ts`.

## Why

The helper is a pure deterministic function and currently lacks direct test coverage.

These tests document and lock the current behavior for:

* missing values
* null values
* whitespace-only values
* populated ria identifiers
* query-string serialization through the existing implementation

## Scope

Test-only change.

No production code modified.

## Validation

```bash
npx vitest run __tests__/navigation/build-marketplace-ria-profile-route.test.ts
```

## Notes

The tests use only the public function interface and characterize existing behavior without changing implementation.
