### PR TITLE
test(routes): characterize buildMarketplaceConnectionsRoute selected-to-requestId mapping

### DIFF
--- a/hushh-webapp/__tests__/navigation/build-marketplace-connections-route.test.ts
+++ b/hushh-webapp/__tests__/navigation/build-marketplace-connections-route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMarketplaceConnectionsRoute } from "@/lib/navigation/routes";
+
+describe("buildMarketplaceConnectionsRoute", () => {
+  it("returns the bare consents path when no entries are provided", () => {
+    expect(buildMarketplaceConnectionsRoute()).toBe("/consents");
+  });
+
+  it("maps tab to the tab query parameter", () => {
+    expect(
+      buildMarketplaceConnectionsRoute({ tab: "pending" })
+    ).toBe("/consents?tab=pending");
+
+    expect(
+      buildMarketplaceConnectionsRoute({ tab: "previous" })
+    ).toBe("/consents?tab=previous");
+  });
+
+  it("maps selected to the requestId query parameter", () => {
+    expect(
+      buildMarketplaceConnectionsRoute({
+        selected: "req-1",
+      })
+    ).toBe("/consents?requestId=req-1");
+  });
+
+  it("omits query parameters when values are null", () => {
+    expect(
+      buildMarketplaceConnectionsRoute({
+        tab: null,
+        selected: null,
+      })
+    ).toBe("/consents");
+  });
+});


### PR DESCRIPTION
## What

Adds characterization tests for `buildMarketplaceConnectionsRoute` in `lib/navigation/routes.ts`.

## Why

The helper is a pure deterministic function and currently lacks direct test coverage.

These tests document and lock the current behavior for:

* base route generation
* tab query parameter mapping
* selected-to-requestId query parameter mapping
* omission of query parameters when values are null

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/navigation/build-marketplace-connections-route.test.ts

## Notes

The tests use only the public function interface and characterize existing behavior without changing implementation.
