### PR TITLE
test(consent-inbox-dropdown): cover pending consents list semantics

### DIFF
--- a/hushh-webapp/__tests__/components/consent-inbox-dropdown.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-inbox-dropdown.test.tsx
@@ -12,9 +12,13 @@ function read(relativePath: string) {
 }
 
 describe("ConsentInboxDropdown", () => {
-  it("covers pending consents list semantics", () => {
+  it("covers pending consents list semantics", async () => {
+    const { ConsentInboxDropdown } = await import(
+      "@/components/consent/consent-inbox-dropdown"
+    );
     const source = read("components/consent/consent-inbox-dropdown.tsx");
 
+    expect(ConsentInboxDropdown).toEqual(expect.any(Function));
     expect(source).toContain("items.length > 0");
     expect(source).toContain('role="list"');
     expect(source).toContain('aria-label="Pending consents"');

--- a/hushh-webapp/__tests__/components/consent-inbox-dropdown.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-inbox-dropdown.test.tsx
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs
+    .readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8")
+    .replace(/\r\n/g, "\n");
+}
+
+describe("ConsentInboxDropdown", () => {
+  it("covers pending consents list semantics", () => {
+    const source = read("components/consent/consent-inbox-dropdown.tsx");
+
+    expect(source).toContain("items.length > 0");
+    expect(source).toContain('role="list"');
+    expect(source).toContain('aria-label="Pending consents"');
+    expect(source).toContain('role="listitem"');
+    expect(source).toContain("items.map((entry) =>");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for `ConsentInboxDropdown` pending-list semantics.

## Reviewer Proof
- Surface: `ConsentInboxDropdown`; file: `__tests__/components/consent-inbox-dropdown.test.tsx`.
- No overlap: only pending dropdown list semantics; no center, audit, dialog, or sheet coverage.
- Test-only; base: `integration/pr-train`.
