### PR TITLE
test(routes): verify buildPhoneMandateRoute redirect handling

### DIFF
--- a/hushh-webapp/__tests__/navigation/build-phone-mandate-route.test.ts
+++ b/hushh-webapp/__tests__/navigation/build-phone-mandate-route.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPhoneMandateRoute } from "@/lib/navigation/routes";
+
+describe("buildPhoneMandateRoute", () => {
+  it("returns the base route when redirect is missing", () => {
+    expect(buildPhoneMandateRoute()).toBe("/register-phone");
+    expect(buildPhoneMandateRoute(null)).toBe("/register-phone");
+  });
+
+  it("returns the base route for whitespace-only redirect values", () => {
+    expect(buildPhoneMandateRoute("  ")).toBe("/register-phone");
+  });
+
+  it("includes the redirect query parameter when provided", () => {
+    expect(buildPhoneMandateRoute("/one")).toBe(
+      "/register-phone?redirect=%2Fone"
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds tests for `buildPhoneMandateRoute` in `lib/navigation/routes.ts`.

## Why

The helper is a small deterministic function and currently lacks direct test coverage.

These tests verify:

* base route behavior for missing values
* null handling
* whitespace-only handling
* redirect query parameter generation

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/navigation/build-phone-mandate-route.test.ts

## Notes

The tests exercise the public function interface and verify existing behavior without modifying implementation.
