### PR TITLE
test(consent-sheet-controller): cover legacy profile panel redirect

### DIFF
--- a/hushh-webapp/__tests__/components/consent-sheet-controller.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-sheet-controller.test.tsx
@@ -1,0 +1,36 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConsentSheetProvider } from "@/components/consent/consent-sheet-controller";
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  push: vi.fn(),
+  search: "panel=consents",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/profile",
+  useRouter: () => ({
+    push: mocks.push,
+    replace: mocks.replace,
+  }),
+  useSearchParams: () => new URLSearchParams(mocks.search),
+}));
+
+describe("ConsentSheetProvider", () => {
+  it("redirects the legacy profile consent panel to the consent manager", async () => {
+    render(
+      <ConsentSheetProvider>
+        <div>Profile content</div>
+      </ConsentSheetProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith(
+        "/consents?tab=pending&from=%2Fprofile%3Ftab%3Dprivacy",
+        { scroll: false },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for `ConsentSheetController` legacy profile redirect behavior.

## Reviewer Proof
- Surface: `ConsentSheetController`; file: `__tests__/components/consent-sheet-controller.test.tsx`.
- No overlap: only legacy profile redirect guard; no center, inbox, audit, or dialog coverage.
- Test-only; base: `integration/pr-train`.
