### PR TITLE
test(ria-client-account-detail): cover loading detail state

### DIFF
--- a/hushh-webapp/__tests__/components/ria-client-account-detail.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-client-account-detail.test.tsx
@@ -31,14 +31,11 @@ describe("RiaClientAccountDetail", () => {
       <RiaClientAccountDetail clientId="client-1" accountId="account-1" />,
     );
 
-    expect(screen.getByText("Loading account detail...")).toBeInTheDocument();
-    expect(
-      container.querySelector(
-        '[data-testid="native-route-ria-client-account-detail"]',
-      ),
-    ).toHaveAttribute(
-      "data-native-data-state",
-      "loading",
+    expect(screen.getByText("Loading account detail...")).toBeTruthy();
+
+    const beacon = container.querySelector(
+      '[data-testid="native-route-ria-client-account-detail"]',
     );
+    expect(beacon?.getAttribute("data-native-data-state")).toBe("loading");
   });
 });

--- a/hushh-webapp/__tests__/components/ria-client-account-detail.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-client-account-detail.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RiaClientAccountDetail } from "@/components/ria/ria-client-account-detail";
+import { useRiaClientWorkspaceState } from "@/components/ria/use-ria-client-workspace-state";
+
+vi.mock("@/components/ria/use-ria-client-workspace-state", () => ({
+  useRiaClientWorkspaceState: vi.fn(),
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
+
+describe("RiaClientAccountDetail", () => {
+  it("covers loading detail state", () => {
+    vi.mocked(useRiaClientWorkspaceState).mockReturnValue({
+      user: { uid: "advisor-1" },
+      riaCapability: "active",
+      personaLoading: false,
+      detail: null,
+      workspace: null,
+      loading: true,
+      detailError: null,
+      iamUnavailable: false,
+      isTestProfile: false,
+      refreshWorkspace: vi.fn(),
+    } as unknown as ReturnType<typeof useRiaClientWorkspaceState>);
+
+    const { container } = render(
+      <RiaClientAccountDetail clientId="client-1" accountId="account-1" />,
+    );
+
+    expect(screen.getByText("Loading account detail...")).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '[data-testid="native-route-ria-client-account-detail"]',
+      ),
+    ).toHaveAttribute(
+      "data-native-data-state",
+      "loading",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused render test for the RIA client account detail loading state.

## Reviewer Proof
- Surface: `components/ria/ria-client-account-detail.tsx`; test renders the real component and mocks only the workspace-state hook.
- No overlap: only account-detail loading state; no workspace, request-detail, onboarding, or runtime code changes.
- DCO signed; base: `integration/pr-train`.

## Validation
- `git diff --check --cached`
- Not run locally: this isolated worktree does not have `node_modules`.
