### PR TITLE
test(focus-timer-widget): cover timer toggle button type

### DIFF
--- a/hushh-webapp/__tests__/components/focus-timer-widget.test.tsx
+++ b/hushh-webapp/__tests__/components/focus-timer-widget.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FocusTimerWidget } from "@/components/features/focus/focus-timer-widget";
+import { useFocusTimer } from "@/lib/hooks/use-focus-timer";
+
+vi.mock("@/lib/hooks/use-focus-timer", () => ({
+  useFocusTimer: vi.fn(),
+}));
+
+describe("FocusTimerWidget", () => {
+  it("covers timer toggle button type", () => {
+    vi.mocked(useFocusTimer).mockReturnValue({
+      isOpen: true,
+      timeLeft: 25 * 60,
+      isRunning: false,
+      mode: "pomodoro",
+      sessionsCompleted: 0,
+      setIsOpen: vi.fn(),
+      toggleTimer: vi.fn(),
+      resetTimer: vi.fn(),
+      setMode: vi.fn(),
+      tick: vi.fn(),
+    });
+
+    render(<FocusTimerWidget />);
+
+    expect(screen.getByRole("button", { name: "Start" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+  });
+});

--- a/hushh-webapp/__tests__/components/focus-timer-widget.test.tsx
+++ b/hushh-webapp/__tests__/components/focus-timer-widget.test.tsx
@@ -25,9 +25,8 @@ describe("FocusTimerWidget", () => {
 
     render(<FocusTimerWidget />);
 
-    expect(screen.getByRole("button", { name: "Start" })).toHaveAttribute(
-      "type",
-      "button",
-    );
+    expect(
+      screen.getByRole("button", { name: "Start" }).getAttribute("type"),
+    ).toBe("button");
   });
 });


### PR DESCRIPTION
## Summary
- Adds a focused render test for the focus timer toggle button type.

## Reviewer Proof
- Surface: `components/features/focus/focus-timer-widget.tsx`; test renders the real widget and mocks only `useFocusTimer` state.
- No overlap: only timer toggle button type; no timer hook, layout, or runtime code changes.
- DCO signed; base: `integration/pr-train`.

## Validation
- `git diff --check --cached`
- Not run locally: this isolated worktree does not have `node_modules`.
