### PR TITLE
test(profile-stack-navigator): cover navigation item selection state

### DIFF
--- a/hushh-webapp/__tests__/components/profile-stack-navigator.test.tsx
+++ b/hushh-webapp/__tests__/components/profile-stack-navigator.test.tsx
@@ -47,4 +47,39 @@ describe("ProfileStackNavigator", () => {
     expect(screen.getByText("Root workspace")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /back/i })).toBeNull();
   });
+
+  it("covers navigation item selection state", () => {
+    const { rerender } = render(
+      <ProfileStackNavigator
+        rootContent={<div>Root workspace</div>}
+        entries={[
+          {
+            key: "detail:overview",
+            title: "Overview",
+            content: <div>Overview content</div>,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Overview")).toBeTruthy();
+    expect(screen.getByText("Overview content")).toBeTruthy();
+
+    rerender(
+      <ProfileStackNavigator
+        rootContent={<div>Root workspace</div>}
+        entries={[
+          {
+            key: "detail:privacy",
+            title: "Privacy",
+            content: <div>Privacy content</div>,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryByText("Overview content")).toBeNull();
+    expect(screen.getByText("Privacy")).toBeTruthy();
+    expect(screen.getByText("Privacy content")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a focused test for profile stack selection changes.

## Reviewer Proof
- Surface: `components/profile/profile-stack-navigator.tsx`; appends one case to the existing canonical test file.
- No overlap: only selected stack entry replacement; no profile page, PKM, connected systems, or runtime code changes.
- DCO signed; base: `integration/pr-train`.

## Validation
- `git diff --check --cached`
- Not run locally: this isolated worktree does not have `node_modules`.
