### PR TITLE
fix(app-sidebar): hide decorative sidebar icons

### DIFF
--- a/hushh-webapp/__tests__/components/app-sidebar.test.tsx
+++ b/hushh-webapp/__tests__/components/app-sidebar.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppSidebar } from "@/components/dashboard/app-sidebar";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/kai",
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/lib/consent/use-consent-pending-summary-count", () => ({
+  useConsentPendingSummaryCount: () => 0,
+}));
+
+describe("AppSidebar", () => {
+  it("covers decorative sidebar icons hidden", () => {
+    const { container } = render(
+      <SidebarProvider>
+        <AppSidebar />
+      </SidebarProvider>,
+    );
+
+    expect(screen.getAllByRole("link", { name: "Kai" })).toHaveLength(2);
+    expect(screen.getByRole("link", { name: /consents/i })).toBeTruthy();
+
+    const hiddenIcons = Array.from(
+      container.querySelectorAll("svg[aria-hidden='true']"),
+    );
+
+    expect(hiddenIcons).toHaveLength(3);
+    expect(
+      hiddenIcons.every(
+        (icon) => icon.getAttribute("aria-hidden") === "true",
+      ),
+    ).toBe(true);
+  });
+});

--- a/hushh-webapp/components/dashboard/app-sidebar.tsx
+++ b/hushh-webapp/components/dashboard/app-sidebar.tsx
@@ -56,7 +56,7 @@ export function AppSidebar() {
                   className="md:h-12 md:text-base font-semibold"
                 >
                   <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                    <Icon icon={Home} size="sm" />
+                    <Icon icon={Home} size="sm" aria-hidden="true" />
                   </div>
                   <span className="ml-2">Kai</span>
                 </SidebarMenuButton>
@@ -79,7 +79,7 @@ export function AppSidebar() {
                 return (
                   <SidebarMenuItem key={domain.href}>
                     <SidebarMenuButton href={domain.href} isActive={isActive}>
-                      <Icon icon={DomainIcon} size="sm" />
+                      <Icon icon={DomainIcon} size="sm" aria-hidden="true" />
                       <span>{domain.name}</span>
                     </SidebarMenuButton>
                     {domain.status === "soon" && (
@@ -102,7 +102,7 @@ export function AppSidebar() {
                   href={buildConsentCenterHref("pending")}
                   isActive={pathname === "/consents"}
                 >
-                  <Icon icon={Shield} size="sm" />
+                  <Icon icon={Shield} size="sm" aria-hidden="true" />
                   <span>Consents</span>
                 </SidebarMenuButton>
                 {pendingCount > 0 && (


### PR DESCRIPTION
## Summary
- Hides decorative AppSidebar navigation icons from assistive technology.
- Adds focused coverage for the hidden icon contract.

## Reviewer Proof
- Surface: \\components/dashboard/app-sidebar.tsx\\; renders the real sidebar in \\__tests__/components/app-sidebar.test.tsx\\.
- No overlap: only AppSidebar decorative icon accessibility; no navigation or layout behavior changes.
- DCO signed; base: \\integration/pr-train\\.

## Validation
- \\git diff --cached --check\\
- Web (Next.js) via GitHub Actions