### PR TITLE
fix(domain-nav): hide decorative domain navigation icon

### DIFF
--- a/hushh-webapp/__tests__/components/domain-nav.test.tsx
+++ b/hushh-webapp/__tests__/components/domain-nav.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DomainNav } from "@/components/dashboard/domain-nav";
+import { ROUTES } from "@/lib/navigation/routes";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => ROUTES.KAI_PORTFOLIO,
+}));
+
+describe("DomainNav", () => {
+  it("covers domain navigation icon accessibility", () => {
+    const { container } = render(<DomainNav />);
+
+    expect(screen.getByRole("link", { name: "Kai" })).toBeTruthy();
+
+    const icon = container.querySelector("svg");
+
+    expect(icon).toBeTruthy();
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/hushh-webapp/components/dashboard/domain-nav.tsx
+++ b/hushh-webapp/components/dashboard/domain-nav.tsx
@@ -40,7 +40,12 @@ export function DomainNav() {
             )}
           >
             <div className="flex items-center gap-3">
-              <Icon icon={Lucide} size="md" className={domain.color} />
+              <Icon
+                icon={Lucide}
+                size="md"
+                className={domain.color}
+                aria-hidden="true"
+              />
               <span>{domain.name}</span>
             </div>
           </Link>


### PR DESCRIPTION
## Summary
- Hides the decorative DomainNav icon from assistive technology.
- Adds focused coverage for the icon accessibility contract.

## Reviewer Proof
- Surface: components/dashboard/domain-nav.tsx, tested through the real DomainNav component.
- No overlap: only DomainNav icon accessibility; no navigation or route behavior changes.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions