### PR TITLE
test(preview-carousel-step): cover slide indicator current state

### DIFF
--- a/hushh-webapp/__tests__/components/preview-carousel-step.test.tsx
+++ b/hushh-webapp/__tests__/components/preview-carousel-step.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PreviewCarouselStep } from "@/components/onboarding/PreviewCarouselStep";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  // @ts-expect-error test-only polyfill
+  globalThis.ResizeObserver = ResizeObserverStub;
+}
+
+if (typeof globalThis.IntersectionObserver === "undefined") {
+  class IntersectionObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds = [];
+  }
+
+  // @ts-expect-error test-only polyfill
+  globalThis.IntersectionObserver = IntersectionObserverStub;
+}
+
+vi.mock("@/lib/morphy-ux/gsap", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/morphy-ux/gsap")>(
+    "@/lib/morphy-ux/gsap",
+  );
+
+  return {
+    ...actual,
+    prefersReducedMotion: () => true,
+  };
+});
+
+vi.mock("@/components/onboarding/previews/KycPreviewCompact", () => ({
+  KycPreviewCompact: () => <div>KYC preview</div>,
+}));
+
+vi.mock("@/components/onboarding/previews/PortfolioPreviewCompact", () => ({
+  PortfolioPreviewCompact: () => <div>Portfolio preview</div>,
+}));
+
+vi.mock("@/components/onboarding/previews/DecisionPreviewCompact", () => ({
+  DecisionPreviewCompact: () => <div>Decision preview</div>,
+}));
+
+describe("PreviewCarouselStep", () => {
+  it("covers slide indicator current state", () => {
+    render(<PreviewCarouselStep onContinue={vi.fn()} />);
+
+    const slides = screen.getAllByRole("group");
+
+    expect(slides).toHaveLength(3);
+    expect(slides[0]?.getAttribute("aria-current")).toBe("step");
+    expect(slides[1]?.getAttribute("aria-current")).toBeNull();
+    expect(slides[2]?.getAttribute("aria-current")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused coverage for the PreviewCarouselStep current slide indicator state.

## Reviewer Proof
- Surface: components/onboarding/PreviewCarouselStep.tsx, rendered through the real component.
- No overlap: test-only coverage for aria-current=step on the active slide.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions