### PR TITLE
test(utils): verify markdown cleanup behavior

### DIFF
--- a/hushh-webapp/__tests__/utils/json-to-human-clean-markdown.test.ts
+++ b/hushh-webapp/__tests__/utils/json-to-human-clean-markdown.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+describe("formatCompleteJson markdown cleanup", () => {
+  it("removes markdown formatting from string values", () => {
+    const output = formatCompleteJson({
+      account_metadata: {
+        institution_name: "***Schwab***",
+      },
+    });
+
+    expect(output).toContain("Institution: Schwab");
+  });
+
+  it("removes mixed markdown formatting from string values", () => {
+    const output = formatCompleteJson({
+      account_metadata: {
+        institution_name:
+          "***bold italic*** and **bold** and *italic* and `code`",
+      },
+    });
+
+    expect(output).toContain(
+      "Institution: bold italic and bold and italic and code",
+    );
+  });
+
+  it("trims whitespace after markdown cleanup", () => {
+    const output = formatCompleteJson({
+      account_metadata: {
+        institution_name: "  **padded**  ",
+      },
+    });
+
+    expect(output).toContain("Institution: padded");
+  });
+});


### PR DESCRIPTION
## What

Adds tests for markdown cleanup behavior in `formatCompleteJson`.

## Why

String values are normalized before rendering, but markdown-bearing values currently lack direct coverage.

The tests verify:

* markdown formatting markers are removed from rendered values
* mixed markdown styles are cleaned consistently
* surrounding whitespace is trimmed after cleanup

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/utils/json-to-human-clean-markdown.test.ts

## Notes

The tests verify user-visible formatting behavior through the public API and avoid depending on implementation details.
