### PR TITLE
test(top-shell-breadcrumbs): verify profile panel remapping

### DIFF
--- a/hushh-webapp/__tests__/navigation/top-shell-breadcrumbs-profile-panel-params.test.ts
+++ b/hushh-webapp/__tests__/navigation/top-shell-breadcrumbs-profile-panel-params.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTopShellBreadcrumb } from "@/lib/navigation/top-shell-breadcrumbs";
+import { ROUTES } from "@/lib/navigation/routes";
+
+describe("resolveTopShellBreadcrumb profile panel remapping", () => {
+  it("remaps tab=privacy to the access panel", () => {
+    const result = resolveTopShellBreadcrumb(
+      ROUTES.PROFILE,
+      new URLSearchParams("tab=privacy"),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.items[1].label).toBe("Access & sharing");
+  });
+
+  it("uses profile breadcrumb defaults when no detail is present", () => {
+    const result = resolveTopShellBreadcrumb(
+      ROUTES.PROFILE,
+      new URLSearchParams("tab=privacy"),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.backHref).toBe(ROUTES.PROFILE);
+    expect(result!.items[1].href).toBeUndefined();
+  });
+
+  it("prefers panel over tab when both are present", () => {
+    const result = resolveTopShellBreadcrumb(
+      ROUTES.PROFILE,
+      new URLSearchParams("panel=security&tab=privacy"),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.items[1].label).toBe("Security");
+  });
+
+  it("passes through non-privacy tab values", () => {
+    const result = resolveTopShellBreadcrumb(
+      ROUTES.PROFILE,
+      new URLSearchParams("tab=account"),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.items[1].label).toBe("Account");
+  });
+
+  it("returns null for unrecognized tab values", () => {
+    expect(
+      resolveTopShellBreadcrumb(
+        ROUTES.PROFILE,
+        new URLSearchParams("tab=something"),
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds tests for profile panel resolution behavior in `resolveTopShellBreadcrumb`.

## Why

Profile breadcrumbs support legacy tab parameters, panel-based navigation, and compatibility mappings that currently lack direct coverage.

The tests verify:

* `tab=privacy` resolves to the access panel
* profile breadcrumb structure remains stable when no detail is present
* `panel` parameters take precedence over `tab`
* non-privacy tab values resolve normally
* unrecognized tab values return null

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/navigation/top-shell-breadcrumbs-profile-panel-params.test.ts

## Notes

The tests verify public breadcrumb behavior through the exported resolver and avoid coupling to internal helper implementations.
