### PR TITLE
test(services): verify auth status classification

### DIFF
--- a/hushh-webapp/__tests__/services/kai-auth-status.test.ts
+++ b/hushh-webapp/__tests__/services/kai-auth-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isKaiAuthStatus } from "@/lib/services/kai-token-guard";
+
+describe("isKaiAuthStatus", () => {
+  it("returns true for status 401", () => {
+    expect(isKaiAuthStatus(401)).toBe(true);
+  });
+
+  it("returns true for status 403", () => {
+    expect(isKaiAuthStatus(403)).toBe(true);
+  });
+
+  it("returns false for status 200", () => {
+    expect(isKaiAuthStatus(200)).toBe(false);
+  });
+
+  it("returns false for status 404", () => {
+    expect(isKaiAuthStatus(404)).toBe(false);
+  });
+
+  it("returns false for status 500", () => {
+    expect(isKaiAuthStatus(500)).toBe(false);
+  });
+
+  it("returns false for status 0", () => {
+    expect(isKaiAuthStatus(0)).toBe(false);
+  });
+
+  it("returns false for a negative number", () => {
+    expect(isKaiAuthStatus(-401)).toBe(false);
+  });
+
+  it("always returns a boolean", () => {
+    expect(typeof isKaiAuthStatus(401)).toBe("boolean");
+    expect(typeof isKaiAuthStatus(200)).toBe("boolean");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `isKaiAuthStatus` in `kai-token-guard`.

## Why

The helper is responsible for identifying authentication-related HTTP status codes but currently lacks direct coverage.

The tests verify:

* HTTP 401 is classified as an authentication status
* HTTP 403 is classified as an authentication status
* non-authentication statuses return false

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/services/kai-auth-status.test.ts

## Notes

The tests verify the exported helper behavior directly and do not exercise token issuance or Vault-related logic.
