### PR TITLE
test(consent): verify event names

### DIFF
--- a/hushh-webapp/__tests__/lib/consent/consent-events.test.ts
+++ b/hushh-webapp/__tests__/lib/consent/consent-events.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import {
+  CONSENT_ACTION_COMPLETE_EVENT,
+  CONSENT_STATE_CHANGED_EVENT,
+} from "@/lib/consent/consent-events";
+
+describe("consent-events constants", () => {
+  it("CONSENT_ACTION_COMPLETE_EVENT has the exact value 'consent-action-complete'", () => {
+    expect(CONSENT_ACTION_COMPLETE_EVENT).toBe("consent-action-complete");
+  });
+
+  it("CONSENT_STATE_CHANGED_EVENT has the exact value 'consent-state-changed'", () => {
+    expect(CONSENT_STATE_CHANGED_EVENT).toBe("consent-state-changed");
+  });
+
+  it("the two event name constants are distinct strings", () => {
+    expect(CONSENT_ACTION_COMPLETE_EVENT).not.toBe(CONSENT_STATE_CHANGED_EVENT);
+  });
+
+  it("both constants are non-empty strings", () => {
+    expect(typeof CONSENT_ACTION_COMPLETE_EVENT).toBe("string");
+    expect(CONSENT_ACTION_COMPLETE_EVENT.length).toBeGreaterThan(0);
+    expect(typeof CONSENT_STATE_CHANGED_EVENT).toBe("string");
+    expect(CONSENT_STATE_CHANGED_EVENT.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for the exported consent event names.

## Why

The consent module exposes event-name constants that are consumed by event dispatch and subscription logic but currently lack direct coverage.

The tests verify:

* the consent action complete event name remains stable
* the consent state changed event name remains stable

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/lib/consent/consent-events.test.ts

## Notes

The tests verify the exported event-name contract without depending on browser event APIs.
