### PR TITLE
fix(frontend-a11y): add accessible name to focus timer reset button

### DIFF
--- a/hushh-webapp/components/features/focus/focus-timer-widget.tsx
+++ b/hushh-webapp/components/features/focus/focus-timer-widget.tsx
@@ -128,6 +128,7 @@ export function FocusTimerWidget() {
               size="icon" 
               className="rounded-xl w-10 shrink-0"
               onClick={resetTimer}
+              aria-label="Reset timer"
             >
               <RotateCcw className="w-4 h-4" />
             </Button>


### PR DESCRIPTION
## Summary

Add an accessible name to the icon-only reset button in the focus timer widget.

## Changes

* Add `aria-label="Reset timer"` to the reset button.

## Why

This change improves accessibility without affecting the existing behavior or appearance of the component.
