### PR TITLE
fix(frontend-a11y): add accessible name to consent search input

### DIFF
--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1918,6 +1918,7 @@ export function ConsentCenterPage() {
                       setSearchValue(next);
                       setParam({ q: next || null, page: "1" });
                     }}
+                    aria-label="Search consents"
                     placeholder={searchPlaceholder}
                     className="pl-9"
                     data-voice-control-id="consent_search"


### PR DESCRIPTION
## Summary

Add an accessible name to the consent search input.

## Changes

* Add `aria-label="Search consents"` to the consent search input.

## Why

The consent search input previously relied on placeholder text to communicate its purpose. Adding an accessible name improves screen reader support without changing the existing behavior or appearance of the component.
