### PR TITLE
test(consent): verify scope humanization

### DIFF
--- a/hushh-webapp/__tests__/lib/consent/consent-display-humanize.test.ts
+++ b/hushh-webapp/__tests__/lib/consent/consent-display-humanize.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { humanizeConsentScope } from "@/lib/consent/consent-display";
+
+describe("humanizeConsentScope", () => {
+  describe("empty inputs", () => {
+    it("returns a default label for null", () => {
+      expect(
+        humanizeConsentScope(null),
+      ).toBe("Consent request");
+    });
+
+    it("returns a default label for whitespace-only values", () => {
+      expect(
+        humanizeConsentScope("   "),
+      ).toBe("Consent request");
+    });
+  });
+
+  describe("known literal mappings", () => {
+    it("maps vault.owner", () => {
+      expect(
+        humanizeConsentScope("vault.owner"),
+      ).toBe("Full vault access");
+    });
+
+    it("maps pkm.read", () => {
+      expect(
+        humanizeConsentScope("pkm.read"),
+      ).toBe("Personal Knowledge Model access");
+    });
+
+    it("maps pkm.write", () => {
+      expect(
+        humanizeConsentScope("pkm.write"),
+      ).toBe("Personal Knowledge Model updates");
+    });
+  });
+
+  describe("attr scopes", () => {
+    it("handles domains without tails", () => {
+      expect(
+        humanizeConsentScope("attr.financial_data"),
+      ).toBe("Financial Data data");
+    });
+
+    it("handles wildcard tails", () => {
+      expect(
+        humanizeConsentScope("attr.financial_data.*"),
+      ).toBe("Financial Data data");
+    });
+
+    it("handles named tails", () => {
+      expect(
+        humanizeConsentScope(
+          "attr.financial_data.transactions",
+        ),
+      ).toBe("Financial Data Transactions");
+    });
+  });
+
+  describe("generic fallback", () => {
+    it("humanizes dot-separated scopes", () => {
+      expect(
+        humanizeConsentScope("profile.read"),
+      ).toBe("Profile Read");
+    });
+
+    it("humanizes underscore-separated scopes", () => {
+      expect(
+        humanizeConsentScope("notification_settings"),
+      ).toBe("Notification Settings");
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `humanizeConsentScope` in `consent-display`.

## Why

The helper contains multiple transformation branches that currently lack direct coverage.

The tests verify:

* default handling for empty inputs
* known consent scope mappings
* attr-scope transformations
* generic scope humanization

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/lib/consent/consent-display-humanize.test.ts

## Notes

The tests verify the public string-transformation contract directly without mocks, browser APIs, or shared test setup.
