### PR TITLE
test(auth-provider-button): cover provider button type

### DIFF
--- a/hushh-webapp/__tests__/components/auth-provider-button.test.tsx
+++ b/hushh-webapp/__tests__/components/auth-provider-button.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthProviderButton } from "@/components/onboarding/AuthProviderButton";
+
+describe("AuthProviderButton", () => {
+  it("covers provider button type", () => {
+    render(
+      <AuthProviderButton
+        label="Continue with Google"
+        icon={<span aria-hidden="true">G</span>}
+        onClick={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Continue with Google",
+    });
+
+    expect(button).toBeTruthy();
+    expect(button.getAttribute("type")).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused coverage for the AuthProviderButton type contract.

## Reviewer Proof
- Surface: components/onboarding/AuthProviderButton.tsx, rendered through the real component.
- No overlap: test-only coverage for provider button type=button.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions