### PR TITLE
test(auth-legal-dialog): cover close button accessible label

### DIFF
--- a/hushh-webapp/__tests__/components/auth-legal-dialog.test.tsx
+++ b/hushh-webapp/__tests__/components/auth-legal-dialog.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AuthLegalDialog } from "@/components/onboarding/AuthLegalDialog";
+
+describe("AuthLegalDialog", () => {
+  it("covers close button accessible label", () => {
+    render(<AuthLegalDialog docType="privacy" onOpenChange={vi.fn()} />);
+
+    const closeButton = screen.getByRole("button", {
+      name: "Close legal document",
+    });
+
+    expect(closeButton).toBeTruthy();
+    expect(closeButton.getAttribute("type")).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused coverage for the AuthLegalDialog close button accessible label.

## Reviewer Proof
- Surface: components/onboarding/AuthLegalDialog.tsx, rendered through the real component.
- No overlap: test-only coverage for the custom legal dialog close control label.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions