### PR TITLE
test(phone-mandate): verify exact route matching

### DIFF
--- a/hushh-webapp/__tests__/services/phone-mandate-path.test.ts
+++ b/hushh-webapp/__tests__/services/phone-mandate-path.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isPhoneMandatePath } from "@/lib/services/phone-mandate-service";
+
+describe("isPhoneMandatePath — exact route match contract", () => {
+  it("returns true for the exact phone mandate path", () => {
+    expect(isPhoneMandatePath("/register-phone")).toBe(true);
+  });
+
+  it("returns false for a nested path under the phone mandate route", () => {
+    expect(isPhoneMandatePath("/register-phone/step1")).toBe(false);
+  });
+
+  it("returns false for a path with a trailing slash", () => {
+    expect(isPhoneMandatePath("/register-phone/")).toBe(false);
+  });
+
+  it("returns false for an unrelated path", () => {
+    expect(isPhoneMandatePath("/login")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isPhoneMandatePath(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isPhoneMandatePath(undefined)).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isPhoneMandatePath("")).toBe(false);
+  });
+
+  it("trims whitespace before comparing", () => {
+    expect(isPhoneMandatePath("  /register-phone  ")).toBe(true);
+  });
+
+  it("is case-sensitive", () => {
+    expect(isPhoneMandatePath("/REGISTER-PHONE")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `isPhoneMandatePath` in `phone-mandate-service`.

## Why

The helper performs route classification using an exact comparison against the phone mandate route but currently lacks direct coverage.

The tests verify:

* exact route matching
* rejection of nested routes
* nullish-input handling
* whitespace trimming before comparison

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/services/phone-mandate-path.test.ts

## Notes

The tests verify the public route-classification contract directly without mocks, browser APIs, or shared test setup.
