### PR TITLE
test(phone-verification-flow): cover country code empty state

### DIFF
--- a/hushh-webapp/__tests__/components/phone-verification-flow.test.ts
+++ b/hushh-webapp/__tests__/components/phone-verification-flow.test.ts
@@ -27,7 +27,15 @@ describe("PhoneVerificationFlow phone input normalization", () => {
       localPhoneNumber: "6505550101",
     });
   });
-      it("preserves empty phone input normalization stability", () => {
+
+  it("covers country code empty state", () => {
+    expect(resolvePhoneInputChange("+")).toEqual({
+      countryValue: "US",
+      localPhoneNumber: "",
+    });
+  });
+
+  it("preserves empty phone input normalization stability", () => {
     expect(resolvePhoneInputChange("")).toEqual({
       localPhoneNumber: "",
     });


### PR DESCRIPTION
## Summary
- Adds focused coverage for empty country-code phone input normalization.

## Reviewer Proof
- Surface: components/auth/phone-verification-flow.tsx, covered through existing exported normalization helpers.
- No overlap: one assertion for bare + country-code input; no UI or flow behavior changes.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions