### PR TITLE
test(services): verify phone mandate bypass route

### DIFF
--- a/hushh-webapp/__tests__/services/phone-mandate-bypass-route.test.ts
+++ b/hushh-webapp/__tests__/services/phone-mandate-bypass-route.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { shouldBypassPhoneMandateForRoute } from "@/lib/services/phone-mandate-service";
+import { ROUTES } from "@/lib/navigation/routes";
+
+describe("shouldBypassPhoneMandateForRoute — exact allowlist match contract", () => {
+  it("returns true for the exact ria onboarding path", () => {
+    expect(shouldBypassPhoneMandateForRoute(ROUTES.RIA_ONBOARDING)).toBe(true);
+  });
+
+  it("returns false for a nested path under ria onboarding (exact match only, no startsWith)", () => {
+    expect(shouldBypassPhoneMandateForRoute("/ria/onboarding/step1")).toBe(false);
+  });
+
+  it("returns false for an unrelated path", () => {
+    expect(shouldBypassPhoneMandateForRoute("/ria/clients")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(shouldBypassPhoneMandateForRoute(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(shouldBypassPhoneMandateForRoute(undefined)).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(shouldBypassPhoneMandateForRoute("")).toBe(false);
+  });
+
+  it("trims whitespace before comparing", () => {
+    expect(shouldBypassPhoneMandateForRoute("  /ria/onboarding  ")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `shouldBypassPhoneMandateForRoute` in `phone-mandate-service`.

## Why

The helper determines whether phone-mandate enforcement should be bypassed for a route but currently lacks direct coverage.

The tests verify:

* exact onboarding-route matching
* rejection of nested onboarding routes
* rejection of unrelated routes
* nullish input handling
* whitespace trimming before comparison

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/services/phone-mandate-bypass-route.test.ts

## Notes

The tests focus on the public route-matching contract without modifying shared helpers, mocks, or test setup.
