### PR TITLE
test(vault-method-prompt): cover method action button type

### DIFF
--- a/hushh-webapp/__tests__/components/vault-method-prompt.test.tsx
+++ b/hushh-webapp/__tests__/components/vault-method-prompt.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { VaultMethodPrompt } from "@/components/vault/vault-method-prompt";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/profile",
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    loading: false,
+    user: {
+      uid: "user-1",
+      displayName: "Test User",
+      email: "test@example.com",
+    },
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    vaultKey: "vault-key",
+    isVaultUnlocked: true,
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-hostname", () => ({
+  useHostname: () => "app.example.com",
+}));
+
+vi.mock("@/lib/services/vault-service", () => ({
+  VaultService: {
+    getVaultState: vi.fn(() =>
+      Promise.resolve({
+        primaryMethod: "passphrase",
+        wrappers: [],
+      }),
+    ),
+    getWrapperByMethod: vi.fn(() => null),
+  },
+}));
+
+vi.mock("@/lib/services/vault-method-service", () => ({
+  VaultMethodService: {
+    getCapabilityMatrix: vi.fn(() =>
+      Promise.resolve({
+        recommendedMethod: "generated_default_web_prf",
+      }),
+    ),
+    switchMethod: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/vault-method-prompt-local-service", () => ({
+  VaultMethodPromptLocalService: {
+    load: vi.fn(() => Promise.resolve(null)),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/kai-nav-tour-local-service", () => ({
+  KaiNavTourLocalService: {
+    load: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("VaultMethodPrompt", () => {
+  it("covers method action button type", async () => {
+    render(<VaultMethodPrompt enabled />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Not now" })).toBeTruthy();
+    });
+
+    expect(screen.getByRole("button", { name: "Not now" }).getAttribute("type")).toBe(
+      "button",
+    );
+    expect(
+      screen.getByRole("button", { name: "Enable now" }).getAttribute("type"),
+    ).toBe("button");
+  });
+});

--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -220,6 +220,7 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
 
         <DialogFooter className="gap-2 sm:gap-2">
           <Button
+            type="button"
             variant="none"
             effect="fade"
             size="lg"
@@ -229,6 +230,7 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
             Not now
           </Button>
           <Button
+            type="button"
             variant="blue-gradient"
             effect="fill"
             size="lg"


### PR DESCRIPTION
## Summary
- Adds explicit button types to VaultMethodPrompt method actions.
- Covers the action button type contract through the rendered prompt.

## Reviewer Proof
- Surface: components/vault/vault-method-prompt.tsx, tested through the real prompt component.
- No overlap: only method prompt action button type behavior; no vault switching logic changes.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions