### PR TITLE
test(recovery-key-dialog): cover copy action button type

### DIFF
--- a/hushh-webapp/__tests__/components/recovery-key-dialog.test.tsx
+++ b/hushh-webapp/__tests__/components/recovery-key-dialog.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RecoveryKeyDialog } from "@/components/vault/recovery-key-dialog";
+
+vi.mock("@/lib/utils/clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/native-download", () => ({
+  downloadTextFile: vi.fn(),
+}));
+
+describe("RecoveryKeyDialog", () => {
+  it("renders the copy action as an explicit button", () => {
+    render(
+      <RecoveryKeyDialog
+        open
+        recoveryKey="recovery-key-123"
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /copy key/i }).getAttribute("type")).toBe(
+      "button",
+    );
+  });
+});

--- a/hushh-webapp/components/vault/recovery-key-dialog.tsx
+++ b/hushh-webapp/components/vault/recovery-key-dialog.tsx
@@ -84,6 +84,7 @@ export function RecoveryKeyDialog({
 
           <div className="grid grid-cols-2 gap-2">
             <Button
+              type="button"
               onClick={handleCopy}
               className="w-full"
             >


### PR DESCRIPTION
## Summary
- Adds an explicit button type to the recovery key copy action.
- Covers that copy action contract in a focused dialog test.

## Reviewer Proof
- Surface: components/vault/recovery-key-dialog.tsx
- Test: __tests__/components/recovery-key-dialog.test.tsx
- No overlap: only the recovery key dialog copy action is touched.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions
