### PR TITLE
test(route-layout): verify layout mode dispatch

### DIFF
--- a/hushh-webapp/__tests__/navigation/app-route-layout-mode.test.ts
+++ b/hushh-webapp/__tests__/navigation/app-route-layout-mode.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAppRouteLayoutMode } from "@/lib/navigation/app-route-layout";
+
+describe("resolveAppRouteLayoutMode", () => {
+  it("returns hidden mode for hidden routes", () => {
+    expect(resolveAppRouteLayoutMode("/login")).toBe(
+      "hidden",
+    );
+  });
+
+  it("returns flow mode for onboarding routes", () => {
+    expect(
+      resolveAppRouteLayoutMode("/one/onboarding"),
+    ).toBe("flow");
+  });
+
+  it("returns redirect mode for redirect routes", () => {
+    expect(resolveAppRouteLayoutMode("/gmail")).toBe(
+      "redirect",
+    );
+  });
+
+  it("returns standard mode for application routes", () => {
+    expect(resolveAppRouteLayoutMode("/one")).toBe(
+      "standard",
+    );
+  });
+
+  it("matches dynamic route segments", () => {
+    expect(
+      resolveAppRouteLayoutMode(
+        "/ria/clients/user-123",
+      ),
+    ).toBe("standard");
+  });
+
+  it("strips query strings before matching", () => {
+    expect(
+      resolveAppRouteLayoutMode(
+        "/login?redirect=%2Fone",
+      ),
+    ).toBe("hidden");
+  });
+
+  it("strips hash fragments before matching", () => {
+    expect(
+      resolveAppRouteLayoutMode(
+        "/ria/onboarding#step-2",
+      ),
+    ).toBe("flow");
+  });
+
+  it("falls back to standard mode for unknown routes", () => {
+    expect(
+      resolveAppRouteLayoutMode(
+        "/no-such-route-anywhere",
+      ),
+    ).toBe("standard");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `resolveAppRouteLayoutMode` in `lib/navigation/app-route-layout.ts`.

## Why

The helper dispatches application routes to layout modes using the route-layout contract but currently lacks direct coverage.

The tests verify:

* hidden mode dispatch
* flow mode dispatch
* redirect mode dispatch
* standard mode dispatch
* dynamic route segment matching
* query-string normalization
* hash-fragment normalization
* default fallback behavior

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/navigation/app-route-layout-mode.test.ts

## Notes

The tests verify public layout-mode behavior directly without mocks, browser APIs, contract mutation, or shared test setup.
