### PR TITLE
test(ria-client-workspace): cover no linked accounts fallback

### DIFF
--- a/hushh-webapp/__tests__/components/ria-client-workspace.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-client-workspace.test.tsx
@@ -1,10 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
+import { RiaClientWorkspace } from "@/components/ria/ria-client-workspace";
 import {
   buildKaiTestClientDetail,
   buildKaiTestClientWorkspace,
   RIA_KAI_SPECIALIZED_TEMPLATE_ID,
 } from "@/components/ria/ria-client-test-profile";
+import { useRiaClientWorkspaceState } from "@/components/ria/use-ria-client-workspace-state";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ria/use-ria-client-workspace-state", () => ({
+  useRiaClientWorkspaceState: vi.fn(),
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
 
 describe("RIA client test profile builders", () => {
   it("produces a stable Kai-specialized advisor workspace payload", () => {
@@ -48,5 +66,41 @@ describe("RIA client test profile builders", () => {
     expect(detail.investor_user_id).toBe(clientId);
     expect(workspace.investor_user_id).toBe(clientId);
     expect(workspace.account_branches).toHaveLength(detail.account_branches.length);
+  });
+});
+
+describe("RiaClientWorkspace", () => {
+  it("covers no linked accounts fallback", () => {
+    vi.mocked(useRiaClientWorkspaceState).mockReturnValue({
+      user: { uid: "advisor-1" },
+      riaCapability: "active",
+      personaLoading: false,
+      detail: {
+        investor_user_id: "client-1",
+        investor_display_name: "Investor One",
+        investor_email: "investor@example.com",
+        investor_secondary_label: null,
+        investor_headline: null,
+        relationship_status: "active",
+        is_self_relationship: true,
+        granted_scopes: [],
+        account_branches: [],
+        request_history: [],
+        available_scope_metadata: [],
+        requestable_scope_templates: [],
+        kai_specialized_bundle: null,
+      },
+      workspace: null,
+      loading: false,
+      detailError: null,
+      iamUnavailable: false,
+      isTestProfile: false,
+      refreshWorkspace: vi.fn(),
+    } as unknown as ReturnType<typeof useRiaClientWorkspaceState>);
+
+    render(<RiaClientWorkspace clientId="client-1" initialTab="overview" />);
+
+    expect(screen.getByText("Accounts")).toBeTruthy();
+    expect(screen.getByText("No linked accounts discovered yet.")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Covers the RIA client workspace no-linked-accounts fallback.

## Reviewer Proof
- Surface: __tests__/components/ria-client-workspace.test.tsx
- No overlap: one focused test for the workspace overview accounts fallback.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions
