### PR TITLE
fix(ui): add explicit type=button to Dialog close icon to prevent form submissions

### DIFF
--- a/hushh-webapp/components/ui/dialog.tsx
+++ b/hushh-webapp/components/ui/dialog.tsx
@@ -72,6 +72,7 @@ function DialogContent({
 
         {showCloseButton && (
           <DialogPrimitive.Close
+            type="button"
             data-slot="dialog-close"
             className="ring-offset-background focus:ring-ring group absolute top-4 right-4 z-30 isolate overflow-hidden rounded-full border border-transparent bg-[color:var(--app-card-surface-compact)] p-2 opacity-70 transition-[opacity,transform] duration-200 hover:opacity-100 active:scale-[0.97] focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >


### PR DESCRIPTION
## Overview
This PR fixes a critical functional hygiene bug in the `Dialog` component by explicitly adding `type="button"` to the internal close button.

## What Changed
* Added `type="button"` to `<DialogPrimitive.Close>` inside `components/ui/dialog.tsx`.

## Why it Matters
By default, standard HTML `<button>` elements act as `type="submit"` when placed inside a `<form>`. If a developer nests a Dialog inside a form structure, clicking the standard "X" close icon would unintentionally submit the form, causing unwanted page reloads or accidental network requests. Explicitly defining the button type prevents this default behavior and ensures the component is safe to use in any context.