### PR TITLE
fix(ui): silence development profiling logs in portfolio review

### DIFF
--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -1335,7 +1335,9 @@ export function PortfolioReviewView({
     const logSavePhase = (phase: string, phaseStartedAt: number) => {
       if (!enableSaveProfiling) return;
       const durationMs = nowMs() - phaseStartedAt;
-      console.log(`[PortfolioReviewView][save] ${phase}: ${durationMs.toFixed(1)}ms`);
+      if (process.env.NODE_ENV !== "production") {
+        console.log(`[PortfolioReviewView][save] ${phase}: ${durationMs.toFixed(1)}ms`);
+      }
     };
 
     // If vault existence isn't resolved yet, resolve it on-demand so copy/flow is correct.


### PR DESCRIPTION
### Description

Silences development profiling logs inside `components/kai/views/portfolio-review-view.tsx` by wrapping the `console.log` statement in a `NODE_ENV !== "production"` check. This prevents the portfolio review saving phase from leaking duration metrics to the production client console if profiling is ever enabled.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/views/portfolio-review-view.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/views/portfolio-review-view.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Purely a logging chore fix.