### PR TITLE
fix(ui): enforce explicit button type on accordion trigger

### DIFF
--- a/hushh-webapp/components/ui/accordion.tsx
+++ b/hushh-webapp/components/ui/accordion.tsx
@@ -33,6 +33,7 @@ function AccordionTrigger({
   return (
     <AccordionPrimitive.Header data-slot="accordion-header" className="flex">
       <AccordionPrimitive.Trigger
+        type="button"
         data-slot="accordion-trigger"
         className={cn(
           "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the `AccordionTrigger` component. Without this, browsers default the trigger to `type="submit"` when the accordion is rendered inside a `<form>` element, causing unintended form submissions and page reloads when users simply try to expand or collapse accordion sections.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/accordion.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logic)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js UI component (`components/ui/accordion.tsx`)

## 🧪 Testing

- [x] Verified component compiles and button type is explicitly set
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none