### PR TITLE
fix(ui): enforce explicit button type on combobox trigger

### DIFF
--- a/hushh-webapp/components/ui/combobox.tsx
+++ b/hushh-webapp/components/ui/combobox.tsx
@@ -26,6 +26,7 @@ function ComboboxTrigger({
 }: ComboboxPrimitive.Trigger.Props) {
   return (
     <ComboboxPrimitive.Trigger
+      type="button"
       data-slot="combobox-trigger"
       className={cn("[&_svg:not([class*='size-'])]:size-4", className)}
       {...props}


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the `ComboboxTrigger` component. Without this explicit definition, browsers will default the trigger button to `type="submit"` when the combobox is rendered inside a `<form>` element. This prevents unintended form submissions and page reloads when users try to open the combobox dropdown menu.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/combobox.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logic)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js UI component (`components/ui/combobox.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Verified component compiles and button type is explicitly set
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a structural HTML fix.