### PR TITLE
fix(ui): silence command fields option loading errors in production

### DIFF
--- a/hushh-webapp/components/app-ui/command-fields.tsx
+++ b/hushh-webapp/components/app-ui/command-fields.tsx
@@ -115,7 +115,9 @@ export function CommandPickerField<T = unknown>({
           setDynamicOptions(nextOptions);
         }
       } catch (error) {
-        console.error("Failed to load options:", error);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("Failed to load options:", error);
+        }
       } finally {
         if (!abortController.signal.aborted) {
           setLoading(false);


### PR DESCRIPTION
### Description

Silences a development `console.error` inside `components/app-ui/command-fields.tsx` by wrapping it in a `NODE_ENV !== "production"` check. This prevents the `CommandPickerField` from leaking internal error stack traces to the production client console if dynamic option loading fails or is aborted.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/app-ui/command-fields.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/app-ui/command-fields.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Purely a logging chore fix.