### PR TITLE
fix(ui): enforce explicit button type on select trigger

### DIFF
--- a/hushh-webapp/components/ui/select.tsx
+++ b/hushh-webapp/components/ui/select.tsx
@@ -34,6 +34,7 @@ function SelectTrigger({
 }) {
   return (
     <SelectPrimitive.Trigger
+      type="button"
       data-slot="select-trigger"
       data-size={size}
       className={cn(


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the `SelectTrigger` component. Without this explicit definition, browsers default the trigger to `type="submit"` when the select dropdown is rendered inside a `<form>` element. This prevents unintended form submissions and page reloads when users try to open the dropdown.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/select.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logic)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js UI component (`components/ui/select.tsx`)

## 🧪 Testing

- [x] Verified component compiles and button type is explicitly set
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a structural HTML fix.