### PR TITLE
fix(one-location): restore People-tab search, drop pending invites list

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -772,6 +772,10 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByRole("button", { name: /Invite trusted person/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Share to contacts/i })).toBeTruthy();
+    // People tab exposes a search bar to filter ready people, and no longer
+    // renders a separate "Pending invites" list.
+    expect(screen.getByPlaceholderText("Search trusted people")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Pending invites" })).toBeNull();
     await switchLocationTab("Links", "Links");
     expect(screen.getByRole("button", { name: /Create public location link/i })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Active public location link" })).toBeTruthy();

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -476,8 +476,10 @@ function PeopleHub({
   onInvite: () => void;
   onStartShare: () => void;
 }) {
-  const ready = vm.recipients.filter((r) => vm.isRecipientShareReady(r));
-  const pending = vm.recipients.filter((r) => !vm.isRecipientShareReady(r));
+  const ready = vm.visibleRecipients.filter((r) =>
+    vm.isRecipientShareReady(r),
+  );
+  const hasSearchQuery = vm.recipientSearch.trim().length > 0;
 
   return (
     <div className="space-y-5">
@@ -515,8 +517,12 @@ function PeopleHub({
       </SectionCard>
 
       <SectionCard title="Ready people">
+        <PersonSearchInput
+          value={vm.recipientSearch}
+          onChange={vm.setRecipientSearch}
+        />
         {ready.length ? (
-          <div className={PEOPLE_LIST_SCROLL_CLASS}>
+          <div className={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}>
             {ready.map((r) => (
               <TrustedPersonCard
                 key={r.userId}
@@ -534,29 +540,18 @@ function PeopleHub({
             ))}
           </div>
         ) : (
-          <EmptyState
-            title="No ready people yet"
-            description="Invite someone to your Circle to start private sharing."
-          />
+          <div className="mt-3">
+            <EmptyState
+              title={hasSearchQuery ? "No matching people" : "No ready people yet"}
+              description={
+                hasSearchQuery
+                  ? "Try a different name."
+                  : "Invite someone to your Circle to start private sharing."
+              }
+            />
+          </div>
         )}
       </SectionCard>
-
-      {pending.length ? (
-        <SectionCard title="Pending invites">
-          <div className={PEOPLE_LIST_SCROLL_CLASS}>
-            {pending.map((r) => (
-              <TrustedPersonCard
-                key={r.userId}
-                name={vm.recipientLabel(r)}
-                subtitle="Invite pending"
-                tone="pending"
-                statusLabel="Pending"
-              />
-            ))}
-          </div>
-        </SectionCard>
-      ) : null}
-
 
       <TrustNoteCard
         title="Private sharing starts after approval"


### PR DESCRIPTION
## Problem

Two People-tab bugs in One Location:

1. **Missing search bar** — the People tab no longer showed a search input, so a large Trusted Circle could not be filtered.
2. **Pending invites list** — the People tab rendered a separate "Pending invites" list that is no longer wanted.

## Fix

- Restored `PersonSearchInput` in the "Ready people" section, wired to the existing `recipientSearch` / `setRecipientSearch` state and the search-filtered `visibleRecipients`. Typing a name now filters the ready list live.
- Made the empty state search-aware: "No matching people / Try a different name" when a query has no hits, vs the normal "No ready people yet" otherwise.
- Removed the "Pending invites" section from the People tab. Only "Ready people" remains alongside the Trusted Circle actions and the trust note.

## Scope

- `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (`PeopleHub`)
- `hushh-webapp/__tests__/components/one-location-agent-page.test.tsx` — assertion locking the search bar presence and the absence of the "Pending invites" heading.

## Tests

All 26 tests in the One Location suite pass.
