### PR TITLE
fix(one-location): restore People-tab search, drop pending invites list

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -772,6 +772,10 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByRole("button", { name: /Invite trusted person/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Sync contacts/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Share to contacts/i })).toBeTruthy();
+    // People tab exposes a search bar to filter ready people, and no longer
+    // renders a separate "Pending invites" list.
+    expect(screen.getByPlaceholderText("Search trusted people")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Pending invites" })).toBeNull();
     await switchLocationTab("Links", "Links");
     expect(screen.getByRole("button", { name: /Create public location link/i })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Active public location link" })).toBeTruthy();

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -476,8 +476,10 @@ function PeopleHub({
   onInvite: () => void;
   onStartShare: () => void;
 }) {
-  const ready = vm.recipients.filter((r) => vm.isRecipientShareReady(r));
-  const pending = vm.recipients.filter((r) => !vm.isRecipientShareReady(r));
+  const ready = vm.visibleRecipients.filter((r) =>
+    vm.isRecipientShareReady(r),
+  );
+  const hasSearchQuery = vm.recipientSearch.trim().length > 0;
 
   return (
     <div className="space-y-5">
@@ -515,8 +517,12 @@ function PeopleHub({
       </SectionCard>
 
       <SectionCard title="Ready people">
+        <PersonSearchInput
+          value={vm.recipientSearch}
+          onChange={vm.setRecipientSearch}
+        />
         {ready.length ? (
-          <div className={PEOPLE_LIST_SCROLL_CLASS}>
+          <div className={cn("mt-3", PEOPLE_LIST_SCROLL_CLASS)}>
             {ready.map((r) => (
               <TrustedPersonCard
                 key={r.userId}
@@ -534,29 +540,18 @@ function PeopleHub({
             ))}
           </div>
         ) : (
-          <EmptyState
-            title="No ready people yet"
-            description="Invite someone to your Circle to start private sharing."
-          />
+          <div className="mt-3">
+            <EmptyState
+              title={hasSearchQuery ? "No matching people" : "No ready people yet"}
+              description={
+                hasSearchQuery
+                  ? "Try a different name."
+                  : "Invite someone to your Circle to start private sharing."
+              }
+            />
+          </div>
         )}
       </SectionCard>
-
-      {pending.length ? (
-        <SectionCard title="Pending invites">
-          <div className={PEOPLE_LIST_SCROLL_CLASS}>
-            {pending.map((r) => (
-              <TrustedPersonCard
-                key={r.userId}
-                name={vm.recipientLabel(r)}
-                subtitle="Invite pending"
-                tone="pending"
-                statusLabel="Pending"
-              />
-            ))}
-          </div>
-        </SectionCard>
-      ) : null}
-
 
       <TrustNoteCard
         title="Private sharing starts after approval"


### PR DESCRIPTION
The People tab lost its search bar, so a large Trusted Circle could not be filtered. Restore the PersonSearchInput in the Ready people section wired to the existing recipientSearch/visibleRecipients state, with a search-aware empty state.

Also remove the separate Pending invites list from the People tab per product direction; only Ready people remain alongside the Trusted Circle actions.

# Description

Briefly explain what you changed and why.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [ ] Listed below:

- API / schema / type changes:
  - [ ] None
  - [ ] Listed below:

- Cache keys touched:
  - [ ] None
  - [ ] Listed below:

- Runtime DB data-plane changes:
  - [ ] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [ ] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [ ] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [ ] None
  - [ ] Listed below:

- Top-level / devex / config / generated / ignore files touched:
  - [ ] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [ ] None
  - [ ] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:

- Caller / proxy / backend pairing:
  - [ ] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [ ] Not applicable
  - [ ] Listed below:

- UI browser or Playwright proof:
  - [ ] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## ✅ Review-Ready Contract

- [ ] Title, body, changed files, and tests describe the same contract.
- [ ] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [ ] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [ ] Reachable production attach point:
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [ ] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here:
- [ ] If this responds to requested changes, the new commit or material explanation is described here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [ ] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?
- [ ] Sensitive surface touched: auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress / none
- [ ] Error path, rollback, or safe-failure behavior proved:

## 📜 Licensing

- [ ] First-party changes remain Apache-2.0 compatible
- [ ] Third-party notice impact reviewed when dependencies changed
