### PR TITLE
fix(frontend-a11y): add accessible name to marketplace search input

### DIFF
--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -1179,6 +1179,7 @@ export default function MarketplacePage() {
                 <Input
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
+                  aria-label="Search marketplace"
                   placeholder={searchPlaceholder}
                   className="min-h-11 rounded-[22px] border-0 bg-card pl-10 text-sm"
                 />


### PR DESCRIPTION
## Summary

Add an accessible name to the marketplace search input.

## Changes

* Add `aria-label="Search marketplace"` to the marketplace search input.

## Why

The marketplace search input relied only on placeholder text to communicate its purpose. Adding an accessible name improves support for assistive technologies without changing the existing behavior or appearance of the component.
