### PR TITLE
fix(frontend-a11y): add accessible name to location request reason field

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -3921,6 +3921,7 @@ function OneLocationAgentPageContent() {
                         onChange={(event) =>
                           setRequestMessage(event.target.value)
                         }
+                        aria-label="Reason for location request"
                         placeholder="Optional reason"
                         rows={3}
                         className="rounded-[14px] border-black/[0.04] bg-white shadow-sm dark:border-white/[0.08] dark:bg-white/[0.07]"


### PR DESCRIPTION
## Summary

Add an accessible name to the location request reason field.

## Changes

* Add `aria-label="Reason for location request"` to the location request textarea.

## Why

The location request textarea previously relied only on placeholder text to communicate its purpose. Adding an accessible name improves support for assistive technologies without changing the existing behavior or appearance of the component.
