### PR TITLE
test(ria-page-shell): cover compatibility warning copy

### DIFF
--- a/hushh-webapp/__tests__/components/ria-page-shell.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-page-shell.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RiaCompatibilityState } from "@/components/ria/ria-page-shell";
+
+describe("RiaCompatibilityState", () => {
+  it("covers compatibility warning copy", () => {
+    render(
+      <RiaCompatibilityState
+        title="Client workspace is unavailable"
+        description="IAM schema is still warming up."
+      />,
+    );
+
+    expect(screen.getByText("Compatibility Mode")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Client workspace is unavailable" })).toBeTruthy();
+    expect(screen.getByText("IAM schema is still warming up.")).toBeTruthy();
+    expect(
+      screen.getByText(
+        /This surface is running in degraded compatibility mode until the full IAM contract is available in the active environment\./,
+      ),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the RIA compatibility warning copy.

## Reviewer Proof
- Surface: __tests__/components/ria-page-shell.test.tsx
- No overlap: new focused test for RiaCompatibilityState only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions
