### PR TITLE
test(ria-onboarding-shell): cover step status live region

### DIFF
--- a/hushh-webapp/__tests__/components/ria-onboarding-shell.test.tsx
+++ b/hushh-webapp/__tests__/components/ria-onboarding-shell.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingShell } from "@/components/ria/onboarding/onboarding-shell";
+
+describe("OnboardingShell", () => {
+  it("covers step status live region", () => {
+    render(
+      <OnboardingShell
+        currentStepIndex={1}
+        totalSteps={4}
+        eyebrow="License"
+        title="Verify your license"
+        description="Confirm your advisor registration."
+        canContinue
+        saving={false}
+        isFirstStep={false}
+        isLastStep={false}
+        advisoryAccessReady={false}
+        onBack={vi.fn()}
+        onContinue={vi.fn()}
+      >
+        <div>License form</div>
+      </OnboardingShell>,
+    );
+
+    const status = screen.getByRole("status");
+
+    expect(status.textContent).toBe("Step 2 of 4");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.getAttribute("aria-atomic")).toBe("true");
+  });
+});

--- a/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-shell.tsx
@@ -68,7 +68,7 @@ export function OnboardingShell({
             />
           ))}
         </div>
-        <span role="status" aria-atomic="true" className="sr-only">
+        <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
           {`Step ${currentStepIndex + 1} of ${totalSteps}`}
         </span>
 


### PR DESCRIPTION
## Summary
- Adds an explicit polite live region to the RIA onboarding step status.
- Covers the step status announcement contract in a focused shell test.

## Reviewer Proof
- Surface: components/ria/onboarding/onboarding-shell.tsx
- Test: __tests__/components/ria-onboarding-shell.test.tsx
- No overlap: only the RIA onboarding shell step status is touched.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions
