### PR TITLE
test(ria-license-details): cover license detail field rendering

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-license-details.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-license-details.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingStepLicenseDetails } from "@/components/ria/onboarding/onboarding-step-license-details";
+
+describe("OnboardingStepLicenseDetails", () => {
+  it("covers license detail field rendering", () => {
+    render(
+      <OnboardingStepLicenseDetails
+        advisorName="Jane Advisor"
+        firmName="Acme Wealth"
+        regulator="SEC"
+        regulatorStatus="Active"
+        licenseExpiry="2027-12-31"
+        certifications={["Series 65", "SIE"]}
+        city="Atlanta"
+        pinZip="30301"
+        crdNumber="123456"
+        onAdvisorNameChange={vi.fn()}
+        onCityChange={vi.fn()}
+        onPinZipChange={vi.fn()}
+        isEnriching={false}
+      />,
+    );
+
+    expect(screen.getByText("SEC - Active")).toBeTruthy();
+    expect(screen.getByDisplayValue("Jane Advisor")).toBeTruthy();
+    expect(screen.getByText("Acme Wealth")).toBeTruthy();
+    expect(screen.getByText("123456")).toBeTruthy();
+    expect(screen.getByText("2027-12-31")).toBeTruthy();
+    expect(screen.getByText("Series 65, SIE")).toBeTruthy();
+    expect(screen.getByDisplayValue("Atlanta")).toBeTruthy();
+    expect(screen.getByDisplayValue("30301")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers RIA license detail field rendering.

## Attachment Plan
- Canonical app surface: `hushh-webapp/app/ria/onboarding/page.tsx` renders `OnboardingStepLicenseDetails` after successful license verification in `/ria/onboarding`.
- Component contract under review: `hushh-webapp/components/ria/onboarding/onboarding-step-license-details.tsx` presents enriched license fields and editable location fields supplied by the route's verification state.
- Test contract: `hushh-webapp/__tests__/components/ria/onboarding-step-license-details.test.tsx` verifies only the child component's field-rendering contract; it does not add a route, alternate onboarding flow, helper, backend path, or product behavior.

## Overlap Review
- Existing route-level coverage in `hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx` mocks `OnboardingStepLicenseDetails`, so it cannot prove the real child component's displayed license fields.
- This PR is a focused component-contract proof for the existing canonical `/ria/onboarding` route, not a competing capability.

## Validation
- `npm test -- __tests__/components/ria/onboarding-step-license-details.test.tsx`
- Web (Next.js) via GitHub Actions