### PR TITLE
test(ria-license-step): cover no registration fallback

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-license.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-license.test.tsx
@@ -39,4 +39,18 @@ describe("OnboardingStepLicense", () => {
     expect(screen.getByRole("button", { name: "Verify licence" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Bypass for dev/UAT" })).toBeNull();
   });
+
+  it("covers no registration fallback", () => {
+    render(
+      <OnboardingStepLicense
+        licenseNumber="999999"
+        onLicenseNumberChange={vi.fn()}
+        verificationStatus="not_found"
+        onVerify={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No matching registration found.")).toBeTruthy();
+    expect(screen.getByText("Try a different licence number.")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Covers the RIA license step no-registration fallback copy.

## Attachment Plan
- Canonical app surface: `hushh-webapp/app/ria/onboarding/page.tsx` renders `OnboardingStepLicense` as the license verification step in `/ria/onboarding`.
- Component contract under review: `hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx` renders the `not_found` verification status as the no-registration fallback copy shown before the user can proceed to license details.
- Test contract: `hushh-webapp/__tests__/components/ria/onboarding-step-license.test.tsx` extends the existing `OnboardingStepLicense` component test file with only that `not_found` state; it does not add a route, alternate onboarding flow, helper, backend path, or product behavior.

## Overlap Review
- Existing route-level coverage in `hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx` mocks `OnboardingStepLicense`, so it cannot prove the real child component's fallback copy.
- This PR is a focused component-contract proof for the existing canonical `/ria/onboarding` route, not a competing capability.

## Validation
- `npm test -- __tests__/components/ria/onboarding-step-license.test.tsx`
- Web (Next.js) via GitHub Actions