### PR TITLE
test(ria-review-step): cover review action button type

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-review.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-review.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingStepReview } from "@/components/ria/onboarding/onboarding-step-review";
+
+describe("OnboardingStepReview", () => {
+  it("covers review action button type", () => {
+    render(
+      <OnboardingStepReview
+        advisorName="Jane Advisor"
+        firmName="Acme Wealth"
+        crdNumber="123456"
+        regulator="SEC"
+        regulatorStatus="Active"
+        certifications={["Series 65"]}
+        servicesOffered={["Portfolio Management"]}
+        feeStructure={["Fee-only"]}
+        minEngagementAmount="$250,000"
+        bio="RIA profile bio"
+        city="Atlanta"
+        pinZip="30301"
+        areaLocality="Downtown"
+        fullStreetAddress="100 Market Street"
+        advisoryAccessReady={false}
+        onEditSection={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /ask kai to update anything/i }).getAttribute("type"),
+    ).toBe("button");
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the RIA review step action button type contract.

## Attachment Plan
- Canonical app surface: `hushh-webapp/app/ria/onboarding/page.tsx` renders `OnboardingStepReview` as the review step in `/ria/onboarding`.
- Component contract under review: `hushh-webapp/components/ria/onboarding/onboarding-step-review.tsx` includes the "Ask Kai to update anything" control as a non-submit `button` so it cannot accidentally submit the onboarding shell form context if one is introduced around the step.
- Test contract: `hushh-webapp/__tests__/components/ria/onboarding-step-review.test.tsx` verifies only that child component button contract; it does not add a route, alternate onboarding flow, helper, backend path, or product behavior.

## Overlap Review
- Existing route-level coverage in `hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx` mocks `OnboardingStepReview`, so it cannot prove the real child component's action-button type.
- This PR is a focused component-contract proof for the existing canonical `/ria/onboarding` route, not a competing capability.

## Validation
- `npm test -- __tests__/components/ria/onboarding-step-review.test.tsx`
- Web (Next.js) via GitHub Actions