### PR TITLE
fix(frontend-a11y): add accessible name to market search input

### DIFF
--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -2031,6 +2031,7 @@ export function KaiMarketPreviewView() {
             <Search className="h-[17px] w-[17px] shrink-0 text-[color:var(--one-fg3)]" />
             <input
               type="text"
+              aria-label="Search stocks, ETFs, indices"
               placeholder="Search stocks, ETFs, indices"
               value={marketSearchQuery}
               onChange={(event) => setMarketSearchQuery(event.target.value)}


### PR DESCRIPTION
## Summary

Add an accessible name to the market search input.

## Changes

* Add `aria-label="Search stocks, ETFs, indices"` to the market search input.

## Why

The market search input previously relied only on placeholder text to communicate its purpose. Adding an accessible name improves support for assistive technologies without changing the existing behavior or appearance of the component.
