### PR TITLE
fix(ui): enforce explicit button type on tabs trigger

### DIFF
--- a/hushh-webapp/components/ui/tabs.tsx
+++ b/hushh-webapp/components/ui/tabs.tsx
@@ -65,6 +65,7 @@ function TabsTrigger({
 }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
+      type="button"
       data-slot="tabs-trigger"
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:outline-ring relative isolate inline-flex min-h-9 min-w-0 flex-1 items-center justify-center gap-1.5 overflow-hidden px-4 py-2 text-sm font-medium whitespace-nowrap transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] focus-visible:ring-[3px] focus-visible:outline-1",


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the `TabsTrigger` component. Without this explicit definition, browsers default the trigger to `type="submit"` when the tabs component is rendered inside a `<form>` element. This prevents unintended form submissions and page reloads when users try to switch between tabs.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/tabs.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logic)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js UI component (`components/ui/tabs.tsx`)

## 🧪 Testing

- [x] Verified component compiles and button type is explicitly set
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a structural HTML fix.