### PR TITLE
test(ria-services-step): cover services group semantics

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-services.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-services.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingStepServices } from "@/components/ria/onboarding/onboarding-step-services";
+
+describe("OnboardingStepServices", () => {
+  it("covers services group semantics", () => {
+    render(
+      <OnboardingStepServices
+        servicesOffered={["Portfolio Management"]}
+        feeStructure={["Fee-only"]}
+        minEngagementAmount="250000"
+        bio="Advisor bio"
+        city="Atlanta"
+        areaLocality="Downtown"
+        fullStreetAddress="100 Market Street"
+        pinZip="30301"
+        onServicesChange={vi.fn()}
+        onFeeStructureChange={vi.fn()}
+        onMinEngagementChange={vi.fn()}
+        onBioChange={vi.fn()}
+        onCityChange={vi.fn()}
+        onAreaLocalityChange={vi.fn()}
+        onFullStreetAddressChange={vi.fn()}
+        onPinZipChange={vi.fn()}
+        onDraftBio={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("group", { name: "Services offered" })).toBeTruthy();
+    expect(screen.getByRole("group", { name: "Fee structure" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Portfolio Management" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(screen.getByRole("button", { name: "Tax Planning" }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the RIA services step group semantics and selected service state.

## Attachment Plan
- Canonical app surface: `hushh-webapp/app/ria/onboarding/page.tsx` renders `OnboardingStepServices` as the services step in `/ria/onboarding`.
- Component contract under review: `hushh-webapp/components/ria/onboarding/onboarding-step-services.tsx` exposes service and fee option sets as named groups and uses `aria-pressed` for selectable service buttons.
- Test contract: `hushh-webapp/__tests__/components/ria/onboarding-step-services.test.tsx` verifies only that child component accessibility contract; it does not add a route, alternate onboarding flow, helper, backend path, or product behavior.

## Overlap Review
- Existing route-level coverage in `hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx` mocks `OnboardingStepServices`, so it cannot prove the real child component's group labels or selected-service semantics.
- This PR is a focused component-contract proof for the existing canonical `/ria/onboarding` route, not a competing capability.

## Validation
- `npm test -- __tests__/components/ria/onboarding-step-services.test.tsx`
- Web (Next.js) via GitHub Actions