### PR TITLE
fix(ui): silence portfolio share sheet errors in production

### DIFF
--- a/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
+++ b/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
@@ -107,7 +107,9 @@ export function PortfolioShareSheet({ open, onOpenChange, payload }: PortfolioSh
       if (isShareCancelError(error)) {
         return;
       }
-      console.error(`[PortfolioShareSheet] ${action} failed:`, error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[PortfolioShareSheet] ${action} failed:`, error);
+      }
       const fallback =
         action === "snapshot"
           ? "Could not share snapshot."


### PR DESCRIPTION
### Description

Silences a development `console.error` inside `components/kai/share/portfolio-share-sheet.tsx` by wrapping it in a `NODE_ENV !== "production"` check. This prevents the Portfolio Share Sheet from leaking internal error stack traces to the production client console when a share or snapshot action fails, while preserving the user-facing toast notification.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/share/portfolio-share-sheet.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/share/portfolio-share-sheet.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - Purely a logging chore fix.