### PR TITLE
test(ria-welcome-step): cover persona option pressed state

### DIFF
--- a/hushh-webapp/__tests__/components/ria/onboarding-step-welcome.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/onboarding-step-welcome.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingStepWelcome } from "@/components/ria/onboarding/onboarding-step-welcome";
+
+describe("OnboardingStepWelcome", () => {
+  it("covers persona option pressed state", () => {
+    render(
+      <OnboardingStepWelcome
+        onboardingType="individual"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /individual ria/i }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /firm \/ practice/i }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the RIA welcome step persona option pressed-state contract.

## Attachment Plan
- Canonical app surface: `hushh-webapp/app/ria/onboarding/page.tsx` renders `OnboardingStepWelcome` as the first `/ria/onboarding` step.
- Component contract under review: `hushh-webapp/components/ria/onboarding/onboarding-step-welcome.tsx` exposes the two persona choices as `button` controls with `aria-pressed` reflecting the selected onboarding type.
- Test contract: `hushh-webapp/__tests__/components/ria/onboarding-step-welcome.test.tsx` verifies only that child component accessibility state; it does not add a route, alternate onboarding flow, helper, backend path, or product behavior.

## Overlap Review
- Existing route-level coverage in `hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx` mocks `OnboardingStepWelcome`, so it cannot prove the real child component's `aria-pressed` semantics.
- This PR is a focused component-contract proof for the existing canonical `/ria/onboarding` route, not a competing capability.

## Validation
- `npm test -- __tests__/components/ria/onboarding-step-welcome.test.tsx`
- Web (Next.js) via GitHub Actions