### PR TITLE
test(ui): verify DrawerTitle heading element

### DIFF
--- a/hushh-webapp/__tests__/ui/drawer-title.test.tsx
+++ b/hushh-webapp/__tests__/ui/drawer-title.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+
+describe("DrawerTitle", () => {
+  it("renders as a heading element", () => {
+    render(
+      <Drawer open>
+        <DrawerContent>
+          <DrawerTitle>
+            Drawer title
+          </DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    expect(
+      screen.getByText("Drawer title").tagName,
+    ).toBe("H2");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `DrawerTitle` in `lib/components/ui/drawer`.

## Why

`DrawerTitle` is expected to render a semantic heading element for accessibility. The component currently lacks direct coverage for this contract.

The test verifies that `DrawerTitle` renders as an `H2` element when used within a drawer.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/drawer-title.test.tsx

## Notes

The test focuses on the public accessibility contract and avoids implementation-specific assertions beyond the rendered heading element.
