### PR TITLE
test(ui): verify SheetTitle heading element

### DIFF
--- a/hushh-webapp/__tests__/ui/sheet-title.test.tsx
+++ b/hushh-webapp/__tests__/ui/sheet-title.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+describe("SheetTitle", () => {
+  it("renders as a heading element", () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>
+            Sheet title
+          </SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(
+      screen.getByText("Sheet title").tagName,
+    ).toBe("H2");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `SheetTitle` in `lib/components/ui/sheet`.

## Why

`SheetTitle` is expected to render a semantic heading element for accessibility. Existing sheet tests verify slot behavior but do not verify the rendered heading element.

The test verifies that `SheetTitle` renders as an `H2` element when used within a sheet.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/sheet-title.test.tsx

## Notes

The test focuses on the public accessibility contract and remains independent of existing slot-based sheet tests.
