### PR TITLE
fix(ui): enforce explicit button type on popover trigger

### DIFF
--- a/hushh-webapp/components/ui/popover.tsx
+++ b/hushh-webapp/components/ui/popover.tsx
@@ -15,7 +15,7 @@ function Popover({
 function PopoverTrigger({
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
-  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+  return <PopoverPrimitive.Trigger type="button" data-slot="popover-trigger" {...props} />
 }
 
 function PopoverContent({


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the `PopoverTrigger` component. Without this explicit definition, browsers default the trigger to `type="submit"` when the popover is rendered inside a `<form>` element. This prevents unintended form submissions and page reloads when users try to open popovers (such as DatePickers or advanced settings) inside of forms.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/popover.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logic)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js UI component (`components/ui/popover.tsx`)

## 🧪 Testing

- [x] Verified component compiles and button type is explicitly set
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none