### PR TITLE
test(ui): cover accordion component className propagation contract

### DIFF
--- a/hushh-webapp/__tests__/ui/accordion.test.tsx
+++ b/hushh-webapp/__tests__/ui/accordion.test.tsx
@@ -36,6 +36,18 @@ describe("Accordion", () => {
     expect(container.querySelector('[data-slot="accordion"]')).toBeTruthy();
   });
 
+  it("propagates custom class names on root", () => {
+    const { container } = render(
+      <Accordion type="single" className="custom-accordion-root">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Trigger</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+    expect(container.querySelector('[data-slot="accordion"]')?.className).toContain("custom-accordion-root");
+  });
+
   it("renders AccordionItem with data-slot='accordion-item'", () => {
     const { container } = render(
       <Accordion type="single">


### PR DESCRIPTION
### Description

Adds missing test coverage to `__tests__/ui/accordion.test.tsx` to explicitly verify that the `Accordion` component correctly propagates custom `className` values to its underlying root element.