### PR TITLE
test(ui): verify SheetDescription paragraph element

### DIFF
--- a/hushh-webapp/__tests__/ui/sheet-description.test.tsx
+++ b/hushh-webapp/__tests__/ui/sheet-description.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+} from "@/components/ui/sheet";
+
+describe("SheetDescription", () => {
+  it("renders as a paragraph element", () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetDescription>
+            Sheet description
+          </SheetDescription>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(
+      screen.getByText("Sheet description").tagName,
+    ).toBe("P");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `SheetDescription` in `lib/components/ui/sheet`.

## Why

`SheetDescription` is expected to render a semantic paragraph element for accessibility and currently lacks direct coverage.

The test verifies that `SheetDescription` renders as a native `P` element when used within a sheet.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/sheet-description.test.tsx

## Notes

The test focuses on the public accessibility contract and avoids implementation-specific assertions beyond the rendered paragraph element.
