### PR TITLE
test(ui): verify DrawerDescription paragraph element

### DIFF
--- a/hushh-webapp/__tests__/ui/drawer-description.test.tsx
+++ b/hushh-webapp/__tests__/ui/drawer-description.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+
+describe("DrawerDescription", () => {
+  it("renders as a paragraph element", () => {
+    render(
+      <Drawer open>
+        <DrawerContent>
+          <DrawerDescription>
+            Drawer description
+          </DrawerDescription>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    expect(
+      screen.getByText("Drawer description").tagName,
+    ).toBe("P");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `DrawerDescription` in `lib/components/ui/drawer`.

## Why

`DrawerDescription` is expected to render a semantic paragraph element for accessibility and currently lacks direct coverage.

The test verifies that `DrawerDescription` renders as a native `P` element when used within a drawer.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/drawer-description.test.tsx

## Notes

The test focuses on the public accessibility contract and avoids implementation-specific assertions beyond the rendered paragraph element.
