### PR TITLE
fix(ui): enforce explicit button type on dropdown-menu trigger

### DIFF
--- a/hushh-webapp/components/ui/dropdown-menu.tsx
+++ b/hushh-webapp/components/ui/dropdown-menu.tsx
@@ -27,6 +27,7 @@ function DropdownMenuTrigger({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
   return (
     <DropdownMenuPrimitive.Trigger
+      type="button"
       data-slot="dropdown-menu-trigger"
       {...props}
     />


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the `DropdownMenuTrigger` component. Without this explicit definition, browsers default the trigger to `type="submit"` when the dropdown menu is rendered inside a `<form>` element. This prevents unintended form submissions and page reloads when users try to open dropdown menus (such as action menus or setting lists) inside of forms.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/ui/dropdown-menu.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logic)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js UI component (`components/ui/dropdown-menu.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Verified component compiles and button type is explicitly set
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a structural HTML fix.