### PR TITLE
test(ui): verify DialogDescription paragraph element

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog-description.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog-description.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Dialog,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+describe("DialogDescription", () => {
+  it("renders as a paragraph element", () => {
+    render(
+      <Dialog open>
+        <DialogDescription>
+          Description text
+        </DialogDescription>
+      </Dialog>,
+    );
+
+    expect(
+      screen.getByText("Description text").tagName,
+    ).toBe("P");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `DialogDescription` in `components/ui/dialog`.

## Why

`DialogDescription` is expected to render a semantic paragraph element for accessibility. Existing dialog tests cover other dialog primitives but do not verify the rendered element type for `DialogDescription`.

The test verifies that `DialogDescription` renders as a native `P` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/dialog-description.test.tsx

## Notes

The test focuses on the public accessibility contract and avoids implementation-specific assertions beyond the rendered paragraph element.
