### PR TITLE
test(ui): verify AlertDialogTitle heading element

### DIFF
--- a/hushh-webapp/__tests__/ui/alert-dialog-title.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert-dialog-title.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AlertDialog,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+describe("AlertDialogTitle", () => {
+  it("renders as a heading element", () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogTitle>
+          Alert title
+        </AlertDialogTitle>
+      </AlertDialog>,
+    );
+
+    expect(
+      screen.getByText("Alert title").tagName,
+    ).toBe("H2");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `AlertDialogTitle` in `components/ui/alert-dialog`.

## Why

`AlertDialogTitle` is expected to render a semantic heading element for accessibility. Existing alert dialog tests cover content structure and button behavior but do not verify the rendered heading element.

The test verifies that `AlertDialogTitle` renders as a native `H2` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/alert-dialog-title.test.tsx

## Notes

The test focuses on the public accessibility contract and avoids implementation-specific assertions beyond the rendered heading element.
