### PR TITLE
test(ui): verify AlertDialogDescription paragraph element

### DIFF
--- a/hushh-webapp/__tests__/ui/alert-dialog-description.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert-dialog-description.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AlertDialog,
+  AlertDialogDescription,
+} from "@/components/ui/alert-dialog";
+
+describe("AlertDialogDescription", () => {
+  it("renders as a paragraph element", () => {
+    render(
+      <AlertDialog open>
+        <AlertDialogDescription>
+          Alert description
+        </AlertDialogDescription>
+      </AlertDialog>,
+    );
+
+    expect(
+      screen.getByText("Alert description").tagName,
+    ).toBe("P");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `AlertDialogDescription` in `components/ui/alert-dialog`.

## Why

`AlertDialogDescription` is expected to render a semantic paragraph element for accessibility. Existing alert dialog tests do not verify the rendered element type for `AlertDialogDescription`.

The test verifies that `AlertDialogDescription` renders as a native `P` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/alert-dialog-description.test.tsx

## Notes

The test focuses on the public accessibility contract and avoids implementation-specific assertions beyond the rendered paragraph element.
