### PR TITLE
test(ui): verify AlertDialogAction button element

### DIFF
--- a/hushh-webapp/__tests__/ui/alert-dialog-action.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert-dialog-action.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+
+describe("AlertDialogAction", () => {
+  it("renders as a button element", () => {
+    const { container } = render(
+      <AlertDialog open>
+        <AlertDialogAction>
+          Continue
+        </AlertDialogAction>
+      </AlertDialog>,
+    );
+
+    const el = container.querySelector(
+      '[data-slot="alert-dialog-action"]',
+    );
+
+    expect(el?.tagName).toBe("BUTTON");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `AlertDialogAction` in `components/ui/alert-dialog`.

## Why

`AlertDialogAction` is expected to render a native button element. Existing alert dialog tests verify button semantics through role assertions, but do not verify the rendered DOM element type.

The test verifies that `AlertDialogAction` renders as a native `BUTTON` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/alert-dialog-action.test.tsx

## Notes

The test focuses on the rendered element type and remains independent of interaction behavior or styling concerns.
