### PR TITLE
fix(ui): silence manage portfolio profiling logs in production

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -228,7 +228,9 @@ export function ManagePortfolioView() {
           
           // Priority 2: Decrypt the financial PKM domain (fallback)
           if (!parsed) {
-            console.log("[ManagePortfolio] No cache, attempting to decrypt the financial PKM domain...");
+            if (process.env.NODE_ENV !== "production") {
+              console.log("[ManagePortfolio] No cache, attempting to decrypt the financial PKM domain...");
+            }
             try {
               const snapshot = await PkmDomainResourceService.getStaleFirst({
                 userId: user.uid,
@@ -247,7 +249,9 @@ export function ManagePortfolioView() {
 
                 // Update cache for future use
                 setCachePortfolioData(user.uid, parsed);
-                console.log("[ManagePortfolio] Decrypted and cached portfolio data");
+                if (process.env.NODE_ENV !== "production") {
+                  console.log("[ManagePortfolio] Decrypted and cached portfolio data");
+                }
               }
             } catch (decryptError) {
               console.error("[ManagePortfolio] Failed to decrypt the financial PKM domain:", decryptError);


### PR DESCRIPTION
### Description

Silences development profiling and state logs inside `components/kai/views/manage-portfolio-view.tsx` by wrapping the `console.log` statements in a `NODE_ENV !== "production"` check. This prevents the portfolio decryption and caching phases from leaking internal execution logs to the production client console.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/views/manage-portfolio-view.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/views/manage-portfolio-view.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.