### PR TITLE
fix(ui): enforce explicit button type on recovery key dialog buttons

### DIFF
--- a/hushh-webapp/components/vault/recovery-key-dialog.tsx
+++ b/hushh-webapp/components/vault/recovery-key-dialog.tsx
@@ -102,6 +102,7 @@ export function RecoveryKeyDialog({
             </Button>
 
             <Button
+              type="button"
               onClick={handleDownload}
               className="w-full"
             >
@@ -113,6 +114,7 @@ export function RecoveryKeyDialog({
 
         <DialogFooter>
           <Button
+            type="button"
             onClick={onContinue}
             variant="gradient"
             effect="glass"


### PR DESCRIPTION
### Description

Enforces an explicit `type="button"` on the "Download" and "Continue" buttons within the `RecoveryKeyDialog` (`components/vault/recovery-key-dialog.tsx`). This prevents the browser from interpreting these actions as implicit submit buttons, which can cause unintentional form submissions or page refreshes if the dialog is rendered within or alongside a `<form>` context.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/vault/recovery-key-dialog.tsx`

- Trust boundary touched:
  - [x] none (purely frontend UI semantics)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/vault/recovery-key-dialog.tsx`)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (UI accessibility/semantics only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a semantic HTML fix.