### PR TITLE
test(ui): verify SelectTrigger button element

### DIFF
--- a/hushh-webapp/__tests__/ui/select-trigger.test.tsx
+++ b/hushh-webapp/__tests__/ui/select-trigger.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+describe("SelectTrigger", () => {
+  it("renders as a button element", () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+      </Select>,
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="select-trigger"]',
+    );
+
+    expect(trigger?.tagName).toBe("BUTTON");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `SelectTrigger` in `components/ui/select`.

## Why

`SelectTrigger` is expected to render a native button element as the primary interactive control for the Select component.

The test verifies that `SelectTrigger` renders as a native `BUTTON` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/select-trigger.test.tsx

## Notes

The test focuses on the rendered element type and avoids interaction, state management, styling, or implementation-specific behavior.
