### PR TITLE
test(ui): verify AccordionTrigger button element

### DIFF
--- a/hushh-webapp/__tests__/ui/accordion-trigger.test.tsx
+++ b/hushh-webapp/__tests__/ui/accordion-trigger.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+describe("AccordionTrigger", () => {
+  it("renders as a button element", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>
+            Trigger
+          </AccordionTrigger>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="accordion-trigger"]',
+    );
+
+    expect(trigger?.tagName).toBe("BUTTON");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `AccordionTrigger` in `components/ui/accordion`.

## Why

`AccordionTrigger` is expected to render a native button element as the interactive control for an accordion item.

The test verifies that `AccordionTrigger` renders as a native `BUTTON` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/accordion-trigger.test.tsx

## Notes

The test focuses on the rendered element type and avoids interaction, keyboard navigation, state transitions, styling assertions, and animation behavior.
