### PR TITLE
fix(ui): silence uncaught route error boundary logs in production

### DIFF
--- a/hushh-webapp/components/app-ui/route-error-boundary.tsx
+++ b/hushh-webapp/components/app-ui/route-error-boundary.tsx
@@ -39,11 +39,13 @@ export class RouteErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error(
-      "[RouteErrorBoundary] Uncaught error:",
-      error,
-      errorInfo.componentStack,
-    );
+    if (process.env.NODE_ENV !== "production") {
+      console.error(
+        "[RouteErrorBoundary] Uncaught error:",
+        error,
+        errorInfo.componentStack,
+      );
+    }
   }
 
   private handleRetry = () => {


### PR DESCRIPTION
### Description

Silences the development `console.error` inside the `componentDidCatch` lifecycle of `components/app-ui/route-error-boundary.tsx` by wrapping it in a `NODE_ENV !== "production"` check. This prevents the Error Boundary from leaking the internal React component stack trace to the production client console when an uncaught error occurs, while preserving the user-facing fallback rendering.
