### PR TITLE
test(ui): verify TooltipContent tooltip role

### DIFF
--- a/hushh-webapp/__tests__/ui/tooltip-role.test.tsx
+++ b/hushh-webapp/__tests__/ui/tooltip-role.test.tsx
@@ -1,0 +1,41 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+describe("TooltipContent", () => {
+  it("exposes role tooltip", () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>
+            Hover me
+          </TooltipTrigger>
+
+          <TooltipContent>
+            Tooltip text
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(
+      document.querySelector('[role="tooltip"]'),
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `TooltipContent` in `components/ui/tooltip`.

## Why

`TooltipContent` is expected to expose the accessibility role `tooltip`.

The test verifies that tooltip content renders with the expected ARIA role when mounted.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/tooltip-role.test.tsx

## Notes

The test uses `defaultOpen` to mount tooltip content without exercising interaction behavior. It focuses exclusively on the accessibility role contract and avoids hover events, keyboard interaction, positioning logic, styling assertions, and animation behavior.
