### PR TITLE
fix(ui): silence kai flow import errors in production

### DIFF
--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -2640,7 +2640,9 @@ export function KaiFlow({
           return;
         }
 
-        console.error("[KaiFlow] Import error:", err);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("[KaiFlow] Import error:", err);
+        }
         const rawErrorMessage =
           err instanceof Error ? String(err.message || "") : String(err || "");
         const isTransientNetworkLoss =


### PR DESCRIPTION
### Description

Silences a development `console.error` inside `components/kai/kai-flow.tsx` by wrapping it in a `NODE_ENV !== "production"` check. This prevents the Kai Flow component from leaking internal import parsing error stack traces to the production client console when a data ingest fails, while preserving the user-facing error UI state fallback.
