### PR TITLE
fix(ui): silence portfolio share sheet errors in production

### DIFF
--- a/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
+++ b/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
@@ -107,7 +107,9 @@ export function PortfolioShareSheet({ open, onOpenChange, payload }: PortfolioSh
       if (isShareCancelError(error)) {
         return;
       }
-      console.error(`[PortfolioShareSheet] ${action} failed:`, error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[PortfolioShareSheet] ${action} failed:`, error);
+      }
       const fallback =
         action === "snapshot"
           ? "Could not share snapshot."


### PR DESCRIPTION
### Description

Silences internal development error logs inside `components/kai/share/portfolio-share-sheet.tsx` by wrapping the `console.error` statements in a `NODE_ENV !== "production"` check. This prevents portfolio export/share errors from leaking into the production client console, while preserving the user-facing fallback toast notifications.