### PR TITLE
test(ui): cover dialog component className propagation contract

### DIFF
--- a/hushh-webapp/__tests__/ui/dialog.test.tsx
+++ b/hushh-webapp/__tests__/ui/dialog.test.tsx
@@ -10,6 +10,17 @@ import {
 } from "@/components/ui/dialog";
 
 describe("DialogContent", () => {
+  it("propagates custom class names", () => {
+    render(
+      <Dialog open>
+        <DialogContent className="custom-dialog">
+          <DialogTitle>Test dialog</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    );
+    expect(document.querySelector('[data-slot="dialog-content"]')?.className).toContain("custom-dialog");
+  });
+
   it("renders the close button by default", () => {
     render(
       <Dialog open>


### PR DESCRIPTION
### Description

Adds missing test coverage to `__tests__/ui/dialog.test.tsx` to explicitly verify that the `DialogContent` component correctly propagates custom `className` values to its underlying root element.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `__tests__/ui/dialog.test.tsx`

- Trust boundary touched:
  - [x] none (purely frontend test coverage)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`__tests__/ui/dialog.test.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [x] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Vitest Suite)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (test coverage only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a test coverage addition.