### PR TITLE
test(ui): verify PaginationLink anchor element

### DIFF
--- a/hushh-webapp/__tests__/ui/pagination-link.test.tsx
+++ b/hushh-webapp/__tests__/ui/pagination-link.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PaginationLink } from "@/components/ui/pagination";
+
+describe("PaginationLink", () => {
+  it("renders as anchor element", () => {
+    const { container } = render(
+      <PaginationLink href="#">
+        1
+      </PaginationLink>,
+    );
+
+    const link = container.querySelector(
+      '[data-slot="pagination-link"]',
+    );
+
+    expect(link?.tagName).toBe("A");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `PaginationLink` in `components/ui/pagination`.

## Why

`PaginationLink` is expected to render a native anchor element.

The test verifies that `PaginationLink` renders as a native `A` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/pagination-link.test.tsx

## Notes

The test focuses exclusively on the rendered element type and avoids navigation behavior, state handling, accessibility state assertions, styling checks, and interaction testing.
