### PR TITLE
test(ui): verify BreadcrumbLink anchor element

### DIFF
--- a/hushh-webapp/__tests__/ui/breadcrumb-link.test.tsx
+++ b/hushh-webapp/__tests__/ui/breadcrumb-link.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BreadcrumbLink } from "@/components/ui/breadcrumb";
+
+describe("BreadcrumbLink", () => {
+  it("renders as an anchor element", () => {
+    render(
+      <BreadcrumbLink href="/profile">
+        Profile
+      </BreadcrumbLink>,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "Profile",
+    });
+
+    expect(link.tagName).toBe("A");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `BreadcrumbLink` in `components/ui/breadcrumb`.

## Why

`BreadcrumbLink` is expected to render a native anchor element when used without the `asChild` prop.

The test verifies that `BreadcrumbLink` renders as a native `A` element.

## Scope

* New test file only
* No production code changes
* No mocks
* No shared setup changes

## Validation

npx vitest run **tests**/ui/breadcrumb-link.test.tsx

## Notes

The test focuses on the public rendering contract and avoids implementation-specific assertions, styling checks, interaction testing, and accessibility state assertions.
