### PR TITLE
test(collapsible): verify trigger button element

### DIFF
--- a/hushh-webapp/__tests__/ui/collapsible-trigger.test.tsx
+++ b/hushh-webapp/__tests__/ui/collapsible-trigger.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Collapsible,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+describe("CollapsibleTrigger", () => {
+  it("renders as a button element", () => {
+    render(
+      <Collapsible>
+        <CollapsibleTrigger>
+          Toggle
+        </CollapsibleTrigger>
+      </Collapsible>,
+    );
+
+    const trigger = screen.getByRole(
+      "button",
+      { name: "Toggle" },
+    );
+
+    expect(trigger.tagName).toBe("BUTTON");
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for `CollapsibleTrigger` in `components/ui/collapsible.tsx`.

## Why

`CollapsibleTrigger` forwards directly to the underlying Radix primitive and currently lacks a test verifying its rendered element type.

The test verifies:

* trigger renders with button semantics
* trigger renders as a native `BUTTON` element

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/collapsible-trigger.test.tsx

## Notes

The test verifies the public DOM contract directly without mocks, browser APIs, animations, interaction testing, snapshots, or shared test setup changes.
