### PR TITLE
test(kai-circle): verify pending request CTAs

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location/kai-circle-ctas-pending-request.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/kai-circle-ctas-pending-request.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveKaiCircleCtas } from "@/lib/one-location/kai-circle-ctas";
+import type { KaiCircleCandidate } from "@/lib/one-location/types";
+
+function minimalCandidate(
+  overrides: Partial<KaiCircleCandidate> = {},
+): KaiCircleCandidate {
+  return {
+    candidateId: "user:user_x",
+    displayName: "Test User",
+    phoneVerified: true,
+    keyAlgorithm: "test-key-algorithm",
+    canReceiveLocation: true,
+    isShareReady: true,
+    readiness: "location_ready",
+    sourceTypes: ["one_location_recipient"],
+    isDiscoverable: true,
+    ...overrides,
+  };
+}
+
+describe("resolveKaiCircleCtas", () => {
+  it("returns approve and deny CTAs for pending owner requests", () => {
+    const ctas = resolveKaiCircleCtas({
+      candidate: minimalCandidate(),
+      mode: "share",
+      hasPendingOwnerRequest: true,
+    });
+
+    expect(ctas).toEqual([
+      {
+        id: "approve",
+        label: "Approve",
+        enabled: true,
+      },
+      {
+        id: "deny",
+        label: "Deny",
+        enabled: true,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for the pending-owner-request branch in `resolveKaiCircleCtas`.

## Why

`resolveKaiCircleCtas` contains an early-return branch that produces approval actions for pending owner requests, but that behavior is not currently covered by tests.

The test verifies:

* pending owner requests return approval CTAs
* approve CTA is enabled when the candidate is share-ready
* the branch returns the expected CTA set

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/lib/one-location/kai-circle-ctas-pending-request.test.ts

## Notes

The test intentionally focuses on the pending-owner-request branch only and does not cover unrelated CTA resolution paths. It uses a minimal type-correct candidate fixture and does not modify shared test setup or production code.
