### PR TITLE
test(navigation): characterize normalizeInternalRouteHref protocol relative slurs

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-protocol-relative.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-protocol-relative.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) on protocol-relative inputs that
+// begin with double forward slashes and omit the protocol word, e.g.
+//   "//hushh.ai/legal"
+//
+// TRUTH-FIRST — CURRENT CONTRACT (verified against source):
+//
+//   normalizeInternalRouteHref(value):
+//     1. href = String(value ?? "").trim()
+//     2. if (!href) return null
+//     3. if (!href.startsWith("/") || href.startsWith("//")) return null
+//     4. if (/[\r\n]/.test(href)) return null
+//     5. return href
+//
+// CORRECTION TO THE TASK PREMISE: there is NO "routing engine" that could
+// interpret "//host/path" as a nested internal pathway. Step 3 explicitly
+// rejects any value beginning with "//" by returning null. The browser would
+// treat "//hushh.ai/legal" as a protocol-relative EXTERNAL pointer, and this
+// guard refuses to emit it as an internal href. So the answer to the premise
+// question is unambiguous: protocol-relative inputs are treated as external
+// and rejected (null), never parsed as internal sub-paths. These tests pin
+// that rejection.
+
+describe("normalizeInternalRouteHref — protocol-relative '//' inputs are rejected as external (null)", () => {
+  it("rejects a bare protocol-relative host+path", () => {
+    expect(normalizeInternalRouteHref("//hushh.ai/legal")).toBeNull();
+  });
+
+  it("rejects protocol-relative even for a same-brand host", () => {
+    expect(normalizeInternalRouteHref("//hushh.ai")).toBeNull();
+  });
+
+  it("rejects a bare double slash", () => {
+    expect(normalizeInternalRouteHref("//")).toBeNull();
+  });
+
+  it("rejects deeper protocol-relative paths and query/hash variants", () => {
+    expect(normalizeInternalRouteHref("//evil.example.com/a/b/c")).toBeNull();
+    expect(normalizeInternalRouteHref("//evil.example.com/p?x=1")).toBeNull();
+    expect(normalizeInternalRouteHref("//evil.example.com/p#frag")).toBeNull();
+  });
+
+  it("rejects protocol-relative even after surrounding whitespace is trimmed", () => {
+    expect(normalizeInternalRouteHref("   //hushh.ai/legal   ")).toBeNull();
+  });
+
+  it("rejects three-or-more leading slashes (still starts with '//')", () => {
+    expect(normalizeInternalRouteHref("///hushh.ai/legal")).toBeNull();
+    expect(normalizeInternalRouteHref("////a")).toBeNull();
+  });
+
+  it("CONTRAST: a single-slash internal path with the same suffix is accepted verbatim", () => {
+    // Only ONE leading slash → genuine internal path → returned unchanged.
+    expect(normalizeInternalRouteHref("/hushh.ai/legal")).toBe("/hushh.ai/legal");
+    expect(normalizeInternalRouteHref("/legal")).toBe("/legal");
+  });
+});


### PR DESCRIPTION
## Summary
Pins down specific routing isolation rules when protocol-relative URLs (double-slash, no protocol word, e.g. `//hushh.ai/legal`) interface with normalizeInternalRouteHref.

Literal assertions pinned by this test:
- `//hushh.ai/legal` → `null` (rejected as external, not parsed as an internal sub-path).
- `//hushh.ai` and bare `//` → `null`.
- Deeper variants `//evil.example.com/a/b/c`, `...?x=1`, `...#frag` → `null`.
- `   //hushh.ai/legal   ` → `null` (rejection survives whitespace trimming).
- `///hushh.ai/legal` and `////a` → `null` (3+ leading slashes still start with `//`).
- CONTRAST: single-slash `/hushh.ai/legal` → `/hushh.ai/legal` and `/legal` → `/legal` (genuine internal paths returned verbatim).

Truth-first answer to the premise question: protocol-relative inputs are treated as EXTERNAL and rejected, never interpreted as nested internal pathways. `normalizeInternalRouteHref` guards with `if (!href.startsWith("/") || href.startsWith("//")) return null;` after trimming, plus a CR/LF reject. There is no "routing engine" doing host parsing — the single explicit `//` guard is the whole isolation rule. These assertions lock that boundary so any future relaxation of the open-redirect guard is caught.

## CI gate checklist
- [x] PR Base Policy — targets integration/pr-train
- [x] DCO Verified
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real, existing open-redirect rejection boundary
