### PR TITLE
test(navigation): characterize resolveInternalRouteHref multi-delimiter fragment splits

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-fragment-splits.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-fragment-splits.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) when an internal route value carries
+// a query string whose value payload itself contains multiple nested hash
+// symbols, e.g. "/search?q=tags#react#node".
+//
+// TRUTH-FIRST — CURRENT CONTRACT (verified against source):
+//
+//   resolveInternalRouteHref(value, fallback) is literally:
+//       normalizeInternalRouteHref(value) ?? fallback
+//
+//   and normalizeInternalRouteHref only:
+//     1. coerces to string and trims,
+//     2. returns null if empty,
+//     3. returns null if it does NOT start with "/" OR starts with "//",
+//     4. returns null if it contains a CR or LF,
+//     5. otherwise returns the trimmed string VERBATIM.
+//
+//   There is NO query parser, NO URL/URLSearchParams parsing, and NO splitting
+//   on "?" or "#". The "?", the query value, and every "#...#..." anchor
+//   segment are preserved as one opaque string.
+//
+// CORRECTION TO THE TASK PREMISE: there is no "parsing matrix" that isolates
+// the active query block from trailing anchor parameters. A valid internal
+// href is returned exactly as given (after trim), hashes and all. These tests
+// pin that pass-through-verbatim contract.
+
+const FALLBACK = "/fallback";
+
+describe("resolveInternalRouteHref — multi-hash query payloads pass through verbatim (no parsing/isolation)", () => {
+  it("returns '/search?q=tags#react#node' unchanged — query + multiple anchors preserved as one string", () => {
+    expect(resolveInternalRouteHref("/search?q=tags#react#node", FALLBACK)).toBe(
+      "/search?q=tags#react#node",
+    );
+  });
+
+  it("does not strip, reorder, or split anchors off the query value", () => {
+    const out = resolveInternalRouteHref("/search?q=tags#react#node", FALLBACK);
+    // Everything after "?" is retained, including both "#" segments.
+    expect(out).toContain("?q=tags");
+    expect(out).toContain("#react#node");
+    // No isolation: the result is NOT reduced to just the query block.
+    expect(out).not.toBe("/search?q=tags");
+    expect(out).not.toBe("/search");
+  });
+
+  it("preserves a leading '#' immediately after the query and additional '#' delimiters", () => {
+    expect(
+      resolveInternalRouteHref("/list?tab=open#a#b#c", FALLBACK),
+    ).toBe("/list?tab=open#a#b#c");
+  });
+
+  it("trims surrounding whitespace but keeps the inner query+hash payload intact", () => {
+    expect(
+      resolveInternalRouteHref("   /search?q=tags#react#node   ", FALLBACK),
+    ).toBe("/search?q=tags#react#node");
+  });
+
+  it("returns the fallback for protocol-relative input even when it carries multi-hash payloads", () => {
+    expect(
+      resolveInternalRouteHref("//evil.example.com/search?q=tags#react#node", FALLBACK),
+    ).toBe(FALLBACK);
+  });
+
+  it("returns the fallback when a CR/LF is injected into the multi-hash payload", () => {
+    expect(
+      resolveInternalRouteHref("/search?q=tags#react\n#node", FALLBACK),
+    ).toBe(FALLBACK);
+  });
+
+  it("returns the fallback for null/empty, and verbatim for a bare hash-only query", () => {
+    expect(resolveInternalRouteHref(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref("", FALLBACK)).toBe(FALLBACK);
+    expect(resolveInternalRouteHref("/p?x=#", FALLBACK)).toBe("/p?x=#");
+  });
+});


### PR DESCRIPTION
## Summary
Maps tracking and extraction boundaries within resolveInternalRouteHref when resolving queries embedded within multi-hash strings (e.g. `/search?q=tags#react#node`).

Literal behavior pinned by this test:
- `/search?q=tags#react#node` → returned unchanged (query `?q=tags` + both `#react` / `#node` anchors preserved as one string).
- No stripping/reordering/splitting: result is NOT reduced to `/search?q=tags` or `/search`.
- `/list?tab=open#a#b#c` → verbatim (additional `#` delimiters preserved).
- `   /search?q=tags#react#node   ` → trimmed at the edges, inner query+hash payload intact.
- `//evil.example.com/search?q=tags#react#node` → returns the fallback (protocol-relative rejected even with multi-hash payload).
- `/search?q=tags#react\n#node` (CR/LF injected) → returns the fallback.
- `null` / `""` → fallback; `/p?x=#` → verbatim.

Truth-first correction: `resolveInternalRouteHref(value, fallback)` is literally `normalizeInternalRouteHref(value) ?? fallback`, and `normalizeInternalRouteHref` only trims, rejects empty / non-`/` / `//` / CRLF, then returns the string verbatim. There is NO query parser, NO `URL`/`URLSearchParams` parsing, and NO splitting on `?` or `#` — so there is no "parsing matrix" that isolates the active query block from trailing anchor parameters. A valid internal href passes through opaque (hashes and all). These assertions lock that pass-through-verbatim contract plus the existing security rejections (protocol-relative + CRLF).

## CI gate checklist
- [x] PR Base Policy — targets integration/pr-train
- [x] DCO Verified
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents real, existing verbatim pass-through behavior
