### PR TITLE
test(native-test-router): characterise normalizeRoute path normalisation contract

### DIFF
--- a/hushh-webapp/__tests__/components/native-test-router.test.tsx
+++ b/hushh-webapp/__tests__/components/native-test-router.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRoute } from "@/components/app-ui/native-test-router";
+
+describe("normalizeRoute", () => {
+  it("returns / for empty string", () => {
+    expect(normalizeRoute("")).toBe("/");
+  });
+
+  it("returns / for null", () => {
+    expect(normalizeRoute(null)).toBe("/");
+  });
+
+  it("strips trailing slash from path", () => {
+    expect(normalizeRoute("/profile/")).toBe("/profile");
+  });
+
+  it("preserves query string", () => {
+    expect(normalizeRoute("/one/kai?tab=analysis")).toBe("/one/kai?tab=analysis");
+  });
+
+  it("normalises full URL to pathname and search", () => {
+    expect(normalizeRoute("https://native-test.local/one/kai?tab=analysis")).toBe("/one/kai?tab=analysis");
+  });
+});

--- a/hushh-webapp/components/app-ui/native-test-router.tsx
+++ b/hushh-webapp/components/app-ui/native-test-router.tsx
@@ -12,7 +12,7 @@ let lastAppliedExpectedRouteRecovery: { key: string; appliedAt: number } | null 
 const NATIVE_TEST_CONFIG_UPDATED_EVENT = "hushh:native-test-config-updated";
 const EXPECTED_ROUTE_RECOVERY_RETRY_MS = 5_000;
 
-function normalizeRoute(value: string | null | undefined) {
+export function normalizeRoute(value: string | null | undefined) {
   const trimmed = String(value || "").trim();
   if (!trimmed || trimmed === "/") {
     return trimmed || "/";


### PR DESCRIPTION
Exports and characterises normalizeRoute from NativeTestRouter — a pure
utility that strips trailing slashes, preserves query strings, and
normalises full URLs to pathname+search.

5 cases: empty string, null, trailing slash, query string preservation,
and full URL normalisation.

Attach point: hushh-webapp/components/app-ui/native-test-router.tsx
is used in app/providers.tsx.
Single file, single surface.