### PR TITLE
test(theme-provider): cover children render contract

### DIFF
--- a/hushh-webapp/__tests__/components/theme-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/theme-provider.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next-themes", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { ThemeProvider } from "@/components/theme-provider";
+
+describe("ThemeProvider", () => {
+  it("renders children", () => {
+    render(
+      <ThemeProvider attribute="class" defaultTheme="system">
+        <span>child content</span>
+      </ThemeProvider>
+    );
+    expect(screen.getByText("child content")).toBeDefined();
+  });
+});


### PR DESCRIPTION
Covers the children render contract of ThemeProvider — wraps 
NextThemesProvider and passes children through correctly.

Attach point: hushh-webapp/app/providers.tsx imports ThemeProvider.
Single file, single surface.