### PR TITLE
test(spinner): cover status role and loading aria label

### DIFF
--- a/hushh-webapp/__tests__/components/spinner.test.tsx
+++ b/hushh-webapp/__tests__/components/spinner.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Spinner } from "@/components/ui/spinner";
+
+describe("Spinner", () => {
+  it("renders with status role and loading label", () => {
+    render(<Spinner />);
+    const el = screen.getByRole("status");
+    expect(el.getAttribute("aria-label")).toBe("Loading");
+  });
+});


### PR DESCRIPTION
Covers the accessibility contract of Spinner — renders with role="status" 
and aria-label="Loading" so screen readers announce loading state correctly.

Attach point: hushh-webapp/components/ui/spinner.tsx
Single file, single surface.