### PR TITLE
test(badge): cover data-slot contract and variant data attribute

### DIFF
--- a/hushh-webapp/__tests__/components/badge.test.tsx
+++ b/hushh-webapp/__tests__/components/badge.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "@/components/ui/badge";
+
+describe("Badge", () => {
+  it("renders with data-slot=badge", () => {
+    const { container } = render(<Badge>Label</Badge>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("badge");
+  });
+
+  it("renders with correct default variant", () => {
+    const { container } = render(<Badge>Label</Badge>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-variant")).toBe("default");
+  });
+
+  it("renders with correct outline variant", () => {
+    const { container } = render(<Badge variant="outline">Label</Badge>);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-variant")).toBe("outline");
+  });
+});


### PR DESCRIPTION
Covers three data-attribute contracts on Badge:
- data-slot="badge" is always present
- data-variant="default" when no variant specified
- data-variant="outline" when outline variant passed

Attach point: hushh-webapp/components/ui/badge.tsx
Single file, single surface.