### PR TITLE
test(avatar): cover data-slot and size data attribute contract

### DIFF
--- a/hushh-webapp/__tests__/components/avatar.test.tsx
+++ b/hushh-webapp/__tests__/components/avatar.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+
+describe("Avatar", () => {
+  it("renders with data-slot=avatar", () => {
+    const { container } = render(
+      <Avatar><AvatarFallback>AB</AvatarFallback></Avatar>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("avatar");
+  });
+
+  it("renders with default size data attribute", () => {
+    const { container } = render(
+      <Avatar><AvatarFallback>AB</AvatarFallback></Avatar>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-size")).toBe("default");
+  });
+
+  it("renders with sm size data attribute", () => {
+    const { container } = render(
+      <Avatar size="sm"><AvatarFallback>AB</AvatarFallback></Avatar>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-size")).toBe("sm");
+  });
+});


### PR DESCRIPTION
Covers three data-attribute contracts on Avatar:
- data-slot="avatar" is always present
- data-size="default" when no size specified  
- data-size="sm" when sm size passed

Attach point: hushh-webapp/components/ui/avatar.tsx
Single file, single surface.