### PR TITLE
test: refactor settings-ui tests with user-event and improved accessibility assertions

### DIFF
--- a/hushh-webapp/__tests__/components/settings-ui.test.tsx
+++ b/hushh-webapp/__tests__/components/settings-ui.test.tsx
@@ -8,6 +8,20 @@ import {
 } from "@/components/profile/settings-ui";
 
 describe("SettingsRow", () => {
+  it("sets clickable row button type", () => {
+    render(
+      <SettingsRow
+        title="Open settings"
+        description="Manage account preferences"
+        onClick={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /open settings/i }).getAttribute("type")
+    ).toBe("button");
+  });
+
   it("wraps both primary action and trailing in a single interactive row", () => {
     const handleOpen = vi.fn();
     const handleTrailing = vi.fn();
@@ -81,6 +95,22 @@ describe("SettingsRow", () => {
     expect(link.tagName).toBe("A");
     expect(link.textContent).toContain("Open profile");
     expect(link.textContent).toContain("Go to privacy workspace");
+  });
+
+  it("stacks trailing content on mobile even when a chevron is present", () => {
+    const { container } = render(
+      <SettingsRow
+        title="Open CRM"
+        description="Inspect a connected customer system"
+        trailing={<span>Status badge</span>}
+        chevron
+        stackTrailingOnMobile
+      />
+    );
+
+    expect(container.innerHTML).toContain("grid-cols-1");
+    expect(container.innerHTML).toContain("w-full justify-start");
+    expect(container.innerHTML).toContain("Status badge");
   });
 });
 
@@ -160,5 +190,39 @@ describe("SettingsDetailPanel", () => {
 
     expect(screen.getByRole("dialog", { name: "Settings" })).toBeTruthy();
     expect(screen.getByText("Settings dialog")).toBeTruthy();
+  });
+
+  it("closes from the explicit close button", () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    const handleOpenChange = vi.fn();
+    render(
+      <SettingsDetailPanel
+        open
+        onOpenChange={handleOpenChange}
+        title="Settings"
+        description="Settings dialog"
+      >
+        <div>Content</div>
+      </SettingsDetailPanel>
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /close detail panel/i })
+    );
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -3,7 +3,7 @@
 import { Children, cloneElement, isValidElement } from "react";
 import type { ReactElement, ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, X } from "lucide-react";
 import { Slot } from "radix-ui";
 
 import {
@@ -93,6 +93,7 @@ export function SettingsGroup({
   children,
   embedded = false,
   className,
+  testId = "settings-group",
 }: {
   eyebrow?: string;
   title?: ReactNode;
@@ -100,6 +101,7 @@ export function SettingsGroup({
   children: ReactNode;
   embedded?: boolean;
   className?: string;
+  testId?: string;
 }) {
   const shell = (
     <div
@@ -114,17 +116,17 @@ export function SettingsGroup({
   );
 
   return (
-    <section className={cn("w-full space-y-[var(--settings-group-stack-gap)]", className)}>
+    <section className={cn("w-full space-y-[var(--settings-group-stack-gap)]", className)} data-testid={testId}>
       {eyebrow || title || description ? (
         <div className="space-y-[var(--settings-heading-stack-gap)] px-0.5 sm:px-1">
           {eyebrow || title ? (
             <div
               role="heading"
               aria-level={embedded ? 3 : 2}
-              className="flex flex-wrap items-center gap-x-2 gap-y-1 text-pretty text-[15px] font-semibold leading-tight tracking-tight text-foreground [overflow-wrap:anywhere] sm:text-[16px]"
+              className="flex flex-wrap items-center gap-x-2 gap-y-1 text-pretty text-[12px] font-medium uppercase leading-tight tracking-[0.14em] text-muted-foreground [overflow-wrap:anywhere]"
             >
               {eyebrow ? (
-                <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground sm:text-[11px]">
+                <span className="text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground sm:text-[11px]">
                   {eyebrow}
                 </span>
               ) : null}
@@ -161,6 +163,7 @@ export function SettingsRow({
   voiceActionId,
   voiceLabel,
   voicePurpose,
+  testId = "settings-row",
 }: {
   asChild?: boolean;
   children?: ReactNode;
@@ -179,10 +182,11 @@ export function SettingsRow({
   voiceActionId?: string;
   voiceLabel?: string;
   voicePurpose?: string;
+  testId?: string;
 }) {
   const resolvedAsChild = asChild && isValidElement(children);
   const isInteractive = !disabled && (typeof onClick === "function" || resolvedAsChild);
-  const shouldStackTrailing = stackTrailingOnMobile && Boolean(trailing) && !chevron;
+  const shouldStackTrailing = stackTrailingOnMobile && Boolean(trailing);
   const hasInteractiveTrailing = containsInteractiveNode(trailing);
   const splitPrimaryAction = Boolean(!asChild && onClick && hasInteractiveTrailing);
   const Comp = resolvedAsChild ? Slot.Root : onClick && !splitPrimaryAction ? "button" : "div";
@@ -216,14 +220,14 @@ export function SettingsRow({
       <div className="min-w-0 flex-1 space-y-0.5">
         <div
           className={cn(
-            "text-[13px] font-medium tracking-tight text-foreground [overflow-wrap:anywhere] sm:text-[14px]",
+            "text-[14px] font-medium tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[15px]",
             tone === "destructive" && "text-destructive"
           )}
         >
           {title}
         </div>
         {description ? (
-          <div className="text-[11px] leading-[1.45] text-muted-foreground [overflow-wrap:anywhere] sm:text-[12px]">
+          <div className="text-[12px] leading-[1.45] text-muted-foreground [overflow-wrap:anywhere] sm:text-[13px]">
             {description}
           </div>
         ) : null}
@@ -241,6 +245,7 @@ export function SettingsRow({
       {trailing}
       {chevron ? (
         <ChevronRight
+          aria-hidden="true"
           className={cn(
             "h-4 w-4 shrink-0 text-muted-foreground/90 transition-transform",
             isInteractive && "group-hover:translate-x-0.5"
@@ -259,7 +264,7 @@ export function SettingsRow({
       "transition-[border-color,box-shadow] focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
   );
   const primaryActionClassName = cn(
-    "relative isolate min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:outline-none focus:ring-0 focus-visible:ring-0"
+    "relative isolate min-w-0 overflow-hidden rounded-[inherit] border-0 bg-transparent px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-left outline-hidden ring-0 transition-[border-color,box-shadow] [-webkit-tap-highlight-color:transparent] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
   );
   const voiceProps = {
     "data-voice-control-id": voiceControlId || undefined,
@@ -274,7 +279,7 @@ export function SettingsRow({
 
   if (splitPrimaryAction) {
     return (
-      <div className={rowShellClassName}>
+      <div className={rowShellClassName} data-testid={testId}>
         <div
           className={cn(
             "relative z-10 grid w-full px-[var(--settings-row-px)] py-[var(--settings-row-py)]",
@@ -299,7 +304,7 @@ export function SettingsRow({
             />
           </button>
           {trailingContent ? (
-            <div onClick={(e) => e.stopPropagation()}>
+            <div role="presentation" onClick={(e) => e.stopPropagation()}>
               {trailingContent}
             </div>
           ) : null}
@@ -310,7 +315,7 @@ export function SettingsRow({
 
   if (resolvedAsChild) {
     return (
-      <div className={rowShellClassName}>
+      <div className={rowShellClassName} data-testid={testId}>
         {isInteractive ? (
           <span
             aria-hidden
@@ -332,7 +337,7 @@ export function SettingsRow({
   }
 
   return (
-    <div className={rowShellClassName}>
+    <div className={rowShellClassName} data-testid={testId}>
       {isInteractive ? (
         <span
           aria-hidden
@@ -384,19 +389,46 @@ export function SettingsDetailPanel({
   desktopMaxWidth?: string;
 }) {
   const isMobile = useIsMobile();
+  const closeButton = (
+    <button
+      type="button"
+      aria-label="Close detail panel"
+      onClick={() => onOpenChange(false)}
+      className={cn(
+        "group absolute right-3 top-3 z-20 isolate inline-flex h-9 w-9 items-center justify-center overflow-hidden rounded-full",
+        "border border-transparent bg-[color:var(--app-card-surface-compact)] text-muted-foreground opacity-75",
+        "transition-[opacity,transform,color] duration-200 hover:text-foreground hover:opacity-100 active:scale-[0.97]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      )}
+    >
+      <Icon icon={X} size="xs" />
+      <MaterialRipple variant="none" effect="fade" className="z-10" />
+    </button>
+  );
+
   if (isMobile) {
     return (
-      <Drawer open={open} onOpenChange={onOpenChange}>
-        <DrawerContent className="h-[100dvh] max-h-[100dvh] rounded-none border-none bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-feature)]">
-          <DrawerHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-3 text-left sm:px-5 sm:py-4">
+      <Drawer open={open} onOpenChange={onOpenChange} modal>
+        <DrawerContent
+          className="h-[100dvh] max-h-[100dvh] rounded-none border-none bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-feature)]"
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            (e.currentTarget as HTMLElement).focus();
+          }}
+        >
+          <DrawerHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-4 py-3 pr-14 text-left sm:px-5 sm:py-4 sm:pr-14">
             <DrawerTitle className="text-base font-semibold tracking-tight">
               {title}
             </DrawerTitle>
-            {description ? (
-              <DrawerDescription className="text-sm leading-5 sm:leading-6">
-                {description}
-              </DrawerDescription>
-            ) : null}
+            <DrawerDescription
+              className={cn(
+                "text-sm leading-5 sm:leading-6",
+                !description && "sr-only"
+              )}
+            >
+              {description ?? "Settings"}
+            </DrawerDescription>
+            {closeButton}
           </DrawerHeader>
           <div className="flex-1 overflow-y-auto bg-[color:var(--app-card-surface-default-solid)] px-3 pb-[calc(var(--app-safe-area-bottom-effective,env(safe-area-inset-bottom,0px))+2rem)] pt-3 sm:px-4 sm:pt-4">
             {children}
@@ -410,21 +442,27 @@ export function SettingsDetailPanel({
     <Dialog open={open} onOpenChange={onOpenChange} modal>
       <DialogContent
         data-settings-detail-panel="true"
+        showCloseButton={false}
         style={desktopMaxWidth ? { maxWidth: desktopMaxWidth } : undefined}
         className={cn(
           "w-[calc(100%-1.5rem)] overflow-hidden p-0",
           desktopMaxWidthClassName || "sm:!max-w-[720px]"
         )}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          (e.currentTarget as HTMLElement).focus();
+        }}
       >
-        <DialogHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-6 py-4 text-left">
+        <DialogHeader className="sticky top-0 z-10 border-b border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] px-6 py-4 pr-16 text-left">
           <DialogTitle className="text-base font-semibold tracking-tight">
             {title}
           </DialogTitle>
-          {description ? (
-            <DialogDescription className="text-sm leading-6">
-              {description}
-            </DialogDescription>
-          ) : null}
+          <DialogDescription
+            className={cn("text-sm leading-6", !description && "sr-only")}
+          >
+            {description ?? "Settings"}
+          </DialogDescription>
+          {closeButton}
         </DialogHeader>
         <div className="min-h-0 flex-1 overflow-y-auto bg-[color:var(--app-card-surface-default-solid)] px-4 pb-8 pt-4 sm:px-5 sm:pt-5">
           {children}


### PR DESCRIPTION
…ns and custom labels

# Description

Briefly explain what you changed and why.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [ ] Listed below:

- API / schema / type changes:
  - [ ] None
  - [ ] Listed below:

- Cache keys touched:
  - [ ] None
  - [ ] Listed below:

- Runtime DB data-plane changes:
  - [ ] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [ ] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [ ] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [ ] None
  - [ ] Listed below:

- Top-level / devex / config / generated / ignore files touched:
  - [ ] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [ ] None
  - [ ] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:

- Caller / proxy / backend pairing:
  - [ ] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [ ] Not applicable
  - [ ] Listed below:

- UI browser or Playwright proof:
  - [ ] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## ✅ Review-Ready Contract

- [ ] Title, body, changed files, and tests describe the same contract.
- [ ] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [ ] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [ ] Reachable production attach point:
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [ ] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here:
- [ ] If this responds to requested changes, the new commit or material explanation is described here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [ ] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?
- [ ] Sensitive surface touched: auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress / none
- [ ] Error path, rollback, or safe-failure behavior proved:

## 📜 Licensing

- [ ] First-party changes remain Apache-2.0 compatible
- [ ] Third-party notice impact reviewed when dependencies changed
