### PR TITLE
test(kbd): verify className propagation

### DIFF
--- a/hushh-webapp/__tests__/ui/kbd.test.tsx
+++ b/hushh-webapp/__tests__/ui/kbd.test.tsx
@@ -18,4 +18,17 @@ describe("Kbd", () => {
     expect(el?.tagName).toBe("KBD");
   });
 
+  it("merges a custom className onto the kbd element", () => {
+    const { container } = render(
+      <Kbd className="test-class">⌘K</Kbd>,
+    );
+
+    const element = container.querySelector('[data-slot="kbd"]');
+    expect(
+      element?.classList.contains(
+        "test-class",
+      ),
+    ).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for custom `className` propagation in the Kbd component.

## Why

The component merges consumer-provided class names with its default styling, but this behavior is not currently verified by the test suite.

The test verifies:

* custom `className` values are applied to the rendered kbd element

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/kbd.test.tsx

## Notes

The test verifies the public rendering contract directly through the rendered DOM. It does not use mocks, snapshots, browser APIs, interactions, or shared test setup changes.
