### PR TITLE
test(spinner): verify className propagation

### DIFF
--- a/hushh-webapp/__tests__/ui/spinner.test.tsx
+++ b/hushh-webapp/__tests__/ui/spinner.test.tsx
@@ -30,4 +30,12 @@ describe("Spinner", () => {
     expect(screen.getByRole("status").tagName).toBe("svg");
   });
 
+  it("merges a custom className onto the svg element", () => {
+    render(<Spinner className="test-class" />,);
+
+    expect(
+      screen.getByRole("status").classList.contains("test-class"),
+    ).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for custom `className` propagation in the Spinner component.

## Why

The Spinner component merges consumer-provided class names with its default classes, but this behavior is not currently verified by the test suite.

The test verifies:

* custom `className` values are applied to the rendered spinner element

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/spinner.test.tsx

## Notes

The test uses the existing `role="status"` selector already present in the Spinner test suite and verifies the public rendering contract directly through the rendered DOM. No mocks, snapshots, browser APIs, interactions, or shared test setup changes are required.
