### PR TITLE
test(alert): verify className propagation

### DIFF
--- a/hushh-webapp/__tests__/ui/alert.test.tsx
+++ b/hushh-webapp/__tests__/ui/alert.test.tsx
@@ -61,4 +61,13 @@ describe("Alert", () => {
     expect(alert?.getAttribute("role")).toBe("alert");
     expect(slots).toEqual(["alert", "alert-title", "alert-description"]);
   });
+
+  it("merges a custom className onto the alert root element", () => {
+    const { container } = render(<Alert className="test-class" />);
+
+    const alert = container.querySelector('[data-slot="alert"]');
+
+    expect(alert?.classList.contains("test-class")).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for custom `className` propagation in the Alert component.

## Why

The Alert component merges consumer-provided class names with its internally generated variant classes, but this behavior is not currently verified by the test suite.

The test verifies:

* custom `className` values are applied to the alert root element

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/alert.test.tsx

## Notes

The test verifies the public rendering contract directly through the rendered DOM using the existing alert root selector already used elsewhere in the test suite. No mocks, snapshots, browser APIs, interactions, or shared test setup changes are required.
