### PR TITLE
test(ui): verify Card className propagation

### DIFF
--- a/hushh-webapp/__tests__/ui/card.test.tsx
+++ b/hushh-webapp/__tests__/ui/card.test.tsx
@@ -90,4 +90,14 @@ describe("Card", () => {
     expect(description?.tagName).toBe("DIV");
   });
 
+  it("merges a custom className onto the Card root element", () => {
+    const { container } = render(
+      <Card className="test-class">Content</Card>,
+    );
+
+    const card = container.querySelector('[data-slot="card"]');
+
+    expect(card?.classList.contains("test-class")).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for `Card` className propagation in `components/ui/card`.

## Why

`Card` accepts a `className` prop and merges it onto the root element through the shared `cn()` utility.

The test verifies that a consumer-provided className is preserved on the rendered Card root element.

## Scope

* Small additive test change
* No production code changes
* No mocks
* No shared setup modifications

## Validation

npx vitest run **tests**/ui/card.test.tsx

## Notes

The test focuses exclusively on className propagation and avoids styling assertions, layout behavior, interaction testing, and implementation changes.
