### PR TITLE
test(radio-group): verify className merging

### DIFF
--- a/hushh-webapp/__tests__/ui/radio-group.test.tsx
+++ b/hushh-webapp/__tests__/ui/radio-group.test.tsx
@@ -69,4 +69,20 @@ describe("RadioGroup", () => {
     expect(item?.getAttribute("role")).toBe("radio");
   });
 
+  it("merges custom className with default classes on the root", () => {
+    const { container } = render(
+      <RadioGroup
+        defaultValue="a"
+        className="custom-radio-class"
+      >
+        <RadioGroupItem value="a" />
+      </RadioGroup>,
+    );
+
+    const root = container.querySelector('[data-slot="radio-group"]');
+
+    expect(root?.classList.contains("custom-radio-class")).toBe(true);
+    expect(root?.classList.contains("grid")).toBe(true);
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for className merging on the RadioGroup root element.

## Why

RadioGroup combines its default layout classes with consumer-provided class names, but this behavior is not currently verified by the test suite.

The test verifies:

* custom class names are applied to the root element
* default layout classes remain present after merging

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/radio-group.test.tsx

## Notes

The test verifies the public rendering contract directly through the rendered DOM using the existing radio-group root selector already exercised elsewhere in the suite. No mocks, snapshots, browser APIs, interactions, asynchronous behavior, or shared test setup changes are required.
