### PR TITLE
test(button): verify default button element

### DIFF
--- a/hushh-webapp/__tests__/ui/button.test.tsx
+++ b/hushh-webapp/__tests__/ui/button.test.tsx
@@ -13,18 +13,29 @@ describe("Button", () => {
     expect(button?.hasAttribute("disabled")).toBe(true);
   });
   it("merges a custom className onto the button element", () => {
-  const { container } = render(
-    <Button className="test-class">
-      Save
-    </Button>,
-  );
+    const { container } = render(
+      <Button className="test-class">
+        Save
+      </Button>,
+    );
 
-  const button =container.querySelector("button");
+    const button =container.querySelector("button");
 
-  expect(
-    button?.classList.contains(
-      "test-class",
-    ),
-  ).toBe(true);
-});
+    expect(
+      button?.classList.contains(
+        "test-class",
+      ),
+    ).toBe(true);
+  });
+
+  it("renders a button element by default", () => {
+    const { container } = render(<Button>Save</Button>);
+
+    const button =container.querySelector("button");
+
+    expect(button).not.toBeNull();
+
+    expect(button?.tagName).toBe("BUTTON");
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for the Button component's default rendered element.

## Why

Button renders a native button element by default and only changes rendering behavior when `asChild` is enabled. This default rendering contract is not currently verified by the test suite.

The test verifies:

* Button renders a button element by default
* the rendered element retains the expected semantic tag

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/button.test.tsx

## Notes

The test exercises the default render path only and verifies the public rendering contract directly through the rendered DOM. No mocks, snapshots, browser APIs, interactions, asynchronous behavior, or shared test setup changes are required.
