### PR TITLE
test(button): verify default button type

### DIFF
--- a/hushh-webapp/__tests__/ui/button.test.tsx
+++ b/hushh-webapp/__tests__/ui/button.test.tsx
@@ -12,4 +12,13 @@ describe("Button", () => {
     expect(button).not.toBeNull();
     expect(button?.hasAttribute("disabled")).toBe(true);
   });
+
+  it("defaults to type='button' to prevent accidental form submission", () => {
+    const { container } = render(<Button>Save</Button>);
+
+    const button = container.querySelector("button");
+
+    expect(button?.getAttribute("type")).toBe("button");
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for the Button component's default type attribute.

## Why

Button explicitly defaults to `type="button"` when rendered as a native button element. This prevents accidental form submission when the component is used inside forms, but the behavior is not currently verified by the test suite.

The test verifies:

* Button renders with `type="button"` by default

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/ui/button.test.tsx

## Notes

The test verifies a public safety contract through a simple DOM attribute assertion. No mocks, snapshots, browser APIs, interactions, asynchronous behavior, or shared test setup changes are required.
