### PR TITLE
feat(one-location): bridge marketplace connections into location recipients

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2287,6 +2287,23 @@ class OneLocationAgentService:
     def list_verified_recipients(
         self, *, owner_user_id: str, limit: int = 50
     ) -> list[dict[str, Any]]:
+        # Eligibility for who can appear as a One Location recipient.
+        #
+        # A user is eligible when ANY of the following holds:
+        #   1. They share an active One Network connection with the owner
+        #      (explicit Circle-invite claim). This is explicit mutual consent
+        #      and always wins, even over marketplace visibility (below).
+        #   2. They are phone-verified (the broad verified-actor directory).
+        #   3. They are connected to the owner through the marketplace
+        #      ("Connect" tab) via an approved advisor<->investor relationship,
+        #      AND they are currently marketplace-discoverable.
+        #
+        # Privacy gate (mirrors the marketplace "Connect" tab): if a user turns
+        # their marketplace visibility OFF (marketplace_public_profiles
+        # .is_discoverable = FALSE) they disappear from the One Location
+        # directory too -- the SAME flag the Connect tab already filters on --
+        # UNLESS the owner has an explicit One Network connection with them.
+        # Users who never created a marketplace profile are unaffected.
         rows = self._execute_many(
             """
             SELECT
@@ -2303,8 +2320,7 @@ class OneLocationAgentService:
             ) k ON TRUE
             WHERE a.user_id <> :owner_user_id
               AND (
-                a.phone_verified = TRUE
-                OR EXISTS (
+                EXISTS (
                   SELECT 1
                   FROM one_location_network_connections nc
                   WHERE nc.status = 'active'
@@ -2313,12 +2329,34 @@ class OneLocationAgentService:
                       OR (nc.user_b_id = :owner_user_id AND nc.user_a_id = a.user_id)
                     )
                 )
+                OR (
+                  (
+                    a.phone_verified = TRUE
+                    OR EXISTS (
+                      SELECT 1
+                      FROM advisor_investor_relationships air
+                      JOIN ria_profiles rp ON rp.id = air.ria_profile_id
+                      WHERE air.status = 'approved'
+                        AND (
+                          (air.investor_user_id = :owner_user_id AND rp.user_id = a.user_id)
+                          OR (rp.user_id = :owner_user_id AND air.investor_user_id = a.user_id)
+                        )
+                    )
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM marketplace_public_profiles mp
+                    WHERE mp.user_id = a.user_id
+                      AND mp.is_discoverable = FALSE
+                  )
+                )
               )
             ORDER BY COALESCE(a.display_name, a.phone_number, a.user_id), a.user_id
             LIMIT :limit
             """,
             {"owner_user_id": owner_user_id, "limit": max(1, min(int(limit), 100))},
         )
+
         recipients = [payload for row in rows if (payload := self._recipient_payload(row))]
         return self._apply_kai_circle_recommendations(
             owner_user_id=owner_user_id,

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -268,13 +268,34 @@ class FourUserMemoryService(OneLocationAgentService):
                 if connection["status"] == "active"
                 and owner in {connection["user_a_id"], connection["user_b_id"]}
             }
+            # Mirror the real SQL: a user connected to the owner through an
+            # approved marketplace (advisor<->investor) relationship is eligible
+            # even if not phone-verified.
+            marketplace_connected_ids = set()
+            for relationship in self.professional_relationships:
+                if str(relationship.get("status") or "") != "approved":
+                    continue
+                investor_id = str(relationship.get("investor_user_id") or "")
+                ria_id = str(relationship.get("ria_user_id") or "")
+                if owner == investor_id and ria_id:
+                    marketplace_connected_ids.add(ria_id)
+                elif owner == ria_id and investor_id:
+                    marketplace_connected_ids.add(investor_id)
             for user_id, identity in self.identities.items():
                 if user_id == owner:
                     continue
-                # Mirror the real SQL: phone-verified users OR active One Network
-                # connections are visible recipients.
-                if not identity["phone_verified"] and user_id not in connected_ids:
-                    continue
+                network_connected = user_id in connected_ids
+                # Explicit One Network connections always win, even over a
+                # marketplace visibility opt-out.
+                if not network_connected:
+                    eligible = identity["phone_verified"] or user_id in marketplace_connected_ids
+                    if not eligible:
+                        continue
+                    # Privacy gate: a user who turned marketplace visibility OFF
+                    # (is_discoverable = FALSE) disappears from the directory too.
+                    profile = self.marketplace_profiles.get(user_id)
+                    if profile is not None and profile.get("is_discoverable") is False:
+                        continue
                 key = self._active_key(user_id)
                 rows.append(
                     {
@@ -286,6 +307,7 @@ class FourUserMemoryService(OneLocationAgentService):
                     }
                 )
             return rows
+
         if (
             "FROM one_location_share_grants" in sql
             and "owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id" in sql
@@ -1811,7 +1833,84 @@ def test_invite_to_one_claim_requires_phone_verified_identity() -> None:
     assert next(iter(service.circle_invites.values()))["status"] == "active"
 
 
+def test_marketplace_connection_makes_user_a_location_recipient() -> None:
+    # An approved marketplace (advisor<->investor) connection should surface the
+    # other party as a One Location recipient even if they are NOT phone-verified
+    # -- the marketplace handshake already established mutual consent.
+    service = FourUserMemoryService()
+    service.identities["user_b"]["phone_verified"] = False
+    service.professional_relationships.append(
+        {
+            "investor_user_id": "user_a",
+            "ria_user_id": "user_b",
+            "status": "approved",
+            "ria_display_name": "User B",
+            "ria_verification_status": "verified",
+            "relationship_share_status": "active",
+        }
+    )
+
+    recipient_ids = {
+        recipient["userId"]
+        for recipient in service.list_verified_recipients(owner_user_id="user_a")
+    }
+
+    assert "user_b" in recipient_ids
+
+
+def test_marketplace_visibility_off_hides_user_from_location_directory() -> None:
+    # Turning marketplace visibility OFF (is_discoverable = FALSE) must hide the
+    # user from the One Location directory too -- the same flag the Connect tab
+    # filters on -- even though they remain phone-verified.
+    service = FourUserMemoryService()
+    service.marketplace_profiles["user_b"] = {
+        "user_id": "user_b",
+        "profile_type": "investor",
+        "is_discoverable": False,
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+    recipient_ids = {
+        recipient["userId"]
+        for recipient in service.list_verified_recipients(owner_user_id="user_a")
+    }
+
+    assert "user_b" not in recipient_ids
+    # A user with no marketplace profile (user_c) is unaffected.
+    assert "user_c" in recipient_ids
+
+
+def test_explicit_network_connection_overrides_marketplace_visibility_off() -> None:
+    # Explicit One Network connections (Circle-invite claim) are explicit mutual
+    # consent and must win even when the user opted out of marketplace
+    # discoverability.
+    service = FourUserMemoryService()
+    service.marketplace_profiles["user_b"] = {
+        "user_id": "user_b",
+        "profile_type": "investor",
+        "is_discoverable": False,
+        "updated_at": datetime.now(timezone.utc),
+    }
+    service.network_connections["conn-1"] = {
+        "id": "conn-1",
+        "user_a_id": "user_a",
+        "user_b_id": "user_b",
+        "inviter_user_id": "user_a",
+        "invitee_user_id": "user_b",
+        "status": "active",
+        "connected_at": datetime.now(timezone.utc),
+    }
+
+    recipient_ids = {
+        recipient["userId"]
+        for recipient in service.list_verified_recipients(owner_user_id="user_a")
+    }
+
+    assert "user_b" in recipient_ids
+
+
 def test_public_invite_submission_limits_bound_duplicate_phone_requests() -> None:
+
     service = FourUserMemoryService()
     service.register_recipient_key(
         user_id="user_b",


### PR DESCRIPTION
## What

Bridge the marketplace **Connect** graph into One Location so connected users become location-share-ready friction-free, and keep visibility symmetric across both surfaces.

## Why

Today the marketplace Connect graph (`advisor_investor_relationships`) and the One Location recipient directory are two separate systems. A user you already connected with in the marketplace does **not** appear on the location page unless they are phone-verified or you separately ran the Circle-invite flow. The marketplace Connect handshake already establishes mutual consent, so that second step is redundant friction.

## Changes (backend, read-time only — no schema migration)

`list_verified_recipients` eligibility is extended. A user is now eligible when **any** of:

1. They share an active `one_location_network_connections` row with the owner (explicit Circle-invite claim) — explicit mutual consent, always wins.
2. They are phone-verified (existing behavior).
3. They are connected to the owner through an **approved** marketplace `advisor_investor_relationships` row (mapping `investor_user_id` ↔ `ria_profiles.user_id`), **and** they are currently marketplace-discoverable.

### Visibility parity (hide everywhere on opt-out)

If a user turns marketplace visibility **OFF** (`marketplace_public_profiles.is_discoverable = FALSE`) they are now hidden from the One Location directory too — the **same flag** the Connect tab already filters on — so they disappear from both the Connect tab and the location page. An explicit One Network connection (Circle-invite claim) overrides this, because that is explicit mutual consent. Users who never created a marketplace profile are unaffected.

## Consent guardrail

This changes **visibility/eligibility only**. Live location is never shared automatically: it still requires an explicit Share + review step and an auto-expiring, revocable grant (the existing `one_location_share_grants` spine). Marketplace connection is not treated as silent-tracking consent.

## Recommendations

Marketplace-connected users already receive a "Professional Network" recommendation signal (via `_add_professional_network_signals`), so they surface meaningfully ranked in the recipients list.

## Tests

- Mirrored the new gate in the in-memory test harness (`FourUserMemoryService`).
- New tests: marketplace-connected becomes a recipient (even unverified); visibility-off hides from the directory; explicit network connection overrides visibility-off.
- Full suite: **25 tests pass** (`tests/services/test_one_location_agent_service.py`).
