### PR TITLE
fix(agent): move welcome suggestion resolution out of render

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -2719,16 +2719,18 @@ export function AgentChatWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activePersona, conversationId, freshOpenKey, hasStartedConversation, pathname, user?.uid],
   );
-  const welcomeSuggestions = useMemo(
-    () =>
+  const [welcomeSuggestions, setWelcomeSuggestions] = useState<AgentWelcomeSuggestion[]>([]);
+
+  useEffect(() => {
+    setWelcomeSuggestions(
       resolveAgentWelcomeSuggestions({
         userId: user?.uid,
         pathname,
         persona: activePersona,
         randomSeed: welcomeSuggestionSeed,
-      }),
-    [activePersona, pathname, user?.uid, welcomeSuggestionSeed],
-  );
+      })
+    );
+  }, [activePersona, pathname, user?.uid, welcomeSuggestionSeed]);
   const latestRetryableAssistantId =
     [...visibleMessages]
       .reverse()


### PR DESCRIPTION
## Summary

Fixes a React lifecycle warning caused by resolving welcome suggestions during the render phase of `AgentChatWorkspace`.

The change moves welcome suggestion resolution from `useMemo()` into a React effect so that cache population occurs after render, eliminating render-phase side effects while preserving the existing `CacheService` behavior.

---

## Problem

`AgentChatWorkspace` previously resolved welcome suggestions inside a `useMemo()`:

```tsx
const welcomeSuggestions = useMemo(() =>
  resolveAgentWelcomeSuggestions(...),
  [...]
);
```

`resolveAgentWelcomeSuggestions()` is not render-pure. On a cache miss it populates `CacheService`, and `CacheService.set()` synchronously emits updates to subscribers.

One subscriber (`KaiCommandBarGlobal`) updates React state in response to those cache events, which resulted in the runtime warning:

```
Cannot update a component (`KaiCommandBarGlobal`) while rendering a different component (`AgentChatWorkspace`)
```

---

## Solution

Move welcome suggestion resolution into a `useEffect()` and store the resolved suggestions in component state.

This ensures that:

* render remains free of side effects,
* cache population still occurs,
* existing cache semantics are preserved,
* subscriber notifications occur after React completes the current render.

The implementation intentionally leaves `resolveAgentWelcomeSuggestions()` and the underlying cache implementation unchanged.

---

## Validation

Manual verification:

* Reproduced the React warning before the change.
* Verified the warning no longer appears after the change.
* Welcome suggestions continue to render correctly.
* Suggestions continue to update when opening a new chat and navigating between routes.
* No additional console warnings or errors observed.

Project checks:

* Typecheck passes.
* Existing `agent-welcome-suggestions` tests continue to pass.

---

## Notes for Review

### Why not keep `useMemo`?

`useMemo` is appropriate only for render-pure computations.

Because `resolveAgentWelcomeSuggestions()` may populate `CacheService` on a cache miss, invoking it during render can synchronously notify subscribers, leading to render-phase state updates.

Moving the invocation into a React effect keeps render pure while preserving the existing cache behavior.

### Why not remove the cache?

The existing implementation and tests indicate that caching is intentional. This change preserves the cache contract rather than altering application behavior.

### Why not defer with `setTimeout`?

A deferred timer would avoid the warning, but it introduces scheduling-based behavior. Using React's lifecycle (`useEffect`) keeps the side effect aligned with React's execution model instead of relying on timing.
