### PR TITLE
test(navigation): characterize resolveInternalRouteHref verbatim preservation of interior space, plus, and %20

### DIFF
--- a/hushh-webapp/__tests__/navigation/resolve-space-splitting.test.ts
+++ b/hushh-webapp/__tests__/navigation/resolve-space-splitting.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for resolveInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on internal route hrefs whose
+// query variables contain un-escaped spaces, plus symbols ("+"), and/or
+// percent-encoded spaces ("%20"), possibly mixed together.
+//
+// TRUTH-FIRST (verified against the source):
+//   resolveInternalRouteHref(value, fallback) is a THIN wrapper:
+//     return normalizeInternalRouteHref(value) ?? fallback;
+//   normalizeInternalRouteHref does ONLY:
+//     1. href = String(value ?? "").trim()           // edge whitespace only
+//     2. if (!href) return null
+//     3. if (!href.startsWith("/") || href.startsWith("//")) return null
+//     4. if (/[\r\n]/.test(href)) return null
+//     5. return href                                  // otherwise VERBATIM
+//
+//   IMPORTANT CONTRACT CORRECTION: there is NO query parsing, NO percent-
+//   decoding, NO "+"->space conversion, and NO "%20"->space collapsing. The
+//   premise that this routine "normalizes input to clean text characters" is
+//   WRONG. Interior spaces, literal "+", and literal "%20" are all PRESERVED
+//   exactly as given (after trimming only the leading/trailing whitespace). The
+//   only space-related effect is trim() at the very edges of the whole string.
+//   These tests pin that verbatim-preservation reality.
+
+const FALLBACK = "/one";
+
+describe("resolveInternalRouteHref — interior spaces / + / %20 are preserved verbatim", () => {
+  it("keeps an un-escaped interior space in a query value (no normalization)", () => {
+    const href = "/one/kai/analysis?ticker=ACME CORP";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("keeps a literal plus symbol (does NOT convert '+' to a space)", () => {
+    const href = "/one/kai/analysis?ticker=ACME+CORP";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("keeps a percent-encoded space (does NOT decode '%20' to a space)", () => {
+    const href = "/one/kai/analysis?ticker=ACME%20CORP";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("keeps all three space variants mixed together untouched", () => {
+    const href = "/search?q=alpha beta+gamma%20delta";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+
+  it("preserves repeated/array-style params that each carry mixed space tokens", () => {
+    const href = "/search?tag=red apple&tag=green+pear&tag=blue%20plum";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+});
+
+describe("resolveInternalRouteHref — trim() only affects the outer edges", () => {
+  it("trims leading/trailing whitespace but keeps the interior space", () => {
+    const href = "  /search?q=alpha beta  ";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe("/search?q=alpha beta");
+  });
+
+  it("does not collapse runs of interior spaces down to one", () => {
+    const href = "/search?q=alpha   beta";
+    expect(resolveInternalRouteHref(href, FALLBACK)).toBe(href);
+  });
+});
+
+describe("resolveInternalRouteHref — guard rejections fall back regardless of spaces", () => {
+  it("returns the fallback for a protocol-relative href even with spaces", () => {
+    expect(resolveInternalRouteHref("//evil.example/x y", FALLBACK)).toBe(
+      FALLBACK
+    );
+  });
+
+  it("returns the fallback when the trimmed value does not start with '/'", () => {
+    expect(resolveInternalRouteHref("  search?q=a b ", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("returns the fallback when a newline is present alongside spaces", () => {
+    expect(resolveInternalRouteHref("/search?q=a b\nc", FALLBACK)).toBe(
+      FALLBACK
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Characterizes `resolveInternalRouteHref` (hushh-webapp/lib/navigation/routes.ts) for internal hrefs whose query values contain interior spaces, a literal `+`, and/or `%20` — alone or mixed.

### Reviewer response — `pr_claim_changed_surface_mismatch` (title corrected)
The blocker was correct: the prior title claimed "array parameter space token **splitting**," which asserts a behavior the surface does **not** have. The verified truth is the opposite — there is **no splitting and no array-parameter handling**. The title now states the real surface: **verbatim preservation**.

### Truth-first finding (verified against source)
`resolveInternalRouteHref(value, fallback)` is a thin wrapper: `return normalizeInternalRouteHref(value) ?? fallback;`. `normalizeInternalRouteHref` only:
1. `String(value ?? "").trim()` — outer-edge whitespace only
2. rejects empty, non-`/`, protocol-relative (`//`), and CRLF inputs (→ fallback)
3. otherwise returns the string **verbatim**

There is **no** query parsing, **no** percent-decoding, **no** `+`→space conversion, and **no** `%20`→space collapsing. Interior spaces, literal `+`, and literal `%20` are preserved exactly. The repeated-`tag=` case simply confirms the whole string (including duplicate keys) is returned untouched — it does not exercise any array-splitting logic, because none exists.

### Scope (test-only, unchanged code surface)
- Interior space / `+` / `%20` preserved verbatim (incl. mixed and repeated keys)
- `trim()` affects only outer edges; interior space runs are not collapsed
- Guard rejections (`//`, non-`/`, CRLF) fall back regardless of spaces

## CI gate checklist
- [x] PR Base Policy — targets integration/pr-train
- [x] DCO Verified
- [x] Test Only Surface Change
- [x] Claim matches surface — title corrected to verbatim-preservation
