### PR TITLE
test(api-json-body): reject array payloads as invalid JSON objects

### DIFF
--- a/hushh-webapp/__tests__/api/api-json-body.test.ts
+++ b/hushh-webapp/__tests__/api/api-json-body.test.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+
+import { readJsonObject } from "@/app/api/_utils/json-body";
+
+describe("readJsonObject", () => {
+  it("rejects array payloads as invalid JSON objects", async () => {
+    const request = new NextRequest("http://localhost:3000/api/test", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([{ id: "item-1" }]),
+    });
+
+    await expect(readJsonObject(request)).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for readJsonObject rejecting JSON array payloads.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/api/api-json-body.test.ts only.
- Production contract: uses the real readJsonObject helper; no mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions