### PR TITLE
test(api-request-id): preserve request id on proxied upstream responses

### DIFF
--- a/hushh-webapp/__tests__/api/api-request-id.test.ts
+++ b/hushh-webapp/__tests__/api/api-request-id.test.ts
@@ -1,0 +1,21 @@
+import { withRequestIdResponse } from "@/app/api/_utils/request-id";
+import { REQUEST_ID_HEADER } from "@/lib/observability/request-id";
+
+describe("withRequestIdResponse", () => {
+  it("preserves request id on proxied upstream responses", async () => {
+    const response = withRequestIdResponse(
+      "req-proxy-123",
+      new Response(JSON.stringify({ ok: true }), {
+        status: 202,
+        headers: {
+          "content-type": "application/json",
+          [REQUEST_ID_HEADER]: "req-upstream-456",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get(REQUEST_ID_HEADER)).toBe("req-proxy-123");
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for proxied responses carrying the proxy request id.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/api/api-request-id.test.ts only.
- Production contract: uses the real withRequestIdResponse helper; no mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions