### PR TITLE
test(hot-get-json-cache): clear inflight only for matching request promise

### DIFF
--- a/hushh-webapp/__tests__/api/hot-get-json-cache.test.ts
+++ b/hushh-webapp/__tests__/api/hot-get-json-cache.test.ts
@@ -1,0 +1,22 @@
+import { createHotGetJsonCache } from "@/app/api/_utils/hot-get-json-cache";
+
+describe("createHotGetJsonCache", () => {
+  it("clears inflight only for matching request promise", () => {
+    const cache = createHotGetJsonCache({
+      freshTtlMs: 1_000,
+      staleTtlMs: 2_000,
+    });
+    const firstRequest = Promise.resolve({ status: 200, payload: "first" });
+    const secondRequest = Promise.resolve({ status: 200, payload: "second" });
+
+    cache.setInflight("portfolio", firstRequest);
+    cache.setInflight("portfolio", secondRequest);
+    cache.clearInflight("portfolio", firstRequest);
+
+    expect(cache.getInflight("portfolio")).toBe(secondRequest);
+
+    cache.clearInflight("portfolio", secondRequest);
+
+    expect(cache.getInflight("portfolio")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for inflight cache clearing by matching promise.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/api/hot-get-json-cache.test.ts only.
- Production contract: uses the real createHotGetJsonCache helper; no mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions