### PR TITLE
test(session-storage): remove only native-prefixed session keys on clear

### DIFF
--- a/hushh-webapp/__tests__/utils/session-storage.test.ts
+++ b/hushh-webapp/__tests__/utils/session-storage.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("clearSessionStorage", () => {
+  afterEach(() => {
+    delete (window as unknown as { Capacitor?: unknown }).Capacitor;
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.resetModules();
+  });
+
+  it("removes only native-prefixed session keys on clear", async () => {
+    (window as unknown as { Capacitor?: { isNativePlatform: () => boolean } }).Capacitor = {
+      isNativePlatform: () => true,
+    };
+    window.localStorage.setItem("_session_native-route", "clear-me");
+    window.localStorage.setItem("native-route", "keep-raw-fallback");
+    window.localStorage.setItem("profile-cache", "keep-local");
+
+    const { clearSessionStorage } = await import("@/lib/utils/session-storage");
+
+    clearSessionStorage();
+
+    expect(window.localStorage.getItem("_session_native-route")).toBeNull();
+    expect(window.localStorage.getItem("native-route")).toBe("keep-raw-fallback");
+    expect(window.localStorage.getItem("profile-cache")).toBe("keep-local");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for native session clear preserving non-session localStorage keys.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/utils/session-storage.test.ts only.
- Production contract: uses the real clearSessionStorage helper; no mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions