### PR TITLE
test(clipboard): remove fallback textarea after failed execCommand copy

### DIFF
--- a/hushh-webapp/__tests__/utils/clipboard.test.ts
+++ b/hushh-webapp/__tests__/utils/clipboard.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+describe("copyToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("removes fallback textarea after failed execCommand copy", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    vi.spyOn(document, "execCommand").mockReturnValue(false);
+
+    await expect(copyToClipboard("copy me")).resolves.toBe(false);
+
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+});

--- a/hushh-webapp/__tests__/utils/clipboard.test.ts
+++ b/hushh-webapp/__tests__/utils/clipboard.test.ts
@@ -13,7 +13,10 @@ describe("copyToClipboard", () => {
       configurable: true,
       value: undefined,
     });
-    vi.spyOn(document, "execCommand").mockReturnValue(false);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => false),
+    });
 
     await expect(copyToClipboard("copy me")).resolves.toBe(false);
 


### PR DESCRIPTION
## Summary
- Adds a focused test for clipboard fallback cleanup after failed execCommand copy.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/utils/clipboard.test.ts only.
- Production contract: uses the real copyToClipboard helper; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions