### PR TITLE
test(browser-navigation): dispatch internal navigation detail and return success

### DIFF
--- a/hushh-webapp/__tests__/utils/browser-navigation.test.ts
+++ b/hushh-webapp/__tests__/utils/browser-navigation.test.ts
@@ -1,0 +1,28 @@
+import {
+  INTERNAL_APP_NAVIGATION_REQUEST_EVENT,
+  requestInternalAppNavigation,
+} from "@/lib/utils/browser-navigation";
+
+describe("requestInternalAppNavigation", () => {
+  it("dispatches internal navigation detail and returns success", () => {
+    const details: unknown[] = [];
+    window.addEventListener(INTERNAL_APP_NAVIGATION_REQUEST_EVENT, (event) => {
+      details.push((event as CustomEvent).detail);
+    });
+
+    const result = requestInternalAppNavigation({
+      href: "/kai/analysis",
+      replace: true,
+      scroll: false,
+    });
+
+    expect(result).toBe(true);
+    expect(details).toEqual([
+      {
+        href: "/kai/analysis",
+        replace: true,
+        scroll: false,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for internal navigation event detail and success return.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/utils/browser-navigation.test.ts only.
- Production contract: uses the real requestInternalAppNavigation helper; no mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions