### PR TITLE
fix(ui): silence dashboard master view errors in production

### DIFF
--- a/hushh-webapp/components/kai/views/dashboard-master-view.tsx
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.tsx
@@ -1742,7 +1742,9 @@ export function DashboardMasterView({
       setHoldingsDraft(managed);
       toast.success("Holdings updated");
     } catch (error) {
-      console.error("[DashboardMasterView] Failed to save holdings:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[DashboardMasterView] Failed to save holdings:", error);
+      }
       toast.error("We could not save your holdings. Please try again.");
     } finally {
       setIsSavingHoldings(false);
@@ -1976,7 +1978,9 @@ export function DashboardMasterView({
         onReupload();
       }
     } catch (error) {
-      console.error("[DashboardMasterView] Failed to delete portfolio data:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[DashboardMasterView] Failed to delete portfolio data:", error);
+      }
       toast.error("We could not delete portfolio data. Please try again.");
     } finally {
       setIsDeletingImportedData(false);
@@ -2253,7 +2257,9 @@ export function DashboardMasterView({
       ) {
         return;
       }
-      console.error("[DashboardMasterView] Failed to share portfolio PDF:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[DashboardMasterView] Failed to share portfolio PDF:", error);
+      }
       toast.error("Could not share portfolio PDF.");
     } finally {
       setIsSharingPortfolioPdf(false);


### PR DESCRIPTION
### Description

Silences internal development error logs inside `components/kai/views/dashboard-master-view.tsx` by wrapping the `console.error` statements in a `NODE_ENV !== "production"` check. This prevents portfolio save, delete, and share errors from leaking into the production client console, while preserving the intended user-facing toast error notifications.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/views/dashboard-master-view.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/views/dashboard-master-view.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.