### PR TITLE
test(ui): cover combobox component className propagation contract

### DIFF
--- a/hushh-webapp/__tests__/ui/combobox.test.tsx
+++ b/hushh-webapp/__tests__/ui/combobox.test.tsx
@@ -5,6 +5,7 @@ import {
   Combobox,
   ComboboxChip,
   ComboboxChips,
+  ComboboxTrigger,
 } from "@/components/ui/combobox";
 
 describe("ComboboxChip", () => {
@@ -20,5 +21,16 @@ describe("ComboboxChip", () => {
     expect(
       container.querySelector('[data-slot="combobox-chip-remove"]'),
     ).toBeTruthy();
+  });
+});
+
+describe("ComboboxTrigger", () => {
+  it("propagates custom class names", () => {
+    const { container } = render(
+      <Combobox>
+        <ComboboxTrigger className="custom-combobox-trigger" />
+      </Combobox>,
+    );
+    expect(container.querySelector('[data-slot="combobox-trigger"]')?.className).toContain("custom-combobox-trigger");
   });
 });


### PR DESCRIPTION
### Description

Adds missing test coverage to `__tests__/ui/combobox.test.tsx` to explicitly verify that the `ComboboxTrigger` component correctly propagates custom `className` values to its underlying `data-slot="combobox-trigger"` element.
