### PR TITLE
fix(ui): silence kai flow preload and import errors in production

### DIFF
--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -2640,7 +2640,9 @@ export function KaiFlow({
           return;
         }
 
-        console.error("[KaiFlow] Import error:", err);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("[KaiFlow] Import error:", err);
+        }
         const rawErrorMessage =
           err instanceof Error ? String(err.message || "") : String(err || "");
         const isTransientNetworkLoss =
@@ -3119,7 +3121,9 @@ export function KaiFlow({
       setError(null);
       toast.success("Sample brokerage data loaded. Review and save to Vault.");
     } catch (preloadError) {
-      console.error("[KaiFlow] Failed to preload schema data:", preloadError);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[KaiFlow] Failed to preload schema data:", preloadError);
+      }
       toast.error("Could not load sample data. Please try again.");
     } finally {
       setPendingSchemaPreload(false);


### PR DESCRIPTION
### Description

Silences internal development error logs inside `components/kai/kai-flow.tsx` by wrapping the `console.error` statements in a `NODE_ENV !== "production"` check. This prevents schema preload and portfolio import errors from leaking into the production client console, while preserving the application's intended error-handling and user-facing fallback toast notifications.
