### PR TITLE
chore(ui): fix debugError helper to properly silence logs in production

### DIFF
--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -192,11 +192,13 @@ export function AuthStep({
   };
 
   const debugError = (label: string, error?: unknown) => {
-    if (process.env.NODE_ENV !== "production" && error !== undefined) {
-      console.error(label, error);
-      return;
+    if (process.env.NODE_ENV !== "production") {
+      if (error !== undefined) {
+        console.error(label, error);
+      } else {
+        console.error(label);
+      }
     }
-    console.error(label);
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Description

Fixes a logic flaw in the `debugError` helper within `components/onboarding/AuthStep.tsx`. Previously, the fallback `console.error` was incorrectly placed outside the environment check, causing the Auth UI to leak internal debug labels directly into the production console. This chore ensures the entire helper is strictly gated behind `NODE_ENV !== "production"`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/onboarding/AuthStep.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/onboarding/AuthStep.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Chrome/Safari)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.