### PR TITLE
fix(ui): silence developer docs hub errors in production

### DIFF
--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -154,7 +154,9 @@ async function copyText(value: string, label: string) {
     }
     toast.success(`${label} copied`);
   } catch (error) {
-    console.error("[developers] copy failed", error);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[developers] copy failed", error);
+    }
     toast.error(`Could not copy ${label.toLowerCase()}`);
   }
 }
@@ -1050,7 +1052,9 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
       await checkAuth();
       await refreshAccess(authResult.user);
     } catch (error) {
-      console.error(`[developers] ${provider} sign-in failed`, error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[developers] ${provider} sign-in failed`, error);
+      }
     }
   }
 
@@ -1135,7 +1139,9 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
       setAccess(null);
       setRevealedToken(null);
     } catch (error) {
-      console.error("[developers] sign out failed", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[developers] sign out failed", error);
+      }
       toast.error("Could not sign out");
     }
   }


### PR DESCRIPTION
### Description

Silences internal development error logs inside `components/developers/developer-docs-hub.tsx` by wrapping the `console.error` statements in a `NODE_ENV !== "production"` check. This prevents copy, sign-in, and sign-out errors from leaking into the production client console, while preserving the application's intended error-handling and user-facing fallback toast notifications.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/developers/developer-docs-hub.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/developers/developer-docs-hub.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.