### PR TITLE
test(ui): cover command component className propagation contract

### DIFF
--- a/hushh-webapp/__tests__/ui/command.test.tsx
+++ b/hushh-webapp/__tests__/ui/command.test.tsx
@@ -3,6 +3,13 @@ import { describe, expect, it } from "vitest";
 
 import { Command, CommandDialog, CommandInput } from "@/components/ui/command";
 
+describe("Command", () => {
+  it("propagates custom class names", () => {
+    const { container } = render(<Command className="custom-command" />);
+    expect(container.querySelector('[data-slot="command"]')?.className).toContain("custom-command");
+  });
+});
+
 describe("CommandDialog", () => {
   it("renders the close button by default", () => {
     render(


### PR DESCRIPTION
### Description

Adds missing test coverage to `__tests__/ui/command.test.tsx` to explicitly verify that the `Command` component correctly propagates custom `className` values to its underlying `data-slot="command"` element.
