### PR TITLE
fix(ui): silence notification provider logs in production

### DIFF
--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -810,11 +810,15 @@ export function ConsentNotificationProvider({
         setFcmInitStatus(result.status);
         setDeliveryDetail(result.detail ?? null);
         setDeliveryMode(deliveryModeFromInitStatus(result.status));
-        console.info("[NotificationProvider] Delivery init:", result);
+        if (process.env.NODE_ENV !== "production") {
+          console.info("[NotificationProvider] Delivery init:", result);
+        }
       } catch (err) {
         if (cancelled) return;
         const detail = err instanceof Error ? err.message : "fcm_init_failed";
-        console.error("[NotificationProvider] FCM initialization failed:", err);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("[NotificationProvider] FCM initialization failed:", err);
+        }
         persistDeliveryState(user.uid, {
           status: "push_failed",
           detail,
@@ -1198,10 +1202,12 @@ export function ConsentNotificationProvider({
         }
       } catch (err) {
         if (cancelled) return;
-        if (isTransientFetchFailure(err)) {
-          console.warn("[NotificationProvider] Initial fetch error:", err);
-        } else {
-          console.error("[NotificationProvider] Initial fetch error:", err);
+        if (process.env.NODE_ENV !== "production") {
+          if (isTransientFetchFailure(err)) {
+            console.warn("[NotificationProvider] Initial fetch error:", err);
+          } else {
+            console.error("[NotificationProvider] Initial fetch error:", err);
+          }
         }
         if (queuedPending.length > 0) {
           clearQueuedPendingConsents(uid);


### PR DESCRIPTION
### Description

Silences internal development logs inside `components/consent/notification-provider.tsx` by wrapping the `console.info`, `console.warn`, and `console.error` statements in a `NODE_ENV !== "production"` check. This prevents FCM initialization successes and fetch errors from leaking into the production client console, while preserving the application's graceful fallback delivery modes.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/consent/notification-provider.tsx`


## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/consent/notification-provider.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none