### PR TITLE
refactor(frontend): use route constant for PKM agent lab navigation

### DIFF
--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -4294,7 +4294,7 @@ function ProfilePageContent() {
                   trailing={<Badge variant="secondary">Local</Badge>}
                   chevron
                   stackTrailingOnMobile
-                  onClick={() => router.push("/profile/pkm-agent-lab")}
+                  onClick={() => router.push(ROUTES.PROFILE_PKM_AGENT_LAB)}
                 />
               ) : null}
             </SettingsGroup>


### PR DESCRIPTION
## Summary

Replace the hardcoded PKM Agent Lab navigation path with the existing centralized route constant.

## Changes

* Replace `"/profile/pkm-agent-lab"` with `ROUTES.PROFILE_PKM_AGENT_LAB`.

## Why

The profile page already uses the centralized `ROUTES` constants for navigation throughout the file. Using the existing constant here keeps route definitions consistent, avoids hardcoded route strings, and improves maintainability without changing behavior.
