### PR TITLE
fix(ui): silence kai preferences sheet errors in production

### DIFF
--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesSheet.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesSheet.tsx
@@ -42,7 +42,9 @@ export function KaiPreferencesSheet(props: {
         });
         if (!cancelled) setProfile(p);
       } catch (error) {
-        console.warn("[KaiPreferencesSheet] Failed to load profile:", error);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[KaiPreferencesSheet] Failed to load profile:", error);
+        }
         if (!cancelled) setProfile(null);
       } finally {
         if (!cancelled) setLoading(false);
@@ -117,7 +119,9 @@ export function KaiPreferencesSheet(props: {
                       toast.success("Preferences updated");
                       props.onOpenChange(false);
                     } catch (error) {
-                      console.error("[KaiPreferencesSheet] Save failed:", error);
+                      if (process.env.NODE_ENV !== "production") {
+                        console.error("[KaiPreferencesSheet] Save failed:", error);
+                      }
                       toast.error("Couldn't save preferences. Please retry.");
                     } finally {
                       setLoading(false);


### PR DESCRIPTION
### Description

Silences internal development logs inside `components/kai/onboarding/KaiPreferencesSheet.tsx` by wrapping the `console.warn` and `console.error` statements in a `NODE_ENV !== "production"` check. This prevents Kai profile load warnings and preference save errors from leaking into the production client console, while preserving the application's intended error-handling and user-facing fallback toast notifications.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/onboarding/KaiPreferencesSheet.tsx`


## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/onboarding/KaiPreferencesSheet.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)