### PR TITLE
chore(ui): silence vault unlock error stack trace in production

### DIFF
--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -363,7 +363,9 @@ export function VaultFlow({
         toast.error(message);
       }
     } catch (err: any) {
-      console.error("Unlock error:", err);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("Unlock error:", err);
+      }
       const message = toInvestorVaultUnlockError(err);
       setError(message);
       toast.error(message);


### PR DESCRIPTION
### Description

Wraps a raw `console.error` in the `VaultFlow` component's vault unlock handler with a production environment check. This prevents exposing internal unlock/decryption error stack traces to end-users if an exception occurs during the unlock flow.
