### PR TITLE
fix(ui): silence profile kai preferences errors in production

### DIFF
--- a/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
@@ -44,7 +44,9 @@ export function ProfileKaiPreferencesPanel({
           setProfile(nextProfile);
         }
       } catch (error) {
-        console.warn("[ProfileKaiPreferencesPanel] Failed to load profile:", error);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[ProfileKaiPreferencesPanel] Failed to load profile:", error);
+        }
         if (!cancelled) {
           setProfile(null);
         }
@@ -140,7 +142,9 @@ export function ProfileKaiPreferencesPanel({
             setProfile(refreshed);
             toast.success("Preferences updated");
           } catch (error) {
-            console.error("[ProfileKaiPreferencesPanel] Save failed:", error);
+            if (process.env.NODE_ENV !== "production") {
+              console.error("[ProfileKaiPreferencesPanel] Save failed:", error);
+            }
             toast.error("Couldn't save preferences. Please retry.");
           } finally {
             setLoading(false);


### PR DESCRIPTION
### Description

Silences internal development error logs inside `components/profile/profile-kai-preferences-panel.tsx` by wrapping the `console.warn` and `console.error` statements in a `NODE_ENV !== "production"` check. This prevents Kai profile load warnings and preference save errors from leaking into the production client console, while preserving the application's intended error-handling and user-facing fallback toast notifications.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/profile/profile-kai-preferences-panel.tsx`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/profile/profile-kai-preferences-panel.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none