### PR TITLE
chore(ui): silence developer docs copy error in production

### DIFF
--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -154,7 +154,9 @@ async function copyText(value: string, label: string) {
     }
     toast.success(`${label} copied`);
   } catch (error) {
-    console.error("[developers] copy failed", error);
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[developers] copy failed", error);
+    }
     toast.error(`Could not copy ${label.toLowerCase()}`);
   }
 }


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `developer-docs-hub` clipboard copy handler with a production environment check. This prevents exposing internal API exceptions and stack traces to end-users if a clipboard copy operation fails due to browser security restrictions or other errors.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/developers/developer-docs-hub.tsx`


## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/developers/developer-docs-hub.tsx`)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)