### PR TITLE
fix(frontend-a11y): add accessible names to renaissance market search…

### DIFF
--- a/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
@@ -373,6 +373,7 @@ export function RiaPicksList({
                       <Input
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
+                        aria-label="Search symbol, company, sector, or thesis"
                         placeholder="Search symbol, company, sector, or thesis"
                         autoComplete="off"
                         autoCorrect="off"
@@ -519,6 +520,7 @@ export function RiaPicksList({
                     <Input
                       value={query}
                       onChange={(event) => setQuery(event.target.value)}
+                      aria-label="Search symbol, company, sector, or thesis"
                       placeholder="Search symbol, company, sector, or thesis"
                       autoComplete="off"
                       autoCorrect="off"


### PR DESCRIPTION
## Summary

Adds accessible names to the Renaissance Market List search inputs used across responsive layouts.

## Changes

* Added `aria-label="Search symbol, company, sector, or thesis"` to the mobile search input.
* Added `aria-label="Search symbol, company, sector, or thesis"` to the desktop search input.

## Why

The search inputs relied on placeholder text for identification. Adding explicit accessible names improves compatibility with screen readers and assistive technologies while preserving the existing user experience and functionality.
