### PR TITLE
chore(ui): silence iam persona route mismatch error in production

### DIFF
--- a/hushh-webapp/components/iam/persona-bootstrap-redirect.tsx
+++ b/hushh-webapp/components/iam/persona-bootstrap-redirect.tsx
@@ -117,7 +117,9 @@ export function PersonaBootstrapRedirect() {
       await switchPersona(targetPersona);
       router.replace(pathname);
     } catch (error) {
-      console.error("[PersonaBootstrapRedirect] Failed to resolve route mismatch:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[PersonaBootstrapRedirect] Failed to resolve route mismatch:", error);
+      }
       toast.error("We couldn't switch roles right now. Please retry.");
     } finally {
       setResolving(null);


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `PersonaBootstrapRedirect` component with a production environment check. This prevents exposing internal IAM role-switching exceptions and route mismatch stack traces to end-users, while preserving the user-friendly `toast` notification.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/iam/persona-bootstrap-redirect.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/iam/persona-bootstrap-redirect.tsx`)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.