### PR TITLE
fix(ui): silence kai flow import errors in production

### DIFF
--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -2640,7 +2640,9 @@ export function KaiFlow({
           return;
         }
 
-        console.error("[KaiFlow] Import error:", err);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("[KaiFlow] Import error:", err);
+        }
         const rawErrorMessage =
           err instanceof Error ? String(err.message || "") : String(err || "");
         const isTransientNetworkLoss =
@@ -2771,7 +2773,9 @@ export function KaiFlow({
         userId,
         vaultOwnerToken: effectiveVaultOwnerToken,
       }).catch((cancelError) => {
-        console.warn("[KaiFlow] Failed to cancel import run on backend:", cancelError);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[KaiFlow] Failed to cancel import run on backend:", cancelError);
+        }
       });
     }
     if (abortControllerRef.current) {
@@ -3119,7 +3123,9 @@ export function KaiFlow({
       setError(null);
       toast.success("Sample brokerage data loaded. Review and save to Vault.");
     } catch (preloadError) {
-      console.error("[KaiFlow] Failed to preload schema data:", preloadError);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[KaiFlow] Failed to preload schema data:", preloadError);
+      }
       toast.error("Could not load sample data. Please try again.");
     } finally {
       setPendingSchemaPreload(false);


### PR DESCRIPTION
### Description

Silences internal development logs inside `components/kai/kai-flow.tsx` by wrapping several `console.warn` and `console.error` statements in a `NODE_ENV !== "production"` check. This prevents common portfolio import network interruptions and sample data preload failures from leaking traces into the production client console, while preserving the application's intended error-handling and user-facing fallback toast notifications.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/kai-flow.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/kai-flow.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.