### PR TITLE
chore(ui): silence kai preferences save error in production

### DIFF
--- a/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
@@ -140,7 +140,9 @@ export function ProfileKaiPreferencesPanel({
             setProfile(refreshed);
             toast.success("Preferences updated");
           } catch (error) {
-            console.error("[ProfileKaiPreferencesPanel] Save failed:", error);
+            if (process.env.NODE_ENV !== "production") {
+              console.error("[ProfileKaiPreferencesPanel] Save failed:", error);
+            }
             toast.error("Couldn't save preferences. Please retry.");
           } finally {
             setLoading(false);


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `ProfileKaiPreferencesPanel` component with a production environment check. This prevents exposing internal API exceptions and stack traces to end-users if a preference update fails, while still preserving the user-friendly `toast` notification.
