### PR TITLE
chore(ui): silence phone verification confirmation error stack trace in production

### DIFF
--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -321,7 +321,9 @@ export function PhoneVerificationFlow({
       morphyToast.success(mode === "replace" ? "Phone number updated." : "Phone number verified.");
       await onCompleted(verifiedUser);
     } catch (error) {
-      console.error("[PhoneVerificationFlow] Failed to confirm verification code:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[PhoneVerificationFlow] Failed to confirm verification code:", error);
+      }
       trackEvent("phone_verification_completed", {
         action: mode,
         result: "error",


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `PhoneVerificationFlow` verification confirmation handler with a production environment check. This prevents exposing internal authentication API exceptions and stack traces to end-users if a 2FA confirmation fails, while preserving the intended UI toast notifications and analytics telemetry.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/auth/phone-verification-flow.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/auth/phone-verification-flow.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.