### PR TITLE
test(cash-management-card): cover empty balance fallback

### DIFF
--- a/hushh-webapp/__tests__/components/cash-management-card.test.tsx
+++ b/hushh-webapp/__tests__/components/cash-management-card.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CashManagementCard } from "@/components/kai/cards/cash-management-card";
+
+describe("CashManagementCard", () => {
+  it("covers the empty balance fallback", () => {
+    const { container } = render(
+      <CashManagementCard
+        cashManagement={{
+          checking_activity: [],
+          debit_card_activity: [],
+          deposits_and_withdrawals: [],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Cash Management")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for the cash management empty fallback.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/components/cash-management-card.test.tsx only.
- Production contract: renders the real CashManagementCard component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions