### PR TITLE
test(income-detail-card): cover missing income value fallback

### DIFF
--- a/hushh-webapp/__tests__/components/income-detail-card.test.tsx
+++ b/hushh-webapp/__tests__/components/income-detail-card.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { IncomeDetailCard } from "@/components/kai/cards/income-detail-card";
+
+describe("IncomeDetailCard", () => {
+  it("covers the missing income value fallback", () => {
+    const { container } = render(
+      <IncomeDetailCard incomeSummary={{}} incomeDetail={{}} ytdMetrics={{}} />,
+    );
+
+    expect(screen.queryByText("Income")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for the income detail missing-value fallback.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/components/income-detail-card.test.tsx only.
- Production contract: renders the real IncomeDetailCard component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions