### PR TITLE
test(kpi-card): cover trend label rendering

### DIFF
--- a/hushh-webapp/__tests__/components/kpi-card.test.tsx
+++ b/hushh-webapp/__tests__/components/kpi-card.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { KPICard } from "@/components/kai/cards/kpi-card";
+
+describe("KPICard", () => {
+  it("covers trend label rendering", () => {
+    render(
+      <KPICard
+        title="Revenue"
+        value="$12.4K"
+        change={3.25}
+        changeLabel="vs last month"
+      />,
+    );
+
+    expect(screen.getByText("+3.25%")).toBeTruthy();
+    expect(screen.getByText("(vs last month)")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused test for KPI card trend label rendering.

## Reviewer Proof
- Surface: hushh-webapp/__tests__/components/kpi-card.test.tsx only.
- Production contract: renders the real KPICard component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions