### PR TITLE
refactor(auth): use login route constant

### DIFF
--- a/hushh-webapp/hooks/use-auth.ts
+++ b/hushh-webapp/hooks/use-auth.ts
@@ -16,6 +16,7 @@
 "use client";
 
 import { useAuth as useContextAuth } from "@/lib/firebase/auth-context";
+import { ROUTES } from "@/lib/navigation/routes";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
 
@@ -34,8 +35,8 @@ export function useRequireAuth() {
   useEffect(() => {
     if (!auth.loading && !auth.isAuthenticated) {
       // Avoid redirect loop if already on login
-      if (pathname !== "/login") {
-        router.push("/login");
+      if (pathname !== ROUTES.LOGIN) {
+        router.push(ROUTES.LOGIN);
       }
     }
   }, [auth.loading, auth.isAuthenticated, router, pathname]);


### PR DESCRIPTION
## Summary

Replaces hardcoded login route strings in `useRequireAuth` with the shared `ROUTES.LOGIN` constant.

## Changes

- Import `ROUTES` from the shared navigation module.
- Replace hardcoded `/login` string comparisons with `ROUTES.LOGIN`.
- Replace hardcoded redirect target with `ROUTES.LOGIN`.

## Why

Using the shared route constant keeps navigation consistent across the codebase and avoids duplicating route literals.