### PR TITLE
test(checkbox): cover data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/checkbox.test.tsx
+++ b/hushh-webapp/__tests__/components/checkbox.test.tsx
@@ -1,0 +1,11 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Checkbox } from "@/components/ui/checkbox";
+
+describe("Checkbox", () => {
+  it("renders with data-slot=checkbox", () => {
+    const { container } = render(<Checkbox />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("checkbox");
+  });
+});


### PR DESCRIPTION
Covers the data-slot="checkbox" contract on Checkbox — ensures the 
root element always carries the correct slot identifier.

Attach point: hushh-webapp/components/ui/checkbox.tsx
Single file, single surface.