### PR TITLE
test(switch): cover data-slot and size data attribute contract

### DIFF
--- a/hushh-webapp/__tests__/components/switch.test.tsx
+++ b/hushh-webapp/__tests__/components/switch.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Switch } from "@/components/ui/switch";
+
+describe("Switch", () => {
+  it("renders with data-slot=switch", () => {
+    const { container } = render(<Switch />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("switch");
+  });
+
+  it("renders with default size data attribute", () => {
+    const { container } = render(<Switch />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-size")).toBe("default");
+  });
+
+  it("renders with sm size data attribute", () => {
+    const { container } = render(<Switch size="sm" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-size")).toBe("sm");
+  });
+});


### PR DESCRIPTION
Covers three data-attribute contracts on Switch:
- data-slot="switch" is always present
- data-size="default" when no size specified
- data-size="sm" when sm size passed

Attach point: hushh-webapp/components/ui/switch.tsx
Single file, single surface.