### PR TITLE
chore(ui): silence kai nav tour state sync errors in production

### DIFF
--- a/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
@@ -161,7 +161,9 @@ export function KaiNavTour() {
             return;
           }
         } catch (error) {
-          console.warn("[KaiNavTour] Failed to read vault-backed tour state:", error);
+          if (process.env.NODE_ENV !== "production") {
+            console.warn("[KaiNavTour] Failed to read vault-backed tour state:", error);
+          }
         }
       }
 
@@ -305,7 +307,9 @@ export function KaiNavTour() {
         });
         await KaiNavTourLocalService.markSynced(user.uid);
       } catch (error) {
-        console.warn("[KaiNavTour] Failed to sync nav tour state:", error);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[KaiNavTour] Failed to sync nav tour state:", error);
+        }
       }
       return;
     }
@@ -322,7 +326,9 @@ export function KaiNavTour() {
       });
       await KaiNavTourLocalService.markSynced(user.uid);
     } catch (error) {
-      console.warn("[KaiNavTour] Failed to sync pre-vault nav tour state:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[KaiNavTour] Failed to sync pre-vault nav tour state:", error);
+      }
     }
   }
 
@@ -336,7 +342,9 @@ export function KaiNavTour() {
         skippedAt: local.skipped_at,
       });
     } catch (error) {
-      console.warn("[KaiNavTour] Failed to mark skipped:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[KaiNavTour] Failed to mark skipped:", error);
+      }
     }
   }
 
@@ -350,7 +358,9 @@ export function KaiNavTour() {
         skippedAt: null,
       });
     } catch (error) {
-      console.warn("[KaiNavTour] Failed to mark completed:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("[KaiNavTour] Failed to mark completed:", error);
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Silences internal development logs inside `components/kai/onboarding/kai-nav-tour.tsx` by wrapping several `console.warn` statements in a `NODE_ENV !== "production"` check. This prevents network fallback traces (e.g., vault-backed tour state read failures, nav tour sync errors, and completed/skipped marker failures) from leaking into the production client console, while preserving the application's intended error-handling and resilient fallback to local IndexedDB state.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/onboarding/kai-nav-tour.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/onboarding/kai-nav-tour.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.