### PR TITLE
chore(ui): silence notification provider fcm init error in production

### DIFF
--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -814,7 +814,9 @@ export function ConsentNotificationProvider({
       } catch (err) {
         if (cancelled) return;
         const detail = err instanceof Error ? err.message : "fcm_init_failed";
-        console.error("[NotificationProvider] FCM initialization failed:", err);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("[NotificationProvider] FCM initialization failed:", err);
+        }
         persistDeliveryState(user.uid, {
           status: "push_failed",
           detail,


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `NotificationProvider` Firebase Cloud Messaging (FCM) initialization handler with a production environment check. This prevents exposing internal FCM stack traces to end-users if push notification registration fails, while preserving the intended backend status telemetry.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/consent/notification-provider.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/consent/notification-provider.tsx`)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.