### PR TITLE
chore(ui): silence vault method switch error in production

### DIFF
--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -187,7 +187,9 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
       toast.success(`Vault unlock updated to ${readableMethod(result.method)}.`);
       setOpen(false);
     } catch (error) {
-      console.error("[VaultMethodPrompt] Failed to switch method:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[VaultMethodPrompt] Failed to switch method:", error);
+      }
       toast.error(
         error instanceof Error
           ? error.message


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `VaultMethodPrompt` authentication switch handler with a production environment check. This prevents exposing internal Vault API exceptions and stack traces to end-users if a method switch fails, while preserving the intended UI `toast` error notifications.
