### PR TITLE
chore(ui): silence debate stream view warnings in production

### DIFF
--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -815,7 +815,9 @@ export function DebateStreamView({
           vaultOwnerToken,
         });
       } catch (cancelError) {
-        console.warn("[DebateStreamView] Failed to cancel run:", cancelError);
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("[DebateStreamView] Failed to cancel run:", cancelError);
+        }
       }
     }
     setBusyOperation("stock_analysis_stream", false);
@@ -1329,7 +1331,9 @@ export function DebateStreamView({
             financial_profile: profile,
           };
         } catch (profileError) {
-          console.warn("[DebateStreamView] Failed to load Kai profile context:", profileError);
+          if (process.env.NODE_ENV !== "production") {
+            console.warn("[DebateStreamView] Failed to load Kai profile context:", profileError);
+          }
         }
       }
 
@@ -1360,10 +1364,12 @@ export function DebateStreamView({
             portfolioContext;
           portfolioContext = hydratedContext;
         } catch (blobError) {
-          console.warn(
-            "[DebateStreamView] Failed to hydrate debate context from the financial PKM domain:",
-            blobError
-          );
+          if (process.env.NODE_ENV !== "production") {
+            console.warn(
+              "[DebateStreamView] Failed to hydrate debate context from the financial PKM domain:",
+              blobError
+            );
+          }
         }
       }
 


### PR DESCRIPTION
### Description

Silences internal development logs inside `components/kai/debate-stream-view.tsx` by wrapping several `console.warn` statements in a `NODE_ENV !== "production"` check. This prevents network fallback traces (e.g., active run cancellation failures, Kai profile context load errors, and financial PKM domain hydration errors) from leaking into the production client console, while preserving the application's intended error-handling and resilient fallback states.