### PR TITLE
chore(ui): silence kai schema preload error stack trace in production

### DIFF
--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -3119,7 +3119,9 @@ export function KaiFlow({
       setError(null);
       toast.success("Sample brokerage data loaded. Review and save to Vault.");
     } catch (preloadError) {
-      console.error("[KaiFlow] Failed to preload schema data:", preloadError);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[KaiFlow] Failed to preload schema data:", preloadError);
+      }
       toast.error("Could not load sample data. Please try again.");
     } finally {
       setPendingSchemaPreload(false);


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `KaiFlow` sample schema preload handler with a production environment check. This prevents exposing internal API exceptions and data model stack traces to end-users if a portfolio template fetch fails, while preserving the intended UI error toast.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/kai-flow.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/kai-flow.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.