### PR TITLE
chore(ui): silence notification provider initial fetch error stack trace in production

### DIFF
--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -1198,10 +1198,12 @@ export function ConsentNotificationProvider({
         }
       } catch (err) {
         if (cancelled) return;
-        if (isTransientFetchFailure(err)) {
-          console.warn("[NotificationProvider] Initial fetch error:", err);
-        } else {
-          console.error("[NotificationProvider] Initial fetch error:", err);
+        if (process.env.NODE_ENV !== "production") {
+          if (isTransientFetchFailure(err)) {
+            console.warn("[NotificationProvider] Initial fetch error:", err);
+          } else {
+            console.error("[NotificationProvider] Initial fetch error:", err);
+          }
         }
         if (queuedPending.length > 0) {
           clearQueuedPendingConsents(uid);


### PR DESCRIPTION
### Description

Wraps raw `console.warn` and `console.error` logs inside the `NotificationProvider` initial background fetch handler with a production environment check. This prevents exposing internal API fetch exceptions and network stack traces to end-users if a transient failure occurs while checking for pending consent requests.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/consent/notification-provider.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/consent/notification-provider.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.