### PR TITLE
chore(ui): silence gmail receipt summary build error stack trace in production

### DIFF
--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -839,10 +839,12 @@ export default function ProfileReceiptsPage() {
         setReceiptMemoryArtifact(artifact);
         setReceiptMemoryMessage("Your shopping summary is ready to review.");
       } catch (error) {
-        console.error(
-          "[ProfileReceiptsPage] Failed to build receipt summary:",
-          error,
-        );
+        if (process.env.NODE_ENV !== "production") {
+          console.error(
+            "[ProfileReceiptsPage] Failed to build receipt summary:",
+            error,
+          );
+        }
         const message = sanitizeGmailUserMessage(error, {
           fallback:
             "We couldn't create a shopping summary right now. Please try again in a moment.",


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `ProfileReceiptsPage` summary generation handler with a production environment check. This prevents exposing internal API exceptions and stack traces to end-users if a shopping summary build fails, while preserving the intended UI error toast.
