### PR TITLE
test(navigation): characterize normalizeInternalRouteHref multi-stage percent decoded hash targets

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-decoded-hashes.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-decoded-hashes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+/**
+ * Characterization tests for normalizeInternalRouteHref
+ * (hushh-webapp/lib/navigation/routes.ts) when the href contains nested,
+ * percent-encoded hash symbols (e.g. `/legal%2523privacy-policy`, where `%25`
+ * is an encoded `%`, so `%2523` is the encoded form of the literal text
+ * `%23`, which is itself the encoded form of `#`).
+ *
+ * TRUTH-FIRST (verified against the source):
+ *   The guard is a pure allow/deny gate on the trimmed string:
+ *     const href = String(value ?? "").trim();
+ *     if (!href) return null;
+ *     if (!href.startsWith("/") || href.startsWith("//")) return null;
+ *     if (/[\r\n]/.test(href)) return null;
+ *     return href;
+ *   It performs NO `decodeURIComponent`, NO percent-decoding of any stage, and
+ *   NO `#`/anchor splitting. For any href that passes the three checks
+ *   (non-empty, single leading slash, no CR/LF) it is an IDENTITY function.
+ *   Consequence: a layered token like `%2523` is left fully intact — it is
+ *   never collapsed to `%23` and never to an active `#` anchor boundary. The
+ *   string stays exactly as given, byte-for-byte.
+ */
+
+describe("normalizeInternalRouteHref — multi-stage percent-encoded hashes are preserved verbatim", () => {
+  it("returns a layered %2523 href byte-for-byte (no decoding to %23 or #)", () => {
+    const href = "/legal%2523privacy-policy";
+    const out = normalizeInternalRouteHref(href);
+    expect(out).toBe("/legal%2523privacy-policy");
+  });
+
+  it("does NOT decode %2523 down to %23", () => {
+    const out = normalizeInternalRouteHref("/legal%2523privacy-policy");
+    expect(out).not.toContain("%23privacy");
+    expect(out).toContain("%2523");
+  });
+
+  it("does NOT decode %2523 into an active # anchor boundary", () => {
+    const out = normalizeInternalRouteHref("/legal%2523privacy-policy");
+    expect(out).not.toContain("#");
+  });
+
+  it("preserves a single-stage encoded hash %23 verbatim too (no anchor split)", () => {
+    const out = normalizeInternalRouteHref("/legal%23privacy-policy");
+    expect(out).toBe("/legal%23privacy-policy");
+    expect(out).not.toContain("#");
+  });
+
+  it("preserves multiple layered %2523 tokens across segments", () => {
+    const out = normalizeInternalRouteHref("/a%2523b/c%2523d");
+    expect(out).toBe("/a%2523b/c%2523d");
+  });
+
+  it("preserves a real literal # alongside an encoded %2523 (no normalization)", () => {
+    const out = normalizeInternalRouteHref("/legal%2523privacy#section");
+    expect(out).toBe("/legal%2523privacy#section");
+  });
+
+  it("trims surrounding whitespace while keeping the inner %2523 intact", () => {
+    const out = normalizeInternalRouteHref("  /legal%2523privacy-policy  ");
+    expect(out).toBe("/legal%2523privacy-policy");
+  });
+
+  it("still rejects protocol-relative hrefs even when they carry %2523", () => {
+    expect(normalizeInternalRouteHref("//evil.example/legal%2523privacy")).toBeNull();
+  });
+
+  it("still rejects non-rooted hrefs even when they carry %2523", () => {
+    expect(normalizeInternalRouteHref("legal%2523privacy-policy")).toBeNull();
+  });
+
+  it("still rejects a %2523-bearing href that contains a newline", () => {
+    expect(normalizeInternalRouteHref("/legal%2523privacy\npolicy")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref` (`hushh-webapp/lib/navigation/routes.ts`) documenting its exact contract when an internal href carries nested, percent-encoded hash symbols (e.g. `/legal%2523privacy-policy`, where `%25` encodes `%`, so `%2523` is the encoded form of the literal text `%23`, which itself encodes `#`). Test-only; no production change.

## Literal code assertion being made

The guard is a pure allow/deny gate over the trimmed string:

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

It performs **no** `decodeURIComponent`, **no** percent-decoding of any stage, and **no** `#`/anchor splitting. For any href that passes the three checks (non-empty, single leading slash, no CR/LF) it is an **identity** function. The test pins exactly that boundary:

- `"/legal%2523privacy-policy"` → returned byte-for-byte as `"/legal%2523privacy-policy"` (never collapsed to `%23`, never to an active `#` anchor)
- output still contains `%2523`, never `%23privacy`, never `#`
- single-stage `"/legal%23privacy-policy"` is also returned verbatim with no anchor split
- multiple layered tokens `"/a%2523b/c%2523d"` preserved across segments
- a real literal `#` alongside `%2523` (`"/legal%2523privacy#section"`) is kept verbatim — no normalization
- leading/trailing whitespace is trimmed while the inner `%2523` stays intact
- the deny rules still hold even with `%2523` present: protocol-relative (`//evil.example/...`) → `null`, non-rooted (`legal%2523...`) → `null`, embedded newline → `null`

The boundary in one line: `normalizeInternalRouteHref` treats a layered escaped hash as opaque path text — it neither decodes nor splits it; the only thing that ever happens is trimming and an allow/deny verdict.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...` and `npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is `@/lib/navigation/routes`. The file therefore lives at `hushh-webapp/__tests__/navigation/normalize-decoded-hashes.test.ts` and imports via the `@/` alias.

## Verification

- `npm test -- __tests__/navigation/normalize-decoded-hashes.test.ts` → 10/10 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real, existing behavioral boundary (no decodeURIComponent, no anchor split; identity-on-allow, null-on-deny)
- [x] Strict Literal Mapping — branch name, commit message, and PR title match verbatim; description states the literal code assertions
