### PR TITLE
test(navigation): characterize normalizeInternalRouteHref inline authentication parameter stripping

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-auth-stripping.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-auth-stripping.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+/**
+ * Characterization tests for normalizeInternalRouteHref
+ * (hushh-webapp/lib/navigation/routes.ts) when the href embeds inline
+ * URL-credential blocks (userinfo) such as `user:pass@legal/privacy`.
+ *
+ * TRUTH-FIRST (verified against the source):
+ *   The guard is a pure allow/deny gate over the trimmed string:
+ *     const href = String(value ?? "").trim();
+ *     if (!href) return null;
+ *     if (!href.startsWith("/") || href.startsWith("//")) return null;
+ *     if (/[\r\n]/.test(href)) return null;
+ *     return href;
+ *   It does NOT parse URL authority, does NOT recognize `user:pass@` userinfo,
+ *   and does NOT strip credential blocks. There is no `@`, `:`, or userinfo
+ *   handling anywhere. Consequences pinned below:
+ *     - A rooted href containing a credential-looking block is treated as opaque
+ *       path text and returned BYTE-FOR-BYTE (credentials retained, not filtered).
+ *     - The deny rules are unchanged by the presence of credentials: a non-rooted
+ *       `user:pass@...` is rejected (does not start with `/`), and a
+ *       protocol-relative `//user:pass@host/...` is rejected (starts with `//`).
+ *   In short: normalizeInternalRouteHref neither flags nor strips inline
+ *   credentials — it only enforces trim + single-leading-slash + no-CRLF.
+ */
+
+describe("normalizeInternalRouteHref — inline credential blocks are retained, not stripped", () => {
+  it("returns a rooted href with an inline user:pass@ block byte-for-byte", () => {
+    const href = "/user:pass@legal/privacy";
+    expect(normalizeInternalRouteHref(href)).toBe("/user:pass@legal/privacy");
+  });
+
+  it("does not strip the credential segment from the path", () => {
+    const out = normalizeInternalRouteHref("/user:pass@legal/privacy");
+    expect(out).toContain("user:pass@");
+    expect(out).toContain("legal/privacy");
+  });
+
+  it("retains username-only userinfo (no password) verbatim", () => {
+    expect(normalizeInternalRouteHref("/admin@dashboard/settings")).toBe(
+      "/admin@dashboard/settings"
+    );
+  });
+
+  it("retains an empty-credential `@` prefix verbatim", () => {
+    expect(normalizeInternalRouteHref("/@legal/privacy")).toBe("/@legal/privacy");
+  });
+
+  it("retains multiple `@`/`:` credential-looking tokens verbatim", () => {
+    expect(normalizeInternalRouteHref("/a:b@c:d@legal/privacy")).toBe(
+      "/a:b@c:d@legal/privacy"
+    );
+  });
+
+  it("trims whitespace but keeps the inner credential block intact", () => {
+    expect(normalizeInternalRouteHref("  /user:pass@legal/privacy  ")).toBe(
+      "/user:pass@legal/privacy"
+    );
+  });
+
+  it("rejects a NON-rooted credentialed href (does not start with `/`)", () => {
+    expect(normalizeInternalRouteHref("user:pass@legal/privacy")).toBeNull();
+  });
+
+  it("rejects a protocol-relative credentialed href (starts with `//`)", () => {
+    expect(
+      normalizeInternalRouteHref("//user:pass@evil.example/legal/privacy")
+    ).toBeNull();
+  });
+
+  it("rejects a credentialed href that contains a newline", () => {
+    expect(
+      normalizeInternalRouteHref("/user:pass@legal\n/privacy")
+    ).toBeNull();
+  });
+
+  it("rejects empty/whitespace-only input regardless of credential intent", () => {
+    expect(normalizeInternalRouteHref("   ")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref` (`hushh-webapp/lib/navigation/routes.ts`) documenting its exact contract when an internal href embeds inline URL-credential blocks (userinfo) such as `user:pass@legal/privacy`. Test-only; no production change.

## Literal code assertion being made

The guard is a pure allow/deny gate over the trimmed string:

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

It does **not** parse URL authority, does **not** recognize `user:pass@` userinfo, and does **not** strip credential blocks. There is no `@`, `:`, or userinfo handling anywhere. The test pins exactly that boundary:

- a rooted href with an inline `user:pass@` block is returned **byte-for-byte** (`/user:pass@legal/privacy`) — credentials retained, not filtered
- the credential segment is not stripped (`user:pass@` and `legal/privacy` both remain)
- username-only userinfo (`/admin@dashboard/settings`) is retained verbatim
- an empty-credential `@` prefix (`/@legal/privacy`) is retained verbatim
- multiple `@`/`:` credential-looking tokens (`/a:b@c:d@legal/privacy`) are retained verbatim
- leading/trailing whitespace is trimmed while the inner credential block stays intact
- the deny rules are unchanged by credentials: a non-rooted `user:pass@...` → `null` (no leading `/`); a protocol-relative `//user:pass@host/...` → `null` (leading `//`); an embedded newline → `null`; whitespace-only input → `null`

The boundary in one line: `normalizeInternalRouteHref` neither flags nor strips inline credentials — it only enforces trim + single-leading-slash + no-CRLF, treating any credential block as opaque path text.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...` and `npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is `@/lib/navigation/routes`. The file therefore lives at `hushh-webapp/__tests__/navigation/normalize-auth-stripping.test.ts` and imports via the `@/` alias. (The task example `'user:pass'legal/privacy''` is also not a real repo file — no such path exists; it is interpreted as the conceptual `user:pass@legal/privacy` userinfo case.)

## Verification

- `npm test -- __tests__/navigation/normalize-auth-stripping.test.ts` → 10/10 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real, existing behavioral boundary (no userinfo parsing/stripping; identity-on-allow, null-on-deny)
- [x] Strict Literal Mapping — branch name, commit message, and PR title match verbatim; description states the literal code assertions
