### PR TITLE
test(utils): characterize formatCompleteJson array nested object string JSON-lookahead breaks

### DIFF
--- a/hushh-webapp/__tests__/utils/format-lookahead-breaks.test.ts
+++ b/hushh-webapp/__tests__/utils/format-lookahead-breaks.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+/**
+ * Characterization tests for formatCompleteJson
+ * (hushh-webapp/lib/utils/json-to-human.ts) when an object's STRING values
+ * contain literal stringified JSON structural delimiters
+ * (e.g. a value like { "a": [1, 2] } or raw closing runs like }}]] ).
+ *
+ * TRUTH-FIRST (verified against the source):
+ *   formatCompleteJson is a plain recursive WALK over the already-parsed object
+ *   graph. String leaves flow through formatValue(key, value) ->
+ *   cleanMarkdown(value), whose ONLY transforms are: remove triple-asterisk
+ *   (bold+italic) markers, remove double-asterisk (bold) markers, remove single
+ *   asterisk (italic) markers, remove code backticks, then trim() surrounding
+ *   whitespace.
+ *   There is NO JSON re-parsing, NO bracket/brace/colon/comma lookahead, NO
+ *   delimiter balancing, and NO whitespace collapsing inside the value. JSON
+ *   structural characters (curly braces, square brackets, colon, comma) are NOT
+ *   in cleanMarkdown's character class, so they pass through untouched.
+ *   Consequences pinned below:
+ *     - A value that is a stringified JSON object/array is emitted verbatim
+ *       (only outer whitespace trimmed) -- no special tracking or layout break.
+ *     - Raw closing runs like }}]] survive unchanged.
+ *     - The line shape stays the flat "  <Label>: <value>" form regardless of
+ *       how "JSON-like" the value text is.
+ *     - The ONLY mutation is markdown/backtick stripping + trim; asterisks that
+ *       happen to sit inside JSON-looking text are still removed.
+ */
+
+describe("formatCompleteJson — stringified JSON delimiters in values are passed through", () => {
+  it("emits a stringified JSON object value verbatim (inner spacing preserved)", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: '{ "a": [1, 2] }' },
+    });
+    expect(out).toBe(
+      '\n--- Account Information ---\n  Account Type: { "a": [1, 2] }'
+    );
+  });
+
+  it("preserves a raw closing-delimiter run unchanged", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: "tail}}]]" },
+    });
+    expect(out).toBe("\n--- Account Information ---\n  Account Type: tail}}]]");
+  });
+
+  it("does not collapse internal whitespace inside a JSON-looking value", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: '{   "x":    [ 1 ,  2 ] }' },
+    });
+    expect(out).toBe(
+      '\n--- Account Information ---\n  Account Type: {   "x":    [ 1 ,  2 ] }'
+    );
+  });
+
+  it("keeps a top-level scalar JSON-looking string intact", () => {
+    const out = formatCompleteJson({ total_value: '[{"k": "v"}]' } as Record<
+      string,
+      unknown
+    >);
+    // total_value is a CURRENCY field, but currency formatting only applies to
+    // numbers; a string flows through formatValue -> cleanMarkdown unchanged.
+    expect(out).toBe('Total Portfolio Value: [{"k": "v"}]');
+  });
+
+  it("preserves delimiters but still strips markdown asterisks/backticks + trims", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: '  `{ "a": **[1, 2]** }`  ' },
+    });
+    expect(out).toBe(
+      '\n--- Account Information ---\n  Account Type: { "a": [1, 2] }'
+    );
+  });
+
+  it("passes structural delimiters through at nested object depth", () => {
+    const out = formatCompleteJson({
+      account_metadata: { nested: { account_type: '{"deep": [null]}' } },
+    });
+    expect(out).toBe(
+      '\n--- Account Information ---\n  Nested:\n    • Account Type: {"deep": [null]}'
+    );
+  });
+
+  it("treats a stringified-JSON value inside a generic array as opaque text", () => {
+    const out = formatCompleteJson({
+      misc: [{ note: '{"a":[1,2]}' }],
+    } as Record<string, unknown>);
+    // Generic array branch prints the first defined value via String(...).
+    expect(out).toBe('\n--- Misc (1 items) ---\n  • {"a":[1,2]}');
+  });
+
+  it("never throws and returns a string for delimiter-heavy values", () => {
+    expect(() =>
+      formatCompleteJson({
+        account_metadata: { account_type: '}}]]{{[[":,:,' },
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`) documenting its exact contract when an object's **string values** contain literal stringified JSON structural delimiters (e.g. a value like `{ "a": [1, 2] }` or raw closing runs like `}}]]`). Test-only; no production change.

## Literal code assertion being made

`formatCompleteJson` is a plain recursive **walk** over the already-parsed object graph. String leaves flow through `formatValue(key, value)` → `cleanMarkdown(value)`, whose only transforms are:

```ts
text
  .replace(/\*\*\*/g, '')  // bold+italic markers
  .replace(/\*\*/g, '')    // bold markers
  .replace(/\*/g, '')      // italic markers
  .replace(/`/g, '')       // code backticks
  .trim();                 // surrounding whitespace
```

There is **no** JSON re-parsing, **no** bracket/brace/colon/comma lookahead, **no** delimiter balancing, and **no** internal-whitespace collapsing. JSON structural characters (`{ } [ ] : ,`) are not in `cleanMarkdown`'s character class, so they pass through untouched. The 8 tests pin exactly that boundary:

- a stringified JSON object value is emitted **verbatim** (`Account Type: { "a": [1, 2] }`) — no special tracking, no layout break
- a raw closing-delimiter run `tail}}]]` survives unchanged
- internal whitespace inside a JSON-looking value is **not** collapsed (`{   "x":    [ 1 ,  2 ] }` preserved)
- a top-level scalar JSON-looking string is intact (currency formatting only applies to numbers, so a string passes through unchanged)
- delimiters are preserved **while** markdown asterisks/backticks are still stripped and the value trimmed (`` `{ "a": **[1, 2]** }` `` → `{ "a": [1, 2] }`)
- structural delimiters pass through at nested object depth (`{"deep": [null]}`)
- a stringified-JSON value inside a generic array is treated as opaque text via `String(...)`
- a delimiter-heavy value never throws

The boundary in one line: `formatCompleteJson` performs no JSON-aware lookahead on string contents — it emits string leaves as-is apart from markdown/backtick stripping + trim, so embedded JSON delimiters are inert path text.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...` and `npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is `@/lib/utils/json-to-human`. The file therefore lives at `hushh-webapp/__tests__/utils/format-lookahead-breaks.test.ts` and imports via the `@/` alias.

## Verification

- `npm test -- __tests__/utils/format-lookahead-breaks.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real, existing behavioral boundary (no JSON lookahead/balancing; identity-apart-from-markdown-strip)
- [x] Strict Literal Mapping — branch name, commit message, and PR title match verbatim; description states the literal code assertions
