### PR TITLE
test(navigation): characterize normalizeInternalRouteHref multi-token question mark query clashes

### DIFF
--- a/hushh-webapp/__tests__/navigation/normalize-query-clashes.test.ts
+++ b/hushh-webapp/__tests__/navigation/normalize-query-clashes.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+/**
+ * Characterization tests for normalizeInternalRouteHref
+ * (hushh-webapp/lib/navigation/routes.ts) when a query string is positioned
+ * BEFORE what look like routing directories
+ * (e.g. /search?q=open/legal/privacy).
+ *
+ * TRUTH-FIRST (verified against the source):
+ *   normalizeInternalRouteHref is a pure allow/deny gate over the trimmed
+ *   string:
+ *     const href = String(value ?? "").trim();
+ *     if (!href) return null;
+ *     if (!href.startsWith("/") || href.startsWith("//")) return null;
+ *     if (/[\r\n]/.test(href)) return null;
+ *     return href;
+ *   It does NOT parse query strings, does NOT split on "?", does NOT segment on
+ *   "/", and does NOT reorder/escape anything. A "?" and any "/" after it are
+ *   ordinary characters inside the opaque path string. Consequences pinned:
+ *     - A rooted href whose query precedes directory-looking text is returned
+ *       BYTE-FOR-BYTE (no query/segment separation, no breaking into markers).
+ *     - The slashes after "?" are NOT treated as distinct segment markers;
+ *       the whole tail is retained as one literal string.
+ *     - Deny rules are unaffected by query content: missing leading slash and
+ *       protocol-relative "//" still return null; CRLF still returns null.
+ *     - The ONLY mutation is outer trim().
+ */
+
+describe("normalizeInternalRouteHref — query strings clashing with directory markers", () => {
+  it("returns a query-before-directories href byte-for-byte", () => {
+    expect(normalizeInternalRouteHref("/search?q=open/legal/privacy")).toBe(
+      "/search?q=open/legal/privacy"
+    );
+  });
+
+  it("does not split the tail into segments after the question mark", () => {
+    const out = normalizeInternalRouteHref("/search?q=a/b/c/d");
+    expect(out).toBe("/search?q=a/b/c/d");
+    // No segmentation occurred: the post-"?" slashes are still literal.
+    expect(out).toContain("?q=a/b/c/d");
+  });
+
+  it("retains multiple question marks and slashes verbatim", () => {
+    expect(
+      normalizeInternalRouteHref("/search?q=open/legal?ref=x/y/privacy")
+    ).toBe("/search?q=open/legal?ref=x/y/privacy");
+  });
+
+  it("preserves a query that itself contains an encoded slash and a raw slash", () => {
+    expect(
+      normalizeInternalRouteHref("/search?path=%2Fdeep/legal/privacy")
+    ).toBe("/search?path=%2Fdeep/legal/privacy");
+  });
+
+  it("trims surrounding whitespace but keeps the inner query/path intact", () => {
+    expect(
+      normalizeInternalRouteHref("  /search?q=open/legal/privacy  ")
+    ).toBe("/search?q=open/legal/privacy");
+  });
+
+  it("rejects a query-leading href with no leading slash", () => {
+    expect(normalizeInternalRouteHref("search?q=open/legal/privacy")).toBeNull();
+  });
+
+  it("rejects a protocol-relative href even when a query follows", () => {
+    expect(
+      normalizeInternalRouteHref("//host/search?q=open/legal/privacy")
+    ).toBeNull();
+  });
+
+  it("rejects an embedded newline inside the query tail", () => {
+    expect(
+      normalizeInternalRouteHref("/search?q=open\n/legal/privacy")
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `normalizeInternalRouteHref` (`hushh-webapp/lib/navigation/routes.ts`) documenting its exact contract when a query string is positioned **before** directory-looking text (e.g. `/search?q=open/legal/privacy`). Test-only; no production change.

## Literal code assertion being made

The guard is a pure allow/deny gate over the trimmed string:

```ts
const href = String(value ?? "").trim();
if (!href) return null;
if (!href.startsWith("/") || href.startsWith("//")) return null;
if (/[\r\n]/.test(href)) return null;
return href;
```

It does **not** parse query strings, does **not** split on `?`, does **not** segment on `/`, and does **not** reorder/escape anything. A `?` and any `/` after it are ordinary characters inside the opaque path string. The 8 tests pin exactly that boundary:

- a rooted query-before-directories href is returned **byte-for-byte** (`/search?q=open/legal/privacy`) — no query/segment separation
- the post-`?` slashes are **not** broken into distinct segment markers; the whole tail is one literal string (`/search?q=a/b/c/d`)
- multiple `?` and `/` tokens are retained verbatim (`/search?q=open/legal?ref=x/y/privacy`)
- a query containing both an encoded `%2F` and a raw `/` is preserved unchanged
- leading/trailing whitespace is trimmed while the inner query/path stays intact
- deny rules are unaffected by query content: no leading slash → `null`; protocol-relative `//host/search?...` → `null`; embedded newline in the query tail → `null`

The boundary in one line: `normalizeInternalRouteHref` treats the query and any trailing directory-looking text as inert opaque path bytes — it neither parses nor segments them, applying only trim + single-leading-slash + no-`//` + no-CRLF gating.

## Truth-first scope note

The original task referenced `hushh-research/__tests__/navigation/...` and `npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is `@/lib/navigation/routes`. The file therefore lives at `hushh-webapp/__tests__/navigation/normalize-query-clashes.test.ts` and imports via the `@/` alias.

## Verification

- `npm test -- __tests__/navigation/normalize-query-clashes.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real, existing behavioral boundary (no query parsing/segmentation; identity-on-allow, null-on-deny)
- [x] Strict Literal Mapping — branch name, commit message, and PR title match verbatim; description states the literal code assertions
