### PR TITLE
test(utils): characterize formatCompleteJson array key density carriage return buffering

### DIFF
--- a/hushh-webapp/__tests__/utils/format-carriage-buffering.test.ts
+++ b/hushh-webapp/__tests__/utils/format-carriage-buffering.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+/**
+ * Characterization tests for formatCompleteJson
+ * (hushh-webapp/lib/utils/json-to-human.ts) when object string values contain
+ * raw Windows-style carriage-return line endings (CR LF) injected throughout
+ * the dictionary structures.
+ *
+ * TRUTH-FIRST (verified against the source):
+ *   formatCompleteJson builds its output from STATIC literal indentation
+ *   prefixes and joins every line with a literal "\n":
+ *     - object fields:   "  " + Label + ": " + value
+ *     - nested fields:   "    \u2022 " + Label + ": " + value
+ *     - array items:     "  \u2022 " + value
+ *     - section header:  "--- Label ---" (preceded by an empty "" line)
+ *     - final assembly:  lines.join("\n")
+ *   There is NO indentation-alignment computation, NO terminal/platform
+ *   detection, and NO CR/LF normalization. The ONLY mutation applied to string
+ *   values is cleanMarkdown(value) -> ... .trim(), which strips markdown markers
+ *   and OUTER whitespace (so leading/trailing CR LF are removed) but leaves
+ *   INTERIOR CR LF untouched. Consequences pinned below:
+ *     - The structural line separator is always "\n" (LF), never "\r\n", on any
+ *       platform -- so the output is platform-stable by construction.
+ *     - Interior "\r\n" inside a string value survives verbatim, embedding raw
+ *       CR LF in the middle of an otherwise statically-indented line.
+ *     - Leading/trailing "\r\n" around a string value is removed by trim().
+ *     - Generic-array branch uses String(...) WITHOUT trim, so even outer
+ *       "\r\n" survives there.
+ *     - Static indentation prefixes are emitted regardless of CR LF content.
+ */
+
+const CRLF = "\r\n";
+
+describe("formatCompleteJson — raw CR LF buffering in string values", () => {
+  it("joins structural lines with LF only (never CR LF) on any platform", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: "Brokerage" },
+    });
+    expect(out).toBe("\n--- Account Information ---\n  Account Type: Brokerage");
+    expect(out).not.toContain(CRLF);
+  });
+
+  it("preserves interior CR LF inside an object field value verbatim", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: `Line1${CRLF}Line2` },
+    });
+    expect(out).toBe(
+      `\n--- Account Information ---\n  Account Type: Line1${CRLF}Line2`
+    );
+  });
+
+  it("trims leading/trailing CR LF around a value but keeps the static indent", () => {
+    const out = formatCompleteJson({
+      account_metadata: { account_type: `${CRLF}${CRLF}Brokerage${CRLF}` },
+    });
+    expect(out).toBe("\n--- Account Information ---\n  Account Type: Brokerage");
+  });
+
+  it("keeps interior CR LF while still applying the nested bullet indent", () => {
+    const out = formatCompleteJson({
+      account_metadata: { nested: { account_type: `A${CRLF}B` } },
+    });
+    expect(out).toBe(
+      `\n--- Account Information ---\n  Nested:\n    \u2022 Account Type: A${CRLF}B`
+    );
+  });
+
+  it("emits CR LF-laden values across multiple fields with stable static prefixes", () => {
+    const out = formatCompleteJson({
+      account_metadata: {
+        institution_name: `Acme${CRLF}Bank`,
+        account_type: `Roth${CRLF}IRA`,
+      },
+    });
+    expect(out).toBe(
+      [
+        "",
+        "--- Account Information ---",
+        `  Institution: Acme${CRLF}Bank`,
+        `  Account Type: Roth${CRLF}IRA`,
+      ].join("\n")
+    );
+  });
+
+  it("retains CR LF in a generic-array value via String() without trimming", () => {
+    const out = formatCompleteJson({
+      misc: [{ note: `${CRLF}row${CRLF}` }],
+    } as Record<string, unknown>);
+    // Generic array branch prints the first defined value with String(...),
+    // which does NOT trim, so outer CR LF survives too.
+    expect(out).toBe(`\n--- Misc (1 items) ---\n  \u2022 ${CRLF}row${CRLF}`);
+  });
+
+  it("keeps a top-level scalar string's interior CR LF intact", () => {
+    const out = formatCompleteJson({ account_type: `X${CRLF}Y` } as Record<
+      string,
+      unknown
+    >);
+    expect(out).toBe(`Account Type: X${CRLF}Y`);
+  });
+
+  it("never throws for CR LF-dense structures and returns a string", () => {
+    expect(() =>
+      formatCompleteJson({
+        account_metadata: {
+          account_type: `${CRLF}${CRLF}a${CRLF}b${CRLF}${CRLF}`,
+        },
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated characterization test for `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`) documenting its exact contract when object string values contain raw Windows-style carriage-return line endings (CR LF) injected throughout the dictionary structures. Test-only; no production change.

## Literal code assertion being made

`formatCompleteJson` builds output from **static literal indentation prefixes** and joins every line with a literal `\n`:

- object fields: `"  " + Label + ": " + value`
- nested fields: `"    • " + Label + ": " + value`
- generic array items: `"  • " + value`
- section header: `"--- Label ---"` preceded by an empty `""` line
- final assembly: `lines.join("\n")`

There is **no** indentation-alignment computation, **no** terminal/platform detection, and **no** CR/LF normalization. The only mutation applied to string values is `cleanMarkdown(value) → … .trim()`, which strips markdown markers and **outer** whitespace (so leading/trailing CR LF are removed) but leaves **interior** CR LF untouched. The 8 tests pin exactly that boundary:

- structural lines are joined with **LF only** (never CR LF) on any platform — output is platform-stable by construction
- interior `\r\n` inside an object field value survives **verbatim** in the middle of an otherwise statically-indented line
- leading/trailing `\r\n` around a value is removed by `trim()` while the static `  ` indent is still emitted
- interior `\r\n` is preserved at nested-object depth while the `    • ` bullet indent is applied
- multiple CR LF-laden fields all keep stable static prefixes
- the generic-array branch uses `String(...)` **without** trim, so even outer `\r\n` survives there
- a top-level scalar string's interior `\r\n` stays intact
- CR LF-dense structures never throw

The boundary in one line: indentation is fixed static text and lines are always LF-joined regardless of OS, so platform stability is structural; CR LF inside string values is inert content — interior CR LF is preserved and only outer CR LF is trimmed (except in the untrimmed generic-array path).

## Truth-first scope note

The original task referenced `hushh-research/__tests__/utils/...` and `npm test -- hushh-research/...`. There is no top-level `__tests__` in this repo; vitest only includes `__tests__/**` under `hushh-webapp`, and the module alias is `@/lib/utils/json-to-human`. The file therefore lives at `hushh-webapp/__tests__/utils/format-carriage-buffering.test.ts` and imports via the `@/` alias. The task framing of "aligns indentation blocks … across differing terminal execution platforms" is corrected to the real behavior: there is no alignment/terminal logic — stability comes from static prefixes plus a fixed LF join.

## Verification

- `npm test -- __tests__/utils/format-carriage-buffering.test.ts` → 8/8 pass
- `git status` limited to the single new test file; zero production source drift
- (An IDE-only `@/` module-resolution warning is a false positive — the alias resolves under vitest, as the passing run confirms.)

## CI gate checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change — zero production runtime risk
- [x] Truth-First — documents the real behavioral boundary (static indent + LF join; interior CR LF preserved, outer trimmed)
- [x] Strict Literal Mapping — branch name, commit message, and PR title match verbatim; description states the literal code assertions
