### PR TITLE
fix(agent): exclude runtime secrets from PKM prompt context

### DIFF
--- a/hushh-webapp/__tests__/agent/agent-pkm-context-store.test.ts
+++ b/hushh-webapp/__tests__/agent/agent-pkm-context-store.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { buildContextText } from "../../lib/agent/agent-pkm-context-store";
+
+type WorkingSet = Parameters<typeof buildContextText>[0]["workingSet"];
+
+function createWorkingSet(overrides: Partial<WorkingSet> = {}): WorkingSet {
+  return {
+    userId: "user_123",
+    metadata: {
+      domains: [],
+      totalAttributes: 0,
+      totalSegments: 0,
+    } as any,
+    fullBlob: {},
+    memorySnapshot: {
+      cards: [],
+      domainInsights: [],
+      totalCards: 0,
+    } as any,
+    loadedAt: Date.now(),
+    metadataUpdatedAt: new Date().toISOString(),
+    ...overrides,
+  } as WorkingSet;
+}
+
+describe("agent-pkm-context-store", () => {
+  describe("buildContextText", () => {
+    it("excludes runtime_secrets from the generated context text", () => {
+      const workingSet = createWorkingSet({
+        metadata: {
+          domains: [
+            {
+              key: "runtime_secrets",
+              attributeCount: 5,
+              readableSummary: "Runtime configuration",
+            },
+            {
+              key: "financial",
+              attributeCount: 2,
+              readableSummary: "Financial details",
+            },
+          ] as any,
+        } as any,
+        fullBlob: {
+          runtime_secrets: {
+            llm: {
+              gemini_api_key: "SECRET_VALUE_123",
+            },
+          },
+          financial: {
+            accounts: ["Checking"],
+          },
+        },
+        memorySnapshot: {
+          cards: [
+            {
+              domain: "runtime_secrets",
+              title: "Gemini Api Key: SECRET_VALUE_123",
+              value: "SECRET_VALUE_123",
+              detail: "Stored in Runtime Secrets > Llm > Gemini Api Key",
+              searchText: "runtime_secrets llm gemini_api_key secret_value_123",
+              confidence: 0.88,
+              kind: "preference",
+              sourceLabel: "Saved memory",
+            } as any,
+            {
+              domain: "financial",
+              title: "Checking Account: Active",
+              value: "Active",
+              detail: "Stored in Financial > Accounts",
+              searchText: "financial accounts active",
+              confidence: 0.88,
+              kind: "financial",
+              sourceLabel: "Saved memory",
+            } as any,
+          ],
+          domainInsights: [
+            {
+              domain: "runtime_secrets",
+              title: "Runtime Secrets",
+              summary: "Updated Gemini Api Key",
+              cardCount: 1,
+              highlights: ["Updated Gemini Api Key"],
+            },
+            {
+              domain: "financial",
+              title: "Financial",
+              summary: "Financial records",
+              cardCount: 1,
+              highlights: [],
+            },
+          ] as any,
+        } as any,
+      });
+
+      const context = buildContextText({
+        workingSet,
+        message: "Hello",
+        maxChars: 16000,
+      });
+
+      const text = context.text;
+
+      // Verify that runtime_secrets is completely excluded
+      expect(text).not.toContain("runtime_secrets");
+      expect(text).not.toContain("Gemini");
+      expect(text).not.toContain("SECRET_VALUE_123");
+      expect(text).not.toContain("Runtime Secrets");
+      expect(text).not.toContain("Updated Gemini Api Key");
+
+      // Verify that other domains are still included
+      expect(text).toContain("financial");
+      expect(text).toContain("Financial");
+      expect(text).toContain("Checking");
+    });
+  });
+});

--- a/hushh-webapp/lib/agent/agent-pkm-context-store.ts
+++ b/hushh-webapp/lib/agent/agent-pkm-context-store.ts
@@ -38,6 +38,10 @@ const MAX_VALUE_CHARS = 260;
 const MAX_ARRAY_ITEMS = 8;
 const MAX_DEPTH = 5;
 
+const EXCLUDED_PROMPT_DOMAINS = new Set([
+  "runtime_secrets",
+]);
+
 const workingSets = new Map<string, AgentPkmWorkingSet>();
 
 function compactWhitespace(value: unknown): string {
@@ -184,7 +188,7 @@ function scoreLine(
 function domainSummaryLines(metadata: PersonalKnowledgeModelMetadata | null): string[] {
   if (!metadata?.domains?.length) return [];
   return metadata.domains
-    .filter((domain) => domain.attributeCount > 0 || domain.readableSummary)
+    .filter((domain) => !EXCLUDED_PROMPT_DOMAINS.has(domain.key) && (domain.attributeCount > 0 || domain.readableSummary))
     .map((domain) => {
       const summary =
         clip(domain.readableSummary, 220) ||
@@ -209,7 +213,7 @@ function memoryDomainSummaryLines(workingSet: AgentPkmWorkingSet): string[] {
     return domainSummaryLines(workingSet.metadata);
   }
   return workingSet.memorySnapshot.domainInsights
-    .filter((domain) => domain.cardCount > 0 || domain.summary)
+    .filter((domain) => !EXCLUDED_PROMPT_DOMAINS.has(domain.domain) && (domain.cardCount > 0 || domain.summary))
     .map((domain) =>
       [
         `- ${domain.title} (${domain.domain})`,
@@ -224,7 +228,7 @@ function memoryDomainSummaryLines(workingSet: AgentPkmWorkingSet): string[] {
     );
 }
 
-function buildContextText(params: {
+export function buildContextText(params: {
   workingSet: AgentPkmWorkingSet;
   message: string;
   maxChars: number;
@@ -240,15 +244,18 @@ function buildContextText(params: {
       ...(workingSet.metadata?.domains.map((domain) => domain.key).filter(Boolean) || []),
       ...Object.keys(workingSet.fullBlob || {}),
     ])
-  );
+  ).filter((domain) => !EXCLUDED_PROMPT_DOMAINS.has(domain));
 
   const allLines = domainKeys.flatMap((domain) =>
     flattenDomain(domain, (workingSet.fullBlob || {})[domain], promptTokens)
   );
+  const safeCards = workingSet.memorySnapshot.cards.filter(
+    (card) => !EXCLUDED_PROMPT_DOMAINS.has(card.domain)
+  );
   const relevantMemoryCards =
     mode === "broad"
-      ? workingSet.memorySnapshot.cards.slice(0, 42)
-      : selectRelevantPkmMemoryCards(workingSet.memorySnapshot.cards, params.message, 24);
+      ? safeCards.slice(0, 42)
+      : selectRelevantPkmMemoryCards(safeCards, params.message, 24);
   const selectedLines =
     mode === "broad"
       ? allLines.slice(0, MAX_DETAIL_LINES)


### PR DESCRIPTION
## Summary

Exclude the `runtime_secrets` domain from conversational PKM prompt generation.

Previously, runtime-only secrets could be serialized into the agent prompt through multiple independent prompt serialization paths. This change ensures runtime secrets remain available for runtime use while preventing them from being included in conversational context.

## Changes

* Introduce a centralized `EXCLUDED_PROMPT_DOMAINS` set.
* Exclude `runtime_secrets` from:

  * flattened PKM serialization (`buildContextText`)
  * metadata fallback domain summaries (`domainSummaryLines`)
  * memory snapshot domain summaries (`memoryDomainSummaryLines`)
  * memory-card selection before prompt generation (`selectRelevantPkmMemoryCards`)
* Add a regression test covering all prompt serialization paths.

## Validation

* Verified through runtime inspection that `pkm_context` no longer includes:

  * `runtime_secrets`
  * `Runtime Secrets`
  * `Gemini Api Key`
  * `Updated Gemini Api Key`
  * decrypted runtime secret values
* Added a regression test with both `runtime_secrets` and non-sensitive memory cards.
* Confirmed that safe domains continue to appear while runtime secrets are excluded.
* Ran:

  * `npx vitest run __tests__/agent/agent-pkm-context-store.test.ts`

## Scope

This PR only changes conversational prompt serialization. It does **not** modify:

* vault persistence
* runtime secret storage
* encryption/decryption
* PKM Explorer
* backend runtime credential handling
* BYOK runtime wiring
