### PR TITLE
test(asset-allocation-donut): cover chart accessible label

### DIFF
--- a/hushh-webapp/__tests__/components/asset-allocation-donut.test.tsx
+++ b/hushh-webapp/__tests__/components/asset-allocation-donut.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AssetAllocationDonut } from "@/components/kai/charts/asset-allocation-donut";
+
+describe("AssetAllocationDonut", () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = class ResizeObserver {
+      disconnect = vi.fn();
+      observe = vi.fn();
+      unobserve = vi.fn();
+    };
+  });
+
+  it("covers chart accessible label", () => {
+    render(
+      <AssetAllocationDonut
+        data={[
+          { name: "Equities", value: 7500, color: "#2563eb" },
+          { name: "Cash", value: 2500, color: "#0ea5e9" },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Asset allocation chart" }),
+    ).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/kai/charts/asset-allocation-donut.tsx
+++ b/hushh-webapp/components/kai/charts/asset-allocation-donut.tsx
@@ -136,7 +136,13 @@ export function AssetAllocationDonut({
 
   return (
     <div className={cn("w-full min-w-0 overflow-hidden", className)}>
-      <ChartContainer config={chartConfig} className="mx-auto w-full min-w-0" style={{ height }}>
+      <ChartContainer
+        aria-label="Asset allocation chart"
+        config={chartConfig}
+        role="img"
+        className="mx-auto w-full min-w-0"
+        style={{ height }}
+      >
         <PieChart>
           <ChartTooltip
             cursor={false}


### PR DESCRIPTION
## Summary
- Adds an explicit accessible label to the asset allocation donut chart.
- Covers that label with a focused component test.

## Reviewer Proof
- Surface: AssetAllocationDonut chart and its focused test only.
- Production contract: renders the real chart component; no module mocks.
- No overlap: new focused test file plus the chart aria contract it asserts.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions