### PR TITLE
test(progress): cover data-slot contract and value clamping

### DIFF
--- a/hushh-webapp/__tests__/components/progress.test.tsx
+++ b/hushh-webapp/__tests__/components/progress.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Progress } from "@/components/ui/progress";
+
+describe("Progress", () => {
+  it("renders with data-slot=progress", () => {
+    const { container } = render(<Progress value={50} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("progress");
+  });
+
+  it("clamps value to 100 when over", () => {
+    const { container } = render(<Progress value={150} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("clamps value to 0 when negative", () => {
+    const { container } = render(<Progress value={-10} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("aria-valuenow")).toBe("0");
+  });
+});


### PR DESCRIPTION
Covers three contracts on Progress:
- data-slot="progress" is always present
- value over 100 is clamped to 100
- negative value is clamped to 0

Attach point: hushh-webapp/components/ui/progress.tsx
Single file, single surface.