### PR TITLE
test(pagination): cover navigation role and data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/pagination.test.tsx
+++ b/hushh-webapp/__tests__/components/pagination.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Pagination } from "@/components/ui/pagination";
+
+describe("Pagination", () => {
+  it("renders with navigation role and aria-label", () => {
+    render(<Pagination />);
+    const el = screen.getByRole("navigation", { name: "pagination" });
+    expect(el).toBeDefined();
+  });
+
+  it("renders with data-slot=pagination", () => {
+    const { container } = render(<Pagination />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("pagination");
+  });
+});


### PR DESCRIPTION
Covers two contracts on Pagination:
- renders with role="navigation" and aria-label="pagination"
- data-slot="pagination" is always present

Attach point: hushh-webapp/components/ui/pagination.tsx
Single file, single surface.