### PR TITLE
test(accordion): cover data-slot contract on root and item

### DIFF
--- a/hushh-webapp/__tests__/components/accordion.test.tsx
+++ b/hushh-webapp/__tests__/components/accordion.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
+
+describe("Accordion", () => {
+  it("renders with data-slot=accordion", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Title</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("accordion");
+  });
+
+  it("renders accordion item with data-slot=accordion-item", () => {
+    const { container } = render(
+      <Accordion type="single">
+        <AccordionItem value="item-1">
+          <AccordionTrigger>Title</AccordionTrigger>
+          <AccordionContent>Content</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+    const item = container.querySelector("[data-slot='accordion-item']");
+    expect(item).toBeDefined();
+  });
+});


### PR DESCRIPTION
Covers two data-slot contracts on Accordion:
- data-slot="accordion" on the root element
- data-slot="accordion-item" on each item

Attach point: hushh-webapp/components/ui/accordion.tsx
Single file, single surface.