### PR TITLE
test(select): cover select-trigger data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/select.test.tsx
+++ b/hushh-webapp/__tests__/components/select.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+
+describe("Select", () => {
+  it("renders trigger with data-slot=select-trigger", () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">Option A</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+    const trigger = container.querySelector("[data-slot='select-trigger']");
+    expect(trigger).toBeDefined();
+  });
+});


### PR DESCRIPTION
Covers the data-slot="select-trigger" contract on SelectTrigger.

Attach point: hushh-webapp/components/ui/select.tsx
Single file, single surface.