### PR TITLE
test(tabs): cover data-slot and default orientation contract

### DIFF
--- a/hushh-webapp/__tests__/components/tabs.test.tsx
+++ b/hushh-webapp/__tests__/components/tabs.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+
+describe("Tabs", () => {
+  it("renders with data-slot=tabs", () => {
+    const { container } = render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">Tab A</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">Content A</TabsContent>
+      </Tabs>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("tabs");
+  });
+
+  it("renders with horizontal orientation by default", () => {
+    const { container } = render(
+      <Tabs defaultValue="a">
+        <TabsList>
+          <TabsTrigger value="a">Tab A</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">Content A</TabsContent>
+      </Tabs>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-orientation")).toBe("horizontal");
+  });
+});


### PR DESCRIPTION
Covers two contracts on Tabs:
- data-slot="tabs" on the root element
- data-orientation="horizontal" by default

Attach point: hushh-webapp/components/ui/tabs.tsx
Single file, single surface.