### PR TITLE
test(tooltip): cover tooltip-provider data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/tooltip.test.tsx
+++ b/hushh-webapp/__tests__/components/tooltip.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+
+describe("TooltipProvider", () => {
+  it("renders with data-slot=tooltip-provider", () => {
+    const { container } = render(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>Hover me</TooltipTrigger>
+          <TooltipContent>Tip</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-slot")).toBe("tooltip-provider");
+  });
+});


### PR DESCRIPTION
Covers the data-slot="tooltip-provider" contract on TooltipProvider.

Attach point: hushh-webapp/components/ui/tooltip.tsx
Single file, single surface.