### PR TITLE
test(popover): cover trigger type=button and data-slot contract

### DIFF
--- a/hushh-webapp/__tests__/components/popover.test.tsx
+++ b/hushh-webapp/__tests__/components/popover.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+
+describe("PopoverTrigger", () => {
+  it("renders with type=button to prevent accidental form submission", () => {
+    render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Content</PopoverContent>
+      </Popover>
+    );
+    const trigger = screen.getByRole("button", { name: "Open" });
+    expect(trigger.getAttribute("type")).toBe("button");
+  });
+
+  it("renders with data-slot=popover-trigger", () => {
+    const { container } = render(
+      <Popover>
+        <PopoverTrigger>Open</PopoverTrigger>
+        <PopoverContent>Content</PopoverContent>
+      </Popover>
+    );
+    const el = container.querySelector("[data-slot='popover-trigger']");
+    expect(el).toBeDefined();
+  });
+});


### PR DESCRIPTION
Covers two contracts on PopoverTrigger:
- type="button" prevents accidental form submission
- data-slot="popover-trigger" is always present

Attach point: hushh-webapp/components/ui/popover.tsx
Single file, single surface.