### PR TITLE
test(debate-readiness-chart): cover readiness score rendering

### DIFF
--- a/hushh-webapp/__tests__/components/debate-readiness-chart.test.tsx
+++ b/hushh-webapp/__tests__/components/debate-readiness-chart.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { DebateReadinessChart } from "@/components/kai/charts/debate-readiness-chart";
+
+describe("DebateReadinessChart", () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = class ResizeObserver {
+      disconnect = vi.fn();
+      observe = vi.fn();
+      unobserve = vi.fn();
+    };
+  });
+
+  it("covers readiness score rendering", () => {
+    render(
+      <DebateReadinessChart
+        data={[{ key: "coverage", label: "Coverage", value: 82 }]}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Coverage: 82%" })).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/kai/charts/debate-readiness-chart.tsx
+++ b/hushh-webapp/components/kai/charts/debate-readiness-chart.tsx
@@ -42,9 +42,15 @@ function clampCoverage(value: number): number {
 export function DebateReadinessChart({ data, className }: DebateReadinessChartProps) {
   if (data.length === 0) return null;
 
+  const readinessLabel = data
+    .map((entry) => `${entry.label}: ${clampCoverage(entry.value).toFixed(0)}%`)
+    .join(", ");
+
   return (
     <ChartContainer
+      aria-label={readinessLabel}
       config={CHART_CONFIG}
+      role="img"
       className={className ?? "h-[236px] w-full rounded-xl border border-border/60 bg-background/70 p-2"}
     >
       <BarChart


### PR DESCRIPTION
## Summary
- Adds an accessible readiness score label to the chart.
- Covers the rendered score with a focused component test.

## Reviewer Proof
- Surface: DebateReadinessChart and its focused test only.
- Production contract: renders the real chart component; no module mocks.
- No overlap: new focused test file plus the chart aria score contract it asserts.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions