### PR TITLE
test(gain-loss-distribution-chart): cover empty distribution fallback

### DIFF
--- a/hushh-webapp/__tests__/components/gain-loss-distribution-chart.test.tsx
+++ b/hushh-webapp/__tests__/components/gain-loss-distribution-chart.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GainLossDistributionChart } from "@/components/kai/charts/gain-loss-distribution-chart";
+
+describe("GainLossDistributionChart", () => {
+  it("covers empty distribution fallback", () => {
+    render(<GainLossDistributionChart data={[]} />);
+
+    expect(screen.getByText("Gain/Loss Distribution")).toBeTruthy();
+    expect(
+      screen.getByText("No gain/loss distribution data available."),
+    ).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/kai/charts/gain-loss-distribution-chart.tsx
+++ b/hushh-webapp/components/kai/charts/gain-loss-distribution-chart.tsx
@@ -58,7 +58,22 @@ export function GainLossDistributionChart({
   );
 
   if (chartData.length === 0) {
-    return null;
+    return (
+      <ChartSurfaceCard
+        title={
+          <span className="flex items-center gap-2">
+            <TrendingUpDown className="h-4 w-4 text-primary" />
+            Gain/Loss Distribution
+          </span>
+        }
+        className={className}
+        contentClassName="space-y-0"
+      >
+        <SurfaceInset className="p-4 text-sm text-muted-foreground">
+          No gain/loss distribution data available.
+        </SurfaceInset>
+      </ChartSurfaceCard>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Adds an empty-state fallback to the gain/loss distribution chart.
- Covers the fallback with a focused component test.

## Reviewer Proof
- Surface: GainLossDistributionChart and its focused test only.
- Production contract: renders the real component; no module mocks.
- No overlap: new focused test file plus the fallback it asserts.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions