### PR TITLE
test(holdings-concentration-chart): cover concentration label rendering

### DIFF
--- a/hushh-webapp/__tests__/components/holdings-concentration-chart.test.tsx
+++ b/hushh-webapp/__tests__/components/holdings-concentration-chart.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { HoldingsConcentrationChart } from "@/components/kai/charts/holdings-concentration-chart";
+
+describe("HoldingsConcentrationChart", () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = class ResizeObserver {
+      disconnect = vi.fn();
+      observe = vi.fn();
+      unobserve = vi.fn();
+    };
+  });
+
+  it("covers concentration label rendering", () => {
+    render(
+      <HoldingsConcentrationChart
+        data={[
+          {
+            symbol: "AAPL",
+            name: "Apple Inc.",
+            marketValue: 12000,
+            weightPct: 12.34,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "AAPL: 12.3%" })).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/kai/charts/holdings-concentration-chart.tsx
+++ b/hushh-webapp/components/kai/charts/holdings-concentration-chart.tsx
@@ -40,6 +40,9 @@ export function HoldingsConcentrationChart({
   className,
 }: HoldingsConcentrationChartProps) {
   const chartData = data.slice(0, 8);
+  const concentrationLabel = chartData
+    .map((entry) => `${entry.symbol}: ${entry.weightPct.toFixed(1)}%`)
+    .join(", ");
   const chartConfig = useMemo<ChartConfig>(
     () => ({
       weightPct: {
@@ -66,7 +69,12 @@ export function HoldingsConcentrationChart({
       contentClassName="space-y-0"
     >
       <SurfaceInset className="min-w-0 overflow-hidden">
-        <ChartContainer config={chartConfig} className="h-[192px] w-full min-w-0 sm:h-[204px]">
+        <ChartContainer
+          aria-label={concentrationLabel}
+          config={chartConfig}
+          role="img"
+          className="h-[192px] w-full min-w-0 sm:h-[204px]"
+        >
           <BarChart
             data={chartData}
             layout="vertical"


### PR DESCRIPTION
## Summary
- Adds an accessible concentration label to HoldingsConcentrationChart.
- Covers the rendered label with a focused component test.

## Proof
- Surface: holdings concentration chart only.
- Contract: renders the real component; no module mocks.
- No overlap: new focused test plus matching chart aria label.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions