### PR TITLE
refactor(profile): use developers route constant

### DIFF
--- a/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
+++ b/hushh-webapp/app/profile/pkm-agent-lab/page-client.tsx
@@ -38,6 +38,7 @@ import { resolveAppEnvironment } from "@/lib/app-env";
 import { ApiService } from "@/lib/services/api-service";
 import { buildReadablePkmMetadata } from "@/lib/personal-knowledge-model/natural-language";
 import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
+import { ROUTES } from "@/lib/navigation/routes";
 import {
   getPersistablePreviewCards,
   getReviewRequiredPreviewCount,
@@ -1130,7 +1131,7 @@ export default function PkmAgentLabPageClient() {
                 description="PKM Agent Lab is restricted to localhost developer runs during this phase."
                 leading={<Code2 className="h-4 w-4 text-amber-500" />}
                 trailing={
-                  <Button variant="none" effect="fade" onClick={() => router.push("/developers")}>
+                  <Button variant="none" effect="fade" onClick={() => router.push(ROUTES.DEVELOPERS)}>
                     Open Developers
                   </Button>
                 }


### PR DESCRIPTION
## Summary

### What

Replaced the hardcoded `"/developers"` navigation in the PKM Agent Lab page with the centralized `ROUTES.DEVELOPERS` constant.

### Why

Using the shared route constants keeps navigation consistent across the application and avoids duplicating route strings.

### Testing

* Verified the button still navigates to the Developers page.
* No functional behavior changed.
