### PR TITLE
refactor(vault): use login route constant

### DIFF
--- a/hushh-webapp/components/vault/vault-lock-guard.tsx
+++ b/hushh-webapp/components/vault/vault-lock-guard.tsx
@@ -28,6 +28,7 @@ import { VaultService } from "@/lib/services/vault-service";
 import { VaultUnlockDialog } from "./vault-unlock-dialog";
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { useStepProgress } from "@/lib/progress/step-progress-context";
+import { ROUTES } from "@/lib/navigation/routes";
 import {
   isSessionUnlockedOnce,
   markSessionUnlocked,
@@ -97,7 +98,7 @@ export function VaultLockGuard({ children }: VaultLockGuardProps) {
 
     if (typeof window !== "undefined") {
       const currentPath = window.location.pathname;
-      router.replace(`/login?redirect=${encodeURIComponent(currentPath)}`);
+      router.replace(`${ROUTES.LOGIN}?redirect=${encodeURIComponent(currentPath)}`);
     }
   }, [authLoading, router, userId]);
 


### PR DESCRIPTION
## Summary

### What

Replace the hardcoded login redirect in `vault-lock-guard.tsx` with the shared `ROUTES.LOGIN` constant while preserving the existing `redirect` query parameter.

### Why

Using the centralized route constant keeps navigation consistent across the application and avoids duplicating route strings, making future route updates easier to maintain.

### Testing

* Verified the login redirect continues to preserve the `redirect` query parameter.
* No functional behavior changed.
