### PR TITLE
refactor(kai): use login route constant for invite redirect

### DIFF
--- a/hushh-webapp/components/kai/onboarding/kai-invite-handshake.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-invite-handshake.tsx
@@ -12,6 +12,7 @@ import {
 import { useAuth } from "@/hooks/use-auth";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { buildOneOnboardingRoute } from "@/lib/navigation/routes";
+import { ROUTES } from "@/lib/navigation/routes";
 import {
   RiaService,
   type RiaInviteResolution,
@@ -98,7 +99,9 @@ export function KaiInviteHandshake({ inviteToken }: { inviteToken: string }) {
   async function acceptInvite() {
     if (!user) {
       router.replace(
-        `/login?redirect=${encodeURIComponent(buildOneOnboardingRoute({ invite: inviteToken }))}`,
+       `${ROUTES.LOGIN}?redirect=${encodeURIComponent(
+         buildOneOnboardingRoute({ invite: inviteToken })
+        )}`,
       );
       return;
     }


### PR DESCRIPTION
## Summary

### What

Replaced the hardcoded login redirect in the Kai invite handshake flow with the shared `ROUTES.LOGIN` constant while preserving the existing `redirect` query parameter.

### Why

Using the centralized route constant keeps navigation consistent across the application and avoids duplicating route strings. Future route changes can be made in a single location.

### Testing

* Verified unauthenticated users are still redirected to the login page.
* Confirmed the original onboarding redirect parameter is preserved.
* No functional behavior changed.