### PR TITLE
test(portfolio-history-chart): cover empty history fallback

### DIFF
--- a/hushh-webapp/__tests__/components/portfolio-history-chart.test.tsx
+++ b/hushh-webapp/__tests__/components/portfolio-history-chart.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PortfolioHistoryChart } from "@/components/kai/charts/portfolio-history-chart";
+
+describe("PortfolioHistoryChart", () => {
+  it("covers empty history fallback", () => {
+    render(
+      <PortfolioHistoryChart
+        data={[]}
+        beginningValue={10000}
+        endingValue={12500}
+        statementPeriod="Jan 1 - Jan 31"
+      />,
+    );
+
+    expect(screen.getByText("Jan 1 - Jan 31")).toBeTruthy();
+    expect(screen.getByText("Beginning Value")).toBeTruthy();
+    expect(screen.getByText("$10,000.00")).toBeTruthy();
+    expect(screen.getByText("Ending Value")).toBeTruthy();
+    expect(screen.getByText("$12,500.00")).toBeTruthy();
+    expect(screen.getByText("$2,500.00 (+25.00%)")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the PortfolioHistoryChart empty-history fallback.
- Asserts the period, value, and change summary copy.

## Proof
- Surface: PortfolioHistoryChart test only.
- Contract: renders the real component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions