### PR TITLE
test(statement-cashflow-chart): cover empty cashflow fallback

### DIFF
--- a/hushh-webapp/__tests__/components/statement-cashflow-chart.test.tsx
+++ b/hushh-webapp/__tests__/components/statement-cashflow-chart.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StatementCashflowChart } from "@/components/kai/charts/statement-cashflow-chart";
+
+describe("StatementCashflowChart", () => {
+  it("covers empty cashflow fallback", () => {
+    render(<StatementCashflowChart data={[]} />);
+
+    expect(screen.getByText("Statement Cashflow Signals")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Cashflow signals will appear after at least two valid statement entries are available.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/kai/charts/statement-cashflow-chart.tsx
+++ b/hushh-webapp/components/kai/charts/statement-cashflow-chart.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/chart";
 import {
   ChartSurfaceCard,
+  FallbackSurfaceCard,
   SurfaceInset,
 } from "@/components/app-ui/surfaces";
 import { cn } from "@/lib/utils";
@@ -58,7 +59,13 @@ export function StatementCashflowChart({
   );
 
   if (rows.length < 2) {
-    return null;
+    return (
+      <FallbackSurfaceCard
+        title="Statement Cashflow Signals"
+        detail="Cashflow signals will appear after at least two valid statement entries are available."
+        className={cn("min-w-0", className)}
+      />
+    );
   }
 
   const chartConfig: ChartConfig = {


### PR DESCRIPTION
## Summary
- Adds a visible empty state for sparse statement cashflow data.
- Covers that fallback with a focused component test.

## Proof
- Surface: StatementCashflowChart only.
- Contract: renders the real component; no module mocks.
- No overlap: chart fallback plus matching focused test.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions