### PR TITLE
test(holding-details-drawer): cover close control button type

### DIFF
--- a/hushh-webapp/__tests__/components/holding-details-drawer.test.tsx
+++ b/hushh-webapp/__tests__/components/holding-details-drawer.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HoldingDetailsDrawer } from "@/components/kai/holdings/holding-details-drawer";
+import type { HoldingMobileCardViewModel } from "@/components/kai/holdings/holding-mobile-card";
+
+const holding: HoldingMobileCardViewModel = {
+  id: "holding-aapl",
+  symbol: "AAPL",
+  name: "Apple Inc.",
+  marketValue: 12000,
+  shares: 24,
+  gainLossValue: 250,
+  gainLossPct: 2.5,
+  averagePrice: 180,
+  currentPrice: 190,
+  portfolioWeightPct: 12.5,
+  sector: "Technology",
+  isCash: false,
+  pendingDelete: false,
+};
+
+describe("HoldingDetailsDrawer", () => {
+  it("covers close control button type", () => {
+    render(
+      <HoldingDetailsDrawer
+        open
+        holding={holding}
+        onOpenChange={vi.fn()}
+        onEdit={vi.fn()}
+        onToggleDelete={vi.fn()}
+      />,
+    );
+
+    const closeButton = screen.getByRole("button", {
+      name: "Close holding details",
+    }) as HTMLButtonElement;
+
+    expect(closeButton.type).toBe("button");
+  });
+});

--- a/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
+++ b/hushh-webapp/components/kai/holdings/holding-details-drawer.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useMemo } from "react";
-import { AlertCircle } from "lucide-react";
-import { Drawer, DrawerContent, DrawerDescription, DrawerFooter, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { AlertCircle, XIcon } from "lucide-react";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
 import { Icon } from "@/lib/morphy-ux/ui";
 import { cn } from "@/lib/utils";
@@ -72,7 +80,19 @@ export function HoldingDetailsDrawer({
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="border-border/70 bg-background/95 backdrop-blur-lg">
+      <DrawerContent className="relative border-border/70 bg-background/95 backdrop-blur-lg">
+        <DrawerClose
+          type="button"
+          aria-label="Close holding details"
+          className={cn(
+            "absolute right-4 top-4 rounded-full p-2 text-muted-foreground",
+            "transition-colors hover:text-foreground focus-visible:outline-none",
+            "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          )}
+        >
+          <XIcon aria-hidden="true" className="size-4" />
+        </DrawerClose>
+
         <DrawerHeader className="sticky top-0 z-10 bg-background/80 px-5 pb-2 text-left backdrop-blur-md">
           {isPending && (
             <div className="mb-2 flex items-center gap-2 rounded-lg bg-rose-500/10 p-2 text-xs text-rose-600">


### PR DESCRIPTION
## Summary
- Adds an explicit close control to HoldingDetailsDrawer.
- Covers its button type with a focused component test.

## Proof
- Surface: HoldingDetailsDrawer only.
- Contract: renders the real component; no module mocks.
- No overlap: drawer close control plus matching focused test.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions