### PR TITLE
test(holding-row-actions): cover menu trigger accessible label

### DIFF
--- a/hushh-webapp/__tests__/components/holding-row-actions.test.tsx
+++ b/hushh-webapp/__tests__/components/holding-row-actions.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HoldingRowActions } from "@/components/kai/holdings/holding-row-actions";
+
+describe("HoldingRowActions", () => {
+  it("covers menu trigger accessible label", () => {
+    render(
+      <HoldingRowActions
+        layout="row"
+        symbol="AAPL"
+        onEdit={vi.fn()}
+        onToggleDelete={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Holding actions for AAPL" }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the HoldingRowActions row menu trigger accessible label.

## Proof
- Surface: HoldingRowActions test only.
- Contract: renders the real component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions