### PR TITLE
test(news-tape): cover empty news fallback

### DIFF
--- a/hushh-webapp/__tests__/components/news-tape.test.tsx
+++ b/hushh-webapp/__tests__/components/news-tape.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { NewsTape } from "@/components/kai/home/news-tape";
+
+describe("NewsTape", () => {
+  it("covers empty news fallback", () => {
+    render(<NewsTape rows={[]} />);
+
+    expect(
+      screen.getByText("No recent market headlines are available right now."),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the NewsTape empty news fallback copy.

## Proof
- Surface: NewsTape test only.
- Contract: renders the real component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions