### PR TITLE
test(sector-rotation-card): cover empty sector rotation fallback

### DIFF
--- a/hushh-webapp/__tests__/components/sector-rotation-card.test.tsx
+++ b/hushh-webapp/__tests__/components/sector-rotation-card.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SectorRotationCard } from "@/components/kai/home/sector-rotation-card";
+
+describe("SectorRotationCard", () => {
+  it("covers empty sector rotation fallback", () => {
+    render(<SectorRotationCard rows={[]} />);
+
+    expect(
+      screen.getByText("Sector movement data is unavailable right now."),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the SectorRotationCard empty fallback copy.

## Proof
- Surface: SectorRotationCard test only.
- Contract: renders the real component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions