### PR TITLE
fix(consent-db): guard audit iteration against empty Supabase responses

### DIFF
--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -446,7 +446,7 @@ class ConsentDBService:
 
         # Post-process to get latest per request_id (DISTINCT ON equivalent)
         latest_per_request = {}
-        for row in response.data:
+        for row in response.data or []:
             if not self._is_external_audit_row(row):
                 continue
             request_id = row.get("request_id")
@@ -710,7 +710,7 @@ class ConsentDBService:
 
         # Post-process to get latest per (agent_id, scope) (DISTINCT ON equivalent)
         latest_per_agent_scope = {}
-        for row in response.data:
+        for row in response.data or []:
             if not self._is_external_audit_row(row):
                 continue
             row_scope = row.get("scope")


### PR DESCRIPTION
## Summary

### What

Updated two audit-processing loops in `consent_db.py` to iterate over `response.data or []` instead of `response.data`.

### Why

`consent_db.py` already uses the defensive `response.data or []` pattern in multiple places to safely handle empty Supabase responses. These two audit-processing loops were remaining exceptions. This change makes them consistent with the existing implementation and avoids potential iteration over `None`.

### Testing

* Ran `uv run pytest consent-protocol/tests/services/test_consent_db_refresh_jobs.py -v`
* Ran `uv run pytest consent-protocol/tests/services/test_consent_request_links.py -v` (43 tests passed)
