### PR TITLE
chore(ui): silence gmail older receipts fetch error stack trace in production

### DIFF
--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -1004,10 +1004,12 @@ export default function ProfileReceiptsPage() {
     try {
       await loadReceipts(page + 1);
     } catch (error) {
-      console.error(
-        "[ProfileReceiptsPage] Failed to load older receipts:",
-        error,
-      );
+      if (process.env.NODE_ENV !== "production") {
+        console.error(
+          "[ProfileReceiptsPage] Failed to load older receipts:",
+          error,
+        );
+      }
       toast.error(
         "We couldn't load older receipts right now. Please try again.",
       );


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `ProfileReceiptsPage` paginated fetch handler with a production environment check. This prevents exposing internal API exceptions and stack traces to end-users if loading older receipts fails, while preserving the intended UI error toast.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/gmail/gmail-receipts-page.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/gmail/gmail-receipts-page.tsx`)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.