### PR TITLE
chore(ui): silence portfolio share sheet error traces in production

### DIFF
--- a/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
+++ b/hushh-webapp/components/kai/share/portfolio-share-sheet.tsx
@@ -107,7 +107,9 @@ export function PortfolioShareSheet({ open, onOpenChange, payload }: PortfolioSh
       if (isShareCancelError(error)) {
         return;
       }
-      console.error(`[PortfolioShareSheet] ${action} failed:`, error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[PortfolioShareSheet] ${action} failed:`, error);
+      }
       const fallback =
         action === "snapshot"
           ? "Could not share snapshot."


### PR DESCRIPTION
### Description

Silences an internal development log inside `components/kai/share/portfolio-share-sheet.tsx` by wrapping a `console.error` statement in a `NODE_ENV !== "production"` check. This prevents background sharing/export traces (e.g., failed snapshot generation or link creation errors) from leaking into the production client console, while preserving the application's intended error-handling and fallback UI toast notifications.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/share/portfolio-share-sheet.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/share/portfolio-share-sheet.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none