### PR TITLE
chore(ui): silence developer docs auth sign-in error in production

### DIFF
--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -1050,7 +1050,9 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
       await checkAuth();
       await refreshAccess(authResult.user);
     } catch (error) {
-      console.error(`[developers] ${provider} sign-in failed`, error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error(`[developers] ${provider} sign-in failed`, error);
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `developer-docs-hub` authentication handler with a production environment check. This prevents exposing internal OAuth SDK exceptions and stack traces to end-users if a Google or Apple sign-in attempt fails or is cancelled by the developer.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/developers/developer-docs-hub.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/developers/developer-docs-hub.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.