### PR TITLE
fix(agent): initialize managed Vertex runtime using ADC

### DIFF
--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -433,23 +433,25 @@ def create_managed_runtime_client(
     project: str | None = None,
     location: str | None = None,
 ):
-    """Create a Vertex AI-backed Gemini client using ADC (Application Default Credentials).
-
-    The client intentionally does NOT accept an API key: the Vertex AI endpoint
-    (aiplatform.googleapis.com) requires OAuth 2.0 Bearer tokens, not API keys.
-    Credentials are resolved via google.auth.default() automatically.
-
-    Args:
-        runtime_provider: Must be "gemini".
-        project: GCP project ID. Falls back to GOOGLE_CLOUD_PROJECT env var.
-        location: GCP region. Falls back to GOOGLE_CLOUD_LOCATION env var,
-            then "us-central1".
-    """
     provider = runtime_provider.strip().lower()
-    resolved_project = (project or os.getenv("GOOGLE_CLOUD_PROJECT", "")).strip() or None
-    resolved_location = (
-        (location or os.getenv("GOOGLE_CLOUD_LOCATION", "")).strip() or "us-central1"
+
+    resolved_project = (
+        project
+        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        or os.getenv("GCP_PROJECT")
     )
+    
+    if resolved_project:
+        resolved_project = resolved_project.strip()
+
+    resolved_location = (
+        location
+        or os.getenv("GOOGLE_CLOUD_LOCATION")
+        or os.getenv("GCP_LOCATION")
+        or os.getenv("GOOGLE_CLOUD_REGION")
+        or "us-central1"
+    )
+    resolved_location = resolved_location.strip()
 
     if provider == "gemini":
         return genai.Client(
@@ -459,7 +461,6 @@ def create_managed_runtime_client(
         )
 
     raise ValueError(f"Unsupported runtime provider: {provider}")
-
 
 
 def _redacted_runtime_evidence(evidence: dict[str, Any]) -> dict[str, Any]:

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -427,17 +427,39 @@ def create_runtime_client(runtime_provider: str, user_key: str):
     raise ValueError(f"Unsupported runtime provider: {provider}")
 
 
-def create_managed_runtime_client(runtime_provider: str, user_key: str):
-    provider = runtime_provider.strip().lower()
-    key = user_key.strip()
+def create_managed_runtime_client(
+    runtime_provider: str,
+    *,
+    project: str | None = None,
+    location: str | None = None,
+):
+    """Create a Vertex AI-backed Gemini client using ADC (Application Default Credentials).
 
-    if not key:
-        raise RuntimeError("Managed Gemini API key is not configured")
+    The client intentionally does NOT accept an API key: the Vertex AI endpoint
+    (aiplatform.googleapis.com) requires OAuth 2.0 Bearer tokens, not API keys.
+    Credentials are resolved via google.auth.default() automatically.
+
+    Args:
+        runtime_provider: Must be "gemini".
+        project: GCP project ID. Falls back to GOOGLE_CLOUD_PROJECT env var.
+        location: GCP region. Falls back to GOOGLE_CLOUD_LOCATION env var,
+            then "us-central1".
+    """
+    provider = runtime_provider.strip().lower()
+    resolved_project = (project or os.getenv("GOOGLE_CLOUD_PROJECT", "")).strip() or None
+    resolved_location = (
+        (location or os.getenv("GOOGLE_CLOUD_LOCATION", "")).strip() or "us-central1"
+    )
 
     if provider == "gemini":
-        return genai.Client(vertexai=True, api_key=key)
+        return genai.Client(
+            vertexai=True,
+            project=resolved_project,
+            location=resolved_location,
+        )
 
     raise ValueError(f"Unsupported runtime provider: {provider}")
+
 
 
 def _redacted_runtime_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
@@ -838,12 +860,8 @@ class AgentChatService:
     @property
     def client(self):
         if self._client is None:
-            api_key = self.settings.google_api_key or os.getenv("GOOGLE_API_KEY", "").strip()
-            if not api_key:
-                raise RuntimeError("Gemini API key is not configured")
             self._client = create_managed_runtime_client(
                 runtime_provider=self.runtime_manifest.model.provider,
-                user_key=api_key,
             )
         return self._client
 

--- a/consent-protocol/tests/services/test_agent_chat_service.py
+++ b/consent-protocol/tests/services/test_agent_chat_service.py
@@ -133,40 +133,47 @@ def test_create_runtime_client_uses_byok_key_without_env_fallback(monkeypatch):
     assert calls == [{"vertexai": False, "api_key": "USER_BYOK_KEY"}]
 
 
-def test_create_managed_runtime_client_uses_adc_not_api_key(monkeypatch):
-    """Managed Vertex client must use ADC (project+location), never an API key."""
+def test_create_managed_runtime_client_project_fallback(monkeypatch):
     calls: list[dict] = []
+    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", lambda **k: calls.append(k) or SimpleNamespace(kind="client"))
 
-    def fake_client(**kwargs):
-        calls.append(kwargs)
-        return SimpleNamespace(kind="client")
-
-    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
-    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
-    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
-
-    client = create_managed_runtime_client("gemini")
-
-    assert client.kind == "client"
-    assert calls == [{"vertexai": True, "project": "test-project", "location": "us-east1"}]
-    assert "api_key" not in calls[0], "API key must never be passed to the Vertex client"
-
-
-def test_create_managed_runtime_client_defaults_location_to_us_central1(monkeypatch):
-    """When GOOGLE_CLOUD_LOCATION is absent, location defaults to us-central1."""
-    calls: list[dict] = []
-
-    def fake_client(**kwargs):
-        calls.append(kwargs)
-        return SimpleNamespace(kind="client")
-
-    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
-    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
-    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
-
+    # GOOGLE_CLOUD_PROJECT takes precedence
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "proj-1")
+    monkeypatch.setenv("GCP_PROJECT", "proj-2")
     create_managed_runtime_client("gemini")
+    assert calls[-1]["project"] == "proj-1"
 
-    assert calls[0]["location"] == "us-central1"
+    # Falls back to GCP_PROJECT
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT")
+    create_managed_runtime_client("gemini")
+    assert calls[-1]["project"] == "proj-2"
+
+
+def test_create_managed_runtime_client_location_fallback(monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", lambda **k: calls.append(k) or SimpleNamespace(kind="client"))
+
+    # GOOGLE_CLOUD_LOCATION takes precedence
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "loc-1")
+    monkeypatch.setenv("GCP_LOCATION", "loc-2")
+    monkeypatch.setenv("GOOGLE_CLOUD_REGION", "loc-3")
+    create_managed_runtime_client("gemini")
+    assert calls[-1]["location"] == "loc-1"
+
+    # Falls back to GCP_LOCATION
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION")
+    create_managed_runtime_client("gemini")
+    assert calls[-1]["location"] == "loc-2"
+
+    # Falls back to GOOGLE_CLOUD_REGION
+    monkeypatch.delenv("GCP_LOCATION")
+    create_managed_runtime_client("gemini")
+    assert calls[-1]["location"] == "loc-3"
+
+    # Defaults to "us-central1"
+    monkeypatch.delenv("GOOGLE_CLOUD_REGION")
+    create_managed_runtime_client("gemini")
+    assert calls[-1]["location"] == "us-central1"
 
 
 @pytest.mark.anyio

--- a/consent-protocol/tests/services/test_agent_chat_service.py
+++ b/consent-protocol/tests/services/test_agent_chat_service.py
@@ -133,7 +133,8 @@ def test_create_runtime_client_uses_byok_key_without_env_fallback(monkeypatch):
     assert calls == [{"vertexai": False, "api_key": "USER_BYOK_KEY"}]
 
 
-def test_create_managed_runtime_client_uses_vertex_api_key(monkeypatch):
+def test_create_managed_runtime_client_uses_adc_not_api_key(monkeypatch):
+    """Managed Vertex client must use ADC (project+location), never an API key."""
     calls: list[dict] = []
 
     def fake_client(**kwargs):
@@ -141,11 +142,31 @@ def test_create_managed_runtime_client_uses_vertex_api_key(monkeypatch):
         return SimpleNamespace(kind="client")
 
     monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
 
-    client = create_managed_runtime_client("gemini", " MANAGED_KEY ")
+    client = create_managed_runtime_client("gemini")
 
     assert client.kind == "client"
-    assert calls == [{"vertexai": True, "api_key": "MANAGED_KEY"}]
+    assert calls == [{"vertexai": True, "project": "test-project", "location": "us-east1"}]
+    assert "api_key" not in calls[0], "API key must never be passed to the Vertex client"
+
+
+def test_create_managed_runtime_client_defaults_location_to_us_central1(monkeypatch):
+    """When GOOGLE_CLOUD_LOCATION is absent, location defaults to us-central1."""
+    calls: list[dict] = []
+
+    def fake_client(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(kind="client")
+
+    monkeypatch.setattr("hushh_mcp.services.agent_chat_service.genai.Client", fake_client)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+    monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+
+    create_managed_runtime_client("gemini")
+
+    assert calls[0]["location"] == "us-central1"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes the managed Vertex runtime initialization used by Kai.

The managed runtime previously initialized the Vertex AI client with an API-key-based configuration. This change updates the managed runtime to construct the client using Application Default Credentials (ADC) with the configured GCP project and location, matching the recommended Vertex AI initialization flow.

The BYOK (Bring Your Own Key) runtime path is unchanged and continues to use the user's API key with the Gemini Developer API.

## Validation

Manual verification:

- Reproduced the managed runtime failure on `integration/pr-train`.
- Applied only the managed runtime initialization change.
- Verified that Kai successfully responds to chat requests after the change.
- Confirmed the BYOK runtime flow remains unchanged.

Project checks:

- Updated the managed runtime unit tests.
- Relevant tests pass successfully.