### PR TITLE
chore(ui): silence top app bar persona switch error stack trace in production

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -506,7 +506,9 @@ export function TopAppBar({ className }: TopAppBarProps) {
         }
         router.push(nextRoute);
       } catch (error) {
-        console.error("[TopAppBar] Failed to switch persona:", error);
+        if (process.env.NODE_ENV !== "production") {
+          console.error("[TopAppBar] Failed to switch persona:", error);
+        }
         trackEvent("persona_switched", {
           action: target,
           result: "error",


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `TopAppBar` persona switch handler with a production environment check. This prevents exposing internal IAM routing exceptions and role validation stack traces to end-users if a persona switch fails, while preserving the intended UI error toast and analytics tracking.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/app-ui/top-app-bar.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/app-ui/top-app-bar.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.