### PR TITLE
chore(ui): silence recovery key dialog clipboard error traces in production

### DIFF
--- a/hushh-webapp/components/vault/recovery-key-dialog.tsx
+++ b/hushh-webapp/components/vault/recovery-key-dialog.tsx
@@ -41,7 +41,9 @@ export function RecoveryKeyDialog({
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {
-      console.error('Failed to copy:', error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error('Failed to copy:', error);
+      }
     }
   };
 


### PR DESCRIPTION
### Description

Silences an internal development log inside `components/vault/recovery-key-dialog.tsx` by wrapping a `console.error` statement in a `NODE_ENV !== "production"` check. This prevents raw clipboard-access failure traces from leaking into the production client console when a user attempts to copy their recovery key in restricted browser environments, while preserving the application's intended safe-failure UI behavior.
