### PR TITLE
chore(ui): silence top app bar delete account error stack trace in production

### DIFF
--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -885,7 +885,9 @@ function OnboardingRouteActions() {
       await signOut();
       router.push(ROUTES.HOME);
     } catch (error) {
-      console.error("[TopAppBar] Failed to delete account:", error);
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[TopAppBar] Failed to delete account:", error);
+      }
       toast.error("Failed to delete account. Please retry.");
     } finally {
       setIsDeleting(false);


### PR DESCRIPTION
### Description

Wraps a raw `console.error` inside the `TopAppBar` account deletion handler with a production environment check. This prevents exposing internal IAM routing exceptions and API deletion stack traces to end-users if deleting an account fails, while preserving the intended UI error toast.
