### PR TITLE
chore(ui): remove redundant debug logs from manage portfolio view

### DIFF
--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -228,7 +228,7 @@ export function ManagePortfolioView() {
           
           // Priority 2: Decrypt the financial PKM domain (fallback)
           if (!parsed) {
-            console.log("[ManagePortfolio] No cache, attempting to decrypt the financial PKM domain...");
+
             try {
               const snapshot = await PkmDomainResourceService.getStaleFirst({
                 userId: user.uid,
@@ -247,7 +247,7 @@ export function ManagePortfolioView() {
 
                 // Update cache for future use
                 setCachePortfolioData(user.uid, parsed);
-                console.log("[ManagePortfolio] Decrypted and cached portfolio data");
+
               }
             } catch (decryptError) {
               console.error("[ManagePortfolio] Failed to decrypt the financial PKM domain:", decryptError);


### PR DESCRIPTION
### Description

Removes redundant debugging `console.log` statements from `components/kai/views/manage-portfolio-view.tsx`. These traces (`"No cache, attempting to decrypt..."` and `"Decrypted and cached portfolio data"`) were firing during the standard portfolio vault-decryption fallback flow, adding unnecessary noise to the browser console. The application's core functionality, error handling, and user-facing notifications remain completely unchanged.
