### PR TITLE
fix(notifications): validate unregister platform values

### DIFF
--- a/consent-protocol/api/routes/notifications.py
+++ b/consent-protocol/api/routes/notifications.py
@@ -86,6 +86,12 @@ async def unregister_push_token(request: Request):
     user_id = body.get("user_id") or body.get("userId") or firebase_uid
     platform = body.get("platform")
 
+    if platform is not None and platform not in ("web", "ios", "android"):
+        raise HTTPException(
+            status_code=400,
+            detail="platform must be one of: web, ios, android",
+        )
+
     if firebase_uid != user_id:
         raise HTTPException(
             status_code=403,

--- a/consent-protocol/tests/test_notifications_routes.py
+++ b/consent-protocol/tests/test_notifications_routes.py
@@ -199,6 +199,29 @@ def test_unregister_push_token_forwards_platform(monkeypatch):
     mock_service.delete_user_push_tokens.assert_called_once_with(user_id="user_123", platform="ios")
 
 
+def test_unregister_push_token_rejects_invalid_platform(monkeypatch):
+    client = TestClient(_build_app())
+    monkeypatch.setattr(
+        "api.routes.notifications.verify_firebase_bearer",
+        lambda auth_header: "user_123",
+    )
+
+    with patch("api.routes.notifications.PushTokensService") as mock_service_class:
+        mock_service = MagicMock()
+        mock_service_class.return_value = mock_service
+
+        response = client.request(
+            "DELETE",
+            "/api/notifications/unregister",
+            json={"platform": "desktop"},
+            headers={"Authorization": "Bearer firebase-token"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "platform must be one of: web, ios, android"
+    mock_service.delete_user_push_tokens.assert_not_called()
+    
+
 def test_unregister_push_token_rejects_cross_user_unregistration(monkeypatch):
     client = TestClient(_build_app())
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

### What changed

* Validate `platform` values in the `/api/notifications/unregister` endpoint.
* Return HTTP 400 when an unsupported platform is provided.
* Add a regression test covering invalid platform input.

### Why

The `/register` endpoint already validates supported platform values (`web`, `ios`, `android`), while `/unregister` accepted arbitrary values and forwarded them to the service layer. This change makes the behavior consistent across both endpoints and prevents invalid input from reaching the service.

### Testing

```bash
uv run pytest consent-protocol/tests/test_notifications_routes.py -v
```

Result:

```
14 passed
```
