### PR TITLE
fix(ui): remove phone mandate vault presence check console warning leak

### DIFF
--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -60,7 +60,6 @@ export function PhoneMandateGuard({
           setHasVault(exists);
         }
       } catch (error) {
-        console.warn("[PhoneMandateGuard] Failed to check vault presence:", error);
         if (!cancelled) {
           vaultPresenceCache.set(user.uid, true);
           setHasVault(true);

--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -59,7 +59,7 @@ export function PhoneMandateGuard({
           vaultPresenceCache.set(user.uid, exists);
           setHasVault(exists);
         }
-      } catch (error) {
+      } catch (_error) {
         if (!cancelled) {
           vaultPresenceCache.set(user.uid, true);
           setHasVault(true);


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `PhoneMandateGuard` vault presence check. If the vault presence API check fails, the guard already gracefully falls back to `setHasVault(true)` to avoid false-positive verification blocks. Removing this log keeps the client console clean without needing environment checks.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/auth/phone-mandate-guard.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging removal)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/auth/phone-mandate-guard.tsx`)

## 🧪 Testing

- [x] Tested on Web (Code inspection)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.