### PR TITLE
fix(ui): remove phone mandate claim check console warning leak

### DIFF
--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -95,7 +95,6 @@ export function PhoneMandateGuard({
           setBackendPhoneVerified(AccountIdentityService.hasVerifiedPhone(identity));
         }
       } catch (error) {
-        console.warn("[PhoneMandateGuard] Failed to check account phone claim:", error);
         if (!cancelled) {
           setBackendPhoneVerified(firebasePhoneVerified);
         }


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `PhoneMandateGuard` account phone claim check. If the IAM identity refresh API check fails, the guard already gracefully falls back to the local Firebase token state (`setBackendPhoneVerified(firebasePhoneVerified)`) to avoid false-positive verification blocks. Removing this log keeps the client console clean without needing environment checks.