### PR TITLE
chore(ui): remove debug logs from consent notification provider

### DIFF
--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -790,10 +790,7 @@ export function ConsentNotificationProvider({
           setFcmInitStatus(persisted.status);
           setDeliveryDetail(persisted.detail);
           setDeliveryMode(deliveryModeFromInitStatus(persisted.status));
-          console.info("[NotificationProvider] Restored delivery state:", persisted);
-          console.info(
-            "[NotificationProvider] Revalidating FCM delivery state after restore..."
-          );
+
         }
       }
 
@@ -810,7 +807,7 @@ export function ConsentNotificationProvider({
         setFcmInitStatus(result.status);
         setDeliveryDetail(result.detail ?? null);
         setDeliveryMode(deliveryModeFromInitStatus(result.status));
-        console.info("[NotificationProvider] Delivery init:", result);
+
       } catch (err) {
         if (cancelled) return;
         const detail = err instanceof Error ? err.message : "fcm_init_failed";


### PR DESCRIPTION
### Description

Removes redundant debugging `console.info` statements from `components/consent/notification-provider.tsx`. These traces (`"Restored delivery state"`, `"Revalidating FCM delivery state after restore"`, and `"Delivery init"`) were firing during the standard FCM initialization flow, adding unnecessary noise to the browser console. The application's core functionality, error handling, and Firebase messaging integration remain completely unchanged.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/consent/notification-provider.tsx`

- Trust boundary touched:
  - [x] none (purely client UI cleanup)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/consent/notification-provider.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.