### PR TITLE
fix(ui): remove vault quick-unlock uitest console warning leak

### DIFF
--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -427,8 +427,8 @@ export function VaultFlow({
             recommendedQuickMethod,
             currentRpId
           );
-        } catch (dismissError) {
-          console.warn("[VaultFlow] UITest quick-unlock dismissal failed:", dismissError);
+        } catch (_dismissError) {
+          // silently ignore UI-test dismissal failure
         }
       }
       await finalizeUnlock(pendingUnlockKey);


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `VaultFlow` UITest quick-unlock dismissal handler. If the native prompt dismissal fails (which is expected in certain automated UI test environments), the application already gracefully continues to `finalizeUnlock`. Removing this log keeps the client console clean without needing environment checks, and the catch variable is appropriately prefixed with an underscore to satisfy TypeScript linters.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/vault/vault-flow.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging removal)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/vault/vault-flow.tsx`)

## 🧪 Testing

- [x] Tested on Web (Code inspection, TypeScript linters)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.