### PR TITLE
fix(ui): remove vault lock guard existence check console warning leak

### DIFF
--- a/hushh-webapp/components/vault/vault-lock-guard.tsx
+++ b/hushh-webapp/components/vault/vault-lock-guard.tsx
@@ -156,8 +156,7 @@ export function VaultLockGuard({ children }: VaultLockGuardProps) {
           vaultPresenceCache.set(userId, exists);
           setHasVault(exists);
         }
-      } catch (error) {
-        console.warn("[VaultLockGuard] Failed to check vault existence:", error);
+      } catch (_error) {
         if (!cancelled) {
           // Fail closed on transient check failures to preserve existing secure behavior.
           vaultPresenceCache.set(userId, true);


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `VaultLockGuard` vault existence check. If the API check for vault presence fails, the guard already gracefully fails closed by falling back to `setHasVault(true)` to preserve secure behavior. Removing this log keeps the client console clean without needing environment checks, and the catch variable is appropriately prefixed with an underscore to satisfy TypeScript linters.
