### PR TITLE
fix(one-setup): resolve master gate before forwarding to hard-gated capability surface

### DIFF
--- a/hushh-webapp/__tests__/app/one/one-onboarding-capability-client.test.tsx
+++ b/hushh-webapp/__tests__/app/one/one-onboarding-capability-client.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression for the UAT redirect loop: tapping a setup-hub tile, then pressing
+ * Continue on `/one/setup/<capability>`, forwarded into a hard-gated `/one/*`
+ * surface (e.g. `/one/location`) while the MASTER setup gate was still
+ * unresolved — so `OneOnboardingGuard` bounced the user straight back to
+ * `/one/setup`. The fix resolves the master gate before forwarding into a
+ * hard-gated surface, while leaving setup-surface forwards (finance wizard) and
+ * off-`/one` forwards (consent) untouched.
+ */
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  user: { uid: "user_1" } as { uid: string } | null,
+  vault: {
+    vaultKey: null as string | null,
+    vaultOwnerToken: null as string | null,
+    isVaultUnlocked: false,
+  },
+  syncKaiSetupState: vi.fn(),
+  setOnboardingCompleted: vi.fn(),
+  markSeen: vi.fn(),
+  syncSetupCapabilities: vi.fn(),
+  markExplored: vi.fn(),
+  loadExploredIds: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock("@/lib/firebase/auth-context", () => ({
+  useAuth: () => ({ user: mocks.user }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => mocks.vault,
+}));
+
+vi.mock("@/lib/services/one-setup-gate-service", () => ({
+  OneSetupGateService: { markSeen: mocks.markSeen },
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    syncKaiSetupState: mocks.syncKaiSetupState,
+    syncSetupCapabilities: mocks.syncSetupCapabilities,
+  },
+}));
+
+vi.mock("@/lib/services/kai-profile-service", () => ({
+  KaiProfileService: { setOnboardingCompleted: mocks.setOnboardingCompleted },
+}));
+
+vi.mock("@/lib/services/capability-tour-service", () => ({
+  CapabilityTourService: {
+    markExplored: mocks.markExplored,
+    loadExploredIds: mocks.loadExploredIds,
+  },
+}));
+
+// The presentational step renders a primary CTA; we only need the button.
+vi.mock("@/components/onboarding/setup/onboarding-capability-step", () => ({
+  OnboardingCapabilityStep: ({ onPrimary }: { onPrimary: () => void }) => (
+    <button data-testid="one-setup-capability-primary" onClick={onPrimary}>
+      Continue
+    </button>
+  ),
+}));
+
+import { OneOnboardingCapabilityClient } from "@/app/one/setup/[capability]/one-onboarding-capability-client";
+
+describe("OneOnboardingCapabilityClient — Continue forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.user = { uid: "user_1" };
+    mocks.vault = {
+      vaultKey: null,
+      vaultOwnerToken: null,
+      isVaultUnlocked: false,
+    };
+    mocks.syncKaiSetupState.mockResolvedValue(undefined);
+    mocks.setOnboardingCompleted.mockResolvedValue(undefined);
+    mocks.loadExploredIds.mockResolvedValue([]);
+    mocks.markExplored.mockResolvedValue(undefined);
+    mocks.syncSetupCapabilities.mockResolvedValue(undefined);
+  });
+
+  it("resolves the master setup gate before forwarding into a hard-gated surface (location)", async () => {
+    render(<OneOnboardingCapabilityClient capabilityId="location" />);
+
+    fireEvent.click(screen.getByTestId("one-setup-capability-primary"));
+
+    await waitFor(() => {
+      expect(mocks.syncKaiSetupState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user_1",
+          completed: true,
+          skipped: false,
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith("/one/location");
+    });
+  });
+
+  it("also flips the vault profile when the vault is unlocked", async () => {
+    mocks.vault = {
+      vaultKey: "key",
+      vaultOwnerToken: "tok",
+      isVaultUnlocked: true,
+    };
+
+    render(<OneOnboardingCapabilityClient capabilityId="connected-systems" />);
+
+    fireEvent.click(screen.getByTestId("one-setup-capability-primary"));
+
+    await waitFor(() => {
+      expect(mocks.setOnboardingCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "user_1",
+          vaultKey: "key",
+          vaultOwnerToken: "tok",
+          skippedPreferences: false,
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith("/one/connected-systems");
+    });
+  });
+
+  it("does NOT resolve the master gate when forwarding to the finance wizard (setup surface)", async () => {
+    render(<OneOnboardingCapabilityClient capabilityId="finance" />);
+
+    fireEvent.click(screen.getByTestId("one-setup-capability-primary"));
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith(
+        expect.stringContaining("/one/setup/kai"),
+      );
+    });
+    expect(mocks.syncKaiSetupState).not.toHaveBeenCalled();
+  });
+
+  it("does NOT resolve the master gate when forwarding off /one/* (consent)", async () => {
+    render(<OneOnboardingCapabilityClient capabilityId="consent" />);
+
+    fireEvent.click(screen.getByTestId("one-setup-capability-primary"));
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith("/consents?tab=pending");
+    });
+    expect(mocks.syncKaiSetupState).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx
+++ b/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx
@@ -9,13 +9,16 @@ import { useAuth } from "@/lib/firebase/auth-context";
 import { useVault } from "@/lib/vault/vault-context";
 import { getOneCapability } from "@/lib/onboarding/one-capabilities";
 import { CapabilityTourService } from "@/lib/services/capability-tour-service";
+import { KaiProfileService } from "@/lib/services/kai-profile-service";
 import { OneSetupGateService } from "@/lib/services/one-setup-gate-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import {
   buildOneSetupCapabilityRoute,
+  isOneSetupSurfaceRoute,
   resolveCapabilityHandoffTarget,
   ROUTES,
 } from "@/lib/navigation/routes";
+
 
 /**
  * Per-capability setup step client: `/one/setup/<capability>`.
@@ -26,11 +29,22 @@ import {
  * tapping a setup-hub tile lands HERE (allowed) instead of a hard-gated
  * canonical route (which bounced the user back to `/one/setup`).
  *
- * Per-capability scope: this screen records ONLY the signal for the capability
- * the user opened (and, for explore-only capabilities, the explore mark). It
- * MUST NOT touch the master setup gate (`setupCompleted` / `setupSkipped`) —
- * that master acknowledgement belongs exclusively to the hub's Skip (0 done) /
- * Continue (1..n done) controls.
+ * Per-capability scope: this screen records the signal for the capability the
+ * user opened (and, for explore-only capabilities, the explore mark). It also
+ * resolves the MASTER setup gate (`setupCompleted`) WHEN — and only when — the
+ * Continue CTA forwards the user into a hard-gated product surface
+ * (`/one/<capability>`, e.g. `/one/location`, `/one/gmail`,
+ * `/one/connected-systems`). Without this, `OneOnboardingGuard` saw the master
+ * gate still unresolved on the destination and bounced the user straight back
+ * to `/one/setup` — the exact redirect loop reported on UAT. Pressing Continue
+ * here is an explicit "proceed into the product" intent, equivalent to the
+ * hub's Continue (1..n done) control, so it satisfies the same gate the hub
+ * does (and mirrors `OneSetupHub.handleMasterAck`).
+ *
+ * Forwards that STAY on the setup surface (finance → the `/one/setup/kai`
+ * wizard) or that leave `/one/*` entirely (consent → `/consents`) do NOT
+ * resolve the master gate here: the wizard owns its own completion, and routes
+ * outside `/one/*` are not behind `OneOnboardingGuard`.
  */
 export function OneOnboardingCapabilityClient({
   capabilityId,
@@ -39,10 +53,11 @@ export function OneOnboardingCapabilityClient({
 }) {
   const router = useRouter();
   const { user } = useAuth();
-  const { isVaultUnlocked } = useVault();
+  const { vaultKey, vaultOwnerToken, isVaultUnlocked } = useVault();
   const [busy, setBusy] = useState(false);
 
   const capability = getOneCapability(capabilityId);
+
   // The step collects nothing and renders pre-vault, but if this capability's
   // workspace reads vault-backed data and the vault is currently locked, set the
   // honest "you'll unlock next" expectation. The destination guard owns the
@@ -61,10 +76,19 @@ export function OneOnboardingCapabilityClient({
           buildOneSetupCapabilityRoute(capabilityId),
         )}`
       : handoffTarget;
+  // Does Continue forward into a hard-gated `/one/*` product surface? Those
+  // (and only those) are guarded by `OneOnboardingGuard`, which bounces back to
+  // `/one/setup` while the master gate is unresolved. Setup-surface forwards
+  // (finance → `/one/setup/kai`) and off-`/one` forwards (consent → `/consents`)
+  // are not gated, so they keep the per-capability-only scope.
+  const forwardsToGatedSurface =
+    handoffTarget.startsWith(`${ROUTES.ONE_HOME}/`) &&
+    !isOneSetupSurfaceRoute(handoffTarget);
 
   // Unknown capability: contain to the hub, never a hard 404.
   useEffect(() => {
     if (!capability) {
+
       router.replace(ROUTES.ONE_SETUP);
     }
   }, [capability, router]);
@@ -92,10 +116,9 @@ export function OneOnboardingCapabilityClient({
 
     void (async () => {
       try {
-        // Per-capability scope ONLY: never touch the master setup gate here.
         // Mark this visit as "seen" so the hub no longer treats it as a fresh,
         // never-opened tile, and record the explore signal for explore-only
-        // capabilities. The master Skip/Continue acknowledgement is the hub's.
+        // capabilities.
         OneSetupGateService.markSeen(userId);
 
         if (capability?.isExploreOnly === true) {
@@ -107,6 +130,38 @@ export function OneOnboardingCapabilityClient({
             ...explored,
           ]).catch(() => undefined);
         }
+
+        // Resolve the MASTER setup gate before forwarding into a hard-gated
+        // `/one/*` surface, otherwise `OneOnboardingGuard` bounces the user back
+        // to `/one/setup` (the reported redirect loop). This mirrors the hub's
+        // Continue path: mark the server pre-vault gate (authoritative for the
+        // gate + PostAuthRouteService) as completed, and — when the vault is
+        // unlocked — flip the vault profile too so the unlocked path agrees.
+        // Both are awaited so the gate is consistent on the very next resolve.
+        // Setup-surface forwards (finance wizard) and off-`/one` forwards
+        // (consent) skip this: they are not behind the hard gate.
+        if (forwardsToGatedSurface) {
+          await PreVaultUserStateService.syncKaiSetupState({
+            userId,
+            completed: true,
+            // Continue with a capability opened is an active completion, not a
+            // skip. The hub's Skip control still owns the 0-done skip path.
+            skipped: false,
+          });
+          if (isVaultUnlocked && vaultKey && vaultOwnerToken) {
+            await KaiProfileService.setOnboardingCompleted({
+              userId,
+              vaultKey,
+              vaultOwnerToken,
+              skippedPreferences: false,
+            }).catch((error) => {
+              console.warn(
+                "[OneOnboardingCapabilityClient] Failed to mark vault profile setup completed:",
+                error,
+              );
+            });
+          }
+        }
       } catch (resolveError) {
         console.warn(
           "[OneOnboardingCapabilityClient] Failed to record capability signal:",
@@ -115,6 +170,7 @@ export function OneOnboardingCapabilityClient({
         // Fail-open: still forward so the user is never stranded.
       } finally {
         router.replace(target);
+
       }
     })();
   };


### PR DESCRIPTION
## Problem (UAT)

After login + vault flow, the user lands on /one/setup. Tapping any tile (Location, Bring your receipts/Gmail, Link your tools/Connected Systems, etc.) opens /one/setup/<capability>, but pressing **Continue** there bounced the user straight back to /one/setup instead of reaching the feature.

## Root cause

The /one/setup **master gate** (setupCompleted in pre-vault state) is only resolved by the hub's master Skip/Continue control (OneSetupHub.handleMasterAck). The per-capability Continue handler (one-onboarding-capability-client.tsx) deliberately only set a soft markSeen flag and forwarded to the canonical /one/<capability>. Those destinations are hard-gated /one/* routes, so OneOnboardingGuard saw the master gate unresolved and did outer.replace('/one/setup') -> redirect loop.

Finance (target /one/setup/kai, a setup surface) and Consent (target /consents, outside /one/*) were unaffected, which matches the reported symptom.

## Fix

In the per-capability Continue handler, resolve the master gate **only when** forwarding into a hard-gated /one/* product surface:
- PreVaultUserStateService.syncKaiSetupState({ completed: true, skipped: false }) (authoritative server gate)
- plus KaiProfileService.setOnboardingCompleted(...) when the vault is unlocked

Both awaited before navigation, mirroring OneSetupHub.handleMasterAck. Setup-surface forwards (finance wizard) and off-/one forwards (consent) are left untouched.

## Tests

- New regression suite \__tests__/app/one/one-onboarding-capability-client.test.tsx\ (4 cases: location resolves gate, vault-unlocked connected-systems flips vault profile, finance wizard no-op, consent no-op).
- ESLint clean, \	sc --noEmit\ clean for touched file, 15/15 in the affected suites pass.

## Lane

Maintainer direct-to-main (author @DamriaNeelesh is in the governed bypass cohort); branched from \origin/main\. CI Status Gate + merge queue + post-merge smoke still apply.