### PR TITLE
fix(agent): close the global agent window on route change

### DIFF
--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -1,7 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
+import {
+  AgentPopoverProvider,
+  useAgentPopover,
+} from "@/components/agent/agent-popover-provider";
+
 
 const navigationMock = vi.hoisted(() => ({
   pathname: "/profile",
@@ -138,4 +142,67 @@ describe("AgentPopoverProvider floating trigger", () => {
 
     expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
   });
+
+  // Regression: the fullscreen agent window must NOT stay mounted on top of the
+  // destination page after a route change. Opening the agent on one screen and
+  // navigating (e.g. into /one/location) previously left the agent covering the
+  // page's real UI. Closing on route change keeps the agent a transient overlay.
+  it("minimizes the agent window when the route changes", () => {
+    navigationMock.pathname = "/profile";
+
+    // openAgent defers setExpanded to requestAnimationFrame; run rAF callbacks
+    // synchronously so the open transition completes within act().
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      });
+
+    function OpenAgentOnMount() {
+      const { openAgent, expanded } = useAgentPopover();
+
+      return (
+        <button
+          type="button"
+          data-testid="probe"
+          data-expanded={expanded ? "1" : "0"}
+          onClick={openAgent}
+        >
+          open
+        </button>
+      );
+    }
+
+    const { rerender } = render(
+      <AgentPopoverProvider>
+        <OpenAgentOnMount />
+      </AgentPopoverProvider>,
+    );
+
+    const probe = () => screen.getByTestId("probe");
+    expect(probe().getAttribute("data-expanded")).toBe("0");
+
+    // Open the agent on the current route.
+    act(() => {
+      probe().click();
+    });
+    expect(probe().getAttribute("data-expanded")).toBe("1");
+
+    // Navigate to a new route; the agent must close itself.
+    act(() => {
+      navigationMock.pathname = "/one/location";
+      rerender(
+        <AgentPopoverProvider>
+          <OpenAgentOnMount />
+        </AgentPopoverProvider>,
+      );
+    });
+
+    expect(probe().getAttribute("data-expanded")).toBe("0");
+
+    rafSpy.mockRestore();
+  });
 });
+
+

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -298,8 +298,24 @@ function AgentPopoverSurface({
     }, 120);
   }, [minimizeAgent]);
 
+  // Close the agent window whenever the route changes. The agent popover is a
+  // SINGLE app-root surface whose expanded state persists across client-side
+  // navigations, and it defaults to a fullscreen size. Without this, opening
+  // the agent on one screen and then navigating elsewhere (e.g. tapping into
+  // /one/location from the dashboard or bottom nav) left the fullscreen agent
+  // window mounted on top of the destination, hiding that page's real UI.
+  // Agent-driven navigations already minimize via handleNavigationActionComplete;
+  // this covers every OTHER navigation (nav bar, links, back/forward).
+  const previousPathnameRef = useRef(pathname);
+  useEffect(() => {
+    if (previousPathnameRef.current === pathname) return;
+    previousPathnameRef.current = pathname;
+    minimizeAgent();
+  }, [pathname, minimizeAgent]);
+
   const handleResizePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
+
       if (isFullscreen) return;
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
## Problem (UAT)

On `/one/location`, the full "One — your personal agent" chat window appeared on top of the page instead of the Location UI. The Location hub was rendering correctly underneath; the agent window was simply covering it.

## Root cause

The agent popover (`AgentPopoverProvider`) is a SINGLE app-root surface (mounted in `app/providers.tsx`). Three facts combined:

1. Its `expanded` state lives in React state at the app root, so it **persists across client-side route navigations** (Next.js never unmounts the provider between pages).
2. Its default size mode is **fullscreen** (`AGENT_POPOVER_DEFAULT_SIZE_MODE = "fullscreen"`), so when open it covers the whole viewport.
3. The only code that closed it on navigation was `handleNavigationActionComplete`, which fires **only for agent-driven navigations**. Every OTHER navigation (bottom nav, links, back/forward) left the fullscreen agent mounted over the destination.

So: open the agent on one screen, navigate to `/one/location`, and the fullscreen agent stays on top, hiding the real page.

## Fix

Add a single `pathname`-change effect in `AgentPopoverSurface` that calls `minimizeAgent()` whenever the route changes. The agent is now always a transient overlay and can never be left covering a destination page. Because the fix lives in the shared provider, it protects every route, not just `/one/location`.

## Tests

- New regression case in `agent-popover-provider.test.tsx`: open the agent, change the route, assert it auto-minimizes.
- 37/37 pass across agent popover, navbar-trigger contract, bottom-nav, and the full One-Location page suites; ESLint clean.

## Lane

Maintainer direct-to-main (author @DamriaNeelesh is in the governed bypass cohort); branched from `origin/main`. Please review — do not merge yet.
