### PR TITLE
fix(one-location): lift onboarding Continue above global chrome; revert accidental agent-popover merge (#4158)

### DIFF
--- a/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-popover-provider.test.tsx
@@ -1,11 +1,7 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  AgentPopoverProvider,
-  useAgentPopover,
-} from "@/components/agent/agent-popover-provider";
-
+import { AgentPopoverProvider } from "@/components/agent/agent-popover-provider";
 
 const navigationMock = vi.hoisted(() => ({
   pathname: "/profile",
@@ -142,67 +138,4 @@ describe("AgentPopoverProvider floating trigger", () => {
 
     expect(screen.queryByRole("button", { name: "Open Agent" })).toBeNull();
   });
-
-  // Regression: the fullscreen agent window must NOT stay mounted on top of the
-  // destination page after a route change. Opening the agent on one screen and
-  // navigating (e.g. into /one/location) previously left the agent covering the
-  // page's real UI. Closing on route change keeps the agent a transient overlay.
-  it("minimizes the agent window when the route changes", () => {
-    navigationMock.pathname = "/profile";
-
-    // openAgent defers setExpanded to requestAnimationFrame; run rAF callbacks
-    // synchronously so the open transition completes within act().
-    const rafSpy = vi
-      .spyOn(window, "requestAnimationFrame")
-      .mockImplementation((cb: FrameRequestCallback) => {
-        cb(0);
-        return 0;
-      });
-
-    function OpenAgentOnMount() {
-      const { openAgent, expanded } = useAgentPopover();
-
-      return (
-        <button
-          type="button"
-          data-testid="probe"
-          data-expanded={expanded ? "1" : "0"}
-          onClick={openAgent}
-        >
-          open
-        </button>
-      );
-    }
-
-    const { rerender } = render(
-      <AgentPopoverProvider>
-        <OpenAgentOnMount />
-      </AgentPopoverProvider>,
-    );
-
-    const probe = () => screen.getByTestId("probe");
-    expect(probe().getAttribute("data-expanded")).toBe("0");
-
-    // Open the agent on the current route.
-    act(() => {
-      probe().click();
-    });
-    expect(probe().getAttribute("data-expanded")).toBe("1");
-
-    // Navigate to a new route; the agent must close itself.
-    act(() => {
-      navigationMock.pathname = "/one/location";
-      rerender(
-        <AgentPopoverProvider>
-          <OpenAgentOnMount />
-        </AgentPopoverProvider>,
-      );
-    });
-
-    expect(probe().getAttribute("data-expanded")).toBe("0");
-
-    rafSpy.mockRestore();
-  });
 });
-
-

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -8,8 +8,11 @@ import {
   useState,
   type ComponentProps,
   type MutableRefObject,
+  type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
+
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
@@ -73,6 +76,24 @@ const LOCATION_TAB_OPTIONS: { value: LocationTab; label: string }[] = [
 function normalizeLocationTab(value: string | null | undefined): LocationTab {
   return value === "activity" ? "activity" : "compose";
 }
+
+/**
+ * Renders children into a portal attached to document.body, escaping any
+ * ancestor stacking context. The app shell wraps page content in a
+ * `position: relative; z-10` scroll root (providers.tsx), which would otherwise
+ * trap a descendant overlay's z-index beneath the global chrome (agent bar /
+ * bottom nav). Mounting to <body> lets a full-screen takeover sit above all
+ * chrome. SSR-safe: renders nothing until mounted on the client.
+ */
+function BodyPortal({ children }: { children: ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  if (!mounted || typeof document === "undefined") return null;
+  return createPortal(children, document.body);
+}
+
 
 import type { HushhLocationPermissionState } from "@/lib/capacitor";
 
@@ -4110,18 +4131,31 @@ function OneLocationAgentPageContent() {
     Boolean(auth.userId && vaultOwnerToken);
 
   if (showLocationOnboarding) {
+    // Render the full-screen onboarding takeover through a portal to
+    // document.body. The page content is mounted INSIDE the app shell's scroll
+    // root (a `position: relative; z-10` stacking context in providers.tsx),
+    // which traps any descendant's z-index — so the overlay's `z-[540]` only
+    // competed *within* that context, while the global agent bar (z-[118]) and
+    // bottom nav (z-[120]/[505]) live in the shell's root context and painted
+    // OVER the onboarding footer, hiding the "Continue" button behind the
+    // "Ask your agent anything" bar. Portaling to <body> lifts the overlay into
+    // the document root so its z-index wins over all app chrome and the
+    // Continue / Allow Location button is always tappable.
     return (
-      <OneLocationOnboardingFlow
-        step={locationOnboardingStep}
-        busy={locationOnboardingBusy}
-        permission={permission}
-        nativeTest={nativeTestConfig}
-        onContinueIntro={handleContinueLocationOnboardingIntro}
-        onRequestPermission={handleLocationOnboardingPermission}
-        onSkip={handleSkipLocationOnboarding}
-      />
+      <BodyPortal>
+        <OneLocationOnboardingFlow
+          step={locationOnboardingStep}
+          busy={locationOnboardingBusy}
+          permission={permission}
+          nativeTest={nativeTestConfig}
+          onContinueIntro={handleContinueLocationOnboardingIntro}
+          onRequestPermission={handleLocationOnboardingPermission}
+          onSkip={handleSkipLocationOnboarding}
+        />
+      </BodyPortal>
     );
   }
+
 
   // ---------------------------------------------------------------------------
   // Mobile-first redesign (Figma: one_location_final_fixed_clean_navigation).

--- a/hushh-webapp/components/agent/agent-popover-provider.tsx
+++ b/hushh-webapp/components/agent/agent-popover-provider.tsx
@@ -298,24 +298,8 @@ function AgentPopoverSurface({
     }, 120);
   }, [minimizeAgent]);
 
-  // Close the agent window whenever the route changes. The agent popover is a
-  // SINGLE app-root surface whose expanded state persists across client-side
-  // navigations, and it defaults to a fullscreen size. Without this, opening
-  // the agent on one screen and then navigating elsewhere (e.g. tapping into
-  // /one/location from the dashboard or bottom nav) left the fullscreen agent
-  // window mounted on top of the destination, hiding that page's real UI.
-  // Agent-driven navigations already minimize via handleNavigationActionComplete;
-  // this covers every OTHER navigation (nav bar, links, back/forward).
-  const previousPathnameRef = useRef(pathname);
-  useEffect(() => {
-    if (previousPathnameRef.current === pathname) return;
-    previousPathnameRef.current = pathname;
-    minimizeAgent();
-  }, [pathname, minimizeAgent]);
-
   const handleResizePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
-
       if (isFullscreen) return;
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
## Why this PR

PR #4158 was merged by accident. It only contained an agent-popover route-change minimize, which was a workaround for the **wrong** root cause. The real defect on the location onboarding screen (\Experience location sharing with One\) is a **z-index/stacking trap**, not the agent.

This PR does two things:
1. **Reverts** the agent-popover change from #4158 (restores \gent-popover-provider.tsx\ and its test to the pre-#4158 baseline).
2. **Lands the real fix**: portal the full-screen location onboarding overlay to \document.body\ so its \Continue\/\Allow Location\ button is no longer painted behind the global agent bar + bottom nav.

## Root cause (real)

The onboarding takeover renders at \z-[540]\, but it lived inside the app shell's \elative z-10\ scroll root. z-index is only meaningful within its own stacking context, so the global \Ask your agent anything\ bar and bottom nav — which paint from the document root — covered the onboarding footer. Taps meant for \Continue\ landed on the agent bar, which is what made the agent pop up.

## Fix

Add a small \BodyPortal\ helper in \pp/one/location/page.tsx\ and portal \OneLocationOnboardingFlow\ to \document.body\. Now its \z-[540]\ is evaluated at the document root and the Continue/Allow button sits above all global chrome and receives the taps directly.

## Tests

- \__tests__/components/one-location-agent-page.test.tsx\: 26/26 pass (incl. the onboarding permission-step tests that render the overlay).
- \__tests__/components/agent-popover-provider.test.tsx\: back to 3/3 baseline after the revert.

## Lane

Maintainer direct-to-main (author @DamriaNeelesh is in the governed bypass cohort); branched from \origin/main\. Both commits are DCO signed-off. Please review — do not merge yet.