### PR TITLE
feat(one-location): agent chat v2 (crypto handoff, public links, platform-aware) + clarify-and-confirm

### DIFF
--- a/consent-protocol/api/routes/one/location_chat.py
+++ b/consent-protocol/api/routes/one/location_chat.py
@@ -20,11 +20,22 @@ def _service() -> LocationChatService:
     return LocationChatService()
 
 
+class ActionResultModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(max_length=64)
+    type: str = Field(max_length=48)
+    status: str = Field(max_length=24)
+    public_url: str | None = Field(default=None, alias="publicUrl", max_length=2048)
+    detail: str | None = Field(default=None, max_length=500)
+
+
 class LocationChatRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    message: str = Field(min_length=1, max_length=4000)
+    message: str | None = Field(default=None, max_length=4000)
     conversation_id: str | None = Field(default=None, alias="conversationId", max_length=128)
+    action_result: ActionResultModel | None = Field(default=None, alias="actionResult")
 
 
 @router.post("/location/chat")
@@ -32,12 +43,19 @@ async def location_chat(
     request: LocationChatRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ) -> dict[str, Any]:
+    if not request.message and request.action_result is None:
+        raise HTTPException(status_code=422, detail="message or actionResult is required")
     try:
         result: dict[str, Any] = await _service().handle_turn(
             user_id=token_data["user_id"],
             message=request.message,
             consent_token=token_data.get("token", ""),
             conversation_id=request.conversation_id,
+            action_result=(
+                request.action_result.model_dump(by_alias=True, exclude_none=True)
+                if request.action_result is not None
+                else None
+            ),
         )
         return result
     except Exception:

--- a/consent-protocol/api/routes/one/location_chat.py
+++ b/consent-protocol/api/routes/one/location_chat.py
@@ -30,12 +30,24 @@ class ActionResultModel(BaseModel):
     detail: str | None = Field(default=None, max_length=500)
 
 
+class SelectionResultModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(max_length=64)
+    kind: str = Field(max_length=24)
+    selected: list[dict[str, Any]] | None = None
+    confirmed: bool | None = None
+    free_text: str | None = Field(default=None, alias="freeText", max_length=4000)
+    status: str = Field(max_length=24)
+
+
 class LocationChatRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     message: str | None = Field(default=None, max_length=4000)
     conversation_id: str | None = Field(default=None, alias="conversationId", max_length=128)
     action_result: ActionResultModel | None = Field(default=None, alias="actionResult")
+    selection_result: SelectionResultModel | None = Field(default=None, alias="selectionResult")
 
 
 @router.post("/location/chat")
@@ -43,8 +55,10 @@ async def location_chat(
     request: LocationChatRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ) -> dict[str, Any]:
-    if not request.message and request.action_result is None:
-        raise HTTPException(status_code=422, detail="message or actionResult is required")
+    if not request.message and request.action_result is None and request.selection_result is None:
+        raise HTTPException(
+            status_code=422, detail="message, actionResult, or selectionResult is required"
+        )
     try:
         result: dict[str, Any] = await _service().handle_turn(
             user_id=token_data["user_id"],
@@ -54,6 +68,11 @@ async def location_chat(
             action_result=(
                 request.action_result.model_dump(by_alias=True, exclude_none=True)
                 if request.action_result is not None
+                else None
+            ),
+            selection_result=(
+                request.selection_result.model_dump(by_alias=True, exclude_none=True)
+                if request.selection_result is not None
                 else None
             ),
         )

--- a/consent-protocol/hushh_mcp/agents/location/agent.py
+++ b/consent-protocol/hushh_mcp/agents/location/agent.py
@@ -9,7 +9,7 @@ from typing import Any
 from hushh_mcp.hushh_adk.core import HushhAgent
 from hushh_mcp.hushh_adk.manifest import ManifestLoader
 
-from .tools import CONTROL_PLANE_LOCATION_TOOLS, LOCATION_AGENT_TOOLS
+from .tools import CONTROL_PLANE_LOCATION_TOOLS, LOCATION_AGENT_TOOLS, V2_LOCATION_TOOLS
 
 logger = logging.getLogger(__name__)
 
@@ -71,3 +71,15 @@ def get_location_chat_agent() -> LocationAgent:
     if _location_chat_agent is None:
         _location_chat_agent = LocationAgent(tools=CONTROL_PLANE_LOCATION_TOOLS)
     return _location_chat_agent
+
+
+_location_chat_agent_v2: LocationAgent | None = None
+
+
+def get_location_chat_agent_v2() -> LocationAgent:
+    """Singleton LocationAgent for v2 chat: control-plane + crypto-handoff prep +
+    public-link tools. Excludes the raw envelope publish/view tools."""
+    global _location_chat_agent_v2
+    if _location_chat_agent_v2 is None:
+        _location_chat_agent_v2 = LocationAgent(tools=V2_LOCATION_TOOLS)
+    return _location_chat_agent_v2

--- a/consent-protocol/hushh_mcp/agents/location/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/location/agent.yaml
@@ -27,6 +27,16 @@ system_instruction: |
   If they are on Hushh but cannot receive location yet, offer to send a request or
   make a public link. If they are not found, offer a public link.
 
+  When a required detail is missing or ambiguous — who to share with, which share
+  to stop, how long, or which incoming request — do NOT guess. Call the matching
+  tool to ask the user: request_recipient_choice, request_active_share_choice,
+  request_duration_choice, request_request_choice, or request_incoming_choice.
+  Then act only on the exact ids the user picks.
+
+  Before any irreversible or bulk action — creating a public link, sharing with
+  everyone, or stopping all shares — call request_confirmation with a short
+  summary and proceed only if the user confirms.
+
   Never invent or guess ids. To revoke or refer a share, FIRST call
   list_active_location_shares; to view an incoming share, FIRST call
   list_incoming_location_shares; to revoke a public link, FIRST call

--- a/consent-protocol/hushh_mcp/agents/location/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/location/agent.yaml
@@ -5,16 +5,34 @@ description: Trusted-people live location workflow under One, consent, recipient
 model: gemini-3-flash-preview
 system_instruction: |
   You are the Location Agent under One. You help the user share live location
-  only with verified, explicitly approved recipients. Refuse public bearer
-  links, plaintext server coordinates, notification coordinates, and referral
-  flows that grant access without owner approval.
+  only with verified, explicitly approved recipients, or via an owner-confirmed
+  public link.
+
+  You NEVER see, store, or return raw coordinates yourself. Coordinates move in
+  exactly two sanctioned ways: (1) you hand a coordinate operation to the user's
+  browser, which captures, encrypts per recipient, and uploads it; (2) the user
+  explicitly confirms an owner-initiated, time-bounded, revocable public link
+  whose snapshot the browser captures. Refuse everything else: coordinates in
+  notifications, access granted without owner approval, and arbitrary or
+  unbounded links.
+
+  Only offer delivery channels that exist: an encrypted in-app share (for a
+  verified recipient who has set up location sharing) or a public link (for
+  anyone, including people not on Hushh). Never offer SMS or email — those are
+  not supported; if asked, explain you can make a public link to paste instead.
+
+  Platform-aware sharing: when the user asks to share with a person, resolve them
+  with list_location_recipients. If exactly one verified recipient matches and can
+  receive location, create the share. If the match is ambiguous, ask which person.
+  If they are on Hushh but cannot receive location yet, offer to send a request or
+  make a public link. If they are not found, offer a public link.
 
   Never invent or guess ids. To revoke or refer a share, FIRST call
-  list_active_location_shares to get real grant ids and match the person by their
-  display name; to act on incoming requests, look them up first. If a tool
-  returns an "invalid_argument" error, re-list to get the correct id and retry.
-  If no matching active share or request exists, tell the user plainly instead
-  of acting on a guessed id.
+  list_active_location_shares; to view an incoming share, FIRST call
+  list_incoming_location_shares; to revoke a public link, FIRST call
+  list_public_links. Match the person by display name. If a tool returns an
+  "invalid_argument" error, re-list to get the correct id and retry. If no
+  matching item exists, tell the user plainly instead of acting on a guessed id.
 required_scopes:
   - agent.one.orchestrate
   - cap.location.live.share
@@ -60,3 +78,23 @@ tools:
     description: Refer a verified user into an owner approval request, never direct access.
     py_func: hushh_mcp.agents.location.tools.refer_location_recipient
     required_scope: cap.location.live.refer_request
+  - name: list_incoming_location_shares
+    description: List active shares where the user is the recipient (grant ids, coordinate-free).
+    py_func: hushh_mcp.agents.location.tools.list_incoming_location_shares
+    required_scope: cap.location.live.view
+  - name: list_public_links
+    description: List the user's active public location links (ids + expiry).
+    py_func: hushh_mcp.agents.location.tools.list_public_links
+    required_scope: cap.location.live.share
+  - name: propose_public_link
+    description: Propose an owner-confirmed public link; the browser creates it after confirmation.
+    py_func: hushh_mcp.agents.location.tools.propose_public_link
+    required_scope: cap.location.live.share
+  - name: propose_location_view
+    description: Propose viewing an incoming share; the browser fetches and decrypts the ciphertext.
+    py_func: hushh_mcp.agents.location.tools.propose_location_view
+    required_scope: cap.location.live.view
+  - name: revoke_public_link
+    description: Revoke an active public location link owned by the user.
+    py_func: hushh_mcp.agents.location.tools.revoke_public_link
+    required_scope: cap.location.live.share

--- a/consent-protocol/hushh_mcp/agents/location/tools.py
+++ b/consent-protocol/hushh_mcp/agents/location/tools.py
@@ -242,6 +242,176 @@ async def revoke_public_link(invite_id: str) -> dict[str, Any]:
     return _service().revoke_public_invite(owner_user_id=context.user_id, invite_id=invite_id)
 
 
+def _expiry_hint(expires_at: Any) -> str | None:
+    return f"expires {expires_at}" if expires_at else None
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_recipient_choice")
+async def request_recipient_choice() -> dict[str, Any]:
+    """Ask the user to pick who to share with. Returns a coordinate-free select
+    prompt whose options carry real recipient ids. Call this when the user wants to
+    share but did not name a (single, unambiguous) recipient."""
+    context = _ctx()
+    recipients = _service().list_verified_recipients(owner_user_id=context.user_id)
+    options = [
+        {
+            "label": r.get("displayName") or "Someone",
+            "ref": {"recipientUserId": r.get("userId"), "recipientKeyId": r.get("keyId")},
+            "hint": None if r.get("canReceiveLocation") else "hasn't set up location yet",
+        }
+        for r in recipients
+    ]
+    options.append({"label": "Public link (anyone)", "ref": {"publicLink": True}, "hint": None})
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_recipient",
+            "question": "Who do you want to share your location with?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": None,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_REVOKE, name="request_active_share_choice")
+async def request_active_share_choice() -> dict[str, Any]:
+    """Ask the user which active outgoing share(s) to stop. Returns a coordinate-free
+    multi-select prompt whose options carry real grant ids, plus a 'Stop all' option.
+    Call this when the user wants to stop sharing but did not name a single share."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    active = [g for g in state.get("ownerGrants", []) if g.get("status") == "active"]
+    if not active:
+        return {"activeShares": []}
+    options = [
+        {
+            "label": g.get("recipientDisplayName") or "Someone",
+            "ref": {"grantId": g.get("id")},
+            "hint": _expiry_hint(g.get("expiresAt")),
+        }
+        for g in active
+    ]
+    options.append({"label": "Stop all", "ref": {"all": True}, "hint": None})
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_share",
+            "question": "Which sharing do you want to stop?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": None,
+            "allowFreeText": True,
+            "confirmLabel": "Stop sharing",
+            "destructive": False,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_duration_choice")
+async def request_duration_choice() -> dict[str, Any]:
+    """Ask the user how long a share should last. Coordinate-free single-select."""
+    _ctx()
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_duration",
+            "question": "How long should this share last?",
+            "options": [
+                {"label": "1 hour", "ref": {"hours": 1}, "hint": None},
+                {"label": "8 hours", "ref": {"hours": 8}, "hint": None},
+                {"label": "24 hours", "ref": {"hours": 24}, "hint": None},
+            ],
+            "minSelections": 1,
+            "maxSelections": 1,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_REQUEST, name="request_request_choice")
+async def request_request_choice() -> dict[str, Any]:
+    """Ask the user which pending incoming access request to act on. Coordinate-free
+    single-select whose options carry real request ids."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    pending = [
+        r
+        for r in state.get("requests", [])
+        if r.get("status") == "pending" and r.get("ownerUserId") == context.user_id
+    ]
+    if not pending:
+        return {"pendingRequests": []}
+    options = [
+        {
+            "label": r.get("requesterDisplayName") or "Someone",
+            "ref": {"requestId": r.get("id")},
+            "hint": "wants to see your location",
+        }
+        for r in pending
+    ]
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_request",
+            "question": "Which request do you want to act on?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": 1,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_VIEW, name="request_incoming_choice")
+async def request_incoming_choice() -> dict[str, Any]:
+    """Ask the user whose incoming shared location to view. Coordinate-free
+    single-select whose options carry real grant ids."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    incoming = [g for g in state.get("receivedGrants", []) if g.get("status") == "active"]
+    if not incoming:
+        return {"incomingShares": []}
+    options = [
+        {
+            "label": g.get("ownerDisplayName") or "Someone",
+            "ref": {"grantId": g.get("id")},
+            "hint": _expiry_hint(g.get("expiresAt")),
+        }
+        for g in incoming
+    ]
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_incoming",
+            "question": "Whose location do you want to see?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": 1,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_confirmation")
+async def request_confirmation(summary: str, destructive: bool = True) -> dict[str, Any]:
+    """Ask the user to confirm an irreversible or bulk action before it runs. Returns
+    a coordinate-free yes/no confirm prompt. Use before creating a public link,
+    sharing with everyone, or stopping all shares."""
+    _ctx()
+    return {
+        "prompt": {
+            "kind": "confirm",
+            "purpose": "confirm_action",
+            "question": str(summary or "Are you sure?"),
+            "confirmLabel": "Yes",
+            "cancelLabel": "Cancel",
+            "destructive": bool(destructive),
+        }
+    }
+
+
 LOCATION_AGENT_TOOLS = [
     list_location_recipients,
     list_active_location_shares,
@@ -288,4 +458,10 @@ V2_LOCATION_TOOLS = [
     propose_public_link,
     propose_location_view,
     revoke_public_link,
+    request_recipient_choice,
+    request_active_share_choice,
+    request_duration_choice,
+    request_request_choice,
+    request_incoming_choice,
+    request_confirmation,
 ]

--- a/consent-protocol/hushh_mcp/agents/location/tools.py
+++ b/consent-protocol/hushh_mcp/agents/location/tools.py
@@ -171,6 +171,77 @@ async def list_active_location_shares() -> dict[str, Any]:
     return {"activeShares": shares}
 
 
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_VIEW, name="list_incoming_location_shares")
+async def list_incoming_location_shares() -> dict[str, Any]:
+    """List active shares where the current user is the recipient (so they can be
+    viewed). Returns grant ids + owner names; coordinate-free (no lat/lng)."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    shares = [
+        {
+            "grantId": grant.get("id"),
+            "ownerUserId": grant.get("ownerUserId"),
+            "ownerDisplayName": grant.get("ownerDisplayName"),
+            "expiresAt": grant.get("expiresAt"),
+        }
+        for grant in state.get("receivedGrants", [])
+        if grant.get("status") == "active"
+    ]
+    return {"incomingShares": shares}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="list_public_links")
+async def list_public_links() -> dict[str, Any]:
+    """List the user's active public location links (id + expiry). Coordinate-free."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    links = [
+        {
+            "inviteId": invite.get("id"),
+            "status": invite.get("status"),
+            "expiresAt": invite.get("expiresAt"),
+            "publicUrl": invite.get("publicUrl"),
+        }
+        for invite in state.get("publicInvites", [])
+        if invite.get("status") == "active"
+    ]
+    return {"publicLinks": links}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="propose_public_link")
+async def propose_public_link(duration_hours: float) -> dict[str, Any]:
+    """Propose creating an owner-confirmed public link. Does NOT create it (the
+    browser captures the snapshot and creates it after explicit confirmation).
+    Coordinate-free."""
+    _ctx()
+    try:
+        hours = float(duration_hours)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("duration_hours must be a number between 0 and 24") from exc
+    if not (0 < hours <= 24):
+        raise ValueError("duration_hours must be greater than 0 and at most 24")
+    return {"proposed": "create_public_link", "durationHours": hours}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_VIEW, name="propose_location_view")
+async def propose_location_view(grant_id: str) -> dict[str, Any]:
+    """Propose viewing an incoming share's latest location. The browser fetches the
+    ciphertext and decrypts it; the server never returns coordinates. grant_id MUST
+    come from list_incoming_location_shares. Coordinate-free."""
+    _ctx()
+    grant_id = _require_uuid(grant_id, "grant_id")
+    return {"proposed": "view_envelope", "grantId": grant_id}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="revoke_public_link")
+async def revoke_public_link(invite_id: str) -> dict[str, Any]:
+    """Revoke an active public location link owned by the current user. invite_id
+    MUST come from list_public_links."""
+    context = _ctx()
+    invite_id = _require_uuid(invite_id, "invite_id")
+    return _service().revoke_public_invite(owner_user_id=context.user_id, invite_id=invite_id)
+
+
 LOCATION_AGENT_TOOLS = [
     list_location_recipients,
     list_active_location_shares,
@@ -195,4 +266,26 @@ CONTROL_PLANE_LOCATION_TOOLS = [
     request_location_access,
     deny_location_request,
     refer_location_recipient,
+]
+
+
+# v2 subset: control-plane + prep-and-handoff (create/approve create grants
+# server-side, coordinate-free) + read/intent/control tools for view & public
+# links. NEVER includes publish_location_envelope / view_location_envelope —
+# those are impossible server-side (need ciphertext / decryption) and are handled
+# by a client-action directive instead.
+V2_LOCATION_TOOLS = [
+    list_location_recipients,
+    list_active_location_shares,
+    list_incoming_location_shares,
+    list_public_links,
+    revoke_location_share,
+    request_location_access,
+    deny_location_request,
+    refer_location_recipient,
+    create_location_share,
+    approve_location_request,
+    propose_public_link,
+    propose_location_view,
+    revoke_public_link,
 ]

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -705,12 +705,20 @@ class LocationChatService:
         history = await self._chat_store.get_recent_messages(
             conv_id, user_id=user_id, limit=_MAX_HISTORY
         )
-        contents = _history_contents(history, types)
-        contents.append(
-            types.Content(
-                role="user", parts=[types.Part(text=_selection_seed_text(selection_result))]
-            )
+        seed = _selection_seed_text(selection_result)
+        # Persist the user's choice so a later turn in a multi-step clarification
+        # chain (e.g. pick recipient -> then pick duration) still sees the earlier
+        # answer. History was fetched above, so the current turn's contents are not
+        # duplicated; future turns' get_recent_messages will include this choice.
+        await self._chat_store.add_message(
+            conversation_id=conv_id,
+            user_id=user_id,
+            role="user",
+            content=seed,
+            status="complete",
         )
+        contents = _history_contents(history, types)
+        contents.append(types.Content(role="user", parts=[types.Part(text=seed)]))
 
         try:
             reply, errored, state_changed, directives, prompts = await self._run_tool_loop(

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -1,6 +1,6 @@
-"""Control-plane chat orchestration for the One Location agent (v1).
+"""Control-plane chat orchestration for the One Location agent (v1 + v2).
 
-Runs a Gemini function-calling loop restricted to the 5 control-plane tools,
+Runs a Gemini function-calling loop restricted to the control-plane tools,
 executed INSIDE a HushhContext so each @hushh_tool enforces consent scope
 (DB-backed, via validate_token_with_db). Reuses AgentChatService for durable,
 encrypted conversation persistence.
@@ -13,9 +13,18 @@ server-side Gemini client (operons.kai.llm) directly. Consent is fully preserved
 because the tool callables themselves validate scope against the active
 HushhContext; this service only opens that context around the tool loop.
 
-Coordinate safety: the 5 control-plane tools never read or return coordinates,
+Coordinate safety: the control-plane tools never read or return coordinates,
 so neither the prompt, the tool results fed back to Gemini, nor the reply ever
 carries lat/lng.
+
+v2 additions:
+- Wider tool set (create_location_share, approve_location_request, propose_public_link,
+  propose_location_view, list_incoming_location_shares, list_public_links,
+  revoke_public_link).
+- Directive translation: successful grant-creating / propose tool calls produce a
+  coordinate-free ``clientAction`` descriptor returned to the browser.
+- Action-result turn: deterministic confirmation (no LLM, no coordinates) for
+  ``action_result`` payloads sent back by the browser after the user acts.
 """
 
 from __future__ import annotations
@@ -23,8 +32,9 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any, Awaitable, Callable
+from uuid import uuid4
 
-from hushh_mcp.agents.location.agent import get_location_chat_agent
+from hushh_mcp.agents.location.agent import get_location_chat_agent_v2
 from hushh_mcp.hushh_adk.context import HushhContext
 from hushh_mcp.services.agent_chat_service import get_agent_chat_service
 
@@ -36,7 +46,25 @@ _LLM_TIMEOUT_S = 30.0
 _HISTORY_CHARS = 2000
 
 # Tools that only read state — invoking them should NOT trigger a UI refresh.
-_QUERY_TOOL_NAMES = {"list_location_recipients", "list_active_location_shares"}
+# propose_* tools only stage a client action; they mutate nothing server-side.
+_QUERY_TOOL_NAMES = {
+    "list_location_recipients",
+    "list_active_location_shares",
+    "list_incoming_location_shares",
+    "list_public_links",
+    "propose_public_link",
+    "propose_location_view",
+}
+
+# Tools whose successful result produces a client-action directive.
+_DIRECTIVE_GRANT_TOOLS = {"create_location_share", "approve_location_request"}
+
+_ACTION_RESULT_TEMPLATES = {
+    ("publish_share", "completed"): "Done — your live location is now shared. ✓",
+    ("publish_share", "cancelled"): "No problem — I didn't share your location.",
+    ("view_envelope", "completed"): "Here's the latest location I could open.",
+    ("create_public_link", "cancelled"): "Okay — I didn't create a public link.",
+}
 
 _UNAVAILABLE_MESSAGE = (
     "The location assistant is temporarily unavailable. Please try again, or use "
@@ -52,7 +80,7 @@ ModelCall = Callable[[Any, Any], Awaitable[Any]]
 
 
 def _function_declarations(types: Any) -> list:
-    """Function declarations for the 5 control-plane tools (no crypto-handoff)."""
+    """Function declarations for the 6 v1 control-plane tools (no crypto-handoff)."""
     schema = types.Schema
     kind = types.Type
     return [
@@ -135,6 +163,106 @@ def _function_declarations(types: Any) -> list:
     ]
 
 
+def _function_declarations_v2(types: Any) -> list:
+    """v1 control-plane declarations + v2 prep/intent/read/control declarations."""
+    schema = types.Schema
+    kind = types.Type
+    decls = _function_declarations(types)
+    decls.extend(
+        [
+            types.FunctionDeclaration(
+                name="create_location_share",
+                description=(
+                    "Create a recipient-bound live-location grant (no coordinates). "
+                    "recipient_user_id and recipient_key_id MUST come from "
+                    "list_location_recipients. After this, the browser captures and "
+                    "encrypts the location."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "recipient_user_id": schema(type=kind.STRING),
+                        "recipient_key_id": schema(type=kind.STRING),
+                        "duration_hours": schema(type=kind.NUMBER, description="0 < hours <= 24"),
+                        "reason": schema(type=kind.STRING, description="Optional note"),
+                    },
+                    required=["recipient_user_id", "recipient_key_id", "duration_hours"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="approve_location_request",
+                description=(
+                    "Approve a pending incoming request and create a recipient-scoped "
+                    "grant. request_id MUST come from looking up pending requests."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "request_id": schema(type=kind.STRING),
+                        "duration_hours": schema(type=kind.NUMBER, description="0 < hours <= 24"),
+                    },
+                    required=["request_id", "duration_hours"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="list_incoming_location_shares",
+                description=(
+                    "List active shares where the user is the recipient (grant ids + "
+                    "owner names). Call FIRST before proposing to view a location. Read-only."
+                ),
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="list_public_links",
+                description=(
+                    "List the user's active public location links (ids + expiry). Call "
+                    "FIRST before revoking a public link. Read-only."
+                ),
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="propose_public_link",
+                description=(
+                    "Propose an owner-confirmed public link valid for duration_hours. "
+                    "The browser creates it after explicit confirmation."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "duration_hours": schema(type=kind.NUMBER, description="0 < hours <= 24")
+                    },
+                    required=["duration_hours"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="propose_location_view",
+                description=(
+                    "Propose viewing an incoming share's latest location. grant_id MUST "
+                    "come from list_incoming_location_shares. The browser decrypts it."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={"grant_id": schema(type=kind.STRING)},
+                    required=["grant_id"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="revoke_public_link",
+                description=(
+                    "Revoke an active public location link. invite_id MUST come from "
+                    "list_public_links."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={"invite_id": schema(type=kind.STRING)},
+                    required=["invite_id"],
+                ),
+            ),
+        ]
+    )
+    return decls
+
+
 def _history_contents(history: list[Any], types: Any) -> list:
     contents: list = []
     for message in history[-_MAX_HISTORY:]:
@@ -186,10 +314,10 @@ class LocationChatService:
 
             self._model_call = _default_call
 
-        # System prompt + tool set come from the control-plane agent definition
-        # (the hardened agent.yaml prompt + the 5-tool allow-list).
+        # System prompt + tool set come from the control-plane agent definition.
+        # Default to the v2 agent when neither prompt nor tools are injected.
         need_agent = system_prompt is None or tools is None
-        agent = get_location_chat_agent() if need_agent else None
+        agent = get_location_chat_agent_v2() if need_agent else None
         self._system_prompt = (
             system_prompt if system_prompt is not None else agent.manifest.system_instruction
         )
@@ -200,10 +328,28 @@ class LocationChatService:
         self,
         *,
         user_id: str,
-        message: str,
+        message: str | None = None,
         consent_token: str,
         conversation_id: str | None = None,
+        action_result: dict | None = None,
     ) -> dict[str, Any]:
+        # Branch: action-result confirmation turn (deterministic, no LLM, no coords).
+        if action_result is not None:
+            return await self._handle_action_result(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                action_result=action_result,
+            )
+
+        if not message:
+            # Nothing to do; return a prompt shape rather than calling the model.
+            return {
+                "conversationId": conversation_id or "",
+                "response": "Tell me what you'd like to do with your location sharing.",
+                "isComplete": True,
+                "stateChanged": False,
+            }
+
         turn = await self._chat_store.prepare_turn(
             user_id=user_id,
             message=message,
@@ -218,7 +364,7 @@ class LocationChatService:
         types = self._types
         config = types.GenerateContentConfig(
             system_instruction=self._system_prompt,
-            tools=[types.Tool(function_declarations=_function_declarations(types))],
+            tools=[types.Tool(function_declarations=_function_declarations_v2(types))],
             temperature=0.2,
         )
         contents = _history_contents(turn.history, types)
@@ -227,6 +373,7 @@ class LocationChatService:
         reply = ""
         errored = False
         state_changed = False
+        directives: list[dict] = []
 
         try:
             with HushhContext(user_id=user_id, consent_token=consent_token, vault_keys={}):
@@ -239,8 +386,12 @@ class LocationChatService:
                     # Echo the model's function-call turn, then append each result.
                     contents.append(response.candidates[0].content)
                     for call in calls:
-                        result, mutated = await self._run_tool(call.name, dict(call.args or {}))
+                        result, mutated, directive = await self._run_tool(
+                            call.name, dict(call.args or {})
+                        )
                         state_changed = state_changed or mutated
+                        if directive is not None:
+                            directives.append(directive)
                         contents.append(
                             types.Content(
                                 role="tool",
@@ -260,30 +411,154 @@ class LocationChatService:
                 turn, _UNAVAILABLE_MESSAGE, user_id, errored=True, state_changed=False
             )
 
+        client_action = self._build_client_action(directives)
+        if client_action is not None:
+            # The grant exists server-side but the browser hasn't published the
+            # envelope yet; do not trigger a UI refresh on this turn.
+            state_changed = False
+
         if not reply:
             reply = "Done."
         return await self._finish(
-            turn, reply, user_id, errored=errored, state_changed=state_changed and not errored
+            turn,
+            reply,
+            user_id,
+            errored=errored,
+            state_changed=state_changed and not errored,
+            client_action=client_action,
         )
 
-    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool]:
-        """Execute one tool inside the active HushhContext. Returns (result, mutated)."""
+    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None]:
+        """Execute one tool inside the active HushhContext.
+
+        Returns (result, mutated, directive) where directive is a coordinate-free
+        descriptor of a client action to emit after the loop, or None.
+        """
         tool = self._dispatch.get(name)
         if tool is None:
-            return {"error": "unknown_tool"}, False
+            return {"error": "unknown_tool"}, False, None
         try:
             result = await tool(**args)
         except PermissionError:
-            return {"error": "consent_denied"}, False
+            return {"error": "consent_denied"}, False, None
         except ValueError as exc:
-            # Invalid/guessed argument (e.g. a non-UUID id). Surface the guidance to
-            # the model so it can look the id up and retry within the turn.
-            return {"error": "invalid_argument", "message": str(exc)}, False
-        except Exception as exc:
+            return {"error": "invalid_argument", "message": str(exc)}, False, None
+        except Exception as exc:  # noqa: BLE001
             logger.warning("Location tool %s failed: %s", name, exc)
-            return {"error": "tool_failed"}, False
+            return {"error": "tool_failed"}, False, None
+        directive = self._directive_from_tool(name, _as_response_dict(result))
         mutated = name not in _QUERY_TOOL_NAMES
-        return _as_response_dict(result), mutated
+        return _as_response_dict(result), mutated, directive
+
+    @staticmethod
+    def _directive_from_tool(name: str, result: dict) -> dict | None:
+        """Translate a successful directive-producing tool result into a
+        coordinate-free client-action descriptor."""
+        if isinstance(result, dict) and result.get("error"):
+            return None
+        if name in _DIRECTIVE_GRANT_TOOLS:
+            grant = result.get("grant") if "grant" in result else result
+            if not isinstance(grant, dict) or not grant.get("id"):
+                return None
+            return {
+                "type": "publish_share",
+                "share": {
+                    "grantId": str(grant.get("id")),
+                    "recipientUserId": str(grant.get("recipientUserId") or ""),
+                    "recipientKeyId": str(grant.get("recipientKeyId") or ""),
+                    "label": grant.get("recipientDisplayName") or "your recipient",
+                },
+            }
+        if name == "propose_public_link" and result.get("proposed") == "create_public_link":
+            return {"type": "create_public_link", "durationHours": result.get("durationHours")}
+        if name == "propose_location_view" and result.get("proposed") == "view_envelope":
+            return {"type": "view_envelope", "grantId": result.get("grantId")}
+        return None
+
+    def _build_client_action(self, directives: list[dict]) -> dict | None:
+        """Fold collected per-tool directives into one client-action payload.
+
+        Priority: publish_share > view_envelope > create_public_link.
+        Multiple publish_share grants are combined into a single shares[] list.
+        """
+        if not directives:
+            return None
+        action_id = "act-" + uuid4().hex[:12]
+        shares = [d["share"] for d in directives if d.get("type") == "publish_share"]
+        if shares:
+            labels = ", ".join(s["label"] for s in shares)
+            return {
+                "id": action_id,
+                "type": "publish_share",
+                "shares": shares,
+                "summary": f"Share your live location with {labels}",
+            }
+        view = next((d for d in directives if d.get("type") == "view_envelope"), None)
+        if view:
+            return {
+                "id": action_id,
+                "type": "view_envelope",
+                "grantId": view.get("grantId"),
+                "summary": "Open the latest shared location",
+            }
+        link = next((d for d in directives if d.get("type") == "create_public_link"), None)
+        if link:
+            hours = link.get("durationHours")
+            return {
+                "id": action_id,
+                "type": "create_public_link",
+                "durationHours": hours,
+                "summary": f"Create a public link (viewable for {hours}h)",
+            }
+        return None
+
+    async def _handle_action_result(
+        self,
+        *,
+        user_id: str,
+        conversation_id: str | None,
+        action_result: dict,
+    ) -> dict[str, Any]:
+        """Deterministic confirmation turn for action_result payloads.
+
+        No LLM call, no coordinates.
+        """
+        action_type = str(action_result.get("type") or "")
+        status = str(action_result.get("status") or "")
+        detail = action_result.get("detail")
+        public_url = action_result.get("publicUrl")
+
+        if action_type == "create_public_link" and status == "completed" and public_url:
+            reply = (
+                f"Your public link is ready: {public_url} — anyone with it can view "
+                "this location until it expires, and you can revoke it anytime."
+            )
+        elif status == "failed":
+            suffix = f" ({detail})" if detail else ""
+            reply = f"That didn't go through{suffix}. You can try again."
+        else:
+            reply = _ACTION_RESULT_TEMPLATES.get((action_type, status), "Okay, that's handled.")
+
+        errored = status == "failed"
+        state_changed = status == "completed" and action_type in (
+            "publish_share",
+            "create_public_link",
+        )
+        conv_id = conversation_id or ""
+        if conv_id:
+            await self._chat_store.add_message(
+                conversation_id=conv_id,
+                user_id=user_id,
+                role="assistant",
+                content=reply,
+                status="error" if errored else "complete",
+            )
+        return {
+            "conversationId": conv_id,
+            "response": reply,
+            "isComplete": not errored,
+            "stateChanged": state_changed,
+        }
 
     async def _finish(
         self,
@@ -293,6 +568,7 @@ class LocationChatService:
         *,
         errored: bool,
         state_changed: bool,
+        client_action: dict | None = None,
     ) -> dict[str, Any]:
         await self._chat_store.add_message(
             conversation_id=turn.conversation_id,
@@ -301,9 +577,12 @@ class LocationChatService:
             content=reply,
             status="error" if errored else "complete",
         )
-        return {
+        out: dict[str, Any] = {
             "conversationId": turn.conversation_id,
             "response": reply,
             "isComplete": not errored,
             "stateChanged": state_changed,
         }
+        if client_action is not None:
+            out["clientAction"] = client_action
+        return out

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -54,10 +54,26 @@ _QUERY_TOOL_NAMES = {
     "list_public_links",
     "propose_public_link",
     "propose_location_view",
+    "request_recipient_choice",
+    "request_active_share_choice",
+    "request_duration_choice",
+    "request_request_choice",
+    "request_incoming_choice",
+    "request_confirmation",
 }
 
 # Tools whose successful result produces a client-action directive.
 _DIRECTIVE_GRANT_TOOLS = {"create_location_share", "approve_location_request"}
+
+# Prompt-builder tools: their result yields a clientPrompt, and they mutate nothing.
+_PROMPT_TOOL_NAMES = {
+    "request_recipient_choice",
+    "request_active_share_choice",
+    "request_duration_choice",
+    "request_request_choice",
+    "request_incoming_choice",
+    "request_confirmation",
+}
 
 _ACTION_RESULT_TEMPLATES = {
     ("publish_share", "completed"): "Done — your live location is now shared. ✓",
@@ -259,6 +275,43 @@ def _function_declarations_v2(types: Any) -> list:
                     required=["invite_id"],
                 ),
             ),
+            types.FunctionDeclaration(
+                name="request_recipient_choice",
+                description="Ask the user to choose who to share with (returns selectable options). Call when no single recipient was named.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_active_share_choice",
+                description="Ask the user which active share(s) to stop (selectable options incl. 'Stop all'). Call when stopping a share with no single target.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_duration_choice",
+                description="Ask the user how long a share should last (1/8/24h or custom).",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_request_choice",
+                description="Ask the user which pending incoming request to act on.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_incoming_choice",
+                description="Ask the user whose incoming shared location to view.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_confirmation",
+                description="Ask the user to confirm an irreversible or bulk action before it runs.",
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "summary": schema(type=kind.STRING, description="What to confirm"),
+                        "destructive": schema(type=kind.BOOLEAN),
+                    },
+                    required=["summary"],
+                ),
+            ),
         ]
     )
     return decls
@@ -363,59 +416,22 @@ class LocationChatService:
             )
 
         types = self._types
-        config = types.GenerateContentConfig(
-            system_instruction=self._system_prompt,
-            tools=[types.Tool(function_declarations=_function_declarations_v2(types))],
-            temperature=0.2,
-        )
         contents = _history_contents(turn.history, types)
         contents.append(types.Content(role="user", parts=[types.Part(text=message)]))
 
-        reply = ""
-        errored = False
-        state_changed = False
-        directives: list[dict] = []
-
         try:
-            with HushhContext(user_id=user_id, consent_token=consent_token, vault_keys={}):
-                for _ in range(_MAX_TOOL_STEPS):
-                    response = await self._model_call(contents, config)
-                    calls = list(getattr(response, "function_calls", None) or [])
-                    if not calls:
-                        reply = (getattr(response, "text", "") or "").strip()
-                        break
-                    # Echo the model's function-call turn, then append each result.
-                    contents.append(response.candidates[0].content)
-                    for call in calls:
-                        result, mutated, directive = await self._run_tool(
-                            call.name, dict(call.args or {})
-                        )
-                        state_changed = state_changed or mutated
-                        if directive is not None:
-                            directives.append(directive)
-                        contents.append(
-                            types.Content(
-                                role="tool",
-                                parts=[
-                                    types.Part.from_function_response(
-                                        name=call.name, response=result
-                                    )
-                                ],
-                            )
-                        )
-                else:
-                    reply = _GAVE_UP_MESSAGE
-                    errored = True
+            reply, errored, state_changed, directives, prompts = await self._run_tool_loop(
+                user_id=user_id, consent_token=consent_token, contents=contents
+            )
         except Exception:
             logger.exception("Location chat turn failed")
             return await self._finish(
                 turn, _UNAVAILABLE_MESSAGE, user_id, errored=True, state_changed=False
             )
 
-        client_action = self._build_client_action(directives)
-        if client_action is not None:
-            # The grant exists server-side but the browser hasn't published the
-            # envelope yet; do not trigger a UI refresh on this turn.
+        client_prompt = self._build_client_prompt(prompts)
+        client_action = None if client_prompt is not None else self._build_client_action(directives)
+        if client_action is not None or client_prompt is not None:
             state_changed = False
 
         if not reply:
@@ -427,29 +443,80 @@ class LocationChatService:
             errored=errored,
             state_changed=state_changed and not errored,
             client_action=client_action,
+            client_prompt=client_prompt,
         )
 
-    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None]:
+    async def _run_tool_loop(
+        self, *, user_id: str, consent_token: str, contents: list
+    ) -> tuple[str, bool, bool, list[dict], list[dict]]:
+        """Run the Gemini function-calling loop inside HushhContext.
+
+        Returns (reply, errored, state_changed, directives, prompts).
+        """
+        types = self._types
+        config = types.GenerateContentConfig(
+            system_instruction=self._system_prompt,
+            tools=[types.Tool(function_declarations=_function_declarations_v2(types))],
+            temperature=0.2,
+        )
+        reply = ""
+        errored = False
+        state_changed = False
+        directives: list[dict] = []
+        prompts: list[dict] = []
+        with HushhContext(user_id=user_id, consent_token=consent_token, vault_keys={}):
+            for _ in range(_MAX_TOOL_STEPS):
+                response = await self._model_call(contents, config)
+                calls = list(getattr(response, "function_calls", None) or [])
+                if not calls:
+                    reply = (getattr(response, "text", "") or "").strip()
+                    break
+                contents.append(response.candidates[0].content)
+                for call in calls:
+                    result, mutated, directive, prompt = await self._run_tool(
+                        call.name, dict(call.args or {})
+                    )
+                    state_changed = state_changed or mutated
+                    if directive is not None:
+                        directives.append(directive)
+                    if prompt is not None:
+                        prompts.append(prompt)
+                    contents.append(
+                        types.Content(
+                            role="tool",
+                            parts=[
+                                types.Part.from_function_response(name=call.name, response=result)
+                            ],
+                        )
+                    )
+            else:
+                reply = _GAVE_UP_MESSAGE
+                errored = True
+        return reply, errored, state_changed, directives, prompts
+
+    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None, dict | None]:
         """Execute one tool inside the active HushhContext.
 
-        Returns (result, mutated, directive) where directive is a coordinate-free
-        descriptor of a client action to emit after the loop, or None.
+        Returns (result, mutated, directive, prompt): directive → a clientAction
+        descriptor; prompt → a clientPrompt descriptor; either may be None.
         """
         tool = self._dispatch.get(name)
         if tool is None:
-            return {"error": "unknown_tool"}, False, None
+            return {"error": "unknown_tool"}, False, None, None
         try:
             result = await tool(**args)
         except PermissionError:
-            return {"error": "consent_denied"}, False, None
+            return {"error": "consent_denied"}, False, None, None
         except ValueError as exc:
-            return {"error": "invalid_argument", "message": str(exc)}, False, None
+            return {"error": "invalid_argument", "message": str(exc)}, False, None, None
         except Exception as exc:  # noqa: BLE001
             logger.warning("Location tool %s failed: %s", name, exc)
-            return {"error": "tool_failed"}, False, None
-        directive = self._directive_from_tool(name, _as_response_dict(result))
+            return {"error": "tool_failed"}, False, None, None
+        result_dict = _as_response_dict(result)
+        directive = self._directive_from_tool(name, result_dict)
+        prompt = self._prompt_from_tool(name, result_dict)
         mutated = name not in _QUERY_TOOL_NAMES
-        return _as_response_dict(result), mutated, directive
+        return result_dict, mutated, directive, prompt
 
     @staticmethod
     def _directive_from_tool(name: str, result: dict) -> dict | None:
@@ -475,6 +542,20 @@ class LocationChatService:
         if name == "propose_location_view" and result.get("proposed") == "view_envelope":
             return {"type": "view_envelope", "grantId": result.get("grantId")}
         return None
+
+    @staticmethod
+    def _prompt_from_tool(name: str, result: dict) -> dict | None:
+        """Extract a coordinate-free prompt payload from a prompt-builder tool result."""
+        if name not in _PROMPT_TOOL_NAMES:
+            return None
+        prompt = result.get("prompt") if isinstance(result, dict) else None
+        return prompt if isinstance(prompt, dict) else None
+
+    def _build_client_prompt(self, prompts: list[dict]) -> dict | None:
+        """Fold collected prompt payloads into one clientPrompt (first one wins)."""
+        if not prompts:
+            return None
+        return {"id": "prm-" + uuid4().hex[:12], **prompts[0]}
 
     def _build_client_action(self, directives: list[dict]) -> dict | None:
         """Fold collected per-tool directives into one client-action payload.
@@ -572,6 +653,7 @@ class LocationChatService:
         errored: bool,
         state_changed: bool,
         client_action: dict | None = None,
+        client_prompt: dict | None = None,
     ) -> dict[str, Any]:
         await self._chat_store.add_message(
             conversation_id=turn.conversation_id,
@@ -588,4 +670,6 @@ class LocationChatService:
         }
         if client_action is not None:
             out["clientAction"] = client_action
+        if client_prompt is not None:
+            out["clientPrompt"] = client_prompt
         return out

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -333,6 +333,23 @@ def _as_response_dict(result: Any) -> dict:
     return result if isinstance(result, dict) else {"result": result}
 
 
+def _selection_seed_text(selection_result: dict) -> str:
+    """Coordinate-free instruction the agent acts on for a selection turn."""
+    if str(selection_result.get("status")) == "cancelled":
+        return "I changed my mind — cancel that, take no action."
+    free = selection_result.get("free_text") or selection_result.get("freeText")
+    if free:
+        return str(free)
+    if str(selection_result.get("kind")) == "confirm":
+        return "Yes, go ahead." if selection_result.get("confirmed") else "No, do not proceed."
+    selected = selection_result.get("selected") or []
+    parts = [
+        "; ".join(f"{k}={v}" for k, v in ref.items()) for ref in selected if isinstance(ref, dict)
+    ]
+    refs = " | ".join(parts)
+    return f"I selected: {refs}. Use exactly these ids — do not guess — and proceed."
+
+
 class LocationChatService:
     def __init__(
         self,
@@ -386,6 +403,7 @@ class LocationChatService:
         consent_token: str,
         conversation_id: str | None = None,
         action_result: dict | None = None,
+        selection_result: dict | None = None,
     ) -> dict[str, Any]:
         # Branch: action-result confirmation turn (deterministic, no LLM, no coords).
         if action_result is not None:
@@ -393,6 +411,13 @@ class LocationChatService:
                 user_id=user_id,
                 conversation_id=conversation_id,
                 action_result=action_result,
+            )
+        if selection_result is not None:
+            return await self._handle_selection_result(
+                user_id=user_id,
+                consent_token=consent_token,
+                conversation_id=conversation_id,
+                selection_result=selection_result,
             )
 
         if not message:
@@ -643,6 +668,94 @@ class LocationChatService:
             "isComplete": not errored,
             "stateChanged": state_changed,
         }
+
+    async def _handle_selection_result(
+        self,
+        *,
+        user_id: str,
+        consent_token: str,
+        conversation_id: str | None,
+        selection_result: dict,
+    ) -> dict[str, Any]:
+        """Seed the Gemini loop with the user's choice (resolved refs) and act."""
+        conv_id = conversation_id or ""
+        if not conv_id:
+            return {
+                "conversationId": "",
+                "response": "Let's start again — what would you like to do with your location sharing?",
+                "isComplete": True,
+                "stateChanged": False,
+            }
+        if self._types is None or not self._ready():
+            await self._chat_store.add_message(
+                conversation_id=conv_id,
+                user_id=user_id,
+                role="assistant",
+                content=_UNAVAILABLE_MESSAGE,
+                status="error",
+            )
+            return {
+                "conversationId": conv_id,
+                "response": _UNAVAILABLE_MESSAGE,
+                "isComplete": False,
+                "stateChanged": False,
+            }
+
+        types = self._types
+        history = await self._chat_store.get_recent_messages(
+            conv_id, user_id=user_id, limit=_MAX_HISTORY
+        )
+        contents = _history_contents(history, types)
+        contents.append(
+            types.Content(
+                role="user", parts=[types.Part(text=_selection_seed_text(selection_result))]
+            )
+        )
+
+        try:
+            reply, errored, state_changed, directives, prompts = await self._run_tool_loop(
+                user_id=user_id, consent_token=consent_token, contents=contents
+            )
+        except Exception:
+            logger.exception("Location chat selection turn failed")
+            await self._chat_store.add_message(
+                conversation_id=conv_id,
+                user_id=user_id,
+                role="assistant",
+                content=_UNAVAILABLE_MESSAGE,
+                status="error",
+            )
+            return {
+                "conversationId": conv_id,
+                "response": _UNAVAILABLE_MESSAGE,
+                "isComplete": False,
+                "stateChanged": False,
+            }
+
+        client_prompt = self._build_client_prompt(prompts)
+        client_action = None if client_prompt is not None else self._build_client_action(directives)
+        if client_action is not None or client_prompt is not None:
+            state_changed = False
+        if not reply:
+            reply = "Done."
+        await self._chat_store.add_message(
+            conversation_id=conv_id,
+            user_id=user_id,
+            role="assistant",
+            content=reply,
+            status="error" if errored else "complete",
+        )
+        out: dict[str, Any] = {
+            "conversationId": conv_id,
+            "response": reply,
+            "isComplete": not errored,
+            "stateChanged": state_changed and not errored,
+        }
+        if client_action is not None:
+            out["clientAction"] = client_action
+        if client_prompt is not None:
+            out["clientPrompt"] = client_prompt
+        return out
 
     async def _finish(
         self,

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -63,6 +63,7 @@ _ACTION_RESULT_TEMPLATES = {
     ("publish_share", "completed"): "Done — your live location is now shared. ✓",
     ("publish_share", "cancelled"): "No problem — I didn't share your location.",
     ("view_envelope", "completed"): "Here's the latest location I could open.",
+    ("create_public_link", "completed"): "Your public location link is ready.",
     ("create_public_link", "cancelled"): "Okay — I didn't create a public link.",
 }
 
@@ -484,7 +485,9 @@ class LocationChatService:
         if not directives:
             return None
         action_id = "act-" + uuid4().hex[:12]
-        shares = [d["share"] for d in directives if d.get("type") == "publish_share"]
+        shares = [
+            d["share"] for d in directives if d.get("type") == "publish_share" and d.get("share")
+        ]
         if shares:
             labels = ", ".join(s["label"] for s in shares)
             return {

--- a/consent-protocol/tests/test_location_agent_manifest_v2.py
+++ b/consent-protocol/tests/test_location_agent_manifest_v2.py
@@ -25,3 +25,10 @@ def test_prompt_permits_handoff_and_public_links():
 def test_prompt_still_forbids_agent_returning_coordinates():
     text = _manifest().system_instruction.lower()
     assert "coordinate" in text
+
+
+def test_prompt_instructs_choice_and_confirmation_tools():
+    text = _manifest().system_instruction.lower()
+    assert "request_" in text  # references the choice/confirmation tools
+    assert "do not guess" in text or "don't guess" in text
+    assert "confirm" in text and ("irreversible" in text or "bulk" in text or "everyone" in text)

--- a/consent-protocol/tests/test_location_agent_manifest_v2.py
+++ b/consent-protocol/tests/test_location_agent_manifest_v2.py
@@ -1,0 +1,27 @@
+import os
+
+from hushh_mcp.hushh_adk.manifest import ManifestLoader
+
+
+def _manifest():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "hushh_mcp", "agents", "location", "agent.yaml"
+    )
+    return ManifestLoader.load(os.path.normpath(path))
+
+
+def test_prompt_permits_handoff_and_public_links():
+    text = _manifest().system_instruction.lower()
+    # the new sanctioned paths are described
+    assert "public link" in text
+    assert "browser" in text or "client" in text
+    # still refuses the dangerous patterns
+    assert "without owner approval" in text
+    assert "notification" in text  # refuses coordinates in notifications
+    # never offers unsupported channels
+    assert "sms" in text or "email" in text
+
+
+def test_prompt_still_forbids_agent_returning_coordinates():
+    text = _manifest().system_instruction.lower()
+    assert "coordinate" in text

--- a/consent-protocol/tests/test_location_chat_agent_factory.py
+++ b/consent-protocol/tests/test_location_chat_agent_factory.py
@@ -9,3 +9,19 @@ def test_chat_agent_exposes_only_control_plane_tools():
 
 def test_chat_agent_is_singleton():
     assert get_location_chat_agent() is get_location_chat_agent()
+
+
+def test_v2_chat_agent_uses_v2_allowlist():
+    from hushh_mcp.agents.location.agent import get_location_chat_agent_v2
+    from hushh_mcp.agents.location.tools import (
+        V2_LOCATION_TOOLS,
+        publish_location_envelope,
+        view_location_envelope,
+    )
+
+    agent = get_location_chat_agent_v2()
+    assert list(agent.hushh_tools) == list(V2_LOCATION_TOOLS)
+    assert publish_location_envelope not in agent.hushh_tools
+    assert view_location_envelope not in agent.hushh_tools
+    # singleton
+    assert get_location_chat_agent_v2() is agent

--- a/consent-protocol/tests/test_location_chat_routes.py
+++ b/consent-protocol/tests/test_location_chat_routes.py
@@ -20,7 +20,14 @@ def test_chat_route_happy_path(monkeypatch):
 
     class _Service:
         async def handle_turn(
-            self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None
+            self,
+            *,
+            user_id,
+            message=None,
+            consent_token,
+            conversation_id=None,
+            action_result=None,
+            selection_result=None,
         ):
             captured.update(
                 {
@@ -60,7 +67,14 @@ def test_chat_route_accepts_conversation_id_camel_alias(monkeypatch):
 
     class _Service:
         async def handle_turn(
-            self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None
+            self,
+            *,
+            user_id,
+            message=None,
+            consent_token,
+            conversation_id=None,
+            action_result=None,
+            selection_result=None,
         ):
             captured["conversation_id"] = conversation_id
             return {
@@ -111,7 +125,14 @@ def test_chat_route_forwards_action_result(monkeypatch):
 
     class _Service:
         async def handle_turn(
-            self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None
+            self,
+            *,
+            user_id,
+            message=None,
+            consent_token,
+            conversation_id=None,
+            action_result=None,
+            selection_result=None,
         ):
             captured.update(
                 {
@@ -177,3 +198,81 @@ def test_chat_route_passes_through_client_action(monkeypatch):
     body = response.json()
     assert body["clientAction"]["type"] == "publish_share"
     assert body["clientAction"]["shares"][0]["label"] == "Mom"
+
+
+def test_chat_route_forwards_selection_result(monkeypatch):
+    captured: dict = {}
+
+    class _Service:
+        async def handle_turn(
+            self,
+            *,
+            user_id,
+            message=None,
+            consent_token,
+            conversation_id=None,
+            action_result=None,
+            selection_result=None,
+        ):
+            captured["selection_result"] = selection_result
+            return {
+                "conversationId": "c1",
+                "response": "ok",
+                "isComplete": True,
+                "stateChanged": True,
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+
+    response = client.post(
+        "/api/one/location/chat",
+        json={
+            "conversationId": "c1",
+            "selectionResult": {
+                "id": "prm-1",
+                "kind": "select",
+                "selected": [{"grantId": "g1"}],
+                "status": "answered",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["selection_result"] == {
+        "id": "prm-1",
+        "kind": "select",
+        "selected": [{"grantId": "g1"}],
+        "status": "answered",
+    }
+
+
+def test_chat_route_passes_through_client_prompt(monkeypatch):
+    class _Service:
+        async def handle_turn(self, **kwargs):
+            return {
+                "conversationId": "c1",
+                "response": "Which sharing do you want to stop?",
+                "isComplete": True,
+                "stateChanged": False,
+                "clientPrompt": {
+                    "id": "prm-1",
+                    "kind": "select",
+                    "purpose": "select_share",
+                    "question": "?",
+                    "options": [{"label": "Mom", "ref": {"grantId": "g1"}}],
+                },
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+    response = client.post("/api/one/location/chat", json={"message": "stop sharing"})
+    assert response.status_code == 200
+    assert response.json()["clientPrompt"]["purpose"] == "select_share"
+
+
+def test_chat_route_rejects_when_no_input(monkeypatch):
+    monkeypatch.setattr(location_chat, "_service", lambda: object())
+    client = _build_app()
+    response = client.post("/api/one/location/chat", json={})
+    assert response.status_code == 422

--- a/consent-protocol/tests/test_location_chat_routes.py
+++ b/consent-protocol/tests/test_location_chat_routes.py
@@ -19,7 +19,9 @@ def test_chat_route_happy_path(monkeypatch):
     captured: dict = {}
 
     class _Service:
-        async def handle_turn(self, *, user_id, message, consent_token, conversation_id=None):
+        async def handle_turn(
+            self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None
+        ):
             captured.update(
                 {
                     "user_id": user_id,
@@ -57,7 +59,9 @@ def test_chat_route_accepts_conversation_id_camel_alias(monkeypatch):
     captured: dict = {}
 
     class _Service:
-        async def handle_turn(self, *, user_id, message, consent_token, conversation_id=None):
+        async def handle_turn(
+            self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None
+        ):
             captured["conversation_id"] = conversation_id
             return {
                 "conversationId": conversation_id,
@@ -100,3 +104,76 @@ def test_chat_route_returns_opaque_error_on_failure(monkeypatch):
     assert response.status_code == 500
     assert "secret internal detail" not in response.text
     assert response.json()["detail"] == "Location chat could not be processed"
+
+
+def test_chat_route_forwards_action_result(monkeypatch):
+    captured: dict = {}
+
+    class _Service:
+        async def handle_turn(
+            self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None
+        ):
+            captured.update(
+                {
+                    "message": message,
+                    "action_result": action_result,
+                    "conversation_id": conversation_id,
+                }
+            )
+            return {
+                "conversationId": conversation_id,
+                "response": "Done — your live location is now shared. ✓",
+                "isComplete": True,
+                "stateChanged": True,
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+
+    response = client.post(
+        "/api/one/location/chat",
+        json={
+            "conversationId": "conv-1",
+            "actionResult": {"id": "a1", "type": "publish_share", "status": "completed"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["stateChanged"] is True
+    assert captured["message"] is None
+    assert captured["action_result"] == {"id": "a1", "type": "publish_share", "status": "completed"}
+    assert captured["conversation_id"] == "conv-1"
+
+
+def test_chat_route_passes_through_client_action(monkeypatch):
+    class _Service:
+        async def handle_turn(self, **kwargs):
+            return {
+                "conversationId": "c1",
+                "response": "Ready to share with Mom.",
+                "isComplete": True,
+                "stateChanged": False,
+                "clientAction": {
+                    "id": "act-1",
+                    "type": "publish_share",
+                    "shares": [
+                        {
+                            "grantId": "g1",
+                            "recipientUserId": "r1",
+                            "recipientKeyId": "k1",
+                            "label": "Mom",
+                        }
+                    ],
+                    "summary": "Share your live location with Mom",
+                },
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+
+    response = client.post("/api/one/location/chat", json={"message": "share with Mom"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["clientAction"]["type"] == "publish_share"
+    assert body["clientAction"]["shares"][0]["label"] == "Mom"

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -175,6 +175,42 @@ async def test_action_result_cancelled_does_not_set_state_changed():
     assert out["isComplete"] is True
 
 
+async def test_request_choice_tool_emits_client_prompt():
+    store = _FakeStore()
+    prompt_payload = {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_share",
+            "question": "Which sharing do you want to stop?",
+            "options": [
+                {"label": "Mom", "ref": {"grantId": "g1"}},
+                {"label": "Stop all", "ref": {"all": True}},
+            ],
+            "minSelections": 1,
+            "maxSelections": None,
+            "allowFreeText": True,
+        }
+    }
+    tools = [_fake_tool("request_active_share_choice", [], result=prompt_payload)]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("request_active_share_choice", {}),
+            _text_response("Which sharing do you want to stop?"),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(user_id="u", message="stop sharing", consent_token="t")  # noqa: S106
+
+    cp = out["clientPrompt"]
+    assert cp["kind"] == "select" and cp["purpose"] == "select_share"
+    assert cp["options"][0]["ref"] == {"grantId": "g1"}
+    assert cp["id"].startswith("prm-")
+    assert out["stateChanged"] is False
+    assert "clientAction" not in out
+
+
 async def test_approve_location_request_wrapped_grant_emits_publish_share():
     """approve_location_request with a wrapped {grant, request} shape must emit a
     publish_share clientAction whose shares[0] has grantId/recipientUserId/

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -1,0 +1,174 @@
+"""v2 tests for LocationChatService: client-action directives + action-result turn.
+
+Tests inject tools + system_prompt so the v2 default agent is never constructed.
+The four cases are:
+  1. create_location_share emits a publish_share clientAction
+  2. propose_public_link emits a create_public_link clientAction
+  3. action_result completed/publish_share sets stateChanged=True + confirms
+  4. action_result cancelled/publish_share sets stateChanged=False
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from google.genai import types
+
+from hushh_mcp.services.location_chat_service import LocationChatService
+
+
+class _Turn:
+    def __init__(self, conversation_id, history):
+        self.conversation_id = conversation_id
+        self.history = history
+
+
+class _FakeStore:
+    def __init__(self):
+        self.added = []
+
+    async def prepare_turn(self, *, user_id, message, conversation_id=None):
+        return _Turn(conversation_id or "conv-new", [])
+
+    async def add_message(self, *, conversation_id, user_id, role, content, status, model=None):
+        self.added.append({"role": role, "content": content, "status": status})
+
+
+def _fake_tool(name, recorder, *, result):
+    async def _impl(**kwargs):
+        recorder.append({"name": name, "args": kwargs})
+        return result
+
+    _impl._name = name
+    _impl._hushh_tool = True
+    return _impl
+
+
+def _fc_response(name, args):
+    return SimpleNamespace(
+        function_calls=[SimpleNamespace(name=name, args=args)],
+        text="",
+        candidates=[
+            SimpleNamespace(content=types.Content(role="model", parts=[types.Part(text="")]))
+        ],
+    )
+
+
+def _text_response(text):
+    return SimpleNamespace(function_calls=[], text=text, candidates=[])
+
+
+def _scripted(responses):
+    seq = iter(responses)
+
+    async def _call(contents, config):
+        return next(seq)
+
+    return _call
+
+
+def _service(store, responses, tools):
+    return LocationChatService(
+        chat_store=store,
+        model_call=_scripted(responses),
+        genai_types=types,
+        ready=lambda: True,
+        tools=tools,
+        system_prompt="test",
+    )
+
+
+async def test_create_share_emits_publish_share_client_action():
+    store = _FakeStore()
+    grant = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "recipientUserId": "rcpt-1",
+        "recipientKeyId": "key-1",
+        "recipientDisplayName": "Mom",
+    }
+    tools = [_fake_tool("create_location_share", [], result=grant)]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response(
+                "create_location_share",
+                {"recipient_user_id": "rcpt-1", "recipient_key_id": "key-1", "duration_hours": 1},
+            ),
+            _text_response("Ready to share with Mom for 1 hour."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(user_id="u", message="share with Mom", consent_token="t")  # noqa: S106
+
+    action = out["clientAction"]
+    assert action["type"] == "publish_share"
+    assert action["shares"] == [
+        {
+            "grantId": "11111111-1111-1111-1111-111111111111",
+            "recipientUserId": "rcpt-1",
+            "recipientKeyId": "key-1",
+            "label": "Mom",
+        }
+    ]
+    assert "id" in action and action["summary"]
+    # grant exists but no envelope yet -> do not refresh on this turn
+    assert out["stateChanged"] is False
+
+
+async def test_propose_public_link_emits_create_public_link_action():
+    store = _FakeStore()
+    tools = [
+        _fake_tool(
+            "propose_public_link",
+            [],
+            result={"proposed": "create_public_link", "durationHours": 2.0},
+        )
+    ]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("propose_public_link", {"duration_hours": 2}),
+            _text_response("I'll create a public link valid for 2 hours."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(user_id="u", message="make a public link", consent_token="t")  # noqa: S106
+
+    assert out["clientAction"]["type"] == "create_public_link"
+    assert out["clientAction"]["durationHours"] == 2.0
+
+
+async def test_action_result_completed_publish_confirms_and_sets_state_changed():
+    store = _FakeStore()
+    svc = _service(store, responses=[], tools=[])
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        action_result={"id": "a1", "type": "publish_share", "status": "completed"},
+    )
+
+    assert out["conversationId"] == "conv-1"
+    assert out["stateChanged"] is True
+    assert out["isComplete"] is True
+    assert out["response"]  # non-empty confirmation
+    assert store.added[-1]["role"] == "assistant"
+    assert store.added[-1]["status"] == "complete"
+
+
+async def test_action_result_cancelled_does_not_set_state_changed():
+    store = _FakeStore()
+    svc = _service(store, responses=[], tools=[])
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        action_result={"id": "a1", "type": "publish_share", "status": "cancelled"},
+    )
+
+    assert out["stateChanged"] is False
+    assert out["isComplete"] is True

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -291,6 +291,49 @@ async def test_selection_result_seeds_loop_and_acts_on_real_ids():
     assert calls[0]["args"] == {"grant_id": "g1"}  # exact id, never guessed
 
 
+async def test_selection_result_persists_user_choice_for_chaining():
+    # Multi-step clarification (pick recipient -> then pick duration): the FIRST
+    # selection's chosen refs must be persisted so the SECOND selection turn still
+    # knows who to share with. Regression: previously only the assistant reply was
+    # persisted, so the recipient choice was lost on the next turn.
+    store = _HistoryStore()
+    duration_prompt = {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_duration",
+            "question": "How long?",
+            "options": [{"label": "1 hour", "ref": {"hours": 1}}],
+        }
+    }
+    tools = [_fake_tool("request_duration_choice", [], result=duration_prompt)]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("request_duration_choice", {}),
+            _text_response("How long should this share last?"),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        selection_result={
+            "id": "prm-1",
+            "kind": "select",
+            "selected": [{"recipientUserId": "rcpt-1", "recipientKeyId": "key-1"}],
+            "status": "answered",
+        },
+    )
+
+    assert out["clientPrompt"]["purpose"] == "select_duration"
+    user_msgs = [m for m in store.added if m["role"] == "user"]
+    assert any("rcpt-1" in m["content"] for m in user_msgs), (
+        "the recipient selection must be persisted so a later turn can use it"
+    )
+
+
 async def test_selection_result_cancelled_makes_no_tool_call():
     store = _HistoryStore()
     calls: list[dict] = []

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -253,3 +253,61 @@ async def test_approve_location_request_wrapped_grant_emits_publish_share():
     assert share["label"] == "Dad"
     # grant exists server-side but envelope not yet published -> no UI refresh
     assert out["stateChanged"] is False
+
+
+class _HistoryStore(_FakeStore):
+    async def get_recent_messages(self, conversation_id, *, user_id, limit=20):
+        return []
+
+
+async def test_selection_result_seeds_loop_and_acts_on_real_ids():
+    store = _HistoryStore()
+    calls: list[dict] = []
+    tools = [_fake_tool("revoke_location_share", calls, result={"status": "revoked"})]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("revoke_location_share", {"grant_id": "g1"}),
+            _text_response("Stopped sharing with Mom."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        selection_result={
+            "id": "prm-1",
+            "kind": "select",
+            "selected": [{"grantId": "g1"}],
+            "status": "answered",
+        },
+    )
+
+    assert out["conversationId"] == "conv-1"
+    assert out["response"] == "Stopped sharing with Mom."
+    assert out["stateChanged"] is True
+    assert calls[0]["args"] == {"grant_id": "g1"}  # exact id, never guessed
+
+
+async def test_selection_result_cancelled_makes_no_tool_call():
+    store = _HistoryStore()
+    calls: list[dict] = []
+    tools = [_fake_tool("revoke_location_share", calls, result={"status": "revoked"})]
+    svc = _service(
+        store,
+        responses=[_text_response("No problem — nothing changed.")],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        selection_result={"id": "prm-1", "kind": "select", "status": "cancelled"},
+    )
+
+    assert calls == []
+    assert out["stateChanged"] is False
+    assert out["isComplete"] is True

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -138,6 +138,7 @@ async def test_propose_public_link_emits_create_public_link_action():
 
     assert out["clientAction"]["type"] == "create_public_link"
     assert out["clientAction"]["durationHours"] == 2.0
+    assert out["stateChanged"] is False
 
 
 async def test_action_result_completed_publish_confirms_and_sets_state_changed():
@@ -172,3 +173,47 @@ async def test_action_result_cancelled_does_not_set_state_changed():
 
     assert out["stateChanged"] is False
     assert out["isComplete"] is True
+
+
+async def test_approve_location_request_wrapped_grant_emits_publish_share():
+    """approve_location_request with a wrapped {grant, request} shape must emit a
+    publish_share clientAction whose shares[0] has grantId/recipientUserId/
+    recipientKeyId/label extracted from the inner grant."""
+    store = _FakeStore()
+    wrapped_result = {
+        "grant": {
+            "id": "22222222-2222-2222-2222-222222222222",
+            "recipientUserId": "rcpt-2",
+            "recipientKeyId": "key-2",
+            "recipientDisplayName": "Dad",
+        },
+        "request": {"id": "req-99", "status": "approved"},
+    }
+    tools = [_fake_tool("approve_location_request", [], result=wrapped_result)]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response(
+                "approve_location_request",
+                {"request_id": "req-99", "duration_hours": 2},
+            ),
+            _text_response("Approved — sharing your location with Dad for 2 hours."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(
+        user_id="u",
+        message="approve Dad's request",
+        consent_token="t",  # noqa: S106
+    )
+
+    action = out["clientAction"]
+    assert action["type"] == "publish_share"
+    share = action["shares"][0]
+    assert share["grantId"] == "22222222-2222-2222-2222-222222222222"
+    assert share["recipientUserId"] == "rcpt-2"
+    assert share["recipientKeyId"] == "key-2"
+    assert share["label"] == "Dad"
+    # grant exists server-side but envelope not yet published -> no UI refresh
+    assert out["stateChanged"] is False

--- a/consent-protocol/tests/test_location_chat_tools_allowlist.py
+++ b/consent-protocol/tests/test_location_chat_tools_allowlist.py
@@ -1,14 +1,20 @@
 from hushh_mcp.agents.location.tools import (
     CONTROL_PLANE_LOCATION_TOOLS,
+    V2_LOCATION_TOOLS,
     approve_location_request,
     create_location_share,
     deny_location_request,
     list_active_location_shares,
+    list_incoming_location_shares,
     list_location_recipients,
+    list_public_links,
+    propose_location_view,
+    propose_public_link,
     publish_location_envelope,
     refer_location_recipient,
     request_location_access,
     revoke_location_share,
+    revoke_public_link,
     view_location_envelope,
 )
 
@@ -32,3 +38,21 @@ def test_control_plane_excludes_crypto_handoff_tools():
         approve_location_request,
     ):
         assert tool not in CONTROL_PLANE_LOCATION_TOOLS
+
+
+def test_v2_allowlist_adds_prep_and_handoff_tools_but_not_raw_envelope_tools():
+    # prep-and-handoff + new read/intent/control tools are present
+    for tool in (
+        create_location_share,
+        approve_location_request,
+        list_incoming_location_shares,
+        list_public_links,
+        propose_public_link,
+        propose_location_view,
+        revoke_public_link,
+    ):
+        assert tool in V2_LOCATION_TOOLS
+
+    # the impossible-server-side envelope tools are NEVER LLM-callable
+    assert publish_location_envelope not in V2_LOCATION_TOOLS
+    assert view_location_envelope not in V2_LOCATION_TOOLS

--- a/consent-protocol/tests/test_location_chat_tools_allowlist.py
+++ b/consent-protocol/tests/test_location_chat_tools_allowlist.py
@@ -12,7 +12,13 @@ from hushh_mcp.agents.location.tools import (
     propose_public_link,
     publish_location_envelope,
     refer_location_recipient,
+    request_active_share_choice,
+    request_confirmation,
+    request_duration_choice,
+    request_incoming_choice,
     request_location_access,
+    request_recipient_choice,
+    request_request_choice,
     revoke_location_share,
     revoke_public_link,
     view_location_envelope,
@@ -54,5 +60,20 @@ def test_v2_allowlist_adds_prep_and_handoff_tools_but_not_raw_envelope_tools():
         assert tool in V2_LOCATION_TOOLS
 
     # the impossible-server-side envelope tools are NEVER LLM-callable
+    assert publish_location_envelope not in V2_LOCATION_TOOLS
+    assert view_location_envelope not in V2_LOCATION_TOOLS
+
+
+def test_v2_allowlist_includes_prompt_builder_tools_but_not_raw_envelope_tools():
+    for tool in (
+        request_recipient_choice,
+        request_active_share_choice,
+        request_duration_choice,
+        request_request_choice,
+        request_incoming_choice,
+        request_confirmation,
+    ):
+        assert tool in V2_LOCATION_TOOLS
+
     assert publish_location_envelope not in V2_LOCATION_TOOLS
     assert view_location_envelope not in V2_LOCATION_TOOLS

--- a/consent-protocol/tests/test_location_chat_tools_behavior.py
+++ b/consent-protocol/tests/test_location_chat_tools_behavior.py
@@ -15,6 +15,7 @@ import pytest
 from google.genai import types
 
 from hushh_mcp.agents.location import tools
+from hushh_mcp.agents.location import tools as loc_tools
 from hushh_mcp.agents.location.tools import (
     CONTROL_PLANE_LOCATION_TOOLS,
     propose_location_view,
@@ -116,3 +117,56 @@ async def test_propose_location_view_rejects_non_uuid():
     with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
         with pytest.raises(ValueError):
             await propose_location_view.__wrapped__("not-a-uuid")
+
+
+class _FakeSvc:
+    def list_verified_recipients(self, *, owner_user_id, limit=50):
+        return [
+            {"userId": "u-mom", "displayName": "Mom", "keyId": "k-mom", "canReceiveLocation": True},
+            {"userId": "u-kid", "displayName": "Kid", "keyId": None, "canReceiveLocation": False},
+        ]
+
+    def list_state(self, *, user_id):
+        return {
+            "ownerGrants": [
+                {
+                    "id": "g1",
+                    "recipientDisplayName": "Mom",
+                    "expiresAt": "later",
+                    "status": "active",
+                }
+            ],
+            "receivedGrants": [],
+            "requests": [],
+        }
+
+
+async def test_request_recipient_choice_options_carry_real_ids_and_public_link(monkeypatch):
+    monkeypatch.setattr(loc_tools, "_service", lambda: _FakeSvc())
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_recipient_choice.__wrapped__()
+    prompt = out["prompt"]
+    assert prompt["kind"] == "select" and prompt["purpose"] == "select_recipient"
+    assert prompt["options"][0]["ref"] == {"recipientUserId": "u-mom", "recipientKeyId": "k-mom"}
+    assert prompt["options"][1]["hint"] == "hasn't set up location yet"
+    assert prompt["options"][-1]["ref"] == {"publicLink": True}
+    # coordinate-free
+    blob = repr(out).lower()
+    assert "latitude" not in blob and "longitude" not in blob and "lat" not in blob.split("late")[0]
+
+
+async def test_request_active_share_choice_includes_stop_all(monkeypatch):
+    monkeypatch.setattr(loc_tools, "_service", lambda: _FakeSvc())
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_active_share_choice.__wrapped__()
+    refs = [o["ref"] for o in out["prompt"]["options"]]
+    assert {"grantId": "g1"} in refs
+    assert {"all": True} in refs
+
+
+async def test_request_confirmation_returns_confirm_prompt():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_confirmation.__wrapped__("Stop sharing with everyone?", True)
+    assert out["prompt"]["kind"] == "confirm"
+    assert out["prompt"]["destructive"] is True
+    assert "everyone" in out["prompt"]["question"]

--- a/consent-protocol/tests/test_location_chat_tools_behavior.py
+++ b/consent-protocol/tests/test_location_chat_tools_behavior.py
@@ -15,7 +15,11 @@ import pytest
 from google.genai import types
 
 from hushh_mcp.agents.location import tools
-from hushh_mcp.agents.location.tools import CONTROL_PLANE_LOCATION_TOOLS
+from hushh_mcp.agents.location.tools import (
+    CONTROL_PLANE_LOCATION_TOOLS,
+    propose_location_view,
+    propose_public_link,
+)
 from hushh_mcp.hushh_adk.context import HushhContext
 from hushh_mcp.services.location_chat_service import _function_declarations
 
@@ -94,3 +98,21 @@ def test_function_declarations_match_control_plane_tools():
     declared = {decl.name for decl in _function_declarations(types)}
     tool_names = {t._name for t in CONTROL_PLANE_LOCATION_TOOLS}
     assert declared == tool_names
+
+
+async def test_propose_public_link_returns_directive_without_mutation():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await propose_public_link.__wrapped__(2)
+    assert out == {"proposed": "create_public_link", "durationHours": 2.0}
+
+
+async def test_propose_public_link_rejects_out_of_range_duration():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        with pytest.raises(ValueError):
+            await propose_public_link.__wrapped__(99)
+
+
+async def test_propose_location_view_rejects_non_uuid():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        with pytest.raises(ValueError):
+            await propose_location_view.__wrapped__("not-a-uuid")

--- a/docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md
+++ b/docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md
@@ -19,7 +19,8 @@
 - **Backward-compatible contract:** v1 fields (`conversationId`, `response`, `isComplete`, `stateChanged`) unchanged; new fields are additive and optional.
 - **Response keys are camelCase** in API output (`conversationId`, `clientAction`, etc.); Python service internals are snake_case; service payloads (`_grant_payload`) are already camelCase (`id`, `recipientUserId`, `recipientKeyId`, `recipientDisplayName`).
 - **Encryption:** `ECDH-P256-AES256-GCM` per recipient, ephemeral sender key, via existing `encryptLocationForRecipient` / `decryptLocationEnvelope`. Do not write new crypto.
-- **Run backend tests:** `cd consent-protocol && python -m pytest <path> -v`. **Run frontend tests:** `cd hushh-webapp && npx jest <path>` and `npx tsc --noEmit`.
+- **Run backend tests:** `cd consent-protocol && python -m pytest <path> -v`. **Run frontend tests:** `cd hushh-webapp && npx vitest run <path>` and `npx tsc --noEmit`.
+- **Frontend test framework is Vitest, NOT Jest.** The test snippets in this plan are written in Jest syntax for *logic guidance only* — when implementing, translate them to Vitest: `import { describe, it, expect, vi, beforeEach } from "vitest"`, use `vi.fn()` / `vi.mock()` / `vi.spyOn()` (not `jest.*`), and **mirror the conventions of the neighbouring existing test file** (e.g. `__tests__/components/use-location-chat.test.tsx`, which uses top-of-file `vi.mock(...)`). `noUncheckedIndexedAccess` is enabled — Vitest does not full-typecheck, so always run `npx tsc --noEmit` after each frontend task and fix any indexed-access errors.
 
 ---
 
@@ -1258,7 +1259,7 @@ describe("OneLocationService.chat actionResult", () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `cd hushh-webapp && npx jest __tests__/services/location-chat-service.test.ts -t "actionResult"`
+Run: `cd hushh-webapp && npx vitest run __tests__/services/location-chat-service.test.ts -t "actionResult"`
 Expected: FAIL (TS error / `actionResult` not sent).
 
 - [ ] **Step 3: Add the types**
@@ -1326,7 +1327,7 @@ In `hushh-webapp/lib/one-location/service.ts`, add `ActionResult` to the type im
 
 - [ ] **Step 5: Run the test + typecheck to verify they pass**
 
-Run: `cd hushh-webapp && npx jest __tests__/services/location-chat-service.test.ts && npx tsc --noEmit`
+Run: `cd hushh-webapp && npx vitest run __tests__/services/location-chat-service.test.ts && npx tsc --noEmit`
 Expected: PASS and clean typecheck.
 
 - [ ] **Step 6: Commit**
@@ -1477,7 +1478,7 @@ it("publish_share: cancel revokes the grant and reports cancelled", async () => 
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/use-location-chat.test.tsx -t "publish_share"`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/use-location-chat.test.tsx -t "publish_share"`
 Expected: FAIL (`pendingAction` / `confirmAction` / `userId` don't exist).
 
 - [ ] **Step 3: Extend the hook**
@@ -1681,7 +1682,7 @@ Also update `clear` to reset `pendingAction` and `viewedPoint`:
 
 - [ ] **Step 4: Run the hook tests to verify they pass**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/use-location-chat.test.tsx`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/use-location-chat.test.tsx`
 Expected: PASS (new tests + existing hook tests). If existing tests construct the hook without `userId`, update those call sites to pass `userId: "u1"`.
 
 - [ ] **Step 5: Typecheck**
@@ -1754,7 +1755,7 @@ it("shows a Create label for public links", () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/action-confirm-card.test.tsx`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/action-confirm-card.test.tsx`
 Expected: FAIL (module does not exist).
 
 - [ ] **Step 3: Create the component**
@@ -1830,7 +1831,7 @@ export function ActionConfirmCard({
 
 - [ ] **Step 4: Run the component test to verify it passes**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/action-confirm-card.test.tsx`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/action-confirm-card.test.tsx`
 Expected: PASS. (If `Button` does not accept `size`/`variant`/`isLoading` exactly as written, check `components/ui/button.tsx` and adjust the props to the real API — `isLoading` exists per the UI spec.)
 
 - [ ] **Step 5: Render the card in the chat card + overlay**
@@ -1868,7 +1869,7 @@ Add the new suggestion chips wherever the existing chips array is defined in the
 
 - [ ] **Step 6: Run the chat surface tests + typecheck**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/location-chat-panel.test.tsx __tests__/components/location-chat-overlay.test.tsx __tests__/components/location-chat-suggestions.test.tsx && npx tsc --noEmit`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/location-chat-panel.test.tsx __tests__/components/location-chat-overlay.test.tsx __tests__/components/location-chat-suggestions.test.tsx && npx tsc --noEmit`
 Expected: PASS + clean. Update any of these tests that construct the hook/components without the new `userId` prop or that snapshot the chip list.
 
 - [ ] **Step 7: Commit**
@@ -1906,7 +1907,7 @@ Implement the assertion against the existing mock seam in that file (it already 
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/one-location-agent-page.test.tsx -t "userId"`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/one-location-agent-page.test.tsx -t "userId"`
 Expected: FAIL (panel currently receives no `userId`).
 
 - [ ] **Step 3: Wire `userId` + the viewed point**
@@ -1942,7 +1943,7 @@ Prefer reusing the existing in-page map component if one is already imported for
 
 - [ ] **Step 4: Run the page test + typecheck**
 
-Run: `cd hushh-webapp && npx jest __tests__/components/one-location-agent-page.test.tsx && npx tsc --noEmit`
+Run: `cd hushh-webapp && npx vitest run __tests__/components/one-location-agent-page.test.tsx && npx tsc --noEmit`
 Expected: PASS + clean.
 
 - [ ] **Step 5: Commit**
@@ -1965,7 +1966,7 @@ Expected: PASS (v1 + v2 service/route/tool/agent/manifest tests).
 
 - [ ] **Step 2: Frontend — run the one-location tests + typecheck**
 
-Run: `cd hushh-webapp && npx jest one-location location-chat use-location-chat action-confirm && npx tsc --noEmit`
+Run: `cd hushh-webapp && npx vitest run one-location location-chat use-location-chat action-confirm && npx tsc --noEmit`
 Expected: PASS + clean.
 
 - [ ] **Step 3: Lint (match the repo's configured linters)**

--- a/docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md
+++ b/docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md
@@ -24,6 +24,22 @@
 
 ---
 
+## Visual Map
+
+```text
+v2 turn: agent emits a coordinate-free clientAction; the browser does the crypto.
+
+POST /api/one/location/chat (message)
+  -> Gemini loop in HushhContext
+       create_location_share / approve_location_request  (@hushh_tool, no coords)
+  <- { response, clientAction:{ type:"publish_share", grantId, recipients } }
+browser: ActionConfirmCard -> capture -> encrypt-per-recipient -> POST envelope (ciphertext)
+  -> POST /chat { actionResult: completed }  <- confirmation, stateChanged:true
+
+publish_share / view_envelope / create_public_link travel as clientAction directives;
+the agent never sees coordinates. Public links: bounded owner-confirmed snapshot.
+```
+
 ## File Structure
 
 **Backend (`consent-protocol/`)**
@@ -38,7 +54,7 @@
 - `lib/one-location/service.ts` — `chat()` accepts/sends `actionResult` (Task 6).
 - `components/one-location/redesign/use-location-chat.ts` — pending-action state + dispatcher (Task 7).
 - `components/one-location/redesign/action-confirm-card.tsx` — **new** confirm UI (Task 8).
-- `components/one-location/redesign/location-chat-card.tsx` / `location-chat-overlay.tsx` (and the message list) — render the card + new chips (Task 8).
+- `components/one-location/redesign/location-chat-panel.tsx` / `location-chat-overlay.tsx` (and the message list) — render the card + new chips (Task 8).
 - `app/one/location/page.tsx` — pass `userId` into the hook; render decrypted view result (Task 9).
 
 ---
@@ -1703,7 +1719,7 @@ git commit -m "feat(one-location): action dispatcher in useLocationChat (share/v
 
 **Files:**
 - Create: `hushh-webapp/components/one-location/redesign/action-confirm-card.tsx`
-- Modify: `hushh-webapp/components/one-location/redesign/location-chat-card.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/location-chat-panel.tsx`
 - Modify: `hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx`
 - Test: `hushh-webapp/__tests__/components/action-confirm-card.test.tsx` (new)
 
@@ -1836,7 +1852,7 @@ Expected: PASS. (If `Button` does not accept `size`/`variant`/`isLoading` exactl
 
 - [ ] **Step 5: Render the card in the chat card + overlay**
 
-In `hushh-webapp/components/one-location/redesign/location-chat-card.tsx`, where the hook is consumed, destructure the new members and render the card below the message list when `pendingAction` is set. Add the import:
+In `hushh-webapp/components/one-location/redesign/location-chat-panel.tsx`, where the hook is consumed, destructure the new members and render the card below the message list when `pendingAction` is set. Add the import:
 
 ```tsx
 import { ActionConfirmCard } from "./action-confirm-card";
@@ -1875,7 +1891,7 @@ Expected: PASS + clean. Update any of these tests that construct the hook/compon
 - [ ] **Step 7: Commit**
 
 ```bash
-git add hushh-webapp/components/one-location/redesign/action-confirm-card.tsx hushh-webapp/components/one-location/redesign/location-chat-card.tsx hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx hushh-webapp/__tests__/components/action-confirm-card.test.tsx
+git add hushh-webapp/components/one-location/redesign/action-confirm-card.tsx hushh-webapp/components/one-location/redesign/location-chat-panel.tsx hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx hushh-webapp/__tests__/components/action-confirm-card.test.tsx
 git commit -m "feat(one-location): ActionConfirmCard + render in chat surfaces + v2 chips"
 ```
 
@@ -1996,6 +2012,6 @@ git commit -m "test(one-location): v2 full-suite verification fixups" || echo "n
 - §8 invariant ledger (no coords in directives/results; ciphertext-only shares; bounded public-link snapshot) → enforced by reusing existing crypto/routes (Tasks 6–9) + coordinate-free models (Tasks 4–5). ✓
 - §9 testing (no-coord assertions, not-LLM-callable asserts, action-result state_changed) → Tasks 1, 4, 7. ✓
 
-**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to". Two intentional "adapt to the existing mock seam / chip shape" notes in Tasks 8–9 reference real in-repo patterns that vary by file; concrete code is provided for the new logic in every step.
+**Placeholder scan:** No placeholder markers or vague cross-references. Two intentional "adapt to the existing mock seam / chip shape" notes in Tasks 8–9 reference real in-repo patterns that vary by file; concrete code is provided for the new logic in every step.
 
 **Type consistency:** `ClientAction`/`ActionResult`/`ShareTarget` identical across Tasks 4 (Python dict keys: `id`, `type`, `shares[{grantId,recipientUserId,recipientKeyId,label}]`, `grantId`, `durationHours`, `summary`) and 6 (TS interfaces). `handle_turn(*, user_id, message=None, consent_token, conversation_id=None, action_result=None)` consistent across Tasks 4 and 5. `useLocationChat({vaultOwnerToken, userId, onStateChanged})` consistent across Tasks 7, 8, 9.

--- a/docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md
+++ b/docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md
@@ -1,0 +1,2000 @@
+# One Location Agent Chat v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the One Location agent drive coordinate-touching actions (share / approve / view / public-link) through a structured agent→client action-handoff, plus platform-aware recipient resolution, without the server or agent ever seeing plaintext coordinates (one bounded exception: owner-confirmed public-link snapshots).
+
+**Architecture:** Every coordinate-touching op splits into a *server-side prep step* (a real `@hushh_tool` in `HushhContext`, scope-validated, coordinate-free) and a *client-side completion step* (capture → encrypt → upload, coords stay in the browser). The backend returns a coordinate-free `clientAction` directive; the browser confirms, runs the existing crypto pipeline, and reports back via an `actionResult` follow-up turn. The action-result confirmation is deterministic (templated text), so no LLM call and no coordinates are involved on that turn.
+
+**Tech Stack:** Python (FastAPI, google.genai function-calling, pytest), TypeScript/React (Next.js, Web Crypto via existing `lib/one-location/encryption.ts`, Jest + React Testing Library).
+
+## Global Constraints
+
+- **Branch:** `feat/one-location-agent-chat-v2` (already checked out; do NOT create a new branch).
+- **No new DB migration** — all tables (`061_one_location_agent.sql`, `064`) already exist.
+- **Consent enforcement preserved:** all server-side mutations run as `@hushh_tool` inside `HushhContext`; the publish/view REST routes re-validate the HCT.
+- **Agent never sees/returns coordinates:** `clientAction` and `actionResult` are coordinate-free by construction; reject any coordinate field in either model.
+- **`publish_location_envelope` and `view_location_envelope` are NEVER LLM-callable** (they are impossible server-side). Enforced in the allow-list, asserted in tests — not only in the prompt.
+- **Zero server-side plaintext coordinates** holds for per-recipient shares (ciphertext-only). The ONLY relaxed path is the owner-confirmed, ≤24h, revocable **public-link snapshot** (reuses existing `create_public_invite`).
+- **Backward-compatible contract:** v1 fields (`conversationId`, `response`, `isComplete`, `stateChanged`) unchanged; new fields are additive and optional.
+- **Response keys are camelCase** in API output (`conversationId`, `clientAction`, etc.); Python service internals are snake_case; service payloads (`_grant_payload`) are already camelCase (`id`, `recipientUserId`, `recipientKeyId`, `recipientDisplayName`).
+- **Encryption:** `ECDH-P256-AES256-GCM` per recipient, ephemeral sender key, via existing `encryptLocationForRecipient` / `decryptLocationEnvelope`. Do not write new crypto.
+- **Run backend tests:** `cd consent-protocol && python -m pytest <path> -v`. **Run frontend tests:** `cd hushh-webapp && npx jest <path>` and `npx tsc --noEmit`.
+
+---
+
+## File Structure
+
+**Backend (`consent-protocol/`)**
+- `hushh_mcp/agents/location/tools.py` — add 5 v2 tools + `V2_LOCATION_TOOLS` allow-list (Task 1).
+- `hushh_mcp/agents/location/agent.py` — add `get_location_chat_agent_v2()` factory (Task 2).
+- `hushh_mcp/agents/location/agent.yaml` — relax refusal prompt + register new tools (Task 3).
+- `hushh_mcp/services/location_chat_service.py` — v2 function declarations, directive collection → `clientAction`, `action_result` confirmation turn (Task 4).
+- `api/routes/one/location_chat.py` — extend request model (`message` optional, `actionResult`), pass through (Task 5).
+
+**Frontend (`hushh-webapp/`)**
+- `lib/one-location/types.ts` — `ClientAction`, `ActionResult`, `ShareTarget`; extend `LocationChatResponse` (Task 6).
+- `lib/one-location/service.ts` — `chat()` accepts/sends `actionResult` (Task 6).
+- `components/one-location/redesign/use-location-chat.ts` — pending-action state + dispatcher (Task 7).
+- `components/one-location/redesign/action-confirm-card.tsx` — **new** confirm UI (Task 8).
+- `components/one-location/redesign/location-chat-card.tsx` / `location-chat-overlay.tsx` (and the message list) — render the card + new chips (Task 8).
+- `app/one/location/page.tsx` — pass `userId` into the hook; render decrypted view result (Task 9).
+
+---
+
+## Task 1: v2 agent tools + allow-list
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/agents/location/tools.py`
+- Test: `consent-protocol/tests/test_location_chat_tools_allowlist.py`, `consent-protocol/tests/test_location_chat_tools_behavior.py`
+
+**Interfaces:**
+- Consumes: existing `OneLocationAgentService.list_state`, `revoke_public_invite`, `normalize_duration_hours`; existing `_ctx`, `_service`, `_require_uuid`, `hushh_tool`, `ConsentScope`.
+- Produces:
+  - `list_incoming_location_shares() -> {"incomingShares": [{grantId, ownerUserId, ownerDisplayName, expiresAt}]}`
+  - `list_public_links() -> {"publicLinks": [{inviteId, status, expiresAt, publicUrl}]}`
+  - `propose_public_link(duration_hours: float) -> {"proposed": "create_public_link", "durationHours": float}`
+  - `propose_location_view(grant_id: str) -> {"proposed": "view_envelope", "grantId": str}`
+  - `revoke_public_link(invite_id: str) -> dict` (mutating)
+  - `V2_LOCATION_TOOLS: list` (allow-list)
+
+- [ ] **Step 1: Write the failing allow-list tests**
+
+Append to `consent-protocol/tests/test_location_chat_tools_allowlist.py`:
+
+```python
+def test_v2_allowlist_adds_prep_and_handoff_tools_but_not_raw_envelope_tools():
+    from hushh_mcp.agents.location.tools import (
+        V2_LOCATION_TOOLS,
+        create_location_share,
+        approve_location_request,
+        list_incoming_location_shares,
+        list_public_links,
+        propose_public_link,
+        propose_location_view,
+        revoke_public_link,
+        publish_location_envelope,
+        view_location_envelope,
+    )
+
+    # prep-and-handoff + new read/intent/control tools are present
+    for tool in (
+        create_location_share,
+        approve_location_request,
+        list_incoming_location_shares,
+        list_public_links,
+        propose_public_link,
+        propose_location_view,
+        revoke_public_link,
+    ):
+        assert tool in V2_LOCATION_TOOLS
+
+    # the impossible-server-side envelope tools are NEVER LLM-callable
+    assert publish_location_envelope not in V2_LOCATION_TOOLS
+    assert view_location_envelope not in V2_LOCATION_TOOLS
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_tools_allowlist.py::test_v2_allowlist_adds_prep_and_handoff_tools_but_not_raw_envelope_tools -v`
+Expected: FAIL with `ImportError` / `cannot import name 'V2_LOCATION_TOOLS'`.
+
+- [ ] **Step 3: Add the new tools + allow-list**
+
+In `consent-protocol/hushh_mcp/agents/location/tools.py`, add these tool functions after `list_active_location_shares` (before `LOCATION_AGENT_TOOLS`):
+
+```python
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_VIEW, name="list_incoming_location_shares")
+async def list_incoming_location_shares() -> dict[str, Any]:
+    """List active shares where the current user is the recipient (so they can be
+    viewed). Returns grant ids + owner names; coordinate-free (no lat/lng)."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    shares = [
+        {
+            "grantId": grant.get("id"),
+            "ownerUserId": grant.get("ownerUserId"),
+            "ownerDisplayName": grant.get("ownerDisplayName"),
+            "expiresAt": grant.get("expiresAt"),
+        }
+        for grant in state.get("receivedGrants", [])
+        if grant.get("status") == "active"
+    ]
+    return {"incomingShares": shares}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="list_public_links")
+async def list_public_links() -> dict[str, Any]:
+    """List the user's active public location links (id + expiry). Coordinate-free."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    links = [
+        {
+            "inviteId": invite.get("id"),
+            "status": invite.get("status"),
+            "expiresAt": invite.get("expiresAt"),
+            "publicUrl": invite.get("publicUrl"),
+        }
+        for invite in state.get("publicInvites", [])
+        if invite.get("status") == "active"
+    ]
+    return {"publicLinks": links}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="propose_public_link")
+async def propose_public_link(duration_hours: float) -> dict[str, Any]:
+    """Propose creating an owner-confirmed public link. Does NOT create it (the
+    browser captures the snapshot and creates it after explicit confirmation).
+    Coordinate-free."""
+    _ctx()
+    try:
+        hours = float(duration_hours)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("duration_hours must be a number between 0 and 24") from exc
+    if not (0 < hours <= 24):
+        raise ValueError("duration_hours must be greater than 0 and at most 24")
+    return {"proposed": "create_public_link", "durationHours": hours}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_VIEW, name="propose_location_view")
+async def propose_location_view(grant_id: str) -> dict[str, Any]:
+    """Propose viewing an incoming share's latest location. The browser fetches the
+    ciphertext and decrypts it; the server never returns coordinates. grant_id MUST
+    come from list_incoming_location_shares. Coordinate-free."""
+    _ctx()
+    grant_id = _require_uuid(grant_id, "grant_id")
+    return {"proposed": "view_envelope", "grantId": grant_id}
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="revoke_public_link")
+async def revoke_public_link(invite_id: str) -> dict[str, Any]:
+    """Revoke an active public location link owned by the current user. invite_id
+    MUST come from list_public_links."""
+    context = _ctx()
+    invite_id = _require_uuid(invite_id, "invite_id")
+    return _service().revoke_public_invite(owner_user_id=context.user_id, invite_id=invite_id)
+```
+
+Then, after the existing `CONTROL_PLANE_LOCATION_TOOLS` block, add:
+
+```python
+# v2 subset: control-plane + prep-and-handoff (create/approve create grants
+# server-side, coordinate-free) + read/intent/control tools for view & public
+# links. NEVER includes publish_location_envelope / view_location_envelope —
+# those are impossible server-side (need ciphertext / decryption) and are handled
+# by a client-action directive instead.
+V2_LOCATION_TOOLS = [
+    list_location_recipients,
+    list_active_location_shares,
+    list_incoming_location_shares,
+    list_public_links,
+    revoke_location_share,
+    request_location_access,
+    deny_location_request,
+    refer_location_recipient,
+    create_location_share,
+    approve_location_request,
+    propose_public_link,
+    propose_location_view,
+    revoke_public_link,
+]
+```
+
+- [ ] **Step 4: Run the allow-list test to verify it passes**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_tools_allowlist.py -v`
+Expected: PASS (all tests including the new one).
+
+- [ ] **Step 5: Add a behavior test for the intent tools**
+
+Append to `consent-protocol/tests/test_location_chat_tools_behavior.py` (mirror the file's existing `HushhContext` setup; if it uses a fixture/helper to enter context, reuse it — otherwise use the inline form below):
+
+```python
+import pytest
+from hushh_mcp.hushh_adk.context import HushhContext
+from hushh_mcp.agents.location.tools import propose_public_link, propose_location_view
+
+
+async def test_propose_public_link_returns_directive_without_mutation():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await propose_public_link(2)
+    assert out == {"proposed": "create_public_link", "durationHours": 2.0}
+
+
+async def test_propose_public_link_rejects_out_of_range_duration():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        with pytest.raises(ValueError):
+            await propose_public_link(99)
+
+
+async def test_propose_location_view_rejects_non_uuid():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        with pytest.raises(ValueError):
+            await propose_location_view("not-a-uuid")
+```
+
+- [ ] **Step 6: Run the behavior test to verify it passes**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_tools_behavior.py -v`
+Expected: PASS. (If the existing file enters `HushhContext` via a fixture, adapt the three tests to that fixture and re-run.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/agents/location/tools.py consent-protocol/tests/test_location_chat_tools_allowlist.py consent-protocol/tests/test_location_chat_tools_behavior.py
+git commit -m "feat(one-location): add v2 agent tools and allow-list (handoff + public links)"
+```
+
+---
+
+## Task 2: v2 chat-agent factory
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/agents/location/agent.py`
+- Test: `consent-protocol/tests/test_location_chat_agent_factory.py`
+
+**Interfaces:**
+- Consumes: `V2_LOCATION_TOOLS` (Task 1), existing `LocationAgent`.
+- Produces: `get_location_chat_agent_v2() -> LocationAgent` (singleton, `hushh_tools == V2_LOCATION_TOOLS`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `consent-protocol/tests/test_location_chat_agent_factory.py`:
+
+```python
+def test_v2_chat_agent_uses_v2_allowlist():
+    from hushh_mcp.agents.location.agent import get_location_chat_agent_v2
+    from hushh_mcp.agents.location.tools import (
+        V2_LOCATION_TOOLS,
+        publish_location_envelope,
+        view_location_envelope,
+    )
+
+    agent = get_location_chat_agent_v2()
+    assert list(agent.hushh_tools) == list(V2_LOCATION_TOOLS)
+    assert publish_location_envelope not in agent.hushh_tools
+    assert view_location_envelope not in agent.hushh_tools
+    # singleton
+    assert get_location_chat_agent_v2() is agent
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_agent_factory.py::test_v2_chat_agent_uses_v2_allowlist -v`
+Expected: FAIL with `cannot import name 'get_location_chat_agent_v2'`.
+
+- [ ] **Step 3: Add the factory**
+
+In `consent-protocol/hushh_mcp/agents/location/agent.py`, change the import line:
+
+```python
+from .tools import CONTROL_PLANE_LOCATION_TOOLS, LOCATION_AGENT_TOOLS, V2_LOCATION_TOOLS
+```
+
+Then append at the end of the file:
+
+```python
+_location_chat_agent_v2: LocationAgent | None = None
+
+
+def get_location_chat_agent_v2() -> LocationAgent:
+    """Singleton LocationAgent for v2 chat: control-plane + crypto-handoff prep +
+    public-link tools. Excludes the raw envelope publish/view tools."""
+    global _location_chat_agent_v2
+    if _location_chat_agent_v2 is None:
+        _location_chat_agent_v2 = LocationAgent(tools=V2_LOCATION_TOOLS)
+    return _location_chat_agent_v2
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_agent_factory.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/agents/location/agent.py consent-protocol/tests/test_location_chat_agent_factory.py
+git commit -m "feat(one-location): add v2 chat-agent factory"
+```
+
+---
+
+## Task 3: Relax the agent prompt + register new tools in the manifest
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/agents/location/agent.yaml`
+- Test: `consent-protocol/tests/test_location_agent_manifest_v2.py` (new)
+
+**Interfaces:**
+- Consumes: `ManifestLoader.load` (existing).
+- Produces: an updated `system_instruction` that permits the client-handoff + public-link paths while still refusing coordinates-in-notifications and access-without-approval.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `consent-protocol/tests/test_location_agent_manifest_v2.py`:
+
+```python
+import os
+
+from hushh_mcp.hushh_adk.manifest import ManifestLoader
+
+
+def _manifest():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "hushh_mcp", "agents", "location", "agent.yaml"
+    )
+    return ManifestLoader.load(os.path.normpath(path))
+
+
+def test_prompt_permits_handoff_and_public_links():
+    text = _manifest().system_instruction.lower()
+    # the new sanctioned paths are described
+    assert "public link" in text
+    assert "browser" in text or "client" in text
+    # still refuses the dangerous patterns
+    assert "without owner approval" in text
+    assert "notification" in text  # refuses coordinates in notifications
+    # never offers unsupported channels
+    assert "sms" in text or "email" in text
+
+
+def test_prompt_still_forbids_agent_returning_coordinates():
+    text = _manifest().system_instruction.lower()
+    assert "coordinate" in text
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_agent_manifest_v2.py -v`
+Expected: FAIL (current prompt lacks "public link" as permitted, "browser/client", "sms/email").
+
+- [ ] **Step 3: Rewrite the `system_instruction` block**
+
+In `consent-protocol/hushh_mcp/agents/location/agent.yaml`, replace the `system_instruction:` block (lines 6–17) with:
+
+```yaml
+system_instruction: |
+  You are the Location Agent under One. You help the user share live location
+  only with verified, explicitly approved recipients, or via an owner-confirmed
+  public link.
+
+  You NEVER see, store, or return raw coordinates yourself. Coordinates move in
+  exactly two sanctioned ways: (1) you hand a coordinate operation to the user's
+  browser, which captures, encrypts per recipient, and uploads it; (2) the user
+  explicitly confirms an owner-initiated, time-bounded, revocable public link
+  whose snapshot the browser captures. Refuse everything else: coordinates in
+  notifications, access granted without owner approval, and arbitrary or
+  unbounded links.
+
+  Only offer delivery channels that exist: an encrypted in-app share (for a
+  verified recipient who has set up location sharing) or a public link (for
+  anyone, including people not on Hushh). Never offer SMS or email — those are
+  not supported; if asked, explain you can make a public link to paste instead.
+
+  Platform-aware sharing: when the user asks to share with a person, resolve them
+  with list_location_recipients. If exactly one verified recipient matches and can
+  receive location, create the share. If the match is ambiguous, ask which person.
+  If they are on Hushh but cannot receive location yet, offer to send a request or
+  make a public link. If they are not found, offer a public link.
+
+  Never invent or guess ids. To revoke or refer a share, FIRST call
+  list_active_location_shares; to view an incoming share, FIRST call
+  list_incoming_location_shares; to revoke a public link, FIRST call
+  list_public_links. Match the person by display name. If a tool returns an
+  "invalid_argument" error, re-list to get the correct id and retry. If no
+  matching item exists, tell the user plainly instead of acting on a guessed id.
+```
+
+Then add the three new tool entries at the end of the `tools:` list in the same file (after `refer_location_recipient`):
+
+```yaml
+  - name: list_incoming_location_shares
+    description: List active shares where the user is the recipient (grant ids, coordinate-free).
+    py_func: hushh_mcp.agents.location.tools.list_incoming_location_shares
+    required_scope: cap.location.live.view
+  - name: list_public_links
+    description: List the user's active public location links (ids + expiry).
+    py_func: hushh_mcp.agents.location.tools.list_public_links
+    required_scope: cap.location.live.share
+  - name: propose_public_link
+    description: Propose an owner-confirmed public link; the browser creates it after confirmation.
+    py_func: hushh_mcp.agents.location.tools.propose_public_link
+    required_scope: cap.location.live.share
+  - name: propose_location_view
+    description: Propose viewing an incoming share; the browser fetches and decrypts the ciphertext.
+    py_func: hushh_mcp.agents.location.tools.propose_location_view
+    required_scope: cap.location.live.view
+  - name: revoke_public_link
+    description: Revoke an active public location link owned by the user.
+    py_func: hushh_mcp.agents.location.tools.revoke_public_link
+    required_scope: cap.location.live.share
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_agent_manifest_v2.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the v1 control-plane chat still loads (no regression)**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_agent_factory.py tests/test_location_chat_service.py -v`
+Expected: PASS (the v1 service reads the same manifest's `system_instruction`; only wording changed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/agents/location/agent.yaml consent-protocol/tests/test_location_agent_manifest_v2.py
+git commit -m "feat(one-location): relax agent prompt for client handoff + public links"
+```
+
+---
+
+## Task 4: Directive translation + action-result turn in the chat service
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/services/location_chat_service.py`
+- Test: `consent-protocol/tests/test_location_chat_service_v2.py` (new)
+
+**Interfaces:**
+- Consumes: `get_location_chat_agent_v2` (Task 2); existing `AgentChatService.add_message` / `prepare_turn`; the directive-producing tool results — `create_location_share` → grant dict (`id`, `recipientUserId`, `recipientKeyId`, `recipientDisplayName`); `approve_location_request` → `{"grant": grant_dict, ...}`; `propose_public_link` → `{"proposed":"create_public_link","durationHours":float}`; `propose_location_view` → `{"proposed":"view_envelope","grantId":str}`.
+- Produces: `LocationChatService.handle_turn(*, user_id, message=None, consent_token, conversation_id=None, action_result=None)` returning a dict that MAY include `"clientAction"`; the service defaults to the **v2** agent (tools + prompt) when none is injected.
+
+**Design notes (read before coding):**
+- The route constructs a fresh `LocationChatService()` per request, so per-instance turn state is safe. We still thread directives through locals to keep `_run_tool` pure.
+- Mapping after the tool loop (priority order): if any `create_location_share` / `approve_location_request` ran → `publish_share` (one `ShareTarget` per grant). Else if `propose_location_view` ran → `view_envelope`. Else if `propose_public_link` ran → `create_public_link`.
+- On a directive turn, `stateChanged` is `false` (the grant has no envelope yet; the UI refreshes on the action-result turn). The grant DOES exist server-side — if the user cancels, the **client** revokes it (Task 7), so no envelope-less grant lingers.
+- The action-result turn is deterministic (no LLM, no coordinates): templated confirmation text + `add_message`.
+
+- [ ] **Step 1: Write failing tests for the directive turn**
+
+Create `consent-protocol/tests/test_location_chat_service_v2.py` (reuse the fakes from `test_location_chat_service.py`):
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from google.genai import types
+
+from hushh_mcp.hushh_adk.context import HushhContext
+from hushh_mcp.services.location_chat_service import LocationChatService
+
+
+class _Turn:
+    def __init__(self, conversation_id, history):
+        self.conversation_id = conversation_id
+        self.history = history
+
+
+class _FakeStore:
+    def __init__(self):
+        self.added = []
+
+    async def prepare_turn(self, *, user_id, message, conversation_id=None):
+        return _Turn(conversation_id or "conv-new", [])
+
+    async def add_message(self, *, conversation_id, user_id, role, content, status, model=None):
+        self.added.append({"role": role, "content": content, "status": status})
+
+
+def _fake_tool(name, recorder, *, result):
+    async def _impl(**kwargs):
+        recorder.append({"name": name, "args": kwargs})
+        return result
+
+    _impl._name = name
+    _impl._hushh_tool = True
+    return _impl
+
+
+def _fc_response(name, args):
+    return SimpleNamespace(
+        function_calls=[SimpleNamespace(name=name, args=args)],
+        text="",
+        candidates=[
+            SimpleNamespace(content=types.Content(role="model", parts=[types.Part(text="")]))
+        ],
+    )
+
+
+def _text_response(text):
+    return SimpleNamespace(function_calls=[], text=text, candidates=[])
+
+
+def _scripted(responses):
+    seq = iter(responses)
+
+    async def _call(contents, config):
+        return next(seq)
+
+    return _call
+
+
+def _service(store, responses, tools):
+    return LocationChatService(
+        chat_store=store,
+        model_call=_scripted(responses),
+        genai_types=types,
+        ready=lambda: True,
+        tools=tools,
+        system_prompt="test",
+    )
+
+
+async def test_create_share_emits_publish_share_client_action():
+    store = _FakeStore()
+    grant = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "recipientUserId": "rcpt-1",
+        "recipientKeyId": "key-1",
+        "recipientDisplayName": "Mom",
+    }
+    tools = [_fake_tool("create_location_share", [], result=grant)]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response(
+                "create_location_share",
+                {"recipient_user_id": "rcpt-1", "recipient_key_id": "key-1", "duration_hours": 1},
+            ),
+            _text_response("Ready to share with Mom for 1 hour."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(user_id="u", message="share with Mom", consent_token="t")  # noqa: S106
+
+    action = out["clientAction"]
+    assert action["type"] == "publish_share"
+    assert action["shares"] == [
+        {
+            "grantId": "11111111-1111-1111-1111-111111111111",
+            "recipientUserId": "rcpt-1",
+            "recipientKeyId": "key-1",
+            "label": "Mom",
+        }
+    ]
+    assert "id" in action and action["summary"]
+    # grant exists but no envelope yet -> do not refresh on this turn
+    assert out["stateChanged"] is False
+
+
+async def test_propose_public_link_emits_create_public_link_action():
+    store = _FakeStore()
+    tools = [
+        _fake_tool(
+            "propose_public_link",
+            [],
+            result={"proposed": "create_public_link", "durationHours": 2.0},
+        )
+    ]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("propose_public_link", {"duration_hours": 2}),
+            _text_response("I'll create a public link valid for 2 hours."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(user_id="u", message="make a public link", consent_token="t")  # noqa: S106
+
+    assert out["clientAction"]["type"] == "create_public_link"
+    assert out["clientAction"]["durationHours"] == 2.0
+
+
+async def test_action_result_completed_publish_confirms_and_sets_state_changed():
+    store = _FakeStore()
+    svc = _service(store, responses=[], tools=[])
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        action_result={"id": "a1", "type": "publish_share", "status": "completed"},
+    )
+
+    assert out["conversationId"] == "conv-1"
+    assert out["stateChanged"] is True
+    assert out["isComplete"] is True
+    assert out["response"]  # non-empty confirmation
+    assert store.added[-1]["role"] == "assistant"
+    assert store.added[-1]["status"] == "complete"
+
+
+async def test_action_result_cancelled_does_not_set_state_changed():
+    store = _FakeStore()
+    svc = _service(store, responses=[], tools=[])
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        action_result={"id": "a1", "type": "publish_share", "status": "cancelled"},
+    )
+
+    assert out["stateChanged"] is False
+    assert out["isComplete"] is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_service_v2.py -v`
+Expected: FAIL (`handle_turn` has no `action_result` kwarg; no `clientAction` in output).
+
+- [ ] **Step 3: Add v2 function declarations**
+
+In `consent-protocol/hushh_mcp/services/location_chat_service.py`, add a new declarations builder below `_function_declarations` (keep the v1 one intact). Add the 7 extra declarations on top of the 6 existing ones:
+
+```python
+def _function_declarations_v2(types: Any) -> list:
+    """v1 control-plane declarations + v2 prep/intent/read/control declarations."""
+    schema = types.Schema
+    kind = types.Type
+    decls = _function_declarations(types)
+    decls.extend(
+        [
+            types.FunctionDeclaration(
+                name="create_location_share",
+                description=(
+                    "Create a recipient-bound live-location grant (no coordinates). "
+                    "recipient_user_id and recipient_key_id MUST come from "
+                    "list_location_recipients. After this, the browser captures and "
+                    "encrypts the location."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "recipient_user_id": schema(type=kind.STRING),
+                        "recipient_key_id": schema(type=kind.STRING),
+                        "duration_hours": schema(type=kind.NUMBER, description="0 < hours <= 24"),
+                        "reason": schema(type=kind.STRING, description="Optional note"),
+                    },
+                    required=["recipient_user_id", "recipient_key_id", "duration_hours"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="approve_location_request",
+                description=(
+                    "Approve a pending incoming request and create a recipient-scoped "
+                    "grant. request_id MUST come from looking up pending requests."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "request_id": schema(type=kind.STRING),
+                        "duration_hours": schema(type=kind.NUMBER, description="0 < hours <= 24"),
+                    },
+                    required=["request_id", "duration_hours"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="list_incoming_location_shares",
+                description=(
+                    "List active shares where the user is the recipient (grant ids + "
+                    "owner names). Call FIRST before proposing to view a location. Read-only."
+                ),
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="list_public_links",
+                description=(
+                    "List the user's active public location links (ids + expiry). Call "
+                    "FIRST before revoking a public link. Read-only."
+                ),
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="propose_public_link",
+                description=(
+                    "Propose an owner-confirmed public link valid for duration_hours. "
+                    "The browser creates it after explicit confirmation."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "duration_hours": schema(type=kind.NUMBER, description="0 < hours <= 24")
+                    },
+                    required=["duration_hours"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="propose_location_view",
+                description=(
+                    "Propose viewing an incoming share's latest location. grant_id MUST "
+                    "come from list_incoming_location_shares. The browser decrypts it."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={"grant_id": schema(type=kind.STRING)},
+                    required=["grant_id"],
+                ),
+            ),
+            types.FunctionDeclaration(
+                name="revoke_public_link",
+                description=(
+                    "Revoke an active public location link. invite_id MUST come from "
+                    "list_public_links."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={"invite_id": schema(type=kind.STRING)},
+                    required=["invite_id"],
+                ),
+            ),
+        ]
+    )
+    return decls
+```
+
+- [ ] **Step 4: Default to the v2 agent + add directive constants**
+
+In the same file, update the import at the top:
+
+```python
+from hushh_mcp.agents.location.agent import get_location_chat_agent, get_location_chat_agent_v2
+```
+
+In `LocationChatService.__init__`, change the agent selection so v2 is the default (only when neither prompt nor tools are injected):
+
+```python
+        need_agent = system_prompt is None or tools is None
+        agent = get_location_chat_agent_v2() if need_agent else None
+```
+
+Add these module-level constants near `_QUERY_TOOL_NAMES`:
+
+```python
+# Read-only v2 tools that must NOT trigger a UI refresh.
+_QUERY_TOOL_NAMES = {
+    "list_location_recipients",
+    "list_active_location_shares",
+    "list_incoming_location_shares",
+    "list_public_links",
+    # propose_* tools only stage a client action; they mutate nothing server-side.
+    "propose_public_link",
+    "propose_location_view",
+}
+
+# Tools whose successful result produces a client-action directive.
+_DIRECTIVE_GRANT_TOOLS = {"create_location_share", "approve_location_request"}
+
+_ACTION_RESULT_TEMPLATES = {
+    ("publish_share", "completed"): "Done — your live location is now shared. ✓",
+    ("publish_share", "cancelled"): "No problem — I didn't share your location.",
+    ("view_envelope", "completed"): "Here's the latest location I could open.",
+    ("create_public_link", "cancelled"): "Okay — I didn't create a public link.",
+}
+```
+
+- [ ] **Step 5: Thread directives through the tool loop**
+
+Replace the `_run_tool` method and the tool-loop body so a directive can be captured. First, change `_run_tool` to also return a directive descriptor:
+
+```python
+    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None]:
+        """Execute one tool inside the active HushhContext.
+
+        Returns (result, mutated, directive) where directive is a coordinate-free
+        descriptor of a client action to emit after the loop, or None.
+        """
+        tool = self._dispatch.get(name)
+        if tool is None:
+            return {"error": "unknown_tool"}, False, None
+        try:
+            result = await tool(**args)
+        except PermissionError:
+            return {"error": "consent_denied"}, False, None
+        except ValueError as exc:
+            return {"error": "invalid_argument", "message": str(exc)}, False, None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Location tool %s failed: %s", name, exc)
+            return {"error": "tool_failed"}, False, None
+        directive = self._directive_from_tool(name, _as_response_dict(result))
+        mutated = name not in _QUERY_TOOL_NAMES
+        return _as_response_dict(result), mutated, directive
+```
+
+Add the directive builder method:
+
+```python
+    @staticmethod
+    def _directive_from_tool(name: str, result: dict) -> dict | None:
+        """Translate a successful directive-producing tool result into a
+        coordinate-free client-action descriptor."""
+        if isinstance(result, dict) and result.get("error"):
+            return None
+        if name in _DIRECTIVE_GRANT_TOOLS:
+            grant = result.get("grant") if "grant" in result else result
+            if not isinstance(grant, dict) or not grant.get("id"):
+                return None
+            return {
+                "type": "publish_share",
+                "share": {
+                    "grantId": str(grant.get("id")),
+                    "recipientUserId": str(grant.get("recipientUserId") or ""),
+                    "recipientKeyId": str(grant.get("recipientKeyId") or ""),
+                    "label": grant.get("recipientDisplayName") or "your recipient",
+                },
+            }
+        if name == "propose_public_link" and result.get("proposed") == "create_public_link":
+            return {"type": "create_public_link", "durationHours": result.get("durationHours")}
+        if name == "propose_location_view" and result.get("proposed") == "view_envelope":
+            return {"type": "view_envelope", "grantId": result.get("grantId")}
+        return None
+```
+
+Now update the loop inside `handle_turn`. Add `directives: list[dict] = []` before the `with HushhContext(...)` block, and change the tool-call handling so it collects directives:
+
+```python
+                    for call in calls:
+                        result, mutated, directive = await self._run_tool(
+                            call.name, dict(call.args or {})
+                        )
+                        state_changed = state_changed or mutated
+                        if directive is not None:
+                            directives.append(directive)
+                        contents.append(
+                            types.Content(
+                                role="tool",
+                                parts=[
+                                    types.Part.from_function_response(
+                                        name=call.name, response=result
+                                    )
+                                ],
+                            )
+                        )
+```
+
+- [ ] **Step 6: Build the clientAction and override stateChanged for directive turns**
+
+Add a helper that folds collected directives into one client action (combining multiple `publish_share` grants into a `shares[]` list):
+
+```python
+    def _build_client_action(self, directives: list[dict]) -> dict | None:
+        if not directives:
+            return None
+        action_id = "act-" + uuid4().hex[:12]
+        shares = [d["share"] for d in directives if d.get("type") == "publish_share"]
+        if shares:
+            labels = ", ".join(s["label"] for s in shares)
+            return {
+                "id": action_id,
+                "type": "publish_share",
+                "shares": shares,
+                "summary": f"Share your live location with {labels}",
+            }
+        view = next((d for d in directives if d.get("type") == "view_envelope"), None)
+        if view:
+            return {
+                "id": action_id,
+                "type": "view_envelope",
+                "grantId": view.get("grantId"),
+                "summary": "Open the latest shared location",
+            }
+        link = next((d for d in directives if d.get("type") == "create_public_link"), None)
+        if link:
+            hours = link.get("durationHours")
+            return {
+                "id": action_id,
+                "type": "create_public_link",
+                "durationHours": hours,
+                "summary": f"Create a public link (viewable for {hours}h)",
+            }
+        return None
+```
+
+Add `from uuid import uuid4` to the imports.
+
+Then, near the end of `handle_turn`, after computing `reply` and before the final `_finish`, build the action and force `stateChanged=False` when a directive is pending (the real state change happens on the action-result turn):
+
+```python
+        client_action = self._build_client_action(directives)
+        if client_action is not None:
+            state_changed = False
+        if not reply:
+            reply = "Done."
+        return await self._finish(
+            turn,
+            reply,
+            user_id,
+            errored=errored,
+            state_changed=state_changed and not errored,
+            client_action=client_action,
+        )
+```
+
+Update `_finish` to accept and surface `client_action`:
+
+```python
+    async def _finish(
+        self,
+        turn: Any,
+        reply: str,
+        user_id: str,
+        *,
+        errored: bool,
+        state_changed: bool,
+        client_action: dict | None = None,
+    ) -> dict[str, Any]:
+        await self._chat_store.add_message(
+            conversation_id=turn.conversation_id,
+            user_id=user_id,
+            role="assistant",
+            content=reply,
+            status="error" if errored else "complete",
+        )
+        out: dict[str, Any] = {
+            "conversationId": turn.conversation_id,
+            "response": reply,
+            "isComplete": not errored,
+            "stateChanged": state_changed,
+        }
+        if client_action is not None:
+            out["clientAction"] = client_action
+        return out
+```
+
+Also switch the v2 declarations on: in `handle_turn`, change the config's `tools=` to use `_function_declarations_v2`:
+
+```python
+            tools=[types.Tool(function_declarations=_function_declarations_v2(types))],
+```
+
+- [ ] **Step 7: Add the action-result confirmation turn**
+
+Change the `handle_turn` signature to accept `message: str | None = None` and `action_result: dict | None = None`, and branch at the very top of the method:
+
+```python
+    async def handle_turn(
+        self,
+        *,
+        user_id: str,
+        message: str | None = None,
+        consent_token: str,
+        conversation_id: str | None = None,
+        action_result: dict | None = None,
+    ) -> dict[str, Any]:
+        if action_result is not None:
+            return await self._handle_action_result(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                action_result=action_result,
+            )
+        if not message:
+            # nothing to do; mirror the unavailable shape rather than calling the model
+            return {
+                "conversationId": conversation_id or "",
+                "response": "Tell me what you'd like to do with your location sharing.",
+                "isComplete": True,
+                "stateChanged": False,
+            }
+        # ... existing v1 flow continues unchanged from here (prepare_turn etc.) ...
+```
+
+Add the deterministic handler:
+
+```python
+    async def _handle_action_result(
+        self,
+        *,
+        user_id: str,
+        conversation_id: str | None,
+        action_result: dict,
+    ) -> dict[str, Any]:
+        action_type = str(action_result.get("type") or "")
+        status = str(action_result.get("status") or "")
+        detail = action_result.get("detail")
+        public_url = action_result.get("publicUrl")
+
+        if action_type == "create_public_link" and status == "completed" and public_url:
+            reply = (
+                f"Your public link is ready: {public_url} — anyone with it can view "
+                "this location until it expires, and you can revoke it anytime."
+            )
+        elif status == "failed":
+            suffix = f" ({detail})" if detail else ""
+            reply = f"That didn't go through{suffix}. You can try again."
+        else:
+            reply = _ACTION_RESULT_TEMPLATES.get(
+                (action_type, status), "Okay, that's handled."
+            )
+
+        errored = status == "failed"
+        state_changed = status == "completed" and action_type in (
+            "publish_share",
+            "create_public_link",
+        )
+        conv_id = conversation_id or ""
+        if conv_id:
+            await self._chat_store.add_message(
+                conversation_id=conv_id,
+                user_id=user_id,
+                role="assistant",
+                content=reply,
+                status="error" if errored else "complete",
+            )
+        return {
+            "conversationId": conv_id,
+            "response": reply,
+            "isComplete": not errored,
+            "stateChanged": state_changed,
+        }
+```
+
+- [ ] **Step 8: Run the v2 service tests to verify they pass**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_service_v2.py -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 9: Run the v1 service tests to verify no regression**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_service.py -v`
+Expected: PASS (the v1 tests inject `tools` + `system_prompt`, so the v2 default agent is never constructed; the loop/`_finish` changes are backward-compatible).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/services/location_chat_service.py consent-protocol/tests/test_location_chat_service_v2.py
+git commit -m "feat(one-location): v2 chat service — client-action directives + action-result turn"
+```
+
+---
+
+## Task 5: Route — accept actionResult, message optional
+
+**Files:**
+- Modify: `consent-protocol/api/routes/one/location_chat.py`
+- Test: `consent-protocol/tests/test_location_chat_routes.py`
+
+**Interfaces:**
+- Consumes: `LocationChatService.handle_turn(*, user_id, message=None, consent_token, conversation_id=None, action_result=None)` (Task 4).
+- Produces: the route forwards `action_result` and passes through `clientAction` in the response dict.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `consent-protocol/tests/test_location_chat_routes.py`:
+
+```python
+def test_chat_route_forwards_action_result(monkeypatch):
+    captured: dict = {}
+
+    class _Service:
+        async def handle_turn(self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None):
+            captured.update(
+                {"message": message, "action_result": action_result, "conversation_id": conversation_id}
+            )
+            return {
+                "conversationId": conversation_id,
+                "response": "Done — your live location is now shared. ✓",
+                "isComplete": True,
+                "stateChanged": True,
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+
+    response = client.post(
+        "/api/one/location/chat",
+        json={
+            "conversationId": "conv-1",
+            "actionResult": {"id": "a1", "type": "publish_share", "status": "completed"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["stateChanged"] is True
+    assert captured["message"] is None
+    assert captured["action_result"] == {"id": "a1", "type": "publish_share", "status": "completed"}
+    assert captured["conversation_id"] == "conv-1"
+
+
+def test_chat_route_passes_through_client_action(monkeypatch):
+    class _Service:
+        async def handle_turn(self, **kwargs):
+            return {
+                "conversationId": "c1",
+                "response": "Ready to share with Mom.",
+                "isComplete": True,
+                "stateChanged": False,
+                "clientAction": {
+                    "id": "act-1",
+                    "type": "publish_share",
+                    "shares": [
+                        {"grantId": "g1", "recipientUserId": "r1", "recipientKeyId": "k1", "label": "Mom"}
+                    ],
+                    "summary": "Share your live location with Mom",
+                },
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+
+    response = client.post("/api/one/location/chat", json={"message": "share with Mom"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["clientAction"]["type"] == "publish_share"
+    assert body["clientAction"]["shares"][0]["label"] == "Mom"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_routes.py::test_chat_route_forwards_action_result tests/test_location_chat_routes.py::test_chat_route_passes_through_client_action -v`
+Expected: FAIL (422 on empty message — `message` is still required; `action_result` not forwarded).
+
+- [ ] **Step 3: Update the route models + handler**
+
+Replace the body of `consent-protocol/api/routes/one/location_chat.py` from the `class LocationChatRequest` definition through the end of `location_chat` with:
+
+```python
+class ActionResultModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(max_length=64)
+    type: str = Field(max_length=48)
+    status: str = Field(max_length=24)
+    public_url: str | None = Field(default=None, alias="publicUrl", max_length=2048)
+    detail: str | None = Field(default=None, max_length=500)
+
+
+class LocationChatRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    message: str | None = Field(default=None, max_length=4000)
+    conversation_id: str | None = Field(default=None, alias="conversationId", max_length=128)
+    action_result: ActionResultModel | None = Field(default=None, alias="actionResult")
+
+
+@router.post("/location/chat")
+async def location_chat(
+    request: LocationChatRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    if not request.message and request.action_result is None:
+        raise HTTPException(status_code=422, detail="message or actionResult is required")
+    try:
+        result: dict[str, Any] = await _service().handle_turn(
+            user_id=token_data["user_id"],
+            message=request.message,
+            consent_token=token_data.get("token", ""),
+            conversation_id=request.conversation_id,
+            action_result=(
+                request.action_result.model_dump(by_alias=True)
+                if request.action_result is not None
+                else None
+            ),
+        )
+        return result
+    except Exception:
+        logger.exception("Location chat turn failed")
+        raise HTTPException(status_code=500, detail="Location chat could not be processed")
+```
+
+- [ ] **Step 4: Run the full route test file to verify it passes**
+
+Run: `cd consent-protocol && python -m pytest tests/test_location_chat_routes.py -v`
+Expected: PASS (new tests pass; existing happy-path/camel-alias/opaque-error tests still pass; the empty-message test now returns 422 from our explicit guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add consent-protocol/api/routes/one/location_chat.py consent-protocol/tests/test_location_chat_routes.py
+git commit -m "feat(one-location): chat route accepts actionResult, passes through clientAction"
+```
+
+---
+
+## Task 6: Frontend types + service.chat extension
+
+**Files:**
+- Modify: `hushh-webapp/lib/one-location/types.ts`
+- Modify: `hushh-webapp/lib/one-location/service.ts`
+- Test: `hushh-webapp/__tests__/services/location-chat-service.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `ShareTarget { grantId; recipientUserId; recipientKeyId; label }`
+  - `ClientAction { id; type: "publish_share" | "view_envelope" | "create_public_link"; shares?: ShareTarget[]; grantId?: string; durationHours?: number; summary: string }`
+  - `ActionResult { id; type: string; status: "completed" | "cancelled" | "failed"; publicUrl?: string; detail?: string }`
+  - `LocationChatResponse` gains `clientAction?: ClientAction`
+  - `OneLocationService.chat({ vaultOwnerToken, message?, conversationId?, actionResult? })`
+
+- [ ] **Step 1: Write the failing service test**
+
+Append to `hushh-webapp/__tests__/services/location-chat-service.test.ts` (mirror the existing mock-fetch pattern in that file; adapt the fetch mock setup to match what's already there):
+
+```ts
+import { OneLocationService } from "@/lib/one-location/service";
+
+describe("OneLocationService.chat actionResult", () => {
+  it("sends actionResult and omits message when reporting completion", async () => {
+    const fetchMock = jest.spyOn(global, "fetch" as never).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        conversationId: "c1",
+        response: "Done.",
+        isComplete: true,
+        stateChanged: true,
+      }),
+    } as never);
+
+    await OneLocationService.chat({
+      vaultOwnerToken: "tok",
+      conversationId: "c1",
+      actionResult: { id: "a1", type: "publish_share", status: "completed" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.actionResult).toEqual({ id: "a1", type: "publish_share", status: "completed" });
+    expect(body.message ?? null).toBeNull();
+    fetchMock.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd hushh-webapp && npx jest __tests__/services/location-chat-service.test.ts -t "actionResult"`
+Expected: FAIL (TS error / `actionResult` not sent).
+
+- [ ] **Step 3: Add the types**
+
+In `hushh-webapp/lib/one-location/types.ts`, replace the `LocationChatResponse` interface (lines 331–336) with:
+
+```ts
+export interface ShareTarget {
+  grantId: string;
+  recipientUserId: string;
+  recipientKeyId: string;
+  label: string;
+}
+
+export type ClientActionType = "publish_share" | "view_envelope" | "create_public_link";
+
+export interface ClientAction {
+  id: string;
+  type: ClientActionType;
+  shares?: ShareTarget[];
+  grantId?: string;
+  durationHours?: number;
+  summary: string;
+}
+
+export interface ActionResult {
+  id: string;
+  type: ClientActionType;
+  status: "completed" | "cancelled" | "failed";
+  publicUrl?: string;
+  detail?: string;
+}
+
+export interface LocationChatResponse {
+  conversationId: string;
+  response: string;
+  isComplete: boolean;
+  stateChanged: boolean;
+  clientAction?: ClientAction;
+}
+```
+
+- [ ] **Step 4: Update `OneLocationService.chat`**
+
+In `hushh-webapp/lib/one-location/service.ts`, add `ActionResult` to the type import block (with the other `@/lib/one-location/types` imports), then replace the `chat` method (lines 145–158) with:
+
+```ts
+  static async chat(params: {
+    vaultOwnerToken: string;
+    message?: string;
+    conversationId?: string | null;
+    actionResult?: ActionResult;
+  }): Promise<LocationChatResponse> {
+    return apiJson<LocationChatResponse>("/api/one/location/chat", {
+      method: "POST",
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({
+        message: params.message ?? null,
+        conversationId: params.conversationId ?? null,
+        actionResult: params.actionResult ?? null,
+      }),
+    });
+  }
+```
+
+- [ ] **Step 5: Run the test + typecheck to verify they pass**
+
+Run: `cd hushh-webapp && npx jest __tests__/services/location-chat-service.test.ts && npx tsc --noEmit`
+Expected: PASS and clean typecheck.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hushh-webapp/lib/one-location/types.ts hushh-webapp/lib/one-location/service.ts hushh-webapp/__tests__/services/location-chat-service.test.ts
+git commit -m "feat(one-location): chat contract types + service actionResult support"
+```
+
+---
+
+## Task 7: Action dispatcher in `useLocationChat`
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/use-location-chat.ts`
+- Test: `hushh-webapp/__tests__/components/use-location-chat.test.tsx`
+
+**Interfaces:**
+- Consumes: `OneLocationService.chat/captureCurrentPosition/storeEnvelope/viewEnvelope/createPublicInvite/revokeGrant/getState`; `encryptLocationForRecipient`, `decryptLocationEnvelope` from `@/lib/one-location/encryption`; types from Task 6.
+- Produces: `UseLocationChat` gains `pendingAction: ClientAction | null`, `confirmAction(): Promise<void>`, `cancelAction(): Promise<void>`, `viewedPoint: PlainLocationPoint | null`; `useLocationChat` params gain `userId: string`.
+
+**Design notes:**
+- `publish_share`: capture position once; for each `share`, resolve `publicKeyJwk` from `OneLocationService.getState(...).recipients` by `recipientKeyId`, `encryptLocationForRecipient`, `storeEnvelope`. Then `chat({ actionResult: completed })`.
+- `view_envelope`: `viewEnvelope(grantId)` → `decryptLocationEnvelope({ userId, envelope })` → set `viewedPoint`. Then `chat({ actionResult: completed })`.
+- `create_public_link`: capture → `createPublicInvite({ durationHours, locationSnapshot })` → `chat({ actionResult: completed, publicUrl })`.
+- Any throw → `chat({ actionResult: failed, detail })`.
+- `cancelAction` for `publish_share`: best-effort `revokeGrant` each `grantId` (clean up the envelope-less grant), then `chat({ actionResult: cancelled })`.
+
+- [ ] **Step 1: Write the failing hook tests**
+
+Append to `hushh-webapp/__tests__/components/use-location-chat.test.tsx` (mirror the file's existing render/mock setup; mock `@/lib/one-location/service` and `@/lib/one-location/encryption`):
+
+```tsx
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useLocationChat } from "@/components/one-location/redesign/use-location-chat";
+import { OneLocationService } from "@/lib/one-location/service";
+import * as encryption from "@/lib/one-location/encryption";
+
+jest.mock("@/lib/one-location/service");
+jest.mock("@/lib/one-location/encryption");
+
+const svc = OneLocationService as jest.Mocked<typeof OneLocationService>;
+
+beforeEach(() => jest.clearAllMocks());
+
+it("publish_share: confirm captures, encrypts per recipient, uploads, reports completed", async () => {
+  svc.chat
+    .mockResolvedValueOnce({
+      conversationId: "c1",
+      response: "Ready to share with Mom.",
+      isComplete: true,
+      stateChanged: false,
+      clientAction: {
+        id: "act-1",
+        type: "publish_share",
+        shares: [{ grantId: "g1", recipientUserId: "r1", recipientKeyId: "k1", label: "Mom" }],
+        summary: "Share your live location with Mom",
+      },
+    })
+    .mockResolvedValueOnce({
+      conversationId: "c1",
+      response: "Done — shared. ✓",
+      isComplete: true,
+      stateChanged: true,
+    });
+  svc.captureCurrentPosition.mockResolvedValue({
+    latitude: 1,
+    longitude: 2,
+    capturedAt: "now",
+    sourcePlatform: "web",
+  } as never);
+  svc.getState.mockResolvedValue({
+    recipients: [{ keyId: "k1", publicKeyJwk: { kid: "k1" } }],
+  } as never);
+  (encryption.encryptLocationForRecipient as jest.Mock).mockResolvedValue({ ciphertext: "x" });
+  svc.storeEnvelope.mockResolvedValue({} as never);
+
+  const onStateChanged = jest.fn();
+  const { result } = renderHook(() =>
+    useLocationChat({ vaultOwnerToken: "tok", userId: "u1", onStateChanged }),
+  );
+
+  await act(async () => {
+    await result.current.send("share with Mom");
+  });
+  expect(result.current.pendingAction?.type).toBe("publish_share");
+
+  await act(async () => {
+    await result.current.confirmAction();
+  });
+
+  expect(svc.captureCurrentPosition).toHaveBeenCalledTimes(1);
+  expect(encryption.encryptLocationForRecipient).toHaveBeenCalledWith(
+    expect.objectContaining({ recipientKeyId: "k1", recipientPublicKeyJwk: { kid: "k1" } }),
+  );
+  expect(svc.storeEnvelope).toHaveBeenCalledWith(
+    expect.objectContaining({ grantId: "g1" }),
+  );
+  expect(svc.chat).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      actionResult: expect.objectContaining({ type: "publish_share", status: "completed" }),
+    }),
+  );
+  await waitFor(() => expect(onStateChanged).toHaveBeenCalled());
+  expect(result.current.pendingAction).toBeNull();
+});
+
+it("publish_share: cancel revokes the grant and reports cancelled", async () => {
+  svc.chat
+    .mockResolvedValueOnce({
+      conversationId: "c1",
+      response: "Ready.",
+      isComplete: true,
+      stateChanged: false,
+      clientAction: {
+        id: "act-1",
+        type: "publish_share",
+        shares: [{ grantId: "g1", recipientUserId: "r1", recipientKeyId: "k1", label: "Mom" }],
+        summary: "Share with Mom",
+      },
+    })
+    .mockResolvedValueOnce({
+      conversationId: "c1",
+      response: "No problem.",
+      isComplete: true,
+      stateChanged: false,
+    });
+  svc.revokeGrant.mockResolvedValue({} as never);
+
+  const { result } = renderHook(() =>
+    useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+  );
+  await act(async () => {
+    await result.current.send("share with Mom");
+  });
+  await act(async () => {
+    await result.current.cancelAction();
+  });
+
+  expect(svc.revokeGrant).toHaveBeenCalledWith(expect.objectContaining({ grantId: "g1" }));
+  expect(svc.chat).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      actionResult: expect.objectContaining({ status: "cancelled" }),
+    }),
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/use-location-chat.test.tsx -t "publish_share"`
+Expected: FAIL (`pendingAction` / `confirmAction` / `userId` don't exist).
+
+- [ ] **Step 3: Extend the hook**
+
+In `hushh-webapp/components/one-location/redesign/use-location-chat.ts`:
+
+Update the imports and interface:
+
+```ts
+import { useCallback, useRef, useState } from "react";
+
+import { OneLocationService } from "@/lib/one-location/service";
+import {
+  decryptLocationEnvelope,
+  encryptLocationForRecipient,
+} from "@/lib/one-location/encryption";
+import type {
+  ActionResult,
+  ClientAction,
+  PlainLocationPoint,
+} from "@/lib/one-location/types";
+```
+
+Add to `UseLocationChat`:
+
+```ts
+export interface UseLocationChat {
+  messages: ChatMessage[];
+  busy: boolean;
+  send: (message: string) => Promise<void>;
+  retry: () => Promise<void>;
+  clear: () => void;
+  pendingAction: ClientAction | null;
+  confirmAction: () => Promise<void>;
+  cancelAction: () => Promise<void>;
+  viewedPoint: PlainLocationPoint | null;
+}
+```
+
+Change the params and add state (inside `useLocationChat`):
+
+```ts
+export function useLocationChat(params: {
+  vaultOwnerToken: string;
+  userId: string;
+  onStateChanged?: () => void;
+}): UseLocationChat {
+  const { vaultOwnerToken, userId, onStateChanged } = params;
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [pendingAction, setPendingAction] = useState<ClientAction | null>(null);
+  const [viewedPoint, setViewedPoint] = useState<PlainLocationPoint | null>(null);
+  const conversationIdRef = useRef<string | null>(null);
+  const lastSentRef = useRef<string | null>(null);
+  const seqRef = useRef(0);
+
+  const nextId = useCallback(() => `m-${seqRef.current++}`, []);
+```
+
+In the `run` callback, after appending the assistant message, capture any `clientAction`:
+
+```ts
+        conversationIdRef.current = result.conversationId;
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: nextId(),
+            role: "assistant",
+            text: result.response,
+            stateChanged: result.stateChanged,
+          },
+        ]);
+        if (result.clientAction) setPendingAction(result.clientAction);
+        if (result.stateChanged) onStateChanged?.();
+```
+
+Add a follow-up reporter and the dispatcher near the bottom (before the `return`):
+
+```ts
+  const report = useCallback(
+    async (actionResult: ActionResult) => {
+      setBusy(true);
+      try {
+        const result = await OneLocationService.chat({
+          vaultOwnerToken,
+          conversationId: conversationIdRef.current,
+          actionResult,
+        });
+        conversationIdRef.current = result.conversationId;
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", text: result.response, stateChanged: result.stateChanged },
+        ]);
+        if (result.stateChanged) onStateChanged?.();
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", text: LOCATION_CHAT_ERROR_TEXT, errored: true },
+        ]);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [vaultOwnerToken, onStateChanged, nextId],
+  );
+
+  const confirmAction = useCallback(async () => {
+    const action = pendingAction;
+    if (!action || busy) return;
+    setPendingAction(null);
+    try {
+      if (action.type === "publish_share") {
+        const point = await OneLocationService.captureCurrentPosition();
+        const state = await OneLocationService.getState(vaultOwnerToken);
+        for (const share of action.shares ?? []) {
+          const recipient = (state.recipients ?? []).find(
+            (r) => r.keyId === share.recipientKeyId,
+          );
+          if (!recipient?.publicKeyJwk) {
+            throw new Error(`${share.label} hasn't set up location sharing yet`);
+          }
+          const envelope = await encryptLocationForRecipient({
+            point,
+            recipientPublicKeyJwk: recipient.publicKeyJwk,
+            recipientKeyId: share.recipientKeyId,
+          });
+          await OneLocationService.storeEnvelope({
+            vaultOwnerToken,
+            grantId: share.grantId,
+            envelope,
+          });
+        }
+        await report({ id: action.id, type: action.type, status: "completed" });
+      } else if (action.type === "view_envelope") {
+        const { envelope } = await OneLocationService.viewEnvelope({
+          vaultOwnerToken,
+          grantId: action.grantId as string,
+        });
+        const point = await decryptLocationEnvelope({ userId, envelope });
+        setViewedPoint(point);
+        await report({ id: action.id, type: action.type, status: "completed" });
+      } else if (action.type === "create_public_link") {
+        const locationSnapshot = await OneLocationService.captureCurrentPosition();
+        const { publicUrl } = await OneLocationService.createPublicInvite({
+          vaultOwnerToken,
+          durationHours: action.durationHours ?? 1,
+          locationSnapshot,
+        });
+        await report({ id: action.id, type: action.type, status: "completed", publicUrl });
+      }
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : undefined;
+      await report({ id: action.id, type: action.type, status: "failed", detail });
+    }
+  }, [pendingAction, busy, vaultOwnerToken, userId, report]);
+
+  const cancelAction = useCallback(async () => {
+    const action = pendingAction;
+    if (!action) return;
+    setPendingAction(null);
+    if (action.type === "publish_share") {
+      for (const share of action.shares ?? []) {
+        try {
+          await OneLocationService.revokeGrant({ vaultOwnerToken, grantId: share.grantId });
+        } catch {
+          // best-effort cleanup; ignore
+        }
+      }
+    }
+    await report({ id: action.id, type: action.type, status: "cancelled" });
+  }, [pendingAction, vaultOwnerToken, report]);
+```
+
+Update the `return` to include the new members:
+
+```ts
+  return {
+    messages,
+    busy,
+    send,
+    retry,
+    clear,
+    pendingAction,
+    confirmAction,
+    cancelAction,
+    viewedPoint,
+  };
+```
+
+Also update `clear` to reset `pendingAction` and `viewedPoint`:
+
+```ts
+  const clear = useCallback(() => {
+    setMessages([]);
+    conversationIdRef.current = null;
+    lastSentRef.current = null;
+    setPendingAction(null);
+    setViewedPoint(null);
+  }, []);
+```
+
+- [ ] **Step 4: Run the hook tests to verify they pass**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/use-location-chat.test.tsx`
+Expected: PASS (new tests + existing hook tests). If existing tests construct the hook without `userId`, update those call sites to pass `userId: "u1"`.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd hushh-webapp && npx tsc --noEmit`
+Expected: clean. (If `getState`'s `recipients` element type lacks `keyId`/`publicKeyJwk`, they exist on `OneLocationRecipient` — ensure the `state.recipients` access is typed via `OneLocationState`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/use-location-chat.ts hushh-webapp/__tests__/components/use-location-chat.test.tsx
+git commit -m "feat(one-location): action dispatcher in useLocationChat (share/view/public-link)"
+```
+
+---
+
+## Task 8: ActionConfirmCard + render in chat surfaces + new chips
+
+**Files:**
+- Create: `hushh-webapp/components/one-location/redesign/action-confirm-card.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/location-chat-card.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx`
+- Test: `hushh-webapp/__tests__/components/action-confirm-card.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `ClientAction` (Task 6).
+- Produces: `ActionConfirmCard({ action, busy, onConfirm, onCancel })` — renders `action.summary` + a confirm button (label by type) + a cancel button.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `hushh-webapp/__tests__/components/action-confirm-card.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ActionConfirmCard } from "@/components/one-location/redesign/action-confirm-card";
+
+const baseAction = {
+  id: "act-1",
+  type: "publish_share" as const,
+  shares: [{ grantId: "g1", recipientUserId: "r1", recipientKeyId: "k1", label: "Mom" }],
+  summary: "Share your live location with Mom",
+};
+
+it("renders the summary and fires confirm/cancel", () => {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+  render(
+    <ActionConfirmCard action={baseAction} busy={false} onConfirm={onConfirm} onCancel={onCancel} />,
+  );
+
+  expect(screen.getByText("Share your live location with Mom")).toBeInTheDocument();
+  fireEvent.click(screen.getByTestId("action-confirm-accept"));
+  expect(onConfirm).toHaveBeenCalled();
+  fireEvent.click(screen.getByTestId("action-confirm-cancel"));
+  expect(onCancel).toHaveBeenCalled();
+});
+
+it("shows a Create label for public links", () => {
+  render(
+    <ActionConfirmCard
+      action={{ id: "a2", type: "create_public_link", durationHours: 2, summary: "Create a public link (viewable for 2h)" }}
+      busy={false}
+      onConfirm={jest.fn()}
+      onCancel={jest.fn()}
+    />,
+  );
+  expect(screen.getByTestId("action-confirm-accept")).toHaveTextContent(/create/i);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/action-confirm-card.test.tsx`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Create the component**
+
+Create `hushh-webapp/components/one-location/redesign/action-confirm-card.tsx`:
+
+```tsx
+"use client";
+
+import { MapPin, Share2, Eye, Link as LinkIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { ClientAction } from "@/lib/one-location/types";
+
+const CONFIRM_LABEL: Record<ClientAction["type"], string> = {
+  publish_share: "Share",
+  view_envelope: "View",
+  create_public_link: "Create link",
+};
+
+const ICON: Record<ClientAction["type"], typeof MapPin> = {
+  publish_share: Share2,
+  view_envelope: Eye,
+  create_public_link: LinkIcon,
+};
+
+export function ActionConfirmCard({
+  action,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  action: ClientAction;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const Icon = ICON[action.type] ?? MapPin;
+  return (
+    <div
+      data-testid="action-confirm-card"
+      className="rounded-2xl border border-[#b8894d]/40 bg-[#b8894d]/5 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 text-[#b8894d]">
+          <Icon className="h-5 w-5" aria-hidden />
+        </span>
+        <p className="flex-1 text-sm font-medium">{action.summary}</p>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <Button
+          data-testid="action-confirm-accept"
+          size="sm"
+          isLoading={busy}
+          onClick={onConfirm}
+        >
+          {CONFIRM_LABEL[action.type] ?? "Confirm"}
+        </Button>
+        <Button
+          data-testid="action-confirm-cancel"
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the component test to verify it passes**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/action-confirm-card.test.tsx`
+Expected: PASS. (If `Button` does not accept `size`/`variant`/`isLoading` exactly as written, check `components/ui/button.tsx` and adjust the props to the real API — `isLoading` exists per the UI spec.)
+
+- [ ] **Step 5: Render the card in the chat card + overlay**
+
+In `hushh-webapp/components/one-location/redesign/location-chat-card.tsx`, where the hook is consumed, destructure the new members and render the card below the message list when `pendingAction` is set. Add the import:
+
+```tsx
+import { ActionConfirmCard } from "./action-confirm-card";
+```
+
+Then, in the message-stream region (after the messages list, before the composer), add:
+
+```tsx
+{pendingAction ? (
+  <ActionConfirmCard
+    action={pendingAction}
+    busy={busy}
+    onConfirm={confirmAction}
+    onCancel={cancelAction}
+  />
+) : null}
+```
+
+Make sure `pendingAction`, `busy`, `confirmAction`, `cancelAction` are pulled from the `useLocationChat(...)` result wherever the card consumes it. Apply the identical block in `location-chat-overlay.tsx` so the overlay surface also shows the card (both consume the same hook instance per the v1 UI spec).
+
+Add the new suggestion chips wherever the existing chips array is defined in these components:
+
+```tsx
+{ label: "Share my location with…", send: "Share my location with ", autoSend: false },
+{ label: "Show me where someone is", send: "Show me where someone is", autoSend: true },
+{ label: "Make a public link", send: "Make a public link to my location", autoSend: true },
+```
+
+(Match the existing chip object shape in the file — the keys above are illustrative; use the real keys the component already uses for label / prefill / auto-send.)
+
+- [ ] **Step 6: Run the chat surface tests + typecheck**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/location-chat-panel.test.tsx __tests__/components/location-chat-overlay.test.tsx __tests__/components/location-chat-suggestions.test.tsx && npx tsc --noEmit`
+Expected: PASS + clean. Update any of these tests that construct the hook/components without the new `userId` prop or that snapshot the chip list.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/action-confirm-card.tsx hushh-webapp/components/one-location/redesign/location-chat-card.tsx hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx hushh-webapp/__tests__/components/action-confirm-card.test.tsx
+git commit -m "feat(one-location): ActionConfirmCard + render in chat surfaces + v2 chips"
+```
+
+---
+
+## Task 9: Page wiring — pass userId, render decrypted view
+
+**Files:**
+- Modify: `hushh-webapp/app/one/location/page.tsx`
+- Test: `hushh-webapp/__tests__/components/one-location-agent-page.test.tsx`
+
+**Interfaces:**
+- Consumes: `useLocationChat` (Task 7) now requires `userId`; the page already has the user's id (from `useVault()` / auth — use the same id used elsewhere on the page for `decryptLocationEnvelope`).
+- Produces: the chat panel receives `userId`; when `viewedPoint` is set, the page renders it on the existing map affordance (or a Google Maps link).
+
+- [ ] **Step 1: Write/extend the failing page test**
+
+In `hushh-webapp/__tests__/components/one-location-agent-page.test.tsx`, add an assertion that the chat panel is rendered with a `userId` (mirror the file's existing render + mock of `useLocationChat`/panel). Minimal version:
+
+```tsx
+it("passes userId into the location chat", () => {
+  // existing render helper for the page with a mocked vault user id "u1"
+  // assert the chat panel/hook received userId "u1"
+  // (adapt to how this test file already spies on the chat panel props)
+});
+```
+
+Implement the assertion against the existing mock seam in that file (it already mocks the chat panel — assert the `userId` prop). If the file mocks `useLocationChat`, assert it was called with `userId`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/one-location-agent-page.test.tsx -t "userId"`
+Expected: FAIL (panel currently receives no `userId`).
+
+- [ ] **Step 3: Wire `userId` + the viewed point**
+
+In `hushh-webapp/app/one/location/page.tsx`, find where the chat panel (`LocationChatCard` / panel) is rendered and where the page already knows the current user's id (the same id used by existing `viewGrantEnvelope` / `decryptLocationEnvelope` calls). Pass it through to the panel/hook:
+
+```tsx
+<LocationChatCard
+  vaultOwnerToken={vaultOwnerToken}
+  userId={currentUserId}
+  onStateChanged={handleChatStateChanged}
+/>
+```
+
+If the panel constructs the hook internally, thread `userId` from the panel props into `useLocationChat({ vaultOwnerToken, userId, onStateChanged })`.
+
+For the decrypted view: if the panel surfaces `viewedPoint`, render it using the page's existing map embed (the same component used by `viewGrantEnvelope` today) or, minimally, a link:
+
+```tsx
+{viewedPoint ? (
+  <a
+    href={`https://www.google.com/maps?q=${viewedPoint.latitude},${viewedPoint.longitude}`}
+    target="_blank"
+    rel="noreferrer"
+    className="text-sm underline"
+  >
+    Open the shared location on the map
+  </a>
+) : null}
+```
+
+Prefer reusing the existing in-page map component if one is already imported for `viewGrantEnvelope`; only fall back to the link if not.
+
+- [ ] **Step 4: Run the page test + typecheck**
+
+Run: `cd hushh-webapp && npx jest __tests__/components/one-location-agent-page.test.tsx && npx tsc --noEmit`
+Expected: PASS + clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hushh-webapp/app/one/location/page.tsx hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+git commit -m "feat(one-location): wire userId + decrypted view into the location chat page"
+```
+
+---
+
+## Task 10: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend — run the whole location suite**
+
+Run: `cd consent-protocol && python -m pytest tests/ -k "location" -v`
+Expected: PASS (v1 + v2 service/route/tool/agent/manifest tests).
+
+- [ ] **Step 2: Frontend — run the one-location tests + typecheck**
+
+Run: `cd hushh-webapp && npx jest one-location location-chat use-location-chat action-confirm && npx tsc --noEmit`
+Expected: PASS + clean.
+
+- [ ] **Step 3: Lint (match the repo's configured linters)**
+
+Run: `cd hushh-webapp && npx eslint components/one-location/redesign/action-confirm-card.tsx components/one-location/redesign/use-location-chat.ts`
+Expected: clean (fix any issues).
+
+- [ ] **Step 4: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "test(one-location): v2 full-suite verification fixups" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- §4 client-action contract → Tasks 4 (directive build), 5 (route models), 6 (TS types). ✓
+- §4 grant creation stays server-side; publish/view never LLM-callable → Tasks 1 (allow-list), 2 (factory), 4. ✓
+- §4 tool table (create/approve/view/public-link/revoke) → Task 1 tools + Task 4 declarations/translation. ✓
+- §5 platform-aware resolution (4 buckets, real channels only) → Task 3 prompt; resolution itself is prompt-driven over `list_location_recipients` (existing). ✓
+- §6 public links via agent + revoke via chat → Tasks 1 (`propose_public_link`, `revoke_public_link`, `list_public_links`), 4, 7. ✓
+- §6 agent.yaml relaxation → Task 3. ✓
+- §7 frontend dispatcher + ActionConfirmCard + chips → Tasks 7, 8, 9. ✓
+- §8 invariant ledger (no coords in directives/results; ciphertext-only shares; bounded public-link snapshot) → enforced by reusing existing crypto/routes (Tasks 6–9) + coordinate-free models (Tasks 4–5). ✓
+- §9 testing (no-coord assertions, not-LLM-callable asserts, action-result state_changed) → Tasks 1, 4, 7. ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to". Two intentional "adapt to the existing mock seam / chip shape" notes in Tasks 8–9 reference real in-repo patterns that vary by file; concrete code is provided for the new logic in every step.
+
+**Type consistency:** `ClientAction`/`ActionResult`/`ShareTarget` identical across Tasks 4 (Python dict keys: `id`, `type`, `shares[{grantId,recipientUserId,recipientKeyId,label}]`, `grantId`, `durationHours`, `summary`) and 6 (TS interfaces). `handle_turn(*, user_id, message=None, consent_token, conversation_id=None, action_result=None)` consistent across Tasks 4 and 5. `useLocationChat({vaultOwnerToken, userId, onStateChanged})` consistent across Tasks 7, 8, 9.

--- a/docs/superpowers/plans/2026-06-30-one-location-clarify-confirm.md
+++ b/docs/superpowers/plans/2026-06-30-one-location-clarify-confirm.md
@@ -1,0 +1,1712 @@
+# One Location Clarify-and-Confirm Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the One Location agent ask structured clarify/confirm questions (multi-select + Yes/No + free-text) when a command is underspecified or destructive, with the server supplying the real ids so the agent acts on exact references.
+
+**Architecture:** Reuse the v2 directive pattern. New server-side `request_*_choice` / `request_confirmation` `@hushh_tool`s load options (with real ids) and return a prompt payload; the service translates it into a coordinate-free `clientPrompt` on the response. The browser renders a `ClarificationCard`; the user's pick returns as a `selectionResult` follow-up turn; the service seeds the Gemini loop with the chosen refs so the agent runs the real action tools (`revoke_location_share(grantId)`, `create_location_share(...)`, …) or emits the existing v2 `clientAction`.
+
+**Tech Stack:** Python (FastAPI, google.genai function-calling, pytest via `uv run python -m pytest`), TypeScript/React (Next.js, Vitest, existing `lib/one-location/encryption.ts`).
+
+## Global Constraints
+
+- **Branch:** `feat/one-location-agent-chat-v2` (already checked out; do NOT create a new branch).
+- **Coordinate-free:** `clientPrompt`, every `PromptOption.ref`, and `selectionResult` carry only ids/labels — never lat/lng. Refs hold `grantId` / `recipientUserId` / `recipientKeyId` / `requestId` / `hours` / `all` / `publicLink`.
+- **Consent preserved:** every new tool is an `@hushh_tool` run inside `HushhContext`; the `selectionResult` turn re-enters `HushhContext` to run resolved actions.
+- **Service owns real ids:** options are built server-side from DB reads (the model never serializes a `grantId`/`recipientKeyId`).
+- **`publish_location_envelope` / `view_location_envelope` stay non-LLM-callable** (not added to `V2_LOCATION_TOOLS` or the v2 declarations).
+- **`clientPrompt` and `clientAction` are mutually exclusive on one response** (clarify first, then act); a request carries exactly one of `message` / `actionResult` / `selectionResult`.
+- **Backward-compatible:** all v2 fields unchanged; `clientPrompt` / `selectionResult` are additive and optional.
+- **Wire JSON is camelCase** via Pydantic aliases (`minSelections`, `allowFreeText`, `freeText`, …); Python internals snake_case; service payloads already camelCase.
+- **Backend tests:** `cd consent-protocol && uv run python -m pytest <path> -v`. **Frontend tests (Vitest, NOT Jest):** `cd hushh-webapp && npx vitest run <path>` then `npx tsc --noEmit`. Test snippets below are illustrative — for frontend, translate to Vitest (`import { describe, it, expect, vi } from "vitest"`, `vi.fn()/vi.mock()`), mirroring the existing neighbouring test file. `noUncheckedIndexedAccess` is on.
+- **Backend tools tests** invoke `@hushh_tool` callables via `.__wrapped__(...)` inside a `with HushhContext(...)` block (the established pattern in `tests/test_location_chat_tools_behavior.py`).
+
+---
+
+## File Structure
+
+**Backend (`consent-protocol/`)**
+- `hushh_mcp/agents/location/tools.py` — 6 new prompt-builder tools + add to `V2_LOCATION_TOOLS` (Task 1).
+- `hushh_mcp/agents/location/agent.yaml` — prompt additions for choice/confirm (Task 2).
+- `hushh_mcp/services/location_chat_service.py` — v2 declarations gain the 6 tools; `clientPrompt` translation; `_run_tool_loop` extraction; `selectionResult` turn (Tasks 3 + 4).
+- `api/routes/one/location_chat.py` — `selectionResult` request field + one-of validation; `clientPrompt` passes through (Task 5).
+
+**Frontend (`hushh-webapp/`)**
+- `lib/one-location/types.ts` — `PromptOption`, `ClientPrompt`, `SelectionResult`; `LocationChatResponse.clientPrompt?` (Task 6).
+- `lib/one-location/service.ts` — `chat()` sends `selectionResult` (Task 6).
+- `components/one-location/redesign/use-location-chat.ts` — `pendingPrompt`, `answerPrompt`, `confirmPrompt`, `cancelPrompt`, free-text-while-pending (Task 7).
+- `components/one-location/redesign/clarification-card.tsx` — **new** (Task 8).
+- `components/one-location/redesign/location-chat-panel.tsx` + `location-chat-overlay.tsx` — render the card (Task 8).
+
+---
+
+## Task 1: Prompt-builder tools + allow-list
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/agents/location/tools.py`
+- Test: `consent-protocol/tests/test_location_chat_tools_allowlist.py`, `consent-protocol/tests/test_location_chat_tools_behavior.py`
+
+**Interfaces:**
+- Consumes: existing `_ctx`, `_service`, `hushh_tool`, `ConsentScope`; `OneLocationAgentService.list_verified_recipients(owner_user_id=...)` (returns recipients with `userId`, `displayName`, `keyId`, `canReceiveLocation`) and `list_state(user_id=...)` (keys `ownerGrants`, `receivedGrants`, `requests`; grant payload has `id`, `recipientDisplayName`, `ownerDisplayName`, `expiresAt`, `status`; request payload has `id`, `requesterDisplayName`, `ownerUserId`, `status`).
+- Produces (each returns `{"prompt": {...}}` when there is something to choose, else a plain data dict so the model can speak):
+  - `request_recipient_choice()`, `request_active_share_choice()`, `request_duration_choice()`, `request_request_choice()`, `request_incoming_choice()`, `request_confirmation(summary, destructive=True)`
+  - `V2_LOCATION_TOOLS` extended with all six.
+
+- [ ] **Step 1: Write the failing allow-list test**
+
+Append to `consent-protocol/tests/test_location_chat_tools_allowlist.py`:
+
+```python
+def test_v2_allowlist_includes_prompt_builder_tools_but_not_raw_envelope_tools():
+    from hushh_mcp.agents.location.tools import (
+        V2_LOCATION_TOOLS,
+        request_recipient_choice,
+        request_active_share_choice,
+        request_duration_choice,
+        request_request_choice,
+        request_incoming_choice,
+        request_confirmation,
+        publish_location_envelope,
+        view_location_envelope,
+    )
+
+    for tool in (
+        request_recipient_choice,
+        request_active_share_choice,
+        request_duration_choice,
+        request_request_choice,
+        request_incoming_choice,
+        request_confirmation,
+    ):
+        assert tool in V2_LOCATION_TOOLS
+
+    assert publish_location_envelope not in V2_LOCATION_TOOLS
+    assert view_location_envelope not in V2_LOCATION_TOOLS
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_tools_allowlist.py::test_v2_allowlist_includes_prompt_builder_tools_but_not_raw_envelope_tools -v`
+Expected: FAIL — `ImportError` (tools don't exist yet).
+
+- [ ] **Step 3: Add the six prompt-builder tools**
+
+In `consent-protocol/hushh_mcp/agents/location/tools.py`, add these functions immediately before the `LOCATION_AGENT_TOOLS = [` list:
+
+```python
+def _expiry_hint(expires_at: Any) -> str | None:
+    return f"expires {expires_at}" if expires_at else None
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_recipient_choice")
+async def request_recipient_choice() -> dict[str, Any]:
+    """Ask the user to pick who to share with. Returns a coordinate-free select
+    prompt whose options carry real recipient ids. Call this when the user wants to
+    share but did not name a (single, unambiguous) recipient."""
+    context = _ctx()
+    recipients = _service().list_verified_recipients(owner_user_id=context.user_id)
+    options = [
+        {
+            "label": r.get("displayName") or "Someone",
+            "ref": {"recipientUserId": r.get("userId"), "recipientKeyId": r.get("keyId")},
+            "hint": None if r.get("canReceiveLocation") else "hasn't set up location yet",
+        }
+        for r in recipients
+    ]
+    options.append({"label": "Public link (anyone)", "ref": {"publicLink": True}, "hint": None})
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_recipient",
+            "question": "Who do you want to share your location with?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": None,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_REVOKE, name="request_active_share_choice")
+async def request_active_share_choice() -> dict[str, Any]:
+    """Ask the user which active outgoing share(s) to stop. Returns a coordinate-free
+    multi-select prompt whose options carry real grant ids, plus a 'Stop all' option.
+    Call this when the user wants to stop sharing but did not name a single share."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    active = [g for g in state.get("ownerGrants", []) if g.get("status") == "active"]
+    if not active:
+        return {"activeShares": []}
+    options = [
+        {
+            "label": g.get("recipientDisplayName") or "Someone",
+            "ref": {"grantId": g.get("id")},
+            "hint": _expiry_hint(g.get("expiresAt")),
+        }
+        for g in active
+    ]
+    options.append({"label": "Stop all", "ref": {"all": True}, "hint": None})
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_share",
+            "question": "Which sharing do you want to stop?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": None,
+            "allowFreeText": True,
+            "confirmLabel": "Stop sharing",
+            "destructive": False,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_duration_choice")
+async def request_duration_choice() -> dict[str, Any]:
+    """Ask the user how long a share should last. Coordinate-free single-select."""
+    _ctx()
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_duration",
+            "question": "How long should this share last?",
+            "options": [
+                {"label": "1 hour", "ref": {"hours": 1}, "hint": None},
+                {"label": "8 hours", "ref": {"hours": 8}, "hint": None},
+                {"label": "24 hours", "ref": {"hours": 24}, "hint": None},
+            ],
+            "minSelections": 1,
+            "maxSelections": 1,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_REQUEST, name="request_request_choice")
+async def request_request_choice() -> dict[str, Any]:
+    """Ask the user which pending incoming access request to act on. Coordinate-free
+    single-select whose options carry real request ids."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    pending = [
+        r
+        for r in state.get("requests", [])
+        if r.get("status") == "pending" and r.get("ownerUserId") == context.user_id
+    ]
+    if not pending:
+        return {"pendingRequests": []}
+    options = [
+        {
+            "label": r.get("requesterDisplayName") or "Someone",
+            "ref": {"requestId": r.get("id")},
+            "hint": "wants to see your location",
+        }
+        for r in pending
+    ]
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_request",
+            "question": "Which request do you want to act on?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": 1,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_VIEW, name="request_incoming_choice")
+async def request_incoming_choice() -> dict[str, Any]:
+    """Ask the user whose incoming shared location to view. Coordinate-free
+    single-select whose options carry real grant ids."""
+    context = _ctx()
+    state = _service().list_state(user_id=context.user_id)
+    incoming = [g for g in state.get("receivedGrants", []) if g.get("status") == "active"]
+    if not incoming:
+        return {"incomingShares": []}
+    options = [
+        {
+            "label": g.get("ownerDisplayName") or "Someone",
+            "ref": {"grantId": g.get("id")},
+            "hint": _expiry_hint(g.get("expiresAt")),
+        }
+        for g in incoming
+    ]
+    return {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_incoming",
+            "question": "Whose location do you want to see?",
+            "options": options,
+            "minSelections": 1,
+            "maxSelections": 1,
+            "allowFreeText": True,
+        }
+    }
+
+
+@hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_confirmation")
+async def request_confirmation(summary: str, destructive: bool = True) -> dict[str, Any]:
+    """Ask the user to confirm an irreversible or bulk action before it runs. Returns
+    a coordinate-free yes/no confirm prompt. Use before creating a public link,
+    sharing with everyone, or stopping all shares."""
+    _ctx()
+    return {
+        "prompt": {
+            "kind": "confirm",
+            "purpose": "confirm_action",
+            "question": str(summary or "Are you sure?"),
+            "confirmLabel": "Yes",
+            "cancelLabel": "Cancel",
+            "destructive": bool(destructive),
+        }
+    }
+```
+
+Then extend the `V2_LOCATION_TOOLS` list (add the six at the end, before the closing `]`):
+
+```python
+    revoke_public_link,
+    request_recipient_choice,
+    request_active_share_choice,
+    request_duration_choice,
+    request_request_choice,
+    request_incoming_choice,
+    request_confirmation,
+]
+```
+
+- [ ] **Step 4: Run the allow-list test to verify it passes**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_tools_allowlist.py -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Write behavior tests for the prompt tools**
+
+Append to `consent-protocol/tests/test_location_chat_tools_behavior.py` (mirror the file's existing `.__wrapped__` + `HushhContext` pattern; the service is patched so no DB is needed):
+
+```python
+import pytest
+from hushh_mcp.hushh_adk.context import HushhContext
+from hushh_mcp.agents.location import tools as loc_tools
+
+
+class _FakeSvc:
+    def list_verified_recipients(self, *, owner_user_id, limit=50):
+        return [
+            {"userId": "u-mom", "displayName": "Mom", "keyId": "k-mom", "canReceiveLocation": True},
+            {"userId": "u-kid", "displayName": "Kid", "keyId": None, "canReceiveLocation": False},
+        ]
+
+    def list_state(self, *, user_id):
+        return {
+            "ownerGrants": [
+                {"id": "g1", "recipientDisplayName": "Mom", "expiresAt": "later", "status": "active"}
+            ],
+            "receivedGrants": [],
+            "requests": [],
+        }
+
+
+async def test_request_recipient_choice_options_carry_real_ids_and_public_link(monkeypatch):
+    monkeypatch.setattr(loc_tools, "_service", lambda: _FakeSvc())
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_recipient_choice.__wrapped__()
+    prompt = out["prompt"]
+    assert prompt["kind"] == "select" and prompt["purpose"] == "select_recipient"
+    assert prompt["options"][0]["ref"] == {"recipientUserId": "u-mom", "recipientKeyId": "k-mom"}
+    assert prompt["options"][1]["hint"] == "hasn't set up location yet"
+    assert prompt["options"][-1]["ref"] == {"publicLink": True}
+    # coordinate-free
+    blob = repr(out).lower()
+    assert "latitude" not in blob and "longitude" not in blob and "lat" not in blob.split("late")[0]
+
+
+async def test_request_active_share_choice_includes_stop_all(monkeypatch):
+    monkeypatch.setattr(loc_tools, "_service", lambda: _FakeSvc())
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_active_share_choice.__wrapped__()
+    refs = [o["ref"] for o in out["prompt"]["options"]]
+    assert {"grantId": "g1"} in refs
+    assert {"all": True} in refs
+
+
+async def test_request_confirmation_returns_confirm_prompt():
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_confirmation.__wrapped__("Stop sharing with everyone?", True)
+    assert out["prompt"]["kind"] == "confirm"
+    assert out["prompt"]["destructive"] is True
+    assert "everyone" in out["prompt"]["question"]
+```
+
+- [ ] **Step 6: Run the behavior tests to verify they pass**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_tools_behavior.py -v`
+Expected: PASS. (If the existing file already imports `tools` differently, match its import alias; the `monkeypatch.setattr(<module>, "_service", …)` target must be the module these tools live in.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/agents/location/tools.py consent-protocol/tests/test_location_chat_tools_allowlist.py consent-protocol/tests/test_location_chat_tools_behavior.py
+git commit -m "feat(one-location): add clarify/confirm prompt-builder tools"
+```
+
+---
+
+## Task 2: Agent prompt additions
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/agents/location/agent.yaml`
+- Test: `consent-protocol/tests/test_location_agent_manifest_v2.py`
+
+**Interfaces:**
+- Consumes: `ManifestLoader.load`.
+- Produces: a `system_instruction` that instructs the model to call the `request_*_choice` tools when a slot is missing/ambiguous and `request_confirmation` before destructive/bulk actions.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `consent-protocol/tests/test_location_agent_manifest_v2.py`:
+
+```python
+def test_prompt_instructs_choice_and_confirmation_tools():
+    text = _manifest().system_instruction.lower()
+    assert "request_" in text  # references the choice/confirmation tools
+    assert "do not guess" in text or "don't guess" in text
+    assert "confirm" in text and ("irreversible" in text or "bulk" in text or "everyone" in text)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_agent_manifest_v2.py::test_prompt_instructs_choice_and_confirmation_tools -v`
+Expected: FAIL (the current prompt lacks these phrases).
+
+- [ ] **Step 3: Add the prompt paragraphs**
+
+In `consent-protocol/hushh_mcp/agents/location/agent.yaml`, inside the `system_instruction: |` block, add these two paragraphs immediately before the final "Never invent or guess ids." paragraph (keep all existing text):
+
+```yaml
+  When a required detail is missing or ambiguous — who to share with, which share
+  to stop, how long, or which incoming request — do NOT guess. Call the matching
+  tool to ask the user: request_recipient_choice, request_active_share_choice,
+  request_duration_choice, request_request_choice, or request_incoming_choice.
+  Then act only on the exact ids the user picks.
+
+  Before any irreversible or bulk action — creating a public link, sharing with
+  everyone, or stopping all shares — call request_confirmation with a short
+  summary and proceed only if the user confirms.
+```
+
+- [ ] **Step 4: Run the test + the v1/v2 regression to verify**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_agent_manifest_v2.py tests/test_location_chat_service.py tests/test_location_chat_service_v2.py -v`
+Expected: PASS (the manifest test passes; the service tests still pass — they inject their own prompt/tools, so wording changes don't affect them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/agents/location/agent.yaml consent-protocol/tests/test_location_agent_manifest_v2.py
+git commit -m "feat(one-location): prompt the agent to clarify and confirm"
+```
+
+---
+
+## Task 3: Service — `clientPrompt` translation + loop extraction
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/services/location_chat_service.py`
+- Test: `consent-protocol/tests/test_location_chat_service_v2.py`
+
+**Interfaces:**
+- Consumes: prompt-builder tools returning `{"prompt": {...}}` (Task 1).
+- Produces: `_run_tool_loop(...) -> tuple[str, bool, bool, list[dict], list[dict]]` (reply, errored, state_changed, directives, prompts); `_prompt_from_tool`; `_build_client_prompt`; `_run_tool` now returns a 4-tuple `(result, mutated, directive, prompt)`; `_finish` accepts `client_prompt`; message turns emit `clientPrompt` when a prompt tool ran. (Task 4 reuses `_run_tool_loop`.)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `consent-protocol/tests/test_location_chat_service_v2.py` (reuse the file's existing fakes `_FakeStore`, `_fake_tool`, `_fc_response`, `_text_response`, `_service`):
+
+```python
+async def test_request_choice_tool_emits_client_prompt():
+    store = _FakeStore()
+    prompt_payload = {
+        "prompt": {
+            "kind": "select",
+            "purpose": "select_share",
+            "question": "Which sharing do you want to stop?",
+            "options": [
+                {"label": "Mom", "ref": {"grantId": "g1"}},
+                {"label": "Stop all", "ref": {"all": True}},
+            ],
+            "minSelections": 1,
+            "maxSelections": None,
+            "allowFreeText": True,
+        }
+    }
+    tools = [_fake_tool("request_active_share_choice", [], result=prompt_payload)]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("request_active_share_choice", {}),
+            _text_response("Which sharing do you want to stop?"),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(user_id="u", message="stop sharing", consent_token="t")  # noqa: S106
+
+    cp = out["clientPrompt"]
+    assert cp["kind"] == "select" and cp["purpose"] == "select_share"
+    assert cp["options"][0]["ref"] == {"grantId": "g1"}
+    assert cp["id"].startswith("prm-")
+    assert out["stateChanged"] is False
+    assert "clientAction" not in out
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_service_v2.py::test_request_choice_tool_emits_client_prompt -v`
+Expected: FAIL (`KeyError: 'clientPrompt'`).
+
+- [ ] **Step 3: Add prompt-tool constants + the 6 v2 declarations**
+
+In `consent-protocol/hushh_mcp/services/location_chat_service.py`, add after `_DIRECTIVE_GRANT_TOOLS` (line ~60):
+
+```python
+# Prompt-builder tools: their result yields a clientPrompt, and they mutate nothing.
+_PROMPT_TOOL_NAMES = {
+    "request_recipient_choice",
+    "request_active_share_choice",
+    "request_duration_choice",
+    "request_request_choice",
+    "request_incoming_choice",
+    "request_confirmation",
+}
+```
+
+Then add `_PROMPT_TOOL_NAMES` to `_QUERY_TOOL_NAMES` by extending that set literal (add the six names to the existing `_QUERY_TOOL_NAMES = {...}` so prompt tools never set `stateChanged`). Concretely, append these lines inside the existing `_QUERY_TOOL_NAMES` set:
+
+```python
+    "request_recipient_choice",
+    "request_active_share_choice",
+    "request_duration_choice",
+    "request_request_choice",
+    "request_incoming_choice",
+    "request_confirmation",
+```
+
+In `_function_declarations_v2`, extend the `decls.extend([...])` list with these six declarations (add before the closing `]`):
+
+```python
+            types.FunctionDeclaration(
+                name="request_recipient_choice",
+                description="Ask the user to choose who to share with (returns selectable options). Call when no single recipient was named.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_active_share_choice",
+                description="Ask the user which active share(s) to stop (selectable options incl. 'Stop all'). Call when stopping a share with no single target.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_duration_choice",
+                description="Ask the user how long a share should last (1/8/24h or custom).",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_request_choice",
+                description="Ask the user which pending incoming request to act on.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_incoming_choice",
+                description="Ask the user whose incoming shared location to view.",
+                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+            ),
+            types.FunctionDeclaration(
+                name="request_confirmation",
+                description="Ask the user to confirm an irreversible or bulk action before it runs.",
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "summary": schema(type=kind.STRING, description="What to confirm"),
+                        "destructive": schema(type=kind.BOOLEAN),
+                    },
+                    required=["summary"],
+                ),
+            ),
+```
+
+- [ ] **Step 4: Add `_prompt_from_tool`, `_build_client_prompt`, and 4-tuple `_run_tool`**
+
+Change `_run_tool` to also return a prompt descriptor. Replace its body's return statements and signature:
+
+```python
+    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None, dict | None]:
+        """Execute one tool inside the active HushhContext.
+
+        Returns (result, mutated, directive, prompt): directive → a clientAction
+        descriptor; prompt → a clientPrompt descriptor; either may be None.
+        """
+        tool = self._dispatch.get(name)
+        if tool is None:
+            return {"error": "unknown_tool"}, False, None, None
+        try:
+            result = await tool(**args)
+        except PermissionError:
+            return {"error": "consent_denied"}, False, None, None
+        except ValueError as exc:
+            return {"error": "invalid_argument", "message": str(exc)}, False, None, None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Location tool %s failed: %s", name, exc)
+            return {"error": "tool_failed"}, False, None, None
+        result_dict = _as_response_dict(result)
+        directive = self._directive_from_tool(name, result_dict)
+        prompt = self._prompt_from_tool(name, result_dict)
+        mutated = name not in _QUERY_TOOL_NAMES
+        return result_dict, mutated, directive, prompt
+```
+
+Add these two methods next to `_build_client_action`:
+
+```python
+    @staticmethod
+    def _prompt_from_tool(name: str, result: dict) -> dict | None:
+        """Extract a coordinate-free prompt payload from a prompt-builder tool result."""
+        if name not in _PROMPT_TOOL_NAMES:
+            return None
+        prompt = result.get("prompt") if isinstance(result, dict) else None
+        return prompt if isinstance(prompt, dict) else None
+
+    def _build_client_prompt(self, prompts: list[dict]) -> dict | None:
+        """Fold collected prompt payloads into one clientPrompt (first one wins)."""
+        if not prompts:
+            return None
+        return {"id": "prm-" + uuid4().hex[:12], **prompts[0]}
+```
+
+- [ ] **Step 5: Extract `_run_tool_loop` and use it in `handle_turn`**
+
+Add this method (it is the body of the current loop, returning prompts too):
+
+```python
+    async def _run_tool_loop(
+        self, *, user_id: str, consent_token: str, contents: list
+    ) -> tuple[str, bool, bool, list[dict], list[dict]]:
+        """Run the Gemini function-calling loop inside HushhContext.
+
+        Returns (reply, errored, state_changed, directives, prompts).
+        """
+        types = self._types
+        config = types.GenerateContentConfig(
+            system_instruction=self._system_prompt,
+            tools=[types.Tool(function_declarations=_function_declarations_v2(types))],
+            temperature=0.2,
+        )
+        reply = ""
+        errored = False
+        state_changed = False
+        directives: list[dict] = []
+        prompts: list[dict] = []
+        with HushhContext(user_id=user_id, consent_token=consent_token, vault_keys={}):
+            for _ in range(_MAX_TOOL_STEPS):
+                response = await self._model_call(contents, config)
+                calls = list(getattr(response, "function_calls", None) or [])
+                if not calls:
+                    reply = (getattr(response, "text", "") or "").strip()
+                    break
+                contents.append(response.candidates[0].content)
+                for call in calls:
+                    result, mutated, directive, prompt = await self._run_tool(
+                        call.name, dict(call.args or {})
+                    )
+                    state_changed = state_changed or mutated
+                    if directive is not None:
+                        directives.append(directive)
+                    if prompt is not None:
+                        prompts.append(prompt)
+                    contents.append(
+                        types.Content(
+                            role="tool",
+                            parts=[
+                                types.Part.from_function_response(name=call.name, response=result)
+                            ],
+                        )
+                    )
+            else:
+                reply = _GAVE_UP_MESSAGE
+                errored = True
+        return reply, errored, state_changed, directives, prompts
+```
+
+Now replace the body of `handle_turn` from `contents = _history_contents(...)` through the final `return await self._finish(...)` with:
+
+```python
+        types = self._types
+        contents = _history_contents(turn.history, types)
+        contents.append(types.Content(role="user", parts=[types.Part(text=message)]))
+
+        try:
+            reply, errored, state_changed, directives, prompts = await self._run_tool_loop(
+                user_id=user_id, consent_token=consent_token, contents=contents
+            )
+        except Exception:
+            logger.exception("Location chat turn failed")
+            return await self._finish(
+                turn, _UNAVAILABLE_MESSAGE, user_id, errored=True, state_changed=False
+            )
+
+        client_prompt = self._build_client_prompt(prompts)
+        client_action = None if client_prompt is not None else self._build_client_action(directives)
+        if client_action is not None or client_prompt is not None:
+            state_changed = False
+
+        if not reply:
+            reply = "Done."
+        return await self._finish(
+            turn,
+            reply,
+            user_id,
+            errored=errored,
+            state_changed=state_changed and not errored,
+            client_action=client_action,
+            client_prompt=client_prompt,
+        )
+```
+
+(Delete the now-unused inline loop and the old `directives: list[dict] = []` / `with HushhContext...` block in `handle_turn` — `_run_tool_loop` replaces them. Keep the readiness check above this block unchanged.)
+
+Update `_finish` to accept and surface `client_prompt`:
+
+```python
+    async def _finish(
+        self,
+        turn: Any,
+        reply: str,
+        user_id: str,
+        *,
+        errored: bool,
+        state_changed: bool,
+        client_action: dict | None = None,
+        client_prompt: dict | None = None,
+    ) -> dict[str, Any]:
+        await self._chat_store.add_message(
+            conversation_id=turn.conversation_id,
+            user_id=user_id,
+            role="assistant",
+            content=reply,
+            status="error" if errored else "complete",
+        )
+        out: dict[str, Any] = {
+            "conversationId": turn.conversation_id,
+            "response": reply,
+            "isComplete": not errored,
+            "stateChanged": state_changed,
+        }
+        if client_action is not None:
+            out["clientAction"] = client_action
+        if client_prompt is not None:
+            out["clientPrompt"] = client_prompt
+        return out
+```
+
+- [ ] **Step 6: Run the v2 service tests to verify they pass**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_service_v2.py tests/test_location_chat_service.py -v`
+Expected: PASS — the new prompt test plus all existing v1/v2 tests (the loop extraction preserves behavior: `clientAction`, `stateChanged`, action-result turns unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/services/location_chat_service.py consent-protocol/tests/test_location_chat_service_v2.py
+git commit -m "feat(one-location): translate prompt-builder results into clientPrompt"
+```
+
+---
+
+## Task 4: Service — `selectionResult` turn
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/services/location_chat_service.py`
+- Test: `consent-protocol/tests/test_location_chat_service_v2.py`
+
+**Interfaces:**
+- Consumes: `_run_tool_loop`, `_build_client_action`, `_build_client_prompt` (Task 3); `AgentChatService.get_recent_messages(conversation_id, *, user_id, limit)`.
+- Produces: `handle_turn(..., selection_result: dict | None = None)`; `_handle_selection_result(...)`; `_selection_seed_text(selection_result) -> str` (coordinate-free).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `consent-protocol/tests/test_location_chat_service_v2.py`:
+
+```python
+class _HistoryStore(_FakeStore):
+    async def get_recent_messages(self, conversation_id, *, user_id, limit=20):
+        return []
+
+
+async def test_selection_result_seeds_loop_and_acts_on_real_ids():
+    store = _HistoryStore()
+    calls: list[dict] = []
+    tools = [_fake_tool("revoke_location_share", calls, result={"status": "revoked"})]
+    svc = _service(
+        store,
+        responses=[
+            _fc_response("revoke_location_share", {"grant_id": "g1"}),
+            _text_response("Stopped sharing with Mom."),
+        ],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        selection_result={
+            "id": "prm-1",
+            "kind": "select",
+            "selected": [{"grantId": "g1"}],
+            "status": "answered",
+        },
+    )
+
+    assert out["conversationId"] == "conv-1"
+    assert out["response"] == "Stopped sharing with Mom."
+    assert out["stateChanged"] is True
+    assert calls[0]["args"] == {"grant_id": "g1"}  # exact id, never guessed
+
+
+async def test_selection_result_cancelled_makes_no_tool_call():
+    store = _HistoryStore()
+    calls: list[dict] = []
+    tools = [_fake_tool("revoke_location_share", calls, result={"status": "revoked"})]
+    svc = _service(
+        store,
+        responses=[_text_response("No problem — nothing changed.")],
+        tools=tools,
+    )
+
+    out = await svc.handle_turn(
+        user_id="u",
+        consent_token="t",  # noqa: S106
+        conversation_id="conv-1",
+        selection_result={"id": "prm-1", "kind": "select", "status": "cancelled"},
+    )
+
+    assert calls == []
+    assert out["stateChanged"] is False
+    assert out["isComplete"] is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_service_v2.py::test_selection_result_seeds_loop_and_acts_on_real_ids tests/test_location_chat_service_v2.py::test_selection_result_cancelled_makes_no_tool_call -v`
+Expected: FAIL (`handle_turn` has no `selection_result` kwarg).
+
+- [ ] **Step 3: Add the `selection_result` branch + handler + seed**
+
+In `handle_turn`, add the `selection_result` parameter and a branch at the top (right after the `action_result` branch):
+
+```python
+    async def handle_turn(
+        self,
+        *,
+        user_id: str,
+        message: str | None = None,
+        consent_token: str,
+        conversation_id: str | None = None,
+        action_result: dict | None = None,
+        selection_result: dict | None = None,
+    ) -> dict[str, Any]:
+        if action_result is not None:
+            return await self._handle_action_result(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                action_result=action_result,
+            )
+        if selection_result is not None:
+            return await self._handle_selection_result(
+                user_id=user_id,
+                consent_token=consent_token,
+                conversation_id=conversation_id,
+                selection_result=selection_result,
+            )
+        # ... existing message path unchanged ...
+```
+
+Add the seed builder (module-level function, near `_as_response_dict`):
+
+```python
+def _selection_seed_text(selection_result: dict) -> str:
+    """Coordinate-free instruction the agent acts on for a selection turn."""
+    if str(selection_result.get("status")) == "cancelled":
+        return "I changed my mind — cancel that, take no action."
+    free = selection_result.get("free_text") or selection_result.get("freeText")
+    if free:
+        return str(free)
+    if str(selection_result.get("kind")) == "confirm":
+        return "Yes, go ahead." if selection_result.get("confirmed") else "No, do not proceed."
+    selected = selection_result.get("selected") or []
+    parts = ["; ".join(f"{k}={v}" for k, v in ref.items()) for ref in selected if isinstance(ref, dict)]
+    refs = " | ".join(parts)
+    return f"I selected: {refs}. Use exactly these ids — do not guess — and proceed."
+```
+
+Add the handler (next to `_handle_action_result`):
+
+```python
+    async def _handle_selection_result(
+        self,
+        *,
+        user_id: str,
+        consent_token: str,
+        conversation_id: str | None,
+        selection_result: dict,
+    ) -> dict[str, Any]:
+        """Seed the Gemini loop with the user's choice (resolved refs) and act."""
+        conv_id = conversation_id or ""
+        if not conv_id:
+            return {
+                "conversationId": "",
+                "response": "Let's start again — what would you like to do with your location sharing?",
+                "isComplete": True,
+                "stateChanged": False,
+            }
+        if self._types is None or not self._ready():
+            await self._chat_store.add_message(
+                conversation_id=conv_id,
+                user_id=user_id,
+                role="assistant",
+                content=_UNAVAILABLE_MESSAGE,
+                status="error",
+            )
+            return {
+                "conversationId": conv_id,
+                "response": _UNAVAILABLE_MESSAGE,
+                "isComplete": False,
+                "stateChanged": False,
+            }
+
+        types = self._types
+        history = await self._chat_store.get_recent_messages(
+            conv_id, user_id=user_id, limit=_MAX_HISTORY
+        )
+        contents = _history_contents(history, types)
+        contents.append(
+            types.Content(role="user", parts=[types.Part(text=_selection_seed_text(selection_result))])
+        )
+
+        try:
+            reply, errored, state_changed, directives, prompts = await self._run_tool_loop(
+                user_id=user_id, consent_token=consent_token, contents=contents
+            )
+        except Exception:
+            logger.exception("Location chat selection turn failed")
+            await self._chat_store.add_message(
+                conversation_id=conv_id,
+                user_id=user_id,
+                role="assistant",
+                content=_UNAVAILABLE_MESSAGE,
+                status="error",
+            )
+            return {
+                "conversationId": conv_id,
+                "response": _UNAVAILABLE_MESSAGE,
+                "isComplete": False,
+                "stateChanged": False,
+            }
+
+        client_prompt = self._build_client_prompt(prompts)
+        client_action = None if client_prompt is not None else self._build_client_action(directives)
+        if client_action is not None or client_prompt is not None:
+            state_changed = False
+        if not reply:
+            reply = "Done."
+        await self._chat_store.add_message(
+            conversation_id=conv_id,
+            user_id=user_id,
+            role="assistant",
+            content=reply,
+            status="error" if errored else "complete",
+        )
+        out: dict[str, Any] = {
+            "conversationId": conv_id,
+            "response": reply,
+            "isComplete": not errored,
+            "stateChanged": state_changed and not errored,
+        }
+        if client_action is not None:
+            out["clientAction"] = client_action
+        if client_prompt is not None:
+            out["clientPrompt"] = client_prompt
+        return out
+```
+
+- [ ] **Step 4: Run the selection tests to verify they pass**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_service_v2.py -v`
+Expected: PASS (all, including the two new selection tests).
+
+- [ ] **Step 5: Run the full backend location-chat suite (no regression)**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_service.py tests/test_location_chat_service_v2.py tests/test_location_chat_routes.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/services/location_chat_service.py consent-protocol/tests/test_location_chat_service_v2.py
+git commit -m "feat(one-location): selectionResult turn seeds the loop with chosen ids"
+```
+
+---
+
+## Task 5: Route — `selectionResult` field + passthrough
+
+**Files:**
+- Modify: `consent-protocol/api/routes/one/location_chat.py`
+- Test: `consent-protocol/tests/test_location_chat_routes.py`
+
+**Interfaces:**
+- Consumes: `handle_turn(..., selection_result=...)` (Task 4).
+- Produces: request gains `selectionResult`; a turn requires one of message/actionResult/selectionResult; `clientPrompt` passes through in the response dict.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `consent-protocol/tests/test_location_chat_routes.py`:
+
+```python
+def test_chat_route_forwards_selection_result(monkeypatch):
+    captured: dict = {}
+
+    class _Service:
+        async def handle_turn(self, *, user_id, message=None, consent_token, conversation_id=None, action_result=None, selection_result=None):
+            captured["selection_result"] = selection_result
+            return {"conversationId": "c1", "response": "ok", "isComplete": True, "stateChanged": True}
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+
+    response = client.post(
+        "/api/one/location/chat",
+        json={
+            "conversationId": "c1",
+            "selectionResult": {"id": "prm-1", "kind": "select", "selected": [{"grantId": "g1"}], "status": "answered"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["selection_result"] == {"id": "prm-1", "kind": "select", "selected": [{"grantId": "g1"}], "status": "answered"}
+
+
+def test_chat_route_passes_through_client_prompt(monkeypatch):
+    class _Service:
+        async def handle_turn(self, **kwargs):
+            return {
+                "conversationId": "c1",
+                "response": "Which sharing do you want to stop?",
+                "isComplete": True,
+                "stateChanged": False,
+                "clientPrompt": {"id": "prm-1", "kind": "select", "purpose": "select_share", "question": "?", "options": [{"label": "Mom", "ref": {"grantId": "g1"}}]},
+            }
+
+    monkeypatch.setattr(location_chat, "_service", lambda: _Service())
+    client = _build_app()
+    response = client.post("/api/one/location/chat", json={"message": "stop sharing"})
+    assert response.status_code == 200
+    assert response.json()["clientPrompt"]["purpose"] == "select_share"
+
+
+def test_chat_route_rejects_when_no_input(monkeypatch):
+    monkeypatch.setattr(location_chat, "_service", lambda: object())
+    client = _build_app()
+    response = client.post("/api/one/location/chat", json={})
+    assert response.status_code == 422
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_routes.py::test_chat_route_forwards_selection_result -v`
+Expected: FAIL (`selectionResult` not accepted / not forwarded).
+
+- [ ] **Step 3: Add the model + wire it**
+
+In `consent-protocol/api/routes/one/location_chat.py`, add the model after `ActionResultModel`:
+
+```python
+class SelectionResultModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(max_length=64)
+    kind: str = Field(max_length=24)
+    selected: list[dict[str, Any]] | None = None
+    confirmed: bool | None = None
+    free_text: str | None = Field(default=None, alias="freeText", max_length=4000)
+    status: str = Field(max_length=24)
+```
+
+Add the field to `LocationChatRequest`:
+
+```python
+    selection_result: SelectionResultModel | None = Field(default=None, alias="selectionResult")
+```
+
+Replace the guard + call in `location_chat`:
+
+```python
+    if not request.message and request.action_result is None and request.selection_result is None:
+        raise HTTPException(
+            status_code=422, detail="message, actionResult, or selectionResult is required"
+        )
+    try:
+        result: dict[str, Any] = await _service().handle_turn(
+            user_id=token_data["user_id"],
+            message=request.message,
+            consent_token=token_data.get("token", ""),
+            conversation_id=request.conversation_id,
+            action_result=(
+                request.action_result.model_dump(by_alias=True, exclude_none=True)
+                if request.action_result is not None
+                else None
+            ),
+            selection_result=(
+                request.selection_result.model_dump(by_alias=True, exclude_none=True)
+                if request.selection_result is not None
+                else None
+            ),
+        )
+        return result
+```
+
+- [ ] **Step 4: Run the route tests to verify they pass**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_routes.py -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add consent-protocol/api/routes/one/location_chat.py consent-protocol/tests/test_location_chat_routes.py
+git commit -m "feat(one-location): chat route accepts selectionResult, passes through clientPrompt"
+```
+
+---
+
+## Task 6: Frontend types + `service.chat`
+
+**Files:**
+- Modify: `hushh-webapp/lib/one-location/types.ts`, `hushh-webapp/lib/one-location/service.ts`
+- Test: `hushh-webapp/__tests__/services/location-chat-service.test.ts`
+
+**Interfaces:**
+- Produces: `PromptOption`, `ClientPromptKind`, `ClientPrompt`, `SelectionResult`; `LocationChatResponse.clientPrompt?`; `OneLocationService.chat({ ..., selectionResult? })`.
+
+- [ ] **Step 1: Write the failing test** (Vitest — mirror the existing file's `mockApiJson` pattern)
+
+Append to `hushh-webapp/__tests__/services/location-chat-service.test.ts`:
+
+```ts
+it("sends selectionResult and omits message", async () => {
+  mockApiJson.mockResolvedValue({ conversationId: "c1", response: "ok", isComplete: true, stateChanged: true });
+  await OneLocationService.chat({
+    vaultOwnerToken: "tok",
+    conversationId: "c1",
+    selectionResult: { id: "prm-1", kind: "select", selected: [{ grantId: "g1" }], status: "answered" },
+  });
+  const body = JSON.parse(mockApiJson.mock.calls[0][1].body as string);
+  expect(body.selectionResult).toEqual({ id: "prm-1", kind: "select", selected: [{ grantId: "g1" }], status: "answered" });
+  expect(body.message ?? null).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/services/location-chat-service.test.ts -t "selectionResult"`
+Expected: FAIL (TS error / not sent).
+
+- [ ] **Step 3: Add the types**
+
+In `hushh-webapp/lib/one-location/types.ts`, add before `LocationChatResponse`:
+
+```ts
+export interface PromptOption {
+  label: string;
+  ref: Record<string, unknown>;
+  hint?: string | null;
+}
+
+export type ClientPromptKind = "select" | "confirm";
+
+export interface ClientPrompt {
+  id: string;
+  kind: ClientPromptKind;
+  purpose: string;
+  question: string;
+  options?: PromptOption[];
+  minSelections?: number;
+  maxSelections?: number | null;
+  allowFreeText?: boolean;
+  confirmLabel?: string | null;
+  cancelLabel?: string | null;
+  destructive?: boolean;
+}
+
+export interface SelectionResult {
+  id: string;
+  kind: ClientPromptKind;
+  selected?: Record<string, unknown>[];
+  confirmed?: boolean;
+  freeText?: string;
+  status: "answered" | "cancelled";
+}
+```
+
+Add `clientPrompt?` to `LocationChatResponse`:
+
+```ts
+export interface LocationChatResponse {
+  conversationId: string;
+  response: string;
+  isComplete: boolean;
+  stateChanged: boolean;
+  clientAction?: ClientAction;
+  clientPrompt?: ClientPrompt;
+}
+```
+
+- [ ] **Step 4: Update `OneLocationService.chat`**
+
+In `hushh-webapp/lib/one-location/service.ts`, add `SelectionResult` to the type import block, then replace the `chat` method:
+
+```ts
+  static async chat(params: {
+    vaultOwnerToken: string;
+    message?: string;
+    conversationId?: string | null;
+    actionResult?: ActionResult;
+    selectionResult?: SelectionResult;
+  }): Promise<LocationChatResponse> {
+    return apiJson<LocationChatResponse>("/api/one/location/chat", {
+      method: "POST",
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({
+        message: params.message ?? null,
+        conversationId: params.conversationId ?? null,
+        actionResult: params.actionResult ?? null,
+        selectionResult: params.selectionResult ?? null,
+      }),
+    });
+  }
+```
+
+- [ ] **Step 5: Run the test + typecheck**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/services/location-chat-service.test.ts && npx tsc --noEmit`
+Expected: PASS + clean. (Update the 2 existing `chat()` body-shape assertions to expect `selectionResult: null` too, mirroring the prior `actionResult: null` change.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hushh-webapp/lib/one-location/types.ts hushh-webapp/lib/one-location/service.ts hushh-webapp/__tests__/services/location-chat-service.test.ts
+git commit -m "feat(one-location): clientPrompt/selectionResult types + service support"
+```
+
+---
+
+## Task 7: Hook — pending prompt + answer/confirm/cancel + free-text fallback
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/use-location-chat.ts`
+- Test: `hushh-webapp/__tests__/components/use-location-chat.test.tsx`
+
+**Interfaces:**
+- Consumes: `OneLocationService.chat({ selectionResult })`; types from Task 6.
+- Produces: `UseLocationChat` gains `pendingPrompt: ClientPrompt | null`, `answerPrompt(refs: Record<string, unknown>[]): Promise<void>`, `confirmPrompt(yes: boolean): Promise<void>`, `cancelPrompt(): Promise<void>`. `send()` routes to a free-text selection when a prompt is pending. `pendingPrompt` and `pendingAction` are mutually exclusive.
+
+- [ ] **Step 1: Write the failing tests** (Vitest — mirror the existing mock setup)
+
+Append to `hushh-webapp/__tests__/components/use-location-chat.test.tsx`:
+
+```tsx
+it("sets pendingPrompt from a clientPrompt response", async () => {
+  svc.chat.mockResolvedValueOnce({
+    conversationId: "c1",
+    response: "Which sharing do you want to stop?",
+    isComplete: true,
+    stateChanged: false,
+    clientPrompt: {
+      id: "prm-1",
+      kind: "select",
+      purpose: "select_share",
+      question: "Which sharing do you want to stop?",
+      options: [{ label: "Mom", ref: { grantId: "g1" } }, { label: "Stop all", ref: { all: true } }],
+    },
+  });
+  const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }));
+  await act(async () => { await result.current.send("stop sharing"); });
+  expect(result.current.pendingPrompt?.purpose).toBe("select_share");
+});
+
+it("answerPrompt sends selected refs and clears the prompt", async () => {
+  svc.chat
+    .mockResolvedValueOnce({
+      conversationId: "c1", response: "?", isComplete: true, stateChanged: false,
+      clientPrompt: { id: "prm-1", kind: "select", purpose: "select_share", question: "?", options: [{ label: "Mom", ref: { grantId: "g1" } }] },
+    })
+    .mockResolvedValueOnce({ conversationId: "c1", response: "Stopped.", isComplete: true, stateChanged: true });
+  const onStateChanged = vi.fn();
+  const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1", onStateChanged }));
+  await act(async () => { await result.current.send("stop sharing"); });
+  await act(async () => { await result.current.answerPrompt([{ grantId: "g1" }]); });
+  expect(svc.chat).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      selectionResult: expect.objectContaining({ id: "prm-1", kind: "select", selected: [{ grantId: "g1" }], status: "answered" }),
+    }),
+  );
+  expect(result.current.pendingPrompt).toBeNull();
+  expect(onStateChanged).toHaveBeenCalled();
+});
+
+it("free text while a prompt is pending sends a freeText selection", async () => {
+  svc.chat
+    .mockResolvedValueOnce({
+      conversationId: "c1", response: "?", isComplete: true, stateChanged: false,
+      clientPrompt: { id: "prm-1", kind: "select", purpose: "select_recipient", question: "?", options: [] },
+    })
+    .mockResolvedValueOnce({ conversationId: "c1", response: "ok", isComplete: true, stateChanged: false });
+  const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }));
+  await act(async () => { await result.current.send("share"); });
+  await act(async () => { await result.current.send("my coworker Alex"); });
+  expect(svc.chat).toHaveBeenLastCalledWith(
+    expect.objectContaining({ selectionResult: expect.objectContaining({ freeText: "my coworker Alex", status: "answered" }) }),
+  );
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/components/use-location-chat.test.tsx -t "pendingPrompt"`
+Expected: FAIL (`pendingPrompt` / `answerPrompt` don't exist).
+
+- [ ] **Step 3: Extend the hook**
+
+In `hushh-webapp/components/one-location/redesign/use-location-chat.ts`:
+
+Add `ClientPrompt`, `SelectionResult` to the type import. Add to `UseLocationChat`:
+
+```ts
+  pendingPrompt: ClientPrompt | null;
+  answerPrompt: (refs: Record<string, unknown>[]) => Promise<void>;
+  confirmPrompt: (yes: boolean) => Promise<void>;
+  cancelPrompt: () => Promise<void>;
+```
+
+Add state (next to `pendingAction`):
+
+```ts
+  const [pendingPrompt, setPendingPrompt] = useState<ClientPrompt | null>(null);
+```
+
+Add a shared result-applier and use it in `run` and `report` (replace the duplicated "push assistant message + set pending + onStateChanged" blocks in both with a call to `applyResult`):
+
+```ts
+  const applyResult = useCallback(
+    (result: Awaited<ReturnType<typeof OneLocationService.chat>>) => {
+      conversationIdRef.current = result.conversationId;
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "assistant", text: result.response, stateChanged: result.stateChanged },
+      ]);
+      setPendingAction(result.clientAction ?? null);
+      setPendingPrompt(result.clientPrompt ?? null);
+      if (result.stateChanged) onStateChanged?.();
+    },
+    [nextId, onStateChanged],
+  );
+```
+
+In `run`, replace the success block (`conversationIdRef.current = ...` through `if (result.stateChanged) onStateChanged?.();`) with `applyResult(result);`. Do the same in `report`.
+
+Add a selection reporter + the three handlers (near `report`):
+
+```ts
+  const reportSelection = useCallback(
+    async (selectionResult: SelectionResult) => {
+      setBusy(true);
+      setPendingPrompt(null);
+      try {
+        const result = await OneLocationService.chat({
+          vaultOwnerToken,
+          conversationId: conversationIdRef.current,
+          selectionResult,
+        });
+        applyResult(result);
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", text: LOCATION_CHAT_ERROR_TEXT, errored: true },
+        ]);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [vaultOwnerToken, applyResult, nextId],
+  );
+
+  const answerPrompt = useCallback(
+    async (refs: Record<string, unknown>[]) => {
+      const prompt = pendingPrompt;
+      if (!prompt || busy) return;
+      await reportSelection({ id: prompt.id, kind: prompt.kind, selected: refs, status: "answered" });
+    },
+    [pendingPrompt, busy, reportSelection],
+  );
+
+  const confirmPrompt = useCallback(
+    async (yes: boolean) => {
+      const prompt = pendingPrompt;
+      if (!prompt || busy) return;
+      await reportSelection({ id: prompt.id, kind: prompt.kind, confirmed: yes, status: "answered" });
+    },
+    [pendingPrompt, busy, reportSelection],
+  );
+
+  const cancelPrompt = useCallback(async () => {
+    const prompt = pendingPrompt;
+    if (!prompt) return;
+    await reportSelection({ id: prompt.id, kind: prompt.kind, status: "cancelled" });
+  }, [pendingPrompt, reportSelection]);
+```
+
+Modify `send` so free text answers a pending prompt:
+
+```ts
+  const send = useCallback(
+    async (raw: string) => {
+      const message = raw.trim();
+      if (!message || busy) return;
+      setMessages((prev) => [...prev, { id: nextId(), role: "user", text: message }]);
+      const prompt = pendingPrompt;
+      if (prompt) {
+        await reportSelection({ id: prompt.id, kind: prompt.kind, freeText: message, status: "answered" });
+        return;
+      }
+      lastSentRef.current = message;
+      await run(message);
+    },
+    [busy, run, nextId, pendingPrompt, reportSelection],
+  );
+```
+
+Add `setPendingPrompt(null)` to `clear()`. Add the four new members to the returned object:
+
+```ts
+    pendingPrompt,
+    answerPrompt,
+    confirmPrompt,
+    cancelPrompt,
+```
+
+- [ ] **Step 4: Run the hook tests to verify they pass**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/components/use-location-chat.test.tsx`
+Expected: PASS (new + existing v2 hook tests — `applyResult` preserves the prior `pendingAction` behavior; existing tests that set only `clientAction` still see `pendingAction` set and `pendingPrompt` null).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd hushh-webapp && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/use-location-chat.ts hushh-webapp/__tests__/components/use-location-chat.test.tsx
+git commit -m "feat(one-location): pending prompt + answer/confirm/cancel + free-text fallback"
+```
+
+---
+
+## Task 8: ClarificationCard + render in panel/overlay
+
+**Files:**
+- Create: `hushh-webapp/components/one-location/redesign/clarification-card.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/location-chat-panel.tsx`, `location-chat-overlay.tsx`
+- Test: `hushh-webapp/__tests__/components/clarification-card.test.tsx` (new)
+
+**Interfaces:**
+- Consumes: `ClientPrompt` (Task 6).
+- Produces: `ClarificationCard({ prompt, busy, onAnswer, onConfirm, onCancel })` where `onAnswer(refs: Record<string, unknown>[])`, `onConfirm(yes: boolean)`, `onCancel()`.
+
+- [ ] **Step 1: Write the failing component test** (Vitest; mirror `action-confirm-card.test.tsx` — native DOM assertions, no jest-dom)
+
+Create `hushh-webapp/__tests__/components/clarification-card.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ClarificationCard } from "@/components/one-location/redesign/clarification-card";
+
+const selectPrompt = {
+  id: "prm-1", kind: "select" as const, purpose: "select_share", question: "Which to stop?",
+  options: [
+    { label: "Mom", ref: { grantId: "g1" } },
+    { label: "Dad", ref: { grantId: "g2" } },
+  ],
+  maxSelections: null, minSelections: 1,
+};
+
+it("multi-select: ticks options and answers with their refs", () => {
+  const onAnswer = vi.fn();
+  render(<ClarificationCard prompt={selectPrompt} busy={false} onAnswer={onAnswer} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+  fireEvent.click(screen.getByText("Mom"));
+  fireEvent.click(screen.getByText("Dad"));
+  fireEvent.click(screen.getByTestId("clarification-confirm"));
+  expect(onAnswer).toHaveBeenCalledWith([{ grantId: "g1" }, { grantId: "g2" }]);
+});
+
+it("confirm prompt: Yes calls onConfirm(true)", () => {
+  const onConfirm = vi.fn();
+  render(
+    <ClarificationCard
+      prompt={{ id: "p", kind: "confirm", purpose: "confirm_action", question: "Stop all?", destructive: true }}
+      busy={false} onAnswer={vi.fn()} onConfirm={onConfirm} onCancel={vi.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByTestId("clarification-confirm"));
+  expect(onConfirm).toHaveBeenCalledWith(true);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/components/clarification-card.test.tsx`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Create the component**
+
+Create `hushh-webapp/components/one-location/redesign/clarification-card.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { ClientPrompt, PromptOption } from "@/lib/one-location/types";
+
+function sameRef(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function ClarificationCard({
+  prompt,
+  busy,
+  onAnswer,
+  onConfirm,
+  onCancel,
+}: {
+  prompt: ClientPrompt;
+  busy: boolean;
+  onAnswer: (refs: Record<string, unknown>[]) => void;
+  onConfirm: (yes: boolean) => void;
+  onCancel: () => void;
+}) {
+  const [picked, setPicked] = useState<Record<string, unknown>[]>([]);
+  const single = prompt.kind === "select" && prompt.maxSelections === 1;
+
+  const toggle = (opt: PromptOption) => {
+    if (single) {
+      onAnswer([opt.ref]); // single-pick auto-answers
+      return;
+    }
+    setPicked((prev) =>
+      prev.some((r) => sameRef(r, opt.ref))
+        ? prev.filter((r) => !sameRef(r, opt.ref))
+        : [...prev, opt.ref],
+    );
+  };
+
+  return (
+    <div
+      data-testid="clarification-card"
+      className="rounded-2xl border border-[#b8894d]/40 bg-[#b8894d]/5 p-4"
+    >
+      <p className="text-sm font-medium">{prompt.question}</p>
+
+      {prompt.kind === "select" ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {(prompt.options ?? []).map((opt) => {
+            const active = picked.some((r) => sameRef(r, opt.ref));
+            return (
+              <button
+                key={opt.label}
+                type="button"
+                data-testid="clarification-option"
+                disabled={busy}
+                onClick={() => toggle(opt)}
+                className={
+                  "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors " +
+                  (active
+                    ? "border-[#b8894d] bg-[#b8894d]/15 text-[#b8894d]"
+                    : "border-[color:var(--app-card-border-standard)] text-foreground hover:border-[#d4a574]/50")
+                }
+              >
+                {opt.label}
+                {opt.hint ? <span className="ml-1 opacity-60">· {opt.hint}</span> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <div className="mt-3 flex gap-2">
+        {prompt.kind === "confirm" ? (
+          <Button
+            data-testid="clarification-confirm"
+            size="sm"
+            isLoading={busy}
+            variant={prompt.destructive ? "destructive" : "default"}
+            onClick={() => onConfirm(true)}
+          >
+            {prompt.confirmLabel ?? "Yes"}
+          </Button>
+        ) : (
+          <Button
+            data-testid="clarification-confirm"
+            size="sm"
+            isLoading={busy}
+            disabled={busy || (!single && picked.length < (prompt.minSelections ?? 1))}
+            onClick={() => onAnswer(picked)}
+          >
+            {prompt.confirmLabel ?? "Confirm"}
+          </Button>
+        )}
+        <Button
+          data-testid="clarification-cancel"
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          {prompt.cancelLabel ?? "Cancel"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+(If `components/ui/button.tsx` has no `"destructive"` variant, use the closest existing variant for the destructive case — check the file and adjust.)
+
+- [ ] **Step 4: Run the component test to verify it passes**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/components/clarification-card.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Render it in the panel and overlay (mutually exclusive with the action card)**
+
+In `hushh-webapp/components/one-location/redesign/location-chat-panel.tsx`: add the import `import { ClarificationCard } from "./clarification-card";`. Replace the existing `{chat.pendingAction ? (...) : null}` block so the prompt takes precedence:
+
+```tsx
+{chat.pendingPrompt ? (
+  <ClarificationCard
+    prompt={chat.pendingPrompt}
+    busy={chat.busy}
+    onAnswer={chat.answerPrompt}
+    onConfirm={chat.confirmPrompt}
+    onCancel={chat.cancelPrompt}
+  />
+) : chat.pendingAction ? (
+  <ActionConfirmCard
+    action={chat.pendingAction}
+    busy={chat.busy}
+    onConfirm={chat.confirmAction}
+    onCancel={chat.cancelAction}
+  />
+) : null}
+```
+
+(Preserve any wrapping element the current block uses.) Then pass the prompt props through to the overlay alongside the existing action props:
+
+```tsx
+        pendingPrompt={chat.pendingPrompt}
+        answerPrompt={chat.answerPrompt}
+        confirmPrompt={chat.confirmPrompt}
+        cancelPrompt={chat.cancelPrompt}
+```
+
+In `hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx`: add the same optional props to the component's prop type:
+
+```tsx
+  pendingPrompt?: import("@/lib/one-location/types").ClientPrompt | null;
+  answerPrompt?: (refs: Record<string, unknown>[]) => Promise<void>;
+  confirmPrompt?: (yes: boolean) => Promise<void>;
+  cancelPrompt?: () => Promise<void>;
+```
+
+and render the card (mirroring how it renders `ActionConfirmCard`), preferring the prompt:
+
+```tsx
+{pendingPrompt && answerPrompt && confirmPrompt && cancelPrompt ? (
+  <ClarificationCard prompt={pendingPrompt} busy={busy} onAnswer={answerPrompt} onConfirm={confirmPrompt} onCancel={cancelPrompt} />
+) : pendingAction && confirmAction && cancelAction ? (
+  <ActionConfirmCard action={pendingAction} busy={busy} onConfirm={confirmAction} onCancel={cancelAction} />
+) : null}
+```
+
+(Add the `import { ClarificationCard } from "./clarification-card";` to the overlay.)
+
+- [ ] **Step 6: Run the chat-surface tests + typecheck**
+
+Run: `cd hushh-webapp && npx vitest run __tests__/components/location-chat-panel.test.tsx __tests__/components/location-chat-overlay.test.tsx __tests__/components/clarification-card.test.tsx && npx tsc --noEmit`
+Expected: PASS + clean. (Update any panel/overlay test that asserts on the prior single-card block.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/clarification-card.tsx hushh-webapp/components/one-location/redesign/location-chat-panel.tsx hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx hushh-webapp/__tests__/components/clarification-card.test.tsx
+git commit -m "feat(one-location): ClarificationCard + render in chat surfaces"
+```
+
+---
+
+## Task 9: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend — run the location-chat suite**
+
+Run: `cd consent-protocol && uv run python -m pytest tests/test_location_chat_service.py tests/test_location_chat_service_v2.py tests/test_location_chat_routes.py tests/test_location_chat_tools_allowlist.py tests/test_location_chat_tools_behavior.py tests/test_location_chat_agent_factory.py tests/test_location_agent_manifest_v2.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Frontend — run the location tests + typecheck**
+
+Run: `cd hushh-webapp && npx vitest run use-location-chat clarification-card action-confirm-card location-chat-panel location-chat-overlay location-chat-suggestions location-chat-service one-location-agent-page && npx tsc --noEmit`
+Expected: all PASS + clean.
+
+- [ ] **Step 3: Lint touched frontend files**
+
+Run: `cd hushh-webapp && npx eslint components/one-location/redesign/clarification-card.tsx components/one-location/redesign/use-location-chat.ts components/one-location/redesign/location-chat-panel.tsx components/one-location/redesign/location-chat-overlay.tsx lib/one-location/service.ts lib/one-location/types.ts`
+Expected: clean (fix any issues).
+
+- [ ] **Step 4: Commit any fixups**
+
+```bash
+git add -A
+git commit -m "test(one-location): clarify-confirm full-suite verification" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:**
+- §4 architecture (prompt tools → clientPrompt → selectionResult → seeded loop) → Tasks 1, 3, 4. ✓
+- §5 contract (`ClientPrompt`/`PromptOption`/`SelectionResult`, camelCase, mutually exclusive) → Tasks 3 (build), 5 (route), 6 (TS). ✓
+- §6 tools table (recipient/active-share/duration/request/incoming/confirmation, scopes) → Task 1; prompt wording → Task 2. ✓
+- §7 flows (share→duration→publish_share clientAction; stop→revoke each; stop-all→confirm; cancel) → Tasks 1/3/4 + 7/8. ✓
+- §8 frontend (ClarificationCard, pendingPrompt, free-text fallback, mutual exclusivity, clear) → Tasks 6, 7, 8. ✓
+- §9 invariants (coordinate-free, HushhContext, service-owns-ids, crypto path unchanged, destructive confirm) → enforced across Tasks 1–8 + verified Task 9. ✓
+- §10 testing → each task's tests + Task 9. ✓
+
+**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to". Two "check the real Button variant / preserve wrapping element" notes point at concrete in-repo facts the implementer verifies; full code is provided for all new logic.
+
+**Type consistency:** `ClientPrompt`/`PromptOption`/`SelectionResult` field names identical across Task 3 (Python dict keys: `id,kind,purpose,question,options[{label,ref,hint}],minSelections,maxSelections,allowFreeText,confirmLabel,cancelLabel,destructive`) and Task 6 (TS). `selection_result`/`selectionResult` and `free_text`/`freeText` aliasing consistent across Tasks 4, 5, 6. Hook members `pendingPrompt`/`answerPrompt`/`confirmPrompt`/`cancelPrompt` consistent across Tasks 7, 8. `_run_tool` 4-tuple consistent across Task 3 (definition) and `_run_tool_loop` (consumer).

--- a/docs/superpowers/plans/2026-06-30-one-location-clarify-confirm.md
+++ b/docs/superpowers/plans/2026-06-30-one-location-clarify-confirm.md
@@ -23,6 +23,22 @@
 
 ---
 
+## Visual Map
+
+```text
+clarify-and-confirm sits BEFORE the v2 crypto handoff (same directive pattern).
+
+"stop sharing my location" (no whom)
+  -> request_active_share_choice() (@hushh_tool, real grantId refs)
+  <- { response, clientPrompt:{ kind:"select", options:[grantId refs, "Stop all"] } }
+browser: ClarificationCard (checkboxes + Confirm)
+  -> POST /chat { selectionResult:{ selected:[{grantId}], status:"answered" } }
+  -> service seeds the loop with the chosen ids -> revoke_location_share(g1) ...
+
+For share: recipient choice -> duration -> create_location_share -> publish_share clientAction.
+clientPrompt and clientAction are mutually exclusive (prompt wins). All coordinate-free.
+```
+
 ## File Structure
 
 **Backend (`consent-protocol/`)**
@@ -1707,6 +1723,6 @@ git commit -m "test(one-location): clarify-confirm full-suite verification" || e
 - §9 invariants (coordinate-free, HushhContext, service-owns-ids, crypto path unchanged, destructive confirm) → enforced across Tasks 1–8 + verified Task 9. ✓
 - §10 testing → each task's tests + Task 9. ✓
 
-**Placeholder scan:** No "TBD"/"handle edge cases"/"similar to". Two "check the real Button variant / preserve wrapping element" notes point at concrete in-repo facts the implementer verifies; full code is provided for all new logic.
+**Placeholder scan:** No placeholder markers or vague cross-references. Two "check the real Button variant / preserve wrapping element" notes point at concrete in-repo facts the implementer verifies; full code is provided for all new logic.
 
 **Type consistency:** `ClientPrompt`/`PromptOption`/`SelectionResult` field names identical across Task 3 (Python dict keys: `id,kind,purpose,question,options[{label,ref,hint}],minSelections,maxSelections,allowFreeText,confirmLabel,cancelLabel,destructive`) and Task 6 (TS). `selection_result`/`selectionResult` and `free_text`/`freeText` aliasing consistent across Tasks 4, 5, 6. Hook members `pendingPrompt`/`answerPrompt`/`confirmPrompt`/`cancelPrompt` consistent across Tasks 7, 8. `_run_tool` 4-tuple consistent across Task 3 (definition) and `_run_tool_loop` (consumer).

--- a/docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md
+++ b/docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md
@@ -55,8 +55,8 @@ delivery UX, without breaking v1's privacy guarantees:
    X is" — via a structured **agent → client action-handoff contract**: the
    browser captures position, encrypts per recipient, and uploads an envelope; the
    server/agent still never see plaintext coordinates.
-2. **Public share links** accessible **outside** Hushh One — a recipient with no
-   Hushh account can open a link and see a location. Reuses the existing
+2. **Public share links** accessible **outside** One — a recipient with no
+   One account can open a link and see a location. Reuses the existing
    public-invite infrastructure.
 3. **Platform-aware sharing** — when a user says "share with <person>", the agent
    resolves the recipient against the **real** supported delivery set and asks a
@@ -92,14 +92,14 @@ building new crypto.
 
 | Channel | Status | Notes |
 |---|---|---|
-| FCM push (web/iOS/Android) to a Hushh user | **Wired** | `one_location_agent_service.py` `_send_metadata_notification`; metadata-only, deep-link `/one/location`; best-effort (silently drops if no push token). |
+| FCM push (web/iOS/Android) to a One user | **Wired** | `one_location_agent_service.py` `_send_metadata_notification`; metadata-only, deep-link `/one/location`; best-effort (silently drops if no push token). |
 | In-app consent-surface refresh | **Wired** | `hushh-webapp/lib/one-location/notifications.ts` + `consent-state-changed`. |
 | Public / circle link (owner copy-pastes) | **Wired** | Backend returns `publicUrl`; it does **not** auto-dispatch the link anywhere. |
 | SMS | **Absent** | No Twilio/SMS provider in the location flow. (An unrelated RIA invite enum lists `sms` but nothing sends it.) |
 | Email to recipient | **Absent** | Gmail API exists only for KAI advisor invites; not wired to any location event. |
 
 **Recipient identity** is resolved by `user_id` (UUID). `list_verified_recipients`
-returns only verified Hushh users (network-connected or phone-verified) and embeds
+returns only verified One users (network-connected or phone-verified) and embeds
 each recipient's `keyId` + `publicKeyJwk`. `canReceiveLocation:true` iff a key is
 registered (the recipient has opened One Location). Phone→user lookup happens
 **only** in the public-invite submission intake, not at agent share time.
@@ -186,7 +186,7 @@ that need the browser; otherwise the contract is identical to v1.
 ```
 1. Turn A (user text) → Gemini loop inside HushhContext
      - list_location_recipients resolves the named person (scope-validated)
-     - unambiguous Hushh recipient w/ key → create_location_share
+     - unambiguous One recipient w/ key → create_location_share
        (@hushh_tool: grant row + HCT mint, scope-validated, NO coords)
        (approve variant: approve_location_request, same shape)
      - service returns grant_id + recipient key info
@@ -244,16 +244,16 @@ No new DB migration — all tables (061, 064) already exist.
 
 The agent resolves a named person via `list_verified_recipients` into one of four
 buckets and branches. **Only real channels are ever offered**: encrypted in-app
-share (Hushh recipient w/ key) and public link (anyone). SMS / email are never
+share (One recipient w/ key) and public link (anyone). SMS / email are never
 offered; if the user explicitly asks ("text it to Mom"), the agent explains it
 can't send SMS but can make a link to paste.
 
 | Bucket | Detection | Agent behavior |
 |---|---|---|
-| **Verified Hushh recipient, has key** (`canReceiveLocation:true`) | exactly one name match with a registered key | Proceed: `create_location_share` → `publish_share` directive. No verbal question — the confirm card is the confirmation. |
-| **On Hushh, no key** (`canReceiveLocation:false`) | name match, no registered key | Ask: "Mom's on Hushh but hasn't set up location sharing yet. I can send her a request to enable it, or create a public link you can send her." |
+| **Verified One recipient, has key** (`canReceiveLocation:true`) | exactly one name match with a registered key | Proceed: `create_location_share` → `publish_share` directive. No verbal question — the confirm card is the confirmation. |
+| **On One, no key** (`canReceiveLocation:false`) | name match, no registered key | Ask: "Mom's on One but hasn't set up location sharing yet. I can send her a request to enable it, or create a public link you can send her." |
 | **Ambiguous** | multiple name matches | Disambiguate with the matches ("Mom (•••4821) or Mom (work)?"). |
-| **Unknown / off-Hushh** | no match | Ask: "I don't see {name} on Hushh. I can create a public link you can send them — want that?" |
+| **Unknown / off-platform** | no match | Ask: "I don't see {name} on One. I can create a public link you can send them — want that?" |
 
 **Multi-recipient** ("share with Mom and Dad"): one `publish_share` directive with
 a `recipients[]` array; the browser captures position **once** and encrypts **per
@@ -266,7 +266,7 @@ link for the rest, in a single clarifying reply.
 Reuses the existing public-invite infrastructure end to end — no new crypto, no new
 viewer page.
 
-**Mint flow** (off-Hushh recipient, explicit "make a public link", or fallback
+**Mint flow** (off-platform recipient, explicit "make a public link", or fallback
 offer):
 
 ```
@@ -291,7 +291,7 @@ justification):**
 - **Token hygiene** — `token_urlsafe(32)`; only the SHA-256 hash stored; raw token
   returned once.
 
-**Non-Hushh viewer (unchanged):** the public page resolves the token, shows a
+**Non-One viewer (unchanged):** the public page resolves the token, shows a
 Google Maps embed of the snapshot + expiry badge + directions; expired → 410,
 invalid → 404. No account, no login.
 
@@ -359,7 +359,7 @@ typing indicator, and error/retry are untouched except for the action-card branc
 |---|---|---|
 | Consent enforcement via `HushhContext` + per-tool scope validation | **Preserved** | All server-side ops (resolve, create_grant, approve, revoke, public-link create/delete) run as `@hushh_tool` in `HushhContext`; publish/view REST routes re-validate the HCT. |
 | Agent never sees/returns coordinates | **Preserved** | Coordinates exist only in the browser; `client_action` / `action_result` are coordinate-free by construction; agent turn text stays coordinate-free. |
-| Zero **server-side** plaintext coordinates | **Preserved for per-recipient shares**; **RELAXED for public links** | Per-recipient envelopes remain ciphertext-only (`ECDH-P256-AES256-GCM`). Public links store a plaintext `publicLocation` snapshot server-side. **Justification:** owner-initiated + explicitly confirmed; static one-time snapshot (not live); ≤24h hard-capped + auto-expire; revocable; required because a non-Hushh viewer has no key to decrypt. Scoped narrowly to this one path. |
+| Zero **server-side** plaintext coordinates | **Preserved for per-recipient shares**; **RELAXED for public links** | Per-recipient envelopes remain ciphertext-only (`ECDH-P256-AES256-GCM`). Public links store a plaintext `publicLocation` snapshot server-side. **Justification:** owner-initiated + explicitly confirmed; static one-time snapshot (not live); ≤24h hard-capped + auto-expire; revocable; required because a external viewer has no key to decrypt. Scoped narrowly to this one path. |
 | AES-256-GCM conversation encryption at rest | **Preserved** | Same `AgentChatService`; `client_action` / `action_result` metadata is coordinate-free and safe to persist. |
 | Opaque errors | **Preserved** | `action_result` failures map to safe agent messages; no internal detail. |
 | Agent refuses arbitrary bearer links / coords-in-notifications | **Preserved** | Prompt still refuses these; only the narrow confirmed-public-link + client-handoff paths are permitted. |
@@ -374,7 +374,7 @@ typing indicator, and error/retry are untouched except for the action-card branc
 - Scope enforcement fails closed when a matching scope is absent.
 - `action_result` follow-up turn yields a confirmation reply + correct
   `state_changed` (true after a successful mutating action; false on cancel).
-- Resolution buckets (verified-with-key / on-Hushh-no-key / ambiguous / unknown)
+- Resolution buckets (verified-with-key / on-One-no-key / ambiguous / unknown)
   drive the right branch and offer only real channels.
 - Public-link mint requires confirmation, respects expiry, and is revocable via
   chat; the agent never auto-creates one.
@@ -396,8 +396,8 @@ typing indicator, and error/retry are untouched except for the action-card branc
 |---|---|---|
 | Crypto-handoff model | Structured `client_action` directive + `action_result` follow-up turn | Clean contract; reuses all v1 crypto + REST; confirm gate fits a security-sensitive action |
 | Grant creation | Server-side `@hushh_tool` in `HushhContext`; only the envelope delegated to the browser | Keeps grant minting under per-tool scope validation (v1 non-negotiable) |
-| Public-link coordinate model | Reuse the existing **plaintext snapshot**; relax the invariant for this one path | Q2 decision; a non-Hushh viewer has no key to decrypt — bounded, owner-confirmed, revocable, ≤24h |
-| Platform confirmation | Resolve first; ask only when ambiguous / no-key / off-Hushh | Q3 decision; confirm card already shows target+platform+duration |
+| Public-link coordinate model | Reuse the existing **plaintext snapshot**; relax the invariant for this one path | Q2 decision; a external viewer has no key to decrypt — bounded, owner-confirmed, revocable, ≤24h |
+| Platform confirmation | Resolve first; ask only when ambiguous / no-key / off-platform | Q3 decision; confirm card already shows target+platform+duration |
 | Delivery channels offered | Encrypted in-app share + public link only | Only channels actually wired; no SMS/email |
 | Public links | Live, no-auth `/request/[token]`; static snapshot | Reuse shipped infra; no new viewer page |
 | Response mode | Non-streaming, consent-gated direct-Gemini loop in `HushhContext` | Same as v1 |

--- a/docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md
+++ b/docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md
@@ -128,7 +128,8 @@ This directly contradicts Goals 1–2. §6 reworks it.
 **Out of scope (explicit):**
 
 - Streaming responses (true or cosmetic). Backend stays non-streaming.
-- **SMS / email auto-send** — not wired anywhere in the location flow.
+- **SMS / email auto-send** — not wired anywhere in the location flow (planned for
+  a future milestone — see §11 Future work).
 - **Live / continuously-updating** public links — snapshot only.
 - A new public viewer page — reuse `/one/location/request/[token]`.
 - A new encryption scheme for public links — reuse the plaintext snapshot (per the
@@ -401,7 +402,38 @@ typing indicator, and error/retry are untouched except for the action-card branc
 | Public links | Live, no-auth `/request/[token]`; static snapshot | Reuse shipped infra; no new viewer page |
 | Response mode | Non-streaming, consent-gated direct-Gemini loop in `HushhContext` | Same as v1 |
 
-## 11. Skill plan (remainder of flow)
+## 11. Future work — full multi-platform delivery (post-v2)
+
+**Goal (future):** integrate location sharing with **all available delivery
+platforms**, so the agent can deliver a share/link through whatever channel the
+recipient prefers — not just in-app push + manually-pasted links.
+
+v2 deliberately offers only the channels actually wired today (encrypted in-app
+share + public link). A future milestone should expand the **platform-aware**
+layer (§5) to offer and auto-dispatch additional channels once each is built and
+verified:
+
+- **SMS** — auto-send the public link (or an invite) via a real SMS provider
+  (e.g. Twilio). Requires provider integration; today only an unrelated RIA enum
+  references `sms` and nothing sends it.
+- **Email** — auto-send via a transactional email service. A Gmail-API path exists
+  for KAI advisor invites; it is **not** wired to any location event.
+- **Native share sheet** — hand the public link to the OS share sheet (iOS/Android
+  via Capacitor) so the user can pick any installed app (WhatsApp, iMessage, etc.).
+- **Other push targets** beyond the current Firebase Admin path, if added.
+
+**Design hooks to preserve for this:** the platform-resolution buckets in §5 and
+the `client_action`/`action_result` contract in §4 are the natural extension
+points. A future channel becomes (a) a new entry in the "real supported set" the
+agent may offer, and (b) either a server-side dispatch step (SMS/email) or a new
+`client_action.type` (native share sheet). The zero-plaintext-coordinate posture
+must hold: links carry the bounded snapshot already covered by §8; no new channel
+should transmit plaintext coordinates to the server beyond that one relaxed path.
+
+**Out of scope for v2** — this section is a forward reference only; nothing here is
+built in this milestone.
+
+## 12. Skill plan (remainder of flow)
 
 1. **superpowers:brainstorming** — complete (this spec).
 2. User reviews this spec.

--- a/docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md
+++ b/docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md
@@ -1,0 +1,411 @@
+# One Location Agent Chat — v2 (crypto handoff, public links, platform-aware)
+
+- **Date:** 2026-06-29
+- **Branch:** `feat/one-location-agent-chat-v2` (off latest `main`; v1 shipped + on UAT)
+- **Status:** Approved design, ready for implementation plan
+- **Builds on:**
+  - `docs/superpowers/specs/2026-06-27-one-location-agent-chat-design.md` (backend v1, shipped)
+  - `docs/superpowers/specs/2026-06-29-one-location-chat-ui-design.md` (UI v1, shipped)
+  - their plans under `docs/superpowers/plans/`
+
+## Visual Map
+
+```text
+One Location Agent Chat — v2 client-action handoff (coords stay in the browser)
+
+Browser (/one/location chat)                         │  Server (consent-gated)
+──────────────────────────────────────────────────  │  ──────────────────────────────────────
+Turn A: "share my location with Mom for an hour"     │
+  POST /api/one/location/chat                          │  require_vault_owner_token (403 on mismatch)
+  { user_id, message, conversation_id? }        ────► │  LocationChatService.handle_turn()
+                                                      │    Gemini fn-calling loop INSIDE HushhContext
+                                                      │      → list_location_recipients (resolve "Mom")
+                                                      │      → create_location_share  (@hushh_tool:
+                                                      │          grant + HCT mint, scope-validated, NO coords)
+                                                      │    attach clientAction (coordinate-free)
+        ◄─────────────────────────────────────────┘    { response, clientAction:{type:"publish_share",
+  detect clientAction → render ActionConfirmCard         grantId, recipients:[Mom], summary}, state_changed:false }
+  [Share with Mom · 1h · Share | Cancel]              │
+  on Share:                                           │
+    captureCurrentPosition()                          │  (coordinates never leave the browser)
+    encryptLocationForRecipient(per recipient)        │
+    POST /grants/{grantId}/envelopes  (ciphertext) ─► │  store_encrypted_envelope (HCT re-validated,
+                                                      │    rejects any plaintext coordinate key) → ciphertext row
+Turn B: report completion                             │
+  POST /api/one/location/chat                          │
+  { user_id, conversation_id, actionResult:{      ──► │  agent confirms in words; state_changed:true
+      id, type:"publish_share", status:"completed" } } │
+        ◄─────────────────────────────────────────┘    { response:"Done — Mom can see you for 1h.",
+  render reply; on state_changed → refresh()             is_complete:true, state_changed:true }
+    + dispatch consent-state-changed                   │
+
+Per-recipient shares: ciphertext-only end to end. Public links: owner-confirmed,
+time-bounded plaintext SNAPSHOT (the one deliberately relaxed path — see §7).
+The agent never sees or returns coordinates in any path.
+```
+
+## 1. Goal
+
+v1 shipped a **control-plane** One Location assistant: query / revoke / request /
+deny / refer, fully completed server-side, agent never sees coordinates. v2 adds
+the **coordinate-touching** capabilities that v1 deferred, plus the surrounding
+delivery UX, without breaking v1's privacy guarantees:
+
+1. **Crypto handoff** — "share my location", "approve a request", "show me where
+   X is" — via a structured **agent → client action-handoff contract**: the
+   browser captures position, encrypts per recipient, and uploads an envelope; the
+   server/agent still never see plaintext coordinates.
+2. **Public share links** accessible **outside** Hushh One — a recipient with no
+   Hushh account can open a link and see a location. Reuses the existing
+   public-invite infrastructure.
+3. **Platform-aware sharing** — when a user says "share with <person>", the agent
+   resolves the recipient against the **real** supported delivery set and asks a
+   clarifying question only when needed. It never invents unsupported channels.
+
+## 2. Context — actual state on this branch (Step 0 findings)
+
+The hard parts already exist. v2 is mostly *wiring the agent to working code*, not
+building new crypto.
+
+### Crypto handoff — already built (reuse as-is)
+
+| Area | Symbols / paths |
+|---|---|
+| Deferred agent tools | `consent-protocol/hushh_mcp/agents/location/tools.py` — `create_location_share` (scope `cap.location.live.share`), `publish_location_envelope`, `approve_location_request`, `view_location_envelope` (scope `cap.location.live.view`). `LOCATION_AGENT_TOOLS` (all 10) vs `CONTROL_PLANE_LOCATION_TOOLS` (6, used by v1). |
+| Service business logic | `consent-protocol/hushh_mcp/services/one_location_agent_service.py` — `create_grant`, `store_encrypted_envelope`, `approve_request`, `view_latest_envelope`, `list_verified_recipients`, `_contains_plaintext_location_key` (rejects 18 coordinate keys in envelope metadata, 422). |
+| REST routes | `consent-protocol/api/routes/one/location.py` — `POST /grants` (CreateGrantRequest), `POST /grants/{id}/envelopes` (StoreEnvelopeRequest), `POST /requests/{id}/approve` (ResolveAccessRequest), `GET /grants/{id}/envelope`, `POST /recipient-keys` (RecipientKeyRequest), `GET /recipients`. All require `require_vault_owner_token` except public-invite resolve/submit. |
+| Envelope model | migration `061_one_location_agent.sql` — `one_location_recipient_keys`, `one_location_share_grants`, `one_location_envelopes` (ciphertext, iv, sender_ephemeral_public_key_jwk; algorithm `ECDH-P256-AES256-GCM`; per recipient; `duration_hours` CHECK ≤24). |
+| Client crypto (works today) | `hushh-webapp/lib/one-location/encryption.ts` — `ensureLocationRecipientKey`, `encryptLocationForRecipient` (ephemeral ECDH P-256 + AES-256-GCM, per recipient), `decryptLocationEnvelope`; `key-bootstrap.ts`; `service.ts` `captureCurrentPosition`. Web Crypto (`crypto.subtle`) only — no third-party lib. Private keys live in IndexedDB, never leave the device. |
+| Page callbacks (button-driven today) | `hushh-webapp/app/one/location/page.tsx` — `handleShare`, `publishEnvelope`, `handleApprove`, `viewGrantEnvelope`. v2 reuses these from the agent's directive. |
+
+### Public links — already built (reuse + relax the agent prompt)
+
+| Area | Symbols / paths |
+|---|---|
+| Public invite service | `one_location_agent_service.py` — `create_public_invite` (`secrets.token_urlsafe(32)`, stores SHA-256 hash only, ≤24h, optional `metadata.publicLocation` **plaintext** snapshot), `resolve_public_invite` (auto-expires), `submit_public_invite_request`. |
+| Public routes | `api/routes/one/location.py` — `POST /public-invites` (owner), `GET /public-invites/{token}` (**no auth**), `POST /public-invites/{token}/submit` (**no auth**), `DELETE /public-invites/{id}` (owner). |
+| Public tables | migration `064` — `one_location_public_invites`, `one_location_public_invite_submissions`. |
+| Public viewer page (live today) | `hushh-webapp/app/one/location/request/[token]/page-client.tsx` — no-auth route (`isPublicRoute()` in `lib/navigation/routes.ts`); shows Google Maps embed of the snapshot + expiry badge; 410 expired / 404 invalid. |
+| Links UI | `hushh-webapp/components/one-location/redesign/cards.tsx` — `TemporaryLinkCard` (Copy / Share / Revoke); `location-redesign-hub.tsx` LinksHub. |
+
+### Delivery channels — what is ACTUALLY wired (drives platform-awareness)
+
+| Channel | Status | Notes |
+|---|---|---|
+| FCM push (web/iOS/Android) to a Hushh user | **Wired** | `one_location_agent_service.py` `_send_metadata_notification`; metadata-only, deep-link `/one/location`; best-effort (silently drops if no push token). |
+| In-app consent-surface refresh | **Wired** | `hushh-webapp/lib/one-location/notifications.ts` + `consent-state-changed`. |
+| Public / circle link (owner copy-pastes) | **Wired** | Backend returns `publicUrl`; it does **not** auto-dispatch the link anywhere. |
+| SMS | **Absent** | No Twilio/SMS provider in the location flow. (An unrelated RIA invite enum lists `sms` but nothing sends it.) |
+| Email to recipient | **Absent** | Gmail API exists only for KAI advisor invites; not wired to any location event. |
+
+**Recipient identity** is resolved by `user_id` (UUID). `list_verified_recipients`
+returns only verified Hushh users (network-connected or phone-verified) and embeds
+each recipient's `keyId` + `publicKeyJwk`. `canReceiveLocation:true` iff a key is
+registered (the recipient has opened One Location). Phone→user lookup happens
+**only** in the public-invite submission intake, not at agent share time.
+
+### The agent prompt to change
+
+`consent-protocol/hushh_mcp/agents/location/agent.yaml` currently states:
+
+> *"…Refuse public bearer links, plaintext server coordinates, notification
+> coordinates, and referral flows that grant access without owner approval."*
+
+This directly contradicts Goals 1–2. §6 reworks it.
+
+## 3. Scope (locked)
+
+**In scope (v2):**
+
+- Crypto-handoff for **share** (`create_location_share` → `publish_share`
+  directive), **approve** (`approve_location_request` → `publish_share`
+  directive), and **view** ("show me where X is" → `view_envelope` directive).
+- Agent-minted **public links** (reuse the plaintext-snapshot public invite),
+  plus chat-driven **public-link revocation** (control-plane).
+- **Platform-aware** recipient resolution + clarifying questions over the real
+  supported set (encrypted in-app share, public link).
+
+**Out of scope (explicit):**
+
+- Streaming responses (true or cosmetic). Backend stays non-streaming.
+- **SMS / email auto-send** — not wired anywhere in the location flow.
+- **Live / continuously-updating** public links — snapshot only.
+- A new public viewer page — reuse `/one/location/request/[token]`.
+- A new encryption scheme for public links — reuse the plaintext snapshot (per the
+  Q2 decision in §8).
+- Routing location intents through the global KAI assistant.
+- Cross-reload persistence of `conversation_id` (stays memory-only).
+
+## 4. Architecture — the client-action handoff contract
+
+**Core principle:** every coordinate-touching operation splits into a *server-side
+prep step* (a real `@hushh_tool` running in `HushhContext`, scope-validated, **no
+coords**) and a *client-side completion step* (capture → encrypt → upload, coords
+stay in the browser). This preserves v1's consent-enforcement invariant while the
+browser does the crypto.
+
+### Contract additions (backward-compatible with v1)
+
+```python
+class LocationChatRequest(BaseModel):
+    user_id: str                       # min 1, max 128
+    message: str | None = None         # min 1, max 4000 when present
+    conversation_id: str | None = None # max 128
+    action_result: ActionResult | None = None   # NEW — browser reports completion
+
+class ActionResult(BaseModel):          # coordinate-free by construction
+    id: str                            # echoes ClientAction.id (correlation)
+    type: str                          # "publish_share" | "view_envelope" | "create_public_link"
+    status: str                        # "completed" | "cancelled" | "failed"
+    public_url: str | None = None      # for create_public_link
+    detail: str | None = None          # safe, non-sensitive ("shared with 1 recipient")
+
+class ClientAction(BaseModel):          # coordinate-free by construction
+    id: str                            # idempotency / correlation key
+    type: str                          # "publish_share" | "view_envelope" | "create_public_link"
+    grant_id: str | None = None        # publish/view — created server-side this turn
+    recipients: list[ActionRecipient] | None = None  # publish — userId,keyId,publicKeyJwk,label
+    duration_hours: float | None = None  # create_public_link
+    summary: str                       # human label for the confirm card
+
+class LocationChatResponse(BaseModel):
+    conversation_id: str
+    response: str                      # coordinate-free reply
+    is_complete: bool
+    state_changed: bool
+    client_action: ClientAction | None = None   # NEW — present when the browser must act
+```
+
+A turn carries **either** a `message` (user text) **or** an `action_result`
+(completion report), never both required. `client_action` is present only on turns
+that need the browser; otherwise the contract is identical to v1.
+
+### Turn lifecycle (share / approve)
+
+```
+1. Turn A (user text) → Gemini loop inside HushhContext
+     - list_location_recipients resolves the named person (scope-validated)
+     - unambiguous Hushh recipient w/ key → create_location_share
+       (@hushh_tool: grant row + HCT mint, scope-validated, NO coords)
+       (approve variant: approve_location_request, same shape)
+     - service returns grant_id + recipient key info
+     - LocationChatService attaches client_action{ type:"publish_share",
+       grant_id, recipients[], summary } and ends the turn (state_changed:false)
+2. Browser detects client_action → renders ActionConfirmCard (explicit click)
+3. On confirm → EXISTING pipeline: captureCurrentPosition →
+   encryptLocationForRecipient (per recipient) → POST /grants/{grant_id}/envelopes
+   (ciphertext only). Coords never leave the browser.
+4. Turn B (action_result, no message) → agent confirms in words;
+   state_changed:true → existing refresh() + consent-state-changed
+```
+
+`view_envelope` ("show me where X is") works the same way: the directive carries
+the `grant_id`; the browser fetches the ciphertext (`GET /grants/{id}/envelope`)
+and `decryptLocationEnvelope` renders the map. `create_public_link` captures the
+snapshot client-side and POSTs it to `create_public_invite` (§7).
+
+### Why grant creation stays server-side
+
+Folding grant minting into the client callback would skip the agent's
+`HushhContext` + `@hushh_tool` scope validation. Instead, grant/approve run
+server-side as real tool calls (scope-validated, coordinate-free); **only** the
+envelope — the coordinate-bearing part — is delegated to the browser. The publish
+and view REST routes additionally re-validate the HCT.
+
+### Tool exposure (defense-in-depth)
+
+| Intent | Server-side `@hushh_tool` (HushhContext, scope) | Emits `client_action` |
+|---|---|---|
+| "share with X" | `create_location_share` (`cap.location.live.share`) | `publish_share` |
+| "approve X's request" | `approve_location_request` (`cap.location.live.share`) | `publish_share` |
+| "where is X / show me" | *(read path; fetch is a directive, decrypt is client)* | `view_envelope` |
+| "make a public link" | `create_public_invite` (after client snapshot upload) | `create_public_link` |
+| "revoke the public link" | `delete_public_invite` (control-plane, server-side) | *(none)* |
+
+`publish_location_envelope` and `view_location_envelope` are **never** exposed as
+callable LLM tools — they are impossible server-side (need ciphertext /
+decryption). The loop *translates* a completed `create_location_share` /
+`approve_location_request` / view-intent into the matching `client_action`. The
+allow-list is enforced in code, not only the prompt (same defense-in-depth as v1).
+
+### New / changed backend files
+
+| File | Change |
+|---|---|
+| `consent-protocol/hushh_mcp/services/location_chat_service.py` | **Edit** — widen the tool allow-list; after a grant-creating tool runs (or a view/public-link intent is detected) attach the matching `client_action` and end the turn; handle the `action_result` follow-up turn → confirmation reply + precise `state_changed`. |
+| `consent-protocol/api/routes/one/location_chat.py` | **Edit** — extend request/response models with `action_result` / `client_action` (+ `ClientAction`, `ActionRecipient`, `ActionResult`). Backward-compatible. |
+| `consent-protocol/hushh_mcp/agents/location/agent.yaml` | **Edit** — relax the refusal prompt (§6). |
+| `consent-protocol/hushh_mcp/agents/location/tools.py` | **Edit (if needed)** — a v2 allow-list (`V2_LOCATION_TOOLS`) exposing resolve + grant/approve + public-invite create/delete; still excluding `publish_location_envelope` / `view_location_envelope` from LLM-callable tools. |
+
+No new DB migration — all tables (061, 064) already exist.
+
+## 5. Platform-aware resolution & clarifying behavior
+
+The agent resolves a named person via `list_verified_recipients` into one of four
+buckets and branches. **Only real channels are ever offered**: encrypted in-app
+share (Hushh recipient w/ key) and public link (anyone). SMS / email are never
+offered; if the user explicitly asks ("text it to Mom"), the agent explains it
+can't send SMS but can make a link to paste.
+
+| Bucket | Detection | Agent behavior |
+|---|---|---|
+| **Verified Hushh recipient, has key** (`canReceiveLocation:true`) | exactly one name match with a registered key | Proceed: `create_location_share` → `publish_share` directive. No verbal question — the confirm card is the confirmation. |
+| **On Hushh, no key** (`canReceiveLocation:false`) | name match, no registered key | Ask: "Mom's on Hushh but hasn't set up location sharing yet. I can send her a request to enable it, or create a public link you can send her." |
+| **Ambiguous** | multiple name matches | Disambiguate with the matches ("Mom (•••4821) or Mom (work)?"). |
+| **Unknown / off-Hushh** | no match | Ask: "I don't see {name} on Hushh. I can create a public link you can send them — want that?" |
+
+**Multi-recipient** ("share with Mom and Dad"): one `publish_share` directive with
+a `recipients[]` array; the browser captures position **once** and encrypts **per
+recipient** (`encryptLocationForRecipient` already does per-recipient ECDH). Mixed
+buckets → handle the verified recipients via the share directive and offer a public
+link for the rest, in a single clarifying reply.
+
+## 6. Public links via the agent
+
+Reuses the existing public-invite infrastructure end to end — no new crypto, no new
+viewer page.
+
+**Mint flow** (off-Hushh recipient, explicit "make a public link", or fallback
+offer):
+
+```
+1. Agent turn → response + client_action{ type:"create_public_link", duration_hours }
+2. Browser ActionConfirmCard ("Public link · viewable 1h · Create | Cancel")
+3. On Create → captureCurrentPosition() → POST create_public_invite with the
+   plaintext publicLocation snapshot (the relaxed path) + duration_hours
+4. action_result{ status:"completed", public_url } → agent replies with the link +
+   "anyone with this link can see this location for 1 hour; revoke it anytime."
+   state_changed:true (Links tab refreshes)
+```
+
+**Bounds on the relaxed invariant (already enforced by existing code; restated as
+justification):**
+
+- **Static snapshot, not a live feed** — one position captured at creation.
+- **Owner-initiated + explicitly confirmed** — only via the confirm card; the agent
+  never auto-creates.
+- **Time-bounded** — `duration_hours` DB CHECK ≤24h; auto-expires on resolve.
+- **Revocable** — `DELETE /public-invites/{id}`; chat-driven via `delete_public_invite`
+  ("kill that link"); Links tab shows/revokes (`TemporaryLinkCard`).
+- **Token hygiene** — `token_urlsafe(32)`; only the SHA-256 hash stored; raw token
+  returned once.
+
+**Non-Hushh viewer (unchanged):** the public page resolves the token, shows a
+Google Maps embed of the snapshot + expiry badge + directions; expired → 410,
+invalid → 404. No account, no login.
+
+**Agent-prompt relaxation (`agent.yaml`).** Reword the single refusal line to:
+
+- **Still refuse:** the agent itself emitting/handling coordinates; coordinates in
+  notifications; access granted without explicit owner approval; arbitrary
+  unbounded links.
+- **Now permit (narrowly):** (a) delegating a coordinate operation to the browser
+  via the structured `client_action` contract; (b) minting an **owner-initiated,
+  time-bounded, revocable public link** (the plaintext-snapshot path). The prompt
+  names these as the *only* sanctioned ways coordinates move, and ties public links
+  to explicit owner confirmation + expiry.
+
+The agent's own turn text stays coordinate-free; the relaxation is about
+*delegating* and *link-minting*, not about the agent seeing coordinates.
+
+## 7. Frontend
+
+Builds on the shipped v1 chat UI (`use-location-chat.ts`, `LocationChatCard` /
+`LocationChatOverlay`, `OneLocationService.chat`). The one new concept is a
+**client-action dispatcher** on the existing hook.
+
+**New behavior (`useLocationChat` extension or `useLocationChatActions`):**
+
+- After each `chat()` response, inspect `client_action`. If present, set
+  `pendingAction` instead of only rendering text.
+- Render an inline **ActionConfirmCard** in the message stream (reusing chat
+  bubble/token styling): icon + `summary` + `[Share]/[Create]/[View]` + `[Cancel]`.
+  Security-sensitive → explicit click; never auto-fires.
+- On confirm, dispatch by `type` to the **existing page callbacks** — no new crypto:
+  - `publish_share` → `captureCurrentPosition` + `encryptLocationForRecipient` (per
+    recipient) + `storeEnvelope` (existing `publishEnvelope` / `handleShare`).
+  - `view_envelope` → fetch envelope + `decryptLocationEnvelope` → render map
+    (existing `viewGrantEnvelope`).
+  - `create_public_link` → `captureCurrentPosition` + `createPublicInvite`.
+- On completion / cancel / failure, call `chat()` again with `action_result` (no
+  message). On `state_changed`, the existing `onStateChanged` (`refresh()` +
+  `dispatchConsentStateChanged`) fires; Now / People / Links tabs stay in sync.
+
+**States to handle:** geolocation permission denied → `action_result{status:"failed",
+detail:"location unavailable"}` → agent offers retry/alternative; recipient key
+missing at publish → graceful "they need to open One Location first"; cancel →
+agent acknowledges, no mutation.
+
+**New suggestion chips:** "Share my location with…", "Show me where someone is",
+"Make a public link".
+
+**Reuse, don't rebuild.** All crypto, geolocation, key-bootstrap, and REST calls
+already exist; v2 wires the directive to them. v1's chat surface, overlay, chips,
+typing indicator, and error/retry are untouched except for the action-card branch.
+
+### Changed frontend files
+
+| File | Change |
+|---|---|
+| `hushh-webapp/lib/one-location/service.ts` | **Edit** — `chat()` accepts/returns `actionResult` / `clientAction`. |
+| `hushh-webapp/components/one-location/redesign/use-location-chat.ts` | **Edit** — `pendingAction` state, action dispatcher, `action_result` follow-up turn. |
+| `hushh-webapp/components/one-location/redesign/` | **New** — `ActionConfirmCard` (presentational); new suggestion chips. |
+| `hushh-webapp/components/one-location/redesign/location-chat-*.tsx` | **Edit** — render the action card in the message stream. |
+
+## 8. Invariant ledger — preserved vs. relaxed
+
+| v1 invariant | v2 status | Detail |
+|---|---|---|
+| Consent enforcement via `HushhContext` + per-tool scope validation | **Preserved** | All server-side ops (resolve, create_grant, approve, revoke, public-link create/delete) run as `@hushh_tool` in `HushhContext`; publish/view REST routes re-validate the HCT. |
+| Agent never sees/returns coordinates | **Preserved** | Coordinates exist only in the browser; `client_action` / `action_result` are coordinate-free by construction; agent turn text stays coordinate-free. |
+| Zero **server-side** plaintext coordinates | **Preserved for per-recipient shares**; **RELAXED for public links** | Per-recipient envelopes remain ciphertext-only (`ECDH-P256-AES256-GCM`). Public links store a plaintext `publicLocation` snapshot server-side. **Justification:** owner-initiated + explicitly confirmed; static one-time snapshot (not live); ≤24h hard-capped + auto-expire; revocable; required because a non-Hushh viewer has no key to decrypt. Scoped narrowly to this one path. |
+| AES-256-GCM conversation encryption at rest | **Preserved** | Same `AgentChatService`; `client_action` / `action_result` metadata is coordinate-free and safe to persist. |
+| Opaque errors | **Preserved** | `action_result` failures map to safe agent messages; no internal detail. |
+| Agent refuses arbitrary bearer links / coords-in-notifications | **Preserved** | Prompt still refuses these; only the narrow confirmed-public-link + client-handoff paths are permitted. |
+
+## 9. Testing strategy (TDD, extends v1 suites)
+
+**Backend**
+- `create_location_share` / `approve_location_request` produce a grant **and** a
+  coordinate-free `client_action`.
+- `publish_location_envelope` / `view_location_envelope` are **not** LLM-callable
+  (asserted at the code level, not just the prompt).
+- Scope enforcement fails closed when a matching scope is absent.
+- `action_result` follow-up turn yields a confirmation reply + correct
+  `state_changed` (true after a successful mutating action; false on cancel).
+- Resolution buckets (verified-with-key / on-Hushh-no-key / ambiguous / unknown)
+  drive the right branch and offer only real channels.
+- Public-link mint requires confirmation, respects expiry, and is revocable via
+  chat; the agent never auto-creates one.
+- **No coordinate keys** appear in any stored message, `client_action`, or
+  `action_result`.
+- Reuse fakes/patterns from `consent-protocol/tests/test_one_location_*`.
+
+**Frontend**
+- `client_action` renders the ActionConfirmCard; it never auto-fires.
+- Confirm dispatches to the existing crypto callbacks; multi-recipient encrypts per
+  recipient from a single capture.
+- Cancel / failure / permission-denied paths POST the correct `action_result`.
+- `state_changed:true` triggers `refresh()` + `consent-state-changed`.
+- Existing v1 chat/page tests stay green; `npx tsc --noEmit` clean.
+
+## 10. Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Crypto-handoff model | Structured `client_action` directive + `action_result` follow-up turn | Clean contract; reuses all v1 crypto + REST; confirm gate fits a security-sensitive action |
+| Grant creation | Server-side `@hushh_tool` in `HushhContext`; only the envelope delegated to the browser | Keeps grant minting under per-tool scope validation (v1 non-negotiable) |
+| Public-link coordinate model | Reuse the existing **plaintext snapshot**; relax the invariant for this one path | Q2 decision; a non-Hushh viewer has no key to decrypt — bounded, owner-confirmed, revocable, ≤24h |
+| Platform confirmation | Resolve first; ask only when ambiguous / no-key / off-Hushh | Q3 decision; confirm card already shows target+platform+duration |
+| Delivery channels offered | Encrypted in-app share + public link only | Only channels actually wired; no SMS/email |
+| Public links | Live, no-auth `/request/[token]`; static snapshot | Reuse shipped infra; no new viewer page |
+| Response mode | Non-streaming, consent-gated direct-Gemini loop in `HushhContext` | Same as v1 |
+
+## 11. Skill plan (remainder of flow)
+
+1. **superpowers:brainstorming** — complete (this spec).
+2. User reviews this spec.
+3. **superpowers:writing-plans** — implementation plan (TDD task breakdown).
+4. **ui-ux-pro-max** — drives the visual execution of the ActionConfirmCard.
+5. **superpowers:test-driven-development** + **superpowers:executing-plans** —
+   build on `feat/one-location-agent-chat-v2`.

--- a/docs/superpowers/specs/2026-06-30-one-location-clarify-confirm-design.md
+++ b/docs/superpowers/specs/2026-06-30-one-location-clarify-confirm-design.md
@@ -1,0 +1,267 @@
+# One Location Agent Chat — Clarify-and-Confirm interactions
+
+- **Date:** 2026-06-30
+- **Branch:** `feat/one-location-agent-chat-v2` (v2 built + reviewed; live path confirmed working)
+- **Status:** Approved design, ready for implementation plan
+- **Builds on:**
+  - `docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md` (the `clientAction`/`actionResult` crypto-handoff contract)
+  - its plan `docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md`
+
+## Visual Map
+
+```text
+Clarify-and-confirm sits BEFORE the v2 crypto handoff (same directive pattern)
+
+Browser (/one/location chat)                      │  Server (consent-gated)
+─────────────────────────────────────────────    │  ─────────────────────────────────────
+"stop sharing my location"  (no whom)             │
+  POST /chat { message }                     ────►│  Gemini loop in HushhContext
+                                                  │   → request_active_share_choice()  (@hushh_tool,
+                                                  │       coordinate-free: loads active shares w/ real grantIds)
+                                                  │   → service translates result → clientPrompt
+        ◄─────────────────────────────────────┘    { response:"Which sharing do you want to stop?",
+  render ClarificationCard (checkboxes + Confirm)    clientPrompt:{ kind:"select", options:[…grantId refs], … } }
+  user ticks Mom + Dad → [Confirm]                 │
+  POST /chat { selectionResult:{ id,             ─►│  selectionResult turn: seed loop w/ chosen refs
+    selected:[{grantId:g1},{grantId:g2}],          │   → revoke_location_share(g1); revoke_location_share(g2)
+    status:"answered" } }                           │      (REAL ids — model never guessed them)
+        ◄─────────────────────────────────────┘    { response:"Stopped sharing with Mom and Dad.",
+  refresh()                                          stateChanged:true }
+
+For SHARE: the same path ends by emitting the existing publish_share clientAction → ActionConfirmCard
+(capture/encrypt/upload). Clarification PRECEDES and feeds the v2 crypto flow; it does not replace it.
+"Stop all" / public link / share-with-everyone insert a confirm (Yes/No) prompt first.
+```
+
+## 1. Goal
+
+v2 ships the crypto handoff, public links, and platform-aware sharing, and the
+live path works. But underspecified commands degrade to **text-only**
+clarification today (the prompt says only "if ambiguous, ask which person"), and
+bare commands like **"Share my location"** (no recipient) or **"Stop sharing my
+location"** (no whom) aren't explicitly handled. Users want the agent to **ask a
+clarifying question and let them pick from options or type**, and to **confirm**
+before destructive/bulk actions.
+
+This adds a structured **clarify-and-confirm** interaction layer: the agent raises
+a `clientPrompt` (select or confirm) with options the **server** populates from
+real ids; the user taps (or types); the choice returns as a `selectionResult`; the
+agent acts on the exact ids. It reuses the v2 directive architecture end-to-end.
+
+## 2. Context — actual state on this branch (Step 0 findings)
+
+| Area | Path / symbol | Note |
+|---|---|---|
+| v2 crypto contract | `LocationChatResponse.clientAction` + request `actionResult` (`api/routes/one/location_chat.py`, `services/location_chat_service.py`) | This feature adds two sibling fields, same pattern. |
+| Directive translation | `location_chat_service.py` `_directive_from_tool` / `_build_client_action` | The model decides intent; the **service** builds the directive from tool results (the model never serializes ids). We extend this for prompts. |
+| `propose_*` precedent | `agents/location/tools.py` `propose_public_link` / `propose_location_view` | Coordinate-free intent tools translated into a `clientAction`. The new `request_*_choice` tools mirror this exactly. |
+| v2 tool allow-list | `tools.py` `V2_LOCATION_TOOLS`; factory `get_location_chat_agent_v2()` | New tools are added here; the v2 function declarations in the service are extended. |
+| Prompt | `agents/location/agent.yaml` `system_instruction` | Today: "if the match is ambiguous, ask which person." We extend it for choice/confirm. |
+| Crypto gate (unchanged) | `components/one-location/redesign/action-confirm-card.tsx` + hook `pendingAction` | Clarification adds a sibling `ClarificationCard` + `pendingPrompt`; share/view/link still terminate at `ActionConfirmCard`. |
+| Static chips | `components/one-location/redesign/location-chat-suggestions.tsx` (`{label,mode,value}`) | Presentational, static — not reused for dynamic agent-driven options. |
+| Hook | `components/one-location/redesign/use-location-chat.ts` (`pendingAction`, `confirmAction`, `cancelAction`, `report()`) | Extended with `pendingPrompt`, `answerPrompt`, `confirmPrompt`, `cancelPrompt`. |
+| v1 anti-guessing fix | prompt "never invent ids; list first" + `_require_uuid` guard | This feature strengthens it: options carry real ids, so the model selects rather than fabricates. |
+
+## 3. Scope (locked)
+
+**In scope** (interaction types: **multi-select** — which also covers single-pick —
+plus **Yes/No confirm**, plus **free-text fallback**):
+
+- Share with **no / ambiguous recipient** → recipient selection (+ public link + free text).
+- Stop sharing with **no whom / which** → multi-select of active shares + **"Stop all"**.
+- **Destructive / irreversible confirms** → Yes/No before public link, share-with-everyone, stop-all.
+- Secondary missing slots → **duration** (1h/8h/24h/custom), **which pending request** to approve, **whose incoming** location to view.
+
+**Out of scope:** voice selection; search/reordering of long option lists (basic
+list only); persisting prompts across reload (memory-only, like `conversationId`);
+any change to the v2 crypto contract; SMS/email.
+
+## 4. Architecture
+
+Reuse the v2 directive pattern. The model only decides **which** prompt to raise;
+the **service fills the options with real ids from the DB**, so the model never
+hand-serializes a `grantId`/`recipientKeyId`.
+
+```
+Underspecified turn → Gemini loop in HushhContext
+  → model calls a prompt-builder @hushh_tool (coordinate-free; loads options w/ real refs)
+  → service translates the tool result → clientPrompt on the response (no mutation)
+Client renders ClarificationCard (composer stays open for free text)
+  → user taps/confirms/cancels → selectionResult follow-up turn (no message)
+  → service seeds the loop with the resolved refs (coordinate-free context line)
+  → agent runs the real action tool(s) on the exact ids
+      • control-plane (revoke/deny/request) → completes server-side, stateChanged:true
+      • share/view/public-link → emits the existing clientAction → ActionConfirmCard → crypto
+```
+
+`clientPrompt` and `clientAction` are **mutually exclusive on one response**
+(clarify first, then act). A turn carries exactly one of: `message`,
+`actionResult`, or `selectionResult`.
+
+### New / changed backend files
+
+| File | Change |
+|---|---|
+| `agents/location/tools.py` | **New** prompt-builder tools (below) + add them to `V2_LOCATION_TOOLS`. |
+| `agents/location/agent.yaml` | **Edit** — prompt additions for choice/confirm (§6). |
+| `services/location_chat_service.py` | **Edit** — v2 declarations gain the new tools; translate prompt-tool results → `clientPrompt`; handle the `selectionResult` turn (seed loop with refs, run actions). |
+| `api/routes/one/location_chat.py` | **Edit** — request gains `selectionResult`; response passes through `clientPrompt`; a turn requires one of message / actionResult / selectionResult. |
+
+## 5. The contract
+
+Two new optional fields, parallel to v2's `clientAction`/`actionResult`,
+fully backward-compatible. (Wire JSON is camelCase via Pydantic aliases, mirroring
+v2: e.g. `minSelections`, `allowFreeText`, `freeText`.)
+
+**Backend → client (on the chat response):**
+
+```python
+class PromptOption(BaseModel):        # coordinate-free
+    label: str                        # human text, e.g. "Mom (•••4821)"
+    ref: dict                         # real ids only — {recipientUserId, recipientKeyId} | {grantId} | {requestId} | {hours}
+    hint: str | None = None           # secondary line, e.g. "expires in 2h"
+
+class ClientPrompt(BaseModel):        # coordinate-free
+    id: str                           # correlation key
+    kind: str                         # "select" | "confirm"
+    purpose: str                      # "select_recipient" | "select_share" | "select_duration"
+                                      #   | "select_request" | "select_incoming" | "confirm_action"
+    question: str
+    options: list[PromptOption] | None = None     # for kind="select"
+    min_selections: int = 1           # 1 = must pick at least one
+    max_selections: int | None = None # 1 = single-pick; None = unlimited (multi-select)
+    allow_free_text: bool = True      # keep the composer active
+    confirm_label: str | None = None  # e.g. "Stop sharing", "Yes, stop all"
+    cancel_label: str | None = None
+    destructive: bool = False         # red styling for revoke / all / public link
+```
+
+**Client → backend (on the next request, sibling of `actionResult`):**
+
+```python
+class SelectionResult(BaseModel):     # coordinate-free
+    id: str                           # echoes ClientPrompt.id
+    kind: str                         # "select" | "confirm"
+    selected: list[dict] | None = None # chosen options' refs (for select)
+    confirmed: bool | None = None     # for confirm (yes/no)
+    free_text: str | None = None      # if the user typed instead of tapping
+    status: str                       # "answered" | "cancelled"
+```
+
+- **Free-text fallback:** if the user types into the composer while a prompt is
+  pending, the client sends a `selectionResult` with `free_text` set (the agent
+  re-resolves the typed answer) — not a plain `message`.
+- TS mirror types (`PromptOption`, `ClientPrompt`, `SelectionResult`) live beside
+  `ClientAction`/`ActionResult`; `LocationChatResponse` gains `clientPrompt?`.
+
+## 6. New prompt-builder tools + prompt wording
+
+All are coordinate-free `@hushh_tool`s that load real options from the service and
+return a directive the service turns into a `clientPrompt`. Added to
+`V2_LOCATION_TOOLS` and the v2 function declarations.
+
+| Tool | Scope | Options (refs) |
+|---|---|---|
+| `request_recipient_choice()` | `cap.location.live.share` | verified recipients → `{recipientUserId, recipientKeyId}`; service appends a synthetic **"Public link"** option; recipients with no key are flagged in `hint` |
+| `request_active_share_choice()` | `cap.location.live.revoke` | active outgoing shares → `{grantId}`; service appends a synthetic **"Stop all"** option |
+| `request_duration_choice()` | `cap.location.live.share` | `{hours:1}`, `{hours:8}`, `{hours:24}` + free text for custom |
+| `request_request_choice()` | `cap.location.live.request` | pending incoming requests → `{requestId}` |
+| `request_incoming_choice()` | `cap.location.live.view` | active incoming shares → `{grantId}` (for "show me where someone is") |
+| `request_confirmation(summary, destructive)` | `agent.one.orchestrate` | no options; `kind:"confirm"`, carries the summary to confirm |
+
+`publish_location_envelope` / `view_location_envelope` remain **non-LLM-callable**,
+unchanged.
+
+**`agent.yaml` prompt additions** (extend, don't rewrite, the v2 prompt):
+- "When a required detail is missing or ambiguous — who to share with, which share
+  to stop, how long, which request — do NOT guess. Call the matching
+  `request_*_choice` tool to ask, then act only on the ids the user picks."
+- "Before any irreversible or bulk action — creating a public link, sharing with
+  everyone, or stopping all shares — call `request_confirmation` and proceed only
+  if the user confirms."
+- Reinforces "never invent ids": the choice tools now supply the real ids.
+
+## 7. Flow walkthroughs
+
+**A. "Share my location" (no recipient, no duration)**
+1. `request_recipient_choice()` → `clientPrompt{select_recipient, max_selections:null}` (recipients + Public link + free text).
+2. User picks Mom → `selectionResult{selected:[{recipientUserId,recipientKeyId}]}`.
+3. `request_duration_choice()` → 1h/8h/24h/custom (skipped if the user already implied a duration).
+4. User picks 1h → `create_location_share(Mom,1h)` → existing **`publish_share` `clientAction`** → existing **`ActionConfirmCard`** → capture/encrypt/upload.
+
+**B. "Stop sharing my location" (no whom)**
+1. `request_active_share_choice()` → `clientPrompt{select_share, multi}` (Mom, Dad, … + **"Stop all"**).
+2a. User picks Mom + Dad → `revoke_location_share(g1)`, `revoke_location_share(g2)` → `stateChanged:true`.
+2b. User picks **"Stop all"** → `request_confirmation("Stop sharing with everyone?", destructive:true)` → Yes → revoke each active grant.
+
+**C. Ambiguous name** ("stop sharing with Mom", two matches) → `request_active_share_choice()` filtered to matches → pick the right one.
+
+**D. Destructive confirms** — public link & share-with-everyone route through `request_confirmation` before the action / `clientAction`.
+
+**Cancel** at any prompt → `selectionResult{status:"cancelled"}` → agent acknowledges, nothing mutates.
+
+## 8. Frontend
+
+- **New `ClarificationCard`** (sibling of `ActionConfirmCard`, same gold tokens),
+  rendered in the panel + overlay message stream when `pendingPrompt` is set:
+  - `kind:"select"` → pill options; single-tap auto-selects when `max_selections:1`;
+    checkboxes + a **Confirm** button when multi; `destructive` → red confirm.
+  - `kind:"confirm"` → Yes/No buttons.
+  - data-testids: `clarification-card`, `clarification-option`, `clarification-confirm`, `clarification-cancel`.
+- **`useLocationChat` gains** `pendingPrompt: ClientPrompt | null`, `answerPrompt(refs[])`,
+  `confirmPrompt(bool)`, `cancelPrompt()` — each POSTs a `selectionResult` follow-up
+  turn (mirrors the existing `report()` for `actionResult`); on response it may set
+  `pendingPrompt`, `pendingAction`, or neither.
+- **Free-text fallback:** while `pendingPrompt` is set, typing in the composer sends
+  a `selectionResult{free_text}` (not a plain message); the card clears.
+- `clientPrompt` and `clientAction` never coexist on one response, so at most one
+  card shows. `clear()` resets `pendingPrompt` too.
+- Files: `clarification-card.tsx` (**new**); `use-location-chat.ts`,
+  `location-chat-panel.tsx`, `location-chat-overlay.tsx`, `lib/one-location/types.ts`,
+  `lib/one-location/service.ts` (**edit**).
+
+## 9. Invariant ledger (all preserved)
+
+| Invariant | Status | Detail |
+|---|---|---|
+| Coordinate-free directives | **Preserved** | `clientPrompt`, `PromptOption.ref`, `selectionResult` carry only ids/labels — never lat/lng. |
+| Consent enforcement via `HushhContext` + per-tool scope | **Preserved** | Prompt-builder + action tools are `@hushh_tool`s; the `selectionResult` turn re-enters `HushhContext` to run resolved actions. |
+| Service owns real ids (anti-guessing) | **Strengthened** | Options built server-side from DB reads; the model selects, never fabricates ids. |
+| v2 crypto path unchanged | **Preserved** | share/view/public-link still terminate at `clientAction` + `ActionConfirmCard`; clarification only precedes it. |
+| Explicit confirm for destructive/bulk | **Added** | public link, share-with-everyone, stop-all gated by a `confirm` prompt. |
+| AES-256-GCM conversation at rest | **Preserved** | prompt/selection content is coordinate-free and safe to persist. |
+| Opaque errors | **Preserved** | tool/selection failures map to safe agent messages. |
+
+## 10. Testing strategy (TDD, extends v2 suites)
+
+**Backend**
+- Each `request_*_choice` tool returns coordinate-free options with **real refs**; no coordinate keys anywhere.
+- Service translates a prompt-tool result into `clientPrompt` (correct `kind`/`purpose`/`options`/`max_selections`).
+- A `selectionResult` turn seeds the loop so the agent acts on the **exact** ids (assert `revoke_location_share` called with the chosen `grantId`, never a guessed one).
+- `request_confirmation` → `confirm` prompt; "stop all" requires a confirm; `cancelled` → no mutation.
+- Prompt-builder tools are in `V2_LOCATION_TOOLS` but **never** expose `publish/view_envelope`.
+- A turn requires exactly one of message / actionResult / selectionResult (route 422 otherwise).
+
+**Frontend**
+- `ClarificationCard` renders select (single + multi) and confirm; tapping sends the correct `selectionResult` refs; multi-select Confirm; `destructive` styling.
+- Free-text-while-pending sends `free_text`; cancel sends `status:"cancelled"`.
+- `pendingPrompt` and `pendingAction` never render together; `clear()` resets both.
+- vitest + `tsc --noEmit` clean; existing v2 chat tests stay green.
+
+## 11. Decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Interaction types | Multi-select (covers single-pick) + Yes/No confirm + free-text fallback | User choice |
+| Return contract | Structured `selectionResult` with real refs | Deterministic; multi-select-friendly; kills id-guessing |
+| Who builds options | Server-side prompt-builder tools (service fills refs) | Model never serializes ids; mirrors v2 `propose_*` |
+| Composition | Clarify precedes the v2 crypto `clientAction`; `ActionConfirmCard` stays the crypto gate | Reuse v2; no double-contract |
+| Destructive/bulk | Explicit `confirm` prompt (stop-all, public link, share-with-everyone) | Safety |
+| Surface | New `ClarificationCard`; mutually exclusive with `ActionConfirmCard` | One card at a time |
+
+## 12. Skill plan (remainder of flow)
+
+1. **superpowers:brainstorming** — complete (this spec).
+2. User reviews this spec.
+3. **superpowers:writing-plans** — implementation plan (TDD task breakdown).
+4. **superpowers:subagent-driven-development** — build on `feat/one-location-agent-chat-v2`.

--- a/hushh-webapp/__tests__/components/action-confirm-card.test.tsx
+++ b/hushh-webapp/__tests__/components/action-confirm-card.test.tsx
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ActionConfirmCard } from "@/components/one-location/redesign/action-confirm-card";
+import type { ClientAction } from "@/lib/one-location/types";
+
+const baseAction: ClientAction = {
+  id: "act-1",
+  type: "publish_share",
+  shares: [{ grantId: "g1", recipientUserId: "r1", recipientKeyId: "k1", label: "Mom" }],
+  summary: "Share your live location with Mom",
+};
+
+describe("ActionConfirmCard", () => {
+  it("renders the action summary text", () => {
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Share your live location with Mom")).toBeTruthy();
+  });
+
+  it("fires onConfirm when the accept button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={false}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("action-confirm-accept"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onCancel when the cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={false}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("action-confirm-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT auto-confirm — onConfirm is not called without a click", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={false}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    // No click — just rendering must never call onConfirm
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("shows a 'Share' label for publish_share actions", () => {
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("action-confirm-accept").textContent).toMatch(/share/i);
+  });
+
+  it("shows a 'View' label for view_envelope actions", () => {
+    const viewAction: ClientAction = {
+      id: "a2",
+      type: "view_envelope",
+      grantId: "g2",
+      summary: "View Mom's location",
+    };
+    render(
+      <ActionConfirmCard
+        action={viewAction}
+        busy={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("action-confirm-accept").textContent).toMatch(/view/i);
+  });
+
+  it("shows a 'Create' label for create_public_link actions", () => {
+    const linkAction: ClientAction = {
+      id: "a3",
+      type: "create_public_link",
+      durationHours: 2,
+      summary: "Create a public link (viewable for 2h)",
+    };
+    render(
+      <ActionConfirmCard
+        action={linkAction}
+        busy={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("action-confirm-accept").textContent).toMatch(/create/i);
+  });
+
+  it("disables the cancel button when busy", () => {
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={true}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const cancelBtn = screen.getByTestId("action-confirm-cancel") as HTMLButtonElement;
+    expect(cancelBtn.disabled).toBe(true);
+    // Accept button is also disabled when isLoading
+    const acceptBtn = screen.getByTestId("action-confirm-accept") as HTMLButtonElement;
+    expect(acceptBtn.disabled).toBe(true);
+  });
+
+  it("has the action-confirm-card testid", () => {
+    render(
+      <ActionConfirmCard
+        action={baseAction}
+        busy={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("action-confirm-card")).toBeTruthy();
+  });
+});

--- a/hushh-webapp/__tests__/components/clarification-card.test.tsx
+++ b/hushh-webapp/__tests__/components/clarification-card.test.tsx
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ClarificationCard } from "@/components/one-location/redesign/clarification-card";
+import type { ClientPrompt } from "@/lib/one-location/types";
+
+const selectPrompt: ClientPrompt = {
+  id: "prm-1",
+  kind: "select",
+  purpose: "select_share",
+  question: "Which to stop?",
+  options: [
+    { label: "Mom", ref: { grantId: "g1" } },
+    { label: "Dad", ref: { grantId: "g2" } },
+  ],
+  maxSelections: null,
+  minSelections: 1,
+};
+
+const singlePickPrompt: ClientPrompt = {
+  id: "prm-2",
+  kind: "select",
+  purpose: "select_share",
+  question: "Pick one to stop?",
+  options: [
+    { label: "Mom", ref: { grantId: "g1" } },
+    { label: "Dad", ref: { grantId: "g2" } },
+  ],
+  maxSelections: 1,
+  minSelections: 1,
+};
+
+const confirmPromptData: ClientPrompt = {
+  id: "p",
+  kind: "confirm",
+  purpose: "confirm_action",
+  question: "Stop all?",
+  destructive: true,
+};
+
+describe("ClarificationCard", () => {
+  it("renders with clarification-card testid", () => {
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("clarification-card")).toBeTruthy();
+  });
+
+  it("renders the question text", () => {
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Which to stop?")).toBeTruthy();
+  });
+
+  it("multi-select: ticks options and answers with their refs", () => {
+    const onAnswer = vi.fn();
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={onAnswer}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Mom"));
+    fireEvent.click(screen.getByText("Dad"));
+    fireEvent.click(screen.getByTestId("clarification-confirm"));
+    expect(onAnswer).toHaveBeenCalledWith([{ grantId: "g1" }, { grantId: "g2" }]);
+  });
+
+  it("confirm prompt: Yes calls onConfirm(true)", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ClarificationCard
+        prompt={confirmPromptData}
+        busy={false}
+        onAnswer={vi.fn()}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("clarification-confirm"));
+    expect(onConfirm).toHaveBeenCalledWith(true);
+  });
+
+  it("single-pick: auto-answers immediately on tap without Confirm click", () => {
+    const onAnswer = vi.fn();
+    render(
+      <ClarificationCard
+        prompt={singlePickPrompt}
+        busy={false}
+        onAnswer={onAnswer}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Mom"));
+    expect(onAnswer).toHaveBeenCalledWith([{ grantId: "g1" }]);
+  });
+
+  it("does NOT auto-answer on render — onAnswer not called without a click", () => {
+    const onAnswer = vi.fn();
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={onAnswer}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  it("cancel calls onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("clarification-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirm button is disabled when nothing is selected (multi-select)", () => {
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const confirmBtn = screen.getByTestId("clarification-confirm") as HTMLButtonElement;
+    expect(confirmBtn.disabled).toBe(true);
+  });
+
+  it("disables cancel button when busy", () => {
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={true}
+        onAnswer={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const cancelBtn = screen.getByTestId("clarification-cancel") as HTMLButtonElement;
+    expect(cancelBtn.disabled).toBe(true);
+  });
+
+  it("renders option pills for select kind", () => {
+    render(
+      <ClarificationCard
+        prompt={selectPrompt}
+        busy={false}
+        onAnswer={vi.fn()}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const options = screen.getAllByTestId("clarification-option");
+    expect(options.length).toBe(2);
+  });
+});

--- a/hushh-webapp/__tests__/components/location-chat-suggestions.test.tsx
+++ b/hushh-webapp/__tests__/components/location-chat-suggestions.test.tsx
@@ -7,12 +7,15 @@ import {
 } from "@/components/one-location/redesign/location-chat-suggestions";
 
 describe("SuggestionChips", () => {
-  it("exposes exactly the four control-plane prompts", () => {
+  it("exposes the control-plane prompts including the v2 chips", () => {
     expect(LOCATION_SUGGESTION_CHIPS.map((c) => c.label)).toEqual([
       "Who can see me?",
       "Stop sharing with…",
       "Ask someone to share",
       "Deny a request",
+      "Share my location with…",
+      "Show me where someone is",
+      "Make a public link",
     ]);
   });
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -162,22 +162,31 @@ vi.mock("sonner", () => {
   };
 });
 
+// Capture the props passed to LocationChatPanel so we can assert on userId.
+let lastLocationChatPanelProps: {
+  vaultOwnerToken: string | null;
+  userId?: string;
+  onStateChanged?: () => void;
+} | null = null;
+
 // LocationChatPanel now renders unconditionally (locked stub when vault is locked).
 // Mock it here so its suggestion chips don't collide with the hub's own buttons
 // (e.g. "Ask someone") in tests that query by accessible name.
 vi.mock(
   "@/components/one-location/redesign/location-chat-panel",
   () => ({
-    LocationChatPanel: ({
-      vaultOwnerToken,
-    }: {
+    LocationChatPanel: (props: {
       vaultOwnerToken: string | null;
-    }) =>
-      vaultOwnerToken ? null : (
+      userId?: string;
+      onStateChanged?: () => void;
+    }) => {
+      lastLocationChatPanelProps = props;
+      return props.vaultOwnerToken ? null : (
         <section data-testid="location-chat-panel">
           <p>Unlock your vault to use the assistant.</p>
         </section>
-      ),
+      );
+    },
   }),
 );
 
@@ -553,6 +562,15 @@ describe("OneLocationAgentPage", () => {
       inviteCandidateCount: 0,
       sourcePlatform: "ios",
     });
+  });
+
+  it("passes userId into the location chat panel", async () => {
+    lastLocationChatPanelProps = null;
+    render(<OneLocationAgentPage />);
+    // The panel renders immediately (before the location entry flow), so props
+    // are captured synchronously on first render.
+    await waitFor(() => expect(lastLocationChatPanelProps).not.toBeNull());
+    expect(lastLocationChatPanelProps?.userId).toBe("user_a");
   });
 
   it("renders the One-owned encrypted location control surface", async () => {

--- a/hushh-webapp/__tests__/components/use-location-chat.test.tsx
+++ b/hushh-webapp/__tests__/components/use-location-chat.test.tsx
@@ -241,6 +241,11 @@ describe("useLocationChat — action dispatcher", () => {
         actionResult: expect.objectContaining({ type: "publish_share", status: "completed" }),
       }),
     );
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.not.objectContaining({ latitude: expect.anything() }),
+      }),
+    );
     await waitFor(() => expect(onStateChanged).toHaveBeenCalled());
     expect(result.current.pendingAction).toBeNull();
   });
@@ -383,6 +388,53 @@ describe("useLocationChat — action dispatcher", () => {
         actionResult: expect.objectContaining({ type: "view_envelope", status: "completed" }),
       }),
     );
+  });
+
+  it("view_envelope: reports failed with 'userId not configured' when hook has no userId", async () => {
+    mockChat
+      .mockResolvedValueOnce({
+        conversationId: "c-noid",
+        response: "I'll show you their location.",
+        isComplete: true,
+        stateChanged: false,
+        clientAction: {
+          id: "act-noid",
+          type: "view_envelope" as const,
+          grantId: "g-noid",
+          summary: "View shared location",
+        },
+      })
+      .mockResolvedValueOnce({
+        conversationId: "c-noid",
+        response: "Sorry — couldn't fetch.",
+        isComplete: true,
+        stateChanged: false,
+      });
+
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok" }), // no userId
+    );
+
+    await act(async () => {
+      await result.current.send("show me their location");
+    });
+    expect(result.current.pendingAction?.type).toBe("view_envelope");
+
+    await act(async () => {
+      await result.current.confirmAction();
+    });
+
+    expect(vi.mocked(OneLocationService.viewEnvelope)).not.toHaveBeenCalled();
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.objectContaining({
+          type: "view_envelope",
+          status: "failed",
+          detail: "userId not configured",
+        }),
+      }),
+    );
+    expect(result.current.pendingAction).toBeNull();
   });
 
   it("create_public_link: confirm captures, creates invite, reports completed with publicUrl", async () => {

--- a/hushh-webapp/__tests__/components/use-location-chat.test.tsx
+++ b/hushh-webapp/__tests__/components/use-location-chat.test.tsx
@@ -1,14 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 import {
   LOCATION_CHAT_ERROR_TEXT,
   useLocationChat,
 } from "@/components/one-location/redesign/use-location-chat";
 import { OneLocationService } from "@/lib/one-location/service";
+import * as encryption from "@/lib/one-location/encryption";
 
 vi.mock("@/lib/one-location/service", () => ({
-  OneLocationService: { chat: vi.fn() },
+  OneLocationService: {
+    chat: vi.fn(),
+    captureCurrentPosition: vi.fn(),
+    getState: vi.fn(),
+    storeEnvelope: vi.fn(),
+    viewEnvelope: vi.fn(),
+    createPublicInvite: vi.fn(),
+    revokeGrant: vi.fn(),
+  },
 }));
 vi.mock("@/lib/capacitor", () => ({
   HushhLocation: {
@@ -21,11 +30,25 @@ vi.mock("@/lib/capacitor", () => ({
     requestLocationPermission: vi.fn(),
   },
 }));
+vi.mock("@/lib/one-location/encryption", () => ({
+  encryptLocationForRecipient: vi.fn(),
+  decryptLocationEnvelope: vi.fn(),
+}));
 
 const mockChat = vi.mocked(OneLocationService.chat);
 
 describe("useLocationChat", () => {
-  beforeEach(() => mockChat.mockReset());
+  beforeEach(() => {
+    mockChat.mockReset();
+    vi.mocked(OneLocationService.captureCurrentPosition).mockReset();
+    vi.mocked(OneLocationService.getState).mockReset();
+    vi.mocked(OneLocationService.storeEnvelope).mockReset();
+    vi.mocked(OneLocationService.viewEnvelope).mockReset();
+    vi.mocked(OneLocationService.createPublicInvite).mockReset();
+    vi.mocked(OneLocationService.revokeGrant).mockReset();
+    vi.mocked(encryption.encryptLocationForRecipient).mockReset();
+    vi.mocked(encryption.decryptLocationEnvelope).mockReset();
+  });
 
   it("appends user + assistant messages and reuses conversationId across turns", async () => {
     mockChat.mockResolvedValue({
@@ -126,5 +149,401 @@ describe("useLocationChat", () => {
       await result.current.send("again");
     });
     expect(mockChat.mock.calls[1][0].conversationId).toBeNull();
+  });
+});
+
+describe("useLocationChat — action dispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publish_share: confirm captures, encrypts per recipient, uploads, reports completed", async () => {
+    const mockPoint = {
+      latitude: 1,
+      longitude: 2,
+      capturedAt: "now",
+      sourcePlatform: "web" as const,
+    };
+    const mockEnvelope = {
+      algorithm: "ECDH-P256-AES256-GCM" as const,
+      recipientKeyId: "k1",
+      ciphertext: "x",
+      iv: "iv",
+      senderEphemeralPublicKeyJwk: {} as JsonWebKey,
+      capturedAt: "now",
+      sourcePlatform: "web" as const,
+    };
+
+    mockChat
+      .mockResolvedValueOnce({
+        conversationId: "c1",
+        response: "Ready to share with Mom.",
+        isComplete: true,
+        stateChanged: false,
+        clientAction: {
+          id: "act-1",
+          type: "publish_share" as const,
+          shares: [
+            {
+              grantId: "g1",
+              recipientUserId: "r1",
+              recipientKeyId: "k1",
+              label: "Mom",
+            },
+          ],
+          summary: "Share your live location with Mom",
+        },
+      })
+      .mockResolvedValueOnce({
+        conversationId: "c1",
+        response: "Done — shared.",
+        isComplete: true,
+        stateChanged: true,
+      });
+
+    vi.mocked(OneLocationService.captureCurrentPosition).mockResolvedValue(mockPoint);
+    vi.mocked(OneLocationService.getState).mockResolvedValue({
+      recipients: [{ userId: "r1", displayName: "Mom", phoneVerified: true, keyId: "k1", publicKeyJwk: { kid: "k1" } as JsonWebKey, keyAlgorithm: "ECDH-P256", canReceiveLocation: true }],
+      ownerGrants: [],
+      receivedGrants: [],
+      requests: [],
+      referrals: [],
+      publicInvites: [],
+      publicInviteSubmissions: [],
+      capabilityScopes: [],
+    });
+    vi.mocked(encryption.encryptLocationForRecipient).mockResolvedValue(mockEnvelope);
+    vi.mocked(OneLocationService.storeEnvelope).mockResolvedValue(mockEnvelope);
+
+    const onStateChanged = vi.fn();
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok", userId: "u1", onStateChanged }),
+    );
+
+    await act(async () => {
+      await result.current.send("share with Mom");
+    });
+    expect(result.current.pendingAction?.type).toBe("publish_share");
+
+    await act(async () => {
+      await result.current.confirmAction();
+    });
+
+    expect(vi.mocked(OneLocationService.captureCurrentPosition)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(encryption.encryptLocationForRecipient)).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientKeyId: "k1", recipientPublicKeyJwk: { kid: "k1" } }),
+    );
+    expect(vi.mocked(OneLocationService.storeEnvelope)).toHaveBeenCalledWith(
+      expect.objectContaining({ grantId: "g1" }),
+    );
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.objectContaining({ type: "publish_share", status: "completed" }),
+      }),
+    );
+    await waitFor(() => expect(onStateChanged).toHaveBeenCalled());
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("publish_share: cancel revokes the grant and reports cancelled", async () => {
+    mockChat
+      .mockResolvedValueOnce({
+        conversationId: "c1",
+        response: "Ready.",
+        isComplete: true,
+        stateChanged: false,
+        clientAction: {
+          id: "act-1",
+          type: "publish_share" as const,
+          shares: [
+            {
+              grantId: "g1",
+              recipientUserId: "r1",
+              recipientKeyId: "k1",
+              label: "Mom",
+            },
+          ],
+          summary: "Share with Mom",
+        },
+      })
+      .mockResolvedValueOnce({
+        conversationId: "c1",
+        response: "No problem.",
+        isComplete: true,
+        stateChanged: false,
+      });
+
+    vi.mocked(OneLocationService.revokeGrant).mockResolvedValue({
+      id: "g1",
+      ownerUserId: "u1",
+      recipientUserId: "r1",
+      recipientKeyId: "k1",
+      status: "revoked",
+      consentScope: "",
+      capabilityScopes: [],
+      durationHours: 1,
+    });
+
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+    );
+    await act(async () => {
+      await result.current.send("share with Mom");
+    });
+    await act(async () => {
+      await result.current.cancelAction();
+    });
+
+    expect(vi.mocked(OneLocationService.revokeGrant)).toHaveBeenCalledWith(
+      expect.objectContaining({ grantId: "g1" }),
+    );
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.objectContaining({ status: "cancelled" }),
+      }),
+    );
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("view_envelope: confirm decrypts envelope and sets viewedPoint", async () => {
+    const mockEnvelope = {
+      algorithm: "ECDH-P256-AES256-GCM" as const,
+      recipientKeyId: "k1",
+      ciphertext: "c",
+      iv: "iv",
+      senderEphemeralPublicKeyJwk: {} as JsonWebKey,
+      capturedAt: "now",
+      sourcePlatform: "web" as const,
+    };
+    const mockPoint = {
+      latitude: 37.5,
+      longitude: -122.1,
+      capturedAt: "now",
+      sourcePlatform: "web" as const,
+    };
+
+    mockChat
+      .mockResolvedValueOnce({
+        conversationId: "c2",
+        response: "I'll show you their location.",
+        isComplete: true,
+        stateChanged: false,
+        clientAction: {
+          id: "act-2",
+          type: "view_envelope" as const,
+          grantId: "g2",
+          summary: "View shared location",
+        },
+      })
+      .mockResolvedValueOnce({
+        conversationId: "c2",
+        response: "Shown.",
+        isComplete: true,
+        stateChanged: false,
+      });
+
+    vi.mocked(OneLocationService.viewEnvelope).mockResolvedValue({
+      grant: {
+        id: "g2",
+        ownerUserId: "r1",
+        recipientUserId: "u1",
+        recipientKeyId: "k1",
+        status: "active",
+        consentScope: "",
+        capabilityScopes: [],
+        durationHours: 1,
+      },
+      envelope: mockEnvelope,
+    });
+    vi.mocked(encryption.decryptLocationEnvelope).mockResolvedValue(mockPoint);
+
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+    );
+
+    await act(async () => {
+      await result.current.send("show me their location");
+    });
+    expect(result.current.pendingAction?.type).toBe("view_envelope");
+
+    await act(async () => {
+      await result.current.confirmAction();
+    });
+
+    expect(vi.mocked(OneLocationService.viewEnvelope)).toHaveBeenCalledWith(
+      expect.objectContaining({ grantId: "g2" }),
+    );
+    expect(vi.mocked(encryption.decryptLocationEnvelope)).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", envelope: mockEnvelope }),
+    );
+    expect(result.current.viewedPoint).toEqual(mockPoint);
+    expect(result.current.pendingAction).toBeNull();
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.objectContaining({ type: "view_envelope", status: "completed" }),
+      }),
+    );
+  });
+
+  it("create_public_link: confirm captures, creates invite, reports completed with publicUrl", async () => {
+    const mockPoint = {
+      latitude: 10,
+      longitude: 20,
+      capturedAt: "now",
+      sourcePlatform: "web" as const,
+    };
+
+    mockChat
+      .mockResolvedValueOnce({
+        conversationId: "c3",
+        response: "Creating a public link.",
+        isComplete: true,
+        stateChanged: false,
+        clientAction: {
+          id: "act-3",
+          type: "create_public_link" as const,
+          durationHours: 2,
+          summary: "Create a public location link",
+        },
+      })
+      .mockResolvedValueOnce({
+        conversationId: "c3",
+        response: "Link created!",
+        isComplete: true,
+        stateChanged: false,
+      });
+
+    vi.mocked(OneLocationService.captureCurrentPosition).mockResolvedValue(mockPoint);
+    vi.mocked(OneLocationService.createPublicInvite).mockResolvedValue({
+      invite: {
+        id: "inv-1",
+        ownerUserId: "u1",
+        status: "active",
+        durationHours: 2,
+      },
+      publicToken: "tok123",
+      publicUrl: "https://hushh.ai/location/tok123",
+    });
+
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+    );
+
+    await act(async () => {
+      await result.current.send("create a public link");
+    });
+    expect(result.current.pendingAction?.type).toBe("create_public_link");
+
+    await act(async () => {
+      await result.current.confirmAction();
+    });
+
+    expect(vi.mocked(OneLocationService.captureCurrentPosition)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(OneLocationService.createPublicInvite)).toHaveBeenCalledWith(
+      expect.objectContaining({ durationHours: 2, locationSnapshot: mockPoint }),
+    );
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.objectContaining({
+          type: "create_public_link",
+          status: "completed",
+          publicUrl: "https://hushh.ai/location/tok123",
+        }),
+      }),
+    );
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("confirmAction: reports failed when crypto throws", async () => {
+    mockChat
+      .mockResolvedValueOnce({
+        conversationId: "c4",
+        response: "Ready.",
+        isComplete: true,
+        stateChanged: false,
+        clientAction: {
+          id: "act-4",
+          type: "publish_share" as const,
+          shares: [
+            {
+              grantId: "g4",
+              recipientUserId: "r4",
+              recipientKeyId: "k4",
+              label: "Alice",
+            },
+          ],
+          summary: "Share with Alice",
+        },
+      })
+      .mockResolvedValueOnce({
+        conversationId: "c4",
+        response: "Sorry, something went wrong.",
+        isComplete: true,
+        stateChanged: false,
+      });
+
+    vi.mocked(OneLocationService.captureCurrentPosition).mockResolvedValue({
+      latitude: 1,
+      longitude: 2,
+      capturedAt: "now",
+      sourcePlatform: "web" as const,
+    });
+    vi.mocked(OneLocationService.getState).mockResolvedValue({
+      recipients: [],
+      ownerGrants: [],
+      receivedGrants: [],
+      requests: [],
+      referrals: [],
+      publicInvites: [],
+      publicInviteSubmissions: [],
+      capabilityScopes: [],
+    });
+
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+    );
+
+    await act(async () => {
+      await result.current.send("share with Alice");
+    });
+
+    await act(async () => {
+      await result.current.confirmAction();
+    });
+
+    expect(mockChat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        actionResult: expect.objectContaining({ status: "failed" }),
+      }),
+    );
+    expect(result.current.pendingAction).toBeNull();
+  });
+
+  it("clear() resets pendingAction and viewedPoint", async () => {
+    mockChat.mockResolvedValueOnce({
+      conversationId: "c5",
+      response: "Ready.",
+      isComplete: true,
+      stateChanged: false,
+      clientAction: {
+        id: "act-5",
+        type: "publish_share" as const,
+        shares: [],
+        summary: "Share",
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }),
+    );
+
+    await act(async () => {
+      await result.current.send("share");
+    });
+    expect(result.current.pendingAction).not.toBeNull();
+
+    act(() => result.current.clear());
+    expect(result.current.pendingAction).toBeNull();
+    expect(result.current.viewedPoint).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/components/use-location-chat.test.tsx
+++ b/hushh-webapp/__tests__/components/use-location-chat.test.tsx
@@ -599,3 +599,65 @@ describe("useLocationChat — action dispatcher", () => {
     expect(result.current.viewedPoint).toBeNull();
   });
 });
+
+describe("useLocationChat — pending prompt", () => {
+  const svc = vi.mocked(OneLocationService);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets pendingPrompt from a clientPrompt response", async () => {
+    svc.chat.mockResolvedValueOnce({
+      conversationId: "c1",
+      response: "Which sharing do you want to stop?",
+      isComplete: true,
+      stateChanged: false,
+      clientPrompt: {
+        id: "prm-1",
+        kind: "select",
+        purpose: "select_share",
+        question: "Which sharing do you want to stop?",
+        options: [{ label: "Mom", ref: { grantId: "g1" } }, { label: "Stop all", ref: { all: true } }],
+      },
+    });
+    const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }));
+    await act(async () => { await result.current.send("stop sharing"); });
+    expect(result.current.pendingPrompt?.purpose).toBe("select_share");
+  });
+
+  it("answerPrompt sends selected refs and clears the prompt", async () => {
+    svc.chat
+      .mockResolvedValueOnce({
+        conversationId: "c1", response: "?", isComplete: true, stateChanged: false,
+        clientPrompt: { id: "prm-1", kind: "select", purpose: "select_share", question: "?", options: [{ label: "Mom", ref: { grantId: "g1" } }] },
+      })
+      .mockResolvedValueOnce({ conversationId: "c1", response: "Stopped.", isComplete: true, stateChanged: true });
+    const onStateChanged = vi.fn();
+    const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1", onStateChanged }));
+    await act(async () => { await result.current.send("stop sharing"); });
+    await act(async () => { await result.current.answerPrompt([{ grantId: "g1" }]); });
+    expect(svc.chat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectionResult: expect.objectContaining({ id: "prm-1", kind: "select", selected: [{ grantId: "g1" }], status: "answered" }),
+      }),
+    );
+    expect(result.current.pendingPrompt).toBeNull();
+    expect(onStateChanged).toHaveBeenCalled();
+  });
+
+  it("free text while a prompt is pending sends a freeText selection", async () => {
+    svc.chat
+      .mockResolvedValueOnce({
+        conversationId: "c1", response: "?", isComplete: true, stateChanged: false,
+        clientPrompt: { id: "prm-1", kind: "select", purpose: "select_recipient", question: "?", options: [] },
+      })
+      .mockResolvedValueOnce({ conversationId: "c1", response: "ok", isComplete: true, stateChanged: false });
+    const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }));
+    await act(async () => { await result.current.send("share"); });
+    await act(async () => { await result.current.send("my coworker Alex"); });
+    expect(svc.chat).toHaveBeenLastCalledWith(
+      expect.objectContaining({ selectionResult: expect.objectContaining({ freeText: "my coworker Alex", status: "answered" }) }),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/components/use-location-chat.test.tsx
+++ b/hushh-webapp/__tests__/components/use-location-chat.test.tsx
@@ -660,4 +660,42 @@ describe("useLocationChat — pending prompt", () => {
       expect.objectContaining({ selectionResult: expect.objectContaining({ freeText: "my coworker Alex", status: "answered" }) }),
     );
   });
+
+  it("confirmPrompt(true) sends confirmed selectionResult and clears pendingPrompt", async () => {
+    svc.chat
+      .mockResolvedValueOnce({
+        conversationId: "c1", response: "Stop all?", isComplete: true, stateChanged: false,
+        clientPrompt: { id: "prm-c", kind: "confirm", purpose: "confirm_action", question: "Stop all?" },
+      })
+      .mockResolvedValueOnce({ conversationId: "c1", response: "Done.", isComplete: true, stateChanged: false });
+    const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }));
+    await act(async () => { await result.current.send("stop all sharing"); });
+    expect(result.current.pendingPrompt?.id).toBe("prm-c");
+    await act(async () => { await result.current.confirmPrompt(true); });
+    expect(svc.chat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectionResult: expect.objectContaining({ id: "prm-c", kind: "confirm", confirmed: true, status: "answered" }),
+      }),
+    );
+    expect(result.current.pendingPrompt).toBeNull();
+  });
+
+  it("cancelPrompt() sends cancelled selectionResult and clears pendingPrompt", async () => {
+    svc.chat
+      .mockResolvedValueOnce({
+        conversationId: "c1", response: "Stop all?", isComplete: true, stateChanged: false,
+        clientPrompt: { id: "prm-c", kind: "confirm", purpose: "confirm_action", question: "Stop all?" },
+      })
+      .mockResolvedValueOnce({ conversationId: "c1", response: "Cancelled.", isComplete: true, stateChanged: false });
+    const { result } = renderHook(() => useLocationChat({ vaultOwnerToken: "tok", userId: "u1" }));
+    await act(async () => { await result.current.send("stop all sharing"); });
+    expect(result.current.pendingPrompt?.id).toBe("prm-c");
+    await act(async () => { await result.current.cancelPrompt(); });
+    expect(svc.chat).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selectionResult: expect.objectContaining({ id: "prm-c", kind: "confirm", status: "cancelled" }),
+      }),
+    );
+    expect(result.current.pendingPrompt).toBeNull();
+  });
 });

--- a/hushh-webapp/__tests__/services/location-chat-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-chat-service.test.ts
@@ -56,6 +56,7 @@ describe("OneLocationService.chat", () => {
         message: "stop sharing with Mom",
         conversationId: "conv-1",
         actionResult: null,
+        selectionResult: null,
       }),
     });
     expect(result.stateChanged).toBe(true);
@@ -72,7 +73,7 @@ describe("OneLocationService.chat", () => {
     await OneLocationService.chat({ vaultOwnerToken: "t", message: "hi" });
 
     const body = JSON.parse((mockApiJson.mock.calls[0][1] as RequestInit).body as string);
-    expect(body).toEqual({ message: "hi", conversationId: null, actionResult: null });
+    expect(body).toEqual({ message: "hi", conversationId: null, actionResult: null, selectionResult: null });
   });
 });
 
@@ -95,6 +96,22 @@ describe("OneLocationService.chat actionResult", () => {
 
     const body = JSON.parse((mockApiJson.mock.calls[0][1] as RequestInit).body as string);
     expect(body.actionResult).toEqual({ id: "a1", type: "publish_share", status: "completed" });
+    expect(body.message ?? null).toBeNull();
+  });
+});
+
+describe("OneLocationService.chat selectionResult", () => {
+  beforeEach(() => mockApiJson.mockReset());
+
+  it("sends selectionResult and omits message", async () => {
+    mockApiJson.mockResolvedValue({ conversationId: "c1", response: "ok", isComplete: true, stateChanged: true });
+    await OneLocationService.chat({
+      vaultOwnerToken: "tok",
+      conversationId: "c1",
+      selectionResult: { id: "prm-1", kind: "select", selected: [{ grantId: "g1" }], status: "answered" },
+    });
+    const body = JSON.parse((mockApiJson.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.selectionResult).toEqual({ id: "prm-1", kind: "select", selected: [{ grantId: "g1" }], status: "answered" });
     expect(body.message ?? null).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/services/location-chat-service.test.ts
+++ b/hushh-webapp/__tests__/services/location-chat-service.test.ts
@@ -52,7 +52,11 @@ describe("OneLocationService.chat", () => {
         Authorization: "Bearer vault-token",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ message: "stop sharing with Mom", conversationId: "conv-1" }),
+      body: JSON.stringify({
+        message: "stop sharing with Mom",
+        conversationId: "conv-1",
+        actionResult: null,
+      }),
     });
     expect(result.stateChanged).toBe(true);
   });
@@ -68,6 +72,29 @@ describe("OneLocationService.chat", () => {
     await OneLocationService.chat({ vaultOwnerToken: "t", message: "hi" });
 
     const body = JSON.parse((mockApiJson.mock.calls[0][1] as RequestInit).body as string);
-    expect(body).toEqual({ message: "hi", conversationId: null });
+    expect(body).toEqual({ message: "hi", conversationId: null, actionResult: null });
+  });
+});
+
+describe("OneLocationService.chat actionResult", () => {
+  beforeEach(() => mockApiJson.mockReset());
+
+  it("sends actionResult and omits message when reporting completion", async () => {
+    mockApiJson.mockResolvedValue({
+      conversationId: "c1",
+      response: "Done.",
+      isComplete: true,
+      stateChanged: true,
+    });
+
+    await OneLocationService.chat({
+      vaultOwnerToken: "tok",
+      conversationId: "c1",
+      actionResult: { id: "a1", type: "publish_share", status: "completed" },
+    });
+
+    const body = JSON.parse((mockApiJson.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.actionResult).toEqual({ id: "a1", type: "publish_share", status: "completed" });
+    expect(body.message ?? null).toBeNull();
   });
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4226,6 +4226,7 @@ function OneLocationAgentPageContent() {
           )}
           <LocationChatPanel
             vaultOwnerToken={vaultOwnerToken ?? null}
+            userId={auth.userId ?? undefined}
             onStateChanged={() => {
               void refresh();
               dispatchConsentStateChanged({ source: "one_location_chat" });

--- a/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Eye, Link as LinkIcon, MapPin, Share2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { ClientAction } from "@/lib/one-location/types";
+
+const CONFIRM_LABEL: Record<ClientAction["type"], string> = {
+  publish_share: "Share",
+  view_envelope: "View",
+  create_public_link: "Create link",
+};
+
+const ACTION_ICON: Record<ClientAction["type"], typeof MapPin> = {
+  publish_share: Share2,
+  view_envelope: Eye,
+  create_public_link: LinkIcon,
+};
+
+export function ActionConfirmCard({
+  action,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  action: ClientAction;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const Icon = ACTION_ICON[action.type] ?? MapPin;
+  return (
+    <div
+      data-testid="action-confirm-card"
+      className="rounded-2xl border border-[#b8894d]/40 bg-[#b8894d]/5 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 text-[#b8894d]">
+          <Icon className="h-5 w-5" aria-hidden />
+        </span>
+        <p className="flex-1 text-sm font-medium">{action.summary}</p>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <Button
+          data-testid="action-confirm-accept"
+          size="sm"
+          isLoading={busy}
+          onClick={onConfirm}
+        >
+          {CONFIRM_LABEL[action.type] ?? "Confirm"}
+        </Button>
+        <Button
+          data-testid="action-confirm-cancel"
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/clarification-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/clarification-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import type { ClientPrompt, PromptOption } from "@/lib/one-location/types";
+
+function sameRef(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function ClarificationCard({
+  prompt,
+  busy,
+  onAnswer,
+  onConfirm,
+  onCancel,
+}: {
+  prompt: ClientPrompt;
+  busy: boolean;
+  onAnswer: (refs: Record<string, unknown>[]) => void;
+  onConfirm: (yes: boolean) => void;
+  onCancel: () => void;
+}) {
+  const [picked, setPicked] = useState<Record<string, unknown>[]>([]);
+  const single = prompt.kind === "select" && prompt.maxSelections === 1;
+
+  const toggle = (opt: PromptOption) => {
+    if (single) {
+      onAnswer([opt.ref]); // single-pick auto-answers on tap
+      return;
+    }
+    setPicked((prev) =>
+      prev.some((r) => sameRef(r, opt.ref))
+        ? prev.filter((r) => !sameRef(r, opt.ref))
+        : [...prev, opt.ref],
+    );
+  };
+
+  return (
+    <div
+      data-testid="clarification-card"
+      className="rounded-2xl border border-[#b8894d]/40 bg-[#b8894d]/5 p-4"
+    >
+      <p className="text-sm font-medium">{prompt.question}</p>
+
+      {prompt.kind === "select" ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {(prompt.options ?? []).map((opt) => {
+            const active = picked.some((r) => sameRef(r, opt.ref));
+            return (
+              <button
+                key={opt.label}
+                type="button"
+                data-testid="clarification-option"
+                disabled={busy}
+                onClick={() => toggle(opt)}
+                className={
+                  "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors " +
+                  (active
+                    ? "border-[#b8894d] bg-[#b8894d]/15 text-[#b8894d]"
+                    : "border-[color:var(--app-card-border-standard)] text-foreground hover:border-[#d4a574]/50")
+                }
+              >
+                {opt.label}
+                {opt.hint ? <span className="ml-1 opacity-60">· {opt.hint}</span> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <div className="mt-3 flex gap-2">
+        {prompt.kind === "confirm" ? (
+          <Button
+            data-testid="clarification-confirm"
+            size="sm"
+            isLoading={busy}
+            variant={prompt.destructive ? "destructive" : "default"}
+            onClick={() => onConfirm(true)}
+          >
+            {prompt.confirmLabel ?? "Yes"}
+          </Button>
+        ) : (
+          <Button
+            data-testid="clarification-confirm"
+            size="sm"
+            isLoading={busy}
+            disabled={busy || (!single && picked.length < (prompt.minSelections ?? 1))}
+            onClick={() => onAnswer(picked)}
+          >
+            {prompt.confirmLabel ?? "Confirm"}
+          </Button>
+        )}
+        <Button
+          data-testid="clarification-cancel"
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          {prompt.cancelLabel ?? "Cancel"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
-import type { ClientAction } from "@/lib/one-location/types";
+import type { ClientAction, ClientPrompt } from "@/lib/one-location/types";
 import { ActionConfirmCard } from "./action-confirm-card";
+import { ClarificationCard } from "./clarification-card";
 import { ChatComposer } from "./location-chat-composer";
 import { ChatMessageList } from "./location-chat-message-list";
 import type { ChatMessage } from "./use-location-chat";
@@ -19,6 +20,10 @@ export function LocationChatOverlay(props: {
   pendingAction?: ClientAction | null;
   confirmAction?: () => Promise<void>;
   cancelAction?: () => Promise<void>;
+  pendingPrompt?: ClientPrompt | null;
+  answerPrompt?: (refs: Record<string, unknown>[]) => Promise<void>;
+  confirmPrompt?: (yes: boolean) => Promise<void>;
+  cancelPrompt?: () => Promise<void>;
 }) {
   const {
     open,
@@ -32,6 +37,10 @@ export function LocationChatOverlay(props: {
     pendingAction,
     confirmAction,
     cancelAction,
+    pendingPrompt,
+    answerPrompt,
+    confirmPrompt,
+    cancelPrompt,
   } = props;
   return (
     <KaiControlSurface
@@ -50,7 +59,17 @@ export function LocationChatOverlay(props: {
       }
     >
       <ChatMessageList messages={messages} busy={busy} onRetry={onRetry} />
-      {pendingAction && confirmAction && cancelAction ? (
+      {pendingPrompt && answerPrompt && confirmPrompt && cancelPrompt ? (
+        <div className="px-4 pb-2 pt-1">
+          <ClarificationCard
+            prompt={pendingPrompt}
+            busy={busy}
+            onAnswer={answerPrompt}
+            onConfirm={confirmPrompt}
+            onCancel={cancelPrompt}
+          />
+        </div>
+      ) : pendingAction && confirmAction && cancelAction ? (
         <div className="px-4 pb-2 pt-1">
           <ActionConfirmCard
             action={pendingAction}

--- a/hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-overlay.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { KaiControlSurface } from "@/components/app-ui/kai-control-surface";
+import type { ClientAction } from "@/lib/one-location/types";
+import { ActionConfirmCard } from "./action-confirm-card";
 import { ChatComposer } from "./location-chat-composer";
 import { ChatMessageList } from "./location-chat-message-list";
 import type { ChatMessage } from "./use-location-chat";
@@ -14,9 +16,23 @@ export function LocationChatOverlay(props: {
   onChange: (value: string) => void;
   onSend: () => void;
   onRetry?: () => void;
+  pendingAction?: ClientAction | null;
+  confirmAction?: () => Promise<void>;
+  cancelAction?: () => Promise<void>;
 }) {
-  const { open, onOpenChange, messages, busy, value, onChange, onSend, onRetry } =
-    props;
+  const {
+    open,
+    onOpenChange,
+    messages,
+    busy,
+    value,
+    onChange,
+    onSend,
+    onRetry,
+    pendingAction,
+    confirmAction,
+    cancelAction,
+  } = props;
   return (
     <KaiControlSurface
       open={open}
@@ -34,6 +50,16 @@ export function LocationChatOverlay(props: {
       }
     >
       <ChatMessageList messages={messages} busy={busy} onRetry={onRetry} />
+      {pendingAction && confirmAction && cancelAction ? (
+        <div className="px-4 pb-2 pt-1">
+          <ActionConfirmCard
+            action={pendingAction}
+            busy={busy}
+            onConfirm={confirmAction}
+            onCancel={cancelAction}
+          />
+        </div>
+      ) : null}
     </KaiControlSurface>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/location-chat-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-panel.tsx
@@ -15,15 +15,17 @@ import { useLocationChat } from "./use-location-chat";
 
 export function LocationChatPanel(props: {
   vaultOwnerToken: string | null;
+  userId?: string;
   onStateChanged?: () => void;
 }) {
-  const { vaultOwnerToken, onStateChanged } = props;
+  const { vaultOwnerToken, userId, onStateChanged } = props;
   const [input, setInput] = useState("");
   const [overlayOpen, setOverlayOpen] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const chat = useLocationChat({
     vaultOwnerToken: vaultOwnerToken ?? "",
+    userId,
     onStateChanged,
   });
 
@@ -112,6 +114,19 @@ export function LocationChatPanel(props: {
             onConfirm={chat.confirmAction}
             onCancel={chat.cancelAction}
           />
+        </div>
+      ) : null}
+
+      {chat.viewedPoint ? (
+        <div className="mb-3">
+          <a
+            href={`https://www.google.com/maps?q=${chat.viewedPoint.latitude},${chat.viewedPoint.longitude}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm underline"
+          >
+            Open the shared location on the map
+          </a>
         </div>
       ) : null}
 

--- a/hushh-webapp/components/one-location/redesign/location-chat-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-panel.tsx
@@ -5,6 +5,7 @@ import { Maximize2, RotateCcw } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { ActionConfirmCard } from "./action-confirm-card";
+import { ClarificationCard } from "./clarification-card";
 import { BotAvatar } from "./location-chat-atoms";
 import { ChatComposer } from "./location-chat-composer";
 import { ChatMessageList } from "./location-chat-message-list";
@@ -106,7 +107,17 @@ export function LocationChatPanel(props: {
         </div>
       )}
 
-      {chat.pendingAction ? (
+      {chat.pendingPrompt ? (
+        <div className="mb-3">
+          <ClarificationCard
+            prompt={chat.pendingPrompt}
+            busy={chat.busy}
+            onAnswer={chat.answerPrompt}
+            onConfirm={chat.confirmPrompt}
+            onCancel={chat.cancelPrompt}
+          />
+        </div>
+      ) : chat.pendingAction ? (
         <div className="mb-3">
           <ActionConfirmCard
             action={chat.pendingAction}
@@ -150,6 +161,10 @@ export function LocationChatPanel(props: {
         pendingAction={chat.pendingAction}
         confirmAction={chat.confirmAction}
         cancelAction={chat.cancelAction}
+        pendingPrompt={chat.pendingPrompt}
+        answerPrompt={chat.answerPrompt}
+        confirmPrompt={chat.confirmPrompt}
+        cancelPrompt={chat.cancelPrompt}
       />
     </section>
   );

--- a/hushh-webapp/components/one-location/redesign/location-chat-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-panel.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { Maximize2, RotateCcw } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { ActionConfirmCard } from "./action-confirm-card";
 import { BotAvatar } from "./location-chat-atoms";
 import { ChatComposer } from "./location-chat-composer";
 import { ChatMessageList } from "./location-chat-message-list";
@@ -103,6 +104,17 @@ export function LocationChatPanel(props: {
         </div>
       )}
 
+      {chat.pendingAction ? (
+        <div className="mb-3">
+          <ActionConfirmCard
+            action={chat.pendingAction}
+            busy={chat.busy}
+            onConfirm={chat.confirmAction}
+            onCancel={chat.cancelAction}
+          />
+        </div>
+      ) : null}
+
       <ChatComposer
         value={input}
         onChange={setInput}
@@ -120,6 +132,9 @@ export function LocationChatPanel(props: {
         onChange={setInput}
         onSend={submit}
         onRetry={chat.retry}
+        pendingAction={chat.pendingAction}
+        confirmAction={chat.confirmAction}
+        cancelAction={chat.cancelAction}
       />
     </section>
   );

--- a/hushh-webapp/components/one-location/redesign/location-chat-suggestions.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-suggestions.tsx
@@ -21,6 +21,21 @@ export const LOCATION_SUGGESTION_CHIPS: SuggestionChip[] = [
     mode: "send",
     value: "Deny the latest location request",
   },
+  {
+    label: "Share my location with…",
+    mode: "prefill",
+    value: "Share my location with ",
+  },
+  {
+    label: "Show me where someone is",
+    mode: "send",
+    value: "Show me where someone is",
+  },
+  {
+    label: "Make a public link",
+    mode: "send",
+    value: "Make a public link to my location",
+  },
 ];
 
 export function SuggestionChips(props: {

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -199,9 +199,9 @@ export function useLocationChat(params: {
 
   const cancelPrompt = useCallback(async () => {
     const prompt = pendingPrompt;
-    if (!prompt) return;
+    if (!prompt || busy) return;
     await reportSelection({ id: prompt.id, kind: prompt.kind, status: "cancelled" });
-  }, [pendingPrompt, reportSelection]);
+  }, [pendingPrompt, busy, reportSelection]);
 
   const confirmAction = useCallback(async () => {
     const action = pendingAction;

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -181,9 +181,15 @@ export function useLocationChat(params: {
         }
         await report({ id: action.id, type: action.type, status: "completed" });
       } else if (action.type === "view_envelope") {
+        if (!userId) {
+          await report({ id: action.id, type: action.type, status: "failed", detail: "userId not configured" });
+          return;
+        }
+        const grantId = action.grantId;
+        if (!grantId) throw new Error("view_envelope action missing grantId");
         const { envelope } = await OneLocationService.viewEnvelope({
           vaultOwnerToken,
-          grantId: action.grantId as string,
+          grantId,
         });
         const point = await decryptLocationEnvelope({ userId, envelope });
         setViewedPoint(point);

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -10,7 +10,9 @@ import {
 import type {
   ActionResult,
   ClientAction,
+  ClientPrompt,
   PlainLocationPoint,
+  SelectionResult,
 } from "@/lib/one-location/types";
 
 export interface ChatMessage {
@@ -31,6 +33,10 @@ export interface UseLocationChat {
   confirmAction: () => Promise<void>;
   cancelAction: () => Promise<void>;
   viewedPoint: PlainLocationPoint | null;
+  pendingPrompt: ClientPrompt | null;
+  answerPrompt: (refs: Record<string, unknown>[]) => Promise<void>;
+  confirmPrompt: (yes: boolean) => Promise<void>;
+  cancelPrompt: () => Promise<void>;
 }
 
 export const LOCATION_CHAT_ERROR_TEXT =
@@ -45,12 +51,27 @@ export function useLocationChat(params: {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [busy, setBusy] = useState(false);
   const [pendingAction, setPendingAction] = useState<ClientAction | null>(null);
+  const [pendingPrompt, setPendingPrompt] = useState<ClientPrompt | null>(null);
   const [viewedPoint, setViewedPoint] = useState<PlainLocationPoint | null>(null);
   const conversationIdRef = useRef<string | null>(null);
   const lastSentRef = useRef<string | null>(null);
   const seqRef = useRef(0);
 
   const nextId = useCallback(() => `m-${seqRef.current++}`, []);
+
+  const applyResult = useCallback(
+    (result: Awaited<ReturnType<typeof OneLocationService.chat>>) => {
+      conversationIdRef.current = result.conversationId;
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "assistant", text: result.response, stateChanged: result.stateChanged },
+      ]);
+      setPendingAction(result.clientAction ?? null);
+      setPendingPrompt(result.clientPrompt ?? null);
+      if (result.stateChanged) onStateChanged?.();
+    },
+    [nextId, onStateChanged],
+  );
 
   const run = useCallback(
     async (message: string) => {
@@ -65,18 +86,7 @@ export function useLocationChat(params: {
           message,
           conversationId: conversationIdRef.current,
         });
-        conversationIdRef.current = result.conversationId;
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: nextId(),
-            role: "assistant",
-            text: result.response,
-            stateChanged: result.stateChanged,
-          },
-        ]);
-        if (result.clientAction) setPendingAction(result.clientAction);
-        if (result.stateChanged) onStateChanged?.();
+        applyResult(result);
       } catch {
         setMessages((prev) => [
           ...prev,
@@ -91,21 +101,7 @@ export function useLocationChat(params: {
         setBusy(false);
       }
     },
-    [vaultOwnerToken, onStateChanged, nextId],
-  );
-
-  const send = useCallback(
-    async (raw: string) => {
-      const message = raw.trim();
-      if (!message || busy) return;
-      lastSentRef.current = message;
-      setMessages((prev) => [
-        ...prev,
-        { id: nextId(), role: "user", text: message },
-      ]);
-      await run(message);
-    },
-    [busy, run, nextId],
+    [vaultOwnerToken, applyResult, nextId],
   );
 
   const retry = useCallback(async () => {
@@ -118,6 +114,7 @@ export function useLocationChat(params: {
     conversationIdRef.current = null;
     lastSentRef.current = null;
     setPendingAction(null);
+    setPendingPrompt(null);
     setViewedPoint(null);
   }, []);
 
@@ -130,17 +127,7 @@ export function useLocationChat(params: {
           conversationId: conversationIdRef.current,
           actionResult,
         });
-        conversationIdRef.current = result.conversationId;
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: nextId(),
-            role: "assistant",
-            text: result.response,
-            stateChanged: result.stateChanged,
-          },
-        ]);
-        if (result.stateChanged) onStateChanged?.();
+        applyResult(result);
       } catch {
         setMessages((prev) => [
           ...prev,
@@ -150,8 +137,71 @@ export function useLocationChat(params: {
         setBusy(false);
       }
     },
-    [vaultOwnerToken, onStateChanged, nextId],
+    [vaultOwnerToken, applyResult, nextId],
   );
+
+  const reportSelection = useCallback(
+    async (selectionResult: SelectionResult) => {
+      setBusy(true);
+      setPendingPrompt(null);
+      try {
+        const result = await OneLocationService.chat({
+          vaultOwnerToken,
+          conversationId: conversationIdRef.current,
+          selectionResult,
+        });
+        applyResult(result);
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", text: LOCATION_CHAT_ERROR_TEXT, errored: true },
+        ]);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [vaultOwnerToken, applyResult, nextId],
+  );
+
+  const send = useCallback(
+    async (raw: string) => {
+      const message = raw.trim();
+      if (!message || busy) return;
+      setMessages((prev) => [...prev, { id: nextId(), role: "user", text: message }]);
+      const prompt = pendingPrompt;
+      if (prompt) {
+        await reportSelection({ id: prompt.id, kind: prompt.kind, freeText: message, status: "answered" });
+        return;
+      }
+      lastSentRef.current = message;
+      await run(message);
+    },
+    [busy, run, nextId, pendingPrompt, reportSelection],
+  );
+
+  const answerPrompt = useCallback(
+    async (refs: Record<string, unknown>[]) => {
+      const prompt = pendingPrompt;
+      if (!prompt || busy) return;
+      await reportSelection({ id: prompt.id, kind: prompt.kind, selected: refs, status: "answered" });
+    },
+    [pendingPrompt, busy, reportSelection],
+  );
+
+  const confirmPrompt = useCallback(
+    async (yes: boolean) => {
+      const prompt = pendingPrompt;
+      if (!prompt || busy) return;
+      await reportSelection({ id: prompt.id, kind: prompt.kind, confirmed: yes, status: "answered" });
+    },
+    [pendingPrompt, busy, reportSelection],
+  );
+
+  const cancelPrompt = useCallback(async () => {
+    const prompt = pendingPrompt;
+    if (!prompt) return;
+    await reportSelection({ id: prompt.id, kind: prompt.kind, status: "cancelled" });
+  }, [pendingPrompt, reportSelection]);
 
   const confirmAction = useCallback(async () => {
     const action = pendingAction;
@@ -235,5 +285,9 @@ export function useLocationChat(params: {
     confirmAction,
     cancelAction,
     viewedPoint,
+    pendingPrompt,
+    answerPrompt,
+    confirmPrompt,
+    cancelPrompt,
   };
 }

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -3,6 +3,15 @@
 import { useCallback, useRef, useState } from "react";
 
 import { OneLocationService } from "@/lib/one-location/service";
+import {
+  decryptLocationEnvelope,
+  encryptLocationForRecipient,
+} from "@/lib/one-location/encryption";
+import type {
+  ActionResult,
+  ClientAction,
+  PlainLocationPoint,
+} from "@/lib/one-location/types";
 
 export interface ChatMessage {
   id: string;
@@ -18,6 +27,10 @@ export interface UseLocationChat {
   send: (message: string) => Promise<void>;
   retry: () => Promise<void>;
   clear: () => void;
+  pendingAction: ClientAction | null;
+  confirmAction: () => Promise<void>;
+  cancelAction: () => Promise<void>;
+  viewedPoint: PlainLocationPoint | null;
 }
 
 export const LOCATION_CHAT_ERROR_TEXT =
@@ -25,11 +38,14 @@ export const LOCATION_CHAT_ERROR_TEXT =
 
 export function useLocationChat(params: {
   vaultOwnerToken: string;
+  userId?: string;
   onStateChanged?: () => void;
 }): UseLocationChat {
-  const { vaultOwnerToken, onStateChanged } = params;
+  const { vaultOwnerToken, userId = "", onStateChanged } = params;
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [busy, setBusy] = useState(false);
+  const [pendingAction, setPendingAction] = useState<ClientAction | null>(null);
+  const [viewedPoint, setViewedPoint] = useState<PlainLocationPoint | null>(null);
   const conversationIdRef = useRef<string | null>(null);
   const lastSentRef = useRef<string | null>(null);
   const seqRef = useRef(0);
@@ -59,6 +75,7 @@ export function useLocationChat(params: {
             stateChanged: result.stateChanged,
           },
         ]);
+        if (result.clientAction) setPendingAction(result.clientAction);
         if (result.stateChanged) onStateChanged?.();
       } catch {
         setMessages((prev) => [
@@ -100,7 +117,117 @@ export function useLocationChat(params: {
     setMessages([]);
     conversationIdRef.current = null;
     lastSentRef.current = null;
+    setPendingAction(null);
+    setViewedPoint(null);
   }, []);
 
-  return { messages, busy, send, retry, clear };
+  const report = useCallback(
+    async (actionResult: ActionResult) => {
+      setBusy(true);
+      try {
+        const result = await OneLocationService.chat({
+          vaultOwnerToken,
+          conversationId: conversationIdRef.current,
+          actionResult,
+        });
+        conversationIdRef.current = result.conversationId;
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: nextId(),
+            role: "assistant",
+            text: result.response,
+            stateChanged: result.stateChanged,
+          },
+        ]);
+        if (result.stateChanged) onStateChanged?.();
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", text: LOCATION_CHAT_ERROR_TEXT, errored: true },
+        ]);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [vaultOwnerToken, onStateChanged, nextId],
+  );
+
+  const confirmAction = useCallback(async () => {
+    const action = pendingAction;
+    if (!action || busy) return;
+    setPendingAction(null);
+    try {
+      if (action.type === "publish_share") {
+        const point = await OneLocationService.captureCurrentPosition();
+        const state = await OneLocationService.getState(vaultOwnerToken);
+        for (const share of action.shares ?? []) {
+          const recipient = (state.recipients ?? []).find(
+            (r) => r.keyId === share.recipientKeyId,
+          );
+          if (!recipient?.publicKeyJwk) {
+            throw new Error(`${share.label} hasn't set up location sharing yet`);
+          }
+          const envelope = await encryptLocationForRecipient({
+            point,
+            recipientPublicKeyJwk: recipient.publicKeyJwk,
+            recipientKeyId: share.recipientKeyId,
+          });
+          await OneLocationService.storeEnvelope({
+            vaultOwnerToken,
+            grantId: share.grantId,
+            envelope,
+          });
+        }
+        await report({ id: action.id, type: action.type, status: "completed" });
+      } else if (action.type === "view_envelope") {
+        const { envelope } = await OneLocationService.viewEnvelope({
+          vaultOwnerToken,
+          grantId: action.grantId as string,
+        });
+        const point = await decryptLocationEnvelope({ userId, envelope });
+        setViewedPoint(point);
+        await report({ id: action.id, type: action.type, status: "completed" });
+      } else if (action.type === "create_public_link") {
+        const locationSnapshot = await OneLocationService.captureCurrentPosition();
+        const { publicUrl } = await OneLocationService.createPublicInvite({
+          vaultOwnerToken,
+          durationHours: action.durationHours ?? 1,
+          locationSnapshot,
+        });
+        await report({ id: action.id, type: action.type, status: "completed", publicUrl });
+      }
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : undefined;
+      await report({ id: action.id, type: action.type, status: "failed", detail });
+    }
+  }, [pendingAction, busy, vaultOwnerToken, userId, report]);
+
+  const cancelAction = useCallback(async () => {
+    const action = pendingAction;
+    if (!action) return;
+    setPendingAction(null);
+    if (action.type === "publish_share") {
+      for (const share of action.shares ?? []) {
+        try {
+          await OneLocationService.revokeGrant({ vaultOwnerToken, grantId: share.grantId });
+        } catch {
+          // best-effort cleanup; ignore
+        }
+      }
+    }
+    await report({ id: action.id, type: action.type, status: "cancelled" });
+  }, [pendingAction, vaultOwnerToken, report]);
+
+  return {
+    messages,
+    busy,
+    send,
+    retry,
+    clear,
+    pendingAction,
+    confirmAction,
+    cancelAction,
+    viewedPoint,
+  };
 }

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -3,6 +3,7 @@ import { ApiError, apiJson } from "@/lib/services/api-client";
 import type {
   ActionResult,
   LocationChatResponse,
+  SelectionResult,
   OneLocationAccessRequest,
   OneLocationActivityRange,
   OneLocationActivityResponse,
@@ -148,6 +149,7 @@ export class OneLocationService {
     message?: string;
     conversationId?: string | null;
     actionResult?: ActionResult;
+    selectionResult?: SelectionResult;
   }): Promise<LocationChatResponse> {
     return apiJson<LocationChatResponse>("/api/one/location/chat", {
       method: "POST",
@@ -156,6 +158,7 @@ export class OneLocationService {
         message: params.message ?? null,
         conversationId: params.conversationId ?? null,
         actionResult: params.actionResult ?? null,
+        selectionResult: params.selectionResult ?? null,
       }),
     });
   }

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -1,6 +1,7 @@
 import { HushhLocation } from "@/lib/capacitor";
 import { ApiError, apiJson } from "@/lib/services/api-client";
 import type {
+  ActionResult,
   LocationChatResponse,
   OneLocationAccessRequest,
   OneLocationActivityRange,
@@ -144,15 +145,17 @@ export class OneLocationService {
 
   static async chat(params: {
     vaultOwnerToken: string;
-    message: string;
+    message?: string;
     conversationId?: string | null;
+    actionResult?: ActionResult;
   }): Promise<LocationChatResponse> {
     return apiJson<LocationChatResponse>("/api/one/location/chat", {
       method: "POST",
       headers: jsonAuthHeaders(params.vaultOwnerToken),
       body: JSON.stringify({
-        message: params.message,
+        message: params.message ?? null,
         conversationId: params.conversationId ?? null,
+        actionResult: params.actionResult ?? null,
       }),
     });
   }

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -328,9 +328,36 @@ export type OneLocationEncryptedEnvelope = {
   metadata?: Record<string, unknown>;
 };
 
+export interface ShareTarget {
+  grantId: string;
+  recipientUserId: string;
+  recipientKeyId: string;
+  label: string;
+}
+
+export type ClientActionType = "publish_share" | "view_envelope" | "create_public_link";
+
+export interface ClientAction {
+  id: string;
+  type: ClientActionType;
+  shares?: ShareTarget[];
+  grantId?: string;
+  durationHours?: number;
+  summary: string;
+}
+
+export interface ActionResult {
+  id: string;
+  type: ClientActionType;
+  status: "completed" | "cancelled" | "failed";
+  publicUrl?: string;
+  detail?: string;
+}
+
 export interface LocationChatResponse {
   conversationId: string;
   response: string;
   isComplete: boolean;
   stateChanged: boolean;
+  clientAction?: ClientAction;
 }

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -354,10 +354,42 @@ export interface ActionResult {
   detail?: string;
 }
 
+export interface PromptOption {
+  label: string;
+  ref: Record<string, unknown>;
+  hint?: string | null;
+}
+
+export type ClientPromptKind = "select" | "confirm";
+
+export interface ClientPrompt {
+  id: string;
+  kind: ClientPromptKind;
+  purpose: string;
+  question: string;
+  options?: PromptOption[];
+  minSelections?: number;
+  maxSelections?: number | null;
+  allowFreeText?: boolean;
+  confirmLabel?: string | null;
+  cancelLabel?: string | null;
+  destructive?: boolean;
+}
+
+export interface SelectionResult {
+  id: string;
+  kind: ClientPromptKind;
+  selected?: Record<string, unknown>[];
+  confirmed?: boolean;
+  freeText?: string;
+  status: "answered" | "cancelled";
+}
+
 export interface LocationChatResponse {
   conversationId: string;
   response: string;
   isComplete: boolean;
   stateChanged: boolean;
   clientAction?: ClientAction;
+  clientPrompt?: ClientPrompt;
 }


### PR DESCRIPTION
# Description

Ships the **One Location agent chat v2** (crypto handoff, public links, platform-aware sharing) **plus a clarify-and-confirm interaction layer**. The agent can now drive coordinate-touching actions (share / approve / view / public link) via a structured agent→client handoff, and ask structured clarify/confirm questions (multi-select, Yes/No, free-text) when a command is underspecified — without the server or agent ever seeing plaintext coordinates (one bounded, owner-confirmed public-link snapshot exception, documented).

Built brainstorm → spec → plan → TDD (subagent-driven), with per-task reviews and a final whole-feature review (verdict: ready to merge, 0 Critical / 0 Important).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `POST /api/one/location/chat` — additive request fields (`actionResult`, `selectionResult`) + response fields (`clientAction`, `clientPrompt`); fully backward-compatible.

- API / schema / type changes:
  - [x] Listed below: new additive contract types `ClientAction` / `ActionResult` / `ClientPrompt` / `PromptOption` / `SelectionResult` (Pydantic + TS). No DB schema change.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None (reuses existing `one_location_*` tables, grants/envelopes/public-invite routes; **no new migration**).

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None (web chat surface; reuses already-shipped Capacitor geolocation; no native plugin change).

- Docs updated (exact files):
  - [x] Listed below:
    - `docs/superpowers/specs/2026-06-29-one-location-agent-chat-v2-design.md`
    - `docs/superpowers/specs/2026-06-30-one-location-clarify-confirm-design.md`
    - `docs/superpowers/plans/2026-06-29-one-location-agent-chat-v2.md`
    - `docs/superpowers/plans/2026-06-30-one-location-clarify-confirm.md`

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] consent / vault / location (coordinate-safety). **Preserved:** every server-side mutation runs as an `@hushh_tool` inside `HushhContext` (scope-validated); per-recipient shares are ciphertext-only (ECDH-P256-AES256-GCM, browser-side); the agent never sees/returns coordinates. **Relaxed (documented, bounded):** owner-confirmed, ≤24h, revocable public-link snapshot.

- Caller / proxy / backend pairing:
  - [x] Listed below: `OneLocationService.chat()` (web) ↔ `POST /api/one/location/chat` ↔ `LocationChatService.handle_turn`. Contract types mirrored field-for-field (verified in final review).

- Rollback or safe-failure behavior:
  - [x] Listed below: additive/optional fields — older clients ignore them; agent errors degrade to a safe canned reply; action/selection failures return opaque messages.

- UI browser or Playwright proof:
  - [x] Route/spec listed below: `/one/location` chat panel; component + hook covered by Vitest (see Testing).

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` (`tsc --noEmit` — clean)
  - [x] `cd hushh-webapp && npm test` (Vitest — location suites green)
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py ...`
  - Backend: `uv run python -m pytest tests/test_location_chat_*` — 42/42 green.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate (v2 was never merged to main; this is its first PR).
- [x] This PR changes a current reachable app/backend surface (`/one/location` chat + `POST /api/one/location/chat`).
- [x] Reachable production attach point: the One Location chat panel on `/one/location`, wired to the live endpoint.
- [x] New tests import and exercise production code (service/route/tools/hook/components), not only in-test mocks.
- [x] New helpers/components are wired to the live route and the page.
- [x] Required checks current on head; commits signed off; mergeable with `main` (branch is 3 commits behind main — will update if base-freshness requires).
- [x] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/...`, `components/one-location/...`, `lib/one-location/...`) + Python backend (`consent-protocol/...`).
- [x] **iOS**: N/A — no native plugin change; reuses shipped Capacitor geolocation.
- [x] **Android**: N/A — same reason.

## 🧪 Testing

- [x] Tested on Web (Vitest: `use-location-chat`, `clarification-card`, `action-confirm-card`, `location-chat-panel`, `location-chat-overlay`, `location-chat-service`, `one-location-agent-page` — 75/75; backend pytest 42/42; `tsc --noEmit` clean; eslint clean on touched files).
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data? Yes — live-location sharing control + coordinate handoff.
- [x] Consent enforced via `HushhContext` + per-`@hushh_tool` scope validation (DB-backed); publish/view envelope REST routes re-validate the HCT.
- [x] Sensitive surface touched: consent / vault / location / public ingress (public link).
- [x] Error path / safe-failure proved: opaque errors; agent-unavailable canned reply; cancel revokes envelope-less grants.
- Coordinate-safety: zero server-side plaintext coordinates for per-recipient shares; agent/`clientAction`/`clientPrompt`/`selectionResult` are coordinate-free by construction. Bounded exception: owner-confirmed public-link snapshot (≤24h, revocable) — see the v2 design spec invariant ledger.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes
