### PR TITLE
test(signal-chips): cover selected signal pressed state

### DIFF
--- a/hushh-webapp/__tests__/components/signal-chips.test.tsx
+++ b/hushh-webapp/__tests__/components/signal-chips.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SignalChips } from "@/components/kai/home/signal-chips";
+import type { KaiHomeSignal } from "@/lib/services/api-service";
+
+const signals: KaiHomeSignal[] = [
+  {
+    id: "quality-signal",
+    title: "Quality holding signal",
+    summary: "Quality names are leading the current tape.",
+    confidence: 0.82,
+    source_tags: ["quality"],
+    degraded: false,
+  },
+  {
+    id: "risk-signal",
+    title: "Risk-off signal",
+    summary: "Risk assets are cooling.",
+    confidence: 0.64,
+    source_tags: ["risk"],
+    degraded: false,
+  },
+];
+
+describe("SignalChips", () => {
+  it("covers selected signal pressed state", () => {
+    render(
+      <SignalChips
+        signals={signals}
+        selectedSignalId="quality-signal"
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: /quality holding signal/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("button", { name: /risk-off signal/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+});

--- a/hushh-webapp/components/kai/home/signal-chips.tsx
+++ b/hushh-webapp/components/kai/home/signal-chips.tsx
@@ -5,9 +5,15 @@ import type { KaiHomeSignal } from "@/lib/services/api-service";
 
 interface SignalChipsProps {
   signals: KaiHomeSignal[];
+  selectedSignalId?: string | null;
+  onSignalSelect?: (signal: KaiHomeSignal) => void;
 }
 
-export function SignalChips({ signals }: SignalChipsProps) {
+export function SignalChips({
+  signals,
+  selectedSignalId,
+  onSignalSelect,
+}: SignalChipsProps) {
   if (!signals.length) {
     return (
       <Card variant="muted" effect="fill" preset="compact">
@@ -20,19 +26,42 @@ export function SignalChips({ signals }: SignalChipsProps) {
 
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-      {signals.map((signal) => (
-        <Card key={signal.id} variant="none" effect="glass" preset="compact">
-          <CardContent className="space-y-2 p-3">
-            <div className="flex items-start justify-between gap-2">
-              <p className="text-sm font-semibold tracking-tight">{signal.title}</p>
+      {signals.map((signal) => {
+        const selected = selectedSignalId === signal.id;
+        const selectable = selectedSignalId !== undefined || Boolean(onSignalSelect);
+        const content = (
+          <>
+            <span className="flex items-start justify-between gap-2">
+              <span className="text-sm font-semibold tracking-tight">{signal.title}</span>
               <span className="rounded-full bg-background/70 px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
                 {(signal.confidence * 100).toFixed(0)}%
               </span>
-            </div>
-            <p className="text-xs leading-relaxed text-muted-foreground">{signal.summary}</p>
-          </CardContent>
-        </Card>
-      ))}
+            </span>
+            <span className="block text-xs leading-relaxed text-muted-foreground">
+              {signal.summary}
+            </span>
+          </>
+        );
+
+        return (
+          <Card key={signal.id} variant="none" effect="glass" preset="compact">
+            <CardContent className={selectable ? "p-0" : "space-y-2 p-3"}>
+              {selectable ? (
+                <button
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => onSignalSelect?.(signal)}
+                  className="w-full space-y-2 rounded-[inherit] p-3 text-left"
+                >
+                  {content}
+                </button>
+              ) : (
+                content
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds an opt-in selected signal state to SignalChips.
- Covers the selected and unselected aria-pressed contract.

## Proof
- Surface: SignalChips only.
- Contract: renders the real component; no module mocks.
- No overlap: signal chip pressed state plus matching focused test.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions