### PR TITLE
test(watchlist-strip): cover empty watchlist fallback

### DIFF
--- a/hushh-webapp/__tests__/components/watchlist-strip.test.tsx
+++ b/hushh-webapp/__tests__/components/watchlist-strip.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { WatchlistStrip } from "@/components/kai/home/watchlist-strip";
+
+describe("WatchlistStrip", () => {
+  it("covers empty watchlist fallback", () => {
+    render(<WatchlistStrip items={[]} />);
+
+    expect(
+      screen.getByText("No watchlist/holdings data available yet."),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the WatchlistStrip empty fallback copy.

## Proof
- Surface: WatchlistStrip test only.
- Contract: renders the real component; no module mocks.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions