### PR TITLE
test(dashboard-route-tabs): cover active tab current state

### DIFF
--- a/hushh-webapp/__tests__/components/dashboard-route-tabs.test.tsx
+++ b/hushh-webapp/__tests__/components/dashboard-route-tabs.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DashboardRouteTabs } from "@/components/kai/layout/dashboard-route-tabs";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/kai/dashboard",
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/navigation/kai-bottom-chrome-visibility", () => ({
+  useKaiBottomChromeVisibility: () => ({
+    hidden: false,
+    progress: 0,
+  }),
+}));
+
+vi.mock("@/lib/stores/kai-session-store", () => ({
+  useKaiSession: (
+    selector: (state: { busyOperations: Record<string, boolean> }) => unknown,
+  ) => selector({ busyOperations: {} }),
+}));
+
+describe("DashboardRouteTabs", () => {
+  it("covers active tab current state", async () => {
+    render(<DashboardRouteTabs embedded />);
+
+    const activeTab = await screen.findByRole("tab", {
+      name: "Portfolio",
+    });
+
+    expect(activeTab.getAttribute("aria-selected")).toBe("true");
+    expect(activeTab.getAttribute("aria-current")).toBe("page");
+  });
+});


### PR DESCRIPTION
## Summary
- Covers the active DashboardRouteTabs tab current-state contract.

## Proof
- Surface: DashboardRouteTabs test only.
- Contract: renders the real component with mocked route state.
- No overlap: new focused test file only.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions