### PR TITLE
test(edit-holding-modal): cover submit button type

### DIFF
--- a/hushh-webapp/__tests__/components/edit-holding-modal.test.tsx
+++ b/hushh-webapp/__tests__/components/edit-holding-modal.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditHoldingModal } from "@/components/kai/modals/edit-holding-modal";
+
+vi.mock("@/lib/kai/ticker-universe-cache", () => ({
+  getTickerUniverseSnapshot: () => [],
+  preloadTickerUniverse: () => Promise.resolve([]),
+  searchTickerUniverse: () => [],
+  searchTickerUniverseRemote: () => Promise.resolve([]),
+}));
+
+describe("EditHoldingModal", () => {
+  it("covers submit button type", () => {
+    render(
+      <EditHoldingModal
+        isOpen
+        holding={{
+          symbol: "AAPL",
+          name: "Apple Inc.",
+          quantity: 10,
+          price: 190,
+          market_value: 1900,
+        }}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: /save changes/i,
+    }) as HTMLButtonElement;
+
+    expect(submitButton.type).toBe("button");
+  });
+});

--- a/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
+++ b/hushh-webapp/components/kai/modals/edit-holding-modal.tsx
@@ -702,6 +702,7 @@ export function EditHoldingModal({
               </Button>
             </DrawerClose>
             <Button
+              type="button"
               onClick={handleSave}
               variant="none"
               effect="fill"


### PR DESCRIPTION
## Summary
- Adds an explicit button type to the EditHoldingModal save action.
- Covers the submit button type with a focused component test.

## Proof
- Surface: EditHoldingModal only.
- Contract: renders the real component; mocks ticker lookup only.
- No overlap: submit button type plus matching focused test.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions