### PR TITLE
test(kai-invite-handshake): cover copy invite button type

### DIFF
--- a/hushh-webapp/__tests__/components/kai-invite-handshake.test.tsx
+++ b/hushh-webapp/__tests__/components/kai-invite-handshake.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { KaiInviteHandshake } from "@/components/kai/onboarding/kai-invite-handshake";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: null,
+  }),
+}));
+
+vi.mock("@/lib/services/ria-service", () => ({
+  RiaService: {
+    acceptInvite: vi.fn(),
+    resolveInvite: vi.fn().mockResolvedValue({
+      invite_id: "invite-1",
+      invite_token: "invite-token",
+      status: "pending",
+      scope_template_id: "standard",
+      duration_mode: "session",
+      ria: {
+        display_name: "Hushh Advisors",
+        headline: "Personalized planning",
+        strategy_summary: null,
+        verification_status: "verified",
+      },
+    }),
+  },
+}));
+
+describe("KaiInviteHandshake", () => {
+  it("covers copy invite button type", async () => {
+    render(<KaiInviteHandshake inviteToken="invite-token" />);
+
+    const copyButton = (await screen.findByRole("button", {
+      name: "Copy invite link",
+    })) as HTMLButtonElement;
+
+    expect(copyButton.type).toBe("button");
+  });
+});

--- a/hushh-webapp/components/kai/onboarding/kai-invite-handshake.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-invite-handshake.tsx
@@ -119,6 +119,11 @@ export function KaiInviteHandshake({ inviteToken }: { inviteToken: string }) {
     }
   }
 
+  function copyInviteLink() {
+    if (typeof window === "undefined" || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(window.location.href);
+  }
+
   if (loading) {
     return <HushhLoader label="Loading invite..." variant="fullscreen" />;
   }
@@ -171,6 +176,13 @@ export function KaiInviteHandshake({ inviteToken }: { inviteToken: string }) {
                   Kai works in the background to connect you and your advisor
                   without exposing more than you approve.
                 </p>
+                <button
+                  type="button"
+                  onClick={copyInviteLink}
+                  className="mt-5 inline-flex min-h-10 items-center justify-center rounded-full border border-border px-4 text-sm font-medium text-foreground"
+                >
+                  Copy invite link
+                </button>
               </>
             ) : null}
 


### PR DESCRIPTION
## Summary
- Adds a copy invite link control to KaiInviteHandshake.
- Covers the copy invite button type with a focused component test.

## Proof
- Surface: KaiInviteHandshake only.
- Contract: renders the real component; mocks auth, router, and invite service state.
- No overlap: copy invite control plus matching focused test.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions