### PR TITLE
test(kai-nav-tour): cover skip action button type

### DIFF
--- a/hushh-webapp/__tests__/components/kai-nav-tour.test.tsx
+++ b/hushh-webapp/__tests__/components/kai-nav-tour.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { KaiNavTour } from "@/components/kai/onboarding/kai-nav-tour";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/kai",
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    loading: false,
+    user: { uid: "user-1" },
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    isVaultUnlocked: false,
+    vaultKey: null,
+    vaultOwnerToken: null,
+  }),
+}));
+
+vi.mock("@/lib/services/kai-nav-tour-local-service", () => ({
+  KaiNavTourLocalService: {
+    load: vi.fn().mockResolvedValue(null),
+    markSkipped: vi.fn().mockResolvedValue({
+      skipped_at: "2026-06-30T00:00:00.000Z",
+    }),
+    markSynced: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    bootstrapState: vi.fn().mockResolvedValue(null),
+    isNavTourResolved: vi.fn(() => false),
+    updatePreVaultState: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/services/kai-profile-service", () => ({
+  KaiProfileService: {
+    getProfile: vi.fn(),
+    setNavTourState: vi.fn(),
+  },
+}));
+
+describe("KaiNavTour", () => {
+  it("covers skip action button type", async () => {
+    render(<KaiNavTour />);
+
+    const skipButton = (await screen.findByRole("button", {
+      name: "Skip",
+    })) as HTMLButtonElement;
+
+    expect(skipButton.type).toBe("button");
+  });
+});

--- a/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-nav-tour.tsx
@@ -437,6 +437,7 @@ export function KaiNavTour() {
 
             <div className="grid grid-cols-3 gap-2 pt-1">
               <Button
+                type="button"
                 variant="blue-gradient"
                 effect="fade"
                 size="default"


### PR DESCRIPTION
## Summary
- Adds an explicit button type to the KaiNavTour skip action.
- Covers the skip action button type with a focused component test.

## Proof
- Surface: KaiNavTour only.
- Contract: renders the real component; mocks auth, vault, route, and tour state.
- No overlap: skip action type plus matching focused test.
- DCO signed; base: integration/pr-train.

## Validation
- git diff --cached --check
- Web (Next.js) via GitHub Actions