### PR TITLE
fix(kai): render all supported income detail types

### DIFF
--- a/hushh-webapp/__tests__/components/income-detail-card.test.tsx
+++ b/hushh-webapp/__tests__/components/income-detail-card.test.tsx
@@ -12,4 +12,21 @@ describe("IncomeDetailCard", () => {
     expect(screen.queryByText("Income")).toBeNull();
     expect(container.firstChild).toBeNull();
   });
+
+
+ it("renders tax-exempt dividend details when they are the only detailed income values", () => {
+  render(
+    <IncomeDetailCard
+      incomeSummary={{}}
+      incomeDetail={{
+        dividends_nontaxable: 125,
+      }}
+      ytdMetrics={{}}
+    />,
+   );
+
+   expect(screen.getByText("Income")).toBeDefined();
+   expect(screen.getByText("Tax-Exempt Dividends")).toBeDefined();
+    expect(screen.getByText("$125.00")).toBeDefined();
+  });
 });

--- a/hushh-webapp/components/kai/cards/income-detail-card.tsx
+++ b/hushh-webapp/components/kai/cards/income-detail-card.tsx
@@ -116,9 +116,12 @@ export function IncomeDetailCard({
   const hasDetail = incomeDetail && (
     incomeDetail.dividends_taxable ||
     incomeDetail.dividends_qualified ||
+    incomeDetail.dividends_nontaxable ||
     incomeDetail.interest_taxable ||
+    incomeDetail.interest_tax_exempt ||
     incomeDetail.short_term_cap_gains ||
-    incomeDetail.long_term_cap_gains
+    incomeDetail.long_term_cap_gains ||
+    incomeDetail.return_of_capital
   );
 
   // Check if we have any income data


### PR DESCRIPTION
## Summary

This change fixes an edge case in `IncomeDetailCard` where some supported income detail fields were not considered when determining whether to render the detailed breakdown.

Previously, the card only treated these fields as detailed income:

- `dividends_taxable`
- `dividends_qualified`
- `interest_taxable`
- `short_term_cap_gains`
- `long_term_cap_gains`

As a result, if only one of the following fields was present:

- `dividends_nontaxable`
- `interest_tax_exempt`
- `return_of_capital`

the detail section would not render even though the component contains UI for displaying those values.

### Changes

- Include all supported income detail fields when computing `hasDetail`.
- Add a regression test covering the case where `dividends_nontaxable` is the only populated detail field.

### Testing

```bash
npx vitest run __tests__/components/income-detail-card.test.tsx