### PR TITLE
test: verify formatCompleteJson top-level string scalar handling

### DIFF
--- a/hushh-webapp/__tests__/utils/json-to-human.test.ts
+++ b/hushh-webapp/__tests__/utils/json-to-human.test.ts
@@ -34,6 +34,28 @@ describe("json-to-human", () => {
       expect(typeof result).toBe("string");
       expect(result.length).toBeGreaterThan(0);
     });
+
+    it("renders a top-level string scalar directly under its resolved label", () => {
+      const output = formatCompleteJson({
+        account_holder: "Jane Doe",
+      });
+
+      expect(output).toBe(
+        "Account Holder: Jane Doe",
+      );
+    });
+
+    it("continues processing subsequent sections after a top-level string scalar", () => {
+      const output = formatCompleteJson({
+        account_holder: "Jane Doe",
+        portfolio_summary: {
+          ending_value: 100,
+        },
+      });
+
+      expect(output).toContain("Account Holder: Jane Doe");
+      expect(output).toContain("--- Portfolio Summary ---");
+    });
   });
 
   describe("tryFormatComplete", () => {
@@ -65,9 +87,7 @@ describe("json-to-human", () => {
       formatJsonChunk("hello ", ctx);
       formatJsonChunk("world", ctx);
 
-      expect(ctx.accumulatedJson).toBe(
-        "hello world",
-      );
+      expect(ctx.accumulatedJson).toBe("hello world");
     });
 
     it("returns text and context", () => {


### PR DESCRIPTION
## What

Adds coverage for top-level string scalar handling in `formatCompleteJson`.

## Why

Existing tests exercise object-based and array-based formatting paths, but do not directly verify behavior when a top-level section value is a string. This branch has deterministic output and is part of the public formatting contract.

The new tests verify:

* top-level string values render directly under their resolved label
* processing continues normally for subsequent sections after a top-level string value

## Scope

Test-only change.

No production code modified.

## Validation

```bash
npx vitest run __tests__/utils/json-to-human.test.ts
```
