### PR TITLE
test: verify historical_values count summary rendering

### DIFF
--- a/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
+++ b/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
@@ -123,4 +123,27 @@ describe("formatCompleteJson — array bounds with null and mixed primitives", (
     expect(out).toContain("--- Legal Disclosures (2 items) ---");
     expect(out).toContain("2 disclosure(s) extracted");
   });
+  it("emits a data point count summary line for the historical_values array", () => {
+    const out = formatCompleteJson({
+      historical_values: [
+        {
+          date: "2024-01-01",
+          value: 10000,
+        },
+        { 
+          date: "2024-02-01",
+          value: 10500,
+        },
+        {
+          date: "2024-03-01",
+          value: 11000,
+        },
+      ],
+    });
+
+    expect(out).toContain("--- Historical Values (3 items) ---");
+
+    expect(out).toContain("3 data point(s) for portfolio history chart");
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for the `historical_values` count-summary rendering path in `formatCompleteJson`.

## Why

Existing tests verify specialized summary rendering for other array-based sections, but do not directly verify the `historical_values` path.

The new test verifies:

* the historical values section renders the expected item-count heading
* the expected portfolio history data-point summary line is emitted

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/utils/format-complete-json-bounds.test.ts

## Notes

The test exercises an existing formatting path only. No mocks, snapshots, browser APIs, asynchronous behavior, shared setup changes, or production code modifications are included.
