### PR TITLE
test: verify generic array item placeholder fallback

### DIFF
--- a/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
+++ b/hushh-webapp/__tests__/utils/format-complete-json-bounds.test.ts
@@ -65,6 +65,20 @@ describe("formatCompleteJson — array bounds with null and mixed primitives", (
     expect(out).toContain("• visible-label");
   });
 
+  it('falls back to the literal string "Item" when a generic-array object element has no non-nullish values', () => {
+    const out = formatCompleteJson({
+      misc_items: [
+        {
+          first: null,
+          second: undefined,
+        },
+      ],
+    });
+
+    expect(out).toContain("• Item");
+  });
+
+
   it("skips empty arrays entirely — no section header is emitted", () => {
     const out = formatCompleteJson({
       misc_items: [],


### PR DESCRIPTION
## What

Adds coverage for the generic-array object placeholder fallback path in `formatCompleteJson`.

## Why

Existing tests verify generic-array rendering when object elements contain usable values. This test covers the remaining fallback path where all object properties are nullish and the formatter emits the default `"Item"` placeholder.

The new test verifies:

* object elements with only nullish values render the fallback placeholder
* the generic-array rendering path remains stable for empty-value objects

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/utils/format-complete-json-bounds.test.ts

