### PR TITLE
test: verify nested object section rendering

### DIFF
--- a/hushh-webapp/__tests__/utils/json-to-human.test.ts
+++ b/hushh-webapp/__tests__/utils/json-to-human.test.ts
@@ -34,6 +34,28 @@ describe("json-to-human", () => {
       expect(typeof result).toBe("string");
       expect(result.length).toBeGreaterThan(0);
     });
+
+    it("renders a nested object within an object section with indented bullet sub-fields", () => {
+      const output = formatCompleteJson({
+        ytd_metrics: {
+          realized_summary: {
+            net_realized: 2500,
+          },
+        },
+      });
+
+      expect(output).toContain(
+        "--- Year-to-Date Metrics ---",
+      );
+
+      expect(output).toContain(
+        "  Realized Summary:",
+      );
+
+      expect(output).toContain(
+        "    • Net Realized: $2,500.00",
+      );
+    });
   });
 
   describe("tryFormatComplete", () => {


### PR DESCRIPTION
## What

Adds coverage for nested object rendering within an object-based section in `formatCompleteJson`.

## Why

Existing tests verify formatting for flat object sections, but do not directly verify rendering when a field inside a section is itself a nested object.

The new test verifies:

* nested object fields render with the expected subsection heading
* nested properties render as indented bullet entries
* nested numeric values continue to use existing formatting behavior

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/utils/json-to-human.test.ts

