### PR TITLE
test: verify getRouteScope route classification

### DIFF
--- a/hushh-webapp/__tests__/navigation/route-scope.test.ts
+++ b/hushh-webapp/__tests__/navigation/route-scope.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { getRouteScope } from "@/lib/navigation/route-scope";
+
+describe("getRouteScope", () => {
+  it("classifies onboarding paths, including the ria onboarding override", () => {
+    expect(getRouteScope("/one/onboarding")).toBe(
+      "onboarding",
+    );
+
+    expect(getRouteScope("/ria/onboarding")).toBe(
+      "onboarding",
+    );
+  });
+
+  it("classifies investor paths", () => {
+    expect(getRouteScope("/one/kai")).toBe(
+      "investor",
+    );
+
+    expect(getRouteScope("/kai")).toBe(
+      "investor",
+    );
+  });
+
+  it("classifies ria paths that are not onboarding", () => {
+    expect(getRouteScope("/ria")).toBe("ria");
+
+    expect(
+      getRouteScope("/ria/clients"),
+    ).toBe("ria");
+  });
+
+  it("classifies shared paths", () => {
+    expect(
+      getRouteScope("/marketplace"),
+    ).toBe("shared");
+
+    expect(getRouteScope("/profile")).toBe(
+      "shared",
+    );
+  });
+
+  it("classifies public paths", () => {
+    expect(getRouteScope("/login")).toBe(
+      "public",
+    );
+
+    expect(getRouteScope("/logout")).toBe(
+      "public",
+    );
+  });
+
+  it("classifies unrecognized and empty paths as unknown", () => {
+    expect(
+      getRouteScope("/some/unmapped/path"),
+    ).toBe("unknown");
+
+    expect(getRouteScope("")).toBe(
+      "unknown",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for route scope classification in `getRouteScope`.

## Why

The route scope helper determines how routes are categorized across onboarding, investor, RIA, shared, public, and unknown route families. This behavior is not currently covered by a dedicated test file.

The new tests verify:

* onboarding route classification
* onboarding precedence for RIA onboarding paths
* investor route classification
* RIA route classification
* shared route classification
* public route classification
* unknown route handling

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/navigation/route-scope.test.ts

