### PR TITLE
test: verify isOneOnboardingRoute non-onboarding paths

### DIFF
--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -6,6 +6,7 @@ import {
   buildRiaClientWorkspaceRoute,
   buildOneOnboardingRoute,
   isKaiOnboardingRoute,
+  isOneOnboardingRoute,
   isPublicRoute,
   isRiaRoute,
 } from "@/lib/navigation/routes";
@@ -63,4 +64,16 @@ describe("navigation routes", () => {
 
     expect(isKaiOnboardingRoute("/one/kai")).toBe(false);
   });
+
+  it("returns false for non-onboarding paths", () => {
+    expect(isOneOnboardingRoute("")).toBe(false);
+
+    expect(isOneOnboardingRoute("/")).toBe(false);
+
+    expect(
+      isOneOnboardingRoute("/one/kai/portfolio")).toBe(false);
+
+    expect(isOneOnboardingRoute("/onboarding")).toBe(false);
+  });
+
 });


### PR DESCRIPTION
## What

Adds coverage for negative path handling in `isOneOnboardingRoute`.

## Why

Existing tests verify onboarding route detection, but do not directly verify behavior for several non-onboarding path variants.

The new test verifies:

* empty paths return false
* root paths return false
* near-match onboarding paths return false
* onboarding paths outside the expected namespace return false

## Scope

Test-only change.

No production code modified.

## Validation

npx vitest run **tests**/navigation/routes.test.ts

