### PR TITLE
test(email): verify queue continues after success callback failures

### DIFF
--- a/consent-protocol/tests/services/test_email_delivery_queue_service.py
+++ b/consent-protocol/tests/services/test_email_delivery_queue_service.py
@@ -60,3 +60,49 @@ async def test_email_delivery_queue_runs_failure_callback():
         assert callback_errors == ["boom"]
     finally:
         await service.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_success_callback_failure_does_not_stop_worker():
+    service = EmailDeliveryQueueService()
+
+    calls: list[str] = []
+    completed: list[str] = []
+
+    def send_job_1():
+        calls.append("job1")
+        return {"message_id": "msg1"}
+
+    def send_job_2():
+        calls.append("job2")
+        return {"message_id": "msg2"}
+
+    async def failing_success_callback(_result):
+        raise RuntimeError("callback failed")
+
+    async def success_callback(result):
+        completed.append(result["message_id"])
+
+    try:
+        ack1 = await service.enqueue(
+            kind="support_message",
+            send_callable=send_job_1,
+            on_success=failing_success_callback,
+        )
+
+        ack2 = await service.enqueue(
+            kind="support_message",
+            send_callable=send_job_2,
+            on_success=success_callback,
+        )
+
+        assert ack1["delivery_status"] == "queued"
+        assert ack2["delivery_status"] == "queued"
+
+        await service.wait_for_idle()
+
+        assert calls == ["job1", "job2"]
+        assert completed == ["msg2"]
+
+    finally:
+        await service.shutdown()


### PR DESCRIPTION
## Summary

- add a regression test covering success callback failures in `EmailDeliveryQueueService`
- verify the worker continues processing queued jobs even when an `on_success` callback raises an exception
- ensure subsequent queued jobs are still delivered successfully

## Testing

```bash
uv run pytest consent-protocol/tests/services/test_email_delivery_queue_service.py -v