### PR TITLE
test(utils): cover cn object input handling

### DIFF
--- a/hushh-webapp/__tests__/utils/cn.test.ts
+++ b/hushh-webapp/__tests__/utils/cn.test.ts
@@ -17,4 +17,7 @@ describe("cn", () => {
     "flex items-center",
   );
 });
+it("handles object inputs with truthy and falsy values", () => {
+  expect(cn("base", { active: true, hidden: false })).toBe("base active");
+});
 });


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `cn` utility to verify that object inputs are handled correctly.

## Changes Made

* Added a test to ensure `cn()` includes class names whose object values are truthy.
* Verifies that class names with falsy object values are excluded from the output.
* Expands utility test coverage with an additional edge-case scenario to help prevent regressions.

## Test

```bash
npx vitest run __tests__/utils/cn.test.ts
```
