### PR TITLE
test(utils): cover cn responsive class merging

### DIFF
--- a/hushh-webapp/__tests__/utils/cn.test.ts
+++ b/hushh-webapp/__tests__/utils/cn.test.ts
@@ -17,4 +17,7 @@ describe("cn", () => {
     "flex items-center",
   );
 });
+it("preserves responsive classes while merging conflicts", () => {
+  expect(cn("p-2 md:p-4", "p-6")).toBe("md:p-4 p-6");
+});
 });


### PR DESCRIPTION
## Summary

Adds unit test coverage for the `cn` utility to verify that responsive Tailwind CSS classes are preserved while conflicting base classes are merged correctly.

## Changes Made

* Added a test to validate responsive class merging behavior in `cn()`.
* Verifies that responsive utility classes (for example, `md:p-4`) are preserved while conflicting base classes are resolved correctly.
* Extends utility test coverage with an additional Tailwind CSS edge case to help prevent regressions.

## Test

```bash
npx vitest run __tests__/utils/cn.test.ts
```
