### PR TITLE
test(utils): cover web session storage clearing

### DIFF
--- a/hushh-webapp/__tests__/utils/session-storage.test.ts
+++ b/hushh-webapp/__tests__/utils/session-storage.test.ts
@@ -24,4 +24,17 @@ describe("clearSessionStorage", () => {
     expect(window.localStorage.getItem("native-route")).toBe("keep-raw-fallback");
     expect(window.localStorage.getItem("profile-cache")).toBe("keep-local");
   });
+  it("clears browser session storage on web platforms", async () => {
+  window.sessionStorage.setItem("session-token", "clear-me");
+  window.localStorage.setItem("_session_native-route", "keep-native-cache");
+
+  const { clearSessionStorage } = await import("@/lib/utils/session-storage");
+
+  clearSessionStorage();
+
+  expect(window.sessionStorage.getItem("session-token")).toBeNull();
+  expect(window.localStorage.getItem("_session_native-route")).toBe(
+    "keep-native-cache",
+  );
+});
 });


### PR DESCRIPTION
## Summary

Adds test coverage for `clearSessionStorage` on web platforms.

## Changes Made

* Added a unit test to verify that `clearSessionStorage` clears browser `sessionStorage` when running in a web environment.
* Verifies that browser session data is removed while native-specific local storage entries remain unchanged.
* Expands existing test coverage by validating the web platform behavior alongside the native platform scenario.

## Test

```bash
npx vitest run __tests__/utils/session-storage.test.ts
```
