### PR TITLE
test(utils): cover clipboard api copy path

### DIFF
--- a/hushh-webapp/__tests__/utils/clipboard.test.ts
+++ b/hushh-webapp/__tests__/utils/clipboard.test.ts
@@ -22,4 +22,16 @@ describe("copyToClipboard", () => {
 
     expect(document.querySelectorAll("textarea")).toHaveLength(0);
   });
+  it("uses navigator clipboard when available", async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+
+  await expect(copyToClipboard("copy me")).resolves.toBe(true);
+
+  expect(writeText).toHaveBeenCalledWith("copy me");
+});
 });


### PR DESCRIPTION
## Summary

Adds test coverage for the Clipboard utility when the browser Clipboard API is available.

## Changes Made

* Added a unit test to verify that `copyToClipboard` uses `navigator.clipboard.writeText()` when the Clipboard API is available.
* Confirms that the provided text is passed to `writeText` and that the operation resolves successfully.
* Complements the existing fallback-path test by covering the modern browser Clipboard API behavior.

## Test

```bash
npx vitest run __tests__/utils/clipboard.test.ts
```
