### PR TITLE
test(utils): cover minimal internal navigation request

### DIFF
--- a/hushh-webapp/__tests__/utils/browser-navigation.test.ts
+++ b/hushh-webapp/__tests__/utils/browser-navigation.test.ts
@@ -25,4 +25,23 @@ describe("requestInternalAppNavigation", () => {
       },
     ]);
   });
+  
+it("uses default navigation options when optional flags are omitted", () => {
+  const details: unknown[] = [];
+
+  window.addEventListener(INTERNAL_APP_NAVIGATION_REQUEST_EVENT, (event) => {
+    details.push((event as CustomEvent).detail);
+  });
+
+  const result = requestInternalAppNavigation({
+    href: "/one",
+  });
+
+  expect(result).toBe(true);
+  expect(details).toEqual([
+    {
+      href: "/one",
+    },
+  ]);
+});
 });


### PR DESCRIPTION
## Summary

Adds test coverage for the browser navigation utility when only the required navigation target is provided.

## Changes Made

* Added a unit test to verify that `requestInternalAppNavigation` dispatches a navigation request when only the required `href` field is supplied.
* Confirms that the dispatched event contains the expected payload without optional `replace` or `scroll` properties.
* Extends browser navigation utility coverage with a minimal navigation request scenario to help prevent regressions.

## Test

```bash
npx vitest run __tests__/utils/browser-navigation.test.ts
```
