### PR TITLE
test(api): cover backend URL surrounding spaces

### DIFF
--- a/hushh-webapp/__tests__/utils/backend-runtime.test.ts
+++ b/hushh-webapp/__tests__/utils/backend-runtime.test.ts
@@ -113,4 +113,12 @@ describe("backend runtime resolution", () => {
 
     expect(helper.getPythonApiUrl()).toContain("127.0.0.1");
   });
+  it("strips surrounding spaces from a backend URL env var", async () => {
+  process.env.K_SERVICE = "hushh-webapp";
+  process.env.PYTHON_API_URL = "  https://api.example.com  ";
+
+  const helper = await loadHelper();
+
+  expect(helper.getPythonApiUrl()).toBe("https://api.example.com");
+});
 });


### PR DESCRIPTION
## Summary

Adds unit test coverage for backend runtime URL sanitization when environment variables contain surrounding spaces.

## Changes Made

* Added a test to verify that `getPythonApiUrl()` trims leading and trailing spaces from the `PYTHON_API_URL` environment variable.
* Confirms that the sanitized URL is returned instead of the raw whitespace-padded value.
* Extends existing backend runtime whitespace sanitization coverage by validating handling of surrounding space characters in addition to tabs, newlines, and carriage returns.

## Test

```bash
npx vitest run __tests__/utils/backend-runtime.test.ts
```
