### PR TITLE
test(services): characterize scoreInvestmentHorizon/computeRiskScore handling of out-of-range investment horizon values

### DIFF
--- a/hushh-webapp/__tests__/lib/services/profile-investment-horizon.test.ts
+++ b/hushh-webapp/__tests__/lib/services/profile-investment-horizon.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Characterization suite — @/lib/services/kai-profile-service
+ *
+ * Pins the PUBLIC scoring contract for investment-horizon handling. The goal is
+ * to lock down how the exported risk-scoring surface behaves when it is fed an
+ * unrecognized / extreme / malformed horizon value, so future refactors cannot
+ * silently change the fallback shape.
+ *
+ * IMPORTANT (verified against source, not assumed):
+ *   - `normalizeInvestmentHorizon` is module-private and is NOT exported, so it
+ *     cannot be imported directly. The sanctioned public surface is the
+ *     `score*` helpers plus `computeRiskScore` / `mapRiskProfile`.
+ *   - `scoreInvestmentHorizon` does NOT collapse unknown strings to null. By the
+ *     implementation it returns 0 for "short_term", 1 for "medium_term", and 2
+ *     for *anything else that is truthy* (the final `return 2`). It returns null
+ *     only for falsy input (null / "" / undefined).
+ *   - `computeRiskScore` returns null only when one of the three component
+ *     scores is null (i.e. a falsy preference), never by throwing.
+ *
+ * These tests therefore characterize the real, shipped behavior: the scoring
+ * surface is total (never throws) and degrades to deterministic values, and the
+ * only path to a null risk score is a missing (falsy) preference.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  scoreInvestmentHorizon,
+  computeRiskScore,
+  mapRiskProfile,
+} from "@/lib/services/kai-profile-service";
+
+// Casts are intentional: we are deliberately probing out-of-contract inputs to
+// characterize runtime safety, which TypeScript would otherwise forbid.
+const asHorizon = (value: unknown) =>
+  value as Parameters<typeof scoreInvestmentHorizon>[0];
+
+describe("kai-profile-service · investment horizon scoring (public contract)", () => {
+  it("scores the three known horizons deterministically", () => {
+    expect(scoreInvestmentHorizon("short_term")).toBe(0);
+    expect(scoreInvestmentHorizon("medium_term")).toBe(1);
+    expect(scoreInvestmentHorizon("long_term")).toBe(2);
+  });
+
+  it("returns null for falsy horizons (null / empty / undefined) without throwing", () => {
+    expect(scoreInvestmentHorizon(null)).toBeNull();
+    expect(() => scoreInvestmentHorizon(asHorizon(""))).not.toThrow();
+    expect(scoreInvestmentHorizon(asHorizon(""))).toBeNull();
+    expect(() => scoreInvestmentHorizon(asHorizon(undefined))).not.toThrow();
+    expect(scoreInvestmentHorizon(asHorizon(undefined))).toBeNull();
+  });
+
+  it("does not throw on unrecognized / extreme horizon strings and degrades to the 'long' bucket (2)", () => {
+    const extremeInputs = [
+      "ultra_long_term",
+      "SHORT_TERM",
+      "forever",
+      "🚀",
+      "a".repeat(10_000),
+      "0",
+    ];
+    for (const value of extremeInputs) {
+      expect(() => scoreInvestmentHorizon(asHorizon(value))).not.toThrow();
+      // Any truthy-but-unknown string falls through to the final `return 2`.
+      expect(scoreInvestmentHorizon(asHorizon(value))).toBe(2);
+    }
+  });
+
+  it("computeRiskScore returns null when the horizon is missing, never throwing", () => {
+    expect(
+      computeRiskScore({
+        investment_horizon: null,
+        drawdown_response: "stay",
+        volatility_preference: "moderate",
+      })
+    ).toBeNull();
+  });
+
+  it("computeRiskScore tolerates an extreme horizon and still produces a mappable numeric score", () => {
+    const score = computeRiskScore({
+      investment_horizon: asHorizon("ultra_long_term"),
+      drawdown_response: "stay",
+      volatility_preference: "moderate",
+    });
+    // 2 (unknown horizon bucket) + 1 (stay) + 1 (moderate) = 4
+    expect(score).toBe(4);
+    expect(score).not.toBeNull();
+    expect(mapRiskProfile(score as number)).toBe("balanced");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an isolated **characterization** test that pins the public investment-horizon
scoring contract in `@/lib/services/kai-profile-service`, so future refactors
cannot silently change how unrecognized / extreme / malformed horizon values are
handled.

Test-only change. No production source is modified.

## What is actually verified (truth-first)

This PR was scoped against the real source, not assumed behavior:

- `normalizeProfile` and `normalizeInvestmentHorizon` are **module-private** and
  not exported, so they cannot be imported directly. The sanctioned public
  surface is `scoreInvestmentHorizon`, `computeRiskScore`, and `mapRiskProfile`.
- `scoreInvestmentHorizon` is **total**: `0` for `short_term`, `1` for
  `medium_term`, and — by the final `return 2` — `2` for any other truthy
  string. It returns `null` only for falsy input (`null` / `""` / `undefined`).
  It does **not** collapse unknown strings to `null`.
- `computeRiskScore` returns `null` only when a component preference is falsy,
  and never throws.

The tests assert exactly this behavior (e.g. an unknown horizon scores `2`, and
`computeRiskScore` with an extreme horizon yields `4` → `"balanced"`).

## Scope

- `hushh-webapp/__tests__/lib/services/profile-investment-horizon.test.ts` (new, 5 tests)

## Verification gate

```
npx vitest run hushh-webapp/__tests__/lib/services/profile-investment-horizon.test.ts
# 1 file, 5 tests passed
```

## Base policy note

Targets `integration/pr-train` per `scripts/ci/verify-pr-base-policy.py`, which
fail-closes direct PRs into `main`. This intentionally goes through the PR train.

## Reviewer risk assessment

- Test-only; zero production runtime change.
- No new exports, no behavior added — purely characterizes shipped behavior.
- The one judgment call: this pins existing behavior (including the unknown→`2`
  fall-through). If that fall-through is considered a latent bug rather than
  intended, that is a separate production fix and is intentionally **not** done
  here; this test would simply be updated alongside it.
