### PR TITLE
fix(one-location): restore bell notifications + deep-link access requests to Needs your review

### DIFF
--- a/hushh-webapp/__tests__/one-location-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-notifications.test.ts
@@ -3,13 +3,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Mock the background-task store so the notification helpers run without the
 // real (sessionStorage-backed) implementation. We only need to confirm the
 // persistent de-dup + unwatch logic in notifications.ts.
-const tasks = new Map<string, { taskId: string; dismissedAt: string | null }>();
+interface MockTask {
+  taskId: string;
+  routeHref: string | null;
+  dismissedAt: string | null;
+}
+const tasks = new Map<string, MockTask>();
 
 vi.mock("@/lib/services/app-background-task-service", () => ({
   AppBackgroundTaskService: {
     getTask: (taskId: string) => tasks.get(taskId) ?? null,
-    startTask: (params: { taskId: string }) => {
-      tasks.set(params.taskId, { taskId: params.taskId, dismissedAt: null });
+    startTask: (params: { taskId: string; routeHref?: string | null }) => {
+      tasks.set(params.taskId, {
+        taskId: params.taskId,
+        routeHref: params.routeHref ?? null,
+        dismissedAt: null,
+      });
       return params.taskId;
     },
     completeTask: () => undefined,
@@ -19,6 +28,7 @@ vi.mock("@/lib/services/app-background-task-service", () => ({
     },
   },
 }));
+
 
 import {
   hasSeenOneLocationNotification,
@@ -78,10 +88,10 @@ describe("One-Location persistent notification de-dup", () => {
   });
 });
 
-describe("One-Location consent-surface routing (not the general bell)", () => {
+describe("One-Location notification surfaces (bell + consent)", () => {
   const CONSENT_EVENT = "consent-state-changed";
 
-  it("dispatches a consent refresh and does NOT create a bell task for a share", () => {
+  it("creates a bell task with a 'shared' deep-link AND a consent refresh for a share", () => {
     const events: string[] = [];
     const handler = () => events.push("consent");
     window.addEventListener(CONSENT_EVENT, handler);
@@ -92,16 +102,22 @@ describe("One-Location consent-surface routing (not the general bell)", () => {
         ownerLabel: "Alex",
       });
       expect(created).toBe(true);
-      // Routed to the consent surface...
+      // Routed to the consent surface (shield icon + consent manager)...
       expect(events.length).toBe(1);
-      // ...and NOT written to the general bell (AppBackgroundTaskService).
-      expect(tasks.size).toBe(0);
+      // ...AND surfaced in the bell with an "Open" deep-link into the
+      // recipient's "Shared with me" section so it is reachable from the bell.
+      expect(tasks.size).toBe(1);
+      const task = tasks.get("one_location_share:grant_routing_1");
+      expect(task).toBeTruthy();
+      expect(task?.routeHref).toContain("/one/location");
+      expect(task?.routeHref).toContain("grantId=grant_routing_1");
+      expect(task?.routeHref).toContain("section=shared");
     } finally {
       window.removeEventListener(CONSENT_EVENT, handler);
     }
   });
 
-  it("dispatches a consent refresh for a workflow (approve/deny/request) event", () => {
+  it("creates a bell task AND a consent refresh for a workflow (approve/deny/request) event", () => {
     const events: string[] = [];
     const handler = () => events.push("consent");
     window.addEventListener(CONSENT_EVENT, handler);
@@ -112,15 +128,24 @@ describe("One-Location consent-surface routing (not the general bell)", () => {
         id: "req_routing_1",
         title: "Location request",
         description: "Someone is asking to view your location.",
+        routeHref: "/one/location?requestId=req_routing_1&section=approvals",
       });
       expect(created).toBe(true);
       expect(events.length).toBe(1);
-      expect(tasks.size).toBe(0);
+      expect(tasks.size).toBe(1);
+      const task = tasks.get(
+        "one_location_workflow:location_access_request:req_routing_1",
+      );
+      expect(task).toBeTruthy();
+      expect(task?.routeHref).toBe(
+        "/one/location?requestId=req_routing_1&section=approvals",
+      );
     } finally {
       window.removeEventListener(CONSENT_EVENT, handler);
     }
   });
 });
+
 
 describe("One-Location unwatch", () => {
   it("hides a grant and suppresses its share notification", () => {

--- a/hushh-webapp/__tests__/one-location-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-notifications.test.ts
@@ -31,12 +31,15 @@ vi.mock("@/lib/services/app-background-task-service", () => ({
 
 
 import {
+  buildOneLocationWorkflowHref,
   hasSeenOneLocationNotification,
   isOneLocationGrantUnwatched,
   markOneLocationGrantUnwatched,
+  oneLocationSectionForWorkflowNotificationType,
   recordOneLocationShareNotification,
   recordOneLocationWorkflowNotification,
 } from "@/lib/one-location/notifications";
+
 
 const USER = "user_recipient_1";
 const GRANT = "grant_abc";
@@ -147,7 +150,31 @@ describe("One-Location notification surfaces (bell + consent)", () => {
 });
 
 
+describe("One-Location workflow deep-link sections", () => {
+  it("routes an access request to the Inbox 'Needs your review' (approvals) section", () => {
+    const section = oneLocationSectionForWorkflowNotificationType(
+      "location_access_request",
+    );
+    expect(section).toBe("approvals");
+
+    const href = buildOneLocationWorkflowHref({
+      requestId: "req_xyz",
+      section,
+    });
+    expect(href).toContain("/one/location");
+    expect(href).toContain("requestId=req_xyz");
+    expect(href).toContain("section=approvals");
+  });
+
+  it("maps each workflow type to its owning section", () => {
+    expect(oneLocationSectionForWorkflowNotificationType("location_access_approved")).toBe("shared");
+    expect(oneLocationSectionForWorkflowNotificationType("location_access_denied")).toBe("my_requests");
+    expect(oneLocationSectionForWorkflowNotificationType("location_public_invite_submitted")).toBe("public_responses");
+  });
+});
+
 describe("One-Location unwatch", () => {
+
   it("hides a grant and suppresses its share notification", () => {
     expect(isOneLocationGrantUnwatched(USER, GRANT)).toBe(false);
     markOneLocationGrantUnwatched(USER, GRANT);

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -72,11 +72,13 @@ import {
   locationShareNotificationDescription,
   locationWorkflowNotificationCopy,
   markOneLocationGrantOpened,
+  oneLocationSectionForWorkflowNotificationType,
   playOneLocationNotificationSound,
   recordOneLocationShareNotification,
   recordOneLocationWorkflowNotification,
   type OneLocationWorkflowNotificationType,
 } from "@/lib/one-location/notifications";
+
 
 // ============================================================================
 // Helpers
@@ -691,8 +693,13 @@ export function ConsentNotificationProvider({
         grantId,
         requestId,
         referralId,
+        submissionId,
+        // Land the recipient on the section that owns this event - e.g. an
+        // access request opens the Inbox "Needs your review" (approvals) section.
+        section: oneLocationSectionForWorkflowNotificationType(msgType),
         openGrant: false,
       });
+
       const created = recordOneLocationWorkflowNotification({
         userId: user.uid,
         notificationType: msgType,

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -478,16 +478,42 @@ export function recordOneLocationShareNotification(params: {
   // The recipient explicitly stopped watching this share - never re-notify.
   if (isOneLocationGrantUnwatched(userId, grantId)) return false;
 
-  // Persistent de-dup: a given share event yields at most one transient toast,
+  // Persistent de-dup: a given share event yields at most one notification,
   // ever (survives refresh, tab change, new session via localStorage).
   const eventId = `share:${grantId}`;
   if (hasSeenOneLocationNotification(userId, eventId)) return false;
   markOneLocationNotificationSeen(userId, eventId);
 
-  // Route to the consent surfaces (shield icon + consent manager), not the bell.
+  // Surface in the bell (DebateTaskCenter / AppBackgroundTaskService) with an
+  // "Open" deep-link into the recipient's "Shared with me" section, so the
+  // share is reachable from the bell - not only the transient toast.
+  const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
+  const description = locationShareNotificationDescription(ownerLabel);
+  const taskId = oneLocationGrantTaskId(grantId);
+  AppBackgroundTaskService.startTask({
+    taskId,
+    userId,
+    kind: LOCATION_SHARE_TASK_KIND,
+    title: "Location shared",
+    description,
+    routeHref: buildOneLocationNotificationHref(grantId),
+    visibility: "primary",
+    groupLabel: "One Location",
+    autoClearAfterMs: 0,
+    metadata: {
+      grantId,
+      ownerLabel,
+      expiresAt: params.expiresAt || null,
+      durationHours: params.durationHours || null,
+    },
+  });
+  AppBackgroundTaskService.completeTask(taskId, description);
+
+  // Also route to the consent surfaces (shield icon + consent manager).
   notifyConsentSurfaceRefresh("location_share_created", grantId);
   return true;
 }
+
 
 export function recordOneLocationWorkflowNotification(params: {
   userId: string;
@@ -503,16 +529,39 @@ export function recordOneLocationWorkflowNotification(params: {
   if (!userId || !id) return false;
 
   // Persistent de-dup keyed by (type, id): each consent event yields at most one
-  // transient toast, ever. This stops the "same notification again after refresh
+  // notification, ever. This stops the "same notification again after refresh
   // / tab change" spam (the seen-set lives in localStorage).
   const eventId = `${params.notificationType}:${id}`;
   if (hasSeenOneLocationNotification(userId, eventId)) return false;
   markOneLocationNotificationSeen(userId, eventId);
 
-  // Route to the consent surfaces (shield icon + consent manager), not the bell.
+  // Surface in the bell (DebateTaskCenter / AppBackgroundTaskService) with an
+  // "Open" deep-link into the relevant One-Location section, so the workflow
+  // event is reachable from the bell - not only the transient toast.
+  const taskId = oneLocationWorkflowTaskId(params.notificationType, id);
+  AppBackgroundTaskService.startTask({
+    taskId,
+    userId,
+    kind: LOCATION_WORKFLOW_TASK_KIND,
+    title: params.title,
+    description: params.description,
+    routeHref: params.routeHref || "/one/location",
+    visibility: "primary",
+    groupLabel: "One Location",
+    autoClearAfterMs: 0,
+    metadata: {
+      notificationType: params.notificationType,
+      id,
+      ...(params.metadata || {}),
+    },
+  });
+  AppBackgroundTaskService.completeTask(taskId, params.description);
+
+  // Also route to the consent surfaces (shield icon + consent manager).
   notifyConsentSurfaceRefresh(params.notificationType, id);
   return true;
 }
+
 
 export function playOneLocationNotificationSound(): void {
   if (typeof window === "undefined") return;


### PR DESCRIPTION
## Problem (UAT)

Two related One-Location notification bugs reported during UAT:

1. **Bell is empty.** When User A shares a location with User B, B gets the transient toast (with an `Open` button) but the **bell icon dropdown shows "No notifications yet."** The share is no longer reachable from the bell. (User reports this worked earlier.)
2. **Access-request "Open" lands nowhere useful.** When User A requests access to User B's location, B's popup works, but tapping `Open` does not land on the Inbox **"Needs your review"** (approvals) section.

## Root cause

- **Bell (regression):** commit `9c39eb935` ("stop notification spam … route consent to consent surfaces") moved One-Location notifications off the bell. `recordOneLocationShareNotification` / `recordOneLocationWorkflowNotification` stopped creating an `AppBackgroundTaskService` task (the bell's data source via `DebateTaskCenter`) and only dispatched a consent-surface refresh for the shield icon. That removed the bell entry **and** its `Open` deep-link. The same commit added a useful localStorage de-dup (the real anti-spam fix) — the regression was throwing out the bell entry along with the spam.
- **Access-request deep-link:** the FCM provider built the workflow href via `buildOneLocationWorkflowHref` **without** a `section`, so `Open` landed on `/one/location` with no target section even though `oneLocationSectionForWorkflowNotificationType` already maps `location_access_request` → `approvals`.

## Fix

1. Restore the bell entry in **both** record functions while **keeping** the localStorage de-dup. The share/workflow event appears in the bell again with an `Open` deep-link:
   - share → `/one/location?grantId=…&locationNotification=opened&section=shared` ("Shared with me").
   - Consent-surface routing (shield + consent manager) is preserved; no spam (persistent seen-set still yields one notification per real event).
2. Pass `section = oneLocationSectionForWorkflowNotificationType(msgType)` (and `submissionId`) into the workflow href so an access request opens the Inbox **"Needs your review"** (approvals) section; approvals/denials/public responses land on their owning sections too.

## Tests

- `__tests__/one-location-notifications.test.ts`: now asserts a bell task IS created with the correct `section=shared` deep-link (share) and the provided workflow `routeHref`, plus the consent refresh; new block asserts `location_access_request` → `approvals` deep-link and the full type→section mapping; de-dup + unwatch unchanged. **8/8 pass.**
- `__tests__/components/one-location-agent-page.test.tsx`: **27/27 pass.**

## Lane

Maintainer direct-to-main (author @DamriaNeelesh is in the governed bypass cohort); branched from `origin/main`. Both commits are DCO signed-off. Please review — do not merge yet.
