### PR TITLE
test(services): characterize exported profile service timestamp validation boundaries

### DIFF
--- a/hushh-webapp/__tests__/lib/services/profile-timestamp-bounds.test.ts
+++ b/hushh-webapp/__tests__/lib/services/profile-timestamp-bounds.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Characterization suite — @/lib/services/kai-profile-service
+ *
+ * Pins how the PUBLIC profile-service timestamp surface behaves when fed
+ * malformed, truncated, or excessively long "ISO" date strings.
+ *
+ * TRUTH-FIRST NOTE (verified against source, not assumed):
+ *   - The proposed premise was that the public service "gracefully normalizes
+ *     or ignores malformed temporal inputs." That is only half true. The actual
+ *     shipped behavior is:
+ *       * `resolveHorizonAnchorAt` is the only EXPORTED function that takes
+ *         timestamp-shaped params. It performs NO date parsing or validation.
+ *         It is pure opaque string selection:
+ *           - choice "keep_original" -> previousAnchorAt ?? now
+ *           - otherwise              -> now
+ *         Whatever string is passed (garbage, truncated, 10k chars) is returned
+ *         verbatim. It never throws and never coerces to a Date.
+ *       * The string-level sanitation that DOES exist (`normalizeOptionalIso`)
+ *         is module-private and unexported. It only type-guards + trims +
+ *         maps empty-string to null. It does NOT reject non-ISO content.
+ *
+ *   These tests therefore pin the real contract: the exported temporal surface
+ *   is a total, non-validating passthrough/selector. This is the behavior any
+ *   future refactor must preserve (or consciously, visibly change).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { resolveHorizonAnchorAt } from "@/lib/services/kai-profile-service";
+
+const MALFORMED_TIMESTAMPS = [
+  "", // empty
+  "not-a-date",
+  "2024-13-45T99:99:99Z", // structurally ISO-ish but semantically impossible
+  "2024-01-01", // truncated (date only)
+  "2024-01-01T00:00", // truncated (no seconds / zone)
+  "1970-01-01T00:00:00.000Z extra trailing garbage",
+  "🚀-not-a-timestamp-🚀",
+  `2024-01-01T00:00:00.000Z${"0".repeat(10_000)}`, // excessively long
+];
+
+describe("kai-profile-service · resolveHorizonAnchorAt timestamp boundaries (public contract)", () => {
+  it("returns `now` verbatim for the from_now choice regardless of how malformed it is", () => {
+    for (const now of MALFORMED_TIMESTAMPS) {
+      const result = resolveHorizonAnchorAt({
+        previousAnchorAt: "2020-01-01T00:00:00.000Z",
+        now,
+        choice: "from_now",
+      });
+      expect(result).toBe(now);
+    }
+  });
+
+  it("returns the malformed previousAnchorAt verbatim for keep_original (no validation, no coercion)", () => {
+    for (const previousAnchorAt of MALFORMED_TIMESTAMPS) {
+      const result = resolveHorizonAnchorAt({
+        previousAnchorAt,
+        now: "2025-06-30T00:00:00.000Z",
+        choice: "keep_original",
+      });
+      expect(result).toBe(previousAnchorAt);
+    }
+  });
+
+  it("falls back to `now` when keep_original is chosen but there is no previous anchor", () => {
+    const now = "2025-06-30T00:00:00.000Z";
+    expect(
+      resolveHorizonAnchorAt({ previousAnchorAt: null, now, choice: "keep_original" })
+    ).toBe(now);
+  });
+
+  it("never throws or coerces malformed temporal strings into Date objects", () => {
+    for (const value of MALFORMED_TIMESTAMPS) {
+      let result: unknown;
+      expect(() => {
+        result = resolveHorizonAnchorAt({
+          previousAnchorAt: value,
+          now: value,
+          choice: "keep_original",
+        });
+      }).not.toThrow();
+      // Output is the raw string, not a Date and not normalized.
+      expect(typeof result).toBe("string");
+      expect(result).not.toBeInstanceOf(Date);
+    }
+  });
+
+  it("preserves an excessively long timestamp byte-for-byte (no truncation in the selector)", () => {
+    const huge = `2024-01-01T00:00:00.000Z${"9".repeat(50_000)}`;
+    const result = resolveHorizonAnchorAt({
+      previousAnchorAt: huge,
+      now: "2025-06-30T00:00:00.000Z",
+      choice: "keep_original",
+    });
+    expect(result).toBe(huge);
+    expect(result.length).toBe(huge.length);
+  });
+});


### PR DESCRIPTION
## Summary
Pins down the boundary behavior of the **exported** profile-service timestamp surface when malformed, truncated, or excessively long "ISO" date strings are passed through. Test-only; no production source changed.

## Truth-first correction (verified against source)
The working premise was that the public service "gracefully normalizes or ignores malformed temporal inputs." That is only **partially** true, and the PR pins the *real* contract rather than an assumed one:

- `resolveHorizonAnchorAt` is the only **exported** function taking timestamp-shaped params. It does **no** date parsing/validation — it is a pure opaque string selector (`keep_original -> previousAnchorAt ?? now`, else `now`). Malformed input is returned **verbatim**; it never throws and never coerces to a `Date`.
- The string sanitation that *does* exist (`normalizeOptionalIso`) is **module-private / unexported** — it only type-guards, trims, and maps empty-string to `null`. It does **not** reject non-ISO content. It is therefore deliberately not imported here (importing a private would be a false contract).

## What this characterizes
- `from_now` returns `now` verbatim across 8 malformed inputs.
- `keep_original` returns the malformed `previousAnchorAt` verbatim (no validation/coercion).
- `keep_original` with no previous anchor falls back to `now`.
- Never throws; output stays a raw `string`, never a `Date`.
- A 50k-char timestamp is preserved byte-for-byte (no silent truncation in the selector).

## Verification gate
`npx vitest run hushh-webapp/__tests__/lib/services/profile-timestamp-bounds.test.ts` → 1 file, **5 tests passed**, zero production drift.

## Reviewer risk assessment (no risks)
- Zero production runtime change; no new exports; no observability-schema touch; no consent/vault surface.
- Correct base: targets `integration/pr-train` (not `main`).
- DCO-signed single-file commit.
- The one honest judgment: tests **pin existing** non-validating passthrough. If non-validation is later deemed a defect, that is a separate production fix and this test would move with it (it documents the current boundary, not an endorsement).

## CI gate checklist
- [x] PR Base Policy — targets integration/pr-train branch
- [x] DCO Verified
- [x] Test Only Surface Change
