### PR TITLE
test(services): characterize computeRiskScore constraints under null inputs

### DIFF
--- a/hushh-webapp/__tests__/lib/services/risk-score-nulls.test.ts
+++ b/hushh-webapp/__tests__/lib/services/risk-score-nulls.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Characterization suite — @/lib/services/kai-profile-service · computeRiskScore
+ *
+ * Pins how the exported risk-score calculation responds to "empty"-shaped
+ * inputs: null/undefined preference fields, empty object structures, and
+ * unexpected empty arrays.
+ *
+ * TRUTH-FIRST NOTE (verified against source, not assumed):
+ *   computeRiskScore delegates to three per-field scorers, each guarded by
+ *   `if (!value) return null`. computeRiskScore then returns null if ANY of the
+ *   three sub-scores is null, else the numeric sum. Concretely:
+ *
+ *     - null / undefined field      -> falsy -> sub-score null -> total null
+ *     - missing field (empty object) -> undefined -> sub-score null -> total null
+ *     - empty array []               -> TRUTHY -> bypasses the null guard and
+ *                                       falls through to the final `return 2`
+ *                                       (it is not a known enum value, so it
+ *                                       lands on the catch-all branch). This is
+ *                                       the surprising boundary worth pinning.
+ *     - whole `preferences` = null   -> throws (no top-level guard); property
+ *                                       access on null is a TypeError.
+ *
+ *   These tests pin the ACTUAL contract. They do not assert a "should",
+ *   they document what ships today so a future refactor changes it visibly.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { computeRiskScore } from "@/lib/services/kai-profile-service";
+
+// Loose alias for feeding deliberately off-contract values into a typed param.
+const compute = computeRiskScore as unknown as (input: unknown) => number | null;
+
+describe("kai-profile-service · computeRiskScore under empty/null inputs (public contract)", () => {
+  it("returns null when every preference field is explicitly null", () => {
+    expect(
+      computeRiskScore({
+        investment_horizon: null,
+        drawdown_response: null,
+        volatility_preference: null,
+      })
+    ).toBeNull();
+  });
+
+  it("returns null for an entirely empty object (all fields missing/undefined)", () => {
+    expect(compute({})).toBeNull();
+  });
+
+  it("returns null if even a single field is null while others are valid", () => {
+    expect(
+      computeRiskScore({
+        investment_horizon: "long_term",
+        drawdown_response: "buy_more",
+        volatility_preference: null,
+      })
+    ).toBeNull();
+  });
+
+  it("does NOT collapse empty arrays to null — they are truthy and fall through to the catch-all score of 2 each (total 6)", () => {
+    // Pins the surprising boundary: [] bypasses `if (!value)` and lands on the
+    // final `return 2` in each scorer, summing to 6.
+    expect(
+      compute({
+        investment_horizon: [],
+        drawdown_response: [],
+        volatility_preference: [],
+      })
+    ).toBe(6);
+  });
+
+  it("throws when the whole preferences object is null (no top-level guard)", () => {
+    expect(() => compute(null)).toThrow();
+  });
+
+  it("computes the additive sum for fully-valid lowest-risk inputs (sanity anchor: 0)", () => {
+    expect(
+      computeRiskScore({
+        investment_horizon: "short_term",
+        drawdown_response: "reduce",
+        volatility_preference: "small",
+      })
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Characterizes how the exported `computeRiskScore` in `hushh-webapp/lib/services/kai-profile-service.ts` responds to "empty"-shaped inputs: null/undefined fields, an entirely empty object, and unexpected empty arrays. Test-only; no production source changed.

## Truth-first findings (verified against source)
`computeRiskScore` fans out to three per-field scorers, each guarded by `if (!value) return null`, and returns `null` if **any** sub-score is `null`, else the numeric sum. The real, shipped boundaries:

- `null` / `undefined` field → falsy → sub-score `null` → **total `null`**.
- Empty object `{}` (fields missing) → `undefined` → **total `null`**.
- Empty array `[]` → **truthy**, so it bypasses the `if (!value)` guard and falls through to each scorer's catch-all `return 2`, summing to **6**. This is the surprising boundary worth pinning — "empty" is not uniformly treated as "absent".
- Whole `preferences === null` → **throws** (no top-level guard; property access on `null`).

The suite documents what ships today (not a "should"), so any future hardening changes it visibly.

## Verification gate
`npx vitest run hushh-webapp/__tests__/lib/services/risk-score-nulls.test.ts` → 1 file, **6 tests passed**, zero production drift.

## Reviewer risk assessment (no risks)
- Zero production runtime change; no new exports; no consent/vault/observability surface touched.
- Correct base: targets `integration/pr-train`.
- DCO-signed single-file commit.
- Off-contract inputs (`[]`, `null`) are fed via a local `unknown` cast confined to the test — no production type loosening.

## CI gate checklist
- [x] PR Base Policy — targets integration/pr-train branch
- [x] DCO Verified
- [x] Test Only Surface Change
