### PR TITLE
fix(pkm): guard missing metadata domains in loadFullBlob

### DIFF
--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -2445,7 +2445,7 @@ export class PersonalKnowledgeModelService {
     } catch {
       metadata = null;
     }
-    const availableDomains = metadata?.domains.map((domain) => domain.key).filter(Boolean) || [];
+    const availableDomains = (metadata?.domains ?? []).map((domain) => domain.key).filter(Boolean);
 
     const legacyEncrypted = await this.getEncryptedData(params.userId, params.vaultOwnerToken);
     const domainBlobs = await Promise.all(


### PR DESCRIPTION
## Summary

Guard against missing `metadata.domains` when loading the full PKM blob.

### Changes

- Default `metadata.domains` to an empty array before mapping over it.

### Why

Previously `loadFullBlob()` called `metadata?.domains.map(...)`, which could throw if metadata existed but `domains` was undefined. This change safely defaults to an empty array while preserving existing behavior when no domains are available.