### PR TITLE
fix(one-location): route notification deep-links to Inbox hub tab; remove duplicate Start button

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -922,13 +922,16 @@ describe("OneLocationAgentPage", () => {
       "https://www.google.com/maps/dir/?api=1&destination=28.613900%2C77.209000&travelmode=driving",
     );
 
-    const startLink = screen.getByRole("link", {
-      name: "Start Google Maps navigation to shared live location",
-    });
-    expect(startLink.getAttribute("target")).toBe("_blank");
-    expect(startLink.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(startLink.getAttribute("href")).toContain("dir_action=navigate");
+    // The duplicate "Start" navigation button was removed from location
+    // previews (it opened the same Google Maps navigation as "Directions").
+    // Only the single "Directions" action should remain.
+    expect(
+      screen.queryByRole("link", {
+        name: "Start Google Maps navigation to shared live location",
+      }),
+    ).toBeNull();
   });
+
 
   it("tracks public location link creation without analytics identity payloads", async () => {
     const longPublicUrl =

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -27,8 +27,8 @@ import {
   Loader2,
   LocateFixed,
   MapPin,
-  Navigation,
   Pencil,
+
   Plus,
   RefreshCw,
   Route,
@@ -759,11 +759,8 @@ function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
   return `https://www.google.com/maps/dir/?api=1&destination=${destination}&travelmode=driving`;
 }
 
-function googleMapsStartNavigationUrl(point: PlainLocationPoint): string {
-  return `${googleMapsDirectionsUrl(point)}&dir_action=navigate`;
-}
-
 function locationAccuracyLabel(point: PlainLocationPoint): string | null {
+
   const accuracyM = point.accuracyM;
   if (typeof accuracyM !== "number" || !Number.isFinite(accuracyM) || accuracyM <= 0) {
     return null;
@@ -803,8 +800,8 @@ function LocalMapPreview({
   const accuracy = locationAccuracyLabel(point);
   const embedUrl = googleMapsLocationEmbedUrl(point);
   const directionsUrl = googleMapsDirectionsUrl(point);
-  const startUrl = googleMapsStartNavigationUrl(point);
   const statusLabel = isStale ? "Last known location" : "Live location";
+
 
   return (
     <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
@@ -851,7 +848,7 @@ function LocalMapPreview({
         </div>
 
         {showNavigation ? (
-          <div className="grid gap-2 sm:grid-cols-2">
+          <div className="grid gap-2">
             <Button
               asChild
               variant="outline"
@@ -868,23 +865,9 @@ function LocalMapPreview({
                 Directions
               </a>
             </Button>
-            <Button
-              asChild
-              size="sm"
-              className="h-10 w-full min-w-0 rounded-full bg-[#1c1c1e] text-white hover:bg-black dark:bg-white dark:text-[#1c1c1e] dark:hover:bg-white/90"
-            >
-              <a
-                href={startUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Start Google Maps navigation to shared live location"
-              >
-                <Navigation className="h-4 w-4" aria-hidden="true" />
-                Start
-              </a>
-            </Button>
           </div>
         ) : null}
+
       </div>
 
 

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -6,9 +6,9 @@ import {
   AlertTriangle,
   CheckCircle2,
   MapPin,
-  Navigation,
   Route,
 } from "lucide-react";
+
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -53,11 +53,8 @@ function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
   )}&travelmode=driving`;
 }
 
-function googleMapsStartUrl(point: PlainLocationPoint): string {
-  return `${googleMapsDirectionsUrl(point)}&dir_action=navigate`;
-}
-
 function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
+
   const capturedAt = formatDateTime(point.capturedAt);
   const accuracy =
     typeof point.accuracyM === "number" && Number.isFinite(point.accuracyM)
@@ -87,7 +84,7 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
             {accuracy ? ` - ${accuracy}` : ""}
           </p>
         </div>
-        <div className="grid gap-2 sm:grid-cols-2">
+        <div className="grid gap-2">
           <Button asChild variant="outline" size="sm" className="h-10 rounded-full">
             <a
               href={googleMapsDirectionsUrl(point)}
@@ -98,17 +95,8 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
               Directions
             </a>
           </Button>
-          <Button asChild size="sm" className="h-10 rounded-full">
-            <a
-              href={googleMapsStartUrl(point)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Navigation className="h-4 w-4" aria-hidden="true" />
-              Start
-            </a>
-          </Button>
         </div>
+
       </div>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -19,6 +19,8 @@
  */
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useSearchParams } from "next/navigation";
+
 
 import {
   Inbox as InboxIcon,
@@ -186,8 +188,46 @@ const PEOPLE_LIST_SCROLL_CLASS =
 
 
 export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
+  const searchParams = useSearchParams();
   const [tab, setTab] = useState<LocationHubTab>("now");
   const [flow, setFlow] = useState<FlowKind>("none");
+  // Deep-link routing: notification "Open" buttons land here with a `section`
+  // (or requestId/grantId/submissionId) query param. The page-level tabs are
+  // compose/activity, but the ACTIVE UI is this hub (now/people/links/inbox),
+  // which owns its own tab state — so it must consume the deep-link itself and
+  // switch to the correct hub tab. Sections map: shared/approvals/my_requests →
+  // inbox, public_responses → links. An access-request (`requestId`) or the
+  // approvals section opens Inbox so User A/B lands on the approve/deny +
+  // "Shared with me" surfaces. Runs on every param change (Next.js keeps the
+  // component mounted across same-path query navigations).
+  useEffect(() => {
+    const section = String(
+      searchParams.get("section") || "",
+    ).trim();
+    const hasRequest = Boolean(String(searchParams.get("requestId") || "").trim());
+    const hasGrant = Boolean(String(searchParams.get("grantId") || "").trim());
+    const hasSubmission = Boolean(
+      String(searchParams.get("submissionId") || "").trim(),
+    );
+    let nextTab: LocationHubTab | null = null;
+    if (
+      section === "approvals" ||
+      section === "shared" ||
+      section === "my_requests" ||
+      hasRequest ||
+      hasGrant
+    ) {
+      nextTab = "inbox";
+    } else if (section === "public_responses" || hasSubmission) {
+      nextTab = "links";
+    } else if (section === "people") {
+      nextTab = "people";
+    }
+    if (nextTab) {
+      setTab(nextTab);
+    }
+  }, [searchParams]);
+
   const [shareStep, setShareStep] = useState<"person" | "details">("person");
   const [locationType, setLocationType] =
     useState<LocationTypeValue>("precise");


### PR DESCRIPTION
## Problems (UAT)

Three One-Location issues reported after prior attempts didn't fully land:

1. **Share-location popup → wrong landing.** Clicking the "Open" button on the "location shared with you" popup did not reliably land User B on the Inbox **"Shared with me"** section.
2. **Access-request popup → wrong landing.** When User B sends an access request (with message) to User A, User A's popup "Open" did not land on the Inbox **approve/deny** ("Needs your review") section. (Verify + fix — must NOT break the consent-manager flow.)
3. **Duplicate "Start" button.** Location previews showed two buttons — "Direction(s)" and "Start" — that do the same thing (open Google Maps navigation). The extra "Start" must be removed everywhere a preview appears.

## Root cause (deep-link routing)

`USE_LOCATION_REDESIGN = true`, so the **active UI is `LocationRedesignHub`** (tabs: now / people / links / **inbox**), which owns its own `useState` tab. The old page-level `section`-param effect only drove the legacy `compose`/`activity` layout (not rendered) and its hidden section refs — so the hub **never consumed the notification deep-link** and stayed on "Now". That's why every prior section-param fix appeared to do nothing.

## Fix

1. **Deep-link routing (bugs 1 + 2):** add a `useSearchParams` effect in `LocationRedesignHub` that maps the notification query params to the correct hub tab:
   - `section=shared` / `approvals` / `my_requests`, or a `requestId` / `grantId` → **inbox** (the "Shared with me" + "Needs your review" approve/deny surfaces).
   - `section=public_responses` / `submissionId` → **links**.
   - `section=people` → **people**.
   - Runs on every param change (Next.js keeps the component mounted across same-path query navigations), so router.push from a toast lands correctly.
   - The consent-manager flow is untouched: approve/deny handlers, consent-surface refresh, and the FCM provider hrefs are unchanged. This only switches which hub tab is visible.
2. **Remove duplicate "Start" button (bug 3):** delete the "Start" button from `LocalMapPreview` (covers shared-with-me + self previews) in `app/one/location/page.tsx` and from the public link page `app/one/location/request/[token]/page-client.tsx`; keep "Directions". Also removed the now-dead `googleMapsStart*` helpers and unused `Navigation` icon imports.

## Files

- `components/one-location/redesign/location-redesign-hub.tsx` — deep-link → hub tab effect.
- `app/one/location/page.tsx` — remove Start button + dead helper/import.
- `app/one/location/request/[token]/page-client.tsx` — remove Start button + dead helper/import.

## Lane

Maintainer direct-to-main (author @DamriaNeelesh is in the governed bypass cohort); branched from `origin/main`. DCO signed-off. Please review — do not merge yet.
