### PR TITLE
fix(ui): remove kai flow plaid status console warning leak

### DIFF
--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -1430,8 +1430,7 @@ export function KaiFlow({
       const status = resource?.plaidStatus ?? null;
       setPlaidStatus(status);
       return status;
-    } catch (plaidError) {
-      console.warn("[KaiFlow] Failed to load Plaid status:", plaidError);
+    } catch (_plaidError) {
       setPlaidStatus(null);
       return null;
     }


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `KaiFlow` Plaid status fetch handler. If the API check for the user's Plaid connection status fails, the UI already gracefully degrades by setting the status to `null` and safely returning. Removing this log keeps the client console clean without needing environment checks, and the catch variable is appropriately prefixed with an underscore to satisfy TypeScript linters.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/kai-flow.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging removal)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/kai-flow.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection, TypeScript linters)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.