### PR TITLE
chore(ui): silence warnings for debate stream background logic failures

### DIFF
--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -814,7 +814,7 @@ export function DebateStreamView({
           userId,
           vaultOwnerToken,
         });
-      } catch (cancelError) {
+      } catch {
         // Run cancellation failure is non-critical
       }
     }
@@ -1328,7 +1328,7 @@ export function DebateStreamView({
             },
             financial_profile: profile,
           };
-        } catch (profileError) {
+        } catch {
           // Handled gracefully below
         }
       }
@@ -1359,7 +1359,7 @@ export function DebateStreamView({
             extractDebatePortfolioContext(userId, financialDomain ?? undefined) ??
             portfolioContext;
           portfolioContext = hydratedContext;
-        } catch (blobError) {
+        } catch {
           // Handled gracefully below
         }
       }

--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -815,7 +815,7 @@ export function DebateStreamView({
           vaultOwnerToken,
         });
       } catch (cancelError) {
-        console.warn("[DebateStreamView] Failed to cancel run:", cancelError);
+        // Run cancellation failure is non-critical
       }
     }
     setBusyOperation("stock_analysis_stream", false);
@@ -1329,7 +1329,7 @@ export function DebateStreamView({
             financial_profile: profile,
           };
         } catch (profileError) {
-          console.warn("[DebateStreamView] Failed to load Kai profile context:", profileError);
+          // Handled gracefully below
         }
       }
 
@@ -1360,10 +1360,7 @@ export function DebateStreamView({
             portfolioContext;
           portfolioContext = hydratedContext;
         } catch (blobError) {
-          console.warn(
-            "[DebateStreamView] Failed to hydrate debate context from the financial PKM domain:",
-            blobError
-          );
+          // Handled gracefully below
         }
       }
 


### PR DESCRIPTION
### Description

Silences redundant `console.warn` traces in `components/kai/debate-stream-view.tsx`. These warnings (`"Failed to cancel run:"`, `"Failed to load Kai profile context:"`, and `"Failed to hydrate debate context..."`) fired during graceful fallbacks for background operations. Since these failures are non-critical and already handled implicitly by the surrounding logic, the warnings were removed to keep the browser console clean during standard usage.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/debate-stream-view.tsx`

- Trust boundary touched:
  - [x] none (purely client UI cleanup)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/debate-stream-view.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.