### PR TITLE
fix(one-location): route native push taps into One Location deep-link (iOS/Android)

### DIFF
--- a/hushh-webapp/lib/notifications/fcm-service.ts
+++ b/hushh-webapp/lib/notifications/fcm-service.ts
@@ -796,12 +796,38 @@ function setupNativeListeners(): void {
               href: ROUTES.KAI_DASHBOARD,
               scroll: false,
             });
+          } else if (
+            data &&
+            ((typeof data.type === "string" &&
+              data.type.startsWith("location_")) ||
+              (typeof data.notification_category === "string" &&
+                data.notification_category === "ONE_LOCATION"))
+          ) {
+            // One Location pushes (share/access-request/approval/etc). The
+            // backend puts the full in-app deep-link (with section / requestId /
+            // grantId / submissionId query params) in `request_url`; the
+            // redesign hub reads those params to open the correct tab
+            // (inbox / links / people). Fall back to `deep_link` or the hub
+            // root so a tap always lands on One Location, never Home.
+            const locationHref =
+              (typeof data.request_url === "string" && data.request_url.trim()
+                ? data.request_url.trim()
+                : "") ||
+              (typeof data.deep_link === "string" && data.deep_link.trim()
+                ? data.deep_link.trim()
+                : "") ||
+              "/one/location";
+            requestInternalAppNavigation({
+              href: locationHref,
+              scroll: false,
+            });
           } else {
             requestInternalAppNavigation({
               href: ROUTES.HOME,
               scroll: false,
             });
           }
+
         }
       );
 


### PR DESCRIPTION
## Context

Founder wants the whole One App on production — **iOS + Android + web**. Web UAT is covered. This PR closes the one real **iOS/Android-native** production gap I found while auditing the One Location feature end-to-end for the Capacitor (WKWebView) build.

## iOS end-to-end audit (what I verified — all PASS)

- **Geolocation + permissions**: backed by the custom `HushhLocation` Capacitor plugin (CoreLocation on iOS). `captureCurrentPosition` / `watchCurrentPosition` / `clearLocationWatch` are consistent (no `clearWatch` mismatch). `Info.plist` has `NSLocationWhenInUseUsageDescription`, `NSContactsUsageDescription`, and `UIBackgroundModes: remote-notification`. ✅
- **E2E encryption**: ECDH-P256 + AES-256-GCM via a single `requireCrypto()` (`globalThis.crypto`); Capacitor serves a secure context (`capacitor://` / `https`) so `crypto.subtle` is available in WKWebView. ✅
- **External links / share / map**: no `Browser.open` needed — Capacitor's `WebViewDelegationHandler` forwards `target="_blank"` (Directions) to the system browser/Maps; `@capacitor/share` handles invite links (text+url on iOS). ✅
- **Tri-architecture + native API routing**: `CAPACITOR_BUILD=true` → `output: "export"` static bundle (no Next.js API routes). `ApiService.apiFetch` correctly prefixes `NEXT_PUBLIC_BACKEND_URL` and uses `CapacitorHttp` on native, with a hard error if the backend URL is missing. Path parity confirmed: native calls `{backend}/api/one/location/...`, identical to what the web proxy maps. ✅ (Release reminder: ensure `NEXT_PUBLIC_BACKEND_URL` is set for the native build.)

## The gap this PR fixes

**Native push-notification taps for One Location dead-ended on Home (iOS + Android).**

`fcm-service.ts`'s native `notificationActionPerformed` handler only branched on `consent_request` and `kai_analysis_complete`; **every other push — including all `location_*` events — fell through to `ROUTES.HOME`.** So when the app is backgrounded/closed and the user taps a One Location push (share received, access request, approval, public response, etc.), they landed on Home instead of the One Location hub. This is the **native counterpart** of the web deep-link gap fixed in PR #4262 (which only fixed in-app/foreground toast routing via `useSearchParams`).

### Fix

Add a `location_*` branch to the native tap handler that navigates to the backend-provided `request_url` — which already carries `section` / `requestId` / `grantId` / `submissionId` (e.g. `/one/location?grantId=...&section=shared`). `LocationRedesignHub` (from PR #4262) consumes exactly those params to open the correct tab (inbox / links / people). Falls back to `deep_link`, then `/one/location`, so a tap never dead-ends on Home. Matches on `data.type` starting with `location_` **or** `data.notification_category === "ONE_LOCATION"` (both are set by the backend `_notify` payload). Web and foreground paths are unchanged.

## Files

- `hushh-webapp/lib/notifications/fcm-service.ts` — native `notificationActionPerformed`: add One Location deep-link branch.

## Lane

Maintainer direct-to-main (author @DamriaNeelesh is in the governed bypass cohort); rebased fresh on `origin/main`. DCO signed-off. Please review — do not merge yet.
