### PR TITLE
chore(governance): add rohansharma4050 to maintainer bypass lists

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -25,7 +25,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "ahujagautam024"
+      "ahujagautam024",
+      "rohansharma4050"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -39,7 +40,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "ahujagautam024"
+      "ahujagautam024",
+      "rohansharma4050"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
@@ -48,7 +50,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "ahujagautam024"
+      "ahujagautam024",
+      "rohansharma4050"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -71,7 +74,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "ahujagautam024"
+      "ahujagautam024",
+      "rohansharma4050"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -85,7 +89,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "ahujagautam024"
+      "ahujagautam024",
+      "rohansharma4050"
     ]
   },
   "uat": {
@@ -99,7 +104,8 @@
       "azfx",
       "Jhumma-hushh",
       "DamriaNeelesh",
-      "ahujagautam024"
+      "ahujagautam024",
+      "rohansharma4050"
     ]
   },
   "production": {


### PR DESCRIPTION
# Description

Adds GitHub user `rohansharma4050` to the maintainer bypass rosters in `config/ci-governance.json`, mirroring the existing `ahujagautam024` membership. This grants Rohan the same maintainer access: merge-queue bypass on `main`, plus the paired review-bypass, protected-pipeline-edit, pr_train, and uat manual-dispatch entries.

`production.manual_dispatch_users` is intentionally left owner-only (`kushaltrivedi5`) — `ahujagautam024` is not in it, so Rohan is not added there either.

Config-only change: no code, routes, schema, or runtime behavior touched.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `config/ci-governance.json` — consumed by `scripts/ci/apply-governance.py` / repo governance CI to configure branch protection, merge-queue, and review bypass.
- Trust boundary touched:
  - [x] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:
    - **deploy / governance**: adds a user to merge-queue and review bypass lists (elevated repo access). No runtime/user-data boundary affected.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Revert this commit to remove `rohansharma4050` from all lists; governance CI re-applies prior state.
- UI browser or Playwright proof:
  - [x] Not applicable
- Verification commands executed:
  - [x] JSON validated well-formed (`python3 -c "import json; json.load(open('config/ci-governance.json'))"`)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: follows the pattern of the prior `maintainer/add-gautam-to-governance` change.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene: **governance/config change.**
- [x] Reachable production attach point: `config/ci-governance.json` is read by repo governance CI (`scripts/ci/apply-governance.py`).
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file: N/A — no test changes.
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint: existing config, no new surface.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`: commit is signed off; CI pending.
- [x] Maintainer edits are enabled, or the reason they cannot be enabled is listed here: enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — config-only, no application layer touched.
- [x] **iOS**: N/A — config-only.
- [x] **Android**: N/A — config-only.

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari) — N/A
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical repo command: N/A — hand-edited config, JSON validated.

## 📸 Screenshots / Video

Not applicable — no UI-visible change. Change is limited to bypass-user lists in `config/ci-governance.json`.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [ ] If yes, have you implemented `checkConsentToken()`? N/A.
- [x] Sensitive surface touched: deploy (repo governance access) — no user data.
- [x] Error path, rollback, or safe-failure behavior proved: revert restores prior list.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed: N/A — no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
