### PR TITLE
feat(one-marketplace): consent-first PKM slice marketplace under One

### DIFF
--- a/consent-protocol/api/routes/pkm.py
+++ b/consent-protocol/api/routes/pkm.py
@@ -5,6 +5,8 @@ Personal Knowledge Model API routes.
 Canonical API surface for PKM.
 """
 
+from typing import Literal
+
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, Header, HTTPException, Path, status
 from pydantic import BaseModel, Field
 
@@ -78,6 +80,7 @@ from api.routes.pkm_routes_shared import (
 from api.routes.pkm_routes_shared import (
     validate_store_domain as _validate_store_domain,
 )
+from hushh_mcp.pricing import SlicePricingInput, compute_suggested_price
 from hushh_mcp.services.pkm_agent_lab_service import get_pkm_agent_lab_service
 
 router = APIRouter(prefix="/api/pkm", tags=["pkm"])
@@ -305,3 +308,59 @@ async def preview_pkm_structure(
         simulated_state=request.simulated_state,
     )
     return PKMAgentLabStructureResponse(**payload)
+
+
+class SlicePriceRequest(BaseModel):
+    """Public slice metadata + demo audience band. No ciphertext, no user data."""
+
+    category: Literal[
+        "identifiers",
+        "quasi_identifiers",
+        "demographics_lifestyle",
+        "private_financial",
+    ] = "demographics_lifestyle"
+    attribute_count: int = Field(default=1, ge=0, le=10000)
+    power: Literal["mass", "mid", "affluent", "hnw", "uhnw"] = "mass"
+    mood: Literal["passive", "affinity", "in_market", "hot"] = "passive"
+    weeks_stale: int = Field(default=0, ge=0, le=520)
+    exclusivity: Literal["shared", "limited", "exclusive"] = "shared"
+    geography: Literal["us", "non_us"] = "us"
+
+
+class SlicePriceResponse(BaseModel):
+    suggested_price_cents: int
+    currency: str
+    floor_cents: int
+    breakdown: dict
+
+
+@router.post("/slice-price", response_model=SlicePriceResponse)
+async def compute_slice_price(
+    request: SlicePriceRequest,
+    _auth: dict = Depends(require_pkm_metadata_access),
+):
+    """
+    Suggested 30-day price for a published default_available slice.
+
+    Display-only (Phase 1): stateless, reads no ciphertext, persists nothing, and
+    does not change any consent scope. The owner sets the real price in a later
+    phase; this endpoint keeps the number server-authoritative so the browser
+    cannot fabricate it. See docs/future/pkm-slice-marketplace-plan.md.
+    """
+    breakdown = compute_suggested_price(
+        SlicePricingInput(
+            category=request.category,
+            attribute_count=request.attribute_count,
+            power=request.power,
+            mood=request.mood,
+            weeks_stale=request.weeks_stale,
+            exclusivity=request.exclusivity,
+            geography=request.geography,
+        )
+    )
+    return SlicePriceResponse(
+        suggested_price_cents=breakdown.suggested_price_cents,
+        currency=breakdown.currency,
+        floor_cents=breakdown.floor_cents,
+        breakdown=breakdown.as_dict(),
+    )

--- a/consent-protocol/hushh_mcp/pricing/__init__.py
+++ b/consent-protocol/hushh_mcp/pricing/__init__.py
@@ -1,0 +1,16 @@
+# consent-protocol/hushh_mcp/pricing/__init__.py
+"""Data-slice pricing primitives (planning phase 1: suggested price only)."""
+
+from .slice_pricing import (
+    SlicePriceBreakdown,
+    SlicePricingInput,
+    category_from_sensitivity,
+    compute_suggested_price,
+)
+
+__all__ = [
+    "SlicePriceBreakdown",
+    "SlicePricingInput",
+    "category_from_sensitivity",
+    "compute_suggested_price",
+]

--- a/consent-protocol/hushh_mcp/pricing/slice_pricing.py
+++ b/consent-protocol/hushh_mcp/pricing/slice_pricing.py
@@ -1,0 +1,164 @@
+# consent-protocol/hushh_mcp/pricing/slice_pricing.py
+"""
+Data-slice suggested-price engine.
+
+Phase 1 scope: a self-contained *pure function* that returns a **suggested**
+30-day subscription price for a published `default_available` PKM slice. It is a
+suggestion only — the owner sets the real price (a later phase), floor-guarded by
+this same floor. This module:
+
+- reads no ciphertext and no protected PKM content;
+- touches no database and no network;
+- takes only public slice metadata plus a demo audience band.
+
+The shape is grounded in published data-market research:
+- weighted-composite category valuation (Cheng et al.),
+- two-part tariff / fixed floor + arbitrage-free bundling (arXiv 2303.04810),
+- purchasing-power/buying-mood, freshness, exclusivity, geography as the primary
+  marketplace price drivers (arXiv 2111.04427).
+
+See docs/future/pkm-slice-marketplace-plan.md for the full rationale.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+# Fixed platform access floor (the fixed leg of the two-part tariff), in cents.
+# Also the hard minimum on any suggested price so it never collapses to zero.
+FLOOR_CENTS = 10  # $0.10
+
+CURRENCY = "USD"
+
+# Published category weight (k) and per-record dollar anchor (a).
+# Keys are the four categories from the weighted-composite valuation model.
+_CATEGORY_WEIGHTS: dict[str, float] = {
+    "identifiers": 0.50,
+    "quasi_identifiers": 0.41,
+    "demographics_lifestyle": 0.45,
+    "private_financial": 0.62,
+}
+_CATEGORY_ANCHORS: dict[str, float] = {
+    "identifiers": 0.05,
+    "quasi_identifiers": 0.02,
+    "demographics_lifestyle": 0.05,
+    "private_financial": 0.50,
+}
+
+# Purchasing power and buying-mood bands (the primary driver B = power x mood).
+_POWER: dict[str, float] = {"mass": 1.0, "mid": 1.5, "affluent": 2.0, "hnw": 3.0, "uhnw": 4.0}
+_MOOD: dict[str, float] = {"passive": 1.0, "affinity": 2.0, "in_market": 4.0, "hot": 6.0}
+
+# Exclusivity / identifiability (X) and geography / coverage (G).
+_EXCLUSIVITY: dict[str, float] = {"shared": 1.0, "limited": 1.5, "exclusive": 3.0}
+_GEOGRAPHY: dict[str, float] = {"us": 1.0, "non_us": 0.6}
+
+_FRESHNESS_DECAY_PER_WEEK = 0.12
+_FRESHNESS_MIN = 0.3
+
+
+@dataclass(frozen=True)
+class SlicePricingInput:
+    """Public, non-sensitive inputs for a single slice's suggested price."""
+
+    category: str = "demographics_lifestyle"
+    attribute_count: int = 1
+    power: str = "mass"
+    mood: str = "passive"
+    weeks_stale: int = 0
+    exclusivity: str = "shared"
+    geography: str = "us"
+
+
+@dataclass(frozen=True)
+class SlicePriceBreakdown:
+    """Deterministic price plus the factors that produced it (for 'show math')."""
+
+    suggested_price_cents: int
+    currency: str = CURRENCY
+    floor_cents: int = FLOOR_CENTS
+    composite_dollars: float = 0.0
+    richness: float = 1.0
+    multiplier_b: float = 1.0
+    multiplier_f: float = 1.0
+    multiplier_x: float = 1.0
+    multiplier_g: float = 1.0
+    floor_applied: bool = False
+    formula: str = ""
+
+    def as_dict(self) -> dict:
+        return {
+            "suggested_price_cents": self.suggested_price_cents,
+            "currency": self.currency,
+            "floor_cents": self.floor_cents,
+            "composite_dollars": round(self.composite_dollars, 6),
+            "richness": round(self.richness, 6),
+            "multiplier_b": round(self.multiplier_b, 6),
+            "multiplier_f": round(self.multiplier_f, 6),
+            "multiplier_x": round(self.multiplier_x, 6),
+            "multiplier_g": round(self.multiplier_g, 6),
+            "floor_applied": self.floor_applied,
+            "formula": self.formula,
+        }
+
+
+def _richness(attribute_count: int) -> float:
+    """Diminishing returns on attribute count: 1 + ln(n), floored at n=1."""
+    n = max(1, int(attribute_count))
+    return 1.0 + math.log(n)
+
+
+def category_from_sensitivity(sensitivity_tier: str | None, scope_kind: str | None = None) -> str:
+    """
+    Map a scope-registry entry's public metadata to a pricing category.
+
+    Conservative Phase-1 mapping: restricted/financial/secret scopes price as
+    private_financial (highest weight); everything else as demographics_lifestyle.
+    """
+    tier = (sensitivity_tier or "").strip().lower()
+    kind = (scope_kind or "").strip().lower()
+    if tier == "restricted" or "financial" in kind or "secret" in kind:
+        return "private_financial"
+    return "demographics_lifestyle"
+
+
+def compute_suggested_price(inp: SlicePricingInput) -> SlicePriceBreakdown:
+    """
+    Suggested 30-day price:
+
+        P = ( p_f + k_c * a_c * richness(n) ) * B * F * X * G
+        final = max(FLOOR, P)
+
+    Pure and deterministic. Raises KeyError on unknown band/category values so the
+    caller (route) can surface a 422 rather than silently mispricing.
+    """
+    k = _CATEGORY_WEIGHTS[inp.category]
+    a = _CATEGORY_ANCHORS[inp.category]
+    richness = _richness(inp.attribute_count)
+
+    floor_dollars = FLOOR_CENTS / 100.0
+    composite = floor_dollars + (k * a * richness)
+
+    power = _POWER[inp.power]
+    mood = _MOOD[inp.mood]
+    b = power * mood
+    f = max(_FRESHNESS_MIN, 1.0 - _FRESHNESS_DECAY_PER_WEEK * max(0, int(inp.weeks_stale)))
+    x = _EXCLUSIVITY[inp.exclusivity]
+    g = _GEOGRAPHY[inp.geography]
+
+    price_dollars = composite * b * f * x * g
+    computed_cents = round(price_dollars * 100.0)
+    floored_cents = max(FLOOR_CENTS, computed_cents)
+
+    return SlicePriceBreakdown(
+        suggested_price_cents=floored_cents,
+        composite_dollars=composite,
+        richness=richness,
+        multiplier_b=b,
+        multiplier_f=f,
+        multiplier_x=x,
+        multiplier_g=g,
+        floor_applied=floored_cents != computed_cents,
+        formula="( floor + k*a*richness ) x (power*mood) x freshness x exclusivity x geo",
+    )

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -2377,7 +2377,7 @@ class PersonalKnowledgeModelService:
                 .select("*")
                 .eq("user_id", user_id)
                 .eq("scope", scope)
-                .is_("revoked_at", "null")
+                .is_("revoked_at", None)
                 .order("updated_at", desc=True)
                 .limit(1)
             )
@@ -2422,7 +2422,7 @@ class PersonalKnowledgeModelService:
                 .eq("user_id", user_id)
                 .eq("domain", canonical_domain)
                 .eq("top_level_scope_path", normalized_path)
-                .is_("revoked_at", "null")
+                .is_("revoked_at", None)
             )
             await self.record_mutation_event(
                 user_id=user_id,

--- a/consent-protocol/tests/test_pkm_slice_price_route.py
+++ b/consent-protocol/tests/test_pkm_slice_price_route.py
@@ -1,0 +1,52 @@
+# consent-protocol/tests/test_pkm_slice_price_route.py
+"""Route test for POST /api/pkm/slice-price (imports the production router)."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import pkm
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(pkm.router)
+    app.dependency_overrides[pkm.require_pkm_metadata_access] = lambda: {
+        "user_id": "user_123",
+        "auth_type": "firebase",
+    }
+    return app
+
+
+def test_slice_price_route_returns_floored_price_and_breakdown():
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/pkm/slice-price",
+        json={
+            "category": "demographics_lifestyle",
+            "attribute_count": 3,
+            "power": "affluent",
+            "mood": "affinity",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["currency"] == "USD"
+    assert body["floor_cents"] == 10
+    assert 55 <= body["suggested_price_cents"] <= 65
+    assert body["breakdown"]["multiplier_b"] == 4.0
+
+
+def test_slice_price_route_rejects_unknown_band():
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/pkm/slice-price",
+        json={"category": "demographics_lifestyle", "attribute_count": 1, "power": "galactic"},
+    )
+    assert response.status_code == 422
+
+
+def test_slice_price_route_uses_defaults_for_minimal_body():
+    client = TestClient(_build_app())
+    response = client.post("/api/pkm/slice-price", json={"attribute_count": 1})
+    assert response.status_code == 200
+    assert response.json()["suggested_price_cents"] >= 10

--- a/consent-protocol/tests/test_slice_pricing.py
+++ b/consent-protocol/tests/test_slice_pricing.py
@@ -1,0 +1,98 @@
+# consent-protocol/tests/test_slice_pricing.py
+"""Unit tests for the pure data-slice suggested-price engine."""
+
+import pytest
+
+from hushh_mcp.pricing.slice_pricing import (
+    FLOOR_CENTS,
+    SlicePricingInput,
+    category_from_sensitivity,
+    compute_suggested_price,
+)
+
+
+def _cents(**kwargs) -> int:
+    return compute_suggested_price(SlicePricingInput(**kwargs)).suggested_price_cents
+
+
+def test_affluent_travel_preferences_is_about_60_cents():
+    # demographics/lifestyle, 3 attrs, affluent x affinity buyer -> ~ $0.60
+    cents = _cents(
+        category="demographics_lifestyle",
+        attribute_count=3,
+        power="affluent",
+        mood="affinity",
+    )
+    assert 55 <= cents <= 65
+
+
+def test_uhnw_luxury_purchase_intent_is_about_20_dollars():
+    # private/financial, 4 attrs, UHNW x in-market, exclusive-to-one -> ~ $20
+    cents = _cents(
+        category="private_financial",
+        attribute_count=4,
+        power="uhnw",
+        mood="in_market",
+        exclusivity="limited",
+    )
+    assert 1900 <= cents <= 2100
+
+
+def test_mass_passive_single_attribute_hits_the_floor():
+    # demographics, 1 attr, mass x passive, stale -> computed dips under floor $0.10
+    result = compute_suggested_price(
+        SlicePricingInput(
+            category="demographics_lifestyle",
+            attribute_count=1,
+            power="mass",
+            mood="passive",
+            weeks_stale=2,
+        )
+    )
+    assert result.suggested_price_cents == FLOOR_CENTS
+    assert result.floor_applied is True
+
+
+def test_price_never_below_floor_for_any_valid_band():
+    for category in (
+        "identifiers",
+        "quasi_identifiers",
+        "demographics_lifestyle",
+        "private_financial",
+    ):
+        for power in ("mass", "mid", "affluent", "hnw", "uhnw"):
+            for mood in ("passive", "affinity", "in_market", "hot"):
+                cents = _cents(
+                    category=category, attribute_count=1, power=power, mood=mood, weeks_stale=52
+                )
+                assert cents >= FLOOR_CENTS
+
+
+def test_more_attributes_never_lowers_price_diminishing_returns():
+    prev = 0
+    for n in range(1, 8):
+        cents = _cents(
+            category="private_financial", attribute_count=n, power="affluent", mood="in_market"
+        )
+        assert cents >= prev
+        prev = cents
+
+
+def test_intent_can_outweigh_wealth():
+    # a "hot" mass-market buyer can outprice a "passive" UHNW buyer for the same slice
+    hot_mass = _cents(category="private_financial", attribute_count=3, power="mass", mood="hot")
+    passive_uhnw = _cents(
+        category="private_financial", attribute_count=3, power="uhnw", mood="passive"
+    )
+    assert hot_mass > passive_uhnw
+
+
+def test_unknown_band_raises_keyerror():
+    with pytest.raises(KeyError):
+        compute_suggested_price(SlicePricingInput(power="galactic"))
+
+
+def test_category_from_sensitivity_maps_restricted_to_financial():
+    assert category_from_sensitivity("restricted") == "private_financial"
+    assert category_from_sensitivity("confidential") == "demographics_lifestyle"
+    assert category_from_sensitivity(None, scope_kind="internal_secret") == "private_financial"

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -64,6 +64,7 @@ Promotion targets:
 - [hussh-one-infra/README.md](./hussh-one-infra/README.md): planning-only One infrastructure architecture for Founder Wiki validation, Salesforce/MuleSoft partner boundaries, private compute, BYOA, and code-persona alignment
 - [one-product-surface-evolution-plan.md](./one-product-surface-evolution-plan.md): planning-only product-surface evolution path for One, Kai, Nav, KYC, PCHP, PKM, OpenClaw/LLM Wiki-style projections, signature, brokerage, and brand-side access
 - [one-nav-runtime-plan.md](./one-nav-runtime-plan.md): planning-only migration path from the current Kai-first runtime to the One/Kai/Nav/KYC ontology
+- [pkm-slice-marketplace-plan.md](./pkm-slice-marketplace-plan.md): planning-only phased plan for a PKM data-slice subscription marketplace under One (backend-led, user-set price per slice, reuses default_available/consent/export)
 
 ## References
 

--- a/docs/future/pkm-slice-marketplace-plan.md
+++ b/docs/future/pkm-slice-marketplace-plan.md
@@ -1,0 +1,215 @@
+# PKM Data-Slice Marketplace Plan
+
+> Still docs/future, not yet a current-state contract. A working Phase 1 prototype (plus parts of
+> Phase 2 and 3) now exists on branch `feat/pkm-slice-pricing-phase1`; see Implementation Status below.
+> It has not graduated out of `docs/future/` because the promotion gate is not fully met (buyer
+> requests are in-session only, owner-set price is not persisted, tri-flow parity is pending).
+> Home rationale: this is a future-facing One product-surface concept, so it lives in `docs/future/`
+> under the promotion rules in [README.md](./README.md) and
+> [one-product-surface-evolution-plan.md](./one-product-surface-evolution-plan.md).
+
+## Implementation Status (branch `feat/pkm-slice-pricing-phase1`)
+
+Last refreshed 2026-07-01.
+
+### Done on this branch
+
+- Backend pricing engine: pure function `compute_suggested_price` in
+  `consent-protocol/hushh_mcp/pricing/slice_pricing.py`, floor-guarded at `$0.10`, with unit tests.
+- Backend route: `POST /api/pkm/slice-price` in `consent-protocol/api/routes/pkm.py`, gated by
+  `require_pkm_metadata_access`, with a route test. Backend suite: 11/11 green.
+- Frontend pricing service and suggested-price display (`lib/services/slice-pricing-service.ts`,
+  `components/profile/slice-price-badge.tsx`) shown on `default_available` scopes.
+- Marketplace surface under One at `app/one/marketplace/` with three tabs: Owner (price plus posture
+  controls), Buyer (browse Available slices, purchasable), and Consent flow and requests (in-session
+  approve/deny inbox that shows the real safe-summary preview on approve).
+- Real PKM data: the marketplace reads the owner's actual domain manifests and scope registry, not
+  hardcoded data.
+- Shared publish flow: `lib/personal-knowledge-model/slice-publishing.ts` (`applySlicePosture`) is
+  used by both the marketplace and Profile so the vault-write posture flow is not forked.
+- Consent-first publish: an explicit owner consent modal before a slice is listed.
+- Server-authoritative reflection: after a publish, the UI re-fetches the persisted posture and
+  reports the truth, so there is no fake success and no silent revert.
+- Buyer privacy: the buyer view shows only safe-summary column names, never real values.
+- Backend correctness fix: corrected a malformed `revoked_at IS 'null'` filter to a real `IS NULL`
+  (it was causing a 500 on the default-available projection path).
+- Nav and route wiring: `ONE_MARKETPLACE` route, One hub tile, route-map, native-route-inventory,
+  and generated surface map updated; dashboard test updated.
+
+### Known limitation (by design)
+
+The consent guardrail refuses `default_available` for scopes it tags `restricted` (or structural
+blocked keys), even with owner consent. Confidential and public slices publish and persist; restricted
+ones stay consent-gated. This is enforced server-side in `_normalize_visibility_posture` and is
+intentional. The client cannot yet reliably tell which categories are publishable before trying,
+because the served manifest does not always carry a scope's real sensitivity tier (the frontend
+defaults a missing tier to `confidential`). Surfacing a backend-computed per-scope publishable flag is
+the next honest improvement (see Later).
+
+### Later (not in this branch)
+
+- Backend-computed per-scope publishable/eligible flag surfaced in the manifest, so the marketplace
+  shows "can be made available" versus "protected" per category instead of guessing.
+- Persisted buyer requests routed through the real consent guardian (current requests are in-session
+  demo only and clear on refresh).
+- Persisted owner-set price on `pkm_scope_registry` and in the consent/audit trail (today the price is
+  computed and displayed, not stored as a purchase term).
+- Payment and settlement rail (Phase 4), still out of near-term scope.
+- Optional policy decision (Option B): allow an owner to consent-override exposure of their own
+  restricted data. Requires consent-owner sign-off and is deliberately not built.
+- Tri-flow (web/iOS/Android) parity and the full promotion gate before graduating out of docs/future.
+
+## Visual Map
+
+```mermaid
+flowchart LR
+  pkm["Encrypted PKM<br/>(vault, ciphertext)"]
+  pub["Owner publishes<br/>default_available safe projection"]
+  scope["Priced scope record<br/>(pkm_scope_registry + owner price)"]
+  buyer["Buyer browses<br/>Available + priced slices"]
+  guardian["Consent guardian<br/>owner approves specific buyer"]
+  export["Encrypted slice delivered<br/>to that buyer only (consent export)"]
+
+  pkm --> pub --> scope --> buyer --> guardian --> export
+```
+
+The storefront adds two things to today's flow: a **price tag** (owner-set) and a **place to browse**.
+It never bypasses the owner's per-buyer approval, and it never exposes raw PKM.
+
+## Purpose
+
+Let a user publish safe projections of their PKM as **priced, individually-consentable subscription
+slices**, and let a buyer (advertiser or agent) pay for time-boxed scoped access — with the owner
+approving each specific buyer through the existing consent guardian. This doc records the verified
+current truth, the backend/frontend split, the pricing model, and a phased path that reuses existing
+contracts instead of building a parallel trust plane.
+
+Originating brainstorm: the "PKM-Priced Subscription Marketplace" notes, Foundation-styled mockup,
+and research-anchored pricing deck (Cheng et al. composite valuation; arXiv 2303.04810 two-part
+tariff; arXiv 2111.04427 marketplace price drivers).
+
+## Current Truth (verified in repo)
+
+| Idea piece | Existing primitive | Location (verified) |
+| --- | --- | --- |
+| Encrypted, portable PKM | Domain-partitioned encrypted PKM + scope registry | `consent-protocol/` (`scope_registry` referenced in `server.py`) |
+| Publishing one shareable slice | `default_available` posture ("user-published safe projection only") | consent-protocol migrations + tests (`test_marketplace_visibility_posture_migration.py`) |
+| External party requesting scoped access | Consent Protocol Developer API + MCP consent/export flow (PCHP) | consent-protocol (`test_developer_api_routes.py`, `test_consent_exports_ttl_eviction.py`) |
+| Owner approving a specific requester | Consent guardian / consent grant + export | `consent-protocol/hushh_mcp/...` (guardian references) |
+| Managing who has access | `/consents` UI | `hushh-webapp/app/consents/` |
+| Two-sided discovery (today) | `/marketplace` (investor↔RIA only) | `hushh-webapp/app/marketplace/`, [../reference/iam/marketplace-contract.md](../reference/iam/marketplace-contract.md) |
+| PKM surface under One | `app/one/pkm` | `hushh-webapp/app/one/pkm/` |
+| Frontend→backend pipe for One | One API proxy | `hushh-webapp/app/api/one/[...path]` |
+| Brand-side access as a named future lane | PCHP brand-side access row (future-facing) | [one-product-surface-evolution-plan.md](./one-product-surface-evolution-plan.md) §Surface Lanes |
+
+## What Does Not Exist Yet (verified absent)
+
+- No pricing engine, no `price` field on any consent or PKM contract.
+- No net-worth-based or dynamic pricing input.
+- No general advertiser/agent marketplace (`/marketplace` is investor↔RIA only).
+- No per-slice monetary transaction of any kind — consent grants are access grants, not purchases.
+- No payment/billing (Stripe or otherwise) rail anywhere in the repo.
+
+## Locked Decisions
+
+1. **Backend-led, not frontend-only.** Consent enforcement and price integrity are trust boundaries.
+   A browser can be tampered with, so both must be server-side. The buyer never touches vault
+   plaintext — the marketplace sells the `default_available` safe projection only.
+2. **User sets the price per slice** (not the platform). The research formula produces a *suggested*
+   price computed on the backend; the **owner's chosen value is the source of truth**, floor-guarded
+   at `p_f = $0.10`, denominated in USD, and recorded in the consent/audit trail so the buyer
+   approves a specific, owner-set price.
+
+## Architecture: Backend vs Frontend Split
+
+| Piece | Layer | Home | Status |
+| --- | --- | --- | --- |
+| Pricing engine (suggested price) | **Backend** — pure function, single source of truth | `consent-protocol/` | new (self-contained, touches no ciphertext) |
+| Priced-scope data shape (owner price + slice = `attr.{domain}.*`) | **Backend** — hangs off scope registry | `pkm_scope_registry` / `default_available` | extend existing |
+| Buyer request → owner approval | **Backend** — reuse consent guardian + consent export | consent-protocol consent flow | already exists |
+| Owner view (set price, posture, approve/deny) | **Frontend** | `hushh-webapp/app/one/` (beside `app/one/pkm`) | extend |
+| Buyer view (browse Available + priced slices) | **Frontend** | `hushh-webapp/app/one/` | new |
+| Frontend→backend calls | **Proxy** | `hushh-webapp/app/api/one/[...path]` | reuse |
+| Payment / money settlement | **Backend** — new rail | none | out of near-term scope |
+
+## Pricing Model
+
+Reference formula (owner-facing **suggestion**; owner may override down to the floor):
+
+```
+suggested(30d) = ( p_f + Σ_c k_c · a_c · richness(n_c) ) × B × F × X × G
+p_f = $0.10 (floor)   richness(n) = 1 + ln(n)
+B = purchasing-power × buying-mood   F = freshness   X = exclusivity   G = geo/coverage
+```
+
+Owner-set price rule: `final_price = max(p_f, owner_input)`, USD, recorded with the scope grant.
+Bundling (later) must stay arbitrage-free: `P_bundle ≤ Σ P_slice`.
+
+Per-slice prices are intentionally small (cents to low tens of dollars) — value comes from **scale
+and recurrence**, not one large number. Audience band is a user-entered demo input; deriving `power`
+from verified financial PKM is a later phase that likely needs its own consent scope.
+
+## Phased Delivery
+
+**Phase 0 — no-code validation. [done]** Walk `/consents` and the `default_available` publish flow as a
+test user to confirm the slice-publishing mechanic feels right before adding any pricing logic.
+
+**Phase 1 — smallest shippable slice (recommended first PR). [done]** Backend pricing engine as a pure
+function + display the computed **suggested** price on an existing `default_available` slice under
+One. No buyers, no money, no new consent scope. Attach point: `app/one/pkm` (display) +
+`app/api/one/[...path]` (proxy) + new backend engine module. Prove with unit tests on the pure
+function and a route/caller test.
+
+**Phase 2 — owner controls. [partial]** Owner toggles posture (Private / Consent-only / Available)
+with a consent-first modal, and approves/denies buyer requests in the marketplace inbox. Done on this
+branch. Still pending: price override UI, persisting the priced-scope shape on `pkm_scope_registry`,
+routing approve/deny through the real consent guardian, and recording the owner-set price in the
+consent/audit trail.
+
+**Phase 3 — buyer-side discovery. [prototype]** A buyer tab lists only `default_available` slices as
+purchasable and files a request. Done on this branch as an in-session prototype. Still pending: real
+persistence, guardian-routed requests, and consent-export delivery (ciphertext to that buyer only).
+
+**Phase 4 — payment rail (out of near-term scope). [not started]** The first billing integration in the repo.
+Money sits **between** owner approval and delivery — an extra gate after consent, never a replacement
+for it. Needs its own audit/consent-event trail. Estimated 2–4 weeks; not part of the first slice.
+
+## Trust Boundaries & Promotion Gate
+
+Per [one-product-surface-evolution-plan.md](./one-product-surface-evolution-plan.md), this graduates
+from `docs/future/` into current-state docs only when:
+
+- a reachable route/component/backend route/native path exists;
+- the owner is clear (One, with backend consent/PKM ownership retained by the consent protocol);
+- vault, consent, auth, and audit boundaries are documented — specifically: buyer receives only the
+  `default_available` projection, never raw PKM/`pkm.read`/blobs; owner approval is mandatory and
+  per-buyer; owner-set price is recorded in the audit trail;
+- tests or smoke checks prove the behavior;
+- tri-flow (web/iOS/Android) parity is maintained — any new route runs the frontend-native-surface-map
+  workflow (`cd hushh-webapp && npm run verify:surface-map`).
+
+## What Not To Build
+
+- A parallel marketplace or trust plane that bypasses the PCHP consent/export flow.
+- Any path that hands a buyer raw PKM, `pkm.read`, encrypted blobs, workflow artifacts, hashes, or
+  provenance — `default_available` is a safe projection only.
+- A pricing value the frontend can set or alter without backend validation and the `p_f` floor.
+- A payment rail that settles before, or in place of, the owner's per-buyer consent approval.
+- Net-worth-derived pricing that pulls protected financial PKM without its own consent scope.
+- A new top-level subsystem — reuse `app/one/`, `app/api/one/[...path]`, `pkm_scope_registry`, and
+  the consent guardian/export flow.
+
+## Open Decisions
+
+- **Buyer identity:** human brand/advertiser vs autonomous agent. If autonomous, define what stops an
+  agent from buying access to bait or manipulate the owner (abuse-protection design). Does not block
+  Phase 1.
+- **Verified `power`:** whether net-worth-based pricing must be verified (e.g. via the portfolio
+  parser), and whether that needs a new consent scope just to compute a price.
+
+## Related References
+
+- [./one-product-surface-evolution-plan.md](./one-product-surface-evolution-plan.md)
+- [./README.md](./README.md)
+- [../reference/iam/marketplace-contract.md](../reference/iam/marketplace-contract.md)
+- [../reference/architecture/architecture.md](../reference/architecture/architecture.md)

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -93,7 +93,7 @@ describe("OneDashboardPage", () => {
     expect(screen.getByText("2 to review")).toBeTruthy(); // consent attention
     expect(screen.getByText("2 consents pending")).toBeTruthy(); // header badge
     expect(screen.getByText("Gmail receipts and saved knowledge.")).toBeTruthy();
-    expect(container.querySelectorAll(".morphy-ripple-host").length).toBe(7);
+    expect(container.querySelectorAll(".morphy-ripple-host").length).toBe(8);
     expect(screen.queryByRole("link", { name: "Open One Agent" })).toBeNull();
   });
 

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -1,0 +1,1175 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Lock, RefreshCw, Store } from "lucide-react";
+import { toast } from "sonner";
+
+import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
+import { PkmSectionPreview } from "@/components/profile/pkm-section-preview";
+import { PkmSettingsShell } from "@/components/profile/pkm-settings-shell";
+import { SettingsSegmentedTabs } from "@/components/profile/settings-ui";
+import {
+  buildPkmSectionPreviewPresentation,
+  type PkmSectionPreviewPresentation,
+} from "@/lib/profile/pkm-section-preview";
+import { useAuth } from "@/hooks/use-auth";
+import { Button } from "@/lib/morphy-ux/morphy";
+import { useVault } from "@/lib/vault/vault-context";
+import {
+  PersonalKnowledgeModelService,
+  PkmScopeExposureError,
+  type DomainSummary,
+  type PkmVisibilityPosture,
+} from "@/lib/services/personal-knowledge-model-service";
+import { type DomainManifest } from "@/lib/personal-knowledge-model/manifest";
+import {
+  buildPkmDomainPermissionPresentation,
+  type PkmDomainPermissionPresentation,
+} from "@/lib/profile/pkm-profile-presentation";
+import {
+  applyManifestExposureChange,
+  applySlicePosture,
+} from "@/lib/personal-knowledge-model/slice-publishing";
+import {
+  categoryFromSensitivity,
+  formatCents,
+  SlicePricingService,
+  type PricingMood,
+  type PricingPower,
+  type SlicePriceBreakdown,
+  type SlicePricingInput,
+} from "@/lib/services/slice-pricing-service";
+
+type MarketplaceView = "owner" | "buyer" | "flow";
+
+/**
+ * In-session demo request. NOT a real consent grant and NOT persisted — clears on
+ * refresh. Real access requests live in the Consent Guardian; wiring the
+ * marketplace to file them there is a later phase.
+ */
+interface MarketRequest {
+  id: string;
+  sliceName: string;
+  domainKey: string;
+  domainTitle: string;
+  topLevelScopePath: string;
+  description: string;
+  input: SlicePricingInput;
+  createdAt: number;
+  status: "pending" | "approved" | "denied";
+}
+
+interface DomainRecord {
+  summary: DomainSummary;
+  manifest: DomainManifest;
+}
+
+const POWER_OPTIONS: { value: PricingPower; label: string }[] = [
+  { value: "mass", label: "Mass · under $50k" },
+  { value: "affluent", label: "Affluent · $150k–500k" },
+  { value: "uhnw", label: "UHNW · $25M+ net worth" },
+];
+const MOOD_OPTIONS: { value: PricingMood; label: string }[] = [
+  { value: "passive", label: "Passive" },
+  { value: "affinity", label: "Affinity" },
+  { value: "in_market", label: "In-market" },
+  { value: "hot", label: "Hot big-ticket" },
+];
+const POSTURE_OPTIONS: { value: PkmVisibilityPosture; label: string }[] = [
+  { value: "private", label: "Private" },
+  { value: "consent_required", label: "Ask first" },
+  { value: "default_available", label: "Available" },
+];
+
+// Mirrors the backend: `default_available` is refused (downgraded to
+// consent_required) for restricted scopes and these structural keys. Restricted
+// data is deliberately never publishable as available-by-default.
+const DEFAULT_AVAILABLE_BLOCKED_KEYS = new Set([
+  "hash",
+  "metadata",
+  "provenance",
+  "schema_version",
+  "workflow",
+  "workflow_id",
+]);
+
+function isRestrictedForPublish(
+  sensitivityTier: string | undefined,
+  topLevelScopePath: string
+): boolean {
+  if ((sensitivityTier || "").trim().toLowerCase() === "restricted") return true;
+  return topLevelScopePath
+    .split(".")
+    .some((part) => DEFAULT_AVAILABLE_BLOCKED_KEYS.has(part));
+}
+
+function attributeCountFor(manifest: DomainManifest, scopeHandle: string | null): number {
+  const entry = (manifest.scope_registry || []).find((s) => s.scope_handle === scopeHandle);
+  return (entry?.segment_ids || []).length || 1;
+}
+
+function usePrice(input: SlicePricingInput | null, token?: string) {
+  const [result, setResult] = useState<SlicePriceBreakdown | null>(null);
+  const [loading, setLoading] = useState(false);
+  const key = input
+    ? `${input.category}:${input.attributeCount}:${input.power}:${input.mood}`
+    : "none";
+  useEffect(() => {
+    let cancelled = false;
+    if (!input || !token) {
+      setResult(null);
+      return;
+    }
+    setLoading(true);
+    SlicePricingService.getSuggestedPrice(input, token)
+      .then((next) => !cancelled && setResult(next))
+      .catch(() => !cancelled && setResult(null))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, token]);
+  return { result, loading };
+}
+
+function dollars(n: number): string {
+  return `$${(Number.isFinite(n) ? n : 0).toFixed(2)}`;
+}
+
+function factor(n: number): string {
+  return `×${(Number.isFinite(n) ? n : 1).toFixed(2).replace(/\.00$/, "").replace(/(\.\d)0$/, "$1")}`;
+}
+
+/** Slide-style price math: ( floor + data value ) × buyer fit × freshness × exclusivity. */
+function PriceMath({ result }: { result: SlicePriceBreakdown }) {
+  const b = result.breakdown as Record<string, number>;
+  const floor = (Number(b.floor_cents) || 10) / 100;
+  const dataValue = Math.max(0, (Number(b.composite_dollars) || floor) - floor);
+  const buyerFit = Number(b.multiplier_b) || 1;
+  const freshness = Number(b.multiplier_f) || 1;
+  const exclusivity = Number(b.multiplier_x) || 1;
+  const geo = Number(b.multiplier_g) || 1;
+  const final = formatCents(result.suggestedPriceCents, result.currency);
+
+  return (
+    <div className="mt-3 rounded-xl border bg-muted/30 p-4 text-sm">
+      <div className="font-mono text-[12.5px] leading-6">
+        Price = ( <span className="text-muted-foreground">floor</span> {dollars(floor)} +{" "}
+        <span className="text-blue-600 dark:text-blue-400">data value</span> {dollars(dataValue)} ){" "}
+        <span className="text-blue-600 dark:text-blue-400">buyer fit</span> {factor(buyerFit)}{" "}
+        <span className="text-blue-600 dark:text-blue-400">freshness</span> {factor(freshness)}{" "}
+        <span className="text-blue-600 dark:text-blue-400">exclusivity</span> {factor(exclusivity)}
+        {geo !== 1 ? (
+          <>
+            {" "}
+            <span className="text-blue-600 dark:text-blue-400">geo</span> {factor(geo)}
+          </>
+        ) : null}{" "}
+        = <span className="font-semibold text-emerald-700 dark:text-emerald-300">{final}</span>
+      </div>
+      <dl className="mt-3 space-y-1.5 text-[12.5px] text-muted-foreground">
+        <div>
+          <span className="font-medium text-foreground">Data value</span> — financial data counts most,
+          plain demographics least; more attributes help, with diminishing returns.
+        </div>
+        <div>
+          <span className="font-medium text-foreground">Buyer fit</span> — spending power × buying mood; an
+          about-to-buy signal matters more than raw wealth.
+        </div>
+        <div>
+          <span className="font-medium text-foreground">Freshness</span> — updated today = full value; stale
+          data fades toward a floor.
+        </div>
+        <div>
+          <span className="font-medium text-foreground">Exclusivity</span> — sold to everyone = base; sold to
+          one buyer = worth more.
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+/**
+ * The actual safe summary that would be shared for a slice — loaded from the
+ * owner's real (vault-decrypted) section data and reduced to the same safe
+ * projection that `default_available` publishes. Never raw PKM.
+ */
+function extractColumns(p: PkmSectionPreviewPresentation): string[] {
+  const cols = new Set<string>();
+  for (const s of p.stats || []) if (s?.label) cols.add(s.label);
+  for (const g of (p.groups || []) as Array<Record<string, unknown>>) {
+    const fields = g.fields as Array<{ label?: string }> | undefined;
+    if (Array.isArray(fields)) for (const f of fields) if (f?.label) cols.add(f.label);
+    const entities = g.entities as Array<{ sections?: Array<{ label?: string }> }> | undefined;
+    if (Array.isArray(entities)) {
+      for (const e of entities) {
+        if (Array.isArray(e.sections)) for (const sec of e.sections) if (sec?.label) cols.add(sec.label);
+      }
+    }
+  }
+  return [...cols];
+}
+
+function SharedDataPreview({
+  userId,
+  vaultKey,
+  token,
+  domainKey,
+  domainTitle,
+  topLevelScopePath,
+  label,
+  description,
+  columnsOnly,
+}: {
+  userId?: string;
+  vaultKey: string | null;
+  token?: string;
+  domainKey: string;
+  domainTitle: string;
+  topLevelScopePath: string;
+  label: string;
+  description?: string | null;
+  columnsOnly?: boolean;
+}) {
+  const [presentation, setPresentation] = useState<PkmSectionPreviewPresentation | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!userId || !vaultKey) {
+      setErr("Unlock your vault to preview the shared summary.");
+      return;
+    }
+    setLoading(true);
+    setErr(null);
+    PersonalKnowledgeModelService.loadDomainData({
+      userId,
+      domain: domainKey,
+      vaultKey,
+      vaultOwnerToken: token,
+      segmentIds: [topLevelScopePath],
+    })
+      .then((value) => {
+        if (cancelled) return;
+        setPresentation(
+          buildPkmSectionPreviewPresentation({
+            domain: domainKey,
+            domainTitle,
+            permissionLabel: label,
+            permissionDescription: description || null,
+            topLevelScopePath,
+            value,
+          })
+        );
+      })
+      .catch(() => !cancelled && setErr("Could not load the shared summary."))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, vaultKey, token, domainKey, topLevelScopePath]);
+
+  if (loading) {
+    return <div className="text-sm text-muted-foreground">Loading safe summary…</div>;
+  }
+  if (err) {
+    return <div className="text-sm text-muted-foreground">{err}</div>;
+  }
+  if (!presentation) return null;
+
+  if (columnsOnly) {
+    const columns = extractColumns(presentation);
+    return (
+      <div className="rounded-xl border bg-muted/20 p-4">
+        <div className="mb-2 text-xs text-muted-foreground">
+          Fields included · <span className="font-medium text-foreground">values are revealed only
+          after the owner approves your request</span>
+        </div>
+        {columns.length === 0 ? (
+          <div className="text-sm text-muted-foreground">Safe summary fields only.</div>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {columns.map((c) => (
+              <span
+                key={c}
+                className="rounded-full bg-background px-2.5 py-1 text-[11px] font-medium text-muted-foreground"
+              >
+                {c}: •••
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border bg-muted/20 p-4">
+      <PkmSectionPreview presentation={presentation} />
+    </div>
+  );
+}
+
+interface PreviewFields {
+  userId?: string;
+  vaultKey: string | null;
+  token?: string;
+  domainKey: string;
+  domainTitle: string;
+  topLevelScopePath: string;
+  label: string;
+  description?: string | null;
+  columnsOnly?: boolean;
+}
+
+/** Expander — shows the real safe summary (owner) or field names only (buyer). */
+function PreviewToggle(props: PreviewFields) {
+  const [open, setOpen] = useState(false);
+  const showLabel = props.columnsOnly ? "See fields included" : "Preview shared data";
+  const hideLabel = props.columnsOnly ? "Hide fields" : "Hide shared data";
+  return (
+    <div className="mt-3">
+      <Button type="button" size="sm" variant="none" effect="fade" onClick={() => setOpen((v) => !v)}>
+        {open ? hideLabel : showLabel}
+      </Button>
+      {open ? (
+        <div className="mt-2">
+          <SharedDataPreview {...props} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PriceLine({
+  input,
+  token,
+  showMath,
+}: {
+  input: SlicePricingInput | null;
+  token?: string;
+  showMath?: boolean;
+}) {
+  const { result, loading } = usePrice(input, token);
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-2xl font-semibold tracking-tight">
+          {loading ? (
+            "…"
+          ) : result ? (
+            <>
+              {formatCents(result.suggestedPriceCents, result.currency)}{" "}
+              <span className="text-sm font-medium text-muted-foreground">/ 30 days</span>
+            </>
+          ) : (
+            <span className="text-sm font-medium text-muted-foreground">—</span>
+          )}
+        </div>
+        {showMath ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="none"
+            effect="fade"
+            disabled={!result}
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? "Hide math" : "Show math"}
+          </Button>
+        ) : null}
+      </div>
+      {showMath && open && result ? <PriceMath result={result} /> : null}
+    </div>
+  );
+}
+
+export default function OneMarketplacePage() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
+  const token = vaultOwnerToken ?? undefined;
+
+  const [view, setView] = useState<MarketplaceView>("owner");
+  const [power, setPower] = useState<PricingPower>("affluent");
+  const [mood, setMood] = useState<PricingMood>("affinity");
+  const [purchaseSection, setPurchaseSection] = useState<Section | null>(null);
+  // Owner is about to publish this section to the marketplace and must explicitly
+  // consent first (consent-first). Null when no confirmation is pending.
+  const [confirmPublish, setConfirmPublish] = useState<Section | null>(null);
+  const [requests, setRequests] = useState<MarketRequest[]>([]);
+
+  const [records, setRecords] = useState<DomainRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  // Load the owner's real PKM domains + manifests. The scope registry on each
+  // manifest is the source of shareable sections and their consent posture.
+  useEffect(() => {
+    let cancelled = false;
+    if (!user?.uid) {
+      setRecords([]);
+      return;
+    }
+    // Do NOT wipe an already-loaded list when the vault/token momentarily drops
+    // (e.g. the owner token rotating right after a publish) — keep the current
+    // sections visible instead of flashing them away.
+    if (!isVaultUnlocked || !token) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const metadata = await PersonalKnowledgeModelService.getMetadata(user.uid, false, token);
+        const summaries = (metadata.domains || []).filter((d) => d.key);
+        const loaded = await Promise.all(
+          summaries.map(async (summary) => {
+            const manifest = await PersonalKnowledgeModelService.getDomainManifest(
+              user.uid,
+              summary.key,
+              token
+            ).catch(() => null);
+            return { summary, manifest };
+          })
+        );
+        if (cancelled) return;
+        // Keep the prior manifest for any domain whose reload transiently failed,
+        // so a hiccup never makes a just-published section vanish.
+        setRecords((prev) => {
+          const prevByKey = new Map(prev.map((r) => [r.summary.key, r]));
+          const next: DomainRecord[] = [];
+          for (const { summary, manifest } of loaded) {
+            if (manifest) next.push({ summary, manifest });
+            else {
+              const prior = prevByKey.get(summary.key);
+              if (prior) next.push(prior);
+            }
+          }
+          return next;
+        });
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Could not load your data");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.uid, isVaultUnlocked, token, refreshToken]);
+
+  interface Section {
+    key: string;
+    domainKey: string;
+    domainTitle: string;
+    manifest: DomainManifest;
+    summary: DomainSummary;
+    permission: PkmDomainPermissionPresentation;
+  }
+
+  const sections = useMemo<Section[]>(() => {
+    const out: Section[] = [];
+    for (const rec of records) {
+      const permissions = buildPkmDomainPermissionPresentation({
+        domain: rec.summary,
+        manifest: rec.manifest,
+        activeGrants: [],
+        upgradeState: null,
+      });
+      for (const permission of permissions) {
+        out.push({
+          key: `${rec.summary.key}:${permission.topLevelScopePath}`,
+          domainKey: rec.summary.key,
+          domainTitle: rec.summary.displayName || rec.summary.key,
+          manifest: rec.manifest,
+          summary: rec.summary,
+          permission,
+        });
+      }
+    }
+    return out;
+  }, [records]);
+
+  const priceInput = useCallback(
+    (section: Section): SlicePricingInput => ({
+      category: categoryFromSensitivity(section.permission.sensitivityTier),
+      attributeCount: attributeCountFor(section.manifest, section.permission.scopeHandle),
+      power,
+      mood,
+    }),
+    [power, mood]
+  );
+
+  const replaceManifest = useCallback((domainKey: string, manifest: DomainManifest) => {
+    setRecords((current) =>
+      current.map((rec) => (rec.summary.key === domainKey ? { ...rec, manifest } : rec))
+    );
+  }, []);
+
+  // The actual posture write. Publishing (`default_available`) only reaches here
+  // after the owner has explicitly confirmed in the consent modal.
+  const runPosture = useCallback(
+    async (section: Section, nextPosture: PkmVisibilityPosture) => {
+      if (!user?.uid || !vaultOwnerToken) {
+        toast.error("Unlock your vault to change sharing.");
+        return;
+      }
+      if (nextPosture === "default_available" && !vaultKey) {
+        toast.error("Unlock your vault to publish a slice.");
+        return;
+      }
+      if (
+        nextPosture === "default_available" &&
+        isRestrictedForPublish(section.permission.sensitivityTier, section.permission.topLevelScopePath)
+      ) {
+        // The backend would silently downgrade this to "Ask first"; block it up
+        // front so the toggle doesn't appear to revert.
+        toast.error(
+          "This section is protected — restricted data stays consent-gated and can't be published as Available."
+        );
+        return;
+      }
+      const previousManifest = section.manifest;
+      const optimistic =
+        applyManifestExposureChange(
+          previousManifest,
+          { scopeHandle: section.permission.scopeHandle, topLevelScopePath: section.permission.topLevelScopePath },
+          nextPosture
+        ) ?? previousManifest;
+
+      setPending((p) => ({ ...p, [section.key]: true }));
+      replaceManifest(section.domainKey, optimistic);
+      try {
+        const { manifest } = await applySlicePosture({
+          userId: user.uid,
+          domain: section.domainKey,
+          domainTitle: section.domainTitle,
+          permission: {
+            scopeHandle: section.permission.scopeHandle,
+            label: section.permission.label,
+            description: section.permission.description,
+            topLevelScopePath: section.permission.topLevelScopePath,
+          },
+          nextPosture,
+          previousManifest,
+          vaultKey: vaultKey ?? undefined,
+          vaultOwnerToken,
+          source: "marketplace_owner",
+        });
+
+        // Authoritative re-fetch: the consent guardrail decides the final posture
+        // server-side and can downgrade `default_available` (e.g. a scope the
+        // backend still tags restricted). Trust what the server actually persisted
+        // rather than our optimistic guess, so the UI never shows a fake success
+        // that then "reverts" on the next load.
+        const fresh = token
+          ? await PersonalKnowledgeModelService.getDomainManifest(
+              user.uid,
+              section.domainKey,
+              token,
+              true
+            ).catch(() => null)
+          : null;
+        const authoritative = fresh ?? manifest;
+        replaceManifest(section.domainKey, authoritative);
+
+        const persistedPosture =
+          buildPkmDomainPermissionPresentation({
+            domain: section.summary,
+            manifest: authoritative,
+            activeGrants: [],
+            upgradeState: null,
+          }).find((p) => p.topLevelScopePath === section.permission.topLevelScopePath)
+            ?.visibilityPosture ?? nextPosture;
+
+        if (nextPosture === "default_available" && persistedPosture !== "default_available") {
+          // Owner consented, but the guardrail still refused to expose this section.
+          // Be honest about it instead of implying the publish stuck.
+          toast.error(
+            "This section is protected — the consent guardrail keeps it consent-gated, so it can't be published to the marketplace."
+          );
+        } else {
+          toast.success(
+            nextPosture === "private"
+              ? "This section is private."
+              : nextPosture === "default_available"
+                ? "Published — available to buyers with a price."
+                : "One will ask before sharing this section."
+          );
+        }
+      } catch (err) {
+        if (err instanceof PkmScopeExposureError && err.status === 409 && user?.uid && token) {
+          // Client manifest was stale (a prior change bumped the version). Re-sync
+          // the live manifest so the next toggle uses the current version.
+          const fresh = await PersonalKnowledgeModelService.getDomainManifest(
+            user.uid,
+            section.domainKey,
+            token,
+            true
+          ).catch(() => null);
+          replaceManifest(section.domainKey, fresh ?? previousManifest);
+          toast.error("Sharing was out of date — refreshed. Tap again.");
+        } else {
+          replaceManifest(section.domainKey, previousManifest);
+          toast.error(err instanceof Error ? err.message : "Couldn't update sharing.");
+        }
+      } finally {
+        setPending((p) => {
+          const next = { ...p };
+          delete next[section.key];
+          return next;
+        });
+      }
+    },
+    [user?.uid, vaultKey, vaultOwnerToken, token, replaceManifest]
+  );
+
+  // Publishing to the marketplace is consent-first: route "Available" through an
+  // explicit confirmation. Making a section private or consent-gated needs no
+  // extra prompt (it only ever tightens sharing).
+  const onTogglePosture = useCallback(
+    (section: Section, nextPosture: PkmVisibilityPosture) => {
+      if (nextPosture === "default_available") {
+        if (isRestrictedForPublish(section.permission.sensitivityTier, section.permission.topLevelScopePath)) {
+          toast.error(
+            "This section is protected — restricted data stays consent-gated and can't be published as Available."
+          );
+          return;
+        }
+        setConfirmPublish(section);
+        return;
+      }
+      void runPosture(section, nextPosture);
+    },
+    [runPosture]
+  );
+
+  const availableSections = sections.filter(
+    (s) => s.permission.visibilityPosture === "default_available"
+  );
+
+  const pendingRequestCount = requests.filter((r) => r.status === "pending").length;
+
+  const confirmPurchase = useCallback(() => {
+    setPurchaseSection((current) => {
+      if (!current) return null;
+      setRequests((cur) => [
+        {
+          id: `${current.key}:${Date.now()}`,
+          sliceName: current.permission.label,
+          domainKey: current.domainKey,
+          domainTitle: current.domainTitle,
+          topLevelScopePath: current.permission.topLevelScopePath,
+          description: current.permission.description,
+          input: priceInput(current),
+          createdAt: Date.now(),
+          status: "pending",
+        },
+        ...cur,
+      ]);
+      return null;
+    });
+    setView("flow");
+    toast.success("Request sent — see Consent flow & requests.");
+  }, [priceInput]);
+
+  const setRequestStatus = useCallback((id: string, status: MarketRequest["status"]) => {
+    setRequests((cur) => cur.map((r) => (r.id === id ? { ...r, status } : r)));
+  }, []);
+
+  const bandControls = (
+    <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+      Buyer band <span className="text-xs">(used only to price your own slices)</span>
+      <select
+        className="rounded-full border bg-background px-3 py-1.5 text-foreground"
+        value={power}
+        onChange={(e) => setPower(e.target.value as PricingPower)}
+      >
+        {POWER_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <select
+        className="rounded-full border bg-background px-3 py-1.5 text-foreground"
+        value={mood}
+        onChange={(e) => setMood(e.target.value as PricingMood)}
+      >
+        {MOOD_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+
+  return (
+    <PkmSettingsShell
+      eyebrow="One / Marketplace"
+      title="Data Slice Marketplace"
+      description="Your data, your business. Choose what each section shares — Private, Ask first, or Available — and see what it's worth. Nothing is ever shared without your approval."
+      actions={
+        <div className="flex flex-wrap items-center gap-2">
+          <SettingsSegmentedTabs
+            value={view}
+            onValueChange={(value) => setView(value as MarketplaceView)}
+            options={[
+              { value: "owner", label: "Owner" },
+              { value: "buyer", label: "Buyer" },
+              {
+                value: "flow",
+                label:
+                  pendingRequestCount > 0
+                    ? `Flow & requests (${pendingRequestCount})`
+                    : "Flow & requests",
+              },
+            ]}
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="none"
+            effect="fade"
+            onClick={() => setRefreshToken((v) => v + 1)}
+          >
+            <RefreshCw className="mr-2 h-4 w-4" aria-hidden />
+            Refresh
+          </Button>
+        </div>
+      }
+    >
+      <NativeTestBeacon
+        routeId="/one/marketplace"
+        marker="native-route-one-marketplace"
+        authState="authenticated"
+        dataState={sections.length ? "loaded" : "empty-valid"}
+      />
+
+      <div className="mb-5 rounded-2xl border border-amber-200/60 bg-amber-50/40 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/10 dark:text-amber-300">
+        Consent-first · a section is shared only after you set it to Available and approve a specific
+        buyer. Prices are a research-anchored suggestion computed live — you set the final price. No
+        money moves here.
+      </div>
+
+      {!isVaultUnlocked ? (
+        <div className="flex items-center gap-2 rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          <Lock className="h-4 w-4" aria-hidden />
+          Unlock your vault to manage and price your data sections.
+        </div>
+      ) : error ? (
+        <div className="rounded-2xl border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : loading ? (
+        <div className="rounded-2xl border p-6 text-center text-sm text-muted-foreground">
+          Loading your data sections…
+        </div>
+      ) : (
+        <>
+          {/* OWNER VIEW — the single consent-first control panel */}
+          {view === "owner" ? (
+            <div className="space-y-4">
+              {bandControls}
+              {sections.length === 0 ? (
+                <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  <Store className="mx-auto mb-2 h-6 w-6 opacity-60" aria-hidden />
+                  No shareable sections yet. Add some Personal Data (e.g. via onboarding or the PKM
+                  workspace), then each section will appear here to price and publish.
+                </div>
+              ) : (
+                sections.map((section) => {
+                  const isAvailable = section.permission.visibilityPosture === "default_available";
+                  const busy = pending[section.key] === true;
+                  const restricted = isRestrictedForPublish(
+                    section.permission.sensitivityTier,
+                    section.permission.topLevelScopePath
+                  );
+                  return (
+                    <div key={section.key} className="rounded-2xl border p-5">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="text-lg font-semibold">{section.permission.label}</div>
+                          <div className="mt-0.5 text-sm text-muted-foreground">
+                            {section.domainTitle} ·{" "}
+                            {attributeCountFor(section.manifest, section.permission.scopeHandle)}{" "}
+                            attribute
+                            {attributeCountFor(section.manifest, section.permission.scopeHandle) === 1
+                              ? ""
+                              : "s"}{" "}
+                            · safe summary only
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            <span className="rounded-full bg-emerald-500/12 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+                              safe summary
+                            </span>
+                            {section.permission.sensitivityTier ? (
+                              <span className="rounded-full bg-muted px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
+                                {section.permission.sensitivityTier}
+                              </span>
+                            ) : null}
+                            {restricted ? (
+                              <span className="rounded-full bg-rose-500/12 px-2.5 py-1 text-[11px] font-medium text-rose-700 dark:text-rose-300">
+                                protected · can’t publish
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className={"mt-4 " + (busy ? "pointer-events-none opacity-60" : "")}>
+                        <SettingsSegmentedTabs
+                          value={section.permission.visibilityPosture}
+                          onValueChange={(next) =>
+                            onTogglePosture(section, next as PkmVisibilityPosture)
+                          }
+                          options={POSTURE_OPTIONS}
+                          mobileColumns={1}
+                        />
+                      </div>
+                      {restricted ? (
+                        <div className="mt-2 text-[12px] text-muted-foreground">
+                          Restricted data stays consent-gated to protect you — it can’t be set to
+                          “Available”. Only non-restricted sections can be published to the marketplace.
+                        </div>
+                      ) : null}
+
+                      <div className="mt-4 border-t pt-4">
+                        {isAvailable ? (
+                          <>
+                            <PriceLine input={priceInput(section)} token={token} showMath />
+                            <PreviewToggle
+                              userId={user?.uid}
+                              vaultKey={vaultKey}
+                              token={token}
+                              domainKey={section.domainKey}
+                              domainTitle={section.domainTitle}
+                              topLevelScopePath={section.permission.topLevelScopePath}
+                              label={section.permission.label}
+                              description={section.permission.description}
+                            />
+                          </>
+                        ) : (
+                          <div className="text-sm text-muted-foreground">
+                            Set to <span className="font-medium text-foreground">Available</span> to
+                            publish a safe summary and see its suggested price.
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          ) : null}
+
+          {/* BUYER — available slices, purchasable */}
+          {view === "buyer" ? (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Slices available to buy — only the safe summary, never raw data. Purchase grants 30-day
+                scoped access, and it is only ever delivered after the owner approves your request.
+              </p>
+              {availableSections.length === 0 ? (
+                <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  <Store className="mx-auto mb-2 h-6 w-6 opacity-60" aria-hidden />
+                  Nothing on the market yet. In the <span className="font-medium text-foreground">Owner</span>{" "}
+                  tab, set a section to <span className="font-medium text-foreground">Available</span> and it
+                  will list here to buy.
+                </div>
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {availableSections.map((section) => (
+                    <div key={section.key} className="flex flex-col rounded-2xl border p-5">
+                      <div className="flex items-center gap-2">
+                        <span className="rounded-full bg-emerald-500/12 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+                          available
+                        </span>
+                        <span className="text-xs text-muted-foreground">{section.domainTitle}</span>
+                      </div>
+                      <div className="mt-2 text-lg font-semibold">{section.permission.label}</div>
+                      <div className="mt-0.5 text-sm text-muted-foreground">
+                        {attributeCountFor(section.manifest, section.permission.scopeHandle)} attribute
+                        {attributeCountFor(section.manifest, section.permission.scopeHandle) === 1 ? "" : "s"}{" "}
+                        · safe summary
+                      </div>
+                      <div className="mt-4 border-t pt-4">
+                        <PriceLine input={priceInput(section)} token={token} showMath />
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="none"
+                        effect="fade"
+                        className="mt-4 self-start"
+                        onClick={() => setPurchaseSection(section)}
+                      >
+                        Purchase 30-day access
+                      </Button>
+                      <PreviewToggle
+                        columnsOnly
+                        userId={user?.uid}
+                        vaultKey={vaultKey}
+                        token={token}
+                        domainKey={section.domainKey}
+                        domainTitle={section.domainTitle}
+                        topLevelScopePath={section.permission.topLevelScopePath}
+                        label={section.permission.label}
+                        description={section.permission.description}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          {/* FLOW & REQUESTS — marketplace's own consent inbox (in-session demo) */}
+          {view === "flow" ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-semibold">Access requests</div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="none"
+                  effect="fade"
+                  onClick={() => router.push("/consents?tab=pending")}
+                >
+                  Real Consent Guardian →
+                </Button>
+              </div>
+
+              {requests.length === 0 ? (
+                <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  No requests yet. In the <span className="font-medium text-foreground">Buyer</span> tab,
+                  buy an available slice — the request lands here for you to approve or deny.
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {requests.map((req) => (
+                    <div key={req.id} className="rounded-2xl border p-4">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-semibold">{req.sliceName}</span>
+                            <span
+                              className={
+                                "rounded-full px-2 py-0.5 text-[11px] font-medium " +
+                                (req.status === "pending"
+                                  ? "bg-amber-500/12 text-amber-700 dark:text-amber-300"
+                                  : req.status === "approved"
+                                    ? "bg-emerald-500/12 text-emerald-700 dark:text-emerald-300"
+                                    : "bg-muted text-muted-foreground")
+                              }
+                            >
+                              {req.status}
+                            </span>
+                          </div>
+                          <div className="mt-0.5 text-sm text-muted-foreground">
+                            {req.domainTitle} · 30-day scoped access · safe summary only
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <PriceLine input={req.input} token={token} />
+                        </div>
+                      </div>
+                      {req.status === "pending" ? (
+                        <div className="mt-3 flex gap-2 border-t pt-3">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="none"
+                            effect="fade"
+                            onClick={() => {
+                              setRequestStatus(req.id, "approved");
+                              toast.success("Approved — the encrypted slice would be delivered to that buyer only.");
+                            }}
+                          >
+                            Approve
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="none"
+                            effect="fade"
+                            onClick={() => {
+                              setRequestStatus(req.id, "denied");
+                              toast("Denied. Nothing shared.");
+                            }}
+                          >
+                            Deny
+                          </Button>
+                        </div>
+                      ) : req.status === "approved" ? (
+                        <div className="mt-3 space-y-2 border-t pt-3">
+                          <div className="text-xs font-medium text-emerald-700 dark:text-emerald-300">
+                            The safe summary the buyer would receive (real data · never raw PKM):
+                          </div>
+                          <SharedDataPreview
+                            userId={user?.uid}
+                            vaultKey={vaultKey}
+                            token={token}
+                            domainKey={req.domainKey}
+                            domainTitle={req.domainTitle}
+                            topLevelScopePath={req.topLevelScopePath}
+                            label={req.sliceName}
+                            description={req.description}
+                          />
+                          <div className="text-[11px] text-muted-foreground">
+                            Approved (demo). This is the actual projection that would be delivered;
+                            encrypted per-buyer delivery and payment are the next phase.
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="mt-3 border-t pt-3 text-xs text-muted-foreground">
+                          Denied — nothing was shared.
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="rounded-xl bg-muted/30 px-4 py-3 text-[12.5px] text-muted-foreground">
+                In-session demo · these requests are not real consent grants and clear on refresh. Real
+                access requests live in your Consent Guardian; filing marketplace requests there (and
+                payment settlement) is the next phase.
+              </div>
+
+              <div className="rounded-2xl border p-5">
+                <div className="mb-3 text-sm font-medium">How a purchase flows</div>
+                <div className="flex flex-wrap items-center gap-2 text-xs">
+                  {[
+                    { t: "1 · Buyer finds slice + price", now: false },
+                    { t: "2 · Buyer requests access", now: true },
+                    { t: "3 · Owner approves", now: true },
+                    { t: "4 · Encrypted slice delivered to that buyer only", now: false },
+                  ].map((step, i, arr) => (
+                    <span key={step.t} className="flex items-center gap-2">
+                      <span
+                        className={
+                          "rounded-full px-3 py-1.5 font-medium " +
+                          (step.now ? "bg-foreground text-background" : "bg-muted text-muted-foreground")
+                        }
+                      >
+                        {step.t}
+                      </span>
+                      {i < arr.length - 1 ? <span className="text-muted-foreground">→</span> : null}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-4 rounded-xl bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-300">
+                  Step 3 is mandatory. Today’s app already enforces steps 2–4 via the Consent Guardian.
+                  The storefront only adds step 1 (price + browse).
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+
+      {/* PURCHASE CONFIRM MODAL */}
+      {purchaseSection ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setPurchaseSection(null);
+          }}
+        >
+          <div className="w-full max-w-md rounded-2xl border bg-background p-6 shadow-xl">
+            <div className="text-lg font-semibold">
+              Purchase — {purchaseSection.permission.label}
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              You’re buying <span className="font-medium text-foreground">30-day scoped access</span> to the
+              safe summary of{" "}
+              <span className="font-medium text-foreground">{purchaseSection.permission.label}</span>. This
+              files a request the owner must approve — nothing is shared until they say yes.
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Consent-first by design. The request appears under{" "}
+              <span className="font-medium text-foreground">Flow &amp; requests</span> (in-session demo). No
+              money moves — payment settlement is a later phase.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                onClick={() => setPurchaseSection(null)}
+              >
+                Cancel
+              </Button>
+              <Button type="button" size="sm" variant="none" effect="fade" onClick={confirmPurchase}>
+                Confirm request
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {/* CONSENT-FIRST PUBLISH — owner explicitly consents before a section is
+          listed on the marketplace. */}
+      {confirmPublish ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setConfirmPublish(null);
+          }}
+        >
+          <div className="w-full max-w-md rounded-2xl border bg-background p-6 shadow-xl">
+            <div className="text-lg font-semibold">
+              Publish to the marketplace?
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              You’re consenting to list a{" "}
+              <span className="font-medium text-foreground">safe summary</span> of{" "}
+              <span className="font-medium text-foreground">{confirmPublish.permission.label}</span> so buyers
+              can discover it and request access.
+            </p>
+            <ul className="mt-3 space-y-1.5 text-xs text-muted-foreground">
+              <li>• Only the safe summary is shared — never your raw data.</li>
+              <li>• Every buyer still needs your approval before anything is delivered.</li>
+              <li>• You can switch it back to “Ask first” or “Private” at any time.</li>
+            </ul>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                onClick={() => setConfirmPublish(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                onClick={() => {
+                  const section = confirmPublish;
+                  setConfirmPublish(null);
+                  void runPosture(section, "default_available");
+                }}
+              >
+                I consent — publish
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </PkmSettingsShell>
+  );
+}

--- a/hushh-webapp/app/profile/page.tsx
+++ b/hushh-webapp/app/profile/page.tsx
@@ -157,6 +157,7 @@ import {
   type PkmSectionPreviewPresentation,
 } from "@/lib/profile/pkm-section-preview";
 import { loadProfilePkmMetadataForVaultState } from "@/lib/profile/profile-pkm-metadata-policy";
+import { applySlicePosture } from "@/lib/personal-knowledge-model/slice-publishing";
 import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
 import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
 import { GmailReceiptsService } from "@/lib/services/gmail-receipts-service";
@@ -290,34 +291,6 @@ function applyManifestExposureChange(
   }
 
   return updated ? nextManifest : manifest;
-}
-
-function defaultAvailableScopeForPermission(
-  domainKey: string,
-  topLevelScopePath: string,
-): string {
-  return `attr.${domainKey}.${topLevelScopePath}.*`;
-}
-
-function buildDefaultAvailableProjectionPayload(params: {
-  domainKey: string;
-  domainTitle: string;
-  permission: {
-    label: string;
-    description?: string | null;
-    topLevelScopePath: string;
-  };
-  presentation: PkmSectionPreviewPresentation;
-}): Record<string, unknown> {
-  return {
-    projection_kind: "pkm_default_available_section_v1",
-    domain: params.domainKey,
-    domain_title: params.domainTitle,
-    section: params.permission.topLevelScopePath,
-    label: params.permission.label,
-    description: params.permission.description || null,
-    presentation: params.presentation,
-  };
 }
 
 function buildPkmEntityDeletionCandidate(
@@ -2874,71 +2847,24 @@ function ProfilePageContent() {
     setDomainManifestErrors((current) => ({ ...current, [domainKey]: null }));
 
     try {
-      let projectionPayload: Record<string, unknown> | null = null;
-      if (nextPosture === "default_available" && vaultKey) {
-        const sectionData = await PersonalKnowledgeModelService.loadDomainData({
-          userId: user.uid,
-          domain: domainKey,
-          vaultKey,
-          vaultOwnerToken,
-          segmentIds: [permission.topLevelScopePath],
-        });
-        const presentation = buildPkmSectionPreviewPresentation({
-          domain: domainKey,
-          domainTitle: selectedDomain?.title || domainKey,
-          permissionLabel: permission.label,
-          permissionDescription: permission.description || null,
-          topLevelScopePath: permission.topLevelScopePath,
-          value: sectionData,
-        });
-        projectionPayload = buildDefaultAvailableProjectionPayload({
-          domainKey,
-          domainTitle: selectedDomain?.title || domainKey,
-          permission,
-          presentation,
-        });
-      }
-
-      const result = await PersonalKnowledgeModelService.updateScopeExposure({
+      // Shared consent-first publish flow — same helper the One → Marketplace
+      // owner surface uses, so the sensitive vault-write path is not forked.
+      const { manifest: updatedManifest } = await applySlicePosture({
         userId: user.uid,
         domain: domainKey,
-        expectedManifestVersion: previousManifest.manifest_version,
+        domainTitle: selectedDomain?.title || domainKey,
+        permission: {
+          scopeHandle: permission.scopeHandle,
+          label: permission.label,
+          description: permission.description,
+          topLevelScopePath: permission.topLevelScopePath,
+        },
+        nextPosture,
+        previousManifest,
+        vaultKey: vaultKey ?? undefined,
         vaultOwnerToken,
-        changes: [
-          {
-            scopeHandle: permission.scopeHandle || undefined,
-            topLevelScopePath: permission.topLevelScopePath,
-            exposureEnabled: nextPosture !== "private",
-            visibilityPosture: nextPosture,
-          },
-        ],
+        source: "profile_visibility_posture",
       });
-
-      let updatedManifest =
-        result.manifest ?? optimisticManifest ?? previousManifest;
-      if (nextPosture === "default_available" && projectionPayload) {
-        const projectionResult =
-          await PersonalKnowledgeModelService.publishDefaultAvailableProjection(
-            {
-              userId: user.uid,
-              domain: domainKey,
-              scope: defaultAvailableScopeForPermission(
-                domainKey,
-                permission.topLevelScopePath,
-              ),
-              scopeHandle: permission.scopeHandle || undefined,
-              topLevelScopePath: permission.topLevelScopePath,
-              projectionPayload,
-              manifestVersion:
-                result.manifestVersion ?? previousManifest.manifest_version,
-              vaultOwnerToken,
-              metadata: {
-                source: "profile_visibility_posture",
-              },
-            },
-          );
-        updatedManifest = projectionResult.manifest ?? updatedManifest;
-      }
 
       setDomainManifests((current) => ({
         ...current,

--- a/hushh-webapp/components/profile/pkm-explorer-panel.tsx
+++ b/hushh-webapp/components/profile/pkm-explorer-panel.tsx
@@ -18,6 +18,7 @@ import {
   SurfaceInset,
 } from "@/components/app-ui/surfaces";
 import { PkmJsonTree, PkmManifestTree } from "@/components/profile/pkm-tree-view";
+import { SlicePriceBadge } from "@/components/profile/slice-price-badge";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
@@ -503,6 +504,14 @@ export function PkmExplorerPanel() {
                                   This is the public scope handle. Raw internal JSON paths stay
                                   private to first-party tooling after vault unlock.
                                 </p>
+                                {scope.visibility_posture === "default_available" ? (
+                                  <SlicePriceBadge
+                                    sensitivityTier={scope.sensitivity_tier}
+                                    scopeKind={scope.scope_kind}
+                                    attributeCount={(scope.segment_ids || []).length || 1}
+                                    vaultOwnerToken={vaultOwnerToken ?? undefined}
+                                  />
+                                ) : null}
                               </AccordionContent>
                             </AccordionItem>
                           ))}

--- a/hushh-webapp/components/profile/slice-price-badge.tsx
+++ b/hushh-webapp/components/profile/slice-price-badge.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/lib/morphy-ux/morphy";
+import {
+  categoryFromSensitivity,
+  formatCents,
+  SlicePricingService,
+  type PricingMood,
+  type PricingPower,
+  type SlicePriceBreakdown,
+} from "@/lib/services/slice-pricing-service";
+
+interface SlicePriceBadgeProps {
+  sensitivityTier?: string | null;
+  scopeKind?: string | null;
+  attributeCount: number;
+  vaultOwnerToken?: string;
+}
+
+const POWER_OPTIONS: { value: PricingPower; label: string }[] = [
+  { value: "mass", label: "Mass" },
+  { value: "mid", label: "Mid" },
+  { value: "affluent", label: "Affluent" },
+  { value: "hnw", label: "HNW" },
+  { value: "uhnw", label: "UHNW" },
+];
+
+const MOOD_OPTIONS: { value: PricingMood; label: string }[] = [
+  { value: "passive", label: "Passive" },
+  { value: "affinity", label: "Affinity" },
+  { value: "in_market", label: "In-market" },
+  { value: "hot", label: "Hot big-ticket" },
+];
+
+/**
+ * Suggested-price badge for a published `default_available` slice.
+ *
+ * Phase 1: display only. The number is computed by the backend; the band selects
+ * below just re-price the owner's own slice for illustration. No money moves and
+ * nothing is shared — this sits next to the slice, it does not sell it.
+ */
+export function SlicePriceBadge({
+  sensitivityTier,
+  scopeKind,
+  attributeCount,
+  vaultOwnerToken,
+}: SlicePriceBadgeProps) {
+  const [power, setPower] = useState<PricingPower>("affluent");
+  const [mood, setMood] = useState<PricingMood>("affinity");
+  const [result, setResult] = useState<SlicePriceBreakdown | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showMath, setShowMath] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!vaultOwnerToken) {
+      setResult(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    SlicePricingService.getSuggestedPrice(
+      {
+        category: categoryFromSensitivity(sensitivityTier, scopeKind),
+        attributeCount,
+        power,
+        mood,
+      },
+      vaultOwnerToken
+    )
+      .then((next) => {
+        if (!cancelled) setResult(next);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Pricing unavailable");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sensitivityTier, scopeKind, attributeCount, power, mood, vaultOwnerToken]);
+
+  return (
+    <div className="rounded-2xl border border-amber-200/60 bg-amber-50/40 p-3 text-sm dark:border-amber-900/40 dark:bg-amber-950/10">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Suggested price
+          </div>
+          <div className="text-lg font-semibold">
+            {loading
+              ? "Calculating…"
+              : result
+                ? `${formatCents(result.suggestedPriceCents, result.currency)} / 30 days`
+                : "—"}
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="none"
+          effect="fade"
+          onClick={() => setShowMath((value) => !value)}
+          disabled={!result}
+        >
+          {showMath ? "Hide price math" : "Show price math"}
+        </Button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <label className="flex items-center gap-1">
+          Buying power
+          <select
+            className="rounded-full border bg-background px-2 py-1 text-foreground"
+            value={power}
+            onChange={(event) => setPower(event.target.value as PricingPower)}
+          >
+            {POWER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-1">
+          Buying mood
+          <select
+            className="rounded-full border bg-background px-2 py-1 text-foreground"
+            value={mood}
+            onChange={(event) => setMood(event.target.value as PricingMood)}
+          >
+            {MOOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
+
+      {showMath && result ? (
+        <pre className="mt-3 overflow-x-auto whitespace-pre-wrap rounded-xl bg-background/70 p-3 text-[11px] text-muted-foreground">
+          {JSON.stringify(result.breakdown, null, 2)}
+        </pre>
+      ) : null}
+
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        Suggested only — you set the final price. Display-only preview; no buyer, no money moves,
+        nothing is shared.
+      </p>
+    </div>
+  );
+}

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -2064,6 +2064,38 @@
       "thread_and_consent_contract": null
     },
     {
+      "route": "/one/marketplace",
+      "page_file": "app/one/marketplace/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": null,
+      "native": {
+        "route": "/one/marketplace",
+        "classification": "native-required-functional",
+        "initialRoute": "/login?redirect=%2Fone%2Fmarketplace",
+        "expectedMarker": "native-route-one-marketplace",
+        "expectedRoute": "/one/marketplace",
+        "autoReviewerLogin": true,
+        "expectedAuth": "authenticated",
+        "allowedDataStates": [
+          "loaded",
+          "empty-valid",
+          "unavailable-valid"
+        ]
+      },
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
       "route": "/one/pkm",
       "page_file": "app/one/pkm/page.tsx",
       "physical_page_exists": true,

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   ONE_SETUP_KAI: "/one/setup/kai",
   GMAIL: "/one/gmail",
   PKM: "/one/pkm",
+  ONE_MARKETPLACE: "/one/marketplace",
   CONNECTED_SYSTEMS: "/one/connected-systems",
   CONSENTS: "/consents",
   AGENT: "/agent",

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -24,6 +24,7 @@ export const ROUTE_ID_VALUES = [
   "marketplace_connection_portfolio",
   "marketplace_ria_profile",
   "one_kyc",
+  "one_marketplace",
   "one_location",
   "one_location_public_request",
   "one_location_circle_invite",
@@ -65,6 +66,7 @@ export function resolveRouteId(pathname: string): RouteId {
   if (pathname === ROUTES.PROFILE) return "profile";
   if (pathname === ROUTES.GMAIL || pathname === ROUTES.LEGACY_GMAIL) return "gmail";
   if (pathname === ROUTES.PKM || pathname === ROUTES.LEGACY_PKM) return "pkm";
+  if (pathname === ROUTES.ONE_MARKETPLACE) return "one_marketplace";
   if (
     pathname === ROUTES.CONNECTED_SYSTEMS ||
     pathname === ROUTES.LEGACY_CONNECTED_SYSTEMS

--- a/hushh-webapp/lib/onboarding/one-capabilities.ts
+++ b/hushh-webapp/lib/onboarding/one-capabilities.ts
@@ -6,6 +6,7 @@ import {
   MailCheck,
   MapPin,
   ShieldCheck,
+  Store,
   type LucideIcon,
 } from "lucide-react";
 
@@ -137,6 +138,17 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
     href: buildConsentCenterHref("pending"),
     icon: ShieldCheck,
     tone: "consent",
+    group: "access",
+    isExploreOnly: true,
+  },
+  {
+    id: "marketplace",
+    title: "Data Marketplace",
+    description: "Preview priced slices of your data you could publish.",
+    previewLabel: "Priced data slices",
+    href: ROUTES.ONE_MARKETPLACE,
+    icon: Store,
+    tone: "pkm",
     group: "access",
     isExploreOnly: true,
   },

--- a/hushh-webapp/lib/personal-knowledge-model/slice-publishing.ts
+++ b/hushh-webapp/lib/personal-knowledge-model/slice-publishing.ts
@@ -1,0 +1,175 @@
+// hushh-webapp/lib/personal-knowledge-model/slice-publishing.ts
+/**
+ * Shared PKM slice-posture publishing flow.
+ *
+ * Single source of truth for the consent-first "publish a slice" write path,
+ * reused by both the Profile sharing controls and the One → Marketplace owner
+ * surface. Extracting it here keeps the sensitive vault-write flow (decrypt the
+ * section, build the safe projection, set the posture, publish the projection)
+ * from being duplicated — the repo forbids forking a canonical flow.
+ *
+ * Setting a section to `default_available` publishes ONLY a safe projection,
+ * never raw PKM. Nothing is shared until the owner flips the posture, and
+ * per-buyer consent still gates every actual read.
+ */
+
+import {
+  PersonalKnowledgeModelService,
+  type PkmVisibilityPosture,
+} from "@/lib/services/personal-knowledge-model-service";
+import { type DomainManifest } from "@/lib/personal-knowledge-model/manifest";
+import { buildPkmSectionPreviewPresentation } from "@/lib/profile/pkm-section-preview";
+
+export interface SlicePermission {
+  scopeHandle: string | null;
+  label: string;
+  description?: string | null;
+  topLevelScopePath: string;
+}
+
+export function cloneManifest(manifest: DomainManifest | null): DomainManifest | null {
+  if (!manifest) return null;
+  if (typeof globalThis.structuredClone === "function") {
+    try {
+      return globalThis.structuredClone(manifest) as DomainManifest;
+    } catch {
+      // Fall through to JSON clone.
+    }
+  }
+  return JSON.parse(JSON.stringify(manifest)) as DomainManifest;
+}
+
+export function applyManifestExposureChange(
+  manifest: DomainManifest | null | undefined,
+  target: { scopeHandle?: string | null; topLevelScopePath: string },
+  visibilityPosture: PkmVisibilityPosture,
+): DomainManifest | null | undefined {
+  if (!manifest) return manifest;
+  const nextManifest = cloneManifest(manifest);
+  if (!nextManifest) return nextManifest;
+
+  let updated = false;
+  if (Array.isArray(nextManifest.scope_registry)) {
+    nextManifest.scope_registry = nextManifest.scope_registry.map((entry) => {
+      const projection =
+        entry.summary_projection && typeof entry.summary_projection === "object"
+          ? entry.summary_projection
+          : {};
+      const matchesHandle = target.scopeHandle && entry.scope_handle === target.scopeHandle;
+      const matchesPath =
+        String(projection.top_level_scope_path || "").trim() === target.topLevelScopePath;
+      if (!matchesHandle && !matchesPath) {
+        return entry;
+      }
+      updated = true;
+      return {
+        ...entry,
+        exposure_enabled: visibilityPosture !== "private",
+        visibility_posture: visibilityPosture,
+        default_projection_ready:
+          visibilityPosture === "default_available" ? entry.default_projection_ready === true : false,
+        default_projection_updated_at:
+          visibilityPosture === "default_available" ? entry.default_projection_updated_at || null : null,
+      };
+    });
+  }
+
+  if (!updated && Array.isArray(nextManifest.top_level_scope_paths)) {
+    updated = nextManifest.top_level_scope_paths.includes(target.topLevelScopePath);
+  }
+
+  return updated ? nextManifest : manifest;
+}
+
+export function defaultAvailableScopeForPermission(
+  domainKey: string,
+  topLevelScopePath: string,
+): string {
+  return `attr.${domainKey}.${topLevelScopePath}.*`;
+}
+
+/**
+ * Run the network write flow for changing a section's visibility posture.
+ * Returns the updated manifest. Pure of React state — callers own optimistic
+ * UI, pending indicators, and error rollback.
+ */
+export async function applySlicePosture(params: {
+  userId: string;
+  domain: string;
+  domainTitle: string;
+  permission: SlicePermission;
+  nextPosture: PkmVisibilityPosture;
+  previousManifest: DomainManifest;
+  vaultKey?: string;
+  vaultOwnerToken: string;
+  source?: string;
+}): Promise<{ manifest: DomainManifest }> {
+  const { userId, domain, domainTitle, permission, nextPosture, previousManifest } = params;
+
+  let projectionPayload: Record<string, unknown> | null = null;
+  if (nextPosture === "default_available" && params.vaultKey) {
+    const sectionData = await PersonalKnowledgeModelService.loadDomainData({
+      userId,
+      domain,
+      vaultKey: params.vaultKey,
+      vaultOwnerToken: params.vaultOwnerToken,
+      segmentIds: [permission.topLevelScopePath],
+    });
+    const presentation = buildPkmSectionPreviewPresentation({
+      domain,
+      domainTitle,
+      permissionLabel: permission.label,
+      permissionDescription: permission.description || null,
+      topLevelScopePath: permission.topLevelScopePath,
+      value: sectionData,
+    });
+    projectionPayload = {
+      projection_kind: "pkm_default_available_section_v1",
+      domain,
+      domain_title: domainTitle,
+      section: permission.topLevelScopePath,
+      label: permission.label,
+      description: permission.description || null,
+      presentation,
+    };
+  }
+
+  const result = await PersonalKnowledgeModelService.updateScopeExposure({
+    userId,
+    domain,
+    expectedManifestVersion: previousManifest.manifest_version,
+    vaultOwnerToken: params.vaultOwnerToken,
+    // Only revoke existing grants when RESTRICTING access. Publishing a section
+    // as `default_available` is opening it up — there is nothing to revoke, and
+    // revoking here can sweep up the owner's own active session token (observed:
+    // scope-exposure revoking the vault-owner HCT, 401-ing the projection call).
+    revokeMatchingActiveGrants: nextPosture !== "default_available",
+    changes: [
+      {
+        scopeHandle: permission.scopeHandle || undefined,
+        topLevelScopePath: permission.topLevelScopePath,
+        exposureEnabled: nextPosture !== "private",
+        visibilityPosture: nextPosture,
+      },
+    ],
+  });
+
+  let updatedManifest = result.manifest ?? previousManifest;
+
+  if (nextPosture === "default_available" && projectionPayload) {
+    const projectionResult = await PersonalKnowledgeModelService.publishDefaultAvailableProjection({
+      userId,
+      domain,
+      scope: defaultAvailableScopeForPermission(domain, permission.topLevelScopePath),
+      scopeHandle: permission.scopeHandle || undefined,
+      topLevelScopePath: permission.topLevelScopePath,
+      projectionPayload,
+      manifestVersion: result.manifestVersion ?? previousManifest.manifest_version,
+      vaultOwnerToken: params.vaultOwnerToken,
+      metadata: { source: params.source || "slice_publishing" },
+    });
+    updatedManifest = projectionResult.manifest ?? updatedManifest;
+  }
+
+  return { manifest: updatedManifest };
+}

--- a/hushh-webapp/lib/services/slice-pricing-service.ts
+++ b/hushh-webapp/lib/services/slice-pricing-service.ts
@@ -1,0 +1,118 @@
+// hushh-webapp/lib/services/slice-pricing-service.ts
+/**
+ * Slice pricing service (Phase 1: suggested price display only).
+ *
+ * Calls the server-authoritative pricing endpoint so the browser never computes
+ * or fabricates a price. Sends only public slice metadata plus a demo audience
+ * band — no ciphertext, no protected PKM content.
+ *
+ * IMPORTANT: goes through ApiService.apiFetch() (never direct fetch("/api/...")),
+ * consistent with the rest of the PKM services.
+ */
+
+import { ApiService } from "./api-service";
+
+export type PricingCategory =
+  | "identifiers"
+  | "quasi_identifiers"
+  | "demographics_lifestyle"
+  | "private_financial";
+export type PricingPower = "mass" | "mid" | "affluent" | "hnw" | "uhnw";
+export type PricingMood = "passive" | "affinity" | "in_market" | "hot";
+export type PricingExclusivity = "shared" | "limited" | "exclusive";
+export type PricingGeography = "us" | "non_us";
+
+export interface SlicePricingInput {
+  category?: PricingCategory;
+  attributeCount: number;
+  power?: PricingPower;
+  mood?: PricingMood;
+  weeksStale?: number;
+  exclusivity?: PricingExclusivity;
+  geography?: PricingGeography;
+}
+
+export interface SlicePriceBreakdown {
+  suggestedPriceCents: number;
+  currency: string;
+  floorCents: number;
+  breakdown: Record<string, unknown>;
+}
+
+export class SlicePricingError extends Error {
+  status: number;
+  constructor(status: number, message?: string) {
+    super(message || `Failed to compute suggested price (${status})`);
+    this.name = "SlicePricingError";
+    this.status = status;
+  }
+}
+
+/**
+ * Mirror of the backend `category_from_sensitivity` mapping so the demo band
+ * pricing lines up with what the server would derive from the same slice.
+ */
+export function categoryFromSensitivity(
+  sensitivityTier?: string | null,
+  scopeKind?: string | null
+): PricingCategory {
+  const tier = (sensitivityTier || "").trim().toLowerCase();
+  const kind = (scopeKind || "").trim().toLowerCase();
+  if (tier === "restricted" || kind.includes("financial") || kind.includes("secret")) {
+    return "private_financial";
+  }
+  return "demographics_lifestyle";
+}
+
+export function formatCents(cents: number, currency = "USD"): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  }).format((Number.isFinite(cents) ? cents : 0) / 100);
+}
+
+export class SlicePricingService {
+  private static readonly ENDPOINT = "/api/pkm/slice-price";
+
+  static async getSuggestedPrice(
+    input: SlicePricingInput,
+    vaultOwnerToken?: string
+  ): Promise<SlicePriceBreakdown> {
+    const response = await ApiService.apiFetch(this.ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(vaultOwnerToken ? { Authorization: `Bearer ${vaultOwnerToken}` } : {}),
+      },
+      body: JSON.stringify({
+        category: input.category ?? "demographics_lifestyle",
+        attribute_count: Math.max(0, Math.trunc(input.attributeCount || 0)),
+        power: input.power ?? "mass",
+        mood: input.mood ?? "passive",
+        weeks_stale: Math.max(0, Math.trunc(input.weeksStale ?? 0)),
+        exclusivity: input.exclusivity ?? "shared",
+        geography: input.geography ?? "us",
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new SlicePricingError(response.status, detail || undefined);
+    }
+
+    const data = (await response.json()) as {
+      suggested_price_cents: number;
+      currency: string;
+      floor_cents: number;
+      breakdown: Record<string, unknown>;
+    };
+
+    return {
+      suggestedPriceCents: data.suggested_price_cents,
+      currency: data.currency,
+      floorCents: data.floor_cents,
+      breakdown: data.breakdown ?? {},
+    };
+  }
+}

--- a/hushh-webapp/native-route-inventory.json
+++ b/hushh-webapp/native-route-inventory.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-06-17",
-  "total_routes": 59,
-  "native_required_routes": 56,
+  "total_routes": 60,
+  "native_required_routes": 57,
   "excluded_routes": 3,
   "routes": [
     {
@@ -479,6 +479,20 @@
       "initialRoute": "/login?redirect=%2Fone%2Fpkm",
       "expectedMarker": "native-route-pkm",
       "expectedRoute": "/one/pkm",
+      "autoReviewerLogin": true,
+      "expectedAuth": "authenticated",
+      "allowedDataStates": [
+        "loaded",
+        "empty-valid",
+        "unavailable-valid"
+      ]
+    },
+    {
+      "route": "/one/marketplace",
+      "classification": "native-required-functional",
+      "initialRoute": "/login?redirect=%2Fone%2Fmarketplace",
+      "expectedMarker": "native-route-one-marketplace",
+      "expectedRoute": "/one/marketplace",
       "autoReviewerLogin": true,
       "expectedAuth": "authenticated",
       "allowedDataStates": [


### PR DESCRIPTION
# Description

Consent-first PKM data-slice marketplace under One: users can price and publish individual PKM slices, with a backend pricing module + route and the One marketplace UI. Fresh PR to `main` from `feat-same` (supersedes the pr-train-targeted #4268, which was conflicting against its base).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/one/marketplace` (new page)
    - PKM slice price route in `consent-protocol/api/routes/pkm.py`

- API / schema / type changes:
  - [x] Listed below:
    - New pricing module `hushh_mcp/pricing/slice_pricing.py` + slice price API route. No DB schema change.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
    - `native-route-inventory.json` and `frontend-native-surface-map.generated.json` regenerated for the new marketplace route.

- Docs updated (exact files):
  - [x] Listed below:
    - `docs/future/pkm-slice-marketplace-plan.md`, `docs/future/README.md`

- Trust boundary touched:
  - [x] Auth / consent / vault / PKM listed below:
    - Adds pricing/publishing metadata around PKM slices; no change to vault encryption or consent token issuance.

- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Additive feature behind the One marketplace surface; revert = drop the route/page. No destructive migration.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; supersedes #4268 (which targeted `integration/pr-train`).
- [x] This PR changes a current reachable app/backend surface.
- [x] New tests exercise production code: `test_slice_pricing.py`, `test_pkm_slice_price_route.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
