### PR TITLE
chore(ui): silence warnings for identity and vault fallback checks

### DIFF
--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -59,7 +59,7 @@ export function PhoneMandateGuard({
           vaultPresenceCache.set(user.uid, exists);
           setHasVault(exists);
         }
-      } catch (error) {
+      } catch {
         // Fallback to assume vault presence if check fails
         if (!cancelled) {
           vaultPresenceCache.set(user.uid, true);
@@ -94,7 +94,7 @@ export function PhoneMandateGuard({
         if (!cancelled) {
           setBackendPhoneVerified(AccountIdentityService.hasVerifiedPhone(identity));
         }
-      } catch (error) {
+      } catch {
         // Fallback to firebase identity if custom backend claim check fails
         if (!cancelled) {
           setBackendPhoneVerified(firebasePhoneVerified);

--- a/hushh-webapp/components/auth/phone-mandate-guard.tsx
+++ b/hushh-webapp/components/auth/phone-mandate-guard.tsx
@@ -60,7 +60,7 @@ export function PhoneMandateGuard({
           setHasVault(exists);
         }
       } catch (error) {
-        console.warn("[PhoneMandateGuard] Failed to check vault presence:", error);
+        // Fallback to assume vault presence if check fails
         if (!cancelled) {
           vaultPresenceCache.set(user.uid, true);
           setHasVault(true);
@@ -95,7 +95,7 @@ export function PhoneMandateGuard({
           setBackendPhoneVerified(AccountIdentityService.hasVerifiedPhone(identity));
         }
       } catch (error) {
-        console.warn("[PhoneMandateGuard] Failed to check account phone claim:", error);
+        // Fallback to firebase identity if custom backend claim check fails
         if (!cancelled) {
           setBackendPhoneVerified(firebasePhoneVerified);
         }


### PR DESCRIPTION
### Description

Silences redundant `console.warn` traces in `components/auth/phone-mandate-guard.tsx`. These warnings (`"Failed to check vault presence:"` and `"Failed to check account phone claim:"`) were firing when background network checks failed. Since the component handles these exact failure scenarios gracefully—by falling back to standard Firebase claims or assuming Vault presence—the warnings were simply removed to prevent browser console clutter during offline or transient network conditions.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/auth/phone-mandate-guard.tsx`

- Trust boundary touched:
  - [x] none (purely client UI cleanup)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/auth/phone-mandate-guard.tsx`)

## 🧪 Testing

- [x] Verified component compiles.
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a console logging chore.