### PR TITLE
chore(ui): silence vault method prompt background evaluation warnings

### DIFF
--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -130,7 +130,7 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
 
         setTargetMethod(capability.recommendedMethod as VaultMethod);
         setOpen(true);
-      } catch (error) {
+      } catch {
         // Handled implicitly by simply not opening the prompt
       }
     }

--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -131,7 +131,7 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
         setTargetMethod(capability.recommendedMethod as VaultMethod);
         setOpen(true);
       } catch (error) {
-        console.warn("[VaultMethodPrompt] Skipping method prompt:", error);
+        // Handled implicitly by simply not opening the prompt
       }
     }
 


### PR DESCRIPTION
### Description

Silences a redundant `console.warn` trace in `components/vault/vault-method-prompt.tsx`. This warning (`"Skipping method prompt:"`) was firing when the background evaluation for vault authentication upgrades failed. Since the component handles this exact scenario gracefully by simply suppressing the prompt, the warning was removed to keep the browser console clean during standard usage or offline conditions.