### PR TITLE
fix(ui): silence vault status check error logging leak

### DIFF
--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -230,8 +230,8 @@ export function VaultFlow({
             setVaultMode(vaultData.primaryMethod);
             setUnlockWithPassphraseFallback(false);
           }
-        } catch (metadataError) {
-          console.warn("Vault mode detection failed, defaulting to passphrase:", metadataError);
+        } catch {
+          // Vault mode detection error is handled implicitly below
           setVaultMode("passphrase");
           setAvailableGeneratedMethod(null);
           setUnlockWithPassphraseFallback(false);
@@ -239,7 +239,7 @@ export function VaultFlow({
         }
         setStep("unlock");
       } catch (err) {
-        console.error("Vault status check failed:", err);
+        // Vault status check error is handled implicitly below
         const errorCode =
           typeof (err as { code?: unknown } | null | undefined)?.code === "string"
             ? (err as { code: string }).code


### PR DESCRIPTION
### Description

Silences explicit `console.warn` and `console.error` leaks in `components/vault/vault-flow.tsx`. These traces (`"Vault mode detection failed, defaulting to passphrase:"` and `"Vault status check failed:"`) were firing when background vault presence or metadata checks failed. Because the UI gracefully handles these exact failure scenarios natively—by falling back to the passphrase method and rendering a formatted `toInvestorMessage`—the explicit `console` logs were removed to prevent internal backend error exceptions from leaking into the browser console during offline scenarios.
