### PR TITLE
Fix phone country selector first-click state

### DIFF
--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -354,6 +354,7 @@ Using a different Node or Python locally can cause â€œpass locally, fail in CIâ€
 | Docs/runtime parity | `npm run verify:docs` | Yes |
 | TypeScript | `npm run typecheck` | Yes |
 | Lint | `npm run lint -- --max-warnings=${WEB_LINT_WARNING_BUDGET}` | Yes |
+| Phone verification regression | `npm run verify:phone-verification` | Yes |
 | Build (web) | `npm run build` (Next.js) | Yes |
 | Security audit budget | `npm audit --json` + budget gate (`moderate/high/critical`) | Yes |
 | Tests | `npm run test:ci` (manifest-driven curated suites) | Yes |

--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
+
+function renderPhoneVerificationFlow() {
+  const startVerification = vi.fn().mockResolvedValue({ autoVerified: false });
+  const confirmVerification = vi.fn();
+  const onCompleted = vi.fn();
+
+  render(
+    <PhoneVerificationFlow
+      mode="link"
+      startVerification={startVerification}
+      confirmVerification={confirmVerification}
+      onCompleted={onCompleted}
+    />
+  );
+
+  return {
+    startVerification,
+  };
+}
+
+async function selectIndiaOnce() {
+  const countryInput = screen.getByRole("combobox", {
+    name: "Country code",
+  }) as HTMLInputElement;
+
+  fireEvent.focus(countryInput);
+
+  const indiaOption = await screen.findByText("India");
+  const indiaItem = (indiaOption.closest("[data-slot='combobox-item']") ??
+    indiaOption) as Element;
+
+  fireEvent.pointerDown(indiaItem);
+  fireEvent.click(indiaItem);
+
+  await waitFor(() => {
+    expect(countryInput.value).toBe("India (+91)");
+  });
+
+  return countryInput;
+}
+
+describe("PhoneVerificationFlow country selector", () => {
+  it("shows India immediately after the first country selection", async () => {
+    renderPhoneVerificationFlow();
+
+    await selectIndiaOnce();
+  });
+
+  it("uses the first selected country when sending the verification phone number", async () => {
+    const { startVerification } = renderPhoneVerificationFlow();
+
+    await selectIndiaOnce();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Phone number" }), {
+      target: { value: "8004482372" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send verification code" }));
+
+    await waitFor(() => {
+      expect(startVerification).toHaveBeenCalledWith("+918004482372", {
+        resendCode: false,
+      });
+    });
+  });
+});

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -180,11 +180,7 @@ export function PhoneVerificationFlow({
     setSelectedCountry(nextFields.countryValue);
     setLocalPhoneNumber(nextFields.localPhoneNumber);
     setSubmittedPhoneNumber(currentPhoneNumber || "");
-    setCountryQuery(
-      getCountryOptionLabel(
-        getCountryOption(nextFields.countryValue)
-      )
-    );
+    setCountryQuery("");
     setVerificationCode("");
     setStep(mode === "link" && currentPhoneNumber ? "linked" : "phone");
   }, [currentPhoneNumber, mode]);
@@ -194,6 +190,11 @@ export function PhoneVerificationFlow({
     () => COUNTRY_PHONE_OPTIONS.find((option) => option.value === selectedCountry),
     [selectedCountry]
   );
+  const selectedCountryLabel = useMemo(
+    () => getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!),
+    [selectedCountryOption]
+  );
+  const countryInputValue = countryComboboxOpen ? countryQuery : selectedCountryLabel;
   const filteredCountryOptions = useMemo(() => {
     const normalizedQuery = countryQuery.trim().toLowerCase();
     if (!normalizedQuery) {
@@ -232,7 +233,7 @@ export function PhoneVerificationFlow({
     }
 
     setSelectedCountry(nextOption.value);
-    setCountryQuery(getCountryOptionLabel(nextOption));
+    setCountryQuery("");
     setCountryComboboxOpen(false);
   }, []);
 
@@ -241,7 +242,7 @@ export function PhoneVerificationFlow({
     if (nextInput.countryValue) {
       const nextOption = getCountryOption(nextInput.countryValue);
       setSelectedCountry(nextOption.value);
-      setCountryQuery(getCountryOptionLabel(nextOption));
+      setCountryQuery("");
     }
     setLocalPhoneNumber(nextInput.localPhoneNumber);
   }, []);
@@ -370,11 +371,7 @@ export function PhoneVerificationFlow({
                 open={countryComboboxOpen}
                 onOpenChange={(open) => {
                   setCountryComboboxOpen(open);
-                  if (!open) {
-                    setCountryQuery(
-                      getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!)
-                    );
-                  }
+                  setCountryQuery("");
                 }}
                 value={selectedCountry}
                 onValueChange={handleCountrySelection}
@@ -383,7 +380,7 @@ export function PhoneVerificationFlow({
                 <ComboboxInput
                   id="phone-flow-country"
                   placeholder="Search country code"
-                  value={countryQuery}
+                  value={countryInputValue}
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                     setCountryQuery(event.target.value);
                     if (!countryComboboxOpen) {

--- a/hushh-webapp/eslint.config.mjs
+++ b/hushh-webapp/eslint.config.mjs
@@ -15,6 +15,7 @@ export default [
       ".next-prod/**/*",
       "out/**",
       "node_modules/**",
+      "node_modules*/**",
       "dist/**",
       "build/**",
       "android/**",

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:ci": "vitest run",
+    "verify:phone-verification": "vitest run __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx",
     "build:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs",
     "verify:voice-gateway": "node ./scripts/voice/generate-kai-action-gateway.mjs --check",
     "verify:analytics": "vitest run __tests__/services/observability-schema.test.ts __tests__/services/observability-route-map.test.ts __tests__/services/observability-growth.test.ts __tests__/services/observability-native-firebase.test.ts __tests__/services/observability-web-transport.test.ts",

--- a/scripts/ci/web-check.sh
+++ b/scripts/ci/web-check.sh
@@ -25,6 +25,7 @@ npm run verify:analytics
 npm run verify:cache
 npm run typecheck
 npm run lint
+npm run verify:phone-verification
 npm run test:ci
 
 NEXT_PUBLIC_BACKEND_URL="${NEXT_PUBLIC_BACKEND_URL:-https://api.example.com}" \


### PR DESCRIPTION
## Summary
- Derive the closed register-phone country label from selectedCountry instead of stale search text
- Keep countryQuery as open-dropdown search state only
- Add explicit phone verification regression coverage and wire it into the web CI lane
- Keep stock combobox untouched

## Tests
- npm run verify:phone-verification
- npm run typecheck
- PATH="/Users/ankitkumarsingh/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/ankitkumarsingh/.codex/tmp/arg0/codex-arg03cRlZu:/Users/ankitkumarsingh/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/ankitkumarsingh/.nvm/versions/node/v20.20.2/bin:/Users/ankitkumarsingh/google-cloud-sdk/bin:/Users/ankitkumarsingh/.local/bin:/Applications/Codex.app/Contents/Resources" bash scripts/ci/orchestrate.sh governance
- npm run test:ci
- npm run lint
