### PR TITLE
feat(one-marketplace): owner consent override for PKM slice publishing

### DIFF
--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -736,6 +736,10 @@ class ScopeExposureChangePayload(BaseModel):
     top_level_scope_path: Optional[str] = Field(default=None, max_length=1024)
     exposure_enabled: Optional[bool] = Field(default=None)
     visibility_posture: Optional[str] = Field(default=None, max_length=128)
+    # Explicit owner consent to publish a safe projection of their own
+    # restricted-tier data as `default_available` (marketplace override). Only
+    # lifts the restricted-tier block; structural blocked keys stay blocked.
+    owner_consent_override: Optional[bool] = Field(default=None)
 
 
 class ScopeExposureRequest(BaseModel):

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 73,
+  "expected_migration_version": 74,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -166,6 +166,7 @@
       "visibility_posture",
       "default_projection_ready",
       "default_projection_updated_at",
+      "owner_consent_override",
       "created_at",
       "updated_at"
     ],

--- a/consent-protocol/db/migrations/074_pkm_scope_registry_owner_consent_override.sql
+++ b/consent-protocol/db/migrations/074_pkm_scope_registry_owner_consent_override.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- Owner-consent override for the PKM slice marketplace.
+--
+-- The visibility guardrail (_normalize_visibility_posture) downgrades a
+-- `default_available` request back to `consent_required` when a scope's
+-- sensitivity_tier is `restricted`. That is correct as a default, but the
+-- marketplace lets an owner explicitly consent to publishing a safe projection
+-- of THEIR OWN restricted-tier data. This column records that explicit,
+-- per-scope owner consent so the override is honored on BOTH the write path and
+-- the read/normalize path (otherwise the buyer's read would re-downgrade it and
+-- the slice would "vanish").
+--
+-- Scope of the override (enforced in code, not here): it lifts ONLY the
+-- `restricted` sensitivity-tier block. Structural blocked keys
+-- (_DEFAULT_AVAILABLE_BLOCKED_KEYS: hash/metadata/provenance/schema_version/
+-- workflow/workflow_id) remain hard-blocked even with owner consent.
+ALTER TABLE pkm_scope_registry
+  ADD COLUMN IF NOT EXISTS owner_consent_override BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -51,7 +51,8 @@
     "070_developer_registry.sql",
     "071_enterprise_crm_registry.sql",
     "072_crm_registry_mulesoft_pbkdf2_cbc.sql",
-    "073_crm_registry_mulesoft_simplify.sql"
+    "073_crm_registry_mulesoft_simplify.sql",
+    "074_pkm_scope_registry_owner_consent_override.sql"
   ],
   "groups": {
     "iam": [
@@ -100,7 +101,8 @@
       "043_ria_pick_share_artifacts.sql",
       "048_merge_pkm_domain_summary_rpc.sql",
       "062_consent_exports_export_key_guard.sql",
-      "063_pkm_default_available_visibility.sql"
+      "063_pkm_default_available_visibility.sql",
+      "074_pkm_scope_registry_owner_consent_override.sql"
     ],
     "developer": [
       "070_developer_registry.sql"

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -145,6 +145,10 @@ class ScopeRegistryEntry:
     visibility_posture: str = "consent_required"
     default_projection_ready: bool = False
     default_projection_updated_at: Optional[str] = None
+    # Explicit per-scope owner consent to publish a safe projection of their own
+    # `restricted`-tier data as `default_available` (marketplace override). Lifts
+    # only the restricted-tier block; structural blocked keys stay hard-blocked.
+    owner_consent_override: bool = False
     summary_projection: dict = field(default_factory=dict)
 
 
@@ -672,6 +676,7 @@ class PersonalKnowledgeModelService:
         consumer_visible: bool = True,
         sensitivity_tier: str | None = None,
         top_level_scope_path: str | None = None,
+        owner_override: bool = False,
     ) -> str:
         if not exposure_enabled or not consumer_visible:
             return "private"
@@ -679,11 +684,18 @@ class PersonalKnowledgeModelService:
         requested = requested if requested in cls._VISIBILITY_POSTURES else "consent_required"
         normalized_path = cls._normalize_manifest_path(top_level_scope_path)
         if requested == "default_available":
-            if str(sensitivity_tier or "").strip().lower() == "restricted":
-                return "consent_required"
+            # Structural blocked keys are NEVER publishable, even with explicit
+            # owner consent — they are system/non-shareable paths, not the
+            # owner's personal data.
             if any(
                 part in cls._DEFAULT_AVAILABLE_BLOCKED_KEYS for part in normalized_path.split(".")
             ):
+                return "consent_required"
+            # The `restricted` sensitivity tier is consent-gated by default, but
+            # an owner may explicitly consent to publishing a safe projection of
+            # their OWN restricted-tier data via the marketplace. That override
+            # lifts only this tier block.
+            if str(sensitivity_tier or "").strip().lower() == "restricted" and not owner_override:
                 return "consent_required"
         return requested
 
@@ -770,6 +782,7 @@ class PersonalKnowledgeModelService:
             or "confidential"
         )
         exposure_enabled = raw_row.get("exposure_enabled") is not False
+        owner_consent_override = raw_row.get("owner_consent_override") is True
         visibility_posture = cls._normalize_visibility_posture(
             raw_row.get("visibility_posture"),
             exposure_enabled=exposure_enabled,
@@ -777,6 +790,7 @@ class PersonalKnowledgeModelService:
             and visibility_projection.get("internal_only") is not True,
             sensitivity_tier=sensitivity_tier,
             top_level_scope_path=top_level_scope_path,
+            owner_override=owner_consent_override,
         )
         default_projection_updated_at = cls._clean_text(
             str(raw_row.get("default_projection_updated_at") or ""),
@@ -815,6 +829,7 @@ class PersonalKnowledgeModelService:
             "default_projection_updated_at": default_projection_updated_at
             if default_projection_ready
             else None,
+            "owner_consent_override": owner_consent_override,
             "summary_projection": summary_projection,
             "manifest_version": cls._to_non_negative_int(raw_row.get("manifest_version")),
         }
@@ -1003,6 +1018,7 @@ class PersonalKnowledgeModelService:
             "visibility_posture": entry.visibility_posture,
             "default_projection_ready": entry.default_projection_ready,
             "default_projection_updated_at": entry.default_projection_updated_at,
+            "owner_consent_override": entry.owner_consent_override,
             "summary_projection": json.dumps(entry.summary_projection or {}),
             "manifest_version": manifest.manifest_version,
         }
@@ -2028,16 +2044,20 @@ class PersonalKnowledgeModelService:
         default_ready_by_top_level: dict[str, bool] = {}
         default_updated_by_handle: dict[str, str | None] = {}
         default_updated_by_top_level: dict[str, str | None] = {}
+        override_by_handle: dict[str, bool] = {}
+        override_by_top_level: dict[str, bool] = {}
         for row in current_registry_rows:
             if not isinstance(row, dict):
                 continue
             handle = self._clean_text(str(row.get("scope_handle") or ""), allow_none=True)
+            row_override = row.get("owner_consent_override") is True
             row_posture = self._normalize_visibility_posture(
                 row.get("visibility_posture"),
                 exposure_enabled=row.get("exposure_enabled") is not False,
                 consumer_visible=True,
                 sensitivity_tier=str(row.get("sensitivity_tier") or "confidential"),
                 top_level_scope_path=self._top_level_scope_path_for_registry_entry(row),
+                owner_override=row_override,
             )
             row_default_ready = (
                 row_posture == "default_available" and row.get("default_projection_ready") is True
@@ -2051,12 +2071,14 @@ class PersonalKnowledgeModelService:
                 posture_by_handle[handle] = row_posture
                 default_ready_by_handle[handle] = row_default_ready
                 default_updated_by_handle[handle] = row_default_updated
+                override_by_handle[handle] = row_override
             top_level_path = self._top_level_scope_path_for_registry_entry(row)
             if top_level_path:
                 exposure_by_top_level[top_level_path] = row.get("exposure_enabled") is not False
                 posture_by_top_level[top_level_path] = row_posture
                 default_ready_by_top_level[top_level_path] = row_default_ready
                 default_updated_by_top_level[top_level_path] = row_default_updated
+                override_by_top_level[top_level_path] = row_override
 
         for entry in normalized_manifest.scope_registry:
             if entry.scope_handle in exposure_by_handle:
@@ -2070,6 +2092,9 @@ class PersonalKnowledgeModelService:
                 entry.default_projection_updated_at = default_updated_by_handle.get(
                     entry.scope_handle
                 )
+                entry.owner_consent_override = override_by_handle.get(
+                    entry.scope_handle, entry.owner_consent_override
+                )
                 continue
             top_level_path = self._top_level_scope_path_for_registry_entry(entry)
             if top_level_path in exposure_by_top_level:
@@ -2079,6 +2104,9 @@ class PersonalKnowledgeModelService:
                 )
                 entry.default_projection_ready = default_ready_by_top_level.get(
                     top_level_path, False
+                )
+                entry.owner_consent_override = override_by_top_level.get(
+                    top_level_path, entry.owner_consent_override
                 )
                 entry.default_projection_updated_at = default_updated_by_top_level.get(
                     top_level_path
@@ -2099,6 +2127,10 @@ class PersonalKnowledgeModelService:
                 allow_none=True,
             )
             exposure_enabled = raw_change.get("exposure_enabled") is not False
+            # Explicit per-scope owner consent to publish restricted-tier data as
+            # `default_available` (marketplace override). Only the marketplace
+            # publish path sends this; the Profile flow never does.
+            change_override = raw_change.get("owner_consent_override") is True
             matched = False
             for entry in normalized_manifest.scope_registry:
                 entry_top_level = self._top_level_scope_path_for_registry_entry(entry)
@@ -2113,10 +2145,31 @@ class PersonalKnowledgeModelService:
                     ),
                     sensitivity_tier=entry.sensitivity_tier,
                     top_level_scope_path=entry_top_level,
+                    owner_override=change_override,
                 )
+                # Persist the override marker only while the slice is actually
+                # published as available under that consent; any other posture
+                # clears it so a later read never resurrects a stale override.
+                next_override = bool(change_override and next_posture == "default_available")
+                if (explicit_posture == "default_available" or change_override) and (
+                    (target_handle and entry.scope_handle == target_handle)
+                    or (target_top_level and entry_top_level == target_top_level)
+                ):
+                    logger.info(
+                        "[slice-override] domain=%s handle=%s top=%s tier=%s "
+                        "change_override=%s -> next_posture=%s next_override=%s",
+                        canonical_domain,
+                        entry.scope_handle,
+                        entry_top_level,
+                        entry.sensitivity_tier,
+                        change_override,
+                        next_posture,
+                        next_override,
+                    )
                 if target_handle and entry.scope_handle == target_handle:
                     entry.visibility_posture = next_posture
                     entry.exposure_enabled = next_posture != "private"
+                    entry.owner_consent_override = next_override
                     if next_posture != "default_available":
                         entry.default_projection_ready = False
                         entry.default_projection_updated_at = None
@@ -2129,6 +2182,7 @@ class PersonalKnowledgeModelService:
                 if target_top_level and entry_top_level == target_top_level:
                     entry.visibility_posture = next_posture
                     entry.exposure_enabled = next_posture != "private"
+                    entry.owner_consent_override = next_override
                     if next_posture != "default_available":
                         entry.default_projection_ready = False
                         entry.default_projection_updated_at = None
@@ -2150,6 +2204,16 @@ class PersonalKnowledgeModelService:
         normalized_manifest.last_structured_at = now
         normalized_manifest.last_content_at = now
         normalized_manifest.summary_projection["manifest_version"] = next_manifest_version
+
+        for _dbg_entry in normalized_manifest.scope_registry:
+            logger.info(
+                "[slice-persist] domain=%s handle=%s top=%s posture=%s override=%s",
+                canonical_domain,
+                _dbg_entry.scope_handle,
+                self._top_level_scope_path_for_registry_entry(_dbg_entry),
+                _dbg_entry.visibility_posture,
+                _dbg_entry.owner_consent_override,
+            )
 
         manifest_ok = await self.upsert_domain_manifest(normalized_manifest)
         if not manifest_ok:
@@ -2291,6 +2355,7 @@ class PersonalKnowledgeModelService:
             else True,
             sensitivity_tier=str(matching_entry.get("sensitivity_tier") or "confidential"),
             top_level_scope_path=normalized_path,
+            owner_override=matching_entry.get("owner_consent_override") is True,
         )
         if posture != "default_available":
             result["message"] = "Section is not set to available by default."
@@ -2329,6 +2394,20 @@ class PersonalKnowledgeModelService:
             self.supabase.table("pkm_default_available_projections").insert(row)
         )
 
+        # Snapshot the already-persisted sharing state before rebuilding the
+        # manifest. `_normalize_manifest_payload` regenerates scope_registry from
+        # paths and resets every scope to `consent_required` (override=False), so
+        # without this we would clobber the posture that the immediately-preceding
+        # scope-exposure write just persisted — the slice would "vanish" for EVERY
+        # published section, not just this one.
+        prior_scope_state: dict[str, dict] = {}
+        for existing in manifest.get("scope_registry") or []:
+            if not isinstance(existing, dict):
+                continue
+            existing_top = self._top_level_scope_path_for_registry_entry(existing)
+            if existing_top:
+                prior_scope_state[existing_top] = existing
+
         current_manifest = self._normalize_manifest_payload(
             user_id,
             canonical_domain,
@@ -2339,7 +2418,22 @@ class PersonalKnowledgeModelService:
             ),
         )
         for entry in current_manifest.scope_registry:
-            if self._top_level_scope_path_for_registry_entry(entry) == normalized_path:
+            entry_top = self._top_level_scope_path_for_registry_entry(entry)
+            prior = prior_scope_state.get(entry_top)
+            if prior is not None:
+                entry.visibility_posture = (
+                    str(prior.get("visibility_posture") or "").strip() or entry.visibility_posture
+                )
+                entry.exposure_enabled = entry.visibility_posture != "private"
+                entry.owner_consent_override = prior.get("owner_consent_override") is True
+                entry.default_projection_ready = prior.get("default_projection_ready") is True
+                entry.default_projection_updated_at = (
+                    prior.get("default_projection_updated_at")
+                    or entry.default_projection_updated_at
+                )
+            if entry_top == normalized_path:
+                entry.visibility_posture = "default_available"
+                entry.exposure_enabled = True
                 entry.default_projection_ready = True
                 entry.default_projection_updated_at = now.isoformat()
         await self.upsert_domain_manifest(current_manifest)

--- a/consent-protocol/tests/services/test_pkm_service_store_domain_data.py
+++ b/consent-protocol/tests/services/test_pkm_service_store_domain_data.py
@@ -670,6 +670,7 @@ async def test_get_domain_manifest_normalizes_duplicate_scope_registry_rows(monk
             "visibility_posture": "consent_required",
             "default_projection_ready": False,
             "default_projection_updated_at": None,
+            "owner_consent_override": False,
             "summary_projection": {
                 "top_level_scope_path": "advisor_package",
                 "storage_mode": "manifest",
@@ -690,6 +691,7 @@ async def test_get_domain_manifest_normalizes_duplicate_scope_registry_rows(monk
             "visibility_posture": "private",
             "default_projection_ready": False,
             "default_projection_updated_at": None,
+            "owner_consent_override": False,
             "summary_projection": {
                 "top_level_scope_path": "updated_at",
                 "storage_mode": "manifest",

--- a/consent-protocol/tests/test_marketplace_owner_consent_override.py
+++ b/consent-protocol/tests/test_marketplace_owner_consent_override.py
@@ -1,0 +1,78 @@
+# consent-protocol/tests/test_marketplace_owner_consent_override.py
+"""
+Owner-consent override for the PKM slice marketplace.
+
+Verifies the visibility guardrail (`_normalize_visibility_posture`):
+- restricted-tier data is consent-gated by default,
+- an explicit owner override lifts ONLY the restricted-tier block,
+- structural blocked keys stay hard-blocked even with owner consent,
+- non-restricted data is unaffected.
+"""
+
+from hushh_mcp.services.personal_knowledge_model_service import (
+    PersonalKnowledgeModelService as PKM,
+)
+
+
+def test_restricted_is_consent_gated_without_override():
+    assert (
+        PKM._normalize_visibility_posture(
+            "default_available",
+            sensitivity_tier="restricted",
+            top_level_scope_path="advisor_package",
+        )
+        == "consent_required"
+    )
+
+
+def test_restricted_is_publishable_with_owner_override():
+    assert (
+        PKM._normalize_visibility_posture(
+            "default_available",
+            sensitivity_tier="restricted",
+            top_level_scope_path="advisor_package",
+            owner_override=True,
+        )
+        == "default_available"
+    )
+
+
+def test_structural_blocked_key_stays_blocked_even_with_override():
+    # "metadata" is a structural blocked key: never publishable, even with
+    # explicit owner consent.
+    assert (
+        PKM._normalize_visibility_posture(
+            "default_available",
+            sensitivity_tier="restricted",
+            top_level_scope_path="metadata",
+            owner_override=True,
+        )
+        == "consent_required"
+    )
+
+
+def test_confidential_is_unaffected_by_override_flag():
+    for override in (False, True):
+        assert (
+            PKM._normalize_visibility_posture(
+                "default_available",
+                sensitivity_tier="confidential",
+                top_level_scope_path="advisor_package",
+                owner_override=override,
+            )
+            == "default_available"
+        )
+
+
+def test_override_does_not_force_exposure_when_disabled():
+    # An override never publishes a section the owner has turned off.
+    assert (
+        PKM._normalize_visibility_posture(
+            "default_available",
+            exposure_enabled=False,
+            sensitivity_tier="restricted",
+            top_level_scope_path="advisor_package",
+            owner_override=True,
+        )
+        == "private"
+    )

--- a/consent-protocol/tests/test_pkm_upgrade_routes.py
+++ b/consent-protocol/tests/test_pkm_upgrade_routes.py
@@ -125,6 +125,7 @@ def test_scope_exposure_route_forwards_payload(monkeypatch):
                 "top_level_scope_path": "portfolio",
                 "exposure_enabled": False,
                 "visibility_posture": None,
+                "owner_consent_override": None,
             }
         ],
         "revoke_matching_active_grants": True,

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -82,9 +82,9 @@ const POSTURE_OPTIONS: { value: PkmVisibilityPosture; label: string }[] = [
   { value: "default_available", label: "Available" },
 ];
 
-// Mirrors the backend: `default_available` is refused (downgraded to
-// consent_required) for restricted scopes and these structural keys. Restricted
-// data is deliberately never publishable as available-by-default.
+// Structural (system / non-personal) scope keys that can NEVER be published as
+// `default_available`, even with explicit owner consent — the backend
+// hard-blocks these too. These are not the owner's personal data.
 const DEFAULT_AVAILABLE_BLOCKED_KEYS = new Set([
   "hash",
   "metadata",
@@ -94,11 +94,11 @@ const DEFAULT_AVAILABLE_BLOCKED_KEYS = new Set([
   "workflow_id",
 ]);
 
-function isRestrictedForPublish(
-  sensitivityTier: string | undefined,
-  topLevelScopePath: string
-): boolean {
-  if ((sensitivityTier || "").trim().toLowerCase() === "restricted") return true;
+// Only structural blocked keys are refused up front. `restricted`-tier data is
+// the owner's own sensitive data: it IS publishable once the owner explicitly
+// consents in the marketplace (the backend honors that consent via
+// owner_consent_override), so we no longer block it client-side.
+function isStructurallyBlockedForPublish(topLevelScopePath: string): boolean {
   return topLevelScopePath
     .split(".")
     .some((part) => DEFAULT_AVAILABLE_BLOCKED_KEYS.has(part));
@@ -528,12 +528,14 @@ export default function OneMarketplacePage() {
       }
       if (
         nextPosture === "default_available" &&
-        isRestrictedForPublish(section.permission.sensitivityTier, section.permission.topLevelScopePath)
+        isStructurallyBlockedForPublish(section.permission.topLevelScopePath)
       ) {
-        // The backend would silently downgrade this to "Ask first"; block it up
-        // front so the toggle doesn't appear to revert.
+        // Structural (system) keys can never publish, even with owner consent —
+        // the backend hard-blocks them too. Restricted-tier personal data is
+        // allowed through: the owner's explicit consent (owner_consent_override)
+        // lets the backend publish it, so we do not block it here.
         toast.error(
-          "This section is protected — restricted data stays consent-gated and can't be published as Available."
+          "This section is system data (not your personal data) and can't be published to the marketplace."
         );
         return;
       }
@@ -563,6 +565,10 @@ export default function OneMarketplacePage() {
           vaultKey: vaultKey ?? undefined,
           vaultOwnerToken,
           source: "marketplace_owner",
+          // Publishing Available from the marketplace goes through the explicit
+          // owner consent modal, so forward that consent as the override. The
+          // backend still hard-blocks structural (non-personal) scope keys.
+          ownerConsentOverride: true,
         });
 
         // Authoritative re-fetch: the consent guardrail decides the final posture
@@ -638,9 +644,9 @@ export default function OneMarketplacePage() {
   const onTogglePosture = useCallback(
     (section: Section, nextPosture: PkmVisibilityPosture) => {
       if (nextPosture === "default_available") {
-        if (isRestrictedForPublish(section.permission.sensitivityTier, section.permission.topLevelScopePath)) {
+        if (isStructurallyBlockedForPublish(section.permission.topLevelScopePath)) {
           toast.error(
-            "This section is protected — restricted data stays consent-gated and can't be published as Available."
+            "This section is system data (not your personal data) and can't be published to the marketplace."
           );
           return;
         }
@@ -790,8 +796,7 @@ export default function OneMarketplacePage() {
                 sections.map((section) => {
                   const isAvailable = section.permission.visibilityPosture === "default_available";
                   const busy = pending[section.key] === true;
-                  const restricted = isRestrictedForPublish(
-                    section.permission.sensitivityTier,
+                  const structurallyBlocked = isStructurallyBlockedForPublish(
                     section.permission.topLevelScopePath
                   );
                   return (
@@ -817,9 +822,9 @@ export default function OneMarketplacePage() {
                                 {section.permission.sensitivityTier}
                               </span>
                             ) : null}
-                            {restricted ? (
+                            {structurallyBlocked ? (
                               <span className="rounded-full bg-rose-500/12 px-2.5 py-1 text-[11px] font-medium text-rose-700 dark:text-rose-300">
-                                protected · can’t publish
+                                system data · can’t publish
                               </span>
                             ) : null}
                           </div>
@@ -836,10 +841,11 @@ export default function OneMarketplacePage() {
                           mobileColumns={1}
                         />
                       </div>
-                      {restricted ? (
+                      {structurallyBlocked ? (
                         <div className="mt-2 text-[12px] text-muted-foreground">
-                          Restricted data stays consent-gated to protect you — it can’t be set to
-                          “Available”. Only non-restricted sections can be published to the marketplace.
+                          This is system data (not your personal data), so it can’t be published to the
+                          marketplace. Your own sections — including restricted ones — can be set to
+                          “Available” with your explicit consent.
                         </div>
                       ) : null}
 

--- a/hushh-webapp/lib/onboarding/one-capabilities.ts
+++ b/hushh-webapp/lib/onboarding/one-capabilities.ts
@@ -143,7 +143,7 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "marketplace",
-    title: "Data Marketplace",
+    title: "Marketplace",
     description: "Preview priced slices of your data you could publish.",
     previewLabel: "Priced data slices",
     href: ROUTES.ONE_MARKETPLACE,

--- a/hushh-webapp/lib/personal-knowledge-model/slice-publishing.ts
+++ b/hushh-webapp/lib/personal-knowledge-model/slice-publishing.ts
@@ -103,6 +103,9 @@ export async function applySlicePosture(params: {
   vaultKey?: string;
   vaultOwnerToken: string;
   source?: string;
+  // Explicit owner consent to publish their own restricted-tier data as
+  // Available. Only the marketplace owner flow passes this; Profile never does.
+  ownerConsentOverride?: boolean;
 }): Promise<{ manifest: DomainManifest }> {
   const { userId, domain, domainTitle, permission, nextPosture, previousManifest } = params;
 
@@ -150,6 +153,9 @@ export async function applySlicePosture(params: {
         topLevelScopePath: permission.topLevelScopePath,
         exposureEnabled: nextPosture !== "private",
         visibilityPosture: nextPosture,
+        // Only forward the override when actually publishing as Available.
+        ownerConsentOverride:
+          nextPosture === "default_available" ? params.ownerConsentOverride === true : undefined,
       },
     ],
   });

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -198,6 +198,10 @@ export interface PkmScopeExposureChange {
   topLevelScopePath?: string;
   exposureEnabled?: boolean;
   visibilityPosture?: PkmVisibilityPosture;
+  // Explicit owner consent to publish their own restricted-tier data as
+  // `default_available` (marketplace override). Only set by the marketplace
+  // publish flow; the backend still hard-blocks structural blocked keys.
+  ownerConsentOverride?: boolean;
 }
 
 export interface PkmScopeExposureResult {
@@ -2293,6 +2297,7 @@ export class PersonalKnowledgeModelService {
                   ? change.visibilityPosture !== "private"
                   : undefined,
             visibility_posture: change.visibilityPosture,
+            owner_consent_override: change.ownerConsentOverride,
           })),
         }),
       }


### PR DESCRIPTION
## Summary
- Adds an explicit owner-consent override path so a marketplace owner can publish a PKM slice as "Available" with the safe default projection.
- Gates the override behind a scope-registry check via new migration `074_pkm_scope_registry_owner_consent_override.sql`.
- Renames the One capability label from "Data Marketplace" to "Marketplace".

## Test plan
- [ ] Run `consent-protocol/tests/test_marketplace_owner_consent_override.py`
- [ ] Run `consent-protocol/tests/services/test_pkm_service_store_domain_data.py`
- [ ] Apply migration 074 on UAT and verify scope-registry override rows land as expected
- [ ] In the One → Marketplace UI, toggle a section to Available, log out and back in, confirm state persists
- [ ] Confirm the capability card in onboarding now reads "Marketplace"