### PR TITLE
chore(ui): silence onboarding state check error trace

### DIFF
--- a/hushh-webapp/components/kai/onboarding/kai-onboarding-guard.tsx
+++ b/hushh-webapp/components/kai/onboarding/kai-onboarding-guard.tsx
@@ -248,8 +248,8 @@ export function KaiOnboardingGuard({ children }: { children: React.ReactNode }) 
             return;
           }
         }
-      } catch (error) {
-        console.warn("[KaiOnboardingGuard] Failed to check onboarding state:", error);
+      } catch {
+        // Handled gracefully by setting guard error state
         if (!cancelled) {
           setGuardError("Unable to load onboarding state. Please retry.");
         }


### PR DESCRIPTION
### Description

Silences a redundant `console.warn` trace in `components/kai/onboarding/kai-onboarding-guard.tsx`. This warning (`"Failed to check onboarding state:"`) fired whenever the Kai onboarding profile check failed on initial component mount. Since the guard component natively catches this exception and handles it safely—by setting an internal error state that renders a localized fallback UI for the user—the explicit `console.warn` was unnecessary. Removing it cleans up the browser console logs from internal debug traces during transient network conditions.
