### PR TITLE
fix(ui): silence phone verification error leak

### DIFF
--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -289,7 +289,6 @@ export function PhoneVerificationFlow({
           resendCode ? "A new verification code has been sent." : "Verification code sent."
         );
       } catch (error) {
-        console.error("[PhoneVerificationFlow] Failed to start verification:", error);
         trackEvent("phone_verification_started", {
           action: mode,
           result: "error",


### PR DESCRIPTION
### Description

Silences an explicit `console.error` leak in `components/auth/phone-verification-flow.tsx`. This error trace (`"Failed to start verification:"`) fired whenever a phone verification attempt failed (e.g., invalid number format or rate-limiting). Since the component actively catches this exception and handles it securely by logging a telemetry event and displaying a formatted UI toast to the user, the explicit `console.error` log was unnecessary and merely leaked backend trace noise into the browser console.