### PR TITLE
fix(one-location): route notification popups to the Inbox tab

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -195,6 +195,21 @@ const SHOW_OWNER_GRANTS_SECTION = false;
 const SHOW_PUBLIC_RESPONSES_SECTION = false;
 const SHOW_REFERRAL_SECTION = false;
 
+// The mobile-first redesign hub (Now | People | Links | Inbox) is the active UI.
+// The legacy compose/activity sections only render as a fallback when the page
+// hits a hard load error. Deep-link focus (from notification "Open" buttons)
+// must therefore be handled by the hub's own searchParams-driven tab switching,
+// NOT the legacy scroll-to-section path — which switched to a non-existent
+// "activity" page tab and, worse, clobbered the deep-link query params via a
+// stale `searchParams` closure inside `setLocationTab`, so the hub never saw the
+// `section`/`grantId`/`requestId` and never switched to Inbox.
+// Typed as `boolean` (not the inferred literal `true`) so the redesign-mode
+// early-return inside `focusOneLocationSection` does not make the legacy
+// scroll-to-section path statically unreachable code.
+const USE_LOCATION_REDESIGN: boolean = true;
+
+
+
 type BusyState =
   | "load"
   | "share"
@@ -1922,6 +1937,20 @@ function OneLocationAgentPageContent() {
   const focusOneLocationSection = useCallback(
     (target: OneLocationFocusTarget | null) => {
       if (!target || typeof window === "undefined") return;
+      // REDESIGN MODE (active): the legacy compose/activity sections below are
+      // NOT rendered — the LocationRedesignHub (Now | People | Links | Inbox)
+      // is. The hub consumes the deep-link query params (`section`, `grantId`,
+      // `requestId`, `submissionId`) itself and switches to the correct swipe
+      // tab (Inbox for shared/approvals/my_requests/grant/request, Links for
+      // public_responses, People for people). We MUST NOT run the legacy
+      // scroll-to-section path here, because it calls `setLocationTab("activity")`
+      // which does a `router.replace` built from a STALE `searchParams` closure —
+      // that strips the very `grantId`/`section`/`locationNotification` params
+      // the notification just pushed, so the hub's own effect never sees them and
+      // the user is stranded on the wrong tab. Returning early keeps the pushed
+      // deep-link URL intact so the hub can route to Inbox / Shared-with-me.
+      if (USE_LOCATION_REDESIGN) return;
+
       const sectionRefs: Record<
         OneLocationFocusTarget,
         MutableRefObject<HTMLElement | null>
@@ -4146,11 +4175,12 @@ function OneLocationAgentPageContent() {
   // EXACT existing state + handlers, so consent gating, crypto, analytics, and
   // routing are unchanged. The full original UI remains intact below and is
   // used for the loading/error states (and as a guaranteed fallback). The
-  // global app footer is never touched.
+  // global app footer is never touched. (USE_LOCATION_REDESIGN is defined at
+  // module scope so notification/deep-link handlers above can branch on it.)
   // ---------------------------------------------------------------------------
-  const USE_LOCATION_REDESIGN = true;
 
   const locationHubVm: LocationHubViewModel = {
+
     userId: auth.userId ?? null,
     canShare,
     busy,

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -210,23 +210,54 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       String(searchParams.get("submissionId") || "").trim(),
     );
     let nextTab: LocationHubTab | null = null;
+    // Which Inbox subsection the notification should land on: an access request
+    // (approvals) scrolls to "Needs your review"; a share (shared) scrolls to
+    // "Shared with me". Anything else just lands on the tab top.
+    let inboxAnchor: string | null = null;
     if (
       section === "approvals" ||
-      section === "shared" ||
       section === "my_requests" ||
-      hasRequest ||
-      hasGrant
+      hasRequest
     ) {
       nextTab = "inbox";
+      inboxAnchor = "one-location-inbox-review";
+    } else if (section === "shared" || hasGrant) {
+      nextTab = "inbox";
+      inboxAnchor = "one-location-inbox-shared";
     } else if (section === "public_responses" || hasSubmission) {
       nextTab = "links";
     } else if (section === "people") {
       nextTab = "people";
     }
     if (nextTab) {
+      // A notification deep-link must always land on the hub, never inside a
+      // half-open task flow (Share / Ask / Invite / Temp link). Close any flow
+      // first so the routed tab is actually visible.
+      setFlow("none");
       setTab(nextTab);
     }
+    // After switching to Inbox, smooth-scroll to the exact subsection so the
+    // user immediately sees the allow/deny request or the shared-with-me card
+    // (rather than the top of a long Inbox). Retry a few frames to cover the
+    // tab transition + list render.
+    if (inboxAnchor && typeof window !== "undefined") {
+      const anchorId = inboxAnchor;
+      let attempts = 0;
+      const tryScroll = () => {
+        const el = document.getElementById(anchorId);
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+          return;
+        }
+        attempts += 1;
+        if (attempts <= 12) {
+          window.setTimeout(tryScroll, 80);
+        }
+      };
+      window.setTimeout(tryScroll, 120);
+    }
   }, [searchParams]);
+
 
   const [shareStep, setShareStep] = useState<"person" | "details">("person");
   const [locationType, setLocationType] =
@@ -687,7 +718,12 @@ function InboxHub({ vm }: { vm: LocationHubViewModel }) {
   const received = vm.receivedGrants;
   return (
     <div className="space-y-5">
+      {/* Anchor: notification deep-links for access requests (approve/deny)
+          scroll here via #one-location-inbox-review. `scroll-mt` keeps the
+          heading clear of the sticky header after scrollIntoView. */}
+      <div id="one-location-inbox-review" className="scroll-mt-24">
       <SectionCard title="Needs your review">
+
         {vm.pendingOwnerRequests.length ? (
           <div className="space-y-2.5">
             {vm.pendingOwnerRequests.map((request) => (
@@ -712,9 +748,15 @@ function InboxHub({ vm }: { vm: LocationHubViewModel }) {
           />
         )}
       </SectionCard>
+      </div>
 
+      {/* Anchor: notification deep-links for received shares scroll here via
+          #one-location-inbox-shared so the recipient lands directly on the
+          person's live-location card. */}
+      <div id="one-location-inbox-shared" className="scroll-mt-24">
       <SectionCard title="Shared with me">
         {received.length ? (
+
           <div className="space-y-2.5">
             {received.map((grant) => {
               const point = vm.decryptedPoints[grant.id];
@@ -745,8 +787,10 @@ function InboxHub({ vm }: { vm: LocationHubViewModel }) {
           />
         )}
       </SectionCard>
+      </div>
 
       {vm.requestedByMe.length ? (
+
         <SectionCard title="Sent by you">
           <div className="space-y-2.5">
             {vm.requestedByMe.map((request) => (


### PR DESCRIPTION
## Problem

When a user tapped the in-app 'Location shared' / 'Location request' popup (toast Open button or the bell notification), they were NOT redirected to the Inbox tab on the One Location page. The allow/deny request surface ('Needs your review') and the 'Shared with me' surface were never reached.

## Root cause

The active One Location UI is the redesign hub with four swipe tabs (Now / People / Links / Inbox). The hub switches tabs by reading the deep-link query params (section / grantId / requestId). But the notification 'Open' handler still called the legacy focusOneLocationSection(), which ran setLocationTab('activity') built from a STALE searchParams closure. That router.replace stripped the grantId/section/locationNotification params the push had just added, so the hub's own searchParams effect re-ran with no section and never switched to Inbox. It also tried to scroll to legacy sections that the redesign no longer renders.

## Fix

- hushh-webapp/app/one/location/page.tsx: focusOneLocationSection now no-ops in redesign mode so it stops clobbering the deep-link URL; USE_LOCATION_REDESIGN hoisted to module scope (typed boolean to avoid unreachable-code lint).
- hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx: the deep-link effect closes any open task flow first, routes a share to Inbox 'Shared with me' and a request to Inbox 'Needs your review', and smooth-scrolls to the exact subsection via new anchors (one-location-inbox-review / one-location-inbox-shared).

## Testing

- ESLint clean on both changed files.
- Verified param persistence across the skeleton to hub mount, and no regression on a params-free fresh load (stays on Now).
- Please re-test User A/B: tapping either popup now lands on the Inbox tab and scrolls straight to the allow/deny request or the shared-with-me card.