### PR TITLE
One + Location chat: UI consistency & visible selections

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -45,6 +45,9 @@ class DelegateResultModel(BaseModel):
     # selection delegate_results so the A2A discriminator ("selection") is never
     # misread as the prompt kind. See location_agent.py for the mapping.
     prompt_kind: Optional[str] = Field(default=None, alias="promptKind", max_length=24)
+    # Human-readable label for the UI chip (e.g. "Abdul Zalil · 8 hours").
+    # Coordinate-free; the backend persists it as encrypted metadata.
+    display: Optional[str] = Field(default=None, max_length=200)
 
 
 class AgentChatStreamRequest(BaseModel):
@@ -86,6 +89,9 @@ class AgentChatMessageModel(BaseModel):
     model: Optional[str] = Field(default=None, max_length=128)
     created_at: Optional[str] = Field(default=None, max_length=64)
     completed_at: Optional[str] = Field(default=None, max_length=64)
+    # UI-safe metadata subset: only "kind" and "display" are returned.
+    # Server-only keys are never exposed to clients.
+    metadata: Optional[dict] = Field(default=None)
 
 
 class AgentChatConversationsResponse(BaseModel):
@@ -180,6 +186,11 @@ def _message_model(message: AgentChatMessage) -> AgentChatMessageModel:
         model=message.model,
         created_at=message.created_at,
         completed_at=message.completed_at,
+        metadata=(
+            {k: message.metadata[k] for k in ("kind", "display") if k in message.metadata}
+            if isinstance(getattr(message, "metadata", None), dict)
+            else None
+        ),
     )
 
 

--- a/consent-protocol/api/routes/one/location_chat.py
+++ b/consent-protocol/api/routes/one/location_chat.py
@@ -39,6 +39,7 @@ class SelectionResultModel(BaseModel):
     confirmed: bool | None = None
     free_text: str | None = Field(default=None, alias="freeText", max_length=4000)
     status: str = Field(max_length=24)
+    display: str | None = Field(default=None, max_length=200)
 
 
 class LocationChatRequest(BaseModel):

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 74,
+  "expected_migration_version": 75,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/075_agent_chat_message_metadata.sql
+++ b/consent-protocol/db/migrations/075_agent_chat_message_metadata.sql
@@ -1,0 +1,22 @@
+-- 075_agent_chat_message_metadata.sql
+--
+-- Add an OPTIONAL, encrypted metadata blob to agent chat messages.
+--
+-- Selection turns in the One+Location delegated chat persist the raw LLM seed
+-- as `content` (so later turns still receive exact recipient/key ids) but need a
+-- separate human-readable display string ("Abdul Zalil · 8 hours") for the UI
+-- chip. The display string is PII (recipient names), so it is encrypted at rest
+-- with the same AES-256-GCM scheme as `content` — never stored plaintext.
+--
+-- Nullable and additive: existing rows and non-selection messages leave these
+-- columns NULL. Idempotent.
+
+BEGIN;
+
+ALTER TABLE agent_chat_messages
+  ADD COLUMN IF NOT EXISTS metadata_ciphertext text,
+  ADD COLUMN IF NOT EXISTS metadata_iv         text,
+  ADD COLUMN IF NOT EXISTS metadata_tag        text,
+  ADD COLUMN IF NOT EXISTS metadata_algorithm  text;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -52,7 +52,8 @@
     "071_enterprise_crm_registry.sql",
     "072_crm_registry_mulesoft_pbkdf2_cbc.sql",
     "073_crm_registry_mulesoft_simplify.sql",
-    "074_pkm_scope_registry_owner_consent_override.sql"
+    "074_pkm_scope_registry_owner_consent_override.sql",
+    "075_agent_chat_message_metadata.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/hushh_mcp/adk_bridge/location_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/location_agent.py
@@ -21,7 +21,7 @@ _ACTION_RESULT_KEYS = ("id", "type", "status", "publicUrl", "detail")
 # must never be forwarded as the location prompt kind ("select"|"confirm").
 # The location prompt kind is carried in a separate "promptKind" field and mapped
 # below when building the selection_result.
-_SELECTION_RESULT_KEYS = ("id", "selected", "confirmed", "freeText", "status")
+_SELECTION_RESULT_KEYS = ("id", "selected", "confirmed", "freeText", "status", "display")
 
 
 def _pick(source: dict, keys: tuple[str, ...]) -> dict:

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -278,6 +278,7 @@ class AgentChatMessage:
     model: str | None
     created_at: str | None
     completed_at: str | None
+    metadata: dict | None = None
 
 
 @dataclass
@@ -1253,9 +1254,15 @@ class AgentChatService:
         status: MessageStatus,
         model: str | None = None,
         error_code: str | None = None,
+        metadata: dict | None = None,
     ) -> AgentChatMessage:
+        import json as _json
+
         message_id = str(uuid4())
         encrypted = self._encrypt_text(content)
+        encrypted_metadata = (
+            self._encrypt_text(_json.dumps(metadata)) if metadata is not None else None
+        )
         result = await self._execute_raw(
             """
             INSERT INTO agent_chat_messages (
@@ -1270,6 +1277,10 @@ class AgentChatService:
               content_algorithm,
               model,
               error_code,
+              metadata_ciphertext,
+              metadata_iv,
+              metadata_tag,
+              metadata_algorithm,
               completed_at
             )
             VALUES (
@@ -1284,6 +1295,10 @@ class AgentChatService:
               :content_algorithm,
               :model,
               :error_code,
+              :metadata_ciphertext,
+              :metadata_iv,
+              :metadata_tag,
+              :metadata_algorithm,
               now()
             )
             RETURNING *
@@ -1300,6 +1315,12 @@ class AgentChatService:
                 "content_algorithm": encrypted.algorithm,
                 "model": model,
                 "error_code": error_code,
+                "metadata_ciphertext": encrypted_metadata.ciphertext
+                if encrypted_metadata
+                else None,
+                "metadata_iv": encrypted_metadata.iv if encrypted_metadata else None,
+                "metadata_tag": encrypted_metadata.tag if encrypted_metadata else None,
+                "metadata_algorithm": encrypted_metadata.algorithm if encrypted_metadata else None,
             },
         )
         await self._execute_raw(
@@ -1892,11 +1913,22 @@ class AgentChatService:
         )
 
     def _message_from_row(self, row: dict[str, Any]) -> AgentChatMessage:
+        import json as _json
+
         try:
             content = self._decrypt_text(row, "content")
         except Exception:
             logger.warning("agent_chat.message_decrypt_failed message_id=%s", row.get("id"))
             content = ""
+        metadata: dict | None = None
+        if row.get("metadata_ciphertext"):
+            try:
+                raw = self._decrypt_text(row, "metadata")
+                parsed = _json.loads(raw) if raw else None
+                metadata = parsed if isinstance(parsed, dict) else None
+            except Exception:
+                logger.warning("agent_chat.metadata_decrypt_failed message_id=%s", row.get("id"))
+                metadata = None
         return AgentChatMessage(
             id=str(row.get("id") or ""),
             conversation_id=str(row.get("conversation_id") or ""),
@@ -1907,6 +1939,7 @@ class AgentChatService:
             model=str(row.get("model")) if row.get("model") else None,
             created_at=_iso(row.get("created_at")),
             completed_at=_iso(row.get("completed_at")),
+            metadata=metadata,
         )
 
 

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -1256,12 +1257,10 @@ class AgentChatService:
         error_code: str | None = None,
         metadata: dict | None = None,
     ) -> AgentChatMessage:
-        import json as _json
-
         message_id = str(uuid4())
         encrypted = self._encrypt_text(content)
         encrypted_metadata = (
-            self._encrypt_text(_json.dumps(metadata)) if metadata is not None else None
+            self._encrypt_text(json.dumps(metadata)) if metadata is not None else None
         )
         result = await self._execute_raw(
             """
@@ -1913,8 +1912,6 @@ class AgentChatService:
         )
 
     def _message_from_row(self, row: dict[str, Any]) -> AgentChatMessage:
-        import json as _json
-
         try:
             content = self._decrypt_text(row, "content")
         except Exception:
@@ -1924,7 +1921,7 @@ class AgentChatService:
         if row.get("metadata_ciphertext"):
             try:
                 raw = self._decrypt_text(row, "metadata")
-                parsed = _json.loads(raw) if raw else None
+                parsed = json.loads(raw) if raw else None
                 metadata = parsed if isinstance(parsed, dict) else None
             except Exception:
                 logger.warning("agent_chat.metadata_decrypt_failed message_id=%s", row.get("id"))

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -350,6 +350,36 @@ def _selection_seed_text(selection_result: dict) -> str:
     return f"I selected: {refs}. Use exactly these ids — do not guess — and proceed."
 
 
+def _selection_display_text(selection_result: dict) -> str:
+    """Human-readable, coordinate-free summary of the user's choice for the UI chip.
+
+    Prefers a frontend-supplied ``display`` label (which knows the friendly names).
+    Falls back to option values (never the raw id seed) so a missing label never
+    leaks ``recipientUserId=…`` into the transcript.
+    """
+    if str(selection_result.get("status")) == "cancelled":
+        return "Cancelled"
+    display = selection_result.get("display")
+    if isinstance(display, str) and display.strip():
+        return display.strip()
+    free = selection_result.get("free_text") or selection_result.get("freeText")
+    if free:
+        return str(free)
+    if str(selection_result.get("kind")) == "confirm":
+        return "Confirmed" if selection_result.get("confirmed") else "Declined"
+    selected = selection_result.get("selected") or []
+    labels: list[str] = []
+    for ref in selected:
+        if not isinstance(ref, dict):
+            continue
+        # Show human-facing values only; skip opaque id keys.
+        for key, value in ref.items():
+            if key in ("recipientUserId", "recipientKeyId", "grantId"):
+                continue
+            labels.append(str(value))
+    return ", ".join(labels) if labels else "Your selection"
+
+
 class LocationChatService:
     def __init__(
         self,
@@ -706,16 +736,21 @@ class LocationChatService:
             conv_id, user_id=user_id, limit=_MAX_HISTORY
         )
         seed = _selection_seed_text(selection_result)
+        display = _selection_display_text(selection_result)
         # Persist the user's choice so a later turn in a multi-step clarification
         # chain (e.g. pick recipient -> then pick duration) still sees the earlier
         # answer. History was fetched above, so the current turn's contents are not
         # duplicated; future turns' get_recent_messages will include this choice.
+        # `content` keeps the raw seed (the LLM needs exact ids — "do not guess");
+        # the UI-facing display string rides in encrypted metadata so the transcript
+        # shows "Abdul Zalil", not the id dump.
         await self._chat_store.add_message(
             conversation_id=conv_id,
             user_id=user_id,
             role="user",
             content=seed,
             status="complete",
+            metadata={"kind": "selection", "display": display},
         )
         contents = _history_contents(history, types)
         contents.append(types.Content(role="user", parts=[types.Part(text=seed)]))

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -41,6 +41,21 @@ from hushh_mcp.services.agent_chat_service import get_agent_chat_service
 logger = logging.getLogger(__name__)
 
 _MAX_HISTORY = 12
+
+# Keys that must never appear in the human-readable selection display string.
+# Includes opaque id keys and every coordinate-variant key name.
+_NON_DISPLAY_REF_KEYS = {
+    "recipientUserId",
+    "recipientKeyId",
+    "grantId",
+    "latitude",
+    "longitude",
+    "coordinates",
+    "lat",
+    "lng",
+    "lon",
+    "accuracyM",
+}
 _MAX_TOOL_STEPS = 5
 _LLM_TIMEOUT_S = 30.0
 _HISTORY_CHARS = 2000
@@ -372,9 +387,9 @@ def _selection_display_text(selection_result: dict) -> str:
     for ref in selected:
         if not isinstance(ref, dict):
             continue
-        # Show human-facing values only; skip opaque id keys.
+        # Show human-facing values only; skip opaque id keys and coordinate keys.
         for key, value in ref.items():
-            if key in ("recipientUserId", "recipientKeyId", "grantId"):
+            if key in _NON_DISPLAY_REF_KEYS:
                 continue
             labels.append(str(value))
     return ", ".join(labels) if labels else "Your selection"

--- a/consent-protocol/tests/test_agent_chat_history_metadata.py
+++ b/consent-protocol/tests/test_agent_chat_history_metadata.py
@@ -1,0 +1,88 @@
+# Tests for Task 4: API — thread `display` in and metadata out.
+#
+# The real serializer that builds AgentChatMessageModel from AgentChatMessage
+# is named `_message_model` (not `_message_to_response` as the brief template
+# suggests). We import it by its real name here.
+
+from api.routes.kai.agent_chat import DelegateResultModel, _message_model
+from hushh_mcp.services.agent_chat_service import AgentChatMessage
+
+
+def test_delegate_result_accepts_display():
+    m = DelegateResultModel(
+        delegate_agent_id="agent_location",
+        kind="selection",
+        id="p1",
+        display="Abdul Zalil",
+    )
+    assert m.display == "Abdul Zalil"
+
+
+def test_history_response_exposes_ui_metadata_only():
+    msg = AgentChatMessage(
+        id="m1",
+        conversation_id="c1",
+        user_id="u1",
+        role="user",
+        status="complete",
+        content="I selected: recipientUserId=x. Use exactly these ids.",
+        model=None,
+        created_at=None,
+        completed_at=None,
+        metadata={"kind": "selection", "display": "Abdul Zalil · 8 hours"},
+    )
+    out = _message_model(msg)
+    assert out.metadata == {"kind": "selection", "display": "Abdul Zalil · 8 hours"}
+
+
+def test_history_response_strips_server_only_metadata_keys():
+    """Server-only keys must never be returned to the client."""
+    msg = AgentChatMessage(
+        id="m2",
+        conversation_id="c2",
+        user_id="u2",
+        role="user",
+        status="complete",
+        content="I selected something.",
+        model=None,
+        created_at=None,
+        completed_at=None,
+        metadata={
+            "kind": "selection",
+            "display": "Bob · 2 hours",
+            "server_secret": "should-not-appear",
+            "internal_flag": True,
+        },
+    )
+    out = _message_model(msg)
+    assert out.metadata == {"kind": "selection", "display": "Bob · 2 hours"}
+    assert "server_secret" not in (out.metadata or {})
+    assert "internal_flag" not in (out.metadata or {})
+
+
+def test_history_response_metadata_none_when_absent():
+    """Messages without metadata must return metadata=None, not {}."""
+    msg = AgentChatMessage(
+        id="m3",
+        conversation_id="c3",
+        user_id="u3",
+        role="assistant",
+        status="complete",
+        content="Hello!",
+        model=None,
+        created_at=None,
+        completed_at=None,
+        metadata=None,
+    )
+    out = _message_model(msg)
+    assert out.metadata is None
+
+
+def test_delegate_result_display_optional():
+    """display must be optional — existing callers without it must not break."""
+    m = DelegateResultModel(
+        delegate_agent_id="agent_location",
+        kind="selection",
+        id="p2",
+    )
+    assert m.display is None

--- a/consent-protocol/tests/test_agent_chat_service_metadata.py
+++ b/consent-protocol/tests/test_agent_chat_service_metadata.py
@@ -1,0 +1,39 @@
+import json
+
+from hushh_mcp.services.agent_chat_service import AgentChatService
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_message_from_row_decrypts_metadata(monkeypatch):
+    service = AgentChatService.__new__(AgentChatService)  # skip __init__/db
+
+    def fake_decrypt(row, prefix):
+        return row.get(f"{prefix}_plain", "")
+
+    monkeypatch.setattr(service, "_decrypt_text", fake_decrypt)
+    row = {
+        "id": "m1",
+        "conversation_id": "c1",
+        "user_id": "u1",
+        "role": "user",
+        "status": "complete",
+        "content_plain": "I selected: recipientUserId=x. Use exactly these ids.",
+        "metadata_plain": json.dumps({"display": "Abdul Zalil · 8 hours", "kind": "selection"}),
+        "metadata_ciphertext": "ct",  # presence signals metadata exists
+    }
+    message = service._message_from_row(row)
+    assert message.content.startswith("I selected:")
+    assert message.metadata == {"display": "Abdul Zalil · 8 hours", "kind": "selection"}
+
+
+def test_message_from_row_metadata_none_when_absent(monkeypatch):
+    service = AgentChatService.__new__(AgentChatService)
+    monkeypatch.setattr(
+        service, "_decrypt_text", lambda row, prefix: "hi" if prefix == "content" else ""
+    )
+    message = service._message_from_row({"id": "m2", "role": "assistant", "content_plain": "hi"})
+    assert message.metadata is None

--- a/consent-protocol/tests/test_developer_registry_migration.py
+++ b/consent-protocol/tests/test_developer_registry_migration.py
@@ -19,7 +19,7 @@ def test_developer_registry_migration_is_registered_at_release_head():
     assert "070_developer_registry.sql" in manifest["groups"]["developer"]
 
     contract = json.loads((ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text())
-    assert contract["expected_migration_version"] == 73
+    assert contract["expected_migration_version"] == 75
     assert contract["migration_version_policy"] == "exact"
 
 

--- a/consent-protocol/tests/test_location_chat_selection_display.py
+++ b/consent-protocol/tests/test_location_chat_selection_display.py
@@ -1,0 +1,214 @@
+"""TDD tests for Task 3: location service selection-turn display metadata.
+
+Verifies:
+  1. _selection_display_text() helper — prefers frontend display, safe fallbacks
+  2. _handle_selection_result() persists metadata={"kind": "selection", "display": ...}
+     on the user message, while keeping content = seed (for the LLM).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hushh_mcp.services.location_chat_service import (
+    LocationChatService,
+    _selection_display_text,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for _selection_display_text helper
+# ---------------------------------------------------------------------------
+
+
+def test_display_text_prefers_frontend_display():
+    assert _selection_display_text({"display": "Abdul Zalil · 8 hours"}) == "Abdul Zalil · 8 hours"
+
+
+def test_display_text_strips_whitespace_from_frontend_display():
+    assert _selection_display_text({"display": "  Mom · 1 hour  "}) == "Mom · 1 hour"
+
+
+def test_display_text_fallback_is_coordinate_free_and_not_raw_seed():
+    text = _selection_display_text(
+        {"selected": [{"recipientUserId": "5dM8", "recipientKeyId": "WlUg"}]}
+    )
+    assert "recipientUserId" not in text
+    assert "recipientKeyId" not in text
+    assert "do not guess" not in text
+    assert "latitude" not in text
+    assert "longitude" not in text
+
+
+def test_display_text_shows_non_id_values_from_selected():
+    text = _selection_display_text({"selected": [{"label": "Alice", "recipientUserId": "abc123"}]})
+    assert "Alice" in text
+    assert "abc123" not in text
+
+
+def test_cancelled_display():
+    assert _selection_display_text({"status": "cancelled"}) == "Cancelled"
+
+
+def test_confirm_confirmed():
+    assert _selection_display_text({"kind": "confirm", "confirmed": True}) == "Confirmed"
+
+
+def test_confirm_declined():
+    assert _selection_display_text({"kind": "confirm", "confirmed": False}) == "Declined"
+
+
+def test_free_text_used_when_no_display():
+    assert _selection_display_text({"free_text": "Custom note"}) == "Custom note"
+
+
+def test_freeText_camel_case_fallback():
+    assert _selection_display_text({"freeText": "camelCase fallback"}) == "camelCase fallback"
+
+
+def test_empty_selected_falls_back_to_your_selection():
+    assert _selection_display_text({"selected": []}) == "Your selection"
+
+
+def test_no_keys_at_all_falls_back_to_your_selection():
+    assert _selection_display_text({}) == "Your selection"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: _handle_selection_result persists metadata
+# ---------------------------------------------------------------------------
+
+
+class _FakeTypes:
+    """Minimal stand-in for google.genai.types so we don't need the real SDK."""
+
+    @staticmethod
+    def Content(role, parts):
+        return SimpleNamespace(role=role, parts=parts)
+
+    @staticmethod
+    def Part(text):
+        return SimpleNamespace(text=text)
+
+
+async def test_selection_turn_persists_display_metadata():
+    """The user message must be persisted with metadata carrying the display label."""
+    persisted: list[dict] = []
+
+    class FakeStore:
+        async def get_recent_messages(self, *a, **k):
+            return []
+
+        async def add_message(self, **kwargs):
+            persisted.append(kwargs)
+
+    service = LocationChatService.__new__(LocationChatService)
+    service._chat_store = FakeStore()
+    service._types = _FakeTypes()  # non-None so the guard passes
+    service._ready = lambda: True
+
+    async def fake_loop(**kwargs):
+        return ("Sharing set up.", False, True, [], [])
+
+    service._run_tool_loop = fake_loop
+    service._build_client_prompt = lambda prompts: None
+    service._build_client_action = lambda directives: None
+
+    await service._handle_selection_result(
+        user_id="u1",
+        consent_token="tok",  # noqa: S106
+        conversation_id="c1",
+        selection_result={
+            "id": "p1",
+            "kind": "select",
+            "selected": [{"recipientUserId": "5dM8", "recipientKeyId": "WlUg"}],
+            "display": "Abdul Zalil",
+            "status": "answered",
+        },
+    )
+
+    user_msgs = [m for m in persisted if m.get("role") == "user"]
+    assert user_msgs, "selection turn must persist a user message"
+    msg = user_msgs[0]
+    assert msg["content"].startswith("I selected:"), (
+        f"seed content must start with 'I selected:' for the LLM; got: {msg['content']!r}"
+    )
+    assert msg["metadata"] == {"kind": "selection", "display": "Abdul Zalil"}, (
+        f"metadata must carry UI display label; got: {msg.get('metadata')!r}"
+    )
+
+
+async def test_selection_turn_seed_contains_ids_for_llm():
+    """content (LLM seed) must still contain the raw ids — do not touch that."""
+    persisted: list[dict] = []
+
+    class FakeStore:
+        async def get_recent_messages(self, *a, **k):
+            return []
+
+        async def add_message(self, **kwargs):
+            persisted.append(kwargs)
+
+    service = LocationChatService.__new__(LocationChatService)
+    service._chat_store = FakeStore()
+    service._types = _FakeTypes()
+    service._ready = lambda: True
+
+    async def fake_loop(**kwargs):
+        return ("Done.", False, False, [], [])
+
+    service._run_tool_loop = fake_loop
+    service._build_client_prompt = lambda prompts: None
+    service._build_client_action = lambda directives: None
+
+    await service._handle_selection_result(
+        user_id="u1",
+        consent_token="tok",  # noqa: S106
+        conversation_id="c1",
+        selection_result={
+            "kind": "select",
+            "selected": [{"recipientUserId": "uid-xyz", "recipientKeyId": "key-abc"}],
+            "status": "answered",
+        },
+    )
+
+    user_msgs = [m for m in persisted if m.get("role") == "user"]
+    assert user_msgs
+    seed = user_msgs[0]["content"]
+    # Raw ids stay in the seed so the LLM can act on them
+    assert "uid-xyz" in seed
+    assert "key-abc" in seed
+
+
+async def test_cancelled_selection_persists_cancelled_display():
+    """A cancelled selection should persist display='Cancelled'."""
+    persisted: list[dict] = []
+
+    class FakeStore:
+        async def get_recent_messages(self, *a, **k):
+            return []
+
+        async def add_message(self, **kwargs):
+            persisted.append(kwargs)
+
+    service = LocationChatService.__new__(LocationChatService)
+    service._chat_store = FakeStore()
+    service._types = _FakeTypes()
+    service._ready = lambda: True
+
+    async def fake_loop(**kwargs):
+        return ("Cancelled.", False, False, [], [])
+
+    service._run_tool_loop = fake_loop
+    service._build_client_prompt = lambda prompts: None
+    service._build_client_action = lambda directives: None
+
+    await service._handle_selection_result(
+        user_id="u1",
+        consent_token="tok",  # noqa: S106
+        conversation_id="c1",
+        selection_result={"status": "cancelled"},
+    )
+
+    user_msgs = [m for m in persisted if m.get("role") == "user"]
+    assert user_msgs
+    assert user_msgs[0]["metadata"]["display"] == "Cancelled"

--- a/consent-protocol/tests/test_location_chat_selection_display.py
+++ b/consent-protocol/tests/test_location_chat_selection_display.py
@@ -73,6 +73,15 @@ def test_no_keys_at_all_falls_back_to_your_selection():
     assert _selection_display_text({}) == "Your selection"
 
 
+def test_display_text_fallback_does_not_leak_coordinate_values():
+    text = _selection_display_text(
+        {"selected": [{"latitude": 37.7749, "longitude": -122.4194, "label": "Home"}]}
+    )
+    assert "37.7749" not in text
+    assert "-122.4194" not in text
+    assert "Home" in text  # non-coordinate value is fine to show
+
+
 # ---------------------------------------------------------------------------
 # Integration test: _handle_selection_result persists metadata
 # ---------------------------------------------------------------------------

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -30,7 +30,9 @@ class _FakeStore:
     async def prepare_turn(self, *, user_id, message, conversation_id=None):
         return _Turn(conversation_id or "conv-new", [])
 
-    async def add_message(self, *, conversation_id, user_id, role, content, status, model=None):
+    async def add_message(
+        self, *, conversation_id, user_id, role, content, status, model=None, metadata=None
+    ):
         self.added.append({"role": role, "content": content, "status": status})
 
 

--- a/consent-protocol/tests/test_location_chat_service_v2.py
+++ b/consent-protocol/tests/test_location_chat_service_v2.py
@@ -33,7 +33,9 @@ class _FakeStore:
     async def add_message(
         self, *, conversation_id, user_id, role, content, status, model=None, metadata=None
     ):
-        self.added.append({"role": role, "content": content, "status": status})
+        self.added.append(
+            {"role": role, "content": content, "status": status, "metadata": metadata}
+        )
 
 
 def _fake_tool(name, recorder, *, result):

--- a/consent-protocol/tests/test_marketplace_visibility_posture_migration.py
+++ b/consent-protocol/tests/test_marketplace_visibility_posture_migration.py
@@ -19,7 +19,7 @@ def test_marketplace_visibility_posture_migration_is_registered() -> None:
     assert manifest["ordered_migrations"].index(migration_name) > manifest[
         "ordered_migrations"
     ].index("065_one_location_retention_indexes.sql")
-    assert schema_contract["expected_migration_version"] == 73
+    assert schema_contract["expected_migration_version"] == 75
 
 
 def test_marketplace_visibility_posture_migration_adds_safe_visibility_columns() -> None:

--- a/consent-protocol/tests/test_one_location_public_invite_migration.py
+++ b/consent-protocol/tests/test_one_location_public_invite_migration.py
@@ -37,7 +37,7 @@ def test_one_location_public_invite_migration_sequence_is_current_and_unique() -
         path.name for path in MIGRATIONS_DIR.glob("*one_location_retention_indexes.sql")
     }
     assert len(ordered) == len(set(ordered))
-    assert schema_contract["expected_migration_version"] == 73
+    assert schema_contract["expected_migration_version"] == 75
     assert migration_name in manifest["groups"]["iam"]
     assert retention_name in manifest["groups"]["iam"]
     assert circle_invite_name in manifest["groups"]["iam"]

--- a/docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md
+++ b/docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the central One chat and the standalone Location chat visually consistent (both on the `primary` palette) and render every user selection as a clean chip + collapsed card instead of the raw `I selected: recipientUserId=…` dump.
 
-**Architecture:** The raw selection text is a backend persistence artifact: `_selection_seed_text` doubles as the LLM instruction seed *and* the persisted `role="user"` content. We keep the seed as `content` (unchanged, so the LLM still receives exact ids) and add an **encrypted** `metadata` column carrying a human-readable `display` string. History returns `metadata.display`; both chat frontends render it as a chip and collapse the source card. The location confirmation/selection cards are shared between surfaces, so retheming them to `primary` fixes both at once.
+**Architecture:** The raw selection text is a backend persistence artifact: `_selection_seed_text` doubles as the LLM instruction seed _and_ the persisted `role="user"` content. We keep the seed as `content` (unchanged, so the LLM still receives exact ids) and add an **encrypted** `metadata` column carrying a human-readable `display` string. History returns `metadata.display`; both chat frontends render it as a chip and collapse the source card. The location confirmation/selection cards are shared between surfaces, so retheming them to `primary` fixes both at once.
 
 **Tech Stack:** Python (FastAPI, asyncpg-style raw SQL, Pydantic v2), PostgreSQL migrations, TypeScript, React, Tailwind, Vitest/Jest, pytest.
 
@@ -22,9 +22,11 @@
 ## File Structure
 
 **Backend (create):**
+
 - `consent-protocol/db/migrations/075_agent_chat_message_metadata.sql` — encrypted metadata columns.
 
 **Backend (modify):**
+
 - `consent-protocol/hushh_mcp/services/agent_chat_service.py` — `AgentChatMessage.metadata`, `add_message(metadata=…)`, `_message_from_row` decrypt.
 - `consent-protocol/hushh_mcp/services/location_chat_service.py` — persist `display` + `metadata` on selection turns; `_selection_display_text` fallback.
 - `consent-protocol/hushh_mcp/adk_bridge/location_agent.py` — thread `display` into `selection_result`.
@@ -32,10 +34,12 @@
 - `consent-protocol/api/routes/one/location_chat.py` — `SelectionResultModel.display`.
 
 **Frontend (create):**
+
 - `hushh-webapp/lib/agent/describe-selection.ts` — refs → human-readable display string.
 - `hushh-webapp/components/agent/selection-chip.tsx` — shared user-side selection chip.
 
 **Frontend (modify):**
+
 - `hushh-webapp/lib/agent/specialist-directive-runtime.ts` — `DelegateResult.display`.
 - `hushh-webapp/lib/one-location/types.ts` — `SelectionResult.display`.
 - `hushh-webapp/lib/services/agent-chat-client.ts` — `AgentChatMessage.metadata`; parse it.
@@ -51,9 +55,11 @@
 ## Task 1: DB migration — encrypted `metadata` columns
 
 **Files:**
+
 - Create: `consent-protocol/db/migrations/075_agent_chat_message_metadata.sql`
 
 **Interfaces:**
+
 - Produces: columns `metadata_ciphertext`, `metadata_iv`, `metadata_tag`, `metadata_algorithm` (all nullable `text`) on `agent_chat_messages`.
 
 - [ ] **Step 1: Write the migration**
@@ -99,10 +105,12 @@ git commit -m "feat(agent-chat): add encrypted metadata column to messages"
 ## Task 2: Chat store — read/write encrypted metadata
 
 **Files:**
+
 - Modify: `consent-protocol/hushh_mcp/services/agent_chat_service.py` (dataclass ~271; `add_message` ~1246; `_message_from_row` ~1894)
 - Test: `consent-protocol/tests/test_agent_chat_service_metadata.py` (create)
 
 **Interfaces:**
+
 - Consumes: `_encrypt_text(text) -> EncryptedPayload`, `_decrypt_text(row, prefix) -> str` (existing).
 - Produces:
   - `AgentChatMessage.metadata: dict | None`
@@ -269,10 +277,12 @@ git commit -m "feat(agent-chat): persist and read encrypted message metadata"
 ## Task 3: Location service — persist display + metadata on selection turns
 
 **Files:**
+
 - Modify: `consent-protocol/hushh_mcp/services/location_chat_service.py` (`_selection_seed_text` ~336; `_handle_selection_result` persist ~708-719)
 - Test: `consent-protocol/tests/test_location_chat_selection_display.py` (create)
 
 **Interfaces:**
+
 - Consumes: `add_message(..., metadata=…)` from Task 2; `selection_result` dict may now carry a `display` string (supplied by the frontend, Tasks 4/6).
 - Produces: on a selection turn the persisted `role="user"` message has `content = seed` (unchanged) and `metadata = {"kind": "selection", "display": <str>}`.
 - New helper: `_selection_display_text(selection_result) -> str` (fallback when frontend omits `display`).
@@ -431,12 +441,14 @@ git commit -m "feat(one-location): persist display metadata for selection turns"
 ## Task 4: API — thread `display` in and metadata out
 
 **Files:**
+
 - Modify: `consent-protocol/api/routes/kai/agent_chat.py` (`DelegateResultModel` ~33; `AgentChatMessageModel` ~76; message serialization `_message_to_response` ~160-183)
 - Modify: `consent-protocol/api/routes/one/location_chat.py` (`SelectionResultModel` ~33)
 - Modify: `consent-protocol/hushh_mcp/adk_bridge/location_agent.py` (`_SELECTION_RESULT_KEYS` ~24)
 - Test: `consent-protocol/tests/test_agent_chat_history_metadata.py` (create)
 
 **Interfaces:**
+
 - Consumes: `AgentChatMessage.metadata` (Task 2).
 - Produces:
   - `DelegateResultModel.display: Optional[str]` and `SelectionResultModel.display: Optional[str]`.
@@ -535,10 +547,12 @@ git commit -m "feat(agent-chat): thread selection display through API"
 ## Task 5: Frontend — `describeSelection` helper
 
 **Files:**
+
 - Create: `hushh-webapp/lib/agent/describe-selection.ts`
 - Test: `hushh-webapp/lib/agent/__tests__/describe-selection.test.ts`
 
 **Interfaces:**
+
 - Produces: `describeSelection(prompt: ClientPrompt, sel: { selected?: Record<string, unknown>[]; confirmed?: boolean; freeText?: string; status?: string }) => string`.
 
 - [ ] **Step 1: Write the failing test**
@@ -550,46 +564,78 @@ import { describeSelection } from "@/lib/agent/describe-selection";
 import type { ClientPrompt } from "@/lib/one-location/types";
 
 const recipientPrompt: ClientPrompt = {
-  id: "p1", kind: "select", purpose: "recipient", question: "Who?",
+  id: "p1",
+  kind: "select",
+  purpose: "recipient",
+  question: "Who?",
   options: [
-    { label: "Abdul Zalil", ref: { recipientUserId: "5dM8", recipientKeyId: "WlUg" } },
+    {
+      label: "Abdul Zalil",
+      ref: { recipientUserId: "5dM8", recipientKeyId: "WlUg" },
+    },
     { label: "Mom", ref: { recipientUserId: "mom1", recipientKeyId: "momK" } },
   ],
 };
 
 const durationPrompt: ClientPrompt = {
-  id: "p2", kind: "select", purpose: "duration", question: "How long?",
+  id: "p2",
+  kind: "select",
+  purpose: "duration",
+  question: "How long?",
   options: [{ label: "8 hours", ref: { hours: 8 } }],
 };
 
 describe("describeSelection", () => {
   it("maps selected refs to option labels", () => {
-    expect(describeSelection(recipientPrompt, { selected: [{ recipientUserId: "5dM8", recipientKeyId: "WlUg" }] }))
-      .toBe("Abdul Zalil");
+    expect(
+      describeSelection(recipientPrompt, {
+        selected: [{ recipientUserId: "5dM8", recipientKeyId: "WlUg" }],
+      }),
+    ).toBe("Abdul Zalil");
   });
 
   it("joins multiple selections", () => {
-    expect(describeSelection(recipientPrompt, {
-      selected: [
-        { recipientUserId: "5dM8", recipientKeyId: "WlUg" },
-        { recipientUserId: "mom1", recipientKeyId: "momK" },
-      ],
-    })).toBe("Abdul Zalil, Mom");
+    expect(
+      describeSelection(recipientPrompt, {
+        selected: [
+          { recipientUserId: "5dM8", recipientKeyId: "WlUg" },
+          { recipientUserId: "mom1", recipientKeyId: "momK" },
+        ],
+      }),
+    ).toBe("Abdul Zalil, Mom");
   });
 
   it("maps a duration selection", () => {
-    expect(describeSelection(durationPrompt, { selected: [{ hours: 8 }] })).toBe("8 hours");
+    expect(
+      describeSelection(durationPrompt, { selected: [{ hours: 8 }] }),
+    ).toBe("8 hours");
   });
 
   it("describes confirm / cancel / free text", () => {
-    expect(describeSelection({ ...recipientPrompt, kind: "confirm" }, { confirmed: true })).toBe("Confirmed");
-    expect(describeSelection({ ...recipientPrompt, kind: "confirm" }, { confirmed: false })).toBe("Declined");
-    expect(describeSelection(recipientPrompt, { status: "cancelled" })).toBe("Cancelled");
-    expect(describeSelection(recipientPrompt, { freeText: "share with my sister" })).toBe("share with my sister");
+    expect(
+      describeSelection(
+        { ...recipientPrompt, kind: "confirm" },
+        { confirmed: true },
+      ),
+    ).toBe("Confirmed");
+    expect(
+      describeSelection(
+        { ...recipientPrompt, kind: "confirm" },
+        { confirmed: false },
+      ),
+    ).toBe("Declined");
+    expect(describeSelection(recipientPrompt, { status: "cancelled" })).toBe(
+      "Cancelled",
+    );
+    expect(
+      describeSelection(recipientPrompt, { freeText: "share with my sister" }),
+    ).toBe("share with my sister");
   });
 
   it("never leaks raw ids when a ref has no matching option", () => {
-    const out = describeSelection(recipientPrompt, { selected: [{ recipientUserId: "ghost", recipientKeyId: "x" }] });
+    const out = describeSelection(recipientPrompt, {
+      selected: [{ recipientUserId: "ghost", recipientKeyId: "x" }],
+    });
     expect(out).not.toContain("recipientUserId");
     expect(out).not.toContain("recipientKeyId");
   });
@@ -607,7 +653,10 @@ Expected: FAIL — module not found.
 // hushh-webapp/lib/agent/describe-selection.ts
 import type { ClientPrompt } from "@/lib/one-location/types";
 
-function sameRef(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+function sameRef(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
@@ -627,18 +676,24 @@ export function describeSelection(
 ): string {
   if (sel.status === "cancelled") return "Cancelled";
   if (sel.freeText && sel.freeText.trim()) return sel.freeText.trim();
-  if (prompt.kind === "confirm") return sel.confirmed ? "Confirmed" : "Declined";
+  if (prompt.kind === "confirm")
+    return sel.confirmed ? "Confirmed" : "Declined";
 
   const options = prompt.options ?? [];
-  const labels = (sel.selected ?? []).map((ref) => {
-    const match = options.find((o) => sameRef(o.ref, ref));
-    if (match) return match.label;
-    // No matching option: surface non-id values only.
-    const values = Object.entries(ref)
-      .filter(([k]) => !["recipientUserId", "recipientKeyId", "grantId"].includes(k))
-      .map(([, v]) => String(v));
-    return values.join(" ");
-  }).filter((s) => s.length > 0);
+  const labels = (sel.selected ?? [])
+    .map((ref) => {
+      const match = options.find((o) => sameRef(o.ref, ref));
+      if (match) return match.label;
+      // No matching option: surface non-id values only.
+      const values = Object.entries(ref)
+        .filter(
+          ([k]) =>
+            !["recipientUserId", "recipientKeyId", "grantId"].includes(k),
+        )
+        .map(([, v]) => String(v));
+      return values.join(" ");
+    })
+    .filter((s) => s.length > 0);
 
   return labels.length ? labels.join(", ") : "Your selection";
 }
@@ -661,11 +716,13 @@ git commit -m "feat(agent): add describeSelection helper for chat chips"
 ## Task 6: Frontend types + client — carry `display` and message metadata
 
 **Files:**
+
 - Modify: `hushh-webapp/lib/agent/specialist-directive-runtime.ts` (`DelegateResult` ~9)
 - Modify: `hushh-webapp/lib/one-location/types.ts` (`SelectionResult` ~379)
 - Modify: `hushh-webapp/lib/services/agent-chat-client.ts` (`AgentChatMessage` ~4)
 
 **Interfaces:**
+
 - Produces:
   - `DelegateResult.display?: string`
   - `SelectionResult.display?: string`
@@ -715,10 +772,12 @@ git commit -m "feat(agent): carry selection display in types and client"
 ## Task 7: Shared `SelectionChip` component
 
 **Files:**
+
 - Create: `hushh-webapp/components/agent/selection-chip.tsx`
 - Test: `hushh-webapp/components/agent/__tests__/selection-chip.test.tsx`
 
 **Interfaces:**
+
 - Produces: `SelectionChip({ label }: { label: string })` — a right-aligned `primary` user-side pill with a check icon.
 
 - [ ] **Step 1: Write the failing test**
@@ -789,10 +848,12 @@ git commit -m "feat(agent): add SelectionChip component"
 ## Task 8: Central chat — append chip, send display, render history chips, collapse card
 
 **Files:**
+
 - Modify: `hushh-webapp/components/agent/agent-chat-workspace.tsx` (message type ~111; specialist render block ~3506-3621; history hydration where `AgentChatMessage`→`AgentMessage`; user-bubble render ~561-569)
 - Test: covered by the workspace's existing test file (extend it) — search for the existing `agent-chat-workspace` test; if none, add `hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx`.
 
 **Interfaces:**
+
 - Consumes: `describeSelection` (Task 5), `SelectionChip` (Task 7), `AgentChatMessage.metadata` (Task 6), `sendDelegateResult` (existing, ~2356).
 - Produces: on selection, a local `AgentMessage` with `kind: "selection"` + `text = display`; `delegate_result.display` set; history messages with `metadata.kind === "selection"` render via `SelectionChip`.
 
@@ -858,14 +919,14 @@ import { describeSelection } from "@/lib/agent/describe-selection";
 In the `SpecialistDirectiveCard` render (~3568-3619), the action summary is the card's `summary`. On confirm, append a chip with the confirm label; on cancel, append "Cancelled". In `onConfirm` (~3575), right after `setSpecialistBusy(true)` and before running crypto, append:
 
 ```tsx
-                        appendMessage({
-                          id: `msg-${Date.now()}-act`,
-                          role: "user",
-                          text: "Share",
-                          timestamp: formatNow(),
-                          status: "done",
-                          kind: "selection",
-                        });
+appendMessage({
+  id: `msg-${Date.now()}-act`,
+  role: "user",
+  text: "Share",
+  timestamp: formatNow(),
+  status: "done",
+  kind: "selection",
+});
 ```
 
 In `onCancel` (~3603), append a chip with text `"Cancelled"` before `sendDelegateResult`.
@@ -875,13 +936,18 @@ In `onCancel` (~3603), append a chip with text `"Cancelled"` before `sendDelegat
 Where messages are mapped to `MessageBubble` (search for `messages.map(`), branch on `message.kind === "selection"` to render `SelectionChip`:
 
 ```tsx
-        {messages.map((message) =>
-          message.kind === "selection" ? (
-            <SelectionChip key={message.id} label={message.text} />
-          ) : (
-            <MessageBubble key={message.id} message={message} /* …existing props… */ />
-          ),
-        )}
+{
+  messages.map((message) =>
+    message.kind === "selection" ? (
+      <SelectionChip key={message.id} label={message.text} />
+    ) : (
+      <MessageBubble
+        key={message.id}
+        message={message} /* …existing props… */
+      />
+    ),
+  );
+}
 ```
 
 Import `SelectionChip`:
@@ -903,7 +969,9 @@ import { SelectionChip } from "@/components/agent/selection-chip";
 describe("selection rendering", () => {
   it("renders a chip for a selection message", () => {
     render(<SelectionChip label="Abdul Zalil" />);
-    expect(screen.getByTestId("selection-chip")).toHaveTextContent("Abdul Zalil");
+    expect(screen.getByTestId("selection-chip")).toHaveTextContent(
+      "Abdul Zalil",
+    );
   });
 });
 ```
@@ -913,14 +981,17 @@ describe("selection rendering", () => {
 Find where `getAgentChatHistory` results are converted into `AgentMessage[]` (search for `getAgentChatHistory` usage in the workspace). For each history message, set `kind` and prefer the display string:
 
 ```ts
-        const mapped: AgentMessage[] = history.map((m) => ({
-          id: m.id,
-          role: m.role === "assistant" ? "assistant" : "user",
-          text: m.metadata?.kind === "selection" && m.metadata.display ? m.metadata.display : m.content,
-          timestamp: formatTimestamp(m.created_at),  // use the existing timestamp formatter in this file
-          status: "done",
-          ...(m.metadata?.kind === "selection" ? { kind: "selection" as const } : {}),
-        }));
+const mapped: AgentMessage[] = history.map((m) => ({
+  id: m.id,
+  role: m.role === "assistant" ? "assistant" : "user",
+  text:
+    m.metadata?.kind === "selection" && m.metadata.display
+      ? m.metadata.display
+      : m.content,
+  timestamp: formatTimestamp(m.created_at), // use the existing timestamp formatter in this file
+  status: "done",
+  ...(m.metadata?.kind === "selection" ? { kind: "selection" as const } : {}),
+}));
 ```
 
 > Match the existing history-mapping shape in the file (role coercion, timestamp helper). The key change is the `text` fallback to `metadata.display` and setting `kind: "selection"`. This is what removes the raw `I selected:` bubble on reload even for messages persisted before the frontend sent a `display` (the backend fallback in Task 3 guarantees a clean `metadata.display`).
@@ -942,11 +1013,13 @@ git commit -m "feat(agent-chat): render selections as chips and send display"
 ## Task 9: Retheme shared cards to `primary` + collapsed state
 
 **Files:**
+
 - Modify: `hushh-webapp/components/one-location/redesign/clarification-card.tsx`
 - Modify: `hushh-webapp/components/one-location/redesign/action-confirm-card.tsx`
 - Test: `hushh-webapp/components/one-location/redesign/__tests__/cards-primary-theme.test.tsx` (create)
 
 **Interfaces:**
+
 - Consumes: nothing new.
 - Produces: both cards render with `primary` tokens; no `#b8894d`/`#d4a574` remain. Behavior/props unchanged (this keeps the central `SpecialistPromptCard`/`SpecialistDirectiveCard` wrappers working and fixes the standalone chat simultaneously).
 
@@ -961,16 +1034,29 @@ import { ActionConfirmCard } from "@/components/one-location/redesign/action-con
 import type { ClientAction, ClientPrompt } from "@/lib/one-location/types";
 
 const prompt: ClientPrompt = {
-  id: "p1", kind: "select", purpose: "recipient", question: "Who?",
+  id: "p1",
+  kind: "select",
+  purpose: "recipient",
+  question: "Who?",
   options: [{ label: "Mom", ref: { recipientUserId: "m" } }],
 };
-const action: ClientAction = { id: "a1", type: "publish_share", summary: "Share with Mom" };
+const action: ClientAction = {
+  id: "a1",
+  type: "publish_share",
+  summary: "Share with Mom",
+};
 const noop = () => {};
 
 describe("cards use primary theme", () => {
   it("ClarificationCard has no cream tokens", () => {
     const { container } = render(
-      <ClarificationCard prompt={prompt} busy={false} onAnswer={noop} onConfirm={noop} onCancel={noop} />,
+      <ClarificationCard
+        prompt={prompt}
+        busy={false}
+        onAnswer={noop}
+        onConfirm={noop}
+        onCancel={noop}
+      />,
     );
     expect(container.innerHTML).not.toContain("#b8894d");
     expect(container.innerHTML).not.toContain("#d4a574");
@@ -978,7 +1064,12 @@ describe("cards use primary theme", () => {
 
   it("ActionConfirmCard has no cream tokens", () => {
     const { container } = render(
-      <ActionConfirmCard action={action} busy={false} onConfirm={noop} onCancel={noop} />,
+      <ActionConfirmCard
+        action={action}
+        busy={false}
+        onConfirm={noop}
+        onCancel={noop}
+      />,
     );
     expect(container.innerHTML).not.toContain("#b8894d");
     expect(container.innerHTML).not.toContain("#d4a574");
@@ -996,7 +1087,7 @@ Expected: FAIL — both cards still contain `#b8894d`.
 Replace the container className (line ~43):
 
 ```tsx
-      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
+className = "rounded-2xl border border-primary/20 bg-primary/5 p-4";
 ```
 
 Replace the option-button className expression (lines ~58-63):
@@ -1015,7 +1106,7 @@ Replace the option-button className expression (lines ~58-63):
 Replace the container className (line ~35):
 
 ```tsx
-      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
+className = "rounded-2xl border border-primary/20 bg-primary/5 p-4";
 ```
 
 Replace the icon color span (line ~38):
@@ -1041,12 +1132,14 @@ git commit -m "feat(one-location): retheme shared cards to primary palette"
 ## Task 10: Retheme location chat surface + append chip on selection
 
 **Files:**
+
 - Modify: `hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx`
 - Modify: `hushh-webapp/components/one-location/redesign/location-chat-atoms.tsx`
 - Modify: `hushh-webapp/components/one-location/redesign/use-location-chat.ts` (`ChatMessage` ~18; `answerPrompt` ~182; `confirmPrompt` ~191; `cancelPrompt` ~200)
 - Test: `hushh-webapp/components/one-location/redesign/__tests__/location-chat-selection.test.tsx` (create)
 
 **Interfaces:**
+
 - Consumes: `describeSelection` (Task 5).
 - Produces: location chat bubbles/atoms use `primary`; on card selection the hook appends a `ChatMessage` with `role:"user"` + `kind:"selection"` and the display text.
 
@@ -1061,7 +1154,7 @@ In `location-chat-message-list.tsx`, replace the user bubble className (line ~26
 Replace the retry button color (line ~50):
 
 ```tsx
-                  className="mt-1 text-xs font-semibold text-primary hover:underline"
+className = "mt-1 text-xs font-semibold text-primary hover:underline";
 ```
 
 (The assistant bubble already uses `var(--app-card-surface-compact)` — neutral, leave it.)
@@ -1071,7 +1164,8 @@ Replace the retry button color (line ~50):
 In `location-chat-atoms.tsx`, replace the `BotAvatar` span className (line ~9):
 
 ```tsx
-      className="flex shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+className =
+  "flex shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary";
 ```
 
 (`StateChangedNote` uses emerald for the "Updated" confirmation — semantic success color, keep it. `TypingIndicator` uses `muted-foreground` — neutral, keep it.)
@@ -1127,16 +1221,25 @@ import { describeSelection } from "@/lib/agent/describe-selection";
 In `answerPrompt` (~182), append a chip before `reportSelection`:
 
 ```ts
-  const answerPrompt = useCallback(
-    async (refs: Record<string, unknown>[]) => {
-      const prompt = pendingPrompt;
-      if (!prompt || busy) return;
-      const display = describeSelection(prompt, { selected: refs });
-      setMessages((prev) => [...prev, { id: nextId(), role: "user", text: display, kind: "selection" }]);
-      await reportSelection({ id: prompt.id, kind: prompt.kind, selected: refs, status: "answered", display });
-    },
-    [pendingPrompt, busy, reportSelection, nextId],
-  );
+const answerPrompt = useCallback(
+  async (refs: Record<string, unknown>[]) => {
+    const prompt = pendingPrompt;
+    if (!prompt || busy) return;
+    const display = describeSelection(prompt, { selected: refs });
+    setMessages((prev) => [
+      ...prev,
+      { id: nextId(), role: "user", text: display, kind: "selection" },
+    ]);
+    await reportSelection({
+      id: prompt.id,
+      kind: prompt.kind,
+      selected: refs,
+      status: "answered",
+      display,
+    });
+  },
+  [pendingPrompt, busy, reportSelection, nextId],
+);
 ```
 
 Apply the same pattern to `confirmPrompt` (`describeSelection(prompt, { confirmed: yes })`, append chip, pass `display`) and `cancelPrompt` (`describeSelection(prompt, { status: "cancelled" })`, append chip, pass `display`). `SelectionResult.display` already exists (Task 6).
@@ -1208,6 +1311,7 @@ git add -A && git commit -m "test: verify One+Location chat consistency end to e
 ## Self-Review
 
 **Spec coverage:**
+
 - Consistent styling (both → primary) → Tasks 9, 10 (shared cards + location surface); central chat already primary.
 - Visible selection as chip + collapsed card → Tasks 7 (chip), 8 (central: append chip, collapse via clearing `pendingSpecialistDirective`, history chips), 10 (location: append chip, clear prompt).
 - Fix raw text at backend source (structured metadata + display, seed internal) → Tasks 1-4.
@@ -1219,4 +1323,4 @@ git add -A && git commit -m "test: verify One+Location chat consistency end to e
 
 **Type consistency:** `display` is optional across `DelegateResultModel`, `SelectionResultModel`, `DelegateResult`, `SelectionResult`. `metadata` shape `{ kind?, display? }` matches between backend serializer (Task 4), client type (Task 6), and workspace mapping (Task 8). `describeSelection` signature is identical in Tasks 5, 8, 10. `SelectionChip({ label })` identical in Tasks 7, 8, 10.
 
-**Note on "collapsed card":** the approved spec chose "chip + collapsed card" with a compact single-line default. This plan realizes collapse by clearing the active card and leaving the chip as the record of the choice (the established pattern — single-select cards already auto-answer and dismiss). If you want the *source card itself* to persist as a greyed compact line rather than disappear, say so and I'll add a `collapsed` render branch to Task 9 before execution.
+**Note on "collapsed card":** the approved spec chose "chip + collapsed card" with a compact single-line default. This plan realizes collapse by clearing the active card and leaving the chip as the record of the choice (the established pattern — single-select cards already auto-answer and dismiss). If you want the _source card itself_ to persist as a greyed compact line rather than disappear, say so and I'll add a `collapsed` render branch to Task 9 before execution.

--- a/docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md
+++ b/docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md
@@ -1,0 +1,1222 @@
+# One + Location chat UI consistency & visible selections — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the central One chat and the standalone Location chat visually consistent (both on the `primary` palette) and render every user selection as a clean chip + collapsed card instead of the raw `I selected: recipientUserId=…` dump.
+
+**Architecture:** The raw selection text is a backend persistence artifact: `_selection_seed_text` doubles as the LLM instruction seed *and* the persisted `role="user"` content. We keep the seed as `content` (unchanged, so the LLM still receives exact ids) and add an **encrypted** `metadata` column carrying a human-readable `display` string. History returns `metadata.display`; both chat frontends render it as a chip and collapse the source card. The location confirmation/selection cards are shared between surfaces, so retheming them to `primary` fixes both at once.
+
+**Tech Stack:** Python (FastAPI, asyncpg-style raw SQL, Pydantic v2), PostgreSQL migrations, TypeScript, React, Tailwind, Vitest/Jest, pytest.
+
+## Global Constraints
+
+- **Coordinate-free invariant:** no `latitude`/`longitude`/coordinate keys may appear in the `display` string, `metadata`, SSE frames, or `delegate_result`. Assert at code level.
+- **Encrypted at rest:** the new `metadata` value is PII (recipient display names). It MUST be encrypted with the existing `_encrypt_text` / `_decrypt_text(row, "metadata")` helpers — never stored plaintext.
+- **Palette:** the two chat surfaces use only the `primary` design tokens. No `#b8894d` / `#d4a574` may remain in the touched chat bubbles, atoms, or the two shared cards.
+- **Backward compatible:** all new request/response fields are optional; existing Kai action-plan turns, the standalone `/api/one/location/chat` flow, and legacy stored messages must keep working.
+- **Migration:** idempotent (`ADD COLUMN IF NOT EXISTS`), wrapped in `BEGIN`/`COMMIT`.
+- **Discipline:** DRY, YAGNI, TDD, frequent commits.
+
+---
+
+## File Structure
+
+**Backend (create):**
+- `consent-protocol/db/migrations/075_agent_chat_message_metadata.sql` — encrypted metadata columns.
+
+**Backend (modify):**
+- `consent-protocol/hushh_mcp/services/agent_chat_service.py` — `AgentChatMessage.metadata`, `add_message(metadata=…)`, `_message_from_row` decrypt.
+- `consent-protocol/hushh_mcp/services/location_chat_service.py` — persist `display` + `metadata` on selection turns; `_selection_display_text` fallback.
+- `consent-protocol/hushh_mcp/adk_bridge/location_agent.py` — thread `display` into `selection_result`.
+- `consent-protocol/api/routes/kai/agent_chat.py` — `DelegateResultModel.display`; `AgentChatMessageModel.metadata`; serialize metadata in history.
+- `consent-protocol/api/routes/one/location_chat.py` — `SelectionResultModel.display`.
+
+**Frontend (create):**
+- `hushh-webapp/lib/agent/describe-selection.ts` — refs → human-readable display string.
+- `hushh-webapp/components/agent/selection-chip.tsx` — shared user-side selection chip.
+
+**Frontend (modify):**
+- `hushh-webapp/lib/agent/specialist-directive-runtime.ts` — `DelegateResult.display`.
+- `hushh-webapp/lib/one-location/types.ts` — `SelectionResult.display`.
+- `hushh-webapp/lib/services/agent-chat-client.ts` — `AgentChatMessage.metadata`; parse it.
+- `hushh-webapp/components/agent/agent-chat-workspace.tsx` — append chip + collapse card + send `display` + render history chips.
+- `hushh-webapp/components/one-location/redesign/clarification-card.tsx` — retheme + collapsed state.
+- `hushh-webapp/components/one-location/redesign/action-confirm-card.tsx` — retheme + collapsed state.
+- `hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx` — retheme bubbles.
+- `hushh-webapp/components/one-location/redesign/location-chat-atoms.tsx` — retheme avatar/notes.
+- `hushh-webapp/components/one-location/redesign/use-location-chat.ts` — append chip on selection.
+
+---
+
+## Task 1: DB migration — encrypted `metadata` columns
+
+**Files:**
+- Create: `consent-protocol/db/migrations/075_agent_chat_message_metadata.sql`
+
+**Interfaces:**
+- Produces: columns `metadata_ciphertext`, `metadata_iv`, `metadata_tag`, `metadata_algorithm` (all nullable `text`) on `agent_chat_messages`.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 075_agent_chat_message_metadata.sql
+--
+-- Add an OPTIONAL, encrypted metadata blob to agent chat messages.
+--
+-- Selection turns in the One+Location delegated chat persist the raw LLM seed
+-- as `content` (so later turns still receive exact recipient/key ids) but need a
+-- separate human-readable display string ("Abdul Zalil · 8 hours") for the UI
+-- chip. The display string is PII (recipient names), so it is encrypted at rest
+-- with the same AES-256-GCM scheme as `content` — never stored plaintext.
+--
+-- Nullable and additive: existing rows and non-selection messages leave these
+-- columns NULL. Idempotent.
+
+BEGIN;
+
+ALTER TABLE agent_chat_messages
+  ADD COLUMN IF NOT EXISTS metadata_ciphertext text,
+  ADD COLUMN IF NOT EXISTS metadata_iv         text,
+  ADD COLUMN IF NOT EXISTS metadata_tag        text,
+  ADD COLUMN IF NOT EXISTS metadata_algorithm  text;
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply the migration to the dev database**
+
+Run the repo's standard migration runner (match how prior migrations are applied in this project — check `consent-protocol/db/` tooling or `README`). Expected: no error; `\d agent_chat_messages` shows the four new nullable columns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add consent-protocol/db/migrations/075_agent_chat_message_metadata.sql
+git commit -m "feat(agent-chat): add encrypted metadata column to messages"
+```
+
+---
+
+## Task 2: Chat store — read/write encrypted metadata
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/services/agent_chat_service.py` (dataclass ~271; `add_message` ~1246; `_message_from_row` ~1894)
+- Test: `consent-protocol/tests/test_agent_chat_service_metadata.py` (create)
+
+**Interfaces:**
+- Consumes: `_encrypt_text(text) -> EncryptedPayload`, `_decrypt_text(row, prefix) -> str` (existing).
+- Produces:
+  - `AgentChatMessage.metadata: dict | None`
+  - `add_message(..., metadata: dict | None = None) -> AgentChatMessage`
+  - `_message_from_row` populates `.metadata` (decrypt + `json.loads`, `None` when absent).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# consent-protocol/tests/test_agent_chat_service_metadata.py
+import json
+
+from hushh_mcp.services.agent_chat_service import AgentChatService
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+def test_message_from_row_decrypts_metadata(monkeypatch):
+    service = AgentChatService.__new__(AgentChatService)  # skip __init__/db
+
+    def fake_decrypt(row, prefix):
+        return row.get(f"{prefix}_plain", "")
+
+    monkeypatch.setattr(service, "_decrypt_text", fake_decrypt)
+    row = {
+        "id": "m1",
+        "conversation_id": "c1",
+        "user_id": "u1",
+        "role": "user",
+        "status": "complete",
+        "content_plain": "I selected: recipientUserId=x. Use exactly these ids.",
+        "metadata_plain": json.dumps({"display": "Abdul Zalil · 8 hours", "kind": "selection"}),
+        "metadata_ciphertext": "ct",  # presence signals metadata exists
+    }
+    message = service._message_from_row(row)
+    assert message.content.startswith("I selected:")
+    assert message.metadata == {"display": "Abdul Zalil · 8 hours", "kind": "selection"}
+
+
+def test_message_from_row_metadata_none_when_absent(monkeypatch):
+    service = AgentChatService.__new__(AgentChatService)
+    monkeypatch.setattr(service, "_decrypt_text", lambda row, prefix: "hi" if prefix == "content" else "")
+    message = service._message_from_row({"id": "m2", "role": "assistant", "content_plain": "hi"})
+    assert message.metadata is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest consent-protocol/tests/test_agent_chat_service_metadata.py -v`
+Expected: FAIL — `AgentChatMessage` has no `metadata` field / `TypeError`.
+
+- [ ] **Step 3: Add the dataclass field**
+
+In `agent_chat_service.py`, add to the `AgentChatMessage` dataclass (after `completed_at`, ~line 280):
+
+```python
+    metadata: dict | None = None
+```
+
+- [ ] **Step 4: Thread metadata through `add_message`**
+
+Add the parameter (after `error_code`, ~line 1255):
+
+```python
+        error_code: str | None = None,
+        metadata: dict | None = None,
+```
+
+Just before the INSERT `result = await self._execute_raw(` (~1259), encrypt the metadata:
+
+```python
+        import json as _json
+
+        encrypted_metadata = (
+            self._encrypt_text(_json.dumps(metadata)) if metadata is not None else None
+        )
+```
+
+Add the four columns to the INSERT column list (after `error_code,`):
+
+```sql
+              error_code,
+              metadata_ciphertext,
+              metadata_iv,
+              metadata_tag,
+              metadata_algorithm,
+              completed_at
+```
+
+Add the matching VALUES placeholders (after `:error_code,`):
+
+```sql
+              :error_code,
+              :metadata_ciphertext,
+              :metadata_iv,
+              :metadata_tag,
+              :metadata_algorithm,
+              now()
+```
+
+Add to the params dict (after `"error_code": error_code,`):
+
+```python
+                "error_code": error_code,
+                "metadata_ciphertext": encrypted_metadata.ciphertext if encrypted_metadata else None,
+                "metadata_iv": encrypted_metadata.iv if encrypted_metadata else None,
+                "metadata_tag": encrypted_metadata.tag if encrypted_metadata else None,
+                "metadata_algorithm": encrypted_metadata.algorithm if encrypted_metadata else None,
+```
+
+- [ ] **Step 5: Decrypt in `_message_from_row`**
+
+Replace the body of `_message_from_row` (~1894) so it also reads metadata:
+
+```python
+    def _message_from_row(self, row: dict[str, Any]) -> AgentChatMessage:
+        import json as _json
+
+        try:
+            content = self._decrypt_text(row, "content")
+        except Exception:
+            logger.warning("agent_chat.message_decrypt_failed message_id=%s", row.get("id"))
+            content = ""
+        metadata: dict | None = None
+        if row.get("metadata_ciphertext"):
+            try:
+                raw = self._decrypt_text(row, "metadata")
+                parsed = _json.loads(raw) if raw else None
+                metadata = parsed if isinstance(parsed, dict) else None
+            except Exception:
+                logger.warning("agent_chat.metadata_decrypt_failed message_id=%s", row.get("id"))
+                metadata = None
+        return AgentChatMessage(
+            id=str(row.get("id") or ""),
+            conversation_id=str(row.get("conversation_id") or ""),
+            user_id=str(row.get("user_id") or ""),
+            role=str(row.get("role") or ""),
+            status=str(row.get("status") or "complete"),
+            content=content,
+            model=str(row.get("model")) if row.get("model") else None,
+            created_at=_iso(row.get("created_at")),
+            completed_at=_iso(row.get("completed_at")),
+            metadata=metadata,
+        )
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pytest consent-protocol/tests/test_agent_chat_service_metadata.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/services/agent_chat_service.py consent-protocol/tests/test_agent_chat_service_metadata.py
+git commit -m "feat(agent-chat): persist and read encrypted message metadata"
+```
+
+---
+
+## Task 3: Location service — persist display + metadata on selection turns
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/services/location_chat_service.py` (`_selection_seed_text` ~336; `_handle_selection_result` persist ~708-719)
+- Test: `consent-protocol/tests/test_location_chat_selection_display.py` (create)
+
+**Interfaces:**
+- Consumes: `add_message(..., metadata=…)` from Task 2; `selection_result` dict may now carry a `display` string (supplied by the frontend, Tasks 4/6).
+- Produces: on a selection turn the persisted `role="user"` message has `content = seed` (unchanged) and `metadata = {"kind": "selection", "display": <str>}`.
+- New helper: `_selection_display_text(selection_result) -> str` (fallback when frontend omits `display`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# consent-protocol/tests/test_location_chat_selection_display.py
+import asyncio
+
+from hushh_mcp.services.location_chat_service import (
+    LocationChatService,
+    _selection_display_text,
+)
+
+
+def test_display_text_prefers_frontend_display():
+    assert _selection_display_text({"display": "Abdul Zalil · 8 hours"}) == "Abdul Zalil · 8 hours"
+
+
+def test_display_text_fallback_is_coordinate_free_and_not_raw_seed():
+    text = _selection_display_text(
+        {"selected": [{"recipientUserId": "5dM8", "recipientKeyId": "WlUg"}]}
+    )
+    assert "recipientUserId" not in text
+    assert "do not guess" not in text
+    assert "latitude" not in text and "longitude" not in text
+
+
+def test_cancelled_display():
+    assert _selection_display_text({"status": "cancelled"}) == "Cancelled"
+
+
+def test_selection_turn_persists_display_metadata(monkeypatch):
+    persisted: list[dict] = []
+
+    class FakeStore:
+        async def get_recent_messages(self, *a, **k):
+            return []
+
+        async def add_message(self, **kwargs):
+            persisted.append(kwargs)
+
+    service = LocationChatService.__new__(LocationChatService)
+    service._chat_store = FakeStore()
+    service._types = None       # force the unavailable branch off; see below
+    service._ready = lambda: True
+
+    async def fake_loop(**kwargs):
+        return ("Sharing set up.", False, True, [], [])
+
+    service._run_tool_loop = fake_loop
+    service._build_client_prompt = lambda prompts: None
+    service._build_client_action = lambda directives: None
+
+    async def run():
+        return await service._handle_selection_result(
+            user_id="u1",
+            consent_token="tok",
+            conversation_id="c1",
+            selection_result={
+                "id": "p1",
+                "kind": "select",
+                "selected": [{"recipientUserId": "5dM8", "recipientKeyId": "WlUg"}],
+                "display": "Abdul Zalil",
+                "status": "answered",
+            },
+        )
+
+    asyncio.get_event_loop().run_until_complete(run())
+    user_msgs = [m for m in persisted if m.get("role") == "user"]
+    assert user_msgs, "selection turn must persist a user message"
+    msg = user_msgs[0]
+    assert msg["content"].startswith("I selected:")           # seed unchanged for the LLM
+    assert msg["metadata"] == {"kind": "selection", "display": "Abdul Zalil"}
+```
+
+> Note: `service._types = None` makes `_ready()`-gated code paths deterministic; if the real `_handle_selection_result` early-returns when `self._types is None`, set `service._types = object()` instead and keep `_ready` returning True. Adjust the fake to whichever branch the real method takes — the assertion on the persisted user message is the contract.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest consent-protocol/tests/test_location_chat_selection_display.py -v`
+Expected: FAIL — `_selection_display_text` does not exist; metadata not persisted.
+
+- [ ] **Step 3: Add the display helper**
+
+In `location_chat_service.py`, right after `_selection_seed_text` (~line 350):
+
+```python
+def _selection_display_text(selection_result: dict) -> str:
+    """Human-readable, coordinate-free summary of the user's choice for the UI chip.
+
+    Prefers a frontend-supplied ``display`` label (which knows the friendly names).
+    Falls back to option values (never the raw id seed) so a missing label never
+    leaks ``recipientUserId=…`` into the transcript.
+    """
+    if str(selection_result.get("status")) == "cancelled":
+        return "Cancelled"
+    display = selection_result.get("display")
+    if isinstance(display, str) and display.strip():
+        return display.strip()
+    free = selection_result.get("free_text") or selection_result.get("freeText")
+    if free:
+        return str(free)
+    if str(selection_result.get("kind")) == "confirm":
+        return "Confirmed" if selection_result.get("confirmed") else "Declined"
+    selected = selection_result.get("selected") or []
+    labels: list[str] = []
+    for ref in selected:
+        if not isinstance(ref, dict):
+            continue
+        # Show human-facing values only; skip opaque id keys.
+        for key, value in ref.items():
+            if key in ("recipientUserId", "recipientKeyId", "grantId"):
+                continue
+            labels.append(str(value))
+    return ", ".join(labels) if labels else "Your selection"
+```
+
+- [ ] **Step 4: Persist display + metadata in `_handle_selection_result`**
+
+Replace the persist block (~708-719) so `content` stays the seed and metadata carries the display:
+
+```python
+        seed = _selection_seed_text(selection_result)
+        display = _selection_display_text(selection_result)
+        # Persist the user's choice so a later turn in a multi-step clarification
+        # chain still sees the earlier answer. `content` keeps the raw seed (the
+        # LLM needs exact ids — "do not guess"); the UI-facing display string
+        # rides in encrypted metadata so the transcript shows "Abdul Zalil", not
+        # the id dump.
+        await self._chat_store.add_message(
+            conversation_id=conv_id,
+            user_id=user_id,
+            role="user",
+            content=seed,
+            status="complete",
+            metadata={"kind": "selection", "display": display},
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest consent-protocol/tests/test_location_chat_selection_display.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add consent-protocol/hushh_mcp/services/location_chat_service.py consent-protocol/tests/test_location_chat_selection_display.py
+git commit -m "feat(one-location): persist display metadata for selection turns"
+```
+
+---
+
+## Task 4: API — thread `display` in and metadata out
+
+**Files:**
+- Modify: `consent-protocol/api/routes/kai/agent_chat.py` (`DelegateResultModel` ~33; `AgentChatMessageModel` ~76; message serialization `_message_to_response` ~160-183)
+- Modify: `consent-protocol/api/routes/one/location_chat.py` (`SelectionResultModel` ~33)
+- Modify: `consent-protocol/hushh_mcp/adk_bridge/location_agent.py` (`_SELECTION_RESULT_KEYS` ~24)
+- Test: `consent-protocol/tests/test_agent_chat_history_metadata.py` (create)
+
+**Interfaces:**
+- Consumes: `AgentChatMessage.metadata` (Task 2).
+- Produces:
+  - `DelegateResultModel.display: Optional[str]` and `SelectionResultModel.display: Optional[str]`.
+  - `location_agent._SELECTION_RESULT_KEYS` includes `"display"` so it reaches `selection_result`.
+  - `AgentChatMessageModel.metadata: Optional[dict]`; history serialization returns `{"display", "kind"}` only (never any server-only keys).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# consent-protocol/tests/test_agent_chat_history_metadata.py
+from api.routes.kai.agent_chat import DelegateResultModel, _message_to_response
+from hushh_mcp.services.agent_chat_service import AgentChatMessage
+
+
+def test_delegate_result_accepts_display():
+    m = DelegateResultModel(delegate_agent_id="agent_location", kind="selection", id="p1", display="Abdul Zalil")
+    assert m.display == "Abdul Zalil"
+
+
+def test_history_response_exposes_ui_metadata_only():
+    msg = AgentChatMessage(
+        id="m1", conversation_id="c1", user_id="u1", role="user", status="complete",
+        content="I selected: recipientUserId=x. Use exactly these ids.",
+        model=None, created_at=None, completed_at=None,
+        metadata={"kind": "selection", "display": "Abdul Zalil · 8 hours"},
+    )
+    out = _message_to_response(msg)
+    assert out.metadata == {"kind": "selection", "display": "Abdul Zalil · 8 hours"}
+```
+
+> If `_message_to_response` is defined with a different name/signature in this file, use the actual serializer that builds `AgentChatMessageModel` from an `AgentChatMessage` (search for where `AgentChatMessageModel(` is constructed, ~line 160-183). Keep the assertion identical.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest consent-protocol/tests/test_agent_chat_history_metadata.py -v`
+Expected: FAIL — `DelegateResultModel` has no `display`; `AgentChatMessageModel` has no `metadata`.
+
+- [ ] **Step 3: Add `display` to `DelegateResultModel`**
+
+In `agent_chat.py`, add to `DelegateResultModel` (after `prompt_kind`, ~line 47):
+
+```python
+    # Human-readable label for the UI chip (e.g. "Abdul Zalil · 8 hours").
+    # Coordinate-free; the backend persists it as encrypted metadata.
+    display: Optional[str] = Field(default=None, max_length=200)
+```
+
+- [ ] **Step 4: Add `metadata` to `AgentChatMessageModel` and serialize it**
+
+Add to `AgentChatMessageModel` (after `completed_at`, ~line 88):
+
+```python
+    metadata: Optional[dict] = Field(default=None)
+```
+
+In the serializer that constructs `AgentChatMessageModel(...)` from an `AgentChatMessage` (~160-183), pass a UI-safe metadata subset:
+
+```python
+        metadata=(
+            {k: message.metadata[k] for k in ("kind", "display") if k in message.metadata}
+            if isinstance(getattr(message, "metadata", None), dict)
+            else None
+        ),
+```
+
+- [ ] **Step 5: Add `display` to `SelectionResultModel`**
+
+In `location_chat.py`, add to `SelectionResultModel` (after `status`, ~line 41):
+
+```python
+    display: str | None = Field(default=None, max_length=200)
+```
+
+- [ ] **Step 6: Let the A2A handler forward `display`**
+
+In `location_agent.py`, extend `_SELECTION_RESULT_KEYS` (~line 24) to include `display`:
+
+```python
+_SELECTION_RESULT_KEYS = ("id", "selected", "confirmed", "freeText", "status", "display")
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `pytest consent-protocol/tests/test_agent_chat_history_metadata.py -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add consent-protocol/api/routes/kai/agent_chat.py consent-protocol/api/routes/one/location_chat.py consent-protocol/hushh_mcp/adk_bridge/location_agent.py consent-protocol/tests/test_agent_chat_history_metadata.py
+git commit -m "feat(agent-chat): thread selection display through API"
+```
+
+---
+
+## Task 5: Frontend — `describeSelection` helper
+
+**Files:**
+- Create: `hushh-webapp/lib/agent/describe-selection.ts`
+- Test: `hushh-webapp/lib/agent/__tests__/describe-selection.test.ts`
+
+**Interfaces:**
+- Produces: `describeSelection(prompt: ClientPrompt, sel: { selected?: Record<string, unknown>[]; confirmed?: boolean; freeText?: string; status?: string }) => string`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// hushh-webapp/lib/agent/__tests__/describe-selection.test.ts
+import { describe, expect, it } from "vitest";
+import { describeSelection } from "@/lib/agent/describe-selection";
+import type { ClientPrompt } from "@/lib/one-location/types";
+
+const recipientPrompt: ClientPrompt = {
+  id: "p1", kind: "select", purpose: "recipient", question: "Who?",
+  options: [
+    { label: "Abdul Zalil", ref: { recipientUserId: "5dM8", recipientKeyId: "WlUg" } },
+    { label: "Mom", ref: { recipientUserId: "mom1", recipientKeyId: "momK" } },
+  ],
+};
+
+const durationPrompt: ClientPrompt = {
+  id: "p2", kind: "select", purpose: "duration", question: "How long?",
+  options: [{ label: "8 hours", ref: { hours: 8 } }],
+};
+
+describe("describeSelection", () => {
+  it("maps selected refs to option labels", () => {
+    expect(describeSelection(recipientPrompt, { selected: [{ recipientUserId: "5dM8", recipientKeyId: "WlUg" }] }))
+      .toBe("Abdul Zalil");
+  });
+
+  it("joins multiple selections", () => {
+    expect(describeSelection(recipientPrompt, {
+      selected: [
+        { recipientUserId: "5dM8", recipientKeyId: "WlUg" },
+        { recipientUserId: "mom1", recipientKeyId: "momK" },
+      ],
+    })).toBe("Abdul Zalil, Mom");
+  });
+
+  it("maps a duration selection", () => {
+    expect(describeSelection(durationPrompt, { selected: [{ hours: 8 }] })).toBe("8 hours");
+  });
+
+  it("describes confirm / cancel / free text", () => {
+    expect(describeSelection({ ...recipientPrompt, kind: "confirm" }, { confirmed: true })).toBe("Confirmed");
+    expect(describeSelection({ ...recipientPrompt, kind: "confirm" }, { confirmed: false })).toBe("Declined");
+    expect(describeSelection(recipientPrompt, { status: "cancelled" })).toBe("Cancelled");
+    expect(describeSelection(recipientPrompt, { freeText: "share with my sister" })).toBe("share with my sister");
+  });
+
+  it("never leaks raw ids when a ref has no matching option", () => {
+    const out = describeSelection(recipientPrompt, { selected: [{ recipientUserId: "ghost", recipientKeyId: "x" }] });
+    expect(out).not.toContain("recipientUserId");
+    expect(out).not.toContain("recipientKeyId");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hushh-webapp && npx vitest run lib/agent/__tests__/describe-selection.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the helper**
+
+```ts
+// hushh-webapp/lib/agent/describe-selection.ts
+import type { ClientPrompt } from "@/lib/one-location/types";
+
+function sameRef(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Human-readable, coordinate-free summary of a user's card selection, for the
+ * chat chip. Resolves refs back to their option labels; falls back to option
+ * *values* (never raw id keys) so an unmatched ref can never leak an id dump.
+ */
+export function describeSelection(
+  prompt: ClientPrompt,
+  sel: {
+    selected?: Record<string, unknown>[];
+    confirmed?: boolean;
+    freeText?: string;
+    status?: string;
+  },
+): string {
+  if (sel.status === "cancelled") return "Cancelled";
+  if (sel.freeText && sel.freeText.trim()) return sel.freeText.trim();
+  if (prompt.kind === "confirm") return sel.confirmed ? "Confirmed" : "Declined";
+
+  const options = prompt.options ?? [];
+  const labels = (sel.selected ?? []).map((ref) => {
+    const match = options.find((o) => sameRef(o.ref, ref));
+    if (match) return match.label;
+    // No matching option: surface non-id values only.
+    const values = Object.entries(ref)
+      .filter(([k]) => !["recipientUserId", "recipientKeyId", "grantId"].includes(k))
+      .map(([, v]) => String(v));
+    return values.join(" ");
+  }).filter((s) => s.length > 0);
+
+  return labels.length ? labels.join(", ") : "Your selection";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hushh-webapp && npx vitest run lib/agent/__tests__/describe-selection.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hushh-webapp/lib/agent/describe-selection.ts hushh-webapp/lib/agent/__tests__/describe-selection.test.ts
+git commit -m "feat(agent): add describeSelection helper for chat chips"
+```
+
+---
+
+## Task 6: Frontend types + client — carry `display` and message metadata
+
+**Files:**
+- Modify: `hushh-webapp/lib/agent/specialist-directive-runtime.ts` (`DelegateResult` ~9)
+- Modify: `hushh-webapp/lib/one-location/types.ts` (`SelectionResult` ~379)
+- Modify: `hushh-webapp/lib/services/agent-chat-client.ts` (`AgentChatMessage` ~4)
+
+**Interfaces:**
+- Produces:
+  - `DelegateResult.display?: string`
+  - `SelectionResult.display?: string`
+  - `AgentChatMessage.metadata?: { kind?: string; display?: string } | null`
+
+- [ ] **Step 1: Add `display` to `DelegateResult`**
+
+In `specialist-directive-runtime.ts`, add to the `DelegateResult` type (after `freeText?`, ~line 23):
+
+```ts
+  // Human-readable label for the chat chip (e.g. "Abdul Zalil · 8 hours").
+  display?: string;
+```
+
+- [ ] **Step 2: Add `display` to `SelectionResult`**
+
+In `lib/one-location/types.ts`, add to `SelectionResult` (after `status`, ~line 385):
+
+```ts
+  display?: string;
+```
+
+- [ ] **Step 3: Add `metadata` to the client `AgentChatMessage`**
+
+In `agent-chat-client.ts`, add to `AgentChatMessage` (after `completed_at?`, ~line 12):
+
+```ts
+  metadata?: { kind?: string; display?: string } | null;
+```
+
+`getAgentChatHistory` returns the parsed JSON as-is, so `metadata` flows through automatically once the backend (Task 4) includes it.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd hushh-webapp && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hushh-webapp/lib/agent/specialist-directive-runtime.ts hushh-webapp/lib/one-location/types.ts hushh-webapp/lib/services/agent-chat-client.ts
+git commit -m "feat(agent): carry selection display in types and client"
+```
+
+---
+
+## Task 7: Shared `SelectionChip` component
+
+**Files:**
+- Create: `hushh-webapp/components/agent/selection-chip.tsx`
+- Test: `hushh-webapp/components/agent/__tests__/selection-chip.test.tsx`
+
+**Interfaces:**
+- Produces: `SelectionChip({ label }: { label: string })` — a right-aligned `primary` user-side pill with a check icon.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// hushh-webapp/components/agent/__tests__/selection-chip.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SelectionChip } from "@/components/agent/selection-chip";
+
+describe("SelectionChip", () => {
+  it("renders the label", () => {
+    render(<SelectionChip label="Abdul Zalil · 8 hours" />);
+    expect(screen.getByText("Abdul Zalil · 8 hours")).toBeInTheDocument();
+  });
+
+  it("uses primary tokens, not cream", () => {
+    const { container } = render(<SelectionChip label="Mom" />);
+    expect(container.innerHTML).not.toContain("#b8894d");
+    expect(container.innerHTML).not.toContain("#d4a574");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hushh-webapp && npx vitest run components/agent/__tests__/selection-chip.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the component**
+
+```tsx
+// hushh-webapp/components/agent/selection-chip.tsx
+"use client";
+
+import { Check } from "lucide-react";
+
+/**
+ * Right-aligned user-side chip summarizing a card selection, styled to match the
+ * central chat's primary user bubble so both surfaces read consistently.
+ */
+export function SelectionChip({ label }: { label: string }) {
+  return (
+    <div className="flex w-full justify-end" data-testid="selection-chip">
+      <span className="inline-flex items-center gap-1.5 rounded-2xl bg-primary/10 px-3.5 py-1.5 text-sm font-medium text-primary shadow-sm shadow-primary/5">
+        <Check className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        {label}
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd hushh-webapp && npx vitest run components/agent/__tests__/selection-chip.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hushh-webapp/components/agent/selection-chip.tsx hushh-webapp/components/agent/__tests__/selection-chip.test.tsx
+git commit -m "feat(agent): add SelectionChip component"
+```
+
+---
+
+## Task 8: Central chat — append chip, send display, render history chips, collapse card
+
+**Files:**
+- Modify: `hushh-webapp/components/agent/agent-chat-workspace.tsx` (message type ~111; specialist render block ~3506-3621; history hydration where `AgentChatMessage`→`AgentMessage`; user-bubble render ~561-569)
+- Test: covered by the workspace's existing test file (extend it) — search for the existing `agent-chat-workspace` test; if none, add `hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx`.
+
+**Interfaces:**
+- Consumes: `describeSelection` (Task 5), `SelectionChip` (Task 7), `AgentChatMessage.metadata` (Task 6), `sendDelegateResult` (existing, ~2356).
+- Produces: on selection, a local `AgentMessage` with `kind: "selection"` + `text = display`; `delegate_result.display` set; history messages with `metadata.kind === "selection"` render via `SelectionChip`.
+
+- [ ] **Step 1: Extend the local message type**
+
+In `agent-chat-workspace.tsx`, add an optional discriminator to `AgentMessage` (~111):
+
+```ts
+type AgentMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  timestamp: string;
+  status?: "streaming" | "done" | "error";
+  ephemeral?: boolean;
+  kind?: "selection";
+};
+```
+
+- [ ] **Step 2: Append a chip + set display in the prompt `onAnswer`/`onConfirm`/`onCancel` handlers**
+
+In the `SpecialistPromptCard` render (~3514-3565), compute a display and append a chip before each `sendDelegateResult`. Replace the `onAnswer` handler body (~3517-3534) with:
+
+```tsx
+                    onAnswer={async (refs) => {
+                      const evt = pendingSpecialistDirective;
+                      const prompt = evt.directive.payload as unknown as ClientPrompt;
+                      const display = describeSelection(prompt, { selected: refs });
+                      setSpecialistBusy(true);
+                      try {
+                        setPendingSpecialistDirective(null);
+                        appendMessage({
+                          id: `msg-${Date.now()}-sel`,
+                          role: "user",
+                          text: display,
+                          timestamp: formatNow(),
+                          status: "done",
+                          kind: "selection",
+                        });
+                        await sendDelegateResult({
+                          delegate_agent_id: evt.delegateAgentId as "agent_location",
+                          kind: "selection",
+                          id: prompt.id,
+                          promptKind: prompt.kind,
+                          selected: refs,
+                          status: "answered",
+                          display,
+                        });
+                      } finally {
+                        setSpecialistBusy(false);
+                      }
+                    }}
+```
+
+Apply the same pattern to `onConfirm` (use `describeSelection(prompt, { confirmed: yes })`, append chip, add `display`) and `onCancel` (use `describeSelection(prompt, { status: "cancelled" })`, append chip, add `display`). Import `describeSelection` at the top:
+
+```ts
+import { describeSelection } from "@/lib/agent/describe-selection";
+```
+
+- [ ] **Step 3: Append a chip for the action card confirm/cancel**
+
+In the `SpecialistDirectiveCard` render (~3568-3619), the action summary is the card's `summary`. On confirm, append a chip with the confirm label; on cancel, append "Cancelled". In `onConfirm` (~3575), right after `setSpecialistBusy(true)` and before running crypto, append:
+
+```tsx
+                        appendMessage({
+                          id: `msg-${Date.now()}-act`,
+                          role: "user",
+                          text: "Share",
+                          timestamp: formatNow(),
+                          status: "done",
+                          kind: "selection",
+                        });
+```
+
+In `onCancel` (~3603), append a chip with text `"Cancelled"` before `sendDelegateResult`.
+
+- [ ] **Step 4: Render selection messages as chips + write the failing test**
+
+Where messages are mapped to `MessageBubble` (search for `messages.map(`), branch on `message.kind === "selection"` to render `SelectionChip`:
+
+```tsx
+        {messages.map((message) =>
+          message.kind === "selection" ? (
+            <SelectionChip key={message.id} label={message.text} />
+          ) : (
+            <MessageBubble key={message.id} message={message} /* …existing props… */ />
+          ),
+        )}
+```
+
+Import `SelectionChip`:
+
+```ts
+import { SelectionChip } from "@/components/agent/selection-chip";
+```
+
+Add the failing test (adjust import/harness to match existing workspace tests):
+
+```tsx
+// hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SelectionChip } from "@/components/agent/selection-chip";
+
+// Smoke test the render branch used by the workspace: a selection message
+// renders as a chip, never as the raw id seed.
+describe("selection rendering", () => {
+  it("renders a chip for a selection message", () => {
+    render(<SelectionChip label="Abdul Zalil" />);
+    expect(screen.getByTestId("selection-chip")).toHaveTextContent("Abdul Zalil");
+  });
+});
+```
+
+- [ ] **Step 5: Map history metadata to selection messages**
+
+Find where `getAgentChatHistory` results are converted into `AgentMessage[]` (search for `getAgentChatHistory` usage in the workspace). For each history message, set `kind` and prefer the display string:
+
+```ts
+        const mapped: AgentMessage[] = history.map((m) => ({
+          id: m.id,
+          role: m.role === "assistant" ? "assistant" : "user",
+          text: m.metadata?.kind === "selection" && m.metadata.display ? m.metadata.display : m.content,
+          timestamp: formatTimestamp(m.created_at),  // use the existing timestamp formatter in this file
+          status: "done",
+          ...(m.metadata?.kind === "selection" ? { kind: "selection" as const } : {}),
+        }));
+```
+
+> Match the existing history-mapping shape in the file (role coercion, timestamp helper). The key change is the `text` fallback to `metadata.display` and setting `kind: "selection"`. This is what removes the raw `I selected:` bubble on reload even for messages persisted before the frontend sent a `display` (the backend fallback in Task 3 guarantees a clean `metadata.display`).
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `cd hushh-webapp && npx vitest run components/agent/__tests__/agent-chat-selection.test.tsx && npx tsc --noEmit`
+Expected: PASS; no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hushh-webapp/components/agent/agent-chat-workspace.tsx hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx
+git commit -m "feat(agent-chat): render selections as chips and send display"
+```
+
+---
+
+## Task 9: Retheme shared cards to `primary` + collapsed state
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/clarification-card.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/action-confirm-card.tsx`
+- Test: `hushh-webapp/components/one-location/redesign/__tests__/cards-primary-theme.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: both cards render with `primary` tokens; no `#b8894d`/`#d4a574` remain. Behavior/props unchanged (this keeps the central `SpecialistPromptCard`/`SpecialistDirectiveCard` wrappers working and fixes the standalone chat simultaneously).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// hushh-webapp/components/one-location/redesign/__tests__/cards-primary-theme.test.tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ClarificationCard } from "@/components/one-location/redesign/clarification-card";
+import { ActionConfirmCard } from "@/components/one-location/redesign/action-confirm-card";
+import type { ClientAction, ClientPrompt } from "@/lib/one-location/types";
+
+const prompt: ClientPrompt = {
+  id: "p1", kind: "select", purpose: "recipient", question: "Who?",
+  options: [{ label: "Mom", ref: { recipientUserId: "m" } }],
+};
+const action: ClientAction = { id: "a1", type: "publish_share", summary: "Share with Mom" };
+const noop = () => {};
+
+describe("cards use primary theme", () => {
+  it("ClarificationCard has no cream tokens", () => {
+    const { container } = render(
+      <ClarificationCard prompt={prompt} busy={false} onAnswer={noop} onConfirm={noop} onCancel={noop} />,
+    );
+    expect(container.innerHTML).not.toContain("#b8894d");
+    expect(container.innerHTML).not.toContain("#d4a574");
+  });
+
+  it("ActionConfirmCard has no cream tokens", () => {
+    const { container } = render(
+      <ActionConfirmCard action={action} busy={false} onConfirm={noop} onCancel={noop} />,
+    );
+    expect(container.innerHTML).not.toContain("#b8894d");
+    expect(container.innerHTML).not.toContain("#d4a574");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/cards-primary-theme.test.tsx`
+Expected: FAIL — both cards still contain `#b8894d`.
+
+- [ ] **Step 3: Retheme `clarification-card.tsx`**
+
+Replace the container className (line ~43):
+
+```tsx
+      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
+```
+
+Replace the option-button className expression (lines ~58-63):
+
+```tsx
+                className={
+                  "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors " +
+                  (active
+                    ? "border-primary bg-primary/15 text-primary"
+                    : "border-[color:var(--app-card-border-standard)] text-foreground hover:border-primary/40")
+                }
+```
+
+- [ ] **Step 4: Retheme `action-confirm-card.tsx`**
+
+Replace the container className (line ~35):
+
+```tsx
+      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
+```
+
+Replace the icon color span (line ~38):
+
+```tsx
+        <span className="mt-0.5 text-primary">
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/cards-primary-theme.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/clarification-card.tsx hushh-webapp/components/one-location/redesign/action-confirm-card.tsx hushh-webapp/components/one-location/redesign/__tests__/cards-primary-theme.test.tsx
+git commit -m "feat(one-location): retheme shared cards to primary palette"
+```
+
+---
+
+## Task 10: Retheme location chat surface + append chip on selection
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/location-chat-atoms.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/use-location-chat.ts` (`ChatMessage` ~18; `answerPrompt` ~182; `confirmPrompt` ~191; `cancelPrompt` ~200)
+- Test: `hushh-webapp/components/one-location/redesign/__tests__/location-chat-selection.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `describeSelection` (Task 5).
+- Produces: location chat bubbles/atoms use `primary`; on card selection the hook appends a `ChatMessage` with `role:"user"` + `kind:"selection"` and the display text.
+
+- [ ] **Step 1: Retheme the message list**
+
+In `location-chat-message-list.tsx`, replace the user bubble className (line ~26):
+
+```tsx
+            <div className="max-w-[85%] rounded-2xl rounded-br-md bg-primary px-3.5 py-2 text-sm text-primary-foreground">
+```
+
+Replace the retry button color (line ~50):
+
+```tsx
+                  className="mt-1 text-xs font-semibold text-primary hover:underline"
+```
+
+(The assistant bubble already uses `var(--app-card-surface-compact)` — neutral, leave it.)
+
+- [ ] **Step 2: Retheme the atoms**
+
+In `location-chat-atoms.tsx`, replace the `BotAvatar` span className (line ~9):
+
+```tsx
+      className="flex shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+```
+
+(`StateChangedNote` uses emerald for the "Updated" confirmation — semantic success color, keep it. `TypingIndicator` uses `muted-foreground` — neutral, keep it.)
+
+- [ ] **Step 3: Write the failing test**
+
+```tsx
+// hushh-webapp/components/one-location/redesign/__tests__/location-chat-selection.test.tsx
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChatMessageList } from "@/components/one-location/redesign/location-chat-message-list";
+
+describe("location chat theme", () => {
+  it("user bubble uses primary, not cream", () => {
+    const { container } = render(
+      <ChatMessageList
+        busy={false}
+        messages={[{ id: "1", role: "user", text: "Abdul Zalil" }]}
+      />,
+    );
+    expect(container.innerHTML).not.toContain("#d4a574");
+    expect(container.innerHTML).not.toContain("#b8894d");
+  });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/location-chat-selection.test.tsx`
+Expected: FAIL — still contains `#d4a574`.
+
+- [ ] **Step 5: Append a chip on selection in the hook**
+
+In `use-location-chat.ts`, add `kind` to `ChatMessage` (~18):
+
+```ts
+export interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  stateChanged?: boolean;
+  errored?: boolean;
+  kind?: "selection";
+}
+```
+
+Import the helper at the top:
+
+```ts
+import { describeSelection } from "@/lib/agent/describe-selection";
+```
+
+In `answerPrompt` (~182), append a chip before `reportSelection`:
+
+```ts
+  const answerPrompt = useCallback(
+    async (refs: Record<string, unknown>[]) => {
+      const prompt = pendingPrompt;
+      if (!prompt || busy) return;
+      const display = describeSelection(prompt, { selected: refs });
+      setMessages((prev) => [...prev, { id: nextId(), role: "user", text: display, kind: "selection" }]);
+      await reportSelection({ id: prompt.id, kind: prompt.kind, selected: refs, status: "answered", display });
+    },
+    [pendingPrompt, busy, reportSelection, nextId],
+  );
+```
+
+Apply the same pattern to `confirmPrompt` (`describeSelection(prompt, { confirmed: yes })`, append chip, pass `display`) and `cancelPrompt` (`describeSelection(prompt, { status: "cancelled" })`, append chip, pass `display`). `SelectionResult.display` already exists (Task 6).
+
+- [ ] **Step 6: Render the chip in the message list**
+
+In `location-chat-message-list.tsx`, in the `messages.map` user branch (line ~24-29), when `message.kind === "selection"` render the shared chip. Import it:
+
+```tsx
+import { SelectionChip } from "@/components/agent/selection-chip";
+```
+
+Replace the user branch:
+
+```tsx
+        message.role === "user" ? (
+          message.kind === "selection" ? (
+            <SelectionChip key={message.id} label={message.text} />
+          ) : (
+            <div key={message.id} className="flex justify-end">
+              <div className="max-w-[85%] rounded-2xl rounded-br-md bg-primary px-3.5 py-2 text-sm text-primary-foreground">
+                {message.text}
+              </div>
+            </div>
+          )
+        ) : (
+```
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/location-chat-selection.test.tsx && npx tsc --noEmit`
+Expected: PASS; no type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx hushh-webapp/components/one-location/redesign/location-chat-atoms.tsx hushh-webapp/components/one-location/redesign/use-location-chat.ts hushh-webapp/components/one-location/redesign/__tests__/location-chat-selection.test.tsx
+git commit -m "feat(one-location): retheme chat to primary and chip selections"
+```
+
+---
+
+## Task 11: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Backend tests**
+
+Run: `cd consent-protocol && pytest tests/test_agent_chat_service_metadata.py tests/test_location_chat_selection_display.py tests/test_agent_chat_history_metadata.py -v` and the existing `tests/test_one_location_*` / agent-chat suites.
+Expected: all PASS.
+
+- [ ] **Step 2: Frontend tests + typecheck + lint**
+
+Run: `cd hushh-webapp && npx vitest run lib/agent components/agent components/one-location && npx tsc --noEmit`
+Expected: all PASS; no type errors. Confirm no `#b8894d`/`#d4a574` remain on the touched surfaces: `grep -rn "#b8894d\|#d4a574" components/one-location/redesign/{clarification-card,action-confirm-card,location-chat-message-list,location-chat-atoms}.tsx` returns nothing.
+
+- [ ] **Step 3: Manual smoke (both surfaces)**
+
+Drive "share my location with …" in the **central One chat** and in the **standalone Location chat**. Verify: selecting a recipient/duration shows a chip (not raw ids), the card collapses/clears, both surfaces look identical (primary), and reloading history shows chips (no `I selected:` text).
+
+- [ ] **Step 4: Commit any fixups**
+
+```bash
+git add -A && git commit -m "test: verify One+Location chat consistency end to end"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Consistent styling (both → primary) → Tasks 9, 10 (shared cards + location surface); central chat already primary.
+- Visible selection as chip + collapsed card → Tasks 7 (chip), 8 (central: append chip, collapse via clearing `pendingSpecialistDirective`, history chips), 10 (location: append chip, clear prompt).
+- Fix raw text at backend source (structured metadata + display, seed internal) → Tasks 1-4.
+- Collapsed card default (compact) → cards clear on selection (single-pick auto-answers; the pending directive is set to `null`), which realizes the "collapse to nothing + chip" behavior; a persistent compact summary line was deprioritized per the spec's adjustable default. If a lingering compact summary is desired, it is an additive follow-up to the chip.
+- Coordinate-free invariant → enforced in `describeSelection`, `_selection_display_text`, and asserted in Tasks 3 & 5.
+- Encrypted metadata → Task 1 (columns) + Task 2 (encrypt/decrypt).
+
+**Placeholder scan:** No TBD/TODO; every code step has concrete code. Line numbers are approximate (marked ~) because files drift; each step names the anchoring symbol to relocate it.
+
+**Type consistency:** `display` is optional across `DelegateResultModel`, `SelectionResultModel`, `DelegateResult`, `SelectionResult`. `metadata` shape `{ kind?, display? }` matches between backend serializer (Task 4), client type (Task 6), and workspace mapping (Task 8). `describeSelection` signature is identical in Tasks 5, 8, 10. `SelectionChip({ label })` identical in Tasks 7, 8, 10.
+
+**Note on "collapsed card":** the approved spec chose "chip + collapsed card" with a compact single-line default. This plan realizes collapse by clearing the active card and leaving the chip as the record of the choice (the established pattern — single-select cards already auto-answer and dismiss). If you want the *source card itself* to persist as a greyed compact line rather than disappear, say so and I'll add a `collapsed` render branch to Task 9 before execution.

--- a/docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md
+++ b/docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md
@@ -8,6 +8,26 @@
 
 **Tech Stack:** Python (FastAPI, asyncpg-style raw SQL, Pydantic v2), PostgreSQL migrations, TypeScript, React, Tailwind, Vitest/Jest, pytest.
 
+## Visual Map
+
+```text
+User taps a card option (recipient / duration / confirm)
+  │  browser: describeSelection(prompt, sel) → display  (coordinate/id-free)
+  │           append SelectionChip ("Abdul Zalil · 8h") + clear the card
+  ▼
+  central One chat:  POST /agent/chat/stream { delegate_result: { …, display } }
+  Location chat:     POST /api/one/location/chat { selectionResult: { …, display } }
+  │
+  ▼  LocationChatService._handle_selection_result  (persist role="user")
+       content  = raw seed            → LLM keeps exact ids ("do not guess")
+       metadata = { kind:"selection", display }  → ENCRYPTED at rest
+  │
+  ▼  history reload → API returns UI-safe { kind, display } only
+       browser renders the chip from metadata.display — never the raw seed
+
+Both chats share the same cards (primary palette) and the same SelectionChip.
+```
+
 ## Global Constraints
 
 - **Coordinate-free invariant:** no `latitude`/`longitude`/coordinate keys may appear in the `display` string, `metadata`, SSE frames, or `delegate_result`. Assert at code level.
@@ -1319,7 +1339,7 @@ git add -A && git commit -m "test: verify One+Location chat consistency end to e
 - Coordinate-free invariant → enforced in `describeSelection`, `_selection_display_text`, and asserted in Tasks 3 & 5.
 - Encrypted metadata → Task 1 (columns) + Task 2 (encrypt/decrypt).
 
-**Placeholder scan:** No TBD/TODO; every code step has concrete code. Line numbers are approximate (marked ~) because files drift; each step names the anchoring symbol to relocate it.
+**Placeholder scan:** No unresolved placeholder markers; every code step has concrete code. Line numbers are approximate (marked ~) because files drift; each step names the anchoring symbol to relocate it.
 
 **Type consistency:** `display` is optional across `DelegateResultModel`, `SelectionResultModel`, `DelegateResult`, `SelectionResult`. `metadata` shape `{ kind?, display? }` matches between backend serializer (Task 4), client type (Task 6), and workspace mapping (Task 8). `describeSelection` signature is identical in Tasks 5, 8, 10. `SelectionChip({ label })` identical in Tasks 7, 8, 10.
 

--- a/docs/superpowers/specs/2026-07-03-one-location-chat-ui-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-03-one-location-chat-ui-consistency-design.md
@@ -1,0 +1,176 @@
+# One + Location chat — UI consistency & visible selections (design)
+
+- **Date:** 2026-07-03
+- **Branch:** `feat/one-location-chat-ui-consistency` (off latest `origin/main`)
+- **Status:** Approved design (pending user spec review)
+- **Builds on:** `docs/superpowers/specs/2026-07-02-one-a2a-location-central-chat-design.md`
+  (the A2A delegation slice that surfaced Location inside the central chat).
+
+## 1. Problem
+
+Two chat surfaces now run the same Location flow but look and behave differently:
+
+- **Central "One" chat** (`agent-chat-workspace.tsx`) — brand `primary` palette, solid
+  primary user pills. It also shows an ugly raw user bubble:
+  `I selected: recipientUserId=5dM8Qij…; recipientKeyId=Wl… Use exactly these ids —
+  do not guess — and proceed.` and `I selected: hours=8. …`.
+- **Standalone Location subagent chat** (`components/one-location/redesign/*`) — cream
+  `#b8894d` / `#d4a574` palette, asymmetric-corner bubbles, cream cards. It never shows
+  the raw id-dump because it uses local message state and ignores the persisted seed.
+
+Two defects follow:
+
+1. **Inconsistent styling** between the two surfaces (and even *within* the central
+   chat: its `primary`-themed specialist wrappers embed the cream location cards).
+2. **Ugly / leaky selection text** in the central chat — raw recipient/key ids surface
+   as a `role="user"` bubble, and reappear on every history reload.
+
+## 2. Root cause (verified)
+
+- The raw string is **backend-generated**, not built in the webapp:
+  `consent-protocol/hushh_mcp/services/location_chat_service.py`,
+  `_selection_seed_text(selection_result)` (defined ~L336–350) returns
+  `f"I selected: {refs}. Use exactly these ids — do not guess — and proceed."`.
+- That one string does **double duty**: it is (a) the instruction seed handed to the
+  LLM, and (b) persisted as a `role="user"` message in the shared chat store
+  (`_handle_selection_result`, ~L708 builds it, ~L713–719 persists it).
+- The standalone location chat never re-hydrates that persisted seed, so it stays
+  hidden there; the central chat *does* re-hydrate the shared conversation, so it leaks.
+- The location confirmation/selection cards are **shared** between surfaces: the central
+  chat's `SpecialistPromptCard` / `SpecialistDirectiveCard`
+  (`components/agent/specialist-directive-card.tsx`) wrap the location
+  `ClarificationCard` / `ActionConfirmCard`
+  (`components/one-location/redesign/`). Retheming those primitives fixes both surfaces.
+
+## 3. Decisions (locked with user)
+
+1. **Target style:** both chats converge on the **central `primary` look**. The Location
+   subagent surface is rethemed away from cream to match the central chat.
+2. **Selection display:** when a user picks an option, show **both** a right-aligned
+   **user selection chip** *and* **collapse the source card** to a read-only selected
+   state.
+3. **Fix depth:** **robust backend + frontend**. Backend persists structured selection
+   metadata + a human-readable display string; the raw LLM seed stays internal-only.
+4. **Collapsed card form (default):** collapsed cards shrink to a **single compact
+   line** (icon + chosen value), not a full-height card. Adjustable on review.
+
+## 4. Architecture — changes by layer
+
+### 4.1 Backend
+
+`consent-protocol/hushh_mcp/services/location_chat_service.py`
+
+- Split the current `_selection_seed_text` responsibility into two:
+  - **`_selection_seed_text` (LLM seed)** — wording unchanged
+    (`recipientUserId=…; … do not guess …`). Continues to feed the model's turn context.
+    It is **no longer** the persisted user-visible content.
+  - **Persisted user message** — store a short human-readable `display` string as the
+    message `content`, plus structured `selection` metadata on the message:
+    `{ type, refs, label }` (e.g. `type:"recipient"`, `label:"Abdul Zalil"`).
+- The `display`/`label` originates on the frontend (the card already knows the friendly
+  label; the backend only had opaque ids). It arrives on the delegate/selection payload.
+- `_handle_selection_result` (~L708–719): persist `role="user"` with
+  `content = display`, `metadata.selection = { type, refs, label }`. The LLM still
+  receives the raw seed for its reasoning; it is never persisted as visible content.
+
+`consent-protocol/api/routes/kai/agent_chat.py`
+
+- Extend the delegate-result request model with the optional `display` /`selection`
+  fields (coordinate-free; recipient/duration labels only). Backward-compatible: if
+  absent, fall back to a best-effort display derived from refs.
+
+**Invariant:** no coordinates enter the display string or metadata; the coordinate-free
+guarantee from the A2A slice is preserved.
+
+### 4.2 Frontend
+
+`hushh-webapp/lib/services/agent-chat-client.ts`
+
+- Add `display` / `selection` to the delegate-result request body.
+- When hydrating history, expose the persisted `selection` metadata so the workspace can
+  render a chip rather than raw text.
+
+`hushh-webapp/components/agent/agent-chat-workspace.tsx`
+
+- On option tap (existing handlers at the specialist-directive render block, ~L3506–3621):
+  1. Append a **user-side selection chip** message locally (from the card's own label).
+  2. **Collapse** the source card to its compact selected state.
+  3. Call `sendDelegateResult({ selected: refs, display, status })` including `display`.
+- On history reload: render any message carrying `selection` metadata as a chip; never
+  render the raw `I selected:` text (guard even for legacy stored messages).
+
+`hushh-webapp/components/agent/selection-chip.tsx` **(new)**
+
+- Small presentational right-aligned chip summarizing the choice
+  (`Abdul Zalil · 8 hours`). Reused by both surfaces.
+
+`hushh-webapp/components/one-location/redesign/*` (retheme to `primary`)
+
+- `location-chat-message-list.tsx` — user/assistant bubbles from cream → primary tokens
+  (match `agent-chat-workspace.tsx` bubble styling).
+- `location-chat-atoms.tsx` — `BotAvatar`, `StateChangedNote` to primary/neutral.
+- `clarification-card.tsx`, `action-confirm-card.tsx` — container, option chips, and
+  buttons from `#b8894d`/`#d4a574` → `primary` (drop the cream palette on these
+  surfaces). Add the compact **collapsed selected state** and emit the selection
+  chip on tap, matching the central chat.
+- `use-location-chat.ts` — on selection, append the chip locally (parity with central).
+
+### 4.3 Shared vs surface-specific
+
+The retheme of `clarification-card.tsx` / `action-confirm-card.tsx` fixes the central
+chat automatically (its wrappers embed these). `selection-chip.tsx` and the
+collapsed-card behavior are shared. Only the message-list bubbles and atoms are
+surface-specific and rethemed per surface.
+
+## 5. Selection data flow
+
+```text
+User taps "Abdul Zalil" in ClarificationCard
+  → append user chip bubble ("Abdul Zalil"); collapse card to compact selected line
+  → sendDelegateResult({ selected:[refs], display:"Abdul Zalil", status:"answered" })
+  → backend: LLM receives raw seed (internal, not persisted);
+             persists user message content = "Abdul Zalil",
+             metadata.selection = { type:"recipient", refs, label:"Abdul Zalil" }
+  → assistant streams next prompt ("how long?") → repeat for duration ("8 hours")
+  → ActionConfirmCard → "Share" → browser crypto → completion confirmation
+On history reload: selection messages render as chips from metadata (no raw ids).
+```
+
+The who → how-long → confirm sequence leaves a stack of compact collapsed cards +
+chips, so the transcript reads naturally on both surfaces.
+
+## 6. Out of scope
+
+- No change to the A2A delegation contract, consent flow, or the browser crypto path.
+- No new specialists (Nav/KYC/Kai) — but `selection-chip.tsx` and the collapsed-card
+  pattern are built specialist-generic so they plug in later.
+- No coordinate-handling changes; zero-knowledge invariants unchanged.
+
+## 7. Testing strategy
+
+**Backend**
+
+- Persisted selection message `content` is the human-readable display string and its
+  `metadata.selection` holds `{ type, refs, label }`; it contains **no** `recipientUserId=`
+  / `recipientKeyId=` / `do not guess` text.
+- The LLM still receives the raw seed for its turn (reasoning unaffected).
+- No coordinates in display string or metadata (assert at code level).
+- Existing standalone `/api/one/location/chat` and central delegate-result flows stay green.
+
+**Frontend**
+
+- Tapping an option appends a chip, collapses the source card, and never renders raw ids.
+- History reload renders chips from `selection` metadata (including a legacy stored
+  `I selected:` message, which must not render raw).
+- Both surfaces use `primary` tokens — no `#b8894d` / `#d4a574` remains on the chat
+  bubbles, atoms, or the two cards.
+- `sendDelegateResult` includes `display`; existing crypto/confirm callbacks unchanged.
+- `npx tsc --noEmit` clean; existing agent-workspace and location-chat tests stay green.
+
+## 8. Skill plan (remainder)
+
+1. **superpowers:brainstorming** — complete (this spec).
+2. User reviews this spec.
+3. **superpowers:writing-plans** — TDD implementation plan.
+4. **ui-ux-pro-max** — drives the visual retheme + chip/collapsed-card execution.
+5. **superpowers:test-driven-development** + **superpowers:executing-plans** — build.

--- a/docs/superpowers/specs/2026-07-03-one-location-chat-ui-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-03-one-location-chat-ui-consistency-design.md
@@ -6,6 +6,26 @@
 - **Builds on:** `docs/superpowers/specs/2026-07-02-one-a2a-location-central-chat-design.md`
   (the A2A delegation slice that surfaced Location inside the central chat).
 
+## Visual Map
+
+```text
+User taps a card option (recipient / duration / confirm)
+  │  browser: describeSelection(prompt, sel) → display  (coordinate/id-free)
+  │           append SelectionChip ("Abdul Zalil · 8h") + clear the card
+  ▼
+  central One chat:  POST /agent/chat/stream { delegate_result: { …, display } }
+  Location chat:     POST /api/one/location/chat { selectionResult: { …, display } }
+  │
+  ▼  LocationChatService._handle_selection_result  (persist role="user")
+       content  = raw seed            → LLM keeps exact ids ("do not guess")
+       metadata = { kind:"selection", display }  → ENCRYPTED at rest
+  │
+  ▼  history reload → API returns UI-safe { kind, display } only
+       browser renders the chip from metadata.display — never the raw seed
+
+Both chats share the same cards (primary palette) and the same SelectionChip.
+```
+
 ## 1. Problem
 
 Two chat surfaces now run the same Location flow but look and behave differently:

--- a/hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx
+++ b/hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx
@@ -64,6 +64,48 @@ describe("storedMessageToAgentMessage — selection history mapping", () => {
     } as unknown as AgentChatMessage;
     expect(storedMessageToAgentMessage(stored)).toBeNull();
   });
+
+  // Fix 1: legacy-row safety-net — raw selection seed with no metadata
+  it("maps legacy raw selection seed (no metadata) to a selection chip with generic label", () => {
+    const stored: AgentChatMessage = {
+      ...base,
+      role: "user",
+      content:
+        "I selected: recipientUserId=u_abc123; recipientKeyId=k_xyz789. Use exactly these ids — do not guess — and proceed.",
+      metadata: null,
+    };
+    const mapped = storedMessageToAgentMessage(stored);
+    expect(mapped).not.toBeNull();
+    expect(mapped?.kind).toBe("selection");
+    expect(mapped?.text).toBe("Your selection");
+    expect(mapped?.text).not.toContain("I selected:");
+    expect(mapped?.text).not.toContain("recipientUserId");
+    expect(mapped?.text).not.toContain("do not guess");
+  });
+
+  it("does not reclassify a normal user message (hello) as a selection", () => {
+    const stored: AgentChatMessage = {
+      ...base,
+      role: "user",
+      content: "hello",
+      metadata: null,
+    };
+    const mapped = storedMessageToAgentMessage(stored);
+    expect(mapped?.kind).toBeUndefined();
+    expect(mapped?.text).toBe("hello");
+  });
+
+  it("does not reclassify 'Yes, go ahead.' acknowledgement seed as a selection", () => {
+    const stored: AgentChatMessage = {
+      ...base,
+      role: "user",
+      content: "Yes, go ahead.",
+      metadata: null,
+    };
+    const mapped = storedMessageToAgentMessage(stored);
+    expect(mapped?.kind).toBeUndefined();
+    expect(mapped?.text).toBe("Yes, go ahead.");
+  });
 });
 
 describe("SelectionChip render branch", () => {

--- a/hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx
+++ b/hushh-webapp/components/agent/__tests__/agent-chat-selection.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SelectionChip } from "@/components/agent/selection-chip";
+import { storedMessageToAgentMessage } from "@/components/agent/agent-chat-workspace";
+import type { AgentChatMessage } from "@/lib/services/agent-chat-client";
+
+// History mapping is the load-bearing behavior: on reload a persisted selection
+// must become a chip (kind:"selection") showing the clean display label, never
+// the raw `I selected:` seed. These tests exercise the real mapping helper the
+// workspace uses to hydrate history.
+describe("storedMessageToAgentMessage — selection history mapping", () => {
+  const base = {
+    id: "m1",
+    conversation_id: "c1",
+    status: "complete" as const,
+    created_at: null,
+    completed_at: null,
+  };
+
+  it("maps a selection message to a chip using metadata.display, not the raw seed", () => {
+    const stored: AgentChatMessage = {
+      ...base,
+      role: "user",
+      content: "I selected: {recipientKeyId:abc123}",
+      metadata: { kind: "selection", display: "Abdul Zalil" },
+    };
+    const mapped = storedMessageToAgentMessage(stored);
+    expect(mapped).not.toBeNull();
+    expect(mapped?.kind).toBe("selection");
+    expect(mapped?.text).toBe("Abdul Zalil");
+    expect(mapped?.text).not.toContain("I selected:");
+  });
+
+  it("does not treat plain assistant/user messages as selection chips", () => {
+    const stored: AgentChatMessage = {
+      ...base,
+      role: "assistant",
+      content: "Here is your answer.",
+      metadata: null,
+    };
+    const mapped = storedMessageToAgentMessage(stored);
+    expect(mapped?.kind).toBeUndefined();
+    expect(mapped?.text).toBe("Here is your answer.");
+  });
+
+  it("falls back gracefully to content when a selection lacks a display label", () => {
+    const stored: AgentChatMessage = {
+      ...base,
+      role: "user",
+      content: "Cancelled",
+      metadata: { kind: "selection" },
+    };
+    const mapped = storedMessageToAgentMessage(stored);
+    expect(mapped?.kind).toBe("selection");
+    expect(mapped?.text).toBe("Cancelled");
+  });
+
+  it("drops non user/assistant roles", () => {
+    const stored = {
+      ...base,
+      role: "system",
+      content: "system prompt",
+      metadata: null,
+    } as unknown as AgentChatMessage;
+    expect(storedMessageToAgentMessage(stored)).toBeNull();
+  });
+});
+
+describe("SelectionChip render branch", () => {
+  it("renders a chip for a selection message label", () => {
+    render(<SelectionChip label="Abdul Zalil" />);
+    const chip = screen.getByTestId("selection-chip");
+    expect(chip.textContent).toContain("Abdul Zalil");
+  });
+});

--- a/hushh-webapp/components/agent/__tests__/selection-chip.test.tsx
+++ b/hushh-webapp/components/agent/__tests__/selection-chip.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SelectionChip } from "@/components/agent/selection-chip";
+
+describe("SelectionChip", () => {
+  it("renders the label", () => {
+    render(<SelectionChip label="Abdul Zalil · 8 hours" />);
+    expect(screen.getByText("Abdul Zalil · 8 hours")).toBeTruthy();
+  });
+
+  it("uses primary tokens, not cream", () => {
+    const { container } = render(<SelectionChip label="Mom" />);
+    expect(container.innerHTML).not.toContain("#b8894d");
+    expect(container.innerHTML).not.toContain("#d4a574");
+  });
+});

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -685,6 +685,15 @@ function AgentPkmActivityLine({ item }: { item: AgentPkmActivity }) {
   );
 }
 
+// Safety-net for legacy DB rows written before Task 8 metadata was added.
+// Those rows carry no metadata and their content is the raw recipient/duration
+// seed "I selected: recipientUserId=…; … do not guess — and proceed."
+// Matching them prevents the ugly id-dump from ever rendering as a user bubble.
+// The shorter acknowledgement seeds ("Yes, go ahead.", "No, do not proceed.",
+// "I changed my mind — cancel that, take no action.") are already human-readable
+// and must NOT be reclassified — the pattern is intentionally narrow.
+const LEGACY_SELECTION_SEED = /^I selected:.*do not guess/s;
+
 export function storedMessageToAgentMessage(
   message: StoredAgentChatMessage,
 ): AgentMessage | null {
@@ -693,11 +702,19 @@ export function storedMessageToAgentMessage(
   // A selection message must never re-render its raw `I selected:` seed on
   // reload: prefer the persisted display label and render it as a chip. The
   // backend (Task 3) guarantees metadata.display for new selection messages;
-  // legacy rows without metadata fall back gracefully to content.
+  // legacy rows without metadata are detected via LEGACY_SELECTION_SEED below.
   const isSelection = message.metadata?.kind === "selection";
+  // Detect legacy rows: user message with raw seed content and no usable metadata.
+  const isLegacySelectionSeed =
+    !isSelection &&
+    message.role === "user" &&
+    LEGACY_SELECTION_SEED.test(message.content);
+
   const displayText =
     isSelection && message.metadata?.display
       ? message.metadata.display
+      : isLegacySelectionSeed
+      ? "Your selection"
       : message.content;
   return {
     id: message.id,
@@ -711,7 +728,7 @@ export function storedMessageToAgentMessage(
           }).format(createdAt)
         : formatNow(),
     status: message.status === "error" ? "error" : "done",
-    ...(isSelection ? { kind: "selection" as const } : {}),
+    ...(isSelection || isLegacySelectionSeed ? { kind: "selection" as const } : {}),
   };
 }
 

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -36,6 +36,8 @@ import { Button } from "@/components/ui/button";
 import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
 import { AgentPkmReviewPanel } from "@/components/agent/agent-pkm-review-panel";
 import { SpecialistDirectiveCard, SpecialistPromptCard } from "@/components/agent/specialist-directive-card";
+import { SelectionChip } from "@/components/agent/selection-chip";
+import { describeSelection } from "@/lib/agent/describe-selection";
 import type { ClientPrompt } from "@/lib/one-location/types";
 import { AgentVoiceWaveInput } from "@/components/agent/agent-voice-wave-input";
 import { StreamingCursor } from "@/lib/morphy-ux/streaming-cursor";
@@ -115,6 +117,7 @@ type AgentMessage = {
   timestamp: string;
   status?: "streaming" | "done" | "error";
   ephemeral?: boolean;
+  kind?: "selection";
 };
 
 type AgentDebugEvent = {
@@ -682,13 +685,24 @@ function AgentPkmActivityLine({ item }: { item: AgentPkmActivity }) {
   );
 }
 
-function storedMessageToAgentMessage(message: StoredAgentChatMessage): AgentMessage | null {
+export function storedMessageToAgentMessage(
+  message: StoredAgentChatMessage,
+): AgentMessage | null {
   if (message.role !== "user" && message.role !== "assistant") return null;
   const createdAt = message.created_at ? new Date(message.created_at) : null;
+  // A selection message must never re-render its raw `I selected:` seed on
+  // reload: prefer the persisted display label and render it as a chip. The
+  // backend (Task 3) guarantees metadata.display for new selection messages;
+  // legacy rows without metadata fall back gracefully to content.
+  const isSelection = message.metadata?.kind === "selection";
+  const displayText =
+    isSelection && message.metadata?.display
+      ? message.metadata.display
+      : message.content;
   return {
     id: message.id,
     role: message.role,
-    text: message.content,
+    text: displayText,
     timestamp:
       createdAt && !Number.isNaN(createdAt.getTime())
         ? new Intl.DateTimeFormat(undefined, {
@@ -697,6 +711,7 @@ function storedMessageToAgentMessage(message: StoredAgentChatMessage): AgentMess
           }).format(createdAt)
         : formatNow(),
     status: message.status === "error" ? "error" : "done",
+    ...(isSelection ? { kind: "selection" as const } : {}),
   };
 }
 
@@ -3476,18 +3491,22 @@ export function AgentChatWorkspace({
                 />
               ) : null}
 
-              {visibleMessages.map((message) => (
-                <AgentBubble
-                  key={message.id}
-                  message={message}
-                  retryDisabled={isChatLoading || isStreaming}
-                  onRetry={
-                    message.id === latestRetryableAssistantId
-                      ? () => handleRetryAssistantResponse(message.id)
-                      : undefined
-                  }
-                />
-              ))}
+              {visibleMessages.map((message) =>
+                message.kind === "selection" ? (
+                  <SelectionChip key={message.id} label={message.text} />
+                ) : (
+                  <AgentBubble
+                    key={message.id}
+                    message={message}
+                    retryDisabled={isChatLoading || isStreaming}
+                    onRetry={
+                      message.id === latestRetryableAssistantId
+                        ? () => handleRetryAssistantResponse(message.id)
+                        : undefined
+                    }
+                  />
+                ),
+              )}
 
               {pkmActivity.map((item) => (
                 <AgentPkmActivityLine key={item.id} item={item} />
@@ -3517,9 +3536,18 @@ export function AgentChatWorkspace({
                     onAnswer={async (refs) => {
                       const evt = pendingSpecialistDirective;
                       const prompt = evt.directive.payload as unknown as ClientPrompt;
+                      const display = describeSelection(prompt, { selected: refs });
                       setSpecialistBusy(true);
                       try {
                         setPendingSpecialistDirective(null);
+                        appendMessage({
+                          id: `msg-${Date.now()}-sel`,
+                          role: "user",
+                          text: display,
+                          timestamp: formatNow(),
+                          status: "done",
+                          kind: "selection",
+                        });
                         await sendDelegateResult({
                           delegate_agent_id: evt.delegateAgentId as "agent_location",
                           kind: "selection",
@@ -3527,6 +3555,7 @@ export function AgentChatWorkspace({
                           promptKind: prompt.kind,
                           selected: refs,
                           status: "answered",
+                          display,
                         });
                       } finally {
                         setSpecialistBusy(false);
@@ -3535,9 +3564,18 @@ export function AgentChatWorkspace({
                     onConfirm={async (yes) => {
                       const evt = pendingSpecialistDirective;
                       const prompt = evt.directive.payload as unknown as ClientPrompt;
+                      const display = describeSelection(prompt, { confirmed: yes });
                       setSpecialistBusy(true);
                       try {
                         setPendingSpecialistDirective(null);
+                        appendMessage({
+                          id: `msg-${Date.now()}-sel`,
+                          role: "user",
+                          text: display,
+                          timestamp: formatNow(),
+                          status: "done",
+                          kind: "selection",
+                        });
                         await sendDelegateResult({
                           delegate_agent_id: evt.delegateAgentId as "agent_location",
                           kind: "selection",
@@ -3545,6 +3583,7 @@ export function AgentChatWorkspace({
                           promptKind: prompt.kind,
                           confirmed: yes,
                           status: "answered",
+                          display,
                         });
                       } finally {
                         setSpecialistBusy(false);
@@ -3553,13 +3592,23 @@ export function AgentChatWorkspace({
                     onCancel={async () => {
                       const evt = pendingSpecialistDirective;
                       const prompt = evt.directive.payload as unknown as ClientPrompt;
+                      const display = describeSelection(prompt, { status: "cancelled" });
                       setPendingSpecialistDirective(null);
+                      appendMessage({
+                        id: `msg-${Date.now()}-sel`,
+                        role: "user",
+                        text: display,
+                        timestamp: formatNow(),
+                        status: "done",
+                        kind: "selection",
+                      });
                       await sendDelegateResult({
                         delegate_agent_id: evt.delegateAgentId as "agent_location",
                         kind: "selection",
                         id: prompt.id,
                         promptKind: prompt.kind,
                         status: "cancelled",
+                        display,
                       });
                     }}
                   />
@@ -3575,6 +3624,14 @@ export function AgentChatWorkspace({
                     onConfirm={async () => {
                       const directive = pendingSpecialistDirective;
                       setSpecialistBusy(true);
+                      appendMessage({
+                        id: `msg-${Date.now()}-act`,
+                        role: "user",
+                        text: "Share",
+                        timestamp: formatNow(),
+                        status: "done",
+                        kind: "selection",
+                      });
                       try {
                         // Source the vault owner token from the same place every
                         // other authed call uses (never hardcoded/invented).
@@ -3603,6 +3660,14 @@ export function AgentChatWorkspace({
                     onCancel={async () => {
                       const directive = pendingSpecialistDirective;
                       setPendingSpecialistDirective(null);
+                      appendMessage({
+                        id: `msg-${Date.now()}-act`,
+                        role: "user",
+                        text: "Cancelled",
+                        timestamp: formatNow(),
+                        status: "done",
+                        kind: "selection",
+                      });
                       await sendDelegateResult({
                         delegate_agent_id: directive.delegateAgentId as "agent_location",
                         kind: "action",

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -3641,14 +3641,6 @@ export function AgentChatWorkspace({
                     onConfirm={async () => {
                       const directive = pendingSpecialistDirective;
                       setSpecialistBusy(true);
-                      appendMessage({
-                        id: `msg-${Date.now()}-act`,
-                        role: "user",
-                        text: "Share",
-                        timestamp: formatNow(),
-                        status: "done",
-                        kind: "selection",
-                      });
                       try {
                         // Source the vault owner token from the same place every
                         // other authed call uses (never hardcoded/invented).
@@ -3657,6 +3649,14 @@ export function AgentChatWorkspace({
                           addErrorMessage("Vault access expired. Unlock again to continue.");
                           return;
                         }
+                        appendMessage({
+                          id: `msg-${Date.now()}-act`,
+                          role: "user",
+                          text: "Share",
+                          timestamp: formatNow(),
+                          status: "done",
+                          kind: "selection",
+                        });
                         const result = await runLocationDirective(directive.directive, token);
                         setPendingSpecialistDirective(null);
                         // view_envelope fetches a coordinate-free result here; the

--- a/hushh-webapp/components/agent/selection-chip.tsx
+++ b/hushh-webapp/components/agent/selection-chip.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Check } from "lucide-react";
+
+/**
+ * Right-aligned user-side chip summarizing a card selection, styled to match the
+ * central chat's primary user bubble so both surfaces read consistently.
+ */
+export function SelectionChip({ label }: { label: string }) {
+  return (
+    <div className="flex w-full justify-end" data-testid="selection-chip">
+      <span className="inline-flex items-center gap-1.5 rounded-2xl bg-primary/10 px-3.5 py-1.5 text-sm font-medium text-primary shadow-sm shadow-primary/5">
+        <Check className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/__tests__/cards-primary-theme.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/cards-primary-theme.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ClarificationCard } from "@/components/one-location/redesign/clarification-card";
+import { ActionConfirmCard } from "@/components/one-location/redesign/action-confirm-card";
+import type { ClientAction, ClientPrompt } from "@/lib/one-location/types";
+
+const prompt: ClientPrompt = {
+  id: "p1",
+  kind: "select",
+  purpose: "recipient",
+  question: "Who?",
+  options: [{ label: "Mom", ref: { recipientUserId: "m" } }],
+};
+const action: ClientAction = {
+  id: "a1",
+  type: "publish_share",
+  summary: "Share with Mom",
+};
+const noop = () => {};
+
+describe("cards use primary theme", () => {
+  it("ClarificationCard has no cream tokens", () => {
+    const { container } = render(
+      <ClarificationCard
+        prompt={prompt}
+        busy={false}
+        onAnswer={noop}
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(container.innerHTML).not.toContain("#b8894d");
+    expect(container.innerHTML).not.toContain("#d4a574");
+  });
+
+  it("ActionConfirmCard has no cream tokens", () => {
+    const { container } = render(
+      <ActionConfirmCard
+        action={action}
+        busy={false}
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(container.innerHTML).not.toContain("#b8894d");
+    expect(container.innerHTML).not.toContain("#d4a574");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/__tests__/location-chat-selection.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/location-chat-selection.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChatMessageList } from "@/components/one-location/redesign/location-chat-message-list";
+
+describe("location chat theme", () => {
+  it("user bubble uses primary, not cream", () => {
+    const { container } = render(
+      <ChatMessageList
+        busy={false}
+        messages={[{ id: "1", role: "user", text: "Abdul Zalil" }]}
+      />,
+    );
+    expect(container.innerHTML).not.toContain("#d4a574");
+    expect(container.innerHTML).not.toContain("#b8894d");
+  });
+
+  it("selection message renders SelectionChip", () => {
+    const { container } = render(
+      <ChatMessageList
+        busy={false}
+        messages={[{ id: "2", role: "user", text: "Mom", kind: "selection" }]}
+      />,
+    );
+    expect(container.querySelector('[data-testid="selection-chip"]')).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
@@ -32,10 +32,10 @@ export function ActionConfirmCard({
   return (
     <div
       data-testid="action-confirm-card"
-      className="rounded-2xl border border-[#b8894d]/40 bg-[#b8894d]/5 p-4"
+      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
     >
       <div className="flex items-start gap-3">
-        <span className="mt-0.5 text-[#b8894d]">
+        <span className="mt-0.5 text-primary">
           <Icon className="h-5 w-5" aria-hidden />
         </span>
         <p className="flex-1 text-sm font-medium">{action.summary}</p>

--- a/hushh-webapp/components/one-location/redesign/clarification-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/clarification-card.tsx
@@ -40,7 +40,7 @@ export function ClarificationCard({
   return (
     <div
       data-testid="clarification-card"
-      className="rounded-2xl border border-[#b8894d]/40 bg-[#b8894d]/5 p-4"
+      className="rounded-2xl border border-primary/20 bg-primary/5 p-4"
     >
       <p className="text-sm font-medium">{prompt.question}</p>
 
@@ -58,8 +58,8 @@ export function ClarificationCard({
                 className={
                   "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors " +
                   (active
-                    ? "border-[#b8894d] bg-[#b8894d]/15 text-[#b8894d]"
-                    : "border-[color:var(--app-card-border-standard)] text-foreground hover:border-[#d4a574]/50")
+                    ? "border-primary bg-primary/15 text-primary"
+                    : "border-[color:var(--app-card-border-standard)] text-foreground hover:border-primary/40")
                 }
               >
                 {opt.label}

--- a/hushh-webapp/components/one-location/redesign/location-chat-atoms.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-atoms.tsx
@@ -6,7 +6,7 @@ export function BotAvatar(props: { size?: number }) {
   const size = props.size ?? 32;
   return (
     <span
-      className="flex shrink-0 items-center justify-center rounded-full bg-[#d4a574]/15 text-[#b8894d]"
+      className="flex shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
       style={{ width: size, height: size }}
       aria-hidden
     >

--- a/hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
+import { SelectionChip } from "@/components/agent/selection-chip";
 import type { ChatMessage } from "./use-location-chat";
 import { BotAvatar, StateChangedNote, TypingIndicator } from "./location-chat-atoms";
 
@@ -22,11 +23,15 @@ export function ChatMessageList(props: {
     >
       {messages.map((message) =>
         message.role === "user" ? (
-          <div key={message.id} className="flex justify-end">
-            <div className="max-w-[85%] rounded-2xl rounded-br-md bg-[#d4a574]/15 px-3.5 py-2 text-sm text-foreground">
-              {message.text}
+          message.kind === "selection" ? (
+            <SelectionChip key={message.id} label={message.text} />
+          ) : (
+            <div key={message.id} className="flex justify-end">
+              <div className="max-w-[85%] rounded-2xl rounded-br-md bg-primary px-3.5 py-2 text-sm text-primary-foreground">
+                {message.text}
+              </div>
             </div>
-          </div>
+          )
         ) : (
           <div key={message.id} className="flex items-start gap-2">
             <BotAvatar size={28} />
@@ -47,7 +52,7 @@ export function ChatMessageList(props: {
                 <button
                   type="button"
                   onClick={onRetry}
-                  className="mt-1 text-xs font-semibold text-[#b8894d] hover:underline"
+                  className="mt-1 text-xs font-semibold text-primary hover:underline"
                 >
                   Retry
                 </button>

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -14,6 +14,7 @@ import type {
   PlainLocationPoint,
   SelectionResult,
 } from "@/lib/one-location/types";
+import { describeSelection } from "@/lib/agent/describe-selection";
 
 export interface ChatMessage {
   id: string;
@@ -21,6 +22,7 @@ export interface ChatMessage {
   text: string;
   stateChanged?: boolean;
   errored?: boolean;
+  kind?: "selection";
 }
 
 export interface UseLocationChat {
@@ -183,25 +185,40 @@ export function useLocationChat(params: {
     async (refs: Record<string, unknown>[]) => {
       const prompt = pendingPrompt;
       if (!prompt || busy) return;
-      await reportSelection({ id: prompt.id, kind: prompt.kind, selected: refs, status: "answered" });
+      const display = describeSelection(prompt, { selected: refs });
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "user", text: display, kind: "selection" },
+      ]);
+      await reportSelection({ id: prompt.id, kind: prompt.kind, selected: refs, status: "answered", display });
     },
-    [pendingPrompt, busy, reportSelection],
+    [pendingPrompt, busy, reportSelection, nextId],
   );
 
   const confirmPrompt = useCallback(
     async (yes: boolean) => {
       const prompt = pendingPrompt;
       if (!prompt || busy) return;
-      await reportSelection({ id: prompt.id, kind: prompt.kind, confirmed: yes, status: "answered" });
+      const display = describeSelection(prompt, { confirmed: yes });
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "user", text: display, kind: "selection" },
+      ]);
+      await reportSelection({ id: prompt.id, kind: prompt.kind, confirmed: yes, status: "answered", display });
     },
-    [pendingPrompt, busy, reportSelection],
+    [pendingPrompt, busy, reportSelection, nextId],
   );
 
   const cancelPrompt = useCallback(async () => {
     const prompt = pendingPrompt;
     if (!prompt || busy) return;
-    await reportSelection({ id: prompt.id, kind: prompt.kind, status: "cancelled" });
-  }, [pendingPrompt, busy, reportSelection]);
+    const display = describeSelection(prompt, { status: "cancelled" });
+    setMessages((prev) => [
+      ...prev,
+      { id: nextId(), role: "user", text: display, kind: "selection" },
+    ]);
+    await reportSelection({ id: prompt.id, kind: prompt.kind, status: "cancelled", display });
+  }, [pendingPrompt, busy, reportSelection, nextId]);
 
   const confirmAction = useCallback(async () => {
     const action = pendingAction;

--- a/hushh-webapp/lib/agent/__tests__/describe-selection.test.ts
+++ b/hushh-webapp/lib/agent/__tests__/describe-selection.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { describeSelection } from "@/lib/agent/describe-selection";
+import type { ClientPrompt } from "@/lib/one-location/types";
+
+const recipientPrompt: ClientPrompt = {
+  id: "p1",
+  kind: "select",
+  purpose: "recipient",
+  question: "Who?",
+  options: [
+    {
+      label: "Abdul Zalil",
+      ref: { recipientUserId: "5dM8", recipientKeyId: "WlUg" },
+    },
+    { label: "Mom", ref: { recipientUserId: "mom1", recipientKeyId: "momK" } },
+  ],
+};
+
+const durationPrompt: ClientPrompt = {
+  id: "p2",
+  kind: "select",
+  purpose: "duration",
+  question: "How long?",
+  options: [{ label: "8 hours", ref: { hours: 8 } }],
+};
+
+describe("describeSelection", () => {
+  it("maps selected refs to option labels", () => {
+    expect(
+      describeSelection(recipientPrompt, {
+        selected: [{ recipientUserId: "5dM8", recipientKeyId: "WlUg" }],
+      }),
+    ).toBe("Abdul Zalil");
+  });
+
+  it("joins multiple selections", () => {
+    expect(
+      describeSelection(recipientPrompt, {
+        selected: [
+          { recipientUserId: "5dM8", recipientKeyId: "WlUg" },
+          { recipientUserId: "mom1", recipientKeyId: "momK" },
+        ],
+      }),
+    ).toBe("Abdul Zalil, Mom");
+  });
+
+  it("maps a duration selection", () => {
+    expect(
+      describeSelection(durationPrompt, { selected: [{ hours: 8 }] }),
+    ).toBe("8 hours");
+  });
+
+  it("describes confirm / cancel / free text", () => {
+    expect(
+      describeSelection(
+        { ...recipientPrompt, kind: "confirm" },
+        { confirmed: true },
+      ),
+    ).toBe("Confirmed");
+    expect(
+      describeSelection(
+        { ...recipientPrompt, kind: "confirm" },
+        { confirmed: false },
+      ),
+    ).toBe("Declined");
+    expect(describeSelection(recipientPrompt, { status: "cancelled" })).toBe(
+      "Cancelled",
+    );
+    expect(
+      describeSelection(recipientPrompt, { freeText: "share with my sister" }),
+    ).toBe("share with my sister");
+  });
+
+  it("never leaks raw ids when a ref has no matching option", () => {
+    const out = describeSelection(recipientPrompt, {
+      selected: [{ recipientUserId: "ghost", recipientKeyId: "x" }],
+    });
+    expect(out).not.toContain("recipientUserId");
+    expect(out).not.toContain("recipientKeyId");
+  });
+
+  it("never leaks coordinate values when a ref has no matching option", () => {
+    // A location ref with a label should surface only the label, not the coords.
+    const promptWithLocationRef: ClientPrompt = {
+      id: "p3",
+      kind: "select",
+      purpose: "location",
+      question: "Where?",
+      options: [], // no matching option — fallback path
+    };
+    const out = describeSelection(promptWithLocationRef, {
+      selected: [{ latitude: 37.7749, longitude: -122.4194, label: "Home" }],
+    });
+    expect(out).toContain("Home");
+    expect(out).not.toContain("37.7749");
+    expect(out).not.toContain("-122.4194");
+  });
+});

--- a/hushh-webapp/lib/agent/describe-selection.ts
+++ b/hushh-webapp/lib/agent/describe-selection.ts
@@ -1,0 +1,62 @@
+import type { ClientPrompt } from "@/lib/one-location/types";
+
+/**
+ * Keys that must never appear as display values in a chip label.
+ * Includes identity keys (would leak user/grant IDs) and coordinate keys
+ * (coordinate-free project constraint, mirrors backend _selection_display_text).
+ */
+const NON_DISPLAY_REF_KEYS = new Set([
+  "recipientUserId",
+  "recipientKeyId",
+  "grantId",
+  "latitude",
+  "longitude",
+  "coordinates",
+  "lat",
+  "lng",
+  "lon",
+  "accuracyM",
+]);
+
+function sameRef(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Human-readable, coordinate-free summary of a user's card selection, for the
+ * chat chip. Resolves refs back to their option labels; falls back to option
+ * *values* (never raw id or coordinate keys) so an unmatched ref can never
+ * leak an id dump or a coordinate.
+ */
+export function describeSelection(
+  prompt: ClientPrompt,
+  sel: {
+    selected?: Record<string, unknown>[];
+    confirmed?: boolean;
+    freeText?: string;
+    status?: string;
+  },
+): string {
+  if (sel.status === "cancelled") return "Cancelled";
+  if (sel.freeText && sel.freeText.trim()) return sel.freeText.trim();
+  if (prompt.kind === "confirm")
+    return sel.confirmed ? "Confirmed" : "Declined";
+
+  const options = prompt.options ?? [];
+  const labels = (sel.selected ?? [])
+    .map((ref) => {
+      const match = options.find((o) => sameRef(o.ref, ref));
+      if (match) return match.label;
+      // No matching option: surface non-id, non-coordinate values only.
+      const values = Object.entries(ref)
+        .filter(([k]) => !NON_DISPLAY_REF_KEYS.has(k))
+        .map(([, v]) => String(v));
+      return values.join(" ");
+    })
+    .filter((s) => s.length > 0);
+
+  return labels.length ? labels.join(", ") : "Your selection";
+}

--- a/hushh-webapp/lib/agent/specialist-directive-runtime.ts
+++ b/hushh-webapp/lib/agent/specialist-directive-runtime.ts
@@ -21,6 +21,8 @@ export type DelegateResult = {
   selected?: Record<string, unknown>[];
   confirmed?: boolean;
   freeText?: string;
+  // Human-readable label for the chat chip (e.g. "Abdul Zalil · 8 hours").
+  display?: string;
 };
 
 type Share = {

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -383,6 +383,7 @@ export interface SelectionResult {
   confirmed?: boolean;
   freeText?: string;
   status: "answered" | "cancelled";
+  display?: string;
 }
 
 export interface LocationChatResponse {

--- a/hushh-webapp/lib/services/agent-chat-client.ts
+++ b/hushh-webapp/lib/services/agent-chat-client.ts
@@ -10,6 +10,7 @@ export type AgentChatMessage = {
   model?: string | null;
   created_at?: string | null;
   completed_at?: string | null;
+  metadata?: { kind?: string; display?: string } | null;
 };
 
 export type AgentChatConversation = {

--- a/hushh-webapp/vitest.config.ts
+++ b/hushh-webapp/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./__tests__/setup.ts"],
-    include: ["__tests__/**/*.test.{ts,tsx}"],
+    include: ["__tests__/**/*.test.{ts,tsx}", "lib/**/__tests__/**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
     coverage: {
       provider: "v8",

--- a/hushh-webapp/vitest.config.ts
+++ b/hushh-webapp/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./__tests__/setup.ts"],
-    include: ["__tests__/**/*.test.{ts,tsx}", "lib/**/__tests__/**/*.test.{ts,tsx}"],
+    include: ["__tests__/**/*.test.{ts,tsx}", "lib/**/__tests__/**/*.test.{ts,tsx}", "components/**/__tests__/**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## What & why

Makes the central **One** agent chat and the standalone **Location** subagent chat visually consistent (both on the `primary` palette) and renders user selections as clean **chips** instead of the raw `I selected: recipientUserId=…; do not guess…` id-dump.

Design & plan: `docs/superpowers/specs/2026-07-03-one-location-chat-ui-consistency-design.md`, `docs/superpowers/plans/2026-07-03-one-location-chat-ui-consistency.md`.

## How

- **Root-cause fix (backend):** the selection seed did double duty as the LLM instruction *and* the persisted user message. Now `content` keeps the raw seed (LLM still gets exact ids), and a new **encrypted** `metadata` column carries a human-readable `display` string. History returns a UI-safe `{kind, display}` subset only.
- **Frontend:** `describeSelection` helper (coordinate/id-safe), a shared `SelectionChip`, central-chat wiring (append chip + send `display` + render history chips + a narrow legacy-seed guard), and retheme of the shared cards + location chat surface cream → `primary`.

## Invariants preserved

- **Coordinate-free** — no lat/lng in display/metadata/SSE/delegate_result (enforced + tested both sides).
- **Encrypted-at-rest** — metadata uses the same AES-256-GCM scheme as `content`.
- **Backward compatible** — all new fields optional; legacy rows handled.

## ⚠️ Deploy prerequisite

Migration **`075_agent_chat_message_metadata.sql`** must be applied to each environment (staging/prod) via the normal release migration process — the code writes these columns on every chat turn, so an un-applied migration breaks all chat. Also confirm whether `db/contracts/uat_integrated_schema.json` `expected_migration_version` should bump to 75 (release-tooling decision).

## Tests

- Backend feature suite: 31 passed. Frontend full `vitest run`: 1541 passed; `tsc --noEmit` clean. No cream tokens remain on touched surfaces.
- Executed via subagent-driven TDD: fresh implementer + spec/quality review per task, plus a final whole-branch review (verdict: ready to merge).
- Remaining: manual browser smoke (needs real auth + geolocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)