### PR TITLE
Feature/a2a nav agent

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -56,6 +56,7 @@ class AgentChatStreamRequest(BaseModel):
     conversation_id: Optional[str] = Field(default=None, max_length=128)
     pkm_context: Optional[str] = Field(default=None, max_length=20000)
     screen_context: Optional[dict] = Field(default=None)
+    timezone: Optional[str] = Field(default=None, max_length=64)
     runtime_credential: Optional[str] = Field(default=None, max_length=12000, exclude=True)
     runtime_credential_mode: Optional[str] = Field(default=None, max_length=64)
     delegate_result: Optional[DelegateResultModel] = Field(default=None)
@@ -256,12 +257,34 @@ async def stream_agent_chat(
         delegate_agent_id = resolve_delegate_target(body.message)
 
     if delegate_agent_id is not None and is_wired_specialist(delegate_agent_id):
+        delegated_turn: PreparedAgentChatTurn | None = None
+        delegated_conversation_id = body.conversation_id
+        if body.message.strip():
+            try:
+                delegated_turn = await service.prepare_turn(
+                    user_id=body.user_id,
+                    message=body.message,
+                    conversation_id=body.conversation_id,
+                )
+                delegated_conversation_id = delegated_turn.conversation_id
+            except Exception as error:
+                logger.exception(
+                    "agent_chat.delegation_prepare_failed user_id=%s: %s",
+                    body.user_id,
+                    error,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail="Agent chat could not be started",
+                ) from error
+
         task = A2ATask(
             user_id=body.user_id,
             consent_token=token_data.get("token", ""),
-            conversation_id=body.conversation_id,
+            conversation_id=delegated_conversation_id,
             message=body.message or None,
             delegate_result=delegate_result_payload,
+            timezone=body.timezone,
         )
 
         async def generate_delegated():
@@ -277,6 +300,21 @@ async def stream_agent_chat(
                     },
                 )
                 return
+            conversation_id = result.conversation_id or delegated_conversation_id
+            if conversation_id:
+                save_turn = PreparedAgentChatTurn(
+                    conversation_id=conversation_id,
+                    user_message_id=delegated_turn.user_message_id if delegated_turn else "",
+                    history=delegated_turn.history if delegated_turn else [],
+                    model=result.model,
+                )
+                await _save_assistant_message(
+                    service=service,
+                    turn=save_turn,
+                    user_id=body.user_id,
+                    text=result.text,
+                    status_value="complete",
+                )
             for name, data in specialist_result_to_frames(result, delegate_agent_id):
                 yield _event(name, data)
 
@@ -286,6 +324,8 @@ async def stream_agent_chat(
             "X-Accel-Buffering": "no",
             "X-Content-Type-Options": "nosniff",
         }
+        if delegated_conversation_id:
+            headers["X-Agent-Conversation-Id"] = delegated_conversation_id
         return StreamingResponse(
             generate_delegated(), media_type="text/event-stream", headers=headers
         )

--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from typing import Any, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -125,13 +126,13 @@ def resolve_delegate_target(message: str) -> str | None:
 
 
 def specialist_result_to_frames(
-    result: SpecialistTurnResult, delegate_agent_id: str
+    result: SpecialistTurnResult, delegate_agent_id: str, *, include_start: bool = True
 ) -> list[tuple[str, dict]]:
     """Format a specialist turn as ordered additive SSE (event, data) tuples."""
-    frames: list[tuple[str, dict]] = [
-        ("start", {"conversation_id": result.conversation_id, "model": result.model}),
-        ("token", {"token": result.text}),
-    ]
+    frames: list[tuple[str, dict]] = []
+    if include_start:
+        frames.append(("start", {"conversation_id": result.conversation_id, "model": result.model}))
+    frames.append(("token", {"token": result.text}))
     if result.directive is not None:
         frames.append(
             (
@@ -259,6 +260,8 @@ async def stream_agent_chat(
     if delegate_agent_id is not None and is_wired_specialist(delegate_agent_id):
         delegated_turn: PreparedAgentChatTurn | None = None
         delegated_conversation_id = body.conversation_id
+        prepare_started = time.perf_counter()
+        prepare_ms = 0.0
         if body.message.strip():
             try:
                 delegated_turn = await service.prepare_turn(
@@ -267,6 +270,7 @@ async def stream_agent_chat(
                     conversation_id=body.conversation_id,
                 )
                 delegated_conversation_id = delegated_turn.conversation_id
+                prepare_ms = (time.perf_counter() - prepare_started) * 1000
             except Exception as error:
                 logger.exception(
                     "agent_chat.delegation_prepare_failed user_id=%s: %s",
@@ -288,10 +292,27 @@ async def stream_agent_chat(
         )
 
         async def generate_delegated():
+            yield _event(
+                "start",
+                {
+                    "conversation_id": delegated_conversation_id or "",
+                    "model": "delegated",
+                    "delegate_agent_id": delegate_agent_id,
+                },
+            )
+            dispatch_started = time.perf_counter()
             try:
                 result = await a2a_dispatch(delegate_agent_id, task)
             except Exception as error:  # noqa: BLE001
-                logger.exception("agent_chat.delegation_failed user_id=%s: %s", body.user_id, error)
+                dispatch_ms = (time.perf_counter() - dispatch_started) * 1000
+                logger.exception(
+                    "agent_chat.delegation_failed user_id=%s delegate_agent_id=%s prepare_ms=%.1f dispatch_ms=%.1f: %s",
+                    body.user_id,
+                    delegate_agent_id,
+                    prepare_ms,
+                    dispatch_ms,
+                    error,
+                )
                 yield _event(
                     "error",
                     {
@@ -300,7 +321,9 @@ async def stream_agent_chat(
                     },
                 )
                 return
+            dispatch_ms = (time.perf_counter() - dispatch_started) * 1000
             conversation_id = result.conversation_id or delegated_conversation_id
+            save_ms = 0.0
             if conversation_id:
                 save_turn = PreparedAgentChatTurn(
                     conversation_id=conversation_id,
@@ -308,6 +331,7 @@ async def stream_agent_chat(
                     history=delegated_turn.history if delegated_turn else [],
                     model=result.model,
                 )
+                save_started = time.perf_counter()
                 await _save_assistant_message(
                     service=service,
                     turn=save_turn,
@@ -315,7 +339,20 @@ async def stream_agent_chat(
                     text=result.text,
                     status_value="complete",
                 )
-            for name, data in specialist_result_to_frames(result, delegate_agent_id):
+                save_ms = (time.perf_counter() - save_started) * 1000
+            logger.info(
+                "agent_chat.delegation_timing user_id=%s conversation_id=%s delegate_agent_id=%s prepare_ms=%.1f dispatch_ms=%.1f save_ms=%.1f total_ms=%.1f",
+                body.user_id,
+                conversation_id or "",
+                delegate_agent_id,
+                prepare_ms,
+                dispatch_ms,
+                save_ms,
+                prepare_ms + dispatch_ms + save_ms,
+            )
+            for name, data in specialist_result_to_frames(
+                result, delegate_agent_id, include_start=False
+            ):
                 yield _event(name, data)
 
         headers = {

--- a/consent-protocol/hushh_mcp/adk_bridge/__init__.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/__init__.py
@@ -6,10 +6,12 @@ chat's dispatch seam can reach them.
 
 from hushh_mcp.adk_bridge.dispatch import register_specialist
 from hushh_mcp.adk_bridge.location_agent import get_location_a2a
+from hushh_mcp.adk_bridge.nav_agent import get_nav_a2a
 
 
 def _register_builtin_specialists() -> None:
     register_specialist("agent_location", lambda task: get_location_a2a().handle(task))
+    register_specialist("agent_nav", lambda task: get_nav_a2a().handle(task))
 
 
 _register_builtin_specialists()

--- a/consent-protocol/hushh_mcp/adk_bridge/contract.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/contract.py
@@ -20,6 +20,7 @@ class A2ATask:
     conversation_id: str | None
     message: str | None = None
     delegate_result: dict | None = None
+    timezone: str | None = None
 
 
 @dataclass(frozen=True)

--- a/consent-protocol/hushh_mcp/adk_bridge/nav_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/nav_agent.py
@@ -6,7 +6,9 @@ changing the core Nav manifest or the working Location A2A path.
 
 from __future__ import annotations
 
+import logging
 import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -20,6 +22,7 @@ from hushh_mcp.services.consent_center_service import ConsentCenterService
 
 DELEGATED_MODEL = "one+nav"
 NAV_AGENT_ID = "agent_nav"
+logger = logging.getLogger(__name__)
 
 
 class NavAgent:
@@ -97,6 +100,7 @@ class NavAgent:
     async def _active_consent_answer(
         self, user_id: str, *, timezone: ZoneInfo
     ) -> tuple[str, Any | None]:
+        started = time.perf_counter()
         try:
             payload = await ConsentCenterService().list_center(
                 user_id,
@@ -105,7 +109,21 @@ class NavAgent:
                 top=10,
             )
         except Exception:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            logger.exception(
+                "nav_agent.consent_center_failed user_id=%s surface=active elapsed_ms=%.1f",
+                user_id,
+                elapsed_ms,
+            )
             return "Nav could not load approved consent requests right now. Please try again.", None
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        logger.info(
+            "nav_agent.consent_center_timing user_id=%s surface=active elapsed_ms=%.1f items=%s total=%s",
+            user_id,
+            elapsed_ms,
+            len(list(payload.get("items") or [])),
+            payload.get("total"),
+        )
 
         grants = list(payload.get("items") or [])
         total = int(payload.get("total") or len(grants))
@@ -140,6 +158,7 @@ class NavAgent:
     async def _previous_consent_answer(
         self, user_id: str, *, timezone: ZoneInfo
     ) -> tuple[str, Any | None]:
+        started = time.perf_counter()
         try:
             payload = await ConsentCenterService().list_center(
                 user_id,
@@ -148,7 +167,21 @@ class NavAgent:
                 top=10,
             )
         except Exception:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            logger.exception(
+                "nav_agent.consent_center_failed user_id=%s surface=previous elapsed_ms=%.1f",
+                user_id,
+                elapsed_ms,
+            )
             return "Nav could not load revoked consent requests right now. Please try again.", None
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        logger.info(
+            "nav_agent.consent_center_timing user_id=%s surface=previous elapsed_ms=%.1f items=%s total=%s",
+            user_id,
+            elapsed_ms,
+            len(list(payload.get("items") or [])),
+            payload.get("total"),
+        )
 
         entries = list(payload.get("items") or [])
         total = int(payload.get("total") or len(entries))

--- a/consent-protocol/hushh_mcp/adk_bridge/nav_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/nav_agent.py
@@ -56,9 +56,13 @@ class NavAgent:
 
         message = (hussh_task.message or "").strip()
         timezone = _safe_timezone(hussh_task.metadata.get("timezone"))
+        answer_text, directive = await self._answer(
+            message, user_id=hussh_task.user_id, timezone=timezone
+        )
         hussh_result = _hussh_result(
             conversation_id=hussh_task.conversation_id,
-            text=await self._answer(message, user_id=hussh_task.user_id, timezone=timezone),
+            text=answer_text,
+            directive=directive,
             is_complete=True,
             model=DELEGATED_MODEL,
             metadata={
@@ -69,22 +73,30 @@ class NavAgent:
         )
         return _research_result(hussh_result)
 
-    async def _answer(self, message: str, *, user_id: str, timezone: ZoneInfo) -> str:
-        instruction = " ".join((self._manifest.system_instruction or "").split())
+    async def _answer(
+        self, message: str, *, user_id: str, timezone: ZoneInfo
+    ) -> tuple[str, Any | None]:
         if not message:
             return (
                 "Nav is ready to review consent, scope release, vault access, "
-                "deletion, and revocation questions."
+                "deletion, and revocation questions.",
+                None,
             )
+        if _is_previous_consent_query(message):
+            return await self._previous_consent_answer(user_id, timezone=timezone)
         if _is_active_consent_query(message):
             return await self._active_consent_answer(user_id, timezone=timezone)
         return (
-            f"{instruction} For this request: {message} Nav can review the "
-            "requested access, explain the trust boundary, and help narrow, "
-            "approve, or revoke scopes before personal context is released."
+            f"For this request: {message}. I can help review consent requests, "
+            "explain what access was granted, "
+            "and help you approve, narrow, or revoke access. Ask me to show active, "
+            "pending, or revoked consent requests.",
+            None,
         )
 
-    async def _active_consent_answer(self, user_id: str, *, timezone: ZoneInfo) -> str:
+    async def _active_consent_answer(
+        self, user_id: str, *, timezone: ZoneInfo
+    ) -> tuple[str, Any | None]:
         try:
             payload = await ConsentCenterService().list_center(
                 user_id,
@@ -93,25 +105,66 @@ class NavAgent:
                 top=10,
             )
         except Exception:
-            return "Nav could not load approved consent requests right now. Please try again."
+            return "Nav could not load approved consent requests right now. Please try again.", None
 
         grants = list(payload.get("items") or [])
         total = int(payload.get("total") or len(grants))
         if not grants:
-            return "You do not have any approved consent requests right now."
+            return "You do not have any approved consent requests right now.", None
 
         lines = [
             f"You have {total} approved consent request"
             f"{'' if total == 1 else 's'} active right now:"
         ]
+        action_items: list[dict[str, Any]] = []
         for index, grant in enumerate(grants[:10], start=1):
             label = _entry_label(grant)
             access = _friendly_scope(grant)
             expires = _friendly_expiry(grant, timezone=timezone)
             lines.append(f"{index}. {label} can {access}{expires}.")
+            action_item = _consent_action_item(grant, label=label, access=access)
+            if action_item is not None:
+                action_items.append(action_item)
         if total > len(grants):
             lines.append(f"There are {total - len(grants)} more approved requests.")
-        return "\n".join(lines)
+        directive = (
+            _hussh_directive(
+                kind="prompt",
+                payload={"kind": "consent_actions", "items": action_items},
+            )
+            if action_items
+            else None
+        )
+        return "\n".join(lines), directive
+
+    async def _previous_consent_answer(
+        self, user_id: str, *, timezone: ZoneInfo
+    ) -> tuple[str, Any | None]:
+        try:
+            payload = await ConsentCenterService().list_center(
+                user_id,
+                actor="investor",
+                surface="previous",
+                top=10,
+            )
+        except Exception:
+            return "Nav could not load revoked consent requests right now. Please try again.", None
+
+        entries = list(payload.get("items") or [])
+        total = int(payload.get("total") or len(entries))
+        if not entries:
+            return "You do not have any revoked or previous consent requests right now.", None
+
+        lines = [f"You have {total} previous consent request{'' if total == 1 else 's'}:"]
+        for index, entry in enumerate(entries[:10], start=1):
+            label = _entry_label(entry)
+            access = _friendly_scope(entry)
+            ended = _friendly_terminal_time(entry, timezone=timezone)
+            status = str(entry.get("status") or "previous").strip().lower()
+            lines.append(f"{index}. {label} had access to {access}{ended} ({status}).")
+        if total > len(entries):
+            lines.append(f"There are {total - len(entries)} more previous requests.")
+        return "\n".join(lines), None
 
 
 _singleton: NavAgent | None = None
@@ -131,11 +184,30 @@ def _default_manifest_path() -> Path:
 def _is_active_consent_query(message: str) -> bool:
     text = message.lower()
     consent_words = ("consent", "access", "grant", "permission", "scope")
-    active_words = ("approved", "active", "granted", "who has access")
+    active_words = (
+        "approved",
+        "active",
+        "granted",
+        "request",
+        "requests",
+        "who has access",
+    )
     list_words = ("show", "list", "all", "what", "who")
     return (
         any(word in text for word in consent_words)
         and any(word in text for word in active_words)
+        and any(word in text for word in list_words)
+    )
+
+
+def _is_previous_consent_query(message: str) -> bool:
+    text = message.lower()
+    consent_words = ("consent", "access", "grant", "permission", "scope", "request")
+    previous_words = ("revoked", "revoke", "expired", "previous", "past", "history", "ended")
+    list_words = ("show", "list", "all", "what", "who", "about")
+    return (
+        any(word in text for word in consent_words)
+        and any(word in text for word in previous_words)
         and any(word in text for word in list_words)
     )
 
@@ -174,6 +246,51 @@ def _friendly_scope(entry: dict[str, Any]) -> str:
     return "access an approved scope"
 
 
+def _consent_action_item(
+    entry: dict[str, Any],
+    *,
+    label: str,
+    access: str,
+) -> dict[str, Any] | None:
+    entry_id = str(entry.get("id") or "").strip()
+    scope = str(entry.get("scope") or "").strip()
+    metadata = dict(entry.get("metadata") or {})
+    request_source = str(metadata.get("request_source") or "").strip()
+    is_location_grant = (
+        entry_id.startswith("one_location_grant:")
+        or request_source == "one_location_share_grant"
+        or scope.startswith("cap.location.")
+    )
+    if not is_location_grant:
+        return None
+
+    grant_id = str(metadata.get("grant_id") or "").strip()
+    if not grant_id and entry_id.startswith("one_location_grant:"):
+        grant_id = entry_id.split(":", 1)[1].strip()
+    if not grant_id:
+        raw_id = str(entry.get("id") or "").strip()
+        if raw_id and not raw_id.startswith("one_location_"):
+            grant_id = raw_id
+    if not grant_id:
+        return None
+
+    item_id = f"one_location_grant:{grant_id}"
+    action_metadata = {
+        **metadata,
+        "request_source": "one_location_share_grant",
+        "grant_id": grant_id,
+    }
+    return {
+        "id": item_id,
+        "label": label,
+        "summary": f"{label} can {access}",
+        "scope": scope,
+        "expiresAt": entry.get("expires_at"),
+        "metadata": action_metadata,
+        "actions": ["revoke", "details"],
+    }
+
+
 def _friendly_expiry(entry: dict[str, Any], *, timezone: ZoneInfo) -> str:
     expires = str(entry.get("expires_at") or "").strip()
     if not expires:
@@ -190,6 +307,26 @@ def _friendly_expiry(entry: dict[str, Any], *, timezone: ZoneInfo) -> str:
         day_label = "tomorrow"
     time_label = local_expires.strftime("%-I:%M %p %Z")
     return f" until {day_label} at {time_label}"
+
+
+def _friendly_terminal_time(entry: dict[str, Any], *, timezone: ZoneInfo) -> str:
+    for key in ("revoked_at", "resolved_at", "expires_at", "updated_at", "issued_at"):
+        value = str(entry.get(key) or "").strip()
+        if not value:
+            continue
+        parsed = _parse_datetime(value)
+        if parsed is None:
+            return f" until {value}"
+        local_value = parsed.astimezone(timezone)
+        local_now = datetime.now(UTC).astimezone(timezone)
+        day_label = local_value.strftime("%b %-d, %Y")
+        if local_value.date() == local_now.date():
+            day_label = "today"
+        elif (local_value.date() - local_now.date()).days == -1:
+            day_label = "yesterday"
+        time_label = local_value.strftime("%-I:%M %p %Z")
+        return f" until {day_label} at {time_label}"
+    return ""
 
 
 def _parse_datetime(value: str) -> datetime | None:

--- a/consent-protocol/hushh_mcp/adk_bridge/nav_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/nav_agent.py
@@ -1,0 +1,288 @@
+"""Inline A2A runtime for Agent Nav.
+
+This file adds an executable A2A surface for the existing Nav specialist without
+changing the core Nav manifest or the working Location A2A path.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from hushh_mcp.adk_bridge.contract import A2ADirective, A2ATask, SpecialistTurnResult
+from hushh_mcp.adk_bridge.delegation import validate_a2a_consent_token
+from hushh_mcp.consent.scope_helpers import get_scope_display_metadata
+from hushh_mcp.hushh_adk.manifest import ManifestLoader
+from hushh_mcp.services.consent_center_service import ConsentCenterService
+
+DELEGATED_MODEL = "one+nav"
+NAV_AGENT_ID = "agent_nav"
+
+
+class NavAgent:
+    agent_id = NAV_AGENT_ID
+
+    def __init__(self, manifest_path: str | Path | None = None) -> None:
+        self._manifest_path = Path(manifest_path) if manifest_path else _default_manifest_path()
+        self._manifest = ManifestLoader.load(str(self._manifest_path))
+
+    async def handle(self, task: A2ATask) -> SpecialistTurnResult:
+        hussh_task = _hussh_task(task)
+        validation = validate_a2a_consent_token(self.agent_id, hussh_task.consent_token)
+        if not validation.ok:
+            hussh_result = _hussh_result(
+                conversation_id=hussh_task.conversation_id,
+                text=(
+                    "Nav cannot review this request without an active "
+                    f"{validation.required_scope.value} consent grant."
+                ),
+                directive=_hussh_directive(
+                    kind="prompt",
+                    payload={
+                        "kind": "consent_required",
+                        "agentId": self.agent_id,
+                        "requiredScope": validation.required_scope.value,
+                        "reason": validation.reason,
+                    },
+                ),
+                is_complete=True,
+                model=DELEGATED_MODEL,
+                metadata={"status": "needs_consent", "reason": validation.reason},
+            )
+            return _research_result(hussh_result)
+
+        message = (hussh_task.message or "").strip()
+        timezone = _safe_timezone(hussh_task.metadata.get("timezone"))
+        hussh_result = _hussh_result(
+            conversation_id=hussh_task.conversation_id,
+            text=await self._answer(message, user_id=hussh_task.user_id, timezone=timezone),
+            is_complete=True,
+            model=DELEGATED_MODEL,
+            metadata={
+                "status": "completed",
+                "agent_id": self.agent_id,
+                "required_scope": validation.required_scope.value,
+            },
+        )
+        return _research_result(hussh_result)
+
+    async def _answer(self, message: str, *, user_id: str, timezone: ZoneInfo) -> str:
+        instruction = " ".join((self._manifest.system_instruction or "").split())
+        if not message:
+            return (
+                "Nav is ready to review consent, scope release, vault access, "
+                "deletion, and revocation questions."
+            )
+        if _is_active_consent_query(message):
+            return await self._active_consent_answer(user_id, timezone=timezone)
+        return (
+            f"{instruction} For this request: {message} Nav can review the "
+            "requested access, explain the trust boundary, and help narrow, "
+            "approve, or revoke scopes before personal context is released."
+        )
+
+    async def _active_consent_answer(self, user_id: str, *, timezone: ZoneInfo) -> str:
+        try:
+            payload = await ConsentCenterService().list_center(
+                user_id,
+                actor="investor",
+                surface="active",
+                top=10,
+            )
+        except Exception:
+            return "Nav could not load approved consent requests right now. Please try again."
+
+        grants = list(payload.get("items") or [])
+        total = int(payload.get("total") or len(grants))
+        if not grants:
+            return "You do not have any approved consent requests right now."
+
+        lines = [
+            f"You have {total} approved consent request"
+            f"{'' if total == 1 else 's'} active right now:"
+        ]
+        for index, grant in enumerate(grants[:10], start=1):
+            label = _entry_label(grant)
+            access = _friendly_scope(grant)
+            expires = _friendly_expiry(grant, timezone=timezone)
+            lines.append(f"{index}. {label} can {access}{expires}.")
+        if total > len(grants):
+            lines.append(f"There are {total - len(grants)} more approved requests.")
+        return "\n".join(lines)
+
+
+_singleton: NavAgent | None = None
+
+
+def get_nav_a2a() -> NavAgent:
+    global _singleton
+    if _singleton is None:
+        _singleton = NavAgent()
+    return _singleton
+
+
+def _default_manifest_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "agents" / "nav" / "agent.yaml"
+
+
+def _is_active_consent_query(message: str) -> bool:
+    text = message.lower()
+    consent_words = ("consent", "access", "grant", "permission", "scope")
+    active_words = ("approved", "active", "granted", "who has access")
+    list_words = ("show", "list", "all", "what", "who")
+    return (
+        any(word in text for word in consent_words)
+        and any(word in text for word in active_words)
+        and any(word in text for word in list_words)
+    )
+
+
+def _entry_label(entry: dict[str, Any]) -> str:
+    for key in ("counterpart_label", "counterpart_email", "counterpart_id"):
+        value = str(entry.get(key) or "").strip()
+        if value:
+            return value
+    return "An approved app or agent"
+
+
+def _friendly_scope(entry: dict[str, Any]) -> str:
+    scope = str(entry.get("scope") or "").strip()
+    if scope == "cap.location.live.view":
+        return "view your live location"
+    if scope == "cap.location.live.share":
+        return "share your live location"
+    if scope == "cap.location.live.request":
+        return "request your live location"
+    if scope == "cap.location.live.revoke":
+        return "revoke a live-location share"
+    if scope == "cap.location.live.refer_request":
+        return "refer a live-location access request"
+    description = str(entry.get("scope_description") or "").strip()
+    if description:
+        return f"access {description[0].lower()}{description[1:]}"
+    if scope:
+        try:
+            label = str(get_scope_display_metadata(scope).get("label") or "").strip()
+        except Exception:
+            label = ""
+        if label:
+            return f"access {label[0].lower()}{label[1:]}"
+        return f"access {scope}"
+    return "access an approved scope"
+
+
+def _friendly_expiry(entry: dict[str, Any], *, timezone: ZoneInfo) -> str:
+    expires = str(entry.get("expires_at") or "").strip()
+    if not expires:
+        return ""
+    parsed = _parse_datetime(expires)
+    if parsed is None:
+        return f" until {expires}"
+    local_expires = parsed.astimezone(timezone)
+    local_now = datetime.now(UTC).astimezone(timezone)
+    day_label = local_expires.strftime("%b %-d, %Y")
+    if local_expires.date() == local_now.date():
+        day_label = "today"
+    elif (local_expires.date() - local_now.date()).days == 1:
+        day_label = "tomorrow"
+    time_label = local_expires.strftime("%-I:%M %p %Z")
+    return f" until {day_label} at {time_label}"
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _safe_timezone(value: Any) -> ZoneInfo:
+    name = str(value or "").strip()
+    if not name:
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(name)
+    except (ValueError, ZoneInfoNotFoundError):
+        return ZoneInfo("UTC")
+
+
+def _hussh_task(task: A2ATask) -> Any:
+    _ensure_hussh_package()
+    from hussh import A2ATask as HusshA2ATask
+
+    return HusshA2ATask(
+        user_id=task.user_id,
+        consent_token=task.consent_token,
+        conversation_id=task.conversation_id,
+        message=task.message,
+        payload={"delegate_result": task.delegate_result} if task.delegate_result else {},
+        metadata={"timezone": task.timezone} if task.timezone else {},
+    )
+
+
+def _hussh_directive(*, kind: str, payload: dict[str, Any]) -> Any:
+    _ensure_hussh_package()
+    from hussh import A2ADirective as HusshA2ADirective
+
+    return HusshA2ADirective(kind=kind, payload=payload)
+
+
+def _hussh_result(
+    *,
+    conversation_id: str | None,
+    text: str,
+    directive: Any = None,
+    is_complete: bool,
+    model: str,
+    metadata: dict[str, Any],
+) -> Any:
+    _ensure_hussh_package()
+    from hussh import A2AResult as HusshA2AResult
+
+    return HusshA2AResult(
+        conversation_id=conversation_id or "",
+        text=text,
+        directive=directive,
+        is_complete=is_complete,
+        model=model,
+        metadata=metadata,
+    )
+
+
+def _research_result(result: Any) -> SpecialistTurnResult:
+    directive = None
+    if result.directive is not None:
+        directive = A2ADirective(
+            kind=result.directive.kind,
+            payload=result.directive.payload,
+        )
+    return SpecialistTurnResult(
+        conversation_id=result.conversation_id,
+        text=result.text,
+        directive=directive,
+        is_complete=result.is_complete,
+        state_changed=result.state_changed,
+        model=result.model or DELEGATED_MODEL,
+    )
+
+
+def _ensure_hussh_package() -> None:
+    try:
+        import hussh  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        checkout_path = (
+            Path(__file__).resolve().parents[3].parent / "hussh.dev" / "packages" / "sdk"
+        )
+        if checkout_path.exists() and str(checkout_path) not in sys.path:
+            sys.path.insert(0, str(checkout_path))

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -3591,40 +3591,67 @@ class OneLocationAgentService:
             UPDATE one_location_share_grants
             SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
             WHERE id = CAST(:grant_id AS UUID)
-              AND owner_user_id = :owner_user_id
+              AND (owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id)
               AND status = 'active'
             RETURNING *
             """,
             {"owner_user_id": owner_user_id, "grant_id": grant_id},
         )
         if not row:
-            raise OneLocationAgentError(
-                "LOCATION_GRANT_NOT_FOUND", "Active location share was not found.", status_code=404
+            existing_row = self._execute_one(
+                """
+                SELECT *
+                FROM one_location_share_grants
+                WHERE id = CAST(:grant_id AS UUID)
+                  AND (owner_user_id = :owner_user_id OR recipient_user_id = :owner_user_id)
+                LIMIT 1
+                """,
+                {"owner_user_id": owner_user_id, "grant_id": grant_id},
             )
+            if existing_row:
+                return self._grant_payload(existing_row) or {}
+            raise OneLocationAgentError(
+                "LOCATION_GRANT_NOT_FOUND", "Location share was not found.", status_code=404
+            )
+        actor_is_owner = str(row.get("owner_user_id") or "") == owner_user_id
+        recipient_user_id = str(row.get("recipient_user_id") or "") or None
         self._insert_event(
-            owner_user_id=owner_user_id,
+            owner_user_id=str(row.get("owner_user_id") or owner_user_id),
             actor_user_id=owner_user_id,
-            recipient_user_id=str(row.get("recipient_user_id") or "") or None,
+            recipient_user_id=recipient_user_id,
             grant_id=grant_id,
             event_type="location_share_revoked",
-            metadata={"reason": "owner_revoke"},
+            metadata={"reason": "owner_revoke" if actor_is_owner else "recipient_revoke"},
         )
-        owner_identity = self._identity_row(owner_user_id)
+        owner_identity = self._identity_row(str(row.get("owner_user_id") or owner_user_id))
         owner_label = _identity_display_label(owner_identity)
+        recipient_identity = self._identity_row(recipient_user_id or "")
+        recipient_label = _identity_display_label(recipient_identity)
+        notification_user_id = (
+            recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")
+        )
         self._send_metadata_notification(
-            user_id=str(row.get("recipient_user_id") or ""),
+            user_id=notification_user_id,
             notification_type="location_share_revoked",
             title="Location access revoked",
-            body=f"{owner_label} removed your location access.",
+            body=(
+                f"{owner_label} removed your location access."
+                if actor_is_owner
+                else f"{recipient_label} stopped receiving your location share."
+            ),
             notification_tag=f"one-location-revoked:{grant_id}",
-            request_url=_one_location_url(grantId=grant_id, section="shared"),
+            request_url=_one_location_url(
+                grantId=grant_id, section="shared" if actor_is_owner else "people"
+            ),
             data={
                 "grant_id": grant_id,
-                "owner_user_id": owner_user_id,
+                "owner_user_id": str(row.get("owner_user_id") or owner_user_id),
                 "owner_display_label": owner_label,
                 "owner_masked_phone": _mask_phone(owner_identity.get("phone_number"))
                 if owner_identity
                 else None,
+                "recipient_user_id": recipient_user_id,
+                "recipient_display_label": recipient_label,
             },
         )
         return self._grant_payload(row) or {}

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -756,6 +756,12 @@ class FourUserMemoryService(OneLocationAgentService):
             return row
         if "FROM one_location_share_grants" in sql and "owner_user_id = :owner_user_id" in sql:
             grant = self.grants.get(params["grant_id"])
+            if (
+                "recipient_user_id = :owner_user_id" in sql
+                and grant
+                and params["owner_user_id"] in {grant["owner_user_id"], grant["recipient_user_id"]}
+            ):
+                return grant
             if grant and grant["owner_user_id"] == params["owner_user_id"]:
                 return grant
             return None
@@ -1062,7 +1068,13 @@ class FourUserMemoryService(OneLocationAgentService):
             grant = self.grants.get(params["grant_id"])
             if (
                 grant
-                and grant["owner_user_id"] == params["owner_user_id"]
+                and (
+                    grant["owner_user_id"] == params["owner_user_id"]
+                    or (
+                        "recipient_user_id = :owner_user_id" in sql
+                        and grant["recipient_user_id"] == params["owner_user_id"]
+                    )
+                )
                 and grant["status"] == "active"
             ):
                 grant["status"] = "revoked"
@@ -1552,6 +1564,43 @@ def test_four_user_location_workflow_contract() -> None:
     assert "longitude" not in serialized_state
 
 
+def test_location_grant_recipient_can_mark_share_revoked() -> None:
+    service = FourUserMemoryService()
+    for user_id in ("user_a", "user_b", "user_c"):
+        service.register_recipient_key(
+            user_id=user_id,
+            key_id=f"key-{user_id}",
+            public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
+        )
+
+    grant = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=1,
+    )
+
+    with pytest.raises(OneLocationAgentError) as unrelated:
+        service.revoke_grant(owner_user_id="user_c", grant_id=grant["id"])
+    assert unrelated.value.code == "LOCATION_GRANT_NOT_FOUND"
+
+    revoked = service.revoke_grant(owner_user_id="user_b", grant_id=grant["id"])
+
+    assert revoked["status"] == "revoked"
+    assert service.grants[grant["id"]]["status"] == "revoked"
+    revoke_events = [
+        event
+        for event in service.events.values()
+        if event["event_type"] == "location_share_revoked"
+    ]
+    assert revoke_events[-1]["actor_user_id"] == "user_b"
+    assert revoke_events[-1]["metadata"]["reason"] == "recipient_revoke"
+    assert service.notifications[-1]["user_id"] == "user_a"
+
+    already_revoked = service.revoke_grant(owner_user_id="user_b", grant_id=grant["id"])
+    assert already_revoked["status"] == "revoked"
+
+
 def test_location_request_creation_does_not_require_requester_key_material() -> None:
     service = FourUserMemoryService()
     service.register_recipient_key(
@@ -1910,7 +1959,6 @@ def test_explicit_network_connection_overrides_marketplace_visibility_off() -> N
 
 
 def test_public_invite_submission_limits_bound_duplicate_phone_requests() -> None:
-
     service = FourUserMemoryService()
     service.register_recipient_key(
         user_id="user_b",

--- a/consent-protocol/tests/test_a2a_delegation_scopes.py
+++ b/consent-protocol/tests/test_a2a_delegation_scopes.py
@@ -19,6 +19,7 @@ def test_specialist_a2a_scope_map_uses_least_privilege_scopes() -> None:
         "agent_kai": ConsentScope.AGENT_KAI_ANALYZE,
         "agent_nav": ConsentScope.AGENT_NAV_REVIEW,
         "agent_kyc": ConsentScope.AGENT_KYC_PROCESS,
+        "agent_location": ConsentScope.AGENT_ONE_ORCHESTRATE,
     }
     assert ConsentScope.VAULT_OWNER not in SPECIALIST_A2A_SCOPE_MAP.values()
 

--- a/consent-protocol/tests/test_agent_chat_routes.py
+++ b/consent-protocol/tests/test_agent_chat_routes.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes.kai import agent_chat
+from hushh_mcp.adk_bridge.contract import SpecialistTurnResult
 from hushh_mcp.services.agent_chat_service import (
     AgentChatActionPlan,
     AgentChatConversation,
@@ -18,6 +19,7 @@ from hushh_mcp.services.agent_chat_service import (
 class _FakeAgentChatService:
     def __init__(self):
         self.saved_messages: list[dict] = []
+        self.prepared_messages: list[str] = []
         self.next_action_plan: AgentChatActionPlan | None = None
         self.prepared_turns = 0
         self.runtime_contract_calls: list[dict] = []
@@ -118,8 +120,8 @@ class _FakeAgentChatService:
 
     async def prepare_turn(self, *, user_id: str, message: str, conversation_id: str | None = None):
         assert user_id == "user-1"
-        assert message == "Hello Agent"
         assert conversation_id is None
+        self.prepared_messages.append(message)
         self.prepared_turns += 1
         return PreparedAgentChatTurn(
             conversation_id="conversation-1",
@@ -257,6 +259,61 @@ def test_agent_chat_stream_sends_token_events_and_saves_assistant(monkeypatch):
             "content": "Hello from Gemini",
             "status": "complete",
             "model": "gemini-2.5-pro",
+            "error_code": None,
+        }
+    ]
+
+
+def test_agent_chat_delegated_stream_saves_specialist_response(monkeypatch):
+    service = _FakeAgentChatService()
+    monkeypatch.setattr(agent_chat, "get_agent_chat_service", lambda: service)
+    monkeypatch.setattr(agent_chat, "resolve_delegate_target", lambda _message: "agent_nav")
+    monkeypatch.setattr(agent_chat, "is_wired_specialist", lambda agent_id: agent_id == "agent_nav")
+
+    import hushh_mcp.adk_bridge.dispatch as dispatch_module
+
+    async def _dispatch(agent_id, task):  # noqa: ANN001
+        assert agent_id == "agent_nav"
+        assert task.user_id == "user-1"
+        assert task.conversation_id == "conversation-1"
+        assert task.message == "show all my consent requests approved"
+        assert task.timezone == "America/Los_Angeles"
+        return SpecialistTurnResult(
+            conversation_id="conversation-1",
+            text="You have 1 approved consent request active right now.",
+            directive=None,
+            is_complete=True,
+            state_changed=False,
+            model="one+nav",
+        )
+
+    monkeypatch.setattr(dispatch_module, "dispatch", _dispatch)
+    client = _client(service)
+
+    response = client.post(
+        "/agent/chat/stream",
+        json={
+            "user_id": "user-1",
+            "message": "show all my consent requests approved",
+            "timezone": "America/Los_Angeles",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-agent-conversation-id"] == "conversation-1"
+    assert (
+        'event: token\ndata: {"token": "You have 1 approved consent request active right now."}'
+        in response.text
+    )
+    assert service.prepared_messages == ["show all my consent requests approved"]
+    assert service.saved_messages == [
+        {
+            "conversation_id": "conversation-1",
+            "user_id": "user-1",
+            "role": "assistant",
+            "content": "You have 1 approved consent request active right now.",
+            "status": "complete",
+            "model": "one+nav",
             "error_code": None,
         }
     ]

--- a/consent-protocol/tests/test_nav_a2a_agent.py
+++ b/consent-protocol/tests/test_nav_a2a_agent.py
@@ -59,11 +59,16 @@ async def test_nav_agent_lists_approved_consent_requests(monkeypatch):
             "total": 2,
             "items": [
                 {
-                    "id": "grant_1",
+                    "id": "one_location_grant:grant_1",
                     "request_id": "req_1",
                     "counterpart_label": "Travel Planner",
                     "scope": "cap.location.live.view",
                     "expires_at": "2026-07-04T01:53:37.924978+00:00",
+                    "metadata": {
+                        "request_source": "one_location_share_grant",
+                        "section": "people",
+                        "grant_id": "grant_1",
+                    },
                 },
                 {
                     "id": "grant_2",
@@ -89,13 +94,172 @@ async def test_nav_agent_lists_approved_consent_requests(monkeypatch):
         )
     )
 
-    assert result.directive is None
+    assert result.directive is not None
+    assert result.directive.kind == "prompt"
+    assert result.directive.payload["kind"] == "consent_actions"
+    assert result.directive.payload["items"] == [
+        {
+            "id": "one_location_grant:grant_1",
+            "label": "Travel Planner",
+            "summary": "Travel Planner can view your live location",
+            "scope": "cap.location.live.view",
+            "expiresAt": "2026-07-04T01:53:37.924978+00:00",
+            "metadata": {
+                "request_source": "one_location_share_grant",
+                "section": "people",
+                "grant_id": "grant_1",
+            },
+            "actions": ["revoke", "details"],
+        }
+    ]
     assert "You have 2 approved consent requests active right now" in result.text
     assert "Travel Planner can view your live location until" in result.text
     assert "6:53 PM PDT" in result.text
     assert "1:53 AM UTC" not in result.text
     assert "Request req_1" not in result.text
     assert "Kai can access portfolio summary" in result.text
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_offers_revoke_for_location_grants_without_section(monkeypatch):
+    async def _list_center(self, user_id, **kwargs):  # noqa: ANN001,ARG001
+        return {
+            "total": 1,
+            "items": [
+                {
+                    "id": "one_location_grant:grant_1",
+                    "counterpart_label": "Gautam Ahuja",
+                    "scope": "cap.location.live.view",
+                    "metadata": {
+                        "request_source": "one_location_share_grant",
+                        "grant_id": "grant_1",
+                    },
+                },
+            ],
+        }
+
+    monkeypatch.setattr(ConsentCenterService, "list_center", _list_center)
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    result = await NavAgent().handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="show all my consent requests approved",
+        )
+    )
+
+    assert result.directive is not None
+    assert result.directive.payload["items"][0]["actions"] == ["revoke", "details"]
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_treats_all_consent_requests_as_list_query(monkeypatch):
+    async def _list_center(self, user_id, **kwargs):  # noqa: ANN001,ARG001
+        return {"total": 0, "items": []}
+
+    monkeypatch.setattr(ConsentCenterService, "list_center", _list_center)
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    result = await NavAgent().handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="show me all my consent requests",
+        )
+    )
+
+    assert result.text == "You do not have any approved consent requests right now."
+    assert "You are Nav" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_offers_revoke_for_shared_location_grants(monkeypatch):
+    async def _list_center(self, user_id, **kwargs):  # noqa: ANN001,ARG001
+        return {
+            "total": 1,
+            "items": [
+                {
+                    "id": "one_location_grant:grant_shared",
+                    "counterpart_label": "Gautam Ahuja",
+                    "scope": "cap.location.live.view",
+                    "metadata": {
+                        "request_source": "one_location_share_grant",
+                        "section": "shared",
+                        "grant_id": "grant_shared",
+                    },
+                },
+            ],
+        }
+
+    monkeypatch.setattr(ConsentCenterService, "list_center", _list_center)
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    result = await NavAgent().handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="show all my consent requests approved",
+        )
+    )
+
+    assert result.directive is not None
+    assert result.directive.payload["items"][0]["actions"] == ["revoke", "details"]
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_lists_revoked_consent_requests(monkeypatch):
+    async def _list_center(self, user_id, **kwargs):  # noqa: ANN001
+        assert user_id == "user_nav"
+        assert kwargs["actor"] == "investor"
+        assert kwargs["surface"] == "previous"
+        return {
+            "total": 1,
+            "items": [
+                {
+                    "id": "one_location_grant:grant_1",
+                    "counterpart_label": "JHUMMA KUMARI",
+                    "scope": "cap.location.live.view",
+                    "status": "revoked",
+                    "revoked_at": "2026-07-04T01:53:37.924978+00:00",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(ConsentCenterService, "list_center", _list_center)
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    result = await NavAgent().handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="what about revoked requests",
+            timezone="America/Los_Angeles",
+        )
+    )
+
+    assert result.directive is None
+    assert "You have 1 previous consent request" in result.text
+    assert "JHUMMA KUMARI had access to view your live location" in result.text
+    assert "6:53 PM PDT" in result.text
+    assert "You are Nav" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_generic_response_does_not_echo_manifest_instruction():
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    result = await NavAgent().handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="explain consent boundaries",
+        )
+    )
+
+    assert "You are Nav" not in result.text
+    assert "Do not provide finance analysis" not in result.text
+    assert "I can help review consent requests" in result.text
 
 
 @pytest.mark.asyncio

--- a/consent-protocol/tests/test_nav_a2a_agent.py
+++ b/consent-protocol/tests/test_nav_a2a_agent.py
@@ -1,0 +1,141 @@
+import pytest
+
+from hushh_mcp.adk_bridge.contract import A2ATask
+from hushh_mcp.adk_bridge.dispatch import dispatch, is_wired_specialist
+from hushh_mcp.adk_bridge.nav_agent import NavAgent
+from hushh_mcp.consent.token import issue_token
+from hushh_mcp.constants import ConsentScope
+from hushh_mcp.services.consent_center_service import ConsentCenterService
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_returns_consent_required_directive_without_review_scope():
+    agent = NavAgent()
+
+    result = await agent.handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token="",
+            conversation_id="thread_nav",
+            message="Who has access to my vault?",
+        )
+    )
+
+    assert result.conversation_id == "thread_nav"
+    assert result.model == "one+nav"
+    assert result.directive is not None
+    assert result.directive.kind == "prompt"
+    assert result.directive.payload["requiredScope"] == ConsentScope.AGENT_NAV_REVIEW.value
+    assert "cannot review" in result.text
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_answers_inline_with_review_scope():
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    agent = NavAgent()
+
+    result = await agent.handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="Who has access to my vault?",
+        )
+    )
+
+    assert result.conversation_id == "thread_nav"
+    assert result.model == "one+nav"
+    assert result.directive is None
+    assert result.text == "You do not have any approved consent requests right now."
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_lists_approved_consent_requests(monkeypatch):
+    async def _list_center(self, user_id, **kwargs):  # noqa: ANN001
+        assert user_id == "user_nav"
+        assert kwargs["actor"] == "investor"
+        assert kwargs["surface"] == "active"
+        return {
+            "total": 2,
+            "items": [
+                {
+                    "id": "grant_1",
+                    "request_id": "req_1",
+                    "counterpart_label": "Travel Planner",
+                    "scope": "cap.location.live.view",
+                    "expires_at": "2026-07-04T01:53:37.924978+00:00",
+                },
+                {
+                    "id": "grant_2",
+                    "request_id": "req_2",
+                    "counterpart_label": "Kai",
+                    "scope": "attr.financial.portfolio.*",
+                    "scope_description": "Portfolio summary",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(ConsentCenterService, "list_center", _list_center)
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    agent = NavAgent()
+
+    result = await agent.handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="show all my consent requests approved",
+            timezone="America/Los_Angeles",
+        )
+    )
+
+    assert result.directive is None
+    assert "You have 2 approved consent requests active right now" in result.text
+    assert "Travel Planner can view your live location until" in result.text
+    assert "6:53 PM PDT" in result.text
+    assert "1:53 AM UTC" not in result.text
+    assert "Request req_1" not in result.text
+    assert "Kai can access portfolio summary" in result.text
+
+
+@pytest.mark.asyncio
+async def test_nav_agent_lists_empty_approved_consent_requests(monkeypatch):
+    async def _list_center(self, user_id, **kwargs):  # noqa: ANN001,ARG001
+        return {"total": 0, "items": []}
+
+    monkeypatch.setattr(ConsentCenterService, "list_center", _list_center)
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    agent = NavAgent()
+
+    result = await agent.handle(
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="show all my consent requests approved",
+        )
+    )
+
+    assert result.text == "You do not have any approved consent requests right now."
+
+
+@pytest.mark.asyncio
+async def test_nav_is_registered_without_replacing_location():
+    import hushh_mcp.adk_bridge  # noqa: F401
+
+    assert is_wired_specialist("agent_location") is True
+    assert is_wired_specialist("agent_nav") is True
+
+    token = issue_token("user_nav", "agent_nav", ConsentScope.AGENT_NAV_REVIEW).token
+    result = await dispatch(
+        "agent_nav",
+        A2ATask(
+            user_id="user_nav",
+            consent_token=token,
+            conversation_id="thread_nav",
+            message="Explain this scope.",
+        ),
+    )
+
+    assert result.model == "one+nav"
+    assert "Explain this scope." in result.text

--- a/hushh-webapp/__tests__/components/specialist-directive-card.test.tsx
+++ b/hushh-webapp/__tests__/components/specialist-directive-card.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SpecialistConsentActionsCard,
+  SpecialistConsentRequiredCard,
+} from "@/components/agent/specialist-directive-card";
+
+describe("SpecialistConsentRequiredCard", () => {
+  it("renders the agent permission request and actions", () => {
+    const onOpenConsent = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <SpecialistConsentRequiredCard
+        agentId="agent_nav"
+        requiredScope="agent.nav.review"
+        reason="missing_scope"
+        onOpenConsent={onOpenConsent}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByTestId("specialist-consent-required-card")).toBeTruthy();
+    expect(screen.getByText("Nav needs permission")).toBeTruthy();
+    expect(screen.getByText(/review your consent and privacy access/)).toBeTruthy();
+    expect(screen.getByText("missing_scope")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("specialist-consent-open"));
+    expect(onOpenConsent).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("specialist-consent-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SpecialistConsentActionsCard", () => {
+  it("renders revoke and details actions for active consent items", () => {
+    const onRevoke = vi.fn();
+    const onDetails = vi.fn();
+    const item = {
+      id: "one_location_grant:grant_1",
+      label: "Gautam Ahuja",
+      summary: "Gautam Ahuja can view your live location",
+      scope: "cap.location.live.view",
+      expiresAt: "2026-07-04T01:53:37.924978+00:00",
+      metadata: {
+        request_source: "one_location_share_grant",
+        grant_id: "grant_1",
+      },
+      actions: ["revoke", "details"],
+    };
+
+    render(
+      <SpecialistConsentActionsCard
+        items={[item]}
+        onRevoke={onRevoke}
+        onDetails={onDetails}
+      />,
+    );
+
+    expect(screen.getByTestId("specialist-consent-actions-card")).toBeTruthy();
+    expect(screen.getByText("Manage access")).toBeTruthy();
+    expect(screen.getByText("Gautam Ahuja")).toBeTruthy();
+    expect(screen.getByText(/^Until /)).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("specialist-consent-revoke"));
+    expect(onRevoke).toHaveBeenCalledWith(item);
+
+    fireEvent.click(screen.getByTestId("specialist-consent-details"));
+    expect(onDetails).toHaveBeenCalledWith(item);
+  });
+
+  it("renders revoke for shared location grants too", () => {
+    const onRevoke = vi.fn();
+    const onDetails = vi.fn();
+    const item = {
+      id: "one_location_grant:grant_shared",
+      label: "Gautam Ahuja",
+      summary: "Gautam Ahuja can view your live location",
+      scope: "cap.location.live.view",
+      metadata: {
+        request_source: "one_location_share_grant",
+        grant_id: "grant_shared",
+        section: "shared",
+      },
+      actions: ["details"],
+    };
+
+    render(
+      <SpecialistConsentActionsCard
+        items={[item]}
+        onRevoke={onRevoke}
+        onDetails={onDetails}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("specialist-consent-revoke"));
+    expect(onRevoke).toHaveBeenCalledWith(item);
+
+    fireEvent.click(screen.getByTestId("specialist-consent-details"));
+    expect(onDetails).toHaveBeenCalledWith(item);
+  });
+
+  it("renders revoke for active location grants even when an older payload only lists details", () => {
+    const onRevoke = vi.fn();
+    const onDetails = vi.fn();
+    const item = {
+      id: "one_location_grant:grant_1",
+      label: "Gautam Ahuja",
+      summary: "Gautam Ahuja can view your live location",
+      scope: "cap.location.live.view",
+      metadata: {
+        request_source: "one_location_share_grant",
+        grant_id: "grant_1",
+      },
+      actions: ["details"],
+    };
+
+    render(
+      <SpecialistConsentActionsCard
+        items={[item]}
+        onRevoke={onRevoke}
+        onDetails={onDetails}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("specialist-consent-revoke"));
+    expect(onRevoke).toHaveBeenCalledWith(item);
+  });
+
+  it("renders revoked items with a disabled revoked button", () => {
+    const onRevoke = vi.fn();
+    const onDetails = vi.fn();
+    const item = {
+      id: "one_location_grant:grant_1",
+      label: "Gautam Ahuja",
+      summary: "Gautam Ahuja can no longer view your live location",
+      scope: "cap.location.live.view",
+      metadata: {
+        request_source: "one_location_share_grant",
+        grant_id: "grant_1",
+      },
+      actions: ["details"],
+      status: "revoked",
+    } as const;
+
+    render(
+      <SpecialistConsentActionsCard
+        items={[item]}
+        onRevoke={onRevoke}
+        onDetails={onDetails}
+      />,
+    );
+
+    expect(screen.getAllByText("Revoked")).toHaveLength(2);
+    expect(
+      (screen.getByTestId("specialist-consent-revoked") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(screen.queryByTestId("specialist-consent-revoke")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("specialist-consent-details"));
+    expect(onDetails).toHaveBeenCalledWith(item);
+    expect(onRevoke).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/services/agent-chat-client-specialist.test.ts
+++ b/hushh-webapp/__tests__/services/agent-chat-client-specialist.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { consumeAgentChatStream } from "@/lib/services/agent-chat-client";
+
+function sse(...frames: Array<[string, unknown]>): Response {
+  const body = frames.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+  return new Response(body, { headers: { "content-type": "text/event-stream" } });
+}
+
+describe("agent chat specialist directives", () => {
+  it("preserves consent-required prompt payloads", async () => {
+    const onSpecialistDirective = vi.fn();
+
+    await consumeAgentChatStream(
+      sse(
+        ["start", { conversation_id: "c1", model: "one+nav" }],
+        ["token", { token: "Nav needs permission." }],
+        [
+          "specialist_directive",
+          {
+            delegate_agent_id: "agent_nav",
+            directive: {
+              kind: "prompt",
+              payload: {
+                kind: "consent_required",
+                agentId: "agent_nav",
+                requiredScope: "agent.nav.review",
+                reason: "missing_scope",
+              },
+            },
+            message: "Nav needs permission.",
+            state_changed: false,
+          },
+        ],
+        ["complete", { conversation_id: "c1", status: "complete", model: "one+nav" }],
+      ),
+      { onSpecialistDirective },
+    );
+
+    expect(onSpecialistDirective).toHaveBeenCalledWith({
+      delegateAgentId: "agent_nav",
+      directive: {
+        kind: "prompt",
+        payload: {
+          kind: "consent_required",
+          agentId: "agent_nav",
+          requiredScope: "agent.nav.review",
+          reason: "missing_scope",
+        },
+      },
+      message: "Nav needs permission.",
+      stateChanged: false,
+    });
+  });
+
+  it("preserves consent action prompt payloads", async () => {
+    const onSpecialistDirective = vi.fn();
+
+    await consumeAgentChatStream(
+      sse(
+        ["start", { conversation_id: "c1", model: "one+nav" }],
+        ["token", { token: "You have approved access." }],
+        [
+          "specialist_directive",
+          {
+            delegate_agent_id: "agent_nav",
+            directive: {
+              kind: "prompt",
+              payload: {
+                kind: "consent_actions",
+                items: [
+                  {
+                    id: "one_location_grant:grant_1",
+                    label: "Gautam Ahuja",
+                    scope: "cap.location.live.view",
+                    actions: ["revoke", "details"],
+                  },
+                ],
+              },
+            },
+            message: "You have approved access.",
+            state_changed: false,
+          },
+        ],
+        ["complete", { conversation_id: "c1", status: "complete", model: "one+nav" }],
+      ),
+      { onSpecialistDirective },
+    );
+
+    expect(onSpecialistDirective).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegateAgentId: "agent_nav",
+        directive: expect.objectContaining({
+          kind: "prompt",
+          payload: expect.objectContaining({
+            kind: "consent_actions",
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                id: "one_location_grant:grant_1",
+                actions: ["revoke", "details"],
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/services/agent-chat-client.test.ts
+++ b/hushh-webapp/__tests__/services/agent-chat-client.test.ts
@@ -87,8 +87,11 @@ describe("agent chat client", () => {
       conversationId: undefined,
       vaultOwnerToken: "vault-token",
       pkmContext: undefined,
+      screenContext: undefined,
+      timezone: expect.any(String),
       runtimeCredential: undefined,
       runtimeCredentialMode: undefined,
+      delegateResult: undefined,
       signal: undefined,
     });
   });
@@ -116,8 +119,11 @@ describe("agent chat client", () => {
       conversationId: undefined,
       vaultOwnerToken: "vault-token",
       pkmContext: "Saved domains: Financial",
+      screenContext: undefined,
+      timezone: expect.any(String),
       runtimeCredential: "USER_BYOK_KEY",
       runtimeCredentialMode: "byok",
+      delegateResult: undefined,
       signal: undefined,
     });
   });

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -35,7 +35,13 @@ import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
 import { AgentPkmReviewPanel } from "@/components/agent/agent-pkm-review-panel";
-import { SpecialistDirectiveCard, SpecialistPromptCard } from "@/components/agent/specialist-directive-card";
+import {
+  SpecialistConsentActionsCard,
+  SpecialistConsentRequiredCard,
+  SpecialistDirectiveCard,
+  SpecialistPromptCard,
+  type SpecialistConsentActionItem,
+} from "@/components/agent/specialist-directive-card";
 import { SelectionChip } from "@/components/agent/selection-chip";
 import { describeSelection } from "@/lib/agent/describe-selection";
 import type { ClientPrompt } from "@/lib/one-location/types";
@@ -102,6 +108,7 @@ import { runLocationDirective, type DelegateResult } from "@/lib/agent/specialis
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
+import { useOneLocationConsentActions } from "@/lib/consent/use-one-location-consent-actions";
 import { useVault } from "@/lib/vault/vault-context";
 import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
@@ -118,6 +125,7 @@ type AgentMessage = {
   status?: "streaming" | "done" | "error";
   ephemeral?: boolean;
   kind?: "selection";
+  specialistDirective?: SpecialistDirectiveEvent | null;
 };
 
 type AgentDebugEvent = {
@@ -154,6 +162,18 @@ type AgentRunTurnOptions = {
   replaceAssistantMessageId?: string | null;
 };
 
+type ConsentRequiredDirectivePayload = {
+  kind: "consent_required";
+  agentId?: string;
+  requiredScope?: string;
+  reason?: string;
+};
+
+type ConsentActionsDirectivePayload = {
+  kind: "consent_actions";
+  items: SpecialistConsentActionItem[];
+};
+
 export type AgentChatWorkspaceVariant = "page" | "popover";
 
 type AgentChatWorkspaceProps = {
@@ -181,6 +201,114 @@ const EMPTY_PKM_CONTEXT: AgentPkmContext = {
 };
 const AGENT_STREAM_RENDER_FRAME_MS = 32;
 const VOICE_PKM_CONTEXT_DEADLINE_MS = 650;
+
+function getConsentRequiredPayload(
+  event: SpecialistDirectiveEvent | null,
+): ConsentRequiredDirectivePayload | null {
+  if (!event || event.directive.kind !== "prompt") return null;
+  const payload = event.directive.payload as Record<string, unknown>;
+  if (payload.kind !== "consent_required") return null;
+  return {
+    kind: "consent_required",
+    agentId: typeof payload.agentId === "string" ? payload.agentId : event.delegateAgentId,
+    requiredScope: typeof payload.requiredScope === "string" ? payload.requiredScope : "",
+    reason: typeof payload.reason === "string" ? payload.reason : undefined,
+  };
+}
+
+function getConsentActionsPayload(
+  event: SpecialistDirectiveEvent | null,
+): ConsentActionsDirectivePayload | null {
+  if (!event || event.directive.kind !== "prompt") return null;
+  const payload = event.directive.payload as Record<string, unknown>;
+  if (payload.kind !== "consent_actions") return null;
+  const rawItems = Array.isArray(payload.items) ? payload.items : [];
+  const items = rawItems
+    .map((item) => (item && typeof item === "object" ? (item as Record<string, unknown>) : null))
+    .filter((item): item is Record<string, unknown> => Boolean(item))
+    .map((item) => ({
+      id: typeof item.id === "string" ? item.id : "",
+      label: typeof item.label === "string" ? item.label : "Approved access",
+      summary: typeof item.summary === "string" ? item.summary : null,
+      scope: typeof item.scope === "string" ? item.scope : null,
+      expiresAt: typeof item.expiresAt === "string" ? item.expiresAt : null,
+      status: typeof item.status === "string" ? item.status : null,
+      metadata:
+        item.metadata && typeof item.metadata === "object"
+          ? (item.metadata as Record<string, unknown>)
+          : null,
+      actions: normalizeConsentActions(item),
+    }))
+    .filter((item) => item.id && item.actions.length > 0);
+  return { kind: "consent_actions", items };
+}
+
+function normalizeConsentActions(item: Record<string, unknown>): string[] {
+  const rawActions = Array.isArray(item.actions)
+    ? item.actions.filter((action): action is string => typeof action === "string")
+    : [];
+  const metadata =
+    item.metadata && typeof item.metadata === "object"
+      ? (item.metadata as Record<string, unknown>)
+      : {};
+  const id = typeof item.id === "string" ? item.id : "";
+  const scope = typeof item.scope === "string" ? item.scope : "";
+  const requestSource =
+    typeof metadata.request_source === "string" ? metadata.request_source.trim() : "";
+  const isLocationGrant =
+    id.startsWith("one_location_grant:") ||
+    requestSource === "one_location_share_grant" ||
+    scope.startsWith("cap.location.");
+
+  if (!isLocationGrant) {
+    return rawActions;
+  }
+
+  const normalized = new Set(["revoke", ...rawActions, "details"]);
+  return Array.from(normalized);
+}
+
+function markConsentDirectiveItemRevoked(
+  event: SpecialistDirectiveEvent | null | undefined,
+  itemId: string,
+): SpecialistDirectiveEvent | null | undefined {
+  if (!event || event.directive.kind !== "prompt") return event;
+  const payload = event.directive.payload as Record<string, unknown>;
+  if (payload.kind !== "consent_actions" || !Array.isArray(payload.items)) return event;
+
+  let changed = false;
+  const nextItems = payload.items.map((rawItem) => {
+    if (!rawItem || typeof rawItem !== "object") return rawItem;
+    const item = rawItem as Record<string, unknown>;
+    if (item.id !== itemId) return rawItem;
+
+    changed = true;
+    const rawActions = Array.isArray(item.actions) ? item.actions : [];
+    const actions = rawActions.filter((action) => action !== "revoke");
+    if (!actions.includes("details")) actions.push("details");
+    const label = typeof item.label === "string" ? item.label : "This person";
+    const summary = `${label} can no longer view your live location`;
+
+    return {
+      ...item,
+      status: "revoked",
+      summary,
+      actions,
+    };
+  });
+
+  if (!changed) return event;
+  return {
+    ...event,
+    directive: {
+      ...event.directive,
+      payload: {
+        ...payload,
+        items: nextItems,
+      },
+    },
+  };
+}
 const VOICE_AGENT_FIRST_EVENT_TIMEOUT_MS = 25_000;
 const VOICE_AGENT_IDLE_TIMEOUT_MS = 45_000;
 const FOCUSABLE_SELECTOR =
@@ -512,10 +640,16 @@ function AgentBubble({
   message,
   onRetry,
   retryDisabled = false,
+  busyConsentItemId = null,
+  onConsentRevoke,
+  onConsentDetails,
 }: {
   message: AgentMessage;
   onRetry?: () => void;
   retryDisabled?: boolean;
+  busyConsentItemId?: string | null;
+  onConsentRevoke?: (item: SpecialistConsentActionItem) => Promise<void> | void;
+  onConsentDetails?: (item: SpecialistConsentActionItem) => void;
 }) {
   const [copied, setCopied] = useState(false);
   const [liked, setLiked] = useState(false);
@@ -526,6 +660,12 @@ function AgentBubble({
   const animated = useAnimatedAssistantText(message.text, !isUser && isStreaming);
   const assistantText = isUser ? message.text : animated.displayedText;
   const showStreamingAffordance = !isUser && animated.isAnimating;
+  const consentActionsPayload = !isUser
+    ? getConsentActionsPayload(message.specialistDirective ?? null)
+    : null;
+  const canRenderConsentActions = Boolean(
+    consentActionsPayload && onConsentRevoke && onConsentDetails,
+  );
   const showResponseActions =
     !isUser && !message.ephemeral && !isStreaming && assistantText.trim().length > 0;
 
@@ -572,6 +712,8 @@ function AgentBubble({
             <span className="whitespace-pre-wrap break-words">{message.text}</span>
           ) : assistantText ? (
             <AgentMarkdown text={assistantText} />
+          ) : canRenderConsentActions ? (
+            null
           ) : (
             <AgentThinkingDots />
           )}
@@ -656,6 +798,20 @@ function AgentBubble({
             </div>
           ) : null}
         </div>
+        {canRenderConsentActions && consentActionsPayload ? (
+          <div className="mt-4">
+            <SpecialistConsentActionsCard
+              items={consentActionsPayload.items}
+              busyItemId={busyConsentItemId}
+              onRevoke={(item) => {
+                void onConsentRevoke?.(item);
+              }}
+              onDetails={(item) => {
+                onConsentDetails?.(item);
+              }}
+            />
+          </div>
+        ) : null}
       </div>
       {isUser ? (
         <div className="mt-1 hidden h-7 w-7 shrink-0 place-items-center rounded-md border border-black/10 bg-black/[0.035] text-[rgba(0,0,0,0.56)] sm:grid dark:border-white/10 dark:bg-white/[0.04] dark:text-zinc-400">
@@ -800,6 +956,7 @@ export function AgentChatWorkspace({
   const [pendingSpecialistDirective, setPendingSpecialistDirective] =
     useState<SpecialistDirectiveEvent | null>(null);
   const [specialistBusy, setSpecialistBusy] = useState(false);
+  const [specialistBusyItemId, setSpecialistBusyItemId] = useState<string | null>(null);
   const [voiceState, setVoiceState] = useState<AgentVoiceStatus>("idle");
   const [voiceTranscriptReview, setVoiceTranscriptReview] =
     useState<AgentVoiceTranscriptReview | null>(null);
@@ -829,6 +986,12 @@ export function AgentChatWorkspace({
   const voiceTtsSpeakingRef = useRef(false);
   const pkmAbortControllersRef = useRef<Set<AbortController>>(new Set());
   const latestVisibleTurnIdRef = useRef<string | null>(null);
+  const oneLocationConsentActions = useOneLocationConsentActions({
+    userId: user?.uid,
+    onActionComplete: () => {
+      setPendingSpecialistDirective(null);
+    },
+  });
 
   const voiceActive = voiceState !== "idle";
   const voiceMuted = voiceState === "muted";
@@ -1197,6 +1360,7 @@ export function AgentChatWorkspace({
     setMessages([createGreetingMessage()]);
     setPendingSpecialistDirective(null);
     setSpecialistBusy(false);
+    setSpecialistBusyItemId(null);
     historyLoadKeyRef.current = null;
     latestVisibleTurnIdRef.current = null;
   }, [abortAgentTurnWork, resetGlobalVoiceState, user?.uid, isVaultUnlocked]);
@@ -2081,6 +2245,7 @@ export function AgentChatWorkspace({
     streamAbortControllerRef.current = streamAbortController;
     let voiceStreamTimeoutMessage: string | null = null;
     let voiceStreamWatchdog: ReturnType<typeof setTimeout> | null = null;
+    let specialistDirectiveReceived = false;
 
     const clearVoiceStreamWatchdog = () => {
       if (voiceStreamWatchdog !== null) {
@@ -2265,10 +2430,30 @@ export function AgentChatWorkspace({
           },
           onSpecialistDirective: (event) => {
             if (streamAbortController.signal.aborted) return;
+            specialistDirectiveReceived = true;
             // Store the directive as a pending card in the current message
             // stream. Security-sensitive: never auto-run an "action"; require
             // an explicit click on the rendered card.
             appendDebugEvent(debugTurnId, "specialist_directive", event);
+            flushAssistantDelta();
+            setIsChatLoading(false);
+            setIsStreaming(false);
+            if (getConsentActionsPayload(event)) {
+              updateMessage(assistantMessageId, (message) => ({
+                ...message,
+                text: message.text.trim() ? message.text : event.message || "",
+                status: "done",
+                specialistDirective: event,
+              }));
+              return;
+            }
+            setMessages((current) =>
+              current.flatMap((message) => {
+                if (message.id !== assistantMessageId) return [message];
+                if (!message.text.trim()) return [];
+                return [{ ...message, status: "done" }];
+              })
+            );
             setPendingSpecialistDirective(event);
           },
           onComplete: ({ conversationId: nextConversationId }) => {
@@ -2329,7 +2514,11 @@ export function AgentChatWorkspace({
           status: "done",
         };
       });
-      if (!pkmAddToolHandled && !EXPLICIT_PKM_SAVE_PATTERN.test(text)) {
+      if (
+        !specialistDirectiveReceived &&
+        !pkmAddToolHandled &&
+        !EXPLICIT_PKM_SAVE_PATTERN.test(text)
+      ) {
         const pkmAbortController = new AbortController();
         pkmAbortControllersRef.current.add(pkmAbortController);
         void runPkmMemoryCapture(turnPkmContext, pkmAbortController.signal).finally(() => {
@@ -2469,6 +2658,25 @@ export function AgentChatWorkspace({
           onSpecialistDirective: (event) => {
             if (streamAbortController.signal.aborted) return;
             appendDebugEvent(debugTurnId, "specialist_directive", event);
+            flushAssistantDelta();
+            setIsChatLoading(false);
+            setIsStreaming(false);
+            if (getConsentActionsPayload(event)) {
+              updateMessage(assistantMessageId, (message) => ({
+                ...message,
+                text: message.text.trim() ? message.text : event.message || "",
+                status: "done",
+                specialistDirective: event,
+              }));
+              return;
+            }
+            setMessages((current) =>
+              current.flatMap((message) => {
+                if (message.id !== assistantMessageId) return [message];
+                if (!message.text.trim()) return [];
+                return [{ ...message, status: "done" }];
+              })
+            );
             setPendingSpecialistDirective(event);
           },
           onComplete: ({ conversationId: nextConversationId }) => {
@@ -3225,7 +3433,25 @@ export function AgentChatWorkspace({
     [user?.displayName, user?.email]
   );
   const hasStartedConversation = messages.some((message) => message.id !== "agent-greeting");
-  const visibleMessages = messages.filter((message) => message.id !== "agent-greeting");
+  const visibleMessages = messages.filter((message) => {
+    if (message.id === "agent-greeting") return false;
+    if (
+      pendingSpecialistDirective &&
+      message.role === "assistant" &&
+      !message.text.trim()
+    ) {
+      return false;
+    }
+    return true;
+  });
+  const trailingSpecialistLoadingMessages = pendingSpecialistDirective
+    ? messages.filter(
+        (message) =>
+          message.id !== "agent-greeting" &&
+          message.role === "assistant" &&
+          !message.text.trim(),
+      )
+    : [];
   const latestRetryableAssistantId =
     [...visibleMessages]
       .reverse()
@@ -3521,6 +3747,31 @@ export function AgentChatWorkspace({
                         ? () => handleRetryAssistantResponse(message.id)
                         : undefined
                     }
+                    busyConsentItemId={specialistBusyItemId}
+                    onConsentRevoke={async (item) => {
+                      setSpecialistBusyItemId(item.id);
+                      try {
+                        await oneLocationConsentActions.handleRevoke({
+                          id: item.id,
+                          scope: item.scope ?? null,
+                          metadata: item.metadata ?? null,
+                        });
+                        updateMessage(message.id, (current) => ({
+                          ...current,
+                          specialistDirective: markConsentDirectiveItemRevoked(
+                            current.specialistDirective,
+                            item.id,
+                          ),
+                        }));
+                      } finally {
+                        setSpecialistBusyItemId(null);
+                      }
+                    }}
+                    onConsentDetails={(item) => {
+                      router.push(
+                        `${ROUTES.CONSENTS}?tab=active&requestId=${encodeURIComponent(item.id)}`,
+                      );
+                    }}
                   />
                 ),
               )}
@@ -3540,7 +3791,26 @@ export function AgentChatWorkspace({
               ))}
 
               {pendingSpecialistDirective ? (
-                pendingSpecialistDirective.directive.kind === "prompt" ? (
+                getConsentRequiredPayload(pendingSpecialistDirective) ? (
+                  <SpecialistConsentRequiredCard
+                    agentId={
+                      getConsentRequiredPayload(pendingSpecialistDirective)?.agentId ??
+                      pendingSpecialistDirective.delegateAgentId
+                    }
+                    requiredScope={
+                      getConsentRequiredPayload(pendingSpecialistDirective)?.requiredScope ?? ""
+                    }
+                    reason={getConsentRequiredPayload(pendingSpecialistDirective)?.reason}
+                    busy={specialistBusy}
+                    onOpenConsent={() => {
+                      setPendingSpecialistDirective(null);
+                      router.push(`${ROUTES.CONSENTS}?tab=pending`);
+                    }}
+                    onCancel={() => {
+                      setPendingSpecialistDirective(null);
+                    }}
+                  />
+                ) : pendingSpecialistDirective.directive.kind === "prompt" ? (
                   // ── Prompt / disambiguation mode ──────────────────────────
                   // The location specialist emits a clientPrompt (which/who?,
                   // confirm duration, etc.) as a directive.kind:"prompt".
@@ -3701,6 +3971,14 @@ export function AgentChatWorkspace({
                   />
                 )
               ) : null}
+
+              {trailingSpecialistLoadingMessages.map((message) => (
+                <AgentBubble
+                  key={message.id}
+                  message={message}
+                  retryDisabled={isChatLoading || isStreaming}
+                />
+              ))}
               <div ref={messagesEndRef} />
             </div>
           </div>

--- a/hushh-webapp/components/agent/specialist-directive-card.tsx
+++ b/hushh-webapp/components/agent/specialist-directive-card.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React from "react";
+import { ExternalLink, ShieldCheck, ShieldOff } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { ClarificationCard } from "@/components/one-location/redesign/clarification-card";
 import type { ClientPrompt } from "@/lib/one-location/types";
 
@@ -74,5 +76,243 @@ export function SpecialistPromptCard({
       onConfirm={onConfirm}
       onCancel={onCancel}
     />
+  );
+}
+
+// ─── Consent-required mode ───────────────────────────────────────────────────
+
+export type SpecialistConsentRequiredCardProps = {
+  agentId: string;
+  requiredScope: string;
+  reason?: string | null;
+  busy?: boolean;
+  onOpenConsent: () => void;
+  onCancel: () => void;
+};
+
+function agentDisplayName(agentId: string): string {
+  if (agentId === "agent_nav") return "Nav";
+  if (agentId === "agent_location") return "Location";
+  if (agentId === "agent_kai") return "Kai";
+  if (agentId === "agent_kyc") return "KYC";
+  return agentId.replace(/^agent_/, "").replace(/_/g, " ") || "This agent";
+}
+
+function scopeDisplayName(scope: string): string {
+  if (scope === "agent.nav.review") return "review your consent and privacy access";
+  if (scope === "agent.location.manage") return "manage One Location requests";
+  if (scope === "agent.one.orchestrate") return "coordinate specialist agents";
+  return scope || "the required permission";
+}
+
+export function SpecialistConsentRequiredCard({
+  agentId,
+  requiredScope,
+  reason,
+  busy,
+  onOpenConsent,
+  onCancel,
+}: SpecialistConsentRequiredCardProps) {
+  const agentName = agentDisplayName(agentId);
+  const scopeName = scopeDisplayName(requiredScope);
+
+  return (
+    <div
+      data-testid="specialist-consent-required-card"
+      className="rounded-2xl border border-[#6b8f71]/35 bg-[#6b8f71]/5 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[#6b8f71]/10 text-[#426548]">
+          <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-foreground">{agentName} needs permission</p>
+          <p className="mt-1 text-sm text-foreground/75">
+            Allow {agentName} to {scopeName} before it continues in this chat.
+          </p>
+          {reason ? <p className="mt-2 text-xs text-foreground/55">{reason}</p> : null}
+        </div>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button
+          data-testid="specialist-consent-open"
+          size="sm"
+          disabled={busy}
+          onClick={onOpenConsent}
+        >
+          <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+          Review access
+        </Button>
+        <Button
+          data-testid="specialist-consent-cancel"
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Consent actions mode ────────────────────────────────────────────────────
+
+export type SpecialistConsentActionItem = {
+  id: string;
+  label: string;
+  summary?: string | null;
+  scope?: string | null;
+  expiresAt?: string | null;
+  metadata?: Record<string, unknown> | null;
+  actions?: string[];
+  status?: "active" | "revoked" | string | null;
+};
+
+export type SpecialistConsentActionsCardProps = {
+  items: SpecialistConsentActionItem[];
+  busyItemId?: string | null;
+  onRevoke: (item: SpecialistConsentActionItem) => void;
+  onDetails: (item: SpecialistConsentActionItem) => void;
+};
+
+function formatConsentExpiry(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
+}
+
+function consentActionSet(item: SpecialistConsentActionItem): Set<string> {
+  const actions = new Set(item.actions ?? []);
+  if (item.status === "revoked") {
+    actions.delete("revoke");
+    actions.add("details");
+    return actions;
+  }
+
+  const requestSource =
+    typeof item.metadata?.request_source === "string"
+      ? item.metadata.request_source.trim()
+      : "";
+  const isLocationGrant =
+    item.id.startsWith("one_location_grant:") ||
+    requestSource === "one_location_share_grant" ||
+    String(item.scope || "").startsWith("cap.location.");
+
+  if (isLocationGrant) {
+    actions.add("revoke");
+    actions.add("details");
+  }
+
+  return actions;
+}
+
+export function SpecialistConsentActionsCard({
+  items,
+  busyItemId,
+  onRevoke,
+  onDetails,
+}: SpecialistConsentActionsCardProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      data-testid="specialist-consent-actions-card"
+      className="rounded-2xl border border-[#6b8f71]/35 bg-[#6b8f71]/5 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[#6b8f71]/10 text-[#426548]">
+          <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-foreground">Manage access</p>
+          <p className="mt-1 text-sm text-foreground/75">
+            Review or revoke approved access directly from this chat.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {items.map((item) => {
+          const actions = consentActionSet(item);
+          const busy = busyItemId === item.id;
+          const revoked = item.status === "revoked";
+          const expiry = formatConsentExpiry(item.expiresAt);
+          return (
+            <div
+              key={item.id}
+              className={
+                revoked
+                  ? "rounded-xl border border-black/10 bg-black/[0.025] p-3 opacity-80 dark:border-white/10 dark:bg-white/[0.03]"
+                  : "rounded-xl border border-black/10 bg-white/70 p-3 dark:border-white/10 dark:bg-white/[0.04]"
+              }
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-medium text-foreground">{item.label}</p>
+                {revoked ? (
+                  <span className="rounded-full border border-black/10 bg-black/[0.04] px-2 py-0.5 text-[11px] font-medium text-foreground/60 dark:border-white/10 dark:bg-white/[0.06]">
+                    Revoked
+                  </span>
+                ) : null}
+              </div>
+              {item.summary ? (
+                <p className="mt-1 text-sm text-foreground/70">{item.summary}</p>
+              ) : null}
+              {expiry ? (
+                <p className="mt-1 text-xs font-medium text-foreground/55">
+                  Until {expiry}
+                </p>
+              ) : null}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {actions.has("revoke") ? (
+                  <Button
+                    data-testid="specialist-consent-revoke"
+                    size="sm"
+                    variant="destructive"
+                    disabled={busy}
+                    isLoading={busy}
+                    onClick={() => onRevoke(item)}
+                  >
+                    <ShieldOff className="h-4 w-4" aria-hidden="true" />
+                    Revoke
+                  </Button>
+                ) : null}
+                {revoked ? (
+                  <Button
+                    data-testid="specialist-consent-revoked"
+                    size="sm"
+                    variant="ghost"
+                    disabled
+                  >
+                    <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                    Revoked
+                  </Button>
+                ) : null}
+                {actions.has("details") ? (
+                  <Button
+                    data-testid="specialist-consent-details"
+                    size="sm"
+                    variant="ghost"
+                    disabled={busy}
+                    onClick={() => onDetails(item)}
+                  >
+                    <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                    Details
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/hushh-webapp/lib/consent/use-one-location-consent-actions.ts
+++ b/hushh-webapp/lib/consent/use-one-location-consent-actions.ts
@@ -226,6 +226,7 @@ export function useOneLocationConsentActions(
             emitComplete({ action: "approve", requestId });
           } catch (error) {
             console.error("[OneLocationConsent] approve failed:", error);
+            throw error;
           }
         },
       );
@@ -267,6 +268,7 @@ export function useOneLocationConsentActions(
             emitComplete({ action: "deny", requestId });
           } catch (error) {
             console.error("[OneLocationConsent] deny failed:", error);
+            throw error;
           }
         },
       );
@@ -332,6 +334,7 @@ export function useOneLocationConsentActions(
             emitComplete({ action: "revoke", scope: scope || undefined });
           } catch (error) {
             console.error("[OneLocationConsent] revoke failed:", error);
+            throw error;
           }
         },
       );

--- a/hushh-webapp/lib/services/agent-chat-client.ts
+++ b/hushh-webapp/lib/services/agent-chat-client.ts
@@ -88,6 +88,17 @@ function formatAgentChatErrorMessage(message: string, code?: string): string {
   return message || "Agent chat failed. Please try again.";
 }
 
+function resolveBrowserTimeZone(): string | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function normalizeToolEvent(payload: Record<string, unknown>): AgentChatToolEvent {
   return {
     callId: readString(payload, "call_id"),
@@ -130,6 +141,7 @@ export async function streamAgentChat(input: {
   signal?: AbortSignal;
   handlers?: AgentChatStreamHandlers;
 }): Promise<{ conversationId: string | null; model: string | null; text: string }> {
+  const timezone = resolveBrowserTimeZone();
   const response = await ApiService.streamAgentChat({
     userId: input.userId,
     message: input.message,
@@ -137,6 +149,7 @@ export async function streamAgentChat(input: {
     vaultOwnerToken: input.vaultOwnerToken,
     pkmContext: input.pkmContext,
     screenContext: input.screenContext,
+    ...(timezone ? { timezone } : {}),
     runtimeCredential: input.runtimeCredential,
     runtimeCredentialMode: input.runtimeCredentialMode,
     delegateResult: input.delegateResult,

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -2612,6 +2612,7 @@ export class ApiService {
     vaultOwnerToken: string;
     pkmContext?: string;
     screenContext?: Record<string, unknown> | null;
+    timezone?: string;
     runtimeCredential?: string | null;
     runtimeCredentialMode?: string | null;
     delegateResult?: Record<string, unknown>;
@@ -2628,6 +2629,7 @@ export class ApiService {
         conversation_id: data.conversationId,
         pkm_context: data.pkmContext,
         screen_context: data.screenContext || undefined,
+        timezone: data.timezone || undefined,
         runtime_credential: data.runtimeCredential || undefined,
         runtime_credential_mode: data.runtimeCredentialMode || undefined,
         delegate_result: data.delegateResult || undefined,


### PR DESCRIPTION
# Description

Briefly explain what you changed and why.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [ ] Listed below:

- API / schema / type changes:
  - [ ] None
  - [ ] Listed below:

- Cache keys touched:
  - [ ] None
  - [ ] Listed below:

- Runtime DB data-plane changes:
  - [ ] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [ ] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [ ] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [ ] None
  - [ ] Listed below:

- Top-level / devex / config / generated / ignore files touched:
  - [ ] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [ ] None
  - [ ] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:

- Caller / proxy / backend pairing:
  - [ ] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [ ] Not applicable
  - [ ] Listed below:

- UI browser or Playwright proof:
  - [ ] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## ✅ Review-Ready Contract

- [ ] Title, body, changed files, and tests describe the same contract.
- [ ] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [ ] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [ ] Reachable production attach point:
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [ ] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here:
- [ ] If this responds to requested changes, the new commit or material explanation is described here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [ ] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?
- [ ] Sensitive surface touched: auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress / none
- [ ] Error path, rollback, or safe-failure behavior proved:

## 📜 Licensing

- [ ] First-party changes remain Apache-2.0 compatible
- [ ] Third-party notice impact reviewed when dependencies changed
