### PR TITLE
feat(one-marketplace): Information Marketplace agent + durable requests + inline publish

### DIFF
--- a/consent-protocol/api/routes/kai/agent_chat.py
+++ b/consent-protocol/api/routes/kai/agent_chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 from typing import Any, Literal, Optional
 
@@ -112,6 +113,32 @@ class AgentChatDeleteResponse(BaseModel):
     deleted: bool
 
 
+# Navigation intent — "open/go to/take me to the marketplace" should OPEN the
+# page (central planner), not delegate a text answer to the specialist.
+_NAV_INTENT_RE = re.compile(
+    r"\b(?:open|go to|take me to|navigate to|launch|bring up)\b", re.IGNORECASE
+)
+
+# "marketplace" is ambiguous (Information Marketplace vs Kai Market Home). Detect
+# a bare mention (no qualifier) so One can deterministically ask which one.
+_BARE_MARKETPLACE_RE = re.compile(r"\bmarketplace\b", re.IGNORECASE)
+_MARKETPLACE_QUALIFIER_RE = re.compile(
+    r"\b(?:information marketplace|data marketplace|kai|market home)\b", re.IGNORECASE
+)
+
+_MARKETPLACE_CLARIFICATION = (
+    "Which marketplace do you mean — your **Information Marketplace** (your "
+    "personal data slices and potential earnings) or **Kai's Market Home** "
+    "(markets and investing)?"
+)
+
+
+def _is_bare_marketplace(message: str | None) -> bool:
+    """True when the user says 'marketplace' without qualifying which one."""
+    text = message or ""
+    return bool(_BARE_MARKETPLACE_RE.search(text) and not _MARKETPLACE_QUALIFIER_RE.search(text))
+
+
 def resolve_delegate_target(message: str) -> str | None:
     """Return a WIRED specialist agent id for this message, else None.
 
@@ -122,7 +149,11 @@ def resolve_delegate_target(message: str) -> str | None:
     classified = classify_specialist_domain(message or "")
     if classified is None:
         return None
-    _domain, target_agent = classified
+    domain, target_agent = classified
+    # "open the information marketplace" is a navigation intent: decline
+    # delegation so the central planner opens the page instead of answering.
+    if domain == "information_marketplace" and _NAV_INTENT_RE.search(message or ""):
+        return None
     import hushh_mcp.adk_bridge  # noqa: F401  (ensures specialists are registered)
 
     return target_agent if is_wired_specialist(target_agent) else None
@@ -428,6 +459,27 @@ async def stream_agent_chat(
             generate_delegated(), media_type="text/event-stream", headers=headers
         )
     # --- end delegation branch --------------------------------------------
+
+    # Deterministic disambiguation: a bare "marketplace" (not already delegated as
+    # a clear data-slice question) gets a fixed clarifying question instead of
+    # letting the planner guess a surface.
+    if body.delegate_result is None and _is_bare_marketplace(body.message):
+        conv_id = body.conversation_id or ""
+        headers = {
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+            "X-Content-Type-Options": "nosniff",
+        }
+
+        async def generate_clarification():
+            yield _event("start", {"conversation_id": conv_id, "model": "one"})
+            yield _event("token", {"token": _MARKETPLACE_CLARIFICATION})
+            yield _event("complete", {"conversation_id": conv_id, "status": "complete"})
+
+        return StreamingResponse(
+            generate_clarification(), media_type="text/event-stream", headers=headers
+        )
 
     try:
         runtime = await service.prepare_agent_runtime(

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -3,12 +3,16 @@
 from fastapi import APIRouter
 
 from .email import router as email_router
+from .information_chat import router as information_chat_router
 from .location import router as location_router
 from .location_chat import router as location_chat_router
+from .marketplace_requests import router as marketplace_requests_router
 
 router = APIRouter()
 router.include_router(email_router)
 router.include_router(location_router)
 router.include_router(location_chat_router)
+router.include_router(information_chat_router)
+router.include_router(marketplace_requests_router)
 
 __all__ = ["router"]

--- a/consent-protocol/api/routes/one/information_chat.py
+++ b/consent-protocol/api/routes/one/information_chat.py
@@ -1,0 +1,47 @@
+"""One Personal Information agent chat endpoint (marketplace, read-only, non-streaming)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.middleware import require_vault_owner_token
+from hushh_mcp.services.information_chat_service import InformationChatService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/one", tags=["One Personal Information Agent Chat"])
+
+
+def _service() -> InformationChatService:
+    return InformationChatService()
+
+
+class InformationChatRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    message: str | None = Field(default=None, max_length=4000)
+    conversation_id: str | None = Field(default=None, alias="conversationId", max_length=128)
+
+
+@router.post("/information/chat")
+async def information_chat(
+    request: InformationChatRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    if not request.message:
+        raise HTTPException(status_code=422, detail="message is required")
+    try:
+        result: dict[str, Any] = await _service().handle_turn(
+            user_id=token_data["user_id"],
+            message=request.message,
+            consent_token=token_data.get("token", ""),
+            conversation_id=request.conversation_id,
+        )
+        return result
+    except Exception:
+        logger.exception("Information chat turn failed")
+        raise HTTPException(status_code=500, detail="Information chat could not be processed")

--- a/consent-protocol/api/routes/one/marketplace_requests.py
+++ b/consent-protocol/api/routes/one/marketplace_requests.py
@@ -1,0 +1,102 @@
+"""Information Marketplace access-request routes (durable, owner-scoped).
+
+Turns marketplace access requests into real records (migration 076) so the owner
+has a durable inbox and approve/deny is server-side — usable from the direct
+marketplace chat, the marketplace page, and Agent One over A2A.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.middleware import require_vault_owner_token
+from hushh_mcp.services.marketplace_request_service import MarketplaceRequestService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/one/marketplace", tags=["One Information Marketplace Requests"])
+
+
+def _service() -> MarketplaceRequestService:
+    return MarketplaceRequestService()
+
+
+class CreateRequestBody(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    slice_name: str = Field(alias="sliceName", max_length=200)
+    domain: str = Field(max_length=128)
+    scope_handle: str | None = Field(default=None, alias="scopeHandle", max_length=256)
+    buyer_label: str | None = Field(default=None, alias="buyerLabel", max_length=200)
+    price_cents: int = Field(default=0, alias="priceCents", ge=0, le=100_000_000)
+    currency: str = Field(default="USD", max_length=8)
+    duration_days: int = Field(default=30, alias="durationDays", ge=1, le=3650)
+    message: str | None = Field(default=None, max_length=2000)
+
+
+@router.post("/requests")
+async def create_marketplace_request(
+    body: CreateRequestBody,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    try:
+        request = await _service().create_request(
+            owner_user_id=token_data["user_id"],
+            slice_label=body.slice_name,
+            domain=body.domain,
+            scope_handle=body.scope_handle,
+            buyer_label=body.buyer_label,
+            price_cents=body.price_cents,
+            currency=body.currency,
+            duration_days=body.duration_days,
+            message=body.message,
+        )
+        return {"request": request}
+    except Exception:
+        logger.exception("marketplace.create_request_failed")
+        raise HTTPException(status_code=500, detail="Could not file the request")
+
+
+@router.get("/requests")
+async def list_marketplace_requests(
+    status: str | None = Query(default=None, max_length=24),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    try:
+        requests = await _service().list_requests(
+            owner_user_id=token_data["user_id"], status=status
+        )
+        return {"requests": requests}
+    except Exception:
+        logger.exception("marketplace.list_requests_failed")
+        raise HTTPException(status_code=500, detail="Could not load requests")
+
+
+@router.post("/requests/{request_id}/approve")
+async def approve_marketplace_request(
+    request_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    result: dict[str, Any] = await _service().approve_request(
+        owner_user_id=token_data["user_id"], request_id=request_id
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail="Request not found or not pending")
+    return result
+
+
+@router.post("/requests/{request_id}/deny")
+async def deny_marketplace_request(
+    request_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    result: dict[str, Any] = await _service().deny_request(
+        owner_user_id=token_data["user_id"], request_id=request_id
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail="Request not found or not pending")
+    return result

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 75,
+  "expected_migration_version": 76,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/076_marketplace_access_requests.sql
+++ b/consent-protocol/db/migrations/076_marketplace_access_requests.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+-- Product-grade persistence for Information Marketplace access requests.
+--
+-- Until now a buyer's request to access a published data slice lived only in the
+-- owner's browser (in-session React state that cleared on refresh). This table
+-- makes a request a real, durable record — the owner has a real inbox, requests
+-- survive refresh, and approve/deny can be driven server-side (including through
+-- Agent One over A2A, the way Location approves a grant). Consent-first: a request
+-- NEVER grants access on its own; the owner must approve, and only the safe
+-- summary of the slice is ever involved.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS marketplace_access_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id TEXT NOT NULL,
+  -- The buyer. buyer_user_id is nullable because a buyer may not be a Hushh user
+  -- (or, in early phases, may be a labeled brand/agent rather than an account).
+  buyer_user_id TEXT,
+  buyer_label TEXT,
+  -- The published slice being requested (safe-summary projection only).
+  domain TEXT NOT NULL,
+  scope_handle TEXT,
+  slice_label TEXT NOT NULL,
+  -- Price the owner set / was suggested for this 30-day scoped access.
+  price_cents INTEGER NOT NULL DEFAULT 0,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  duration_days INTEGER NOT NULL DEFAULT 30
+    CHECK (duration_days > 0 AND duration_days <= 3650),
+  message TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'denied', 'expired')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT marketplace_access_requests_not_self
+    CHECK (buyer_user_id IS NULL OR owner_user_id <> buyer_user_id)
+);
+
+-- The owner's inbox query: pending/other requests for a given owner, newest first.
+CREATE INDEX IF NOT EXISTS idx_marketplace_access_requests_owner
+  ON marketplace_access_requests (owner_user_id, status, created_at DESC);
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -53,7 +53,8 @@
     "072_crm_registry_mulesoft_pbkdf2_cbc.sql",
     "073_crm_registry_mulesoft_simplify.sql",
     "074_pkm_scope_registry_owner_consent_override.sql",
-    "075_agent_chat_message_metadata.sql"
+    "075_agent_chat_message_metadata.sql",
+    "076_marketplace_access_requests.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/hushh_mcp/adk_bridge/__init__.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/__init__.py
@@ -8,6 +8,7 @@ from hushh_mcp.adk_bridge.connected_systems_agent import get_connected_systems_a
 from hushh_mcp.adk_bridge.dispatch import register_specialist
 from hushh_mcp.adk_bridge.location_agent import get_location_a2a
 from hushh_mcp.adk_bridge.nav_agent import get_nav_a2a
+from hushh_mcp.adk_bridge.personal_information_agent import get_personal_information_a2a
 
 
 def _register_builtin_specialists() -> None:
@@ -16,6 +17,10 @@ def _register_builtin_specialists() -> None:
     )
     register_specialist("agent_location", lambda task: get_location_a2a().handle(task))
     register_specialist("agent_nav", lambda task: get_nav_a2a().handle(task))
+    register_specialist(
+        "agent_personal_information",
+        lambda task: get_personal_information_a2a().handle(task),
+    )
 
 
 _register_builtin_specialists()

--- a/consent-protocol/hushh_mcp/adk_bridge/delegation.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/delegation.py
@@ -14,6 +14,7 @@ SPECIALIST_A2A_SCOPE_MAP: dict[str, ConsentScope] = {
     "agent_nav": ConsentScope.AGENT_NAV_REVIEW,
     "agent_kyc": ConsentScope.AGENT_KYC_PROCESS,
     "agent_location": ConsentScope.AGENT_ONE_ORCHESTRATE,
+    "agent_personal_information": ConsentScope.AGENT_ONE_ORCHESTRATE,
 }
 
 

--- a/consent-protocol/hushh_mcp/adk_bridge/personal_information_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/personal_information_agent.py
@@ -1,0 +1,66 @@
+"""In-process A2A handler for the Information Marketplace specialist.
+
+Wraps the EXISTING InformationChatService.handle_turn loop unchanged and adapts
+its dict output into the generic SpecialistTurnResult. Consent is enforced
+exactly as on the direct chat — per-@hushh_tool scope validation inside
+HushhContext during the loop.
+
+Full parity with the direct chat: query/explain (what's published, what it's
+worth, show-math) AND request management (list/approve/deny). Because marketplace
+access requests are now durable server-side records, One can approve/deny them
+over A2A exactly the way it approves a Location grant — the agent looks the
+request up and updates it server-side, no browser round-trip. ``stateChanged``
+flows back so One's client refetches the inbox.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hushh_mcp.adk_bridge.contract import A2ADirective, A2ATask, SpecialistTurnResult
+
+# Label surfaced to the client for delegated turns (SSE start/complete "model").
+DELEGATED_MODEL = "one+marketplace"
+
+
+class PersonalInformationAgentA2A:
+    def __init__(self, service: Any = None) -> None:
+        if service is not None:
+            self._service = service
+        else:
+            from hushh_mcp.services.information_chat_service import InformationChatService
+
+            self._service = InformationChatService()
+
+    async def handle(self, task: A2ATask) -> SpecialistTurnResult:
+        out: dict = await self._service.handle_turn(
+            user_id=task.user_id,
+            message=task.message,
+            consent_token=task.consent_token,
+            conversation_id=task.conversation_id,
+        )
+
+        # A publish card (propose_publish) surfaces in One's chat via the directive
+        # channel — the same path Location uses to render its cards in central chat.
+        directive: A2ADirective | None = None
+        if isinstance(out.get("clientAction"), dict):
+            directive = A2ADirective(kind="action", payload=out["clientAction"])
+
+        return SpecialistTurnResult(
+            conversation_id=str(out.get("conversationId") or task.conversation_id or ""),
+            text=str(out.get("response") or ""),
+            directive=directive,
+            is_complete=bool(out.get("isComplete", True)),
+            state_changed=bool(out.get("stateChanged", False)),
+            model=DELEGATED_MODEL,
+        )
+
+
+_singleton: PersonalInformationAgentA2A | None = None
+
+
+def get_personal_information_a2a() -> PersonalInformationAgentA2A:
+    global _singleton
+    if _singleton is None:
+        _singleton = PersonalInformationAgentA2A()
+    return _singleton

--- a/consent-protocol/hushh_mcp/agents/orchestrator/tools.py
+++ b/consent-protocol/hushh_mcp/agents/orchestrator/tools.py
@@ -31,6 +31,37 @@ def _create_delegation_response(
 # deterministically (and testably) without a live model. Each entry maps a
 # specialist to its delegation domain/target plus the cues that route to it.
 _SPECIALIST_ROUTES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    # Information Marketplace must precede finance (kai claims the generic
+    # "market"/"earnings" cues). Cues are QUALIFIED — bare "marketplace" is left
+    # unrouted on purpose so One can ask which marketplace the user means
+    # (Information Marketplace vs Kai Market Home).
+    (
+        "information_marketplace",
+        "agent_personal_information",
+        (
+            "information marketplace",
+            "data marketplace",
+            "slice",
+            "slices",
+            "made available",
+            "available to buyers",
+            "available for buyers",
+            "publish my data",
+            "sell my data",
+            "sell my information",
+            "what have i published",
+            "what data have i published",
+            "my data worth",
+            "from my data",
+            "for my data",
+            "access request",
+            "my request for",
+            "approve my request",
+            "deny my request",
+            "approve the request",
+            "pending request",
+        ),
+    ),
     (
         "connected_systems_crm",
         "agent_connected_systems",

--- a/consent-protocol/hushh_mcp/agents/personal_information/__init__.py
+++ b/consent-protocol/hushh_mcp/agents/personal_information/__init__.py
@@ -1,0 +1,16 @@
+"""One Personal Information Agent package."""
+
+from .agent import (
+    PersonalInformationAgent,
+    get_personal_information_agent,
+    get_personal_information_chat_agent,
+)
+from .manifest import MANIFEST, get_manifest
+
+__all__ = [
+    "PersonalInformationAgent",
+    "MANIFEST",
+    "get_personal_information_agent",
+    "get_personal_information_chat_agent",
+    "get_manifest",
+]

--- a/consent-protocol/hushh_mcp/agents/personal_information/agent.py
+++ b/consent-protocol/hushh_mcp/agents/personal_information/agent.py
@@ -1,0 +1,76 @@
+"""One Personal Information Agent ADK wrapper."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from hushh_mcp.hushh_adk.core import HushhAgent
+from hushh_mcp.hushh_adk.manifest import ManifestLoader
+
+from .tools import PERSONAL_INFORMATION_AGENT_TOOLS, PERSONAL_INFORMATION_CHAT_TOOLS
+
+logger = logging.getLogger(__name__)
+
+
+class PersonalInformationAgent(HushhAgent):
+    """Marketplace data-slice chatbot under One."""
+
+    def __init__(self, tools: list[Any] | None = None) -> None:
+        manifest_path = os.path.join(os.path.dirname(__file__), "agent.yaml")
+        self.manifest = ManifestLoader.load(manifest_path)
+
+        selected_tools = tools if tools is not None else PERSONAL_INFORMATION_AGENT_TOOLS
+        self.hushh_tools = selected_tools
+
+        super().__init__(
+            name=self.manifest.name,
+            model=self.manifest.model,
+            system_prompt=self.manifest.system_instruction,
+            tools=selected_tools,
+            required_scopes=self.manifest.required_scopes,
+        )
+
+    def handle_message(
+        self,
+        message: str,
+        user_id: str,
+        consent_token: str = "",
+    ) -> dict[str, Any]:
+        try:
+            response = self.run(message, user_id=user_id, consent_token=consent_token)
+            return {
+                "response": response.text if hasattr(response, "text") else str(response),
+                "is_complete": True,
+            }
+        except Exception as exc:
+            logger.error("PersonalInformationAgent error: %s", exc)
+            return {
+                "response": "I can't answer that about your marketplace data right now.",
+                "error": str(exc),
+            }
+
+
+_personal_information_agent: PersonalInformationAgent | None = None
+
+
+def get_personal_information_agent() -> PersonalInformationAgent:
+    global _personal_information_agent
+    if _personal_information_agent is None:
+        _personal_information_agent = PersonalInformationAgent()
+    return _personal_information_agent
+
+
+_personal_information_chat_agent: PersonalInformationAgent | None = None
+
+
+def get_personal_information_chat_agent() -> PersonalInformationAgent:
+    """Singleton marketplace chatbot agent: query tools, propose-publish, and
+    server-side list/approve/deny of durable access requests."""
+    global _personal_information_chat_agent
+    if _personal_information_chat_agent is None:
+        _personal_information_chat_agent = PersonalInformationAgent(
+            tools=PERSONAL_INFORMATION_CHAT_TOOLS
+        )
+    return _personal_information_chat_agent

--- a/consent-protocol/hushh_mcp/agents/personal_information/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/personal_information/agent.yaml
@@ -1,0 +1,97 @@
+id: agent_personal_information
+name: Information Marketplace
+version: 0.1.0
+description: >
+  Marketplace chatbot under One. Lets the owner query, publish, and manage their
+  own PKM data slices with consent, and answers what is published and what it is
+  worth. Delegatable by Agent One over A2A.
+model: gemini-3-flash-preview
+system_instruction: |
+  You are the Information Marketplace agent under One — the assistant inside the
+  user's personal-data-slice marketplace. You help the user understand and control the
+  personal-data slices they publish so they can receive offers, favorable deals,
+  or money on THEIR terms. Everything is consent-first: the user's data is never
+  shared without their explicit approval.
+
+  What you can do: tell the user which slices they have published to the
+  marketplace (list_published_slices) and what those slices are worth
+  (get_earnings_summary). Only the safe summary of a slice is ever exposed to a
+  buyer — never raw personal data.
+
+  PROPOSING WHAT TO PUBLISH. When the conversation is about putting data on the
+  marketplace, earning from data, or a specific topic the user could monetize
+  (e.g. "what financial data can I sell?", "help me earn from my data"), call
+  propose_publish to surface a publish card of their unpublished, offer-worthy
+  slices. Pass a `topic` (like "financial" or "travel") to tailor the card to what
+  they're asking about. The card lets the user publish in one tap (consent-first);
+  you never publish on your own. If nothing relevant is unpublished, say so plainly.
+
+  APPROVING / DENYING ACCESS REQUESTS. The owner has a durable marketplace inbox.
+  To see pending requests, call list_access_requests (never guess a request id).
+  Because the owner is the only one who can authorize sharing, YOU act only on the
+  owner's explicit instruction. When the owner tells you to approve or deny a
+  specific request (e.g. "approve the Preferences request", "yes, approve it"),
+  first call list_access_requests to find the matching id, then call
+  approve_access_request or deny_access_request with that id — this is the owner
+  exercising their own consent through you, which is allowed. If there are no
+  pending requests, say there is nothing to approve. If it is ambiguous which
+  request they mean, ask. Never approve or deny on your own initiative.
+
+  EXPLAINING PRICE ("show math"). Every price is the same research-anchored
+  formula shown on the dashboard:
+      Price = ( floor + data value ) × buyer fit × freshness × exclusivity × geo,
+      floored at $0.10.
+  - Data value: financial data counts most, plain demographics least; more
+    attributes help, with diminishing returns.
+  - Buyer fit: spending power × buying mood (an about-to-buy signal beats raw wealth).
+  - Freshness: updated today = full value; stale fades toward a floor.
+  - Exclusivity: sold to everyone = base; sold to one buyer = worth more.
+  get_earnings_summary returns each slice's `math` factors and the `formula`
+  string — use them to explain how a number was reached. You DO have the formula;
+  never say you lack access to it.
+
+  BE HONEST ABOUT MONEY. There is no payment rail and no settled money. Earnings
+  are POTENTIAL only: a suggested monthly price if a buyer subscribes. Nothing is
+  accrued. When the user asks how much they have made, say clearly that nothing
+  is accrued yet and give the potential figure, labeled as such. Never invent a
+  sale or a settled amount. (A pending request in the inbox is a buyer asking for
+  access — not a settled purchase; the owner still approves and no money moves.)
+
+  Do NOT invent slices, prices, requests, or numbers. Always call a tool to get
+  real values; if a tool returns nothing published, tell the user plainly that
+  they have not published anything yet and can set a section to "Available" in
+  the Marketplace to publish a safe summary.
+
+  Keep replies short, concrete, and calm. Never return raw personal data — only
+  labels, counts, and prices.
+required_scopes:
+  - agent.one.orchestrate
+  - cap.pkm.marketplace.view
+optional_scopes:
+  - cap.pkm.marketplace.publish
+  - cap.pkm.marketplace.manage
+tools:
+  - name: list_published_slices
+    description: List the data slices the user has published (set to Available) to the marketplace. Read-only; safe metadata only.
+    py_func: hushh_mcp.agents.personal_information.tools.list_published_slices
+    required_scope: cap.pkm.marketplace.view
+  - name: get_earnings_summary
+    description: Summarize POTENTIAL monthly earnings across published slices, with per-slice show-math factors and the pricing formula. No buyers or payment rail yet; nothing is accrued.
+    py_func: hushh_mcp.agents.personal_information.tools.get_earnings_summary
+    required_scope: cap.pkm.marketplace.view
+  - name: propose_publish
+    description: Propose unpublished, offer-worthy slices as a publish card, optionally tailored to a topic (e.g. financial). Read-only; the owner taps Publish.
+    py_func: hushh_mcp.agents.personal_information.tools.propose_publish
+    required_scope: cap.pkm.marketplace.view
+  - name: list_access_requests
+    description: List the owner's pending marketplace access requests (durable, server-side). Call first to get a real request id.
+    py_func: hushh_mcp.agents.personal_information.tools.list_access_requests
+    required_scope: cap.pkm.marketplace.manage
+  - name: approve_access_request
+    description: Approve a pending marketplace access request server-side on the owner's explicit instruction. request_id from list_access_requests.
+    py_func: hushh_mcp.agents.personal_information.tools.approve_access_request
+    required_scope: cap.pkm.marketplace.manage
+  - name: deny_access_request
+    description: Deny a pending marketplace access request server-side on the owner's explicit instruction. request_id from list_access_requests.
+    py_func: hushh_mcp.agents.personal_information.tools.deny_access_request
+    required_scope: cap.pkm.marketplace.manage

--- a/consent-protocol/hushh_mcp/agents/personal_information/manifest.py
+++ b/consent-protocol/hushh_mcp/agents/personal_information/manifest.py
@@ -1,0 +1,48 @@
+"""One Personal Information Agent manifest."""
+
+from hushh_mcp.constants import ConsentScope
+
+MANIFEST = {
+    "agent_id": "agent_personal_information",
+    "name": "Information Marketplace",
+    "version": "0.1.0",
+    "description": (
+        "Marketplace chatbot under One: lets the owner query, publish, and manage "
+        "their own PKM data slices with consent, and answers what is published and "
+        "what it is worth. Delegatable by Agent One over A2A."
+    ),
+    "required_scopes": [
+        ConsentScope.AGENT_ONE_ORCHESTRATE,
+        ConsentScope.CAP_PKM_MARKETPLACE_VIEW,
+    ],
+    "optional_scopes": [
+        ConsentScope.CAP_PKM_MARKETPLACE_PUBLISH,
+        ConsentScope.CAP_PKM_MARKETPLACE_MANAGE,
+    ],
+    "specialists": [
+        {
+            "id": "nav",
+            "name": "Nav",
+            "description": "Consent, revocation, and audit language for published slices.",
+            "color": "#10B981",
+            "icon": "shield-check",
+        }
+    ],
+    "capabilities": {
+        "reads_published_slice_metadata": True,
+        "returns_raw_pkm_values": False,
+        "server_authoritative_pricing": True,
+        "payment_rail": False,
+    },
+    "compliance": {
+        "consent_required": True,
+        "owner_only_reads": True,
+        "raw_pkm_values_returned": False,
+        "audit_trail": True,
+    },
+}
+
+
+def get_manifest():
+    """Get agent manifest."""
+    return MANIFEST

--- a/consent-protocol/hushh_mcp/agents/personal_information/tools.py
+++ b/consent-protocol/hushh_mcp/agents/personal_information/tools.py
@@ -1,0 +1,151 @@
+"""ADK tools for the One Personal Information Agent (marketplace chatbot).
+
+Slice 1 = read-only query tools. They let the owner ask, in chat, what data
+they have published to the marketplace and what it is worth. Persistence and
+pricing live in MarketplaceInformationService; scope checks live in @hushh_tool.
+
+Every tool reads ONLY the current user's own published-slice metadata and the
+deterministic pricing engine — never raw PKM values, never another user's data.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hushh_mcp.constants import ConsentScope
+from hushh_mcp.hushh_adk.context import HushhContext
+from hushh_mcp.hushh_adk.tools import hushh_tool
+from hushh_mcp.services.marketplace_information_service import (
+    MarketplaceInformationService,
+)
+from hushh_mcp.services.marketplace_request_service import MarketplaceRequestService
+
+
+def _ctx() -> HushhContext:
+    context = HushhContext.current()
+    if not context:
+        raise PermissionError("No active context - marketplace consent required")
+    return context
+
+
+def _service() -> MarketplaceInformationService:
+    return MarketplaceInformationService()
+
+
+def _requests() -> MarketplaceRequestService:
+    return MarketplaceRequestService()
+
+
+@hushh_tool(scope=ConsentScope.CAP_PKM_MARKETPLACE_VIEW, name="list_published_slices")
+async def list_published_slices() -> dict[str, Any]:
+    """List the data slices the user has published to the marketplace (every scope
+    set to 'Available'). Read-only; returns labels + public metadata, never raw
+    data. Call this to answer 'what have I published / what data is on the market'.
+    """
+    context = _ctx()
+    slices = await _service().list_published_slices(user_id=context.user_id)
+    return {"publishedSlices": slices, "count": len(slices)}
+
+
+@hushh_tool(scope=ConsentScope.CAP_PKM_MARKETPLACE_VIEW, name="get_earnings_summary")
+async def get_earnings_summary(
+    power: str = "affluent",
+    mood: str = "affinity",
+) -> dict[str, Any]:
+    """Summarize potential monthly earnings across the user's published slices.
+
+    Read-only. Earnings are POTENTIAL only — there is no payment rail and no buyer
+    yet, so accruedCents is always 0. Use this to answer 'how much money have I
+    made / what are my slices worth'. Always be honest that nothing is accrued yet.
+    """
+    context = _ctx()
+    return await _service().earnings_summary(user_id=context.user_id, power=power, mood=mood)
+
+
+@hushh_tool(scope=ConsentScope.CAP_PKM_MARKETPLACE_MANAGE, name="list_access_requests")
+async def list_access_requests() -> dict[str, Any]:
+    """List the owner's pending marketplace access requests (durable, server-side).
+    Call this FIRST to get a real request id before approving or denying — never
+    guess an id. Read-only.
+    """
+    context = _ctx()
+    pending = await _requests().list_requests(owner_user_id=context.user_id, status="pending")
+    return {"pendingRequests": pending, "count": len(pending)}
+
+
+@hushh_tool(scope=ConsentScope.CAP_PKM_MARKETPLACE_MANAGE, name="approve_access_request")
+async def approve_access_request(request_id: str) -> dict[str, Any]:
+    """Approve a pending marketplace access request server-side, on the owner's
+    explicit instruction. request_id MUST come from list_access_requests. This is
+    the owner exercising their own consent; only the safe summary is ever shared.
+    """
+    context = _ctx()
+    rid = str(request_id or "").strip()
+    if not rid:
+        raise ValueError("request_id is required; call list_access_requests first.")
+    result = await _requests().approve_request(owner_user_id=context.user_id, request_id=rid)
+    if not result.get("ok"):
+        raise ValueError(
+            "That request could not be approved (not found or already resolved). "
+            "Call list_access_requests to get current pending ids."
+        )
+    return result
+
+
+@hushh_tool(scope=ConsentScope.CAP_PKM_MARKETPLACE_MANAGE, name="deny_access_request")
+async def deny_access_request(request_id: str) -> dict[str, Any]:
+    """Deny a pending marketplace access request server-side, on the owner's
+    explicit instruction. request_id MUST come from list_access_requests. Nothing
+    is shared.
+    """
+    context = _ctx()
+    rid = str(request_id or "").strip()
+    if not rid:
+        raise ValueError("request_id is required; call list_access_requests first.")
+    result = await _requests().deny_request(owner_user_id=context.user_id, request_id=rid)
+    if not result.get("ok"):
+        raise ValueError(
+            "That request could not be denied (not found or already resolved). "
+            "Call list_access_requests to get current pending ids."
+        )
+    return result
+
+
+@hushh_tool(scope=ConsentScope.CAP_PKM_MARKETPLACE_VIEW, name="propose_publish")
+async def propose_publish(topic: str | None = None) -> dict[str, Any]:
+    """Propose unpublished, offer-worthy slices the owner could publish for offers,
+    as a publish card the UI renders. Pass a `topic` (e.g. 'financial', 'travel')
+    to tailor the suggestions to what the conversation is about. Read-only — does
+    NOT publish anything; the owner taps Publish in the card, which runs the normal
+    consent-first publish. Call this whenever the talk is about putting data on the
+    marketplace / earning from data and there is something not yet published.
+    """
+    context = _ctx()
+    slices = await _service().list_publishable_slices(
+        user_id=context.user_id, topic=(topic or None)
+    )
+    return {"proposed": "publish_slices", "topic": (topic or None), "slices": slices}
+
+
+# Read-only query tools available to the marketplace chatbot (slice 1).
+PERSONAL_INFORMATION_QUERY_TOOLS = [
+    list_published_slices,
+    get_earnings_summary,
+    propose_publish,
+]
+
+# Manage tools: list + approve/deny pending access requests (durable, server-side).
+PERSONAL_INFORMATION_MANAGE_TOOLS = [
+    list_access_requests,
+    approve_access_request,
+    deny_access_request,
+]
+
+# Tool set the marketplace chatbot runs with (query + manage).
+PERSONAL_INFORMATION_CHAT_TOOLS = [
+    *PERSONAL_INFORMATION_QUERY_TOOLS,
+    *PERSONAL_INFORMATION_MANAGE_TOOLS,
+]
+
+# Full tool set for the agent.
+PERSONAL_INFORMATION_AGENT_TOOLS = list(PERSONAL_INFORMATION_CHAT_TOOLS)

--- a/consent-protocol/hushh_mcp/consent/scope_helpers.py
+++ b/consent-protocol/hushh_mcp/consent/scope_helpers.py
@@ -67,6 +67,9 @@ def resolve_scope_to_enum(scope: str) -> ConsentScope:
         "cap.location.live.request": ConsentScope.CAP_LOCATION_LIVE_REQUEST,
         "cap.location.live.revoke": ConsentScope.CAP_LOCATION_LIVE_REVOKE,
         "cap.location.live.refer_request": ConsentScope.CAP_LOCATION_LIVE_REFER_REQUEST,
+        "cap.pkm.marketplace.view": ConsentScope.CAP_PKM_MARKETPLACE_VIEW,
+        "cap.pkm.marketplace.publish": ConsentScope.CAP_PKM_MARKETPLACE_PUBLISH,
+        "cap.pkm.marketplace.manage": ConsentScope.CAP_PKM_MARKETPLACE_MANAGE,
     }
     if scope.startswith("agent."):
         resolved = _AGENT_SCOPE_MAP.get(scope)

--- a/consent-protocol/hushh_mcp/constants.py
+++ b/consent-protocol/hushh_mcp/constants.py
@@ -72,6 +72,16 @@ class ConsentScope(str, Enum):
     CAP_LOCATION_LIVE_REVOKE = "cap.location.live.revoke"
     CAP_LOCATION_LIVE_REFER_REQUEST = "cap.location.live.refer_request"
 
+    # ============ MARKETPLACE / PERSONAL INFORMATION AGENT CAPABILITIES ============
+    # Capability scopes for the One Personal Information Agent — the marketplace
+    # chatbot that lets an owner query, publish, and manage their own PKM data
+    # slices. Workflow/action scopes, not durable attr.* PKM scopes. VIEW is
+    # read-only (list published slices + potential earnings); PUBLISH and MANAGE
+    # gate the write/consent paths (later slices).
+    CAP_PKM_MARKETPLACE_VIEW = "cap.pkm.marketplace.view"
+    CAP_PKM_MARKETPLACE_PUBLISH = "cap.pkm.marketplace.publish"
+    CAP_PKM_MARKETPLACE_MANAGE = "cap.pkm.marketplace.manage"
+
     # ==================== EXTERNAL DATA SOURCES ====================
     # Hybrid mode - per-request consent
     EXTERNAL_SEC_FILINGS = "external.sec.filings"
@@ -228,6 +238,9 @@ class ConsentScope(str, Enum):
             cls.CAP_LOCATION_LIVE_REQUEST,
             cls.CAP_LOCATION_LIVE_REVOKE,
             cls.CAP_LOCATION_LIVE_REFER_REQUEST,
+            cls.CAP_PKM_MARKETPLACE_VIEW,
+            cls.CAP_PKM_MARKETPLACE_PUBLISH,
+            cls.CAP_PKM_MARKETPLACE_MANAGE,
         ]
 
     @classmethod
@@ -250,6 +263,7 @@ AGENT_PORTS = {
     "agent_kai": 10005,  # Kai investment analysis agent
     "agent_nav": 10006,  # Nav privacy and consent guardian
     "agent_kyc": 10007,  # KYC identity workflow specialist
+    "agent_personal_information": 10008,  # One marketplace data-slice agent
 }
 
 # ==================== Token & Link Prefixes ====================

--- a/consent-protocol/hushh_mcp/services/agent_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/agent_chat_service.py
@@ -53,6 +53,7 @@ Current capability boundary:
 - When the stream includes a planned frontend app action, keep the reply to a short receipt. The frontend owns the actual navigation/action state.
 - For Connected Systems CRM, read/create/update requests require explicit user approval. Delete is blocked in v1.
 - Destructive, account-changing, trading, approval, revocation, and manual-only actions must be blocked and explained safely.
+- "Marketplace" is ambiguous: there are TWO. The Information Marketplace is where the user publishes and prices their own personal-data slices (what they've published, potential earnings). Kai's Market Home is the markets/investing surface. If the user says just "marketplace" without qualifying which, ask a short clarifying question — "Do you mean your Information Marketplace (your personal data slices) or Kai's Market Home (markets)?" — before answering or navigating. Once qualified (e.g. "information marketplace", "data marketplace", or "market home"), proceed to the right one.
 - Keep answers concise, practical, and clear. Financial answers are educational, not personalized investment advice.
 """
 
@@ -86,6 +87,11 @@ _APP_SURFACE_ACTIONS: dict[str, tuple[str, str]] = {
     "analysis_history": ("route.analysis_history", "Open Analysis History"),
     "optimize": ("route.kai_optimize", "Open Optimize Surface"),
     "market_home": ("route.kai_home", "Open Market Home"),
+    # NOTE: the Information Marketplace surface is intentionally NOT exposed to the
+    # LLM action planner. The planner opens surfaces too eagerly (it would navigate
+    # on questions and on a bare "marketplace"). Marketplace navigation is handled
+    # deterministically by _plan_marketplace_navigation (qualified open-intent only),
+    # and marketplace questions are answered by the delegated specialist.
     "connected_systems": ("route.profile_connected_systems", "Open Connected Systems"),
 }
 
@@ -185,8 +191,21 @@ _NAVIGATION_ACTION_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "Open Optimize Surface",
     ),
     (
+        # Must precede the "market"/kai-home pattern: "marketplace" contains
+        # "market". Cues are QUALIFIED (information/data marketplace, data slices)
+        # so a bare "open marketplace" is left for One to disambiguate rather than
+        # silently opening the wrong surface.
         re.compile(
-            r"\b(?:open|go to|show|take me to|navigate to)\b.*\b(?:market|kai home|home)\b",
+            r"\b(?:open|go to|show|take me to|navigate to)\b.*"
+            r"\b(?:information marketplace|data marketplace|data slices?|my slices)\b",
+            re.IGNORECASE,
+        ),
+        "route.one_marketplace",
+        "Open Information Marketplace",
+    ),
+    (
+        re.compile(
+            r"\b(?:open|go to|show|take me to|navigate to)\b.*\b(?:market home|kai market|kai home|home)\b",
             re.IGNORECASE,
         ),
         "route.kai_home",
@@ -201,6 +220,15 @@ _NAVIGATION_ACTION_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "Open Connected Systems",
     ),
 ]
+
+# Deterministic Information Marketplace navigation: only a QUALIFIED open-intent
+# ("open/take me to the information/data marketplace", "open my slices"). A bare
+# "marketplace" deliberately does NOT match so One can disambiguate.
+_INFO_MARKETPLACE_NAV_RE = re.compile(
+    r"\b(?:open|go to|show|take me to|navigate to|bring up|launch)\b.*"
+    r"\b(?:information marketplace|data marketplace|data slices?|my slices)\b",
+    re.IGNORECASE,
+)
 
 _CRM_READ_PATTERNS = [
     re.compile(
@@ -1479,6 +1507,13 @@ class AgentChatService:
         if deterministic_block is not None:
             return deterministic_block
 
+        # Deterministic Information Marketplace navigation (qualified open-intent
+        # only), decided BEFORE the LLM planner so questions and a bare
+        # "marketplace" are never auto-navigated by the model.
+        marketplace_nav = self._plan_marketplace_navigation(user_message)
+        if marketplace_nav is not None:
+            return _enrich_plan_with_manifest(marketplace_nav, current_screen=current_screen)
+
         try:
             # Action planning is a non-streaming, idempotent call, so a short
             # jittered retry on transient 429/503 is safe (unlike the token
@@ -1589,6 +1624,22 @@ class AgentChatService:
                     message=f"{label} in the app.",
                 )
         return None
+
+    def _plan_marketplace_navigation(self, user_message: str) -> AgentChatActionPlan | None:
+        """Deterministic navigation to the Information Marketplace on a QUALIFIED
+        open-intent. Bare "marketplace" and questions return None (One handles them:
+        disambiguation for bare, delegated answer for questions)."""
+        message = " ".join(str(user_message or "").split())
+        if not message or not _INFO_MARKETPLACE_NAV_RE.search(message):
+            return None
+        return AgentChatActionPlan(
+            call_id=_tool_call_id(),
+            action_id="route.one_marketplace",
+            label="Open Information Marketplace",
+            execution="frontend",
+            slots={},
+            message="Open Information Marketplace in the app.",
+        )
 
     def _plan_crm_action(self, user_message: str) -> AgentChatActionPlan | None:
         message = " ".join(str(user_message or "").split())

--- a/consent-protocol/hushh_mcp/services/information_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/information_chat_service.py
@@ -1,0 +1,444 @@
+"""Chat orchestration for the One Personal Information Agent (marketplace).
+
+Runs a Gemini function-calling loop restricted to the marketplace query tools,
+executed INSIDE a HushhContext so each @hushh_tool enforces its consent scope
+(DB-backed). Reuses AgentChatService for durable, encrypted conversation
+persistence. Mirrors LocationChatService but is read-only for slice 1: the tools
+only read the owner's published-slice metadata and pricing, so no client-action
+or client-prompt handoff is needed and no turn ever mutates state.
+
+Why not HushhAgent / Google ADK execution: identical to LocationChatService —
+that wrapper targets an ADK API incompatible with the pinned google-adk and has
+never executed. We call the backend Gemini client (operons.kai.llm) directly;
+consent is preserved because the tool callables validate scope against the
+active HushhContext, which this service opens around the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import Any, Awaitable, Callable
+
+from hushh_mcp.agents.personal_information.agent import (
+    get_personal_information_chat_agent,
+)
+from hushh_mcp.hushh_adk.context import HushhContext
+from hushh_mcp.services.agent_chat_service import get_agent_chat_service
+from hushh_mcp.services.marketplace_information_service import (
+    MarketplaceInformationService,
+)
+
+logger = logging.getLogger(__name__)
+
+# Deterministic publish-card trigger: the model is unreliable at calling
+# propose_publish, so when the user's message is clearly a publish/monetize intent
+# we attach the publish card ourselves (in the marketplace chat AND Agent One).
+_PUBLISH_INTENT_RE = re.compile(
+    r"\b(?:publish|sell|monet|earn|make money|offers?|put .* (?:on|up)|list my)\b",
+    re.IGNORECASE,
+)
+# Topic words to tailor the card to what the user is asking about.
+_TOPIC_WORDS = (
+    "financial",
+    "finance",
+    "travel",
+    "health",
+    "professional",
+    "career",
+    "insurance",
+    "shopping",
+    "personal",
+    "lifestyle",
+    "education",
+    "home",
+)
+
+
+def _publish_intent_topic(message: str | None) -> tuple[bool, str | None]:
+    """(is_publish_intent, topic). Topic is the first known category word in the
+    message, else None (all offer-worthy)."""
+    text = (message or "").lower()
+    if not text or not _PUBLISH_INTENT_RE.search(text):
+        return False, None
+    topic = next((w for w in _TOPIC_WORDS if w in text), None)
+    return True, topic
+
+
+_MAX_HISTORY = 12
+_MAX_TOOL_STEPS = 5
+_LLM_TIMEOUT_S = 30.0
+_HISTORY_CHARS = 2000
+
+_UNAVAILABLE_MESSAGE = (
+    "The marketplace assistant is temporarily unavailable. Please try again, or "
+    "use the controls on this page to manage your published slices."
+)
+_GAVE_UP_MESSAGE = (
+    "I couldn't finish that — please try rephrasing, or use the controls on this "
+    "page to manage your published slices."
+)
+
+# model call seam: (contents, config) -> Gemini response. Injectable for tests.
+ModelCall = Callable[[Any, Any], Awaitable[Any]]
+
+
+def _function_declarations(types: Any) -> list:
+    """Function declarations for the read-only marketplace query tools."""
+    schema = types.Schema
+    kind = types.Type
+    return [
+        types.FunctionDeclaration(
+            name="list_published_slices",
+            description=(
+                "List the data slices the user has published (set to 'Available') to "
+                "the marketplace, with labels and public metadata. Read-only. Call "
+                "this to answer what data the user has on the market."
+            ),
+            parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+        ),
+        types.FunctionDeclaration(
+            name="get_earnings_summary",
+            description=(
+                "Summarize POTENTIAL monthly earnings across the user's published "
+                "slices. Returns each slice's price plus its `math` factors (floor, "
+                "data value, buyer fit, freshness, exclusivity, geo) and the pricing "
+                "`formula` — use these to explain 'show math'. There is no buyer or "
+                "payment rail yet, so nothing is accrued (accruedCents is 0). Read-only."
+            ),
+            parameters=schema(
+                type=kind.OBJECT,
+                properties={
+                    "power": schema(
+                        type=kind.STRING,
+                        description="Buyer spending band: mass|mid|affluent|hnw|uhnw",
+                    ),
+                    "mood": schema(
+                        type=kind.STRING,
+                        description="Buyer intent: passive|affinity|in_market|hot",
+                    ),
+                },
+                required=[],
+            ),
+        ),
+        types.FunctionDeclaration(
+            name="propose_publish",
+            description=(
+                "Propose unpublished, offer-worthy slices the owner could publish "
+                "for offers, as a publish card the UI renders. Pass `topic` (e.g. "
+                "'financial', 'travel') to tailor suggestions to the conversation. "
+                "Read-only — does NOT publish. Call whenever the talk is about "
+                "putting data on the marketplace / earning from data."
+            ),
+            parameters=schema(
+                type=kind.OBJECT,
+                properties={
+                    "topic": schema(
+                        type=kind.STRING,
+                        description="Optional context to tailor suggestions, e.g. 'financial'",
+                    )
+                },
+                required=[],
+            ),
+        ),
+        types.FunctionDeclaration(
+            name="list_access_requests",
+            description=(
+                "List the owner's pending marketplace access requests (durable, "
+                "server-side). Call this FIRST to get a real request id before "
+                "approving or denying — never guess an id. Read-only."
+            ),
+            parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+        ),
+        types.FunctionDeclaration(
+            name="approve_access_request",
+            description=(
+                "Approve a pending marketplace access request server-side, ONLY when "
+                "the owner explicitly asks. request_id MUST come from "
+                "list_access_requests."
+            ),
+            parameters=schema(
+                type=kind.OBJECT,
+                properties={
+                    "request_id": schema(
+                        type=kind.STRING, description="Pending request id from list_access_requests"
+                    )
+                },
+                required=["request_id"],
+            ),
+        ),
+        types.FunctionDeclaration(
+            name="deny_access_request",
+            description=(
+                "Deny a pending marketplace access request server-side, ONLY when the "
+                "owner explicitly asks. request_id MUST come from list_access_requests."
+            ),
+            parameters=schema(
+                type=kind.OBJECT,
+                properties={
+                    "request_id": schema(
+                        type=kind.STRING, description="Pending request id from list_access_requests"
+                    )
+                },
+                required=["request_id"],
+            ),
+        ),
+    ]
+
+
+# Tools that mutate durable state — a successful call means the UI should refetch
+# (stateChanged). Everything else is read-only.
+_MUTATING_TOOLS = {"approve_access_request", "deny_access_request"}
+
+
+def _history_contents(history: list[Any], types: Any) -> list:
+    contents: list = []
+    for message in history[-_MAX_HISTORY:]:
+        role = getattr(message, "role", "")
+        if role not in ("user", "assistant"):
+            continue
+        genai_role = "user" if role == "user" else "model"
+        text = (getattr(message, "content", "") or "")[:_HISTORY_CHARS]
+        contents.append(types.Content(role=genai_role, parts=[types.Part(text=text)]))
+    return contents
+
+
+def _as_response_dict(result: Any) -> dict:
+    return result if isinstance(result, dict) else {"result": result}
+
+
+class InformationChatService:
+    def __init__(
+        self,
+        *,
+        chat_store: Any = None,
+        model_call: ModelCall | None = None,
+        genai_types: Any = None,
+        ready: Callable[[], bool] | None = None,
+        tools: list | None = None,
+        system_prompt: str | None = None,
+    ) -> None:
+        self._chat_store = chat_store if chat_store is not None else get_agent_chat_service()
+
+        if model_call is not None:
+            self._model_call = model_call
+            self._types = genai_types
+            self._ready = ready or (lambda: True)
+        else:
+            from hushh_mcp.operons.kai import llm as _llm
+
+            self._types = genai_types or _llm.types
+            self._ready = ready or _llm._require_gemini_ready
+
+            async def _default_call(contents: Any, config: Any) -> Any:
+                return await asyncio.wait_for(
+                    _llm._gemini_client.aio.models.generate_content(
+                        model=_llm._gemini_model_name,
+                        contents=contents,
+                        config=config,
+                    ),
+                    timeout=_LLM_TIMEOUT_S,
+                )
+
+            self._model_call = _default_call
+
+        need_agent = system_prompt is None or tools is None
+        agent = get_personal_information_chat_agent() if need_agent else None
+        self._system_prompt = (
+            system_prompt if system_prompt is not None else agent.manifest.system_instruction
+        )
+        tool_list = tools if tools is not None else agent.hushh_tools
+        self._dispatch = {getattr(t, "_name", getattr(t, "__name__", "")): t for t in tool_list}
+
+    async def handle_turn(
+        self,
+        *,
+        user_id: str,
+        message: str | None = None,
+        consent_token: str,
+        conversation_id: str | None = None,
+    ) -> dict[str, Any]:
+        if not message:
+            return {
+                "conversationId": conversation_id or "",
+                "response": "Ask me what you've published to the marketplace or what it's worth.",
+                "isComplete": True,
+                "stateChanged": False,
+            }
+
+        turn = await self._chat_store.prepare_turn(
+            user_id=user_id,
+            message=message,
+            conversation_id=conversation_id,
+        )
+
+        if self._types is None or not self._ready():
+            return await self._finish(turn, _UNAVAILABLE_MESSAGE, user_id, errored=True)
+
+        types = self._types
+        contents = _history_contents(turn.history, types)
+        contents.append(types.Content(role="user", parts=[types.Part(text=message)]))
+
+        try:
+            reply, errored, state_changed, directives = await self._run_tool_loop(
+                user_id=user_id, consent_token=consent_token, contents=contents
+            )
+        except Exception:
+            logger.exception("Information chat turn failed")
+            return await self._finish(turn, _UNAVAILABLE_MESSAGE, user_id, errored=True)
+
+        if not reply:
+            reply = "Done."
+        client_action = self._build_publish_action(directives)
+        # Deterministic publish card: if the model didn't stage one but the user
+        # clearly asked to publish/monetize, attach it ourselves (topic-tailored).
+        if client_action is None and not errored:
+            intent, topic = _publish_intent_topic(message)
+            if intent:
+                try:
+                    slices = await MarketplaceInformationService().list_publishable_slices(
+                        user_id=user_id, topic=topic
+                    )
+                    if slices:
+                        client_action = {
+                            "type": "publish_slices",
+                            "topic": topic,
+                            "slices": slices,
+                        }
+                except Exception:
+                    logger.warning("mkt.deterministic_publish_card_failed", exc_info=True)
+        return await self._finish(
+            turn,
+            reply,
+            user_id,
+            errored=errored,
+            state_changed=state_changed and not errored,
+            client_action=client_action,
+        )
+
+    async def _run_tool_loop(
+        self, *, user_id: str, consent_token: str, contents: list
+    ) -> tuple[str, bool, bool, list[dict]]:
+        """Run the Gemini function-calling loop inside HushhContext.
+
+        Returns (reply, errored, state_changed, directives). state_changed is True
+        when a mutating tool (approve/deny) succeeded; directives are publish-card
+        payloads staged by propose_publish.
+        """
+        types = self._types
+        config = types.GenerateContentConfig(
+            system_instruction=self._system_prompt,
+            tools=[types.Tool(function_declarations=_function_declarations(types))],
+            temperature=0.2,
+        )
+        reply = ""
+        errored = False
+        state_changed = False
+        directives: list[dict] = []
+        with HushhContext(user_id=user_id, consent_token=consent_token, vault_keys={}):
+            for _ in range(_MAX_TOOL_STEPS):
+                response = await self._model_call(contents, config)
+                calls = list(getattr(response, "function_calls", None) or [])
+                if not calls:
+                    reply = (getattr(response, "text", "") or "").strip()
+                    break
+                contents.append(response.candidates[0].content)
+                # Gemini requires the number of function_response parts to equal the
+                # number of function_call parts in the model turn. When the model
+                # emits several parallel calls, all their responses must go back in a
+                # SINGLE tool content — one response per call — not one message each.
+                tool_parts = []
+                for call in calls:
+                    result, mutated, directive = await self._run_tool(
+                        call.name, dict(call.args or {})
+                    )
+                    state_changed = state_changed or mutated
+                    if directive is not None:
+                        directives.append(directive)
+                    tool_parts.append(
+                        types.Part.from_function_response(name=call.name, response=result)
+                    )
+                contents.append(types.Content(role="tool", parts=tool_parts))
+            else:
+                reply = _GAVE_UP_MESSAGE
+                errored = True
+        return reply, errored, state_changed, directives
+
+    async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None]:
+        """Execute one tool inside the active HushhContext.
+
+        Returns (result, mutated, directive): mutated is True when a mutating tool
+        (approve/deny) succeeded; directive is a publish card from propose_publish.
+        """
+        tool = self._dispatch.get(name)
+        if tool is None:
+            logger.warning("mkt.tool_dispatch_miss name=%s known=%s", name, list(self._dispatch))
+            return {"error": "unknown_tool"}, False, None
+        try:
+            result = await tool(**args)
+        except PermissionError as exc:
+            logger.warning("mkt.tool_consent_denied name=%s err=%s", name, exc)
+            return {"error": "consent_denied"}, False, None
+        except ValueError as exc:
+            logger.warning("mkt.tool_invalid_argument name=%s err=%s", name, exc)
+            return {"error": "invalid_argument", "message": str(exc)}, False, None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Marketplace tool %s failed: %s", name, exc, exc_info=True)
+            return {"error": "tool_failed"}, False, None
+        result_dict = _as_response_dict(result)
+        mutated = name in _MUTATING_TOOLS and not result_dict.get("error")
+        directive = self._directive_from_tool(name, result_dict)
+        return result_dict, mutated, directive
+
+    @staticmethod
+    def _directive_from_tool(name: str, result: dict) -> dict | None:
+        """A propose_publish result with slices becomes a publish-card directive."""
+        if name != "propose_publish" or result.get("error"):
+            return None
+        slices = result.get("slices") or []
+        if not slices:
+            return None
+        return {"type": "publish_slices", "topic": result.get("topic"), "slices": slices}
+
+    @staticmethod
+    def _build_publish_action(directives: list[dict]) -> dict | None:
+        """Fold publish-card directives into one clientAction (first non-empty wins)."""
+        for d in directives:
+            if d.get("type") == "publish_slices" and d.get("slices"):
+                return {
+                    "type": "publish_slices",
+                    "topic": d.get("topic"),
+                    "slices": d["slices"],
+                }
+        return None
+
+    async def _finish(
+        self,
+        turn: Any,
+        reply: str,
+        user_id: str,
+        *,
+        errored: bool,
+        state_changed: bool = False,
+        client_action: dict | None = None,
+    ) -> dict[str, Any]:
+        await self._chat_store.add_message(
+            conversation_id=turn.conversation_id,
+            user_id=user_id,
+            role="assistant",
+            content=reply,
+            status="error" if errored else "complete",
+        )
+        out: dict[str, Any] = {
+            "conversationId": turn.conversation_id,
+            "response": reply,
+            "isComplete": not errored,
+            # True when a mutating tool (approve/deny) succeeded — the UI refetches
+            # the durable request inbox.
+            "stateChanged": state_changed,
+        }
+        if client_action is not None:
+            # Publish card (propose_publish) the UI renders inline.
+            out["clientAction"] = client_action
+        return out

--- a/consent-protocol/hushh_mcp/services/marketplace_information_service.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_information_service.py
@@ -1,0 +1,298 @@
+"""Read model for the One Personal Information Agent (marketplace).
+
+The Personal Information Agent is the marketplace chatbot: it answers what the
+owner has published as `default_available` PKM slices and what those slices are
+worth. This service is the single, truthful read source for those questions.
+
+Consent safety: it reads ONLY the owner's own scope-registry metadata (labels,
+sensitivity tier, attribute count, visibility posture) and the safe summary
+projection. It never returns raw PKM values or another user's data. Pricing is
+computed by the pure, deterministic backend engine (hushh_mcp.pricing), so the
+agent cannot fabricate a number.
+
+Honesty about "earnings": there is NO payment rail and NO buyers yet. Published
+slices have a *potential* monthly price only; nothing is accrued or settled. The
+summary makes that explicit (accrued_cents is always 0) so the agent never
+implies money that does not exist.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hushh_mcp.pricing import (
+    SlicePricingInput,
+    category_from_sensitivity,
+    compute_suggested_price,
+)
+from hushh_mcp.services.personal_knowledge_model_service import (
+    PersonalKnowledgeModelService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _domain_title(domain: str) -> str:
+    """Human-readable title for a domain key (e.g. 'personal_data' -> 'Personal Data')."""
+    return (domain or "").replace(".", " ").replace("_", " ").strip().title() or "Data"
+
+
+def _attribute_count(entry: dict) -> int:
+    segments = entry.get("segment_ids") or []
+    return max(1, len(segments))
+
+
+# Commercial-intent / life-event cues that make an unpublished slice worth offers
+# (mirrors the frontend detectOfferSignal so backend and UI agree).
+_OFFER_KEYWORDS = (
+    "insurance",
+    "renewal",
+    "renew",
+    "expir",
+    "mortgage",
+    "loan",
+    "credit",
+    "travel",
+    "trip",
+    "flight",
+    "hotel",
+    "vacation",
+    "car",
+    "vehicle",
+    "auto",
+    "shopping",
+    "purchase",
+    "buying",
+    "move",
+    "moving",
+    "relocat",
+    "baby",
+    "expecting",
+    "pregnan",
+    "wedding",
+    "engaged",
+    "job",
+    "salary",
+    "income",
+    "subscription",
+    "warranty",
+    "health",
+    "fitness",
+    "education",
+    "tuition",
+    "home",
+    "property",
+    "invest",
+    "portfolio",
+    "retirement",
+    "savings",
+    "spend",
+    "financial",
+    "professional",
+)
+
+# System/structural scope labels that can never be published (not personal data).
+_STRUCTURAL_LABELS = {
+    "hash",
+    "metadata",
+    "provenance",
+    "schema version",
+    "workflow",
+    "workflow id",
+    "domain intent",
+    "updated at",
+    "schema",
+    "version",
+}
+
+
+def _looks_offer_worthy(label: str, domain_title: str) -> bool:
+    hay = f"{label} {domain_title}".lower()
+    return any(kw in hay for kw in _OFFER_KEYWORDS)
+
+
+def _matches_topic(topic: str, label: str, domain_title: str) -> bool:
+    t = (topic or "").strip().lower()
+    if not t:
+        return True
+    hay = f"{label} {domain_title}".lower()
+    # match on the topic word or any whitespace-separated token of it
+    return any(tok and tok in hay for tok in [t, *t.split()])
+
+
+class MarketplaceInformationService:
+    """Read-only view over the owner's published marketplace slices + pricing."""
+
+    def __init__(self, pkm_service: PersonalKnowledgeModelService | None = None) -> None:
+        self._pkm = pkm_service or PersonalKnowledgeModelService()
+
+    async def list_published_slices(self, *, user_id: str) -> list[dict[str, Any]]:
+        """Every scope the owner has set to `default_available` (published), across
+        all their domains. Coordinate/value-free — labels and public metadata only.
+        """
+        index = await self._pkm.get_index_v2(user_id)
+        if index is None:
+            return []
+        domains = list(index.available_domains or [])
+        published: list[dict[str, Any]] = []
+        for domain in domains:
+            manifest = await self._pkm.get_domain_manifest(user_id, domain)
+            if not manifest:
+                continue
+            for entry in manifest.get("scope_registry") or []:
+                if entry.get("visibility_posture") != "default_available":
+                    continue
+                published.append(
+                    {
+                        "domain": entry.get("domain") or domain,
+                        "domainTitle": _domain_title(entry.get("domain") or domain),
+                        "label": entry.get("scope_label") or "Data slice",
+                        "scopeHandle": entry.get("scope_handle"),
+                        "sensitivityTier": entry.get("sensitivity_tier"),
+                        "scopeKind": entry.get("scope_kind"),
+                        "attributeCount": _attribute_count(entry),
+                    }
+                )
+        return published
+
+    async def list_publishable_slices(
+        self,
+        *,
+        user_id: str,
+        topic: str | None = None,
+        power: str = "affluent",
+        mood: str = "affinity",
+    ) -> list[dict[str, Any]]:
+        """Unpublished, offer-worthy slices the owner could publish for offers —
+        the source for the inline 'publish for offers' card. When `topic` is given
+        (e.g. 'financial'), results are filtered to that context; otherwise all
+        offer-worthy unpublished slices are returned. Excludes system/structural
+        scopes. Value/coordinate-free — labels, counts, suggested price only.
+        """
+        index = await self._pkm.get_index_v2(user_id)
+        if index is None:
+            return []
+        out: list[dict[str, Any]] = []
+        for domain in list(index.available_domains or []):
+            manifest = await self._pkm.get_domain_manifest(user_id, domain)
+            if not manifest:
+                continue
+            for entry in manifest.get("scope_registry") or []:
+                if entry.get("visibility_posture") == "default_available":
+                    continue  # already published
+                label = entry.get("scope_label") or "Data slice"
+                if label.strip().lower() in _STRUCTURAL_LABELS:
+                    continue
+                domain_title = _domain_title(entry.get("domain") or domain)
+                if topic:
+                    if not _matches_topic(topic, label, domain_title):
+                        continue
+                elif not _looks_offer_worthy(label, domain_title):
+                    continue
+                category = category_from_sensitivity(
+                    entry.get("sensitivity_tier"), entry.get("scope_kind")
+                )
+                try:
+                    breakdown = compute_suggested_price(
+                        SlicePricingInput(
+                            category=category,
+                            attribute_count=_attribute_count(entry),
+                            power=power,
+                            mood=mood,
+                        )
+                    )
+                    price_cents = breakdown.suggested_price_cents
+                    currency = breakdown.currency
+                except KeyError:
+                    price_cents = 0
+                    currency = "USD"
+                out.append(
+                    {
+                        "domain": entry.get("domain") or domain,
+                        "domainTitle": domain_title,
+                        "label": label,
+                        "scopeHandle": entry.get("scope_handle"),
+                        "attributeCount": _attribute_count(entry),
+                        "suggestedPriceCents": price_cents,
+                        "currency": currency,
+                    }
+                )
+        return out[:6]
+
+    async def earnings_summary(
+        self,
+        *,
+        user_id: str,
+        power: str = "affluent",
+        mood: str = "affinity",
+    ) -> dict[str, Any]:
+        """Potential (never accrued) monthly earnings across the owner's published
+        slices. `accruedCents` is always 0 — there is no payment rail or buyer yet.
+        """
+        slices = await self.list_published_slices(user_id=user_id)
+        per_slice: list[dict[str, Any]] = []
+        total_potential_cents = 0
+        currency = "USD"
+        for sl in slices:
+            category = category_from_sensitivity(sl.get("sensitivityTier"), sl.get("scopeKind"))
+            try:
+                breakdown = compute_suggested_price(
+                    SlicePricingInput(
+                        category=category,
+                        attribute_count=int(sl.get("attributeCount") or 1),
+                        power=power,
+                        mood=mood,
+                    )
+                )
+            except KeyError:
+                # Unknown band/category — skip pricing this slice rather than guess.
+                continue
+            currency = breakdown.currency
+            total_potential_cents += breakdown.suggested_price_cents
+            # The same "show math" factors the dashboard's PriceMath renders:
+            # Price = ( floor + data value ) × buyer fit × freshness × exclusivity × geo
+            floor_dollars = breakdown.floor_cents / 100.0
+            data_value_dollars = max(0.0, breakdown.composite_dollars - floor_dollars)
+            per_slice.append(
+                {
+                    "label": sl["label"],
+                    "domainTitle": sl["domainTitle"],
+                    "suggestedPriceCents": breakdown.suggested_price_cents,
+                    "currency": breakdown.currency,
+                    "math": {
+                        "floorDollars": round(floor_dollars, 2),
+                        "dataValueDollars": round(data_value_dollars, 2),
+                        "buyerFit": round(breakdown.multiplier_b, 2),
+                        "freshness": round(breakdown.multiplier_f, 2),
+                        "exclusivity": round(breakdown.multiplier_x, 2),
+                        "geo": round(breakdown.multiplier_g, 2),
+                        "finalDollars": round(breakdown.suggested_price_cents / 100.0, 2),
+                    },
+                }
+            )
+        return {
+            "sliceCount": len(slices),
+            "pricedSliceCount": len(per_slice),
+            "totalPotentialMonthlyCents": total_potential_cents,
+            "accruedCents": 0,
+            "currency": currency,
+            "perSlice": per_slice,
+            # The pricing formula the dashboard shows under "Show math" — the agent
+            # can explain it and reference each slice's `math` factors above.
+            "formula": (
+                "Price = ( floor + data value ) × buyer fit × freshness × exclusivity × geo, "
+                "floored at $0.10. Data value: financial data counts most, plain demographics "
+                "least; more attributes help with diminishing returns. Buyer fit: spending power "
+                "× buying mood. Freshness: updated today = full value, stale fades toward a floor. "
+                "Exclusivity: sold to everyone = base, one buyer = worth more."
+            ),
+            "band": {"power": power, "mood": mood},
+            # Explicit honesty flags the agent's prompt relies on.
+            "hasBuyers": False,
+            "hasPaymentRail": False,
+            "note": (
+                "Potential only. No buyer has subscribed and no payment rail exists "
+                "yet, so nothing is accrued or settled."
+            ),
+        }

--- a/consent-protocol/hushh_mcp/services/marketplace_request_service.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_request_service.py
@@ -1,0 +1,148 @@
+"""Durable persistence for Information Marketplace access requests.
+
+A buyer's request to access a published data slice is a real record in
+`marketplace_access_requests` (migration 076), not browser-only state. The owner
+has a real inbox; approve/deny is server-side and can be driven from the direct
+marketplace chat OR through Agent One over A2A (the same way Location approves a
+grant). Consent-first: a request never grants access on its own — the owner must
+approve, and only the safe-summary projection of the slice is ever involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from db.db_client import get_db
+
+logger = logging.getLogger(__name__)
+
+_STATUSES = {"pending", "approved", "denied", "expired"}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Coerce UUID/datetime/etc. to a JSON-safe string. The DB returns UUID and
+    datetime objects that json.dumps (used when feeding tool results back to the
+    model) cannot serialize; the REST layer is fine, but the chat path is not."""
+    return None if value is None else str(value)
+
+
+def _row_to_request(row: dict) -> dict[str, Any]:
+    """Shape a DB row into the JSON-safe camelCase contract the agent/frontend consume."""
+    return {
+        "id": _str_or_none(row.get("id")),
+        "ownerUserId": _str_or_none(row.get("owner_user_id")),
+        "buyerUserId": _str_or_none(row.get("buyer_user_id")),
+        "buyerLabel": row.get("buyer_label"),
+        "domain": row.get("domain"),
+        "scopeHandle": row.get("scope_handle"),
+        "sliceName": row.get("slice_label"),
+        "priceCents": row.get("price_cents"),
+        "currency": row.get("currency"),
+        "durationDays": row.get("duration_days"),
+        "message": row.get("message"),
+        "status": row.get("status"),
+        "createdAt": _str_or_none(row.get("created_at")),
+        "resolvedAt": _str_or_none(row.get("resolved_at")),
+    }
+
+
+class MarketplaceRequestService:
+    """CRUD for durable marketplace access requests (owner-scoped)."""
+
+    def __init__(self) -> None:
+        self._supabase = None
+
+    @property
+    def supabase(self):
+        if self._supabase is None:
+            self._supabase = get_db()
+        return self._supabase
+
+    async def _execute_query(self, query):
+        return await asyncio.to_thread(query.execute)
+
+    async def create_request(
+        self,
+        *,
+        owner_user_id: str,
+        slice_label: str,
+        domain: str,
+        scope_handle: str | None = None,
+        buyer_user_id: str | None = None,
+        buyer_label: str | None = None,
+        price_cents: int = 0,
+        currency: str = "USD",
+        duration_days: int = 30,
+        message: str | None = None,
+    ) -> dict[str, Any]:
+        """File a new pending access request for a published slice."""
+        payload = {
+            "owner_user_id": owner_user_id,
+            "buyer_user_id": buyer_user_id,
+            "buyer_label": buyer_label,
+            "domain": domain,
+            "scope_handle": scope_handle,
+            "slice_label": slice_label,
+            "price_cents": int(price_cents or 0),
+            "currency": currency or "USD",
+            "duration_days": int(duration_days or 30),
+            "message": message,
+            "status": "pending",
+        }
+        result = await self._execute_query(
+            self.supabase.table("marketplace_access_requests").insert(payload)
+        )
+        rows = getattr(result, "data", None) or []
+        return _row_to_request(rows[0]) if rows else _row_to_request(payload)
+
+    async def list_requests(
+        self, *, owner_user_id: str, status: str | None = None
+    ) -> list[dict[str, Any]]:
+        """List the owner's requests (optionally filtered by status), newest first."""
+        query = (
+            self.supabase.table("marketplace_access_requests")
+            .select("*")
+            .eq("owner_user_id", owner_user_id)
+        )
+        if status in _STATUSES:
+            query = query.eq("status", status)
+        query = query.order("created_at", desc=True)
+        result = await self._execute_query(query)
+        return [_row_to_request(r) for r in (getattr(result, "data", None) or [])]
+
+    async def _resolve(
+        self, *, owner_user_id: str, request_id: str, next_status: str
+    ) -> dict[str, Any]:
+        """Owner-scoped status transition; only a pending request the owner owns
+        can be resolved (prevents cross-user or double resolution)."""
+        if next_status not in ("approved", "denied"):
+            raise ValueError("next_status must be 'approved' or 'denied'")
+        update = {"status": next_status, "resolved_at": _now_iso()}
+        result = await self._execute_query(
+            self.supabase.table("marketplace_access_requests")
+            .update(update)
+            .eq("id", request_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("status", "pending")
+        )
+        rows = getattr(result, "data", None) or []
+        if not rows:
+            return {"ok": False, "reason": "not_found_or_not_pending", "requestId": request_id}
+        return {"ok": True, "request": _row_to_request(rows[0])}
+
+    async def approve_request(self, *, owner_user_id: str, request_id: str) -> dict[str, Any]:
+        return await self._resolve(
+            owner_user_id=owner_user_id, request_id=request_id, next_status="approved"
+        )
+
+    async def deny_request(self, *, owner_user_id: str, request_id: str) -> dict[str, Any]:
+        return await self._resolve(
+            owner_user_id=owner_user_id, request_id=request_id, next_status="denied"
+        )

--- a/consent-protocol/tests/test_a2a_delegation_scopes.py
+++ b/consent-protocol/tests/test_a2a_delegation_scopes.py
@@ -21,6 +21,7 @@ def test_specialist_a2a_scope_map_uses_least_privilege_scopes() -> None:
         "agent_nav": ConsentScope.AGENT_NAV_REVIEW,
         "agent_kyc": ConsentScope.AGENT_KYC_PROCESS,
         "agent_location": ConsentScope.AGENT_ONE_ORCHESTRATE,
+        "agent_personal_information": ConsentScope.AGENT_ONE_ORCHESTRATE,
     }
     assert ConsentScope.VAULT_OWNER not in SPECIALIST_A2A_SCOPE_MAP.values()
 

--- a/consent-protocol/tests/test_information_chat_service.py
+++ b/consent-protocol/tests/test_information_chat_service.py
@@ -1,0 +1,253 @@
+"""Tests for the One Personal Information agent chat runner + read model.
+
+The chat runner executes a Gemini function-calling loop INSIDE a HushhContext so
+each @hushh_tool enforces consent scope. These tests inject a fake model_call
+(the Gemini seam), real google.genai types, and fake tools — no live LLM or DB.
+
+The read-model tests inject a fake PKM service to verify published-slice
+filtering and the honesty invariant that earnings are potential-only (nothing is
+ever accrued while there is no payment rail).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from google.genai import types
+
+from hushh_mcp.hushh_adk.context import HushhContext
+from hushh_mcp.services.information_chat_service import InformationChatService
+from hushh_mcp.services.marketplace_information_service import (
+    MarketplaceInformationService,
+)
+
+# --- chat-runner fakes ------------------------------------------------------
+
+
+class _Turn:
+    def __init__(self, conversation_id: str, history: list) -> None:
+        self.conversation_id = conversation_id
+        self.history = history
+
+
+class _FakeStore:
+    def __init__(self, history=None) -> None:
+        self.history = history or []
+        self.added: list[dict] = []
+
+    async def prepare_turn(self, *, user_id, message, conversation_id=None):
+        return _Turn(conversation_id or "conv-new", self.history)
+
+    async def add_message(self, *, conversation_id, user_id, role, content, status, model=None):
+        self.added.append({"role": role, "content": content, "status": status})
+
+
+def _fake_tool(name: str, recorder: list, *, result: dict | None = None):
+    async def _impl(**kwargs):
+        ctx = HushhContext.current()
+        recorder.append(
+            {
+                "name": name,
+                "args": kwargs,
+                "ctx_user": getattr(ctx, "user_id", None),
+                "ctx_token": getattr(ctx, "consent_token", None),
+            }
+        )
+        return result if result is not None else {"ok": True}
+
+    _impl._name = name
+    _impl._hushh_tool = True
+    return _impl
+
+
+def _fc_response(name: str, args: dict):
+    return SimpleNamespace(
+        function_calls=[SimpleNamespace(name=name, args=args)],
+        text="",
+        candidates=[
+            SimpleNamespace(content=types.Content(role="model", parts=[types.Part(text="")]))
+        ],
+    )
+
+
+def _text_response(text: str):
+    return SimpleNamespace(function_calls=[], text=text, candidates=[])
+
+
+def _scripted_model_call(responses: list, captured: list):
+    seq = iter(responses)
+
+    async def _call(contents, config):
+        captured.append(list(contents))
+        return next(seq)
+
+    return _call
+
+
+def _build_service(*, store, responses, captured, tools):
+    return InformationChatService(
+        chat_store=store,
+        model_call=_scripted_model_call(responses, captured),
+        genai_types=types,
+        ready=lambda: True,
+        tools=tools,
+        system_prompt="test-system-prompt",
+    )
+
+
+# --- chat-runner tests ------------------------------------------------------
+
+
+async def test_query_tool_runs_in_consent_context_and_never_changes_state():
+    store = _FakeStore()
+    calls: list[dict] = []
+    tools = [_fake_tool("list_published_slices", calls, result={"publishedSlices": [], "count": 0})]
+    captured: list = []
+    service = _build_service(
+        store=store,
+        responses=[
+            _fc_response("list_published_slices", {}),
+            _text_response("You have not published anything yet."),
+        ],
+        captured=captured,
+        tools=tools,
+    )
+
+    out = await service.handle_turn(
+        user_id="user_123",
+        message="what have I published?",
+        consent_token="vault-token",  # noqa: S106
+    )
+
+    assert out["response"] == "You have not published anything yet."
+    assert out["isComplete"] is True
+    # Read-only surface: a query turn must never report a state change.
+    assert out["stateChanged"] is False
+    # The tool executed inside the caller's consent context.
+    assert calls[0]["ctx_user"] == "user_123"
+    assert calls[0]["ctx_token"] == "vault-token"  # noqa: S105
+
+
+async def test_approve_tool_sets_state_changed():
+    store = _FakeStore()
+    calls: list[dict] = []
+    # A successful approve is a mutating tool → the turn reports stateChanged so
+    # the UI refetches the durable inbox.
+    tools = [_fake_tool("approve_access_request", calls, result={"ok": True})]
+    captured: list = []
+    service = _build_service(
+        store=store,
+        responses=[
+            _fc_response("approve_access_request", {"request_id": "req-1"}),
+            _text_response("Approved."),
+        ],
+        captured=captured,
+        tools=tools,
+    )
+
+    out = await service.handle_turn(
+        user_id="u1",
+        message="approve the Insurance request",
+        consent_token="vault-token",  # noqa: S106
+    )
+
+    assert out["response"] == "Approved."
+    assert out["stateChanged"] is True
+
+
+async def test_empty_message_short_circuits_without_model_call():
+    store = _FakeStore()
+    captured: list = []
+    service = _build_service(store=store, responses=[], captured=captured, tools=[])
+
+    out = await service.handle_turn(user_id="u1", message="", consent_token="t")  # noqa: S106
+
+    assert out["stateChanged"] is False
+    assert captured == []  # model never called
+
+
+# --- read-model fakes + tests ----------------------------------------------
+
+
+class _FakePkm:
+    def __init__(self, *, available_domains, manifests) -> None:
+        self._index = SimpleNamespace(available_domains=available_domains)
+        self._manifests = manifests
+
+    async def get_index_v2(self, user_id):
+        return self._index
+
+    async def get_domain_manifest(self, user_id, domain):
+        return self._manifests.get(domain)
+
+
+def _scope(label, posture, *, tier="confidential", segments=("a",)):
+    return {
+        "domain": "personal_data",
+        "scope_label": label,
+        "visibility_posture": posture,
+        "sensitivity_tier": tier,
+        "scope_kind": "subtree",
+        "scope_handle": f"h_{label}",
+        "segment_ids": list(segments),
+    }
+
+
+async def test_list_published_slices_returns_only_available():
+    pkm = _FakePkm(
+        available_domains=["personal_data"],
+        manifests={
+            "personal_data": {
+                "scope_registry": [
+                    _scope("Insurance", "default_available"),
+                    _scope("SSN", "private"),
+                    _scope("Email", "consent_required"),
+                ]
+            }
+        },
+    )
+    svc = MarketplaceInformationService(pkm_service=pkm)
+
+    slices = await svc.list_published_slices(user_id="u1")
+
+    assert [s["label"] for s in slices] == ["Insurance"]
+    assert slices[0]["domainTitle"] == "Personal Data"
+    assert slices[0]["attributeCount"] == 1
+
+
+async def test_earnings_summary_is_potential_only_never_accrued():
+    pkm = _FakePkm(
+        available_domains=["personal_data"],
+        manifests={
+            "personal_data": {
+                "scope_registry": [
+                    _scope(
+                        "Insurance", "default_available", tier="restricted", segments=("a", "b")
+                    ),
+                ]
+            }
+        },
+    )
+    svc = MarketplaceInformationService(pkm_service=pkm)
+
+    summary = await svc.earnings_summary(user_id="u1")
+
+    assert summary["sliceCount"] == 1
+    assert summary["pricedSliceCount"] == 1
+    # The honesty invariant: nothing is ever accrued without a payment rail.
+    assert summary["accruedCents"] == 0
+    assert summary["hasBuyers"] is False
+    assert summary["hasPaymentRail"] is False
+    assert summary["totalPotentialMonthlyCents"] > 0
+    assert summary["perSlice"][0]["label"] == "Insurance"
+
+
+async def test_earnings_summary_with_nothing_published():
+    pkm = _FakePkm(available_domains=[], manifests={})
+    svc = MarketplaceInformationService(pkm_service=pkm)
+
+    summary = await svc.earnings_summary(user_id="u1")
+
+    assert summary["sliceCount"] == 0
+    assert summary["totalPotentialMonthlyCents"] == 0
+    assert summary["accruedCents"] == 0

--- a/consent-protocol/tests/test_marketplace_request_service.py
+++ b/consent-protocol/tests/test_marketplace_request_service.py
@@ -1,0 +1,162 @@
+"""Tests for durable marketplace access-request persistence.
+
+Injects a fake Supabase client (chainable query stub) so the shaping and the
+owner-scoped resolve logic are covered without a real database.
+"""
+
+from __future__ import annotations
+
+from hushh_mcp.services.marketplace_request_service import MarketplaceRequestService
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    """Records the chained call and returns a preset result on execute()."""
+
+    def __init__(self, result):
+        self._result = result
+        self.inserted = None
+        self.updated = None
+        self.eqs: list[tuple] = []
+        self.order_called = False
+
+    def insert(self, payload):
+        self.inserted = payload
+        return self
+
+    def select(self, *_a):
+        return self
+
+    def update(self, payload):
+        self.updated = payload
+        return self
+
+    def eq(self, key, value):
+        self.eqs.append((key, value))
+        return self
+
+    def order(self, *_a, **_k):
+        self.order_called = True
+        return self
+
+    def execute(self):
+        return self._result
+
+
+class _FakeTable:
+    def __init__(self, query):
+        self._query = query
+
+    def insert(self, payload):
+        return self._query.insert(payload)
+
+    def select(self, *a):
+        return self._query.select(*a)
+
+    def update(self, payload):
+        return self._query.update(payload)
+
+
+class _FakeDB:
+    def __init__(self, result):
+        self.query = _FakeQuery(result)
+
+    def table(self, _name):
+        return _FakeTable(self.query)
+
+
+def _service_with(result_data) -> tuple[MarketplaceRequestService, _FakeDB]:
+    svc = MarketplaceRequestService()
+    fake = _FakeDB(_FakeResult(result_data))
+    svc._supabase = fake
+    return svc, fake
+
+
+async def test_create_request_shapes_row_to_contract():
+    row = {
+        "id": "req-1",
+        "owner_user_id": "owner",
+        "buyer_label": "Acme",
+        "domain": "personal_data",
+        "scope_handle": "h1",
+        "slice_label": "Insurance",
+        "price_cents": 55,
+        "currency": "USD",
+        "duration_days": 30,
+        "status": "pending",
+    }
+    svc, fake = _service_with([row])
+
+    out = await svc.create_request(
+        owner_user_id="owner",
+        slice_label="Insurance",
+        domain="personal_data",
+        scope_handle="h1",
+        buyer_label="Acme",
+        price_cents=55,
+    )
+
+    assert out["id"] == "req-1"
+    assert out["sliceName"] == "Insurance"
+    assert out["priceCents"] == 55
+    assert out["status"] == "pending"
+    # The insert payload defaulted status to pending.
+    assert fake.query.inserted["status"] == "pending"
+
+
+async def test_list_requests_filters_by_status_and_shapes():
+    rows = [
+        {"id": "a", "owner_user_id": "owner", "slice_label": "One", "status": "pending"},
+        {"id": "b", "owner_user_id": "owner", "slice_label": "Two", "status": "pending"},
+    ]
+    svc, fake = _service_with(rows)
+
+    out = await svc.list_requests(owner_user_id="owner", status="pending")
+
+    assert [r["id"] for r in out] == ["a", "b"]
+    assert [r["sliceName"] for r in out] == ["One", "Two"]
+    assert ("owner_user_id", "owner") in fake.query.eqs
+    assert ("status", "pending") in fake.query.eqs
+
+
+async def test_approve_request_ok_when_pending_row_updated():
+    row = {
+        "id": "req-1",
+        "owner_user_id": "owner",
+        "slice_label": "Insurance",
+        "status": "approved",
+    }
+    svc, fake = _service_with([row])
+
+    result = await svc.approve_request(owner_user_id="owner", request_id="req-1")
+
+    assert result["ok"] is True
+    assert result["request"]["status"] == "approved"
+    # Owner-scoped, pending-only, id-matched update.
+    assert fake.query.updated["status"] == "approved"
+    assert ("owner_user_id", "owner") in fake.query.eqs
+    assert ("id", "req-1") in fake.query.eqs
+    assert ("status", "pending") in fake.query.eqs
+
+
+async def test_approve_request_not_ok_when_no_row_matched():
+    svc, _ = _service_with([])  # no pending row owned by this user
+
+    result = await svc.approve_request(owner_user_id="owner", request_id="missing")
+
+    assert result["ok"] is False
+    assert result["reason"] == "not_found_or_not_pending"
+
+
+async def test_deny_request_marks_denied():
+    row = {"id": "req-1", "owner_user_id": "owner", "slice_label": "Insurance", "status": "denied"}
+    svc, fake = _service_with([row])
+
+    result = await svc.deny_request(owner_user_id="owner", request_id="req-1")
+
+    assert result["ok"] is True
+    assert fake.query.updated["status"] == "denied"

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -6,6 +6,7 @@
     "hushh-webapp/app/one/gmail/page.voice-action-contract.json",
     "hushh-webapp/app/one/kai/analysis/page.voice-action-contract.json",
     "hushh-webapp/app/one/kyc/page.voice-action-contract.json",
+    "hushh-webapp/app/one/marketplace/page.voice-action-contract.json",
     "hushh-webapp/app/profile/page.voice-action-contract.json",
     "hushh-webapp/app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
     "hushh-webapp/app/ria/clients/page.voice-action-contract.json",
@@ -101,6 +102,23 @@
         },
         "speaker_persona": "kyc",
         "delegate_agent_id": "kyc"
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_marketplace",
+      "surface_title": "Information Marketplace",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/app/one/marketplace/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        }
       }
     },
     {
@@ -2021,6 +2039,76 @@
       "expected_effects": {
         "state_changes": [
           "current route becomes /one/kyc"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      }
+    },
+    {
+      "action_id": "route.one_marketplace",
+      "surface_id": "one_marketplace",
+      "label": "Open Information Marketplace",
+      "aliases": [
+        "open information marketplace",
+        "open the information marketplace",
+        "open data marketplace",
+        "go to information marketplace",
+        "go to the data marketplace",
+        "take me to the information marketplace",
+        "show me the information marketplace",
+        "open my data marketplace"
+      ],
+      "search_keywords": [
+        "marketplace",
+        "data marketplace",
+        "data slices",
+        "sell my data",
+        "published slices"
+      ],
+      "meaning": "Navigates to the One Information Marketplace (personal data-slice) route.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/marketplace"
+        ],
+        "screens": [
+          "one_marketplace"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/marketplace"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/kai/kai-voice-runtime-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/marketplace"
         ],
         "backend_effects": []
       },

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -905,6 +905,45 @@
       ]
     },
     {
+      "id": "route.one_marketplace",
+      "label": "Open Information Marketplace",
+      "meaning": "Navigates to the One Information Marketplace (personal data-slice) route.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "aliases": [
+        "open information marketplace",
+        "open the information marketplace",
+        "open data marketplace",
+        "go to information marketplace",
+        "go to the data marketplace",
+        "take me to the information marketplace",
+        "show me the information marketplace",
+        "open my data marketplace"
+      ],
+      "scope": {
+        "routes": [
+          "/one/marketplace"
+        ],
+        "screens": [
+          "one_marketplace"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/marketplace"
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/kai/kai-voice-runtime-architecture.md"
+      ]
+    },
+    {
       "id": "route.profile",
       "label": "Open Profile",
       "meaning": "Navigates to profile landing route.",

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -65,6 +65,7 @@ Promotion targets:
 - [one-product-surface-evolution-plan.md](./one-product-surface-evolution-plan.md): planning-only product-surface evolution path for One, Kai, Nav, KYC, PCHP, PKM, OpenClaw/LLM Wiki-style projections, signature, brokerage, and brand-side access
 - [one-nav-runtime-plan.md](./one-nav-runtime-plan.md): planning-only migration path from the current Kai-first runtime to the One/Kai/Nav/KYC ontology
 - [pkm-slice-marketplace-plan.md](./pkm-slice-marketplace-plan.md): planning-only phased plan for a PKM data-slice subscription marketplace under One (backend-led, user-set price per slice, reuses default_available/consent/export)
+- [information-marketplace-agent-plan.md](./information-marketplace-agent-plan.md): Information Marketplace conversational agent — what's built on `feat/personal-information-agent` plus the product-grade forward path (persist requests end-to-end, approve/deny over One A2A, inline publish-for-offers nudge)
 
 ## References
 

--- a/docs/future/information-marketplace-agent-plan.md
+++ b/docs/future/information-marketplace-agent-plan.md
@@ -1,0 +1,113 @@
+# Information Marketplace Agent — product plan
+
+Status: **planning + partially built.** The conversational Information Marketplace
+agent exists on branch `feat/personal-information-agent` (not merged). This doc
+captures what is built and the **product-grade** forward path. Decision anchor:
+treat this as a real product, **not a demo** — no browser-only state end to end.
+
+Builds on [pkm-slice-marketplace-plan.md](./pkm-slice-marketplace-plan.md) (pricing
+engine, `default_available` publish path, consent-first posture).
+
+## Visual Map
+
+```
+User ──▶ Information Marketplace chat        Agent One ──(A2A delegate)──▶ Information Marketplace
+        (/one/marketplace panel)                       specialist (adk_bridge)
+                 │                                                │
+                 ▼                                                ▼
+        InformationChatService.handle_turn ◀──────────────────────┘
+        (Gemini tool loop, per-@hushh_tool consent scope)
+                 │
+     ┌───────────┼───────────────────────────┬─────────────────────────┐
+     ▼           ▼                           ▼                         ▼
+ list_published  get_earnings_summary   propose_publish        list/approve/deny_
+ _slices         (price + show-math)    (publish card,          access_request
+     │           │                       topic-tailored)                │
+     ▼           ▼                           ▼                         ▼
+ MarketplaceInformationService  ◀── pkm_scope_registry     MarketplaceRequestService
+ (owner's own safe metadata + pricing engine)              (marketplace_access_requests, mig 076)
+                                                                       │
+                                                                       ▼
+                                          durable owner inbox: /one/marketplace Flow & requests
+```
+
+## What "Information Marketplace" is
+
+A user publishes safe projections of their own PKM as priced, consentable data
+slices so verified buyers can send them offers / favorable deals / money — the
+value advertisers already extract, returned to the user with consent-first
+control. Distinct from Kai's **Market Home** (markets/investing); "marketplace"
+said bare is disambiguated by One.
+
+## Built so far (branch `feat/personal-information-agent`)
+
+- **Agent** `hushh_mcp/agents/personal_information/` (name: "Information Marketplace"),
+  mirrors the Location agent: `agent.py` / `agent.yaml` / `manifest.py` / `tools.py`.
+- **Tools**: `list_published_slices`, `get_earnings_summary` (potential-only,
+  `accruedCents` always 0 with `math` factors + `formula`), `approve_access_request`
+  / `deny_access_request` (emit a client-action).
+- **Chat**: `services/information_chat_service.py` + route `POST /api/one/information/chat`;
+  frontend panel `components/one-marketplace/` on `/one/marketplace`.
+- **Scopes**: `cap.pkm.marketplace.{view,publish,manage}` (registered in the enum,
+  `capability_scopes()`, and the `_AGENT_SCOPE_MAP` resolver).
+- **A2A**: registered specialist `agent_personal_information` (delegation.py scope
+  map + `adk_bridge/personal_information_agent.py` + `adk_bridge/__init__.py`);
+  One delegates marketplace **questions** to it. Routing: qualified cues delegate;
+  "open …" navigates (deterministic `route.one_marketplace` + voice-action contract);
+  bare "marketplace" → One asks which (deterministic clarification).
+- **Nav/UX**: `/one/marketplace` breadcrumb (Profile › Marketplace), One capability
+  tile "Information Marketplace".
+
+Known gap: marketplace **access requests are browser-only in-session state**
+(`MarketRequest` in `app/one/marketplace/page.tsx`) — they clear on refresh and
+have no backend record. This is the thing to fix first.
+
+## Forward plan (product-grade, phased)
+
+### Phase 1 — Persist marketplace requests end-to-end (foundation)
+Turn the in-session `MarketRequest` into a real backend record, like a location
+grant. New table (e.g. `marketplace_access_requests`): buyer ref, slice ref
+(domain + scope handle), status (pending/approved/denied/expired), price, created/
+resolved timestamps, owner user id. Routes to create/list/resolve. Requests
+survive refresh; the owner has a real inbox. Consent + audit trail on approve.
+**No browser-only state.**
+
+### Phase 2 — Approve/deny over Agent One (A2A), mirroring Location
+Once requests are real records, One → Information Marketplace → `approve_access_request`
+updates the record **server-side** — identical to how One approves a Location
+request today. No browser round-trip. Remove the "approve stays on direct chat"
+caveat. Delegation router already sends marketplace intents; extend the A2A handler
+to carry approve/deny (it already surfaces the client-action directive path).
+
+### Phase 3 — Inline "publish for offers" nudge
+Meet the user in the moment instead of making them visit the dashboard.
+- **Signal detection** (new, small): tag a saved memory / mentioned fact as
+  "offer-worthy" (renewals, purchase intent, life events) — keywords first, LLM later.
+- **`propose_publish` card/tool** (new, small; mirrors approve/deny client-action):
+  returns a publish card — safe summary + suggested price + [Publish] / [Not now].
+- **Surfaces in BOTH**: the direct Information Marketplace chat AND Agent One (the
+  A2A `specialist_directive` channel already carries specialist cards into One's
+  chat — Location's directive rendering is the template). Plus an optional
+  **dashboard flash card** ("N things worth publishing") as a catch-up nudge.
+- **One-tap publish** reuses the existing `default_available` + owner-consent +
+  pricing path — no new publish backend.
+
+Smallest first step for Phase 3: the **chat publish card** (largest reuse), then
+the save-to-PKM trigger and the on-page flash card.
+
+## Reuse vs new (summary)
+
+| Piece | Status |
+|---|---|
+| Publish a slice (Available + consent + price) | built |
+| Pricing engine (price + math + formula) | built |
+| Chat client-action card mechanism | built (approve/deny) |
+| A2A delegation + directive-into-One channel | built |
+| **Persisted marketplace requests + inbox** | Phase 1 (new) |
+| **Approve/deny over One A2A** | Phase 2 (falls out of Phase 1) |
+| **Offer-worthy signal detection** | Phase 3 (new, small) |
+| **`propose_publish` card + inline triggers** | Phase 3 (new) |
+
+## Out of scope (for now)
+Payment rail / settlement (still no money moves); autonomous buyer/business agent
+(demo runs on One ↔ Information Marketplace only).

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -304,6 +304,21 @@
       "expected_row_growth": "medium_per_user_share"
     },
     {
+      "id": "information_marketplace_requests",
+      "owner": "iam-consent-governance",
+      "data_class": "workflow_state",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "marketplace_access_requests"
+      ],
+      "primary_access_path": "One Information Marketplace access-request inbox: a buyer files a request for owner-approved access to a published data-slice safe projection; the owner lists, approves, or denies server-side from the marketplace surface or via Agent One over A2A.",
+      "retention_policy": "Pending requests are retained until resolved; approved, denied, or expired rows are retained only for bounded operational and consent-audit review before compaction.",
+      "deletion_behavior": "Delete rows where the deleting account is the owner (or the buyer once buyer identity exists); resolve pending requests to a terminal status before deletion where possible.",
+      "trust_boundary": "Backend stores only request metadata (owner and buyer references, slice domain, scope handle, label, price, status, timestamps). It never stores raw PKM values; a request grants no access on its own and only the safe-summary projection is ever shared after explicit owner approval.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "medium_per_user_request"
+    },
+    {
       "id": "market_reference_and_cache",
       "owner": "backend-runtime-governance",
       "data_class": "reference",

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -40,25 +40,14 @@ import {
   type SlicePriceBreakdown,
   type SlicePricingInput,
 } from "@/lib/services/slice-pricing-service";
+import { MarketplaceChatPanel } from "@/components/one-marketplace/marketplace-chat-panel";
+import {
+  OneMarketplaceService,
+  type MarketplaceRequest,
+  type PublishableSlice,
+} from "@/lib/one-marketplace/service";
 
 type MarketplaceView = "owner" | "buyer" | "flow";
-
-/**
- * In-session demo request. NOT a real consent grant and NOT persisted — clears on
- * refresh. Real access requests live in the Consent Guardian; wiring the
- * marketplace to file them there is a later phase.
- */
-interface MarketRequest {
-  id: string;
-  sliceName: string;
-  domainKey: string;
-  domainTitle: string;
-  topLevelScopePath: string;
-  description: string;
-  input: SlicePricingInput;
-  createdAt: number;
-  status: "pending" | "approved" | "denied";
-}
 
 interface DomainRecord {
   summary: DomainSummary;
@@ -402,13 +391,29 @@ export default function OneMarketplacePage() {
   // Owner is about to publish this section to the marketplace and must explicitly
   // consent first (consent-first). Null when no confirmation is pending.
   const [confirmPublish, setConfirmPublish] = useState<Section | null>(null);
-  const [requests, setRequests] = useState<MarketRequest[]>([]);
+  // Durable access-request inbox (server-side records, migration 075).
+  const [requests, setRequests] = useState<MarketplaceRequest[]>([]);
 
   const [records, setRecords] = useState<DomainRecord[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Record<string, boolean>>({});
   const [refreshToken, setRefreshToken] = useState(0);
+
+  // Load the durable request inbox on mount and whenever the page refreshes.
+  const loadRequests = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    try {
+      const rows = await OneMarketplaceService.listRequests({ vaultOwnerToken });
+      setRequests(rows);
+    } catch {
+      // Non-fatal: the inbox stays as-is until the next refresh.
+    }
+  }, [vaultOwnerToken]);
+
+  useEffect(() => {
+    void loadRequests();
+  }, [loadRequests, refreshToken]);
 
   // Load the owner's real PKM domains + manifests. The scope registry on each
   // manifest is the source of shareable sections and their consent posture.
@@ -664,32 +669,101 @@ export default function OneMarketplacePage() {
 
   const pendingRequestCount = requests.filter((r) => r.status === "pending").length;
 
-  const confirmPurchase = useCallback(() => {
-    setPurchaseSection((current) => {
-      if (!current) return null;
-      setRequests((cur) => [
-        {
-          id: `${current.key}:${Date.now()}`,
-          sliceName: current.permission.label,
-          domainKey: current.domainKey,
-          domainTitle: current.domainTitle,
-          topLevelScopePath: current.permission.topLevelScopePath,
-          description: current.permission.description,
-          input: priceInput(current),
-          createdAt: Date.now(),
-          status: "pending",
-        },
-        ...cur,
-      ]);
-      return null;
-    });
-    setView("flow");
-    toast.success("Request sent — see Consent flow & requests.");
-  }, [priceInput]);
+  // Identity keys of slices already published — the chat publish card filters
+  // these out so a just-published slice drops off the recommendation.
+  const publishedSliceKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const s of sections) {
+      if (s.permission.visibilityPosture !== "default_available") continue;
+      if (s.permission.scopeHandle) keys.add(`h:${s.permission.scopeHandle}`);
+      keys.add(`l:${s.domainKey}:${s.permission.label}`);
+    }
+    return keys;
+  }, [sections]);
 
-  const setRequestStatus = useCallback((id: string, status: MarketRequest["status"]) => {
-    setRequests((cur) => cur.map((r) => (r.id === id ? { ...r, status } : r)));
-  }, []);
+  // Publish a slice the agent suggested in a chat publish-card. Match by scope
+  // handle first, then fall back to domain + label.
+  const onPublishSlice = useCallback(
+    (slice: PublishableSlice) => {
+      const section = sections.find(
+        (s) =>
+          (slice.scopeHandle && s.permission.scopeHandle === slice.scopeHandle) ||
+          (s.domainKey === slice.domain && s.permission.label === slice.label)
+      );
+      if (section) onTogglePosture(section, "default_available");
+      else toast.error("Couldn't find that section to publish.");
+    },
+    [sections, onTogglePosture]
+  );
+
+  // File a real, durable access request (server-side). The buyer is simulated by
+  // the owner in this tab; the record persists and survives refresh.
+  const confirmPurchase = useCallback(() => {
+    const current = purchaseSection;
+    if (!current || !vaultOwnerToken) {
+      setPurchaseSection(null);
+      return;
+    }
+    setPurchaseSection(null);
+    void (async () => {
+      let priceCents = 0;
+      let currency = "USD";
+      try {
+        const price = await SlicePricingService.getSuggestedPrice(
+          priceInput(current),
+          vaultOwnerToken
+        );
+        priceCents = price.suggestedPriceCents;
+        currency = price.currency;
+      } catch {
+        // Price is best-effort; the request still files at the floor.
+      }
+      try {
+        await OneMarketplaceService.createRequest({
+          vaultOwnerToken,
+          sliceName: current.permission.label,
+          domain: current.domainKey,
+          scopeHandle: current.permission.scopeHandle,
+          buyerLabel: "Buyer",
+          priceCents,
+          currency,
+        });
+        await loadRequests();
+        setView("flow");
+        toast.success("Request filed — see Flow & requests.");
+      } catch {
+        toast.error("Couldn't file the request. Try again.");
+      }
+    })();
+  }, [purchaseSection, vaultOwnerToken, priceInput, loadRequests]);
+
+  const approveRequest = useCallback(
+    async (id: string) => {
+      if (!vaultOwnerToken) return;
+      try {
+        await OneMarketplaceService.approveRequest({ vaultOwnerToken, requestId: id });
+        await loadRequests();
+        toast.success("Approved — the safe summary would be delivered to that buyer only.");
+      } catch {
+        toast.error("Couldn't approve. Refresh and try again.");
+      }
+    },
+    [vaultOwnerToken, loadRequests]
+  );
+
+  const denyRequest = useCallback(
+    async (id: string) => {
+      if (!vaultOwnerToken) return;
+      try {
+        await OneMarketplaceService.denyRequest({ vaultOwnerToken, requestId: id });
+        await loadRequests();
+        toast("Denied. Nothing shared.");
+      } catch {
+        toast.error("Couldn't deny. Refresh and try again.");
+      }
+    },
+    [vaultOwnerToken, loadRequests]
+  );
 
   const bandControls = (
     <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
@@ -722,7 +796,7 @@ export default function OneMarketplacePage() {
   return (
     <PkmSettingsShell
       eyebrow="One / Marketplace"
-      title="Data Slice Marketplace"
+      title="Information Marketplace"
       description="Your data, your business. Choose what each section shares — Private, Ask first, or Available — and see what it's worth. Nothing is ever shared without your approval."
       actions={
         <div className="flex flex-wrap items-center gap-2">
@@ -765,6 +839,17 @@ export default function OneMarketplacePage() {
         Consent-first · a section is shared only after you set it to Available and approve a specific
         buyer. Prices are a research-anchored suggestion computed live — you set the final price. No
         money moves here.
+      </div>
+
+      {/* Personal Information Agent — the marketplace chatbot. Ask what you've
+          published and what it's worth; read-only and consent-scoped. */}
+      <div className="mb-5">
+        <MarketplaceChatPanel
+          vaultOwnerToken={token ?? null}
+          onStateChanged={loadRequests}
+          onPublishSlice={onPublishSlice}
+          publishedSliceKeys={publishedSliceKeys}
+        />
       </div>
 
       {!isVaultUnlocked ? (
@@ -939,7 +1024,7 @@ export default function OneMarketplacePage() {
             </div>
           ) : null}
 
-          {/* FLOW & REQUESTS — marketplace's own consent inbox (in-session demo) */}
+          {/* FLOW & REQUESTS — marketplace's own durable consent inbox */}
           {view === "flow" ? (
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-3">
@@ -982,11 +1067,13 @@ export default function OneMarketplacePage() {
                             </span>
                           </div>
                           <div className="mt-0.5 text-sm text-muted-foreground">
-                            {req.domainTitle} · 30-day scoped access · safe summary only
+                            {req.buyerLabel ? `${req.buyerLabel} · ` : ""}
+                            {req.durationDays ?? 30}-day scoped access · safe summary only
                           </div>
                         </div>
-                        <div className="text-right">
-                          <PriceLine input={req.input} token={token} />
+                        <div className="text-right text-lg font-semibold tracking-tight">
+                          {formatCents(req.priceCents ?? 0, req.currency ?? "USD")}{" "}
+                          <span className="text-sm font-medium text-muted-foreground">/ 30 days</span>
                         </div>
                       </div>
                       {req.status === "pending" ? (
@@ -996,10 +1083,7 @@ export default function OneMarketplacePage() {
                             size="sm"
                             variant="none"
                             effect="fade"
-                            onClick={() => {
-                              setRequestStatus(req.id, "approved");
-                              toast.success("Approved — the encrypted slice would be delivered to that buyer only.");
-                            }}
+                            onClick={() => void approveRequest(req.id)}
                           >
                             Approve
                           </Button>
@@ -1008,37 +1092,23 @@ export default function OneMarketplacePage() {
                             size="sm"
                             variant="none"
                             effect="fade"
-                            onClick={() => {
-                              setRequestStatus(req.id, "denied");
-                              toast("Denied. Nothing shared.");
-                            }}
+                            onClick={() => void denyRequest(req.id)}
                           >
                             Deny
                           </Button>
                         </div>
                       ) : req.status === "approved" ? (
-                        <div className="mt-3 space-y-2 border-t pt-3">
-                          <div className="text-xs font-medium text-emerald-700 dark:text-emerald-300">
-                            The safe summary the buyer would receive (real data · never raw PKM):
-                          </div>
-                          <SharedDataPreview
-                            userId={user?.uid}
-                            vaultKey={vaultKey}
-                            token={token}
-                            domainKey={req.domainKey}
-                            domainTitle={req.domainTitle}
-                            topLevelScopePath={req.topLevelScopePath}
-                            label={req.sliceName}
-                            description={req.description}
-                          />
-                          <div className="text-[11px] text-muted-foreground">
-                            Approved (demo). This is the actual projection that would be delivered;
-                            encrypted per-buyer delivery and payment are the next phase.
-                          </div>
+                        <div className="mt-3 border-t pt-3 text-xs text-emerald-700 dark:text-emerald-300">
+                          Approved — the safe summary would be delivered to this buyer only (never raw
+                          PKM). Encrypted per-buyer delivery and payment settlement are the next phase.
+                        </div>
+                      ) : req.status === "denied" ? (
+                        <div className="mt-3 border-t pt-3 text-xs text-muted-foreground">
+                          Denied — nothing was shared.
                         </div>
                       ) : (
                         <div className="mt-3 border-t pt-3 text-xs text-muted-foreground">
-                          Denied — nothing was shared.
+                          Expired — access is no longer available.
                         </div>
                       )}
                     </div>
@@ -1047,9 +1117,9 @@ export default function OneMarketplacePage() {
               )}
 
               <div className="rounded-xl bg-muted/30 px-4 py-3 text-[12.5px] text-muted-foreground">
-                In-session demo · these requests are not real consent grants and clear on refresh. Real
-                access requests live in your Consent Guardian; filing marketplace requests there (and
-                payment settlement) is the next phase.
+                These are real, saved requests — they persist across refresh. You can approve or deny
+                here or by asking the Information Marketplace agent. Encrypted per-buyer delivery and
+                payment settlement are the next phase.
               </div>
 
               <div className="rounded-2xl border p-5">
@@ -1104,8 +1174,8 @@ export default function OneMarketplacePage() {
             </p>
             <p className="mt-2 text-xs text-muted-foreground">
               Consent-first by design. The request appears under{" "}
-              <span className="font-medium text-foreground">Flow &amp; requests</span> (in-session demo). No
-              money moves — payment settlement is a later phase.
+              <span className="font-medium text-foreground">Flow &amp; requests</span>. No money moves —
+              payment settlement is a later phase.
             </p>
             <div className="mt-4 flex justify-end gap-2">
               <Button

--- a/hushh-webapp/app/one/marketplace/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/marketplace/page.voice-action-contract.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "one_marketplace",
+  "surface_title": "Information Marketplace",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": [
+        "investor",
+        "ria"
+      ]
+    }
+  },
+  "actions": [
+    {
+      "action_id": "route.one_marketplace",
+      "label": "Open Information Marketplace",
+      "meaning": "Navigates to the One Information Marketplace (personal data-slice) route.",
+      "aliases": [
+        "open information marketplace",
+        "open the information marketplace",
+        "open data marketplace",
+        "go to information marketplace",
+        "go to the data marketplace",
+        "take me to the information marketplace",
+        "show me the information marketplace",
+        "open my data marketplace"
+      ],
+      "search_keywords": [
+        "marketplace",
+        "data marketplace",
+        "data slices",
+        "sell my data",
+        "published slices"
+      ],
+      "reachability": {
+        "routes": [
+          "/one/marketplace"
+        ],
+        "screens": [
+          "one_marketplace"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/marketplace"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-voice-runtime-architecture.md"
+      ],
+      "speaker_persona": "nav"
+    }
+  ]
+}

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -43,8 +43,10 @@ import {
   SpecialistPromptCard,
   type SpecialistConsentActionItem,
 } from "@/components/agent/specialist-directive-card";
+import { MarketplacePublishDirectiveCard } from "@/components/agent/marketplace-publish-directive-card";
 import { SelectionChip } from "@/components/agent/selection-chip";
 import { describeSelection } from "@/lib/agent/describe-selection";
+import type { PublishableSlice } from "@/lib/one-marketplace/service";
 import type { ClientPrompt } from "@/lib/one-location/types";
 import { AgentVoiceWaveInput } from "@/components/agent/agent-voice-wave-input";
 import { StreamingCursor } from "@/lib/morphy-ux/streaming-cursor";
@@ -3977,6 +3979,28 @@ export function AgentChatWorkspace({
                         display,
                       });
                     }}
+                  />
+                ) : String(
+                    (pendingSpecialistDirective.directive.payload as Record<string, unknown>)
+                      .type ?? "",
+                  ) === "publish_slices" ? (
+                  // ── Information Marketplace publish card ──────────────────
+                  // propose_publish delivered over A2A. Publishing needs the vault
+                  // on the marketplace surface, so hand off there.
+                  <MarketplacePublishDirectiveCard
+                    topic={
+                      (pendingSpecialistDirective.directive.payload as Record<string, unknown>)
+                        .topic as string | null | undefined
+                    }
+                    slices={
+                      ((pendingSpecialistDirective.directive.payload as Record<string, unknown>)
+                        .slices as PublishableSlice[]) ?? []
+                    }
+                    onOpenMarketplace={() => {
+                      setPendingSpecialistDirective(null);
+                      router.push(ROUTES.ONE_MARKETPLACE);
+                    }}
+                    onDismiss={() => setPendingSpecialistDirective(null)}
                   />
                 ) : pendingSpecialistDirective.delegateAgentId === "agent_connected_systems" ? (
                   <SpecialistDirectiveCard

--- a/hushh-webapp/components/agent/marketplace-publish-directive-card.tsx
+++ b/hushh-webapp/components/agent/marketplace-publish-directive-card.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+
+import { Button } from "@/lib/morphy-ux/morphy";
+import { formatCents } from "@/lib/services/slice-pricing-service";
+import type { PublishableSlice } from "@/lib/one-marketplace/service";
+
+/**
+ * Agent One rendering of the Information Marketplace "publish for offers?" card
+ * (the propose_publish directive delivered over A2A). Publishing itself needs the
+ * vault on the marketplace surface, so the primary action hands the user off
+ * there; the card is the in-conversation nudge.
+ */
+export function MarketplacePublishDirectiveCard(props: {
+  topic?: string | null;
+  slices: PublishableSlice[];
+  onOpenMarketplace: () => void;
+  onDismiss: () => void;
+}) {
+  const { topic, slices, onOpenMarketplace, onDismiss } = props;
+  if (!slices || slices.length === 0) return null;
+  return (
+    <div className="rounded-2xl border border-emerald-300/50 bg-emerald-50/50 p-3 dark:border-emerald-900/40 dark:bg-emerald-950/15">
+      <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+        <Sparkles className="h-4 w-4" aria-hidden />
+        {topic ? `Publish your ${topic} data for offers?` : "Publish these for offers?"}
+      </div>
+      <div className="flex flex-col gap-2">
+        {slices.map((slice) => (
+          <div
+            key={`${slice.domain}:${slice.scopeHandle ?? slice.label}`}
+            className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-emerald-300/40 bg-background/60 px-3 py-2 text-sm"
+          >
+            <div className="min-w-0">
+              <span className="font-medium text-foreground">{slice.label}</span>
+              <span className="text-muted-foreground"> · {slice.domainTitle ?? slice.domain}</span>
+              {slice.suggestedPriceCents ? (
+                <span className="text-muted-foreground">
+                  {" "}
+                  · ~{formatCents(slice.suggestedPriceCents, slice.currency ?? "USD")}/mo
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 flex items-center gap-3">
+        <Button type="button" size="sm" variant="none" effect="fade" onClick={onOpenMarketplace}>
+          Open marketplace to publish
+        </Button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="text-xs font-medium text-emerald-700/80 hover:underline dark:text-emerald-300/80"
+        >
+          Not now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-atoms.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-atoms.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Store } from "lucide-react";
+
+/** Shared card surface + muted-copy tokens (same app-card design system the
+ *  Location chat uses, inlined here so the marketplace chat is self-contained). */
+export const MARKET_CARD_SURFACE =
+  "rounded-[var(--app-card-radius-standard)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)]";
+export const MARKET_MUTED_TEXT = "text-sm leading-snug text-muted-foreground";
+
+export function MarketBotAvatar(props: { size?: number }) {
+  const size = props.size ?? 32;
+  return (
+    <span
+      className="flex shrink-0 items-center justify-center rounded-full bg-emerald-500/12 text-emerald-700 dark:text-emerald-300"
+      style={{ width: size, height: size }}
+      aria-hidden
+    >
+      <Store style={{ width: size * 0.55, height: size * 0.55 }} />
+    </span>
+  );
+}
+
+export function MarketTypingIndicator() {
+  return (
+    <span
+      data-testid="marketplace-chat-typing"
+      className="inline-flex items-center gap-1"
+      aria-label="The marketplace assistant is typing"
+    >
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground/60 motion-reduce:animate-none"
+          style={{ animationDelay: `${i * 120}ms` }}
+        />
+      ))}
+    </span>
+  );
+}

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-composer.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-composer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { Ref } from "react";
+import { SendHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function MarketplaceChatComposer(props: {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  busy: boolean;
+  inputRef?: Ref<HTMLTextAreaElement>;
+}) {
+  const { value, onChange, onSend, busy, inputRef } = props;
+  return (
+    <div className="flex items-end gap-2">
+      <textarea
+        ref={inputRef}
+        data-testid="marketplace-chat-input"
+        value={value}
+        disabled={busy}
+        rows={1}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            onSend();
+          }
+        }}
+        placeholder="Ask about your published data…"
+        aria-label="Ask the marketplace assistant"
+        className={cn(
+          "max-h-32 min-h-10 flex-1 resize-none rounded-2xl px-3.5 py-2.5 text-sm",
+          "border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-compact)]",
+          "text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500/40",
+        )}
+      />
+      <Button
+        type="button"
+        size="icon"
+        data-testid="marketplace-chat-send"
+        disabled={busy}
+        onClick={onSend}
+        aria-label="Send"
+        className="h-10 w-10 shrink-0 rounded-full"
+      >
+        <SendHorizontal className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-message-list.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-message-list.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { cn } from "@/lib/utils";
+import type { MarketplaceChatMessage } from "./use-marketplace-chat";
+import { MarketBotAvatar, MarketTypingIndicator } from "./marketplace-chat-atoms";
+
+export function MarketplaceChatMessageList(props: {
+  messages: MarketplaceChatMessage[];
+  busy: boolean;
+  onRetry?: () => void;
+}) {
+  const { messages, busy, onRetry } = props;
+  return (
+    <div
+      data-testid="marketplace-chat-log"
+      role="log"
+      aria-live="polite"
+      className="flex flex-col gap-3"
+    >
+      {messages.map((message) =>
+        message.role === "user" ? (
+          <div key={message.id} className="flex justify-end">
+            <div className="max-w-[85%] rounded-2xl rounded-br-md bg-emerald-500/12 px-3.5 py-2 text-sm text-foreground">
+              {message.text}
+            </div>
+          </div>
+        ) : (
+          <div key={message.id} className="flex items-start gap-2">
+            <MarketBotAvatar size={28} />
+            <div className="min-w-0 max-w-[85%]">
+              <div
+                className={cn(
+                  "rounded-2xl rounded-tl-md bg-[color:var(--app-card-surface-compact)] px-3.5 py-2 text-sm text-foreground",
+                  "[&_p]:m-0 [&_p+p]:mt-2 [&_ul]:my-1 [&_ul]:pl-4 [&_li]:list-disc",
+                  message.errored && "text-muted-foreground",
+                )}
+              >
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {message.text}
+                </ReactMarkdown>
+              </div>
+              {message.errored ? (
+                <button
+                  type="button"
+                  onClick={onRetry}
+                  className="mt-1 text-xs font-semibold text-emerald-700 hover:underline dark:text-emerald-300"
+                >
+                  Retry
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ),
+      )}
+      {busy ? (
+        <div className="flex items-center gap-2">
+          <MarketBotAvatar size={28} />
+          <div className="rounded-2xl rounded-tl-md bg-[color:var(--app-card-surface-compact)] px-3.5 py-2.5">
+            <MarketTypingIndicator />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-panel.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-panel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { RotateCcw } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/lib/morphy-ux/morphy";
+import {
+  MARKET_CARD_SURFACE,
+  MARKET_MUTED_TEXT,
+  MarketBotAvatar,
+} from "./marketplace-chat-atoms";
+import { MarketplaceChatComposer } from "./marketplace-chat-composer";
+import { MarketplaceChatMessageList } from "./marketplace-chat-message-list";
+import { MarketplaceSuggestionChips } from "./marketplace-chat-suggestions";
+import { useMarketplaceChat } from "./use-marketplace-chat";
+import type { PublishableSlice } from "@/lib/one-marketplace/service";
+import { formatCents } from "@/lib/services/slice-pricing-service";
+import { Sparkles } from "lucide-react";
+
+/**
+ * The Information Marketplace chat panel — the marketplace's conversational
+ * surface. Ask what you've published and what it's worth, approve/deny a pending
+ * request (server-side), and get an inline "publish for offers?" card the agent
+ * surfaces (tailored to the topic). Publishing runs the page's consent-first flow
+ * via `onPublishSlice`.
+ */
+export function MarketplaceChatPanel(props: {
+  vaultOwnerToken: string | null;
+  onStateChanged?: () => void;
+  onPublishSlice?: (slice: PublishableSlice) => void;
+  /** Identity keys ("h:<scopeHandle>", "l:<domain>:<label>") of already-published
+   *  slices, so a just-published slice drops off the publish card. */
+  publishedSliceKeys?: Set<string>;
+}) {
+  const { vaultOwnerToken, onStateChanged, onPublishSlice, publishedSliceKeys } = props;
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const chat = useMarketplaceChat({
+    vaultOwnerToken: vaultOwnerToken ?? "",
+    onStateChanged,
+  });
+
+  const isPublished = (slice: PublishableSlice) =>
+    Boolean(
+      publishedSliceKeys &&
+        ((slice.scopeHandle && publishedSliceKeys.has(`h:${slice.scopeHandle}`)) ||
+          publishedSliceKeys.has(`l:${slice.domain}:${slice.label}`)),
+    );
+
+  const publishCardSlices = (chat.publishCard?.slices ?? []).filter((s) => !isPublished(s));
+
+  const submit = () => {
+    const message = input.trim();
+    if (!message) return;
+    setInput("");
+    void chat.send(message);
+  };
+
+  const sendValue = (value: string) => {
+    setInput("");
+    void chat.send(value);
+  };
+
+  const prefill = (value: string) => {
+    setInput(value);
+    inputRef.current?.focus();
+  };
+
+  if (!vaultOwnerToken) {
+    return (
+      <section data-testid="marketplace-chat-panel" className={cn(MARKET_CARD_SURFACE, "p-4")}>
+        <div className="flex items-center gap-3">
+          <MarketBotAvatar />
+          <div>
+            <p className="text-sm font-semibold text-foreground">Information Marketplace</p>
+            <p className={MARKET_MUTED_TEXT}>Unlock your vault to use the assistant.</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const hasMessages = chat.messages.length > 0;
+
+  return (
+    <section data-testid="marketplace-chat-panel" className={cn(MARKET_CARD_SURFACE, "p-4")}>
+      <header className="mb-3 flex items-center gap-3">
+        <MarketBotAvatar />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-foreground">Marketplace assistant</p>
+          <p className={MARKET_MUTED_TEXT}>
+            Ask what you&apos;ve published — and what it&apos;s worth.
+          </p>
+        </div>
+        {hasMessages ? (
+          <button
+            type="button"
+            onClick={chat.clear}
+            aria-label="Clear conversation"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          >
+            <RotateCcw className="h-4 w-4" />
+          </button>
+        ) : null}
+      </header>
+
+      {hasMessages || chat.busy ? (
+        <div className="mb-3">
+          <MarketplaceChatMessageList
+            messages={chat.messages}
+            busy={chat.busy}
+            onRetry={chat.retry}
+          />
+        </div>
+      ) : (
+        <div className="mb-3">
+          <MarketplaceSuggestionChips onSend={sendValue} onPrefill={prefill} />
+        </div>
+      )}
+
+      {chat.publishCard && publishCardSlices.length > 0 ? (
+        <div
+          data-testid="marketplace-chat-publish-card"
+          className="mb-3 rounded-2xl border border-emerald-300/50 bg-emerald-50/50 p-3 dark:border-emerald-900/40 dark:bg-emerald-950/15"
+        >
+          <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+            <Sparkles className="h-4 w-4" aria-hidden />
+            {chat.publishCard.topic
+              ? `Publish your ${chat.publishCard.topic} data for offers?`
+              : "Publish these for offers?"}
+          </div>
+          <div className="flex flex-col gap-2">
+            {publishCardSlices.map((slice) => (
+              <div
+                key={`${slice.domain}:${slice.scopeHandle ?? slice.label}`}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-emerald-300/40 bg-background/60 px-3 py-2"
+              >
+                <div className="min-w-0 text-sm">
+                  <span className="font-medium text-foreground">{slice.label}</span>
+                  <span className="text-muted-foreground"> · {slice.domainTitle ?? slice.domain}</span>
+                  {slice.suggestedPriceCents ? (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      · ~{formatCents(slice.suggestedPriceCents, slice.currency ?? "USD")}/mo
+                    </span>
+                  ) : null}
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="none"
+                  effect="fade"
+                  onClick={() => onPublishSlice?.(slice)}
+                >
+                  Publish
+                </Button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={chat.dismissPublishCard}
+            className="mt-2 text-xs font-medium text-emerald-700/80 hover:underline dark:text-emerald-300/80"
+          >
+            Not now
+          </button>
+        </div>
+      ) : null}
+
+      <MarketplaceChatComposer
+        value={input}
+        onChange={setInput}
+        onSend={submit}
+        busy={chat.busy}
+        inputRef={inputRef}
+      />
+    </section>
+  );
+}

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-suggestions.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-suggestions.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export interface MarketplaceSuggestionChip {
+  label: string;
+  mode: "send" | "prefill";
+  value: string;
+}
+
+// Slice-1 chips map to the two read-only tools (list published / earnings).
+export const MARKETPLACE_SUGGESTION_CHIPS: MarketplaceSuggestionChip[] = [
+  { label: "What have I published?", mode: "send", value: "What have I published to the marketplace?" },
+  { label: "What's it worth?", mode: "send", value: "What are my published slices worth?" },
+  { label: "How much have I made?", mode: "send", value: "How much money have I made so far?" },
+  { label: "Anything on the market?", mode: "send", value: "Do I have anything on the market right now?" },
+];
+
+export function MarketplaceSuggestionChips(props: {
+  onSend: (value: string) => void;
+  onPrefill: (value: string) => void;
+}) {
+  const { onSend, onPrefill } = props;
+  return (
+    <div className="flex flex-wrap gap-2" data-testid="marketplace-chat-suggestions">
+      {MARKETPLACE_SUGGESTION_CHIPS.map((chip) => (
+        <button
+          key={chip.label}
+          type="button"
+          onClick={() =>
+            chip.mode === "send" ? onSend(chip.value) : onPrefill(chip.value)
+          }
+          className={cn(
+            "rounded-full border border-[color:var(--app-card-border-standard)]",
+            "bg-[color:var(--app-card-surface-compact)] px-3 py-1.5 text-xs font-medium",
+            "text-foreground transition-colors hover:border-emerald-500/50 hover:text-emerald-700 dark:hover:text-emerald-300",
+          )}
+        >
+          {chip.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-marketplace/use-marketplace-chat.ts
+++ b/hushh-webapp/components/one-marketplace/use-marketplace-chat.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+import {
+  OneMarketplaceService,
+  type PublishSlicesAction,
+} from "@/lib/one-marketplace/service";
+
+export interface MarketplaceChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  errored?: boolean;
+}
+
+export interface UseMarketplaceChat {
+  messages: MarketplaceChatMessage[];
+  busy: boolean;
+  send: (message: string) => Promise<void>;
+  retry: () => Promise<void>;
+  clear: () => void;
+  publishCard: PublishSlicesAction | null;
+  dismissPublishCard: () => void;
+}
+
+export const MARKETPLACE_CHAT_ERROR_TEXT =
+  "Sorry — that couldn't be processed. Try rephrasing.";
+
+/**
+ * State + orchestration for the Information Marketplace chatbot. Sends messages,
+ * renders replies. When a turn reports `stateChanged` (the agent approved/denied
+ * a request server-side), it calls `onStateChanged` so the page refetches the
+ * durable request inbox — no client-side action plumbing needed.
+ */
+export function useMarketplaceChat(params: {
+  vaultOwnerToken: string;
+  onStateChanged?: () => void;
+}): UseMarketplaceChat {
+  const { vaultOwnerToken, onStateChanged } = params;
+  const [messages, setMessages] = useState<MarketplaceChatMessage[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [publishCard, setPublishCard] = useState<PublishSlicesAction | null>(null);
+  const conversationIdRef = useRef<string | null>(null);
+  const lastSentRef = useRef<string | null>(null);
+  const seqRef = useRef(0);
+
+  const changedRef = useRef(onStateChanged);
+  changedRef.current = onStateChanged;
+
+  const nextId = useCallback(() => `m-${seqRef.current++}`, []);
+
+  const run = useCallback(
+    async (message: string) => {
+      setBusy(true);
+      // Retry case: drop a trailing errored assistant bubble before re-asking.
+      setMessages((prev) =>
+        prev.length && prev[prev.length - 1]?.errored ? prev.slice(0, -1) : prev,
+      );
+      try {
+        const result = await OneMarketplaceService.chat({
+          vaultOwnerToken,
+          message,
+          conversationId: conversationIdRef.current,
+        });
+        conversationIdRef.current = result.conversationId;
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId(), role: "assistant", text: result.response },
+        ]);
+        if (result.clientAction?.type === "publish_slices") {
+          setPublishCard(result.clientAction);
+        }
+        if (result.stateChanged) changedRef.current?.();
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: nextId(),
+            role: "assistant",
+            text: MARKETPLACE_CHAT_ERROR_TEXT,
+            errored: true,
+          },
+        ]);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [vaultOwnerToken, nextId],
+  );
+
+  const send = useCallback(
+    async (raw: string) => {
+      const message = raw.trim();
+      if (!message || busy) return;
+      setMessages((prev) => [...prev, { id: nextId(), role: "user", text: message }]);
+      lastSentRef.current = message;
+      await run(message);
+    },
+    [busy, run, nextId],
+  );
+
+  const retry = useCallback(async () => {
+    if (busy || !lastSentRef.current) return;
+    await run(lastSentRef.current);
+  }, [busy, run]);
+
+  const clear = useCallback(() => {
+    setMessages([]);
+    conversationIdRef.current = null;
+    lastSentRef.current = null;
+    setPublishCard(null);
+  }, []);
+
+  const dismissPublishCard = useCallback(() => setPublishCard(null), []);
+
+  return { messages, busy, send, retry, clear, publishCard, dismissPublishCard };
+}

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -6,6 +6,7 @@
     "hushh-webapp/app/one/gmail/page.voice-action-contract.json",
     "hushh-webapp/app/one/kai/analysis/page.voice-action-contract.json",
     "hushh-webapp/app/one/kyc/page.voice-action-contract.json",
+    "hushh-webapp/app/one/marketplace/page.voice-action-contract.json",
     "hushh-webapp/app/profile/page.voice-action-contract.json",
     "hushh-webapp/app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
     "hushh-webapp/app/ria/clients/page.voice-action-contract.json",
@@ -101,6 +102,23 @@
         },
         "speaker_persona": "kyc",
         "delegate_agent_id": "kyc"
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_marketplace",
+      "surface_title": "Information Marketplace",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md"
+      ],
+      "contract_file": "hushh-webapp/app/one/marketplace/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        }
       }
     },
     {
@@ -2021,6 +2039,76 @@
       "expected_effects": {
         "state_changes": [
           "current route becomes /one/kyc"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      }
+    },
+    {
+      "action_id": "route.one_marketplace",
+      "surface_id": "one_marketplace",
+      "label": "Open Information Marketplace",
+      "aliases": [
+        "open information marketplace",
+        "open the information marketplace",
+        "open data marketplace",
+        "go to information marketplace",
+        "go to the data marketplace",
+        "take me to the information marketplace",
+        "show me the information marketplace",
+        "open my data marketplace"
+      ],
+      "search_keywords": [
+        "marketplace",
+        "data marketplace",
+        "data slices",
+        "sell my data",
+        "published slices"
+      ],
+      "meaning": "Navigates to the One Information Marketplace (personal data-slice) route.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/marketplace"
+        ],
+        "screens": [
+          "one_marketplace"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/marketplace"
+      },
+      "control_ids": [],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/kai/kai-voice-runtime-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/marketplace"
         ],
         "backend_effects": []
       },

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -905,6 +905,45 @@
       ]
     },
     {
+      "id": "route.one_marketplace",
+      "label": "Open Information Marketplace",
+      "meaning": "Navigates to the One Information Marketplace (personal data-slice) route.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "aliases": [
+        "open information marketplace",
+        "open the information marketplace",
+        "open data marketplace",
+        "go to information marketplace",
+        "go to the data marketplace",
+        "take me to the information marketplace",
+        "show me the information marketplace",
+        "open my data marketplace"
+      ],
+      "scope": {
+        "routes": [
+          "/one/marketplace"
+        ],
+        "screens": [
+          "one_marketplace"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/marketplace"
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/kai/kai-voice-runtime-architecture.md"
+      ]
+    },
+    {
       "id": "route.profile",
       "label": "Open Profile",
       "meaning": "Navigates to profile landing route.",

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -311,6 +311,18 @@ export function resolveTopShellBreadcrumb(
     };
   }
 
+  if (pathname === ROUTES.ONE_MARKETPLACE) {
+    return {
+      backHref: ROUTES.PROFILE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: ROUTES.PROFILE },
+        { label: "Marketplace" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.GMAIL) {
     const originHref = normalizeInternalRouteHref(searchParams?.get("from"));
     return {

--- a/hushh-webapp/lib/onboarding/one-capabilities.ts
+++ b/hushh-webapp/lib/onboarding/one-capabilities.ts
@@ -143,7 +143,7 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "marketplace",
-    title: "Marketplace",
+    title: "Information Marketplace",
     description: "Preview priced slices of your data you could publish.",
     previewLabel: "Priced data slices",
     href: ROUTES.ONE_MARKETPLACE,

--- a/hushh-webapp/lib/one-marketplace/service.ts
+++ b/hushh-webapp/lib/one-marketplace/service.ts
@@ -1,0 +1,139 @@
+import { apiJson } from "@/lib/services/api-client";
+
+/** A durable Information Marketplace access request (migration 075). */
+export interface MarketplaceRequest {
+  id: string;
+  ownerUserId?: string;
+  buyerUserId?: string | null;
+  buyerLabel?: string | null;
+  domain?: string;
+  scopeHandle?: string | null;
+  sliceName: string;
+  priceCents?: number;
+  currency?: string;
+  durationDays?: number;
+  message?: string | null;
+  status: "pending" | "approved" | "denied" | "expired";
+  createdAt?: string;
+  resolvedAt?: string | null;
+}
+
+/** One publishable slice suggested in a publish card. */
+export interface PublishableSlice {
+  label: string;
+  domain: string;
+  domainTitle?: string;
+  scopeHandle?: string | null;
+  suggestedPriceCents?: number;
+  currency?: string;
+}
+
+/** Inline "publish for offers?" card the agent can surface in chat. */
+export interface PublishSlicesAction {
+  type: "publish_slices";
+  topic?: string | null;
+  slices: PublishableSlice[];
+}
+
+/** Response shape of POST /api/one/information/chat (see InformationChatService). */
+export interface InformationChatResponse {
+  conversationId: string;
+  response: string;
+  isComplete: boolean;
+  stateChanged: boolean;
+  clientAction?: PublishSlicesAction;
+}
+
+function authHeaders(vaultOwnerToken: string): Record<string, string> {
+  return { Authorization: `Bearer ${vaultOwnerToken}` };
+}
+
+function jsonAuthHeaders(vaultOwnerToken: string): Record<string, string> {
+  return { ...authHeaders(vaultOwnerToken), "Content-Type": "application/json" };
+}
+
+/**
+ * Client for the Information Marketplace: the conversational agent plus the
+ * durable access-request inbox. Requests are real server-side records — approve/
+ * deny happen server-side (from here, or via Agent One over A2A), and the chat's
+ * `stateChanged` tells the page to refetch the inbox.
+ */
+export class OneMarketplaceService {
+  static async chat(params: {
+    vaultOwnerToken: string;
+    message: string;
+    conversationId?: string | null;
+  }): Promise<InformationChatResponse> {
+    return apiJson<InformationChatResponse>("/api/one/information/chat", {
+      method: "POST",
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({
+        message: params.message,
+        conversationId: params.conversationId ?? null,
+      }),
+    });
+  }
+
+  static async listRequests(params: {
+    vaultOwnerToken: string;
+    status?: string;
+  }): Promise<MarketplaceRequest[]> {
+    const qs = params.status ? `?status=${encodeURIComponent(params.status)}` : "";
+    const res = await apiJson<{ requests: MarketplaceRequest[] }>(
+      `/api/one/marketplace/requests${qs}`,
+      { headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+    return res.requests ?? [];
+  }
+
+  static async createRequest(params: {
+    vaultOwnerToken: string;
+    sliceName: string;
+    domain: string;
+    scopeHandle?: string | null;
+    buyerLabel?: string;
+    priceCents?: number;
+    currency?: string;
+    durationDays?: number;
+    message?: string;
+  }): Promise<MarketplaceRequest> {
+    const res = await apiJson<{ request: MarketplaceRequest }>(
+      "/api/one/marketplace/requests",
+      {
+        method: "POST",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({
+          sliceName: params.sliceName,
+          domain: params.domain,
+          scopeHandle: params.scopeHandle ?? null,
+          buyerLabel: params.buyerLabel ?? null,
+          priceCents: params.priceCents ?? 0,
+          currency: params.currency ?? "USD",
+          durationDays: params.durationDays ?? 30,
+          message: params.message ?? null,
+        }),
+      },
+    );
+    return res.request;
+  }
+
+  static async approveRequest(params: {
+    vaultOwnerToken: string;
+    requestId: string;
+  }): Promise<void> {
+    await apiJson(
+      `/api/one/marketplace/requests/${encodeURIComponent(params.requestId)}/approve`,
+      { method: "POST", headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+  }
+
+  static async denyRequest(params: {
+    vaultOwnerToken: string;
+    requestId: string;
+  }): Promise<void> {
+    await apiJson(
+      `/api/one/marketplace/requests/${encodeURIComponent(params.requestId)}/deny`,
+      { method: "POST", headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds the **Information Marketplace** conversational agent under One (mirrors the Location agent), wired into **Agent One over A2A**, with **product-grade persistent access requests**, **server-side approve/deny** (incl. over A2A), and an **inline, topic-tailored publish-for-offers card**.

(Reopened from #4294, which GitHub could not reopen after a rebase/force-push; identical branch, CI-fixes included.)

## What's included
- **Agent** `hushh_mcp/agents/personal_information/` — `list_published_slices`, `get_earnings_summary` (potential-only, "show math"), `propose_publish`, `list/approve/deny_access_request`. Chat service + `POST /api/one/information/chat`.
- **Scopes** `cap.pkm.marketplace.{view,publish,manage}`; A2A specialist registration; deterministic delegation + nav routing with bare-"marketplace" disambiguation.
- **Durable requests** — migration `076_marketplace_access_requests` + service + REST routes; frontend loads the real inbox (survives refresh). Browser-only request state removed.
- **Approve/deny over Agent One** — server-side, no browser round-trip (like Location).
- **Inline publish card** — deterministic trigger, topic-tailored; renders in the marketplace chat and Agent One (A2A directive → hands off to publish via the consent-first `default_available` path).
- **Nav/UX** — `/one/marketplace` breadcrumb + back button; surface renamed to "Information Marketplace".
- **Governance** — data-plane contract classifies `marketplace_access_requests`; UAT schema contract bumped to migration 76.

## Consent-first / honesty
Reads only the owner's own scope metadata + safe summary (never raw PKM). No payment rail — earnings potential-only (`accruedCents` 0). A request never grants access; the owner approves.

## Migration
`076_marketplace_access_requests.sql` (renumbered from 075 to avoid collision with `075_agent_chat_message_metadata` on main). Apply with `python db/migrate.py --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)