### PR TITLE
fix(uat): backend --set-env-vars breaks on comma-containing values (SOS seed)

### DIFF
--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -114,7 +114,10 @@ steps:
         append_optional_env "APP_REVIEW_MODE" "${_APP_REVIEW_MODE}"
         append_optional_env "SOS_SEED_DEV_USER_IDS" "${_SOS_SEED_DEV_USER_IDS}"
 
-        env_var_string="$(IFS=,; echo "${env_vars[*]}")"
+        # Join with '|' (not ',') so env VALUES may themselves contain commas
+        # (e.g. SOS_SEED_DEV_USER_IDS is a comma-separated id list). Paired with
+        # gcloud's alternate-delimiter syntax on --set-env-vars below.
+        env_var_string="$(IFS='|'; echo "${env_vars[*]}")"
         deploy_labels="managed-by=hushh-github-actions,deploy-env=${_DEPLOY_ENV},deploy-source=${_DEPLOY_SOURCE},deploy-sha=${_DEPLOY_SHA},github-run-id=${_GITHUB_RUN_ID}"
 
         cmd=(
@@ -130,7 +133,7 @@ steps:
           "--max-instances=10"
           "--min-instances=1"
           "--labels=${deploy_labels}"
-          "--set-env-vars=${env_var_string}"
+          "--set-env-vars=^|^${env_var_string}"
           "--set-secrets=${secrets}"
         )
 


### PR DESCRIPTION
The UAT backend deploy failed (run 28711337028, Cloud Build step 4 `gcloud run deploy` exit 2) because env vars are joined with commas for `--set-env-vars`, and `SOS_SEED_DEV_USER_IDS` is itself a comma-separated id list — so gcloud read the extra ids as malformed env entries.

Fix: join the env-var string with `|` and use gcloud's alternate-delimiter syntax `--set-env-vars=^|^...`, so any value may contain commas. No deploy value contains `|`. Backend-only; frontend deploy uses a separate substitution path and is unaffected.

After merge + green post-merge smoke, re-run Deploy to UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)