### PR TITLE
Harden Agent One A2A consent execution

### DIFF
--- a/consent-protocol/api/consent_listener.py
+++ b/consent-protocol/api/consent_listener.py
@@ -43,6 +43,9 @@ MIN_FINAL_REMINDER_WINDOW_MS = 2 * 60 * 60 * 1000
 _CONSENT_NOTIFY_QUEUE_MAXSIZE = 100
 _consent_notify_queues: Dict[str, asyncio.Queue] = {}
 _consent_notify_queues_lock = asyncio.Lock()
+_DEVELOPER_CONSENT_QUEUE_MAXSIZE = 20
+_developer_consent_subscribers: Dict[tuple[str, str], set[asyncio.Queue]] = {}
+_developer_consent_subscribers_lock = asyncio.Lock()
 
 # Diagnostic: set when listener is running and when NOTIFY is received
 _listener_active = False
@@ -135,6 +138,30 @@ async def _push_to_consent_queue(user_id: str, data: Dict[str, Any]) -> None:
             logger.warning("consent notify queue full; dropped oldest event to bound memory")
 
 
+async def _push_to_developer_consent_queues(data: Dict[str, Any]) -> None:
+    request_id = str(data.get("request_id") or "").strip()
+    agent_id = str(data.get("agent_id") or "").strip()
+    if not request_id or not agent_id:
+        return
+
+    async with _developer_consent_subscribers_lock:
+        queues = list(_developer_consent_subscribers.get((request_id, agent_id), set()))
+
+    for q in queues:
+        try:
+            q.put_nowait(data)
+        except asyncio.QueueFull:
+            try:
+                q.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                q.put_nowait(data)
+            except asyncio.QueueFull:
+                pass
+            logger.warning("developer consent SSE queue full; dropped oldest event")
+
+
 def get_consent_queue(user_id: str) -> asyncio.Queue:
     """Get or create the asyncio queue for this user (used by SSE generator)."""
     if user_id not in _consent_notify_queues:
@@ -142,11 +169,43 @@ def get_consent_queue(user_id: str) -> asyncio.Queue:
     return _consent_notify_queues[user_id]
 
 
+async def subscribe_developer_consent_queue(
+    *,
+    request_id: str,
+    agent_id: str,
+) -> asyncio.Queue:
+    """Subscribe a developer SSE consumer to one request without touching owner queues."""
+    key = (str(request_id or "").strip(), str(agent_id or "").strip())
+    q: asyncio.Queue = asyncio.Queue(maxsize=_DEVELOPER_CONSENT_QUEUE_MAXSIZE)
+    async with _developer_consent_subscribers_lock:
+        _developer_consent_subscribers.setdefault(key, set()).add(q)
+    return q
+
+
+async def unsubscribe_developer_consent_queue(
+    *,
+    request_id: str,
+    agent_id: str,
+    queue: asyncio.Queue,
+) -> None:
+    key = (str(request_id or "").strip(), str(agent_id or "").strip())
+    async with _developer_consent_subscribers_lock:
+        queues = _developer_consent_subscribers.get(key)
+        if queues is None:
+            return
+        queues.discard(queue)
+        if not queues:
+            _developer_consent_subscribers.pop(key, None)
+
+
 def get_consent_listener_status() -> dict:
     """Return status for GET /debug/consent-listener (listener_active, queue_count, notify_received_count)."""
     return {
         "listener_active": _listener_active,
         "queue_count": len(_consent_notify_queues),
+        "developer_queue_count": sum(
+            len(queues) for queues in _developer_consent_subscribers.values()
+        ),
         "notify_received_count": _notify_received_count,
         "last_notify_user_id": _last_notify_user_id,
         "last_notify_action": _last_notify_action,
@@ -183,6 +242,7 @@ async def _handle_notify(payload_str: str):
         _last_notify_action = action
         data = await _enrich_notify_payload(data)
         logger.info("Consent NOTIFY received user_id=%s action=%s", user_id, action)
+        await _push_to_developer_consent_queues(data)
         if str(action).strip().upper() == "REQUESTED":
             notification_payload = {
                 **data,

--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -36,7 +36,9 @@ router = APIRouter()
 developer_api_router = APIRouter(prefix="/api/v1", tags=["Developer API"])
 portal_router = APIRouter(prefix="/api/developer", tags=["Developer Portal"])
 
-_STATIC_REQUESTABLE_SCOPES: frozenset[str] = frozenset({"pkm.read", "pkm.write"})
+_STATIC_REQUESTABLE_SCOPES: frozenset[str] = frozenset(
+    {"agent.one.orchestrate", "pkm.read", "pkm.write"}
+)
 _MIN_PUBLIC_EXPIRY_HOURS = 24
 _MAX_PUBLIC_EXPIRY_HOURS = 24 * 90
 _MIN_PUBLIC_APPROVAL_TIMEOUT_MINUTES = 5
@@ -306,6 +308,10 @@ def _scope_catalog() -> list[DeveloperScopeDescriptor]:
         DeveloperScopeDescriptor(
             name="pkm.write",
             description="Write to the user personal knowledge model in governed flows.",
+        ),
+        DeveloperScopeDescriptor(
+            name="agent.one.orchestrate",
+            description="Coordinate a user request through Agent One and its specialist handoff layer.",
         ),
         DeveloperScopeDescriptor(
             name="attr.{domain}.*",

--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -1220,7 +1220,8 @@ async def stream_consent_events(
             initial_latest=latest,
         ),
         headers={
-            "Cache-Control": "no-cache",
+            "Cache-Control": "no-store, no-cache",
+            "Pragma": "no-cache",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },

--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
+import json
 import logging
 import time
 import uuid
-from typing import Any, Literal, Optional, TypedDict, cast
+from typing import Any, AsyncGenerator, Literal, Optional, TypedDict, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from pydantic import BaseModel, ConfigDict, Field
+from sse_starlette.sse import EventSourceResponse
 
 from api.developer_auth import (
     authenticate_developer_principal,
@@ -44,6 +47,15 @@ _MAX_PUBLIC_EXPIRY_HOURS = 24 * 90
 _MIN_PUBLIC_APPROVAL_TIMEOUT_MINUTES = 5
 _MAX_PUBLIC_APPROVAL_TIMEOUT_MINUTES = 24 * 60
 _CONNECTOR_WRAPPING_ALG = "X25519-AES256-GCM"
+_CONSENT_REQUEST_STATUS_MAP = {
+    "REQUESTED": "pending",
+    "CONSENT_GRANTED": "granted",
+    "CONSENT_DENIED": "denied",
+    "TIMEOUT": "expired",
+    "CANCELLED": "cancelled",
+    "REVOKED": "revoked",
+}
+_TERMINAL_CONSENT_STATUSES = {"granted", "denied", "expired", "cancelled", "revoked"}
 
 
 class DeveloperScopeDescriptor(BaseModel):
@@ -592,6 +604,121 @@ def _offer_response_fields(metadata: dict[str, object] | None) -> dict[str, obje
     }
 
 
+def _developer_consent_status_payload(
+    *,
+    latest: dict[str, Any],
+    user_id: str,
+    request_id: str,
+    principal: DeveloperPrincipal,
+) -> dict[str, Any]:
+    latest_action = str(latest.get("action") or "").strip().upper()
+    resolved_status = _CONSENT_REQUEST_STATUS_MAP.get(latest_action, "unknown")
+    metadata = _metadata_object_map(latest.get("metadata"))
+    approval_timeout_at = latest.get("poll_timeout_at") or metadata.get("approval_timeout_at")
+    consent_token = latest.get("token_id") if latest_action == "CONSENT_GRANTED" else None
+    return {
+        "status": resolved_status,
+        "user_id": user_id,
+        "request_id": request_id,
+        "scope": latest.get("scope"),
+        "requested_scope": str(latest.get("scope") or "") or None,
+        "granted_scope": str(latest.get("scope") or "") or None,
+        "coverage_kind": "exact" if latest.get("scope") else None,
+        "covered_by_existing_grant": False,
+        "consent_token": consent_token,
+        "expires_at": latest.get("expires_at"),
+        "poll_timeout_at": _optional_int(latest.get("poll_timeout_at")),
+        "approval_timeout_at": _optional_int(approval_timeout_at),
+        "approval_timeout_minutes": _optional_int(metadata.get("approval_timeout_minutes")),
+        "expiry_hours": _optional_int(metadata.get("expiry_hours")),
+        "request_url": _request_url_from_metadata(request_id, metadata),
+        "requester_label": _optional_str(metadata.get("requester_label")),
+        "requester_image_url": _optional_str(metadata.get("requester_image_url")),
+        "reason": _optional_str(metadata.get("reason")),
+        "app_id": principal.app_id,
+        "app_display_name": principal.display_name,
+        "terminal": resolved_status in _TERMINAL_CONSENT_STATUSES,
+    }
+
+
+async def _developer_consent_event_generator(
+    *,
+    request: Request,
+    user_id: str,
+    request_id: str,
+    principal: DeveloperPrincipal,
+    initial_latest: dict[str, Any],
+) -> AsyncGenerator[dict[str, str], None]:
+    from api.consent_listener import (
+        subscribe_developer_consent_queue,
+        unsubscribe_developer_consent_queue,
+    )
+
+    queue = await subscribe_developer_consent_queue(
+        request_id=request_id,
+        agent_id=principal.agent_id,
+    )
+    try:
+        initial_payload = _developer_consent_status_payload(
+            latest=initial_latest,
+            user_id=user_id,
+            request_id=request_id,
+            principal=principal,
+        )
+        yield {
+            "event": "snapshot",
+            "id": f"{request_id}:snapshot",
+            "data": json.dumps(initial_payload),
+        }
+        if initial_payload["terminal"]:
+            return
+
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                data = await asyncio.wait_for(queue.get(), timeout=30)
+            except asyncio.TimeoutError:
+                yield {
+                    "event": "heartbeat",
+                    "data": json.dumps(
+                        {
+                            "request_id": request_id,
+                            "timestamp": int(time.time() * 1000),
+                        }
+                    ),
+                }
+                continue
+
+            if str(data.get("request_id") or "") != request_id:
+                continue
+            if str(data.get("agent_id") or "") != principal.agent_id:
+                continue
+            payload = _developer_consent_status_payload(
+                latest=data,
+                user_id=user_id,
+                request_id=request_id,
+                principal=principal,
+            )
+            event_id = (
+                f"{request_id}:{data.get('action') or 'UNKNOWN'}:"
+                f"{data.get('issued_at') or int(time.time() * 1000)}"
+            )
+            yield {
+                "event": "consent_update",
+                "id": event_id,
+                "data": json.dumps(payload),
+            }
+            if payload["terminal"]:
+                return
+    finally:
+        await unsubscribe_developer_consent_queue(
+            request_id=request_id,
+            agent_id=principal.agent_id,
+            queue=queue,
+        )
+
+
 def _resolve_principal(
     *,
     request: Request,
@@ -1012,6 +1139,7 @@ async def get_consent_status(
                     str(latest.get("token_id"))
                 )
             export_fields = _export_fields(export_metadata)
+            consent_token = latest.get("token_id") if latest_action == "CONSENT_GRANTED" else None
             return DeveloperConsentStatusResponse(
                 status=resolved_status,
                 user_id=user_id,
@@ -1021,7 +1149,7 @@ async def get_consent_status(
                 coverage_kind="exact" if latest.get("scope") else None,
                 covered_by_existing_grant=False,
                 request_id=request_id,
-                consent_token=latest.get("token_id"),
+                consent_token=consent_token,
                 expires_at=latest.get("expires_at"),
                 export_revision=export_fields["export_revision"],
                 export_generated_at=export_fields["export_generated_at"],
@@ -1057,6 +1185,45 @@ async def get_consent_status(
         app_id=principal.app_id,
         app_display_name=principal.display_name,
         message="No matching consent state was found for this app.",
+    )
+
+
+@developer_api_router.get("/consent-events")
+async def stream_consent_events(
+    request: Request,
+    user_id: str = Query(..., alias="user_id", max_length=128),
+    request_id: str = Query(..., max_length=200),
+    token: Optional[str] = Query(None, max_length=2048),
+    authorization: Optional[str] = Header(None),
+):
+    principal = _resolve_principal(
+        request=request,
+        token=token,
+        authorization=authorization,
+    )
+    latest = await ConsentDBService().get_request_status(user_id, request_id)
+    if not latest or latest.get("agent_id") != principal.agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "error_code": "CONSENT_REQUEST_NOT_FOUND",
+                "message": "No matching consent request was found for this developer app.",
+            },
+        )
+
+    return EventSourceResponse(
+        _developer_consent_event_generator(
+            request=request,
+            user_id=user_id,
+            request_id=request_id,
+            principal=principal,
+            initial_latest=latest,
+        ),
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from .a2a import router as a2a_router
 from .email import router as email_router
 from .information_chat import router as information_chat_router
 from .location import router as location_router
@@ -9,6 +10,7 @@ from .location_chat import router as location_chat_router
 from .marketplace_requests import router as marketplace_requests_router
 
 router = APIRouter()
+router.include_router(a2a_router)
 router.include_router(email_router)
 router.include_router(location_router)
 router.include_router(location_chat_router)

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from .a2a import router as a2a_router
+from .a2a import well_known_router as a2a_well_known_router
 from .email import router as email_router
 from .information_chat import router as information_chat_router
 from .location import router as location_router
@@ -10,6 +11,7 @@ from .location_chat import router as location_chat_router
 from .marketplace_requests import router as marketplace_requests_router
 
 router = APIRouter()
+router.include_router(a2a_well_known_router)
 router.include_router(a2a_router)
 router.include_router(email_router)
 router.include_router(location_router)

--- a/consent-protocol/api/routes/one/a2a.py
+++ b/consent-protocol/api/routes/one/a2a.py
@@ -29,6 +29,7 @@ from hushh_mcp.services.user_identifier_service import resolve_lookup_identifier
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/one/a2a", tags=["Agent One A2A"])
+well_known_router = APIRouter(tags=["Agent One A2A"])
 
 
 class AgentOneA2AMessageRequest(BaseModel):
@@ -308,6 +309,12 @@ async def _create_or_report_consent_request(
 @router.get("/card")
 async def agent_one_a2a_card() -> dict[str, Any]:
     """Return Agent One capability metadata from the checked-in manifest."""
+    return _agent_card()
+
+
+@well_known_router.get("/.well-known/agent-card.json")
+async def agent_one_well_known_agent_card() -> dict[str, Any]:
+    """Return the public A2A Agent Card at the standard well-known URI."""
     return _agent_card()
 
 

--- a/consent-protocol/api/routes/one/a2a.py
+++ b/consent-protocol/api/routes/one/a2a.py
@@ -178,7 +178,7 @@ async def _resolve_consent_user_id(body: AgentOneA2AMessageRequest) -> str:
         ) from exc
 
     if lookup_kind == "uid":
-        return lookup_value
+        return str(lookup_value)
 
     from firebase_admin import auth
 

--- a/consent-protocol/api/routes/one/a2a.py
+++ b/consent-protocol/api/routes/one/a2a.py
@@ -17,10 +17,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from api.developer_auth import authenticate_developer_principal
 from api.utils.firebase_admin import get_firebase_auth_app
-from hushh_mcp.adk_bridge.delegation import validate_a2a_consent_token
 from hushh_mcp.agents.one.manifest import get_manifest
 from hushh_mcp.agents.orchestrator.agent import get_orchestrator
 from hushh_mcp.consent.scope_helpers import get_scope_description
+from hushh_mcp.consent.token import validate_token_with_db
+from hushh_mcp.constants import ConsentScope
 from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.consent_db import ConsentDBService
 from hushh_mcp.services.consent_request_links import build_consent_request_url
@@ -90,6 +91,7 @@ def _agent_card() -> dict[str, Any]:
         },
         "protocol": {
             "transport": "https",
+            "developerAuth": "Authorization: Bearer <developer-token>",
             "consentHeader": "X-Consent-Token",
             "requiredScope": "agent.one.orchestrate",
         },
@@ -102,6 +104,17 @@ def _required_scope() -> str:
 
 def _consent_reason(body: AgentOneA2AMessageRequest) -> str:
     return str(body.reason or "").strip() or "Coordinate this request through Agent One."
+
+
+def _has_user_target(body: AgentOneA2AMessageRequest) -> bool:
+    return any(
+        str(value or "").strip()
+        for value in (
+            body.user_id,
+            body.email,
+            body.phone_number,
+        )
+    )
 
 
 def _a2a_requester_metadata(
@@ -336,15 +349,29 @@ async def agent_one_a2a_message(
             developer_token=token,
         )
 
-    validation = validate_a2a_consent_token("agent_one", consent_token)
-    if not validation.ok or not validation.user_id:
+    principal = authenticate_developer_principal(
+        token=token,
+        authorization=authorization,
+        request=request,
+    )
+    valid, _reason, token_obj = await validate_token_with_db(
+        consent_token,
+        expected_scope=ConsentScope.AGENT_ONE_ORCHESTRATE,
+    )
+    if not valid or token_obj is None:
         logger.warning("agent_one_a2a.request_rejected_invalid_token")
         raise HTTPException(status_code=403, detail="Invalid consent token")
 
-    user_id = str(validation.user_id)
-    if body.user_id is not None and body.user_id != user_id:
-        logger.warning("agent_one_a2a.request_rejected_user_mismatch")
-        raise HTTPException(status_code=403, detail="Token user does not match request user")
+    if str(token_obj.agent_id) != principal.agent_id:
+        logger.warning("agent_one_a2a.request_rejected_app_mismatch")
+        raise HTTPException(status_code=403, detail="Token app does not match caller")
+
+    user_id = str(token_obj.user_id)
+    if _has_user_target(body):
+        requested_user_id = await _resolve_consent_user_id(body)
+        if requested_user_id != user_id:
+            logger.warning("agent_one_a2a.request_rejected_user_mismatch")
+            raise HTTPException(status_code=403, detail="Token user does not match request user")
 
     try:
         result = get_orchestrator().handle_message(

--- a/consent-protocol/api/routes/one/a2a.py
+++ b/consent-protocol/api/routes/one/a2a.py
@@ -8,14 +8,23 @@ caller must present a consent token scoped to ``agent.one.orchestrate``.
 from __future__ import annotations
 
 import logging
+import time
+import uuid
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from api.developer_auth import authenticate_developer_principal
+from api.utils.firebase_admin import get_firebase_auth_app
 from hushh_mcp.adk_bridge.delegation import validate_a2a_consent_token
 from hushh_mcp.agents.one.manifest import get_manifest
 from hushh_mcp.agents.orchestrator.agent import get_orchestrator
+from hushh_mcp.consent.scope_helpers import get_scope_description
+from hushh_mcp.services.actor_identity_service import ActorIdentityService
+from hushh_mcp.services.consent_db import ConsentDBService
+from hushh_mcp.services.consent_request_links import build_consent_request_url
+from hushh_mcp.services.user_identifier_service import resolve_lookup_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +36,20 @@ class AgentOneA2AMessageRequest(BaseModel):
 
     message: str = Field(..., min_length=1, max_length=8192)
     user_id: str | None = Field(default=None, alias="userId", min_length=1, max_length=128)
+    email: str | None = Field(default=None, max_length=320)
+    phone_number: str | None = Field(default=None, alias="phoneNumber", max_length=32)
+    country_iso2: str | None = Field(default=None, alias="countryIso2", max_length=2)
+    country: str | None = Field(default=None, max_length=64)
     conversation_id: str | None = Field(default=None, alias="conversationId", max_length=128)
     persona: str = Field(default="investor", min_length=1, max_length=32)
+    reason: str | None = Field(default=None, max_length=1000)
+    approval_timeout_minutes: int = Field(
+        default=60,
+        alias="approvalTimeoutMinutes",
+        ge=5,
+        le=24 * 60,
+    )
+    expiry_hours: int = Field(default=24, alias="expiryHours", ge=1, le=24 * 90)
 
 
 class AgentOneA2AMessageResponse(BaseModel):
@@ -39,6 +60,7 @@ class AgentOneA2AMessageResponse(BaseModel):
     user_id: str = Field(alias="userId")
     response: str
     delegation: dict[str, Any] | None = None
+    consent: dict[str, Any] | None = None
     is_complete: bool = Field(default=True, alias="isComplete")
 
 
@@ -73,6 +95,216 @@ def _agent_card() -> dict[str, Any]:
     }
 
 
+def _required_scope() -> str:
+    return "agent.one.orchestrate"
+
+
+def _consent_reason(body: AgentOneA2AMessageRequest) -> str:
+    return str(body.reason or "").strip() or "Coordinate this request through Agent One."
+
+
+def _a2a_requester_metadata(
+    *,
+    principal: Any,
+    body: AgentOneA2AMessageRequest,
+    request_id: str,
+    request_url: str,
+    poll_timeout_at: int,
+) -> dict[str, Any]:
+    return {
+        "request_source": "agent_one_a2a_consent_v1",
+        "requester_actor_type": "a2a_agent",
+        "developer_app_id": principal.app_id,
+        "developer_agent_id": principal.agent_id,
+        "developer_app_display_name": principal.display_name,
+        "developer_allowed_tool_groups": list(principal.allowed_tool_groups),
+        "requester_label": principal.display_name,
+        "requester_image_url": getattr(principal, "brand_image_url", None),
+        "requester_website_url": getattr(principal, "website_url", None),
+        "reason": _consent_reason(body),
+        "approval_timeout_minutes": body.approval_timeout_minutes,
+        "approval_timeout_at": poll_timeout_at,
+        "expiry_hours": body.expiry_hours,
+        "request_url": request_url,
+        "a2a_request_id": request_id,
+    }
+
+
+def _consent_response(
+    *,
+    user_id: str,
+    conversation_id: str | None,
+    message: str,
+    consent: dict[str, Any],
+) -> AgentOneA2AMessageResponse:
+    return AgentOneA2AMessageResponse(
+        agentId="agent_one",
+        conversationId=conversation_id,
+        userId=user_id,
+        response=message,
+        delegation=None,
+        consent=consent,
+        isComplete=False,
+    )
+
+
+async def _resolve_consent_user_id(body: AgentOneA2AMessageRequest) -> str:
+    try:
+        lookup_kind, lookup_value = resolve_lookup_identifier(
+            identifier=body.user_id,
+            email=body.email,
+            phone_number=body.phone_number,
+            country_iso2=body.country_iso2,
+            country=body.country,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Missing user identifier for consent request",
+        ) from exc
+
+    if lookup_kind == "uid":
+        return lookup_value
+
+    from firebase_admin import auth
+
+    firebase_app = get_firebase_auth_app()
+    if firebase_app is None:
+        raise HTTPException(status_code=503, detail="Firebase Admin not configured")
+
+    try:
+        if lookup_kind == "email":
+            user_record = auth.get_user_by_email(lookup_value, app=firebase_app)
+        else:
+            user_record = auth.get_user_by_phone_number(lookup_value, app=firebase_app)
+    except auth.UserNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail="No Hussh account found for the requested user identifier",
+        ) from exc
+
+    try:
+        ActorIdentityService().schedule_sync_from_firebase(user_record.uid, force=False)
+    except Exception as identity_error:
+        logger.debug(
+            "agent_one_a2a.identity_warmup_skipped uid=%s error=%s",
+            user_record.uid,
+            identity_error,
+        )
+    return str(user_record.uid)
+
+
+async def _create_or_report_consent_request(
+    *,
+    body: AgentOneA2AMessageRequest,
+    request: Request,
+    authorization: str | None,
+    developer_token: str | None,
+) -> AgentOneA2AMessageResponse:
+    principal = authenticate_developer_principal(
+        token=developer_token,
+        authorization=authorization,
+        request=request,
+    )
+    user_id = await _resolve_consent_user_id(body)
+    scope = _required_scope()
+    service = ConsentDBService()
+
+    active_tokens = await service.get_covering_active_tokens(
+        user_id,
+        agent_id=principal.agent_id,
+        requested_scope=scope,
+    )
+    if active_tokens:
+        return _consent_response(
+            user_id=user_id,
+            conversation_id=body.conversation_id,
+            message="Consent already exists. Present the consent token to execute Agent One.",
+            consent={
+                "status": "granted",
+                "requiredScope": scope,
+                "agentId": principal.agent_id,
+                "appId": principal.app_id,
+                "appDisplayName": principal.display_name,
+                "tokenRequired": True,
+            },
+        )
+
+    pending = await service.get_pending_request_for_scope(
+        user_id,
+        agent_id=principal.agent_id,
+        scope=scope,
+    )
+    if pending:
+        return _consent_response(
+            user_id=user_id,
+            conversation_id=body.conversation_id,
+            message="Consent request is already pending. User approval is still required.",
+            consent={
+                "status": "pending",
+                "requiredScope": scope,
+                "requestId": pending.get("id"),
+                "requestUrl": pending.get("requestUrl"),
+                "approvalSurface": "/consents?tab=pending",
+                "pollTimeoutAt": pending.get("pollTimeoutAt"),
+                "approvalTimeoutAt": pending.get("approvalTimeoutAt"),
+                "agentId": principal.agent_id,
+                "appId": principal.app_id,
+                "appDisplayName": principal.display_name,
+                "tokenRequired": True,
+            },
+        )
+
+    request_id = f"req_{uuid.uuid4().hex[:28]}"
+    now_ms = int(time.time() * 1000)
+    poll_timeout_at = now_ms + (body.approval_timeout_minutes * 60 * 1000)
+    request_url = build_consent_request_url(request_id=request_id)
+    metadata = _a2a_requester_metadata(
+        principal=principal,
+        body=body,
+        request_id=request_id,
+        request_url=request_url,
+        poll_timeout_at=poll_timeout_at,
+    )
+
+    await service.insert_event(
+        user_id=user_id,
+        agent_id=principal.agent_id,
+        scope=scope,
+        action="REQUESTED",
+        request_id=request_id,
+        scope_description=get_scope_description(scope),
+        poll_timeout_at=poll_timeout_at,
+        metadata=metadata,
+    )
+    logger.info(
+        "agent_one_a2a.consent_requested app_id=%s request_id=%s",
+        principal.app_id,
+        request_id,
+    )
+
+    return _consent_response(
+        user_id=user_id,
+        conversation_id=body.conversation_id,
+        message="Consent request submitted. User approval is required before Agent One can execute.",
+        consent={
+            "status": "pending",
+            "requiredScope": scope,
+            "requestId": request_id,
+            "requestUrl": request_url,
+            "approvalSurface": "/consents?tab=pending",
+            "pollTimeoutAt": poll_timeout_at,
+            "approvalTimeoutAt": poll_timeout_at,
+            "approvalTimeoutMinutes": body.approval_timeout_minutes,
+            "expiryHours": body.expiry_hours,
+            "agentId": principal.agent_id,
+            "appId": principal.app_id,
+            "appDisplayName": principal.display_name,
+            "tokenRequired": True,
+        },
+    )
+
+
 @router.get("/card")
 async def agent_one_a2a_card() -> dict[str, Any]:
     """Return Agent One capability metadata from the checked-in manifest."""
@@ -81,15 +313,23 @@ async def agent_one_a2a_card() -> dict[str, Any]:
 
 @router.post("/message", response_model=AgentOneA2AMessageResponse)
 async def agent_one_a2a_message(
+    request: Request,
     body: AgentOneA2AMessageRequest,
     x_consent_token: str | None = Header(default=None, alias="X-Consent-Token"),
+    authorization: str | None = Header(default=None),
+    token: str | None = Query(default=None, max_length=256),
 ) -> AgentOneA2AMessageResponse:
     """Route a caller request through Agent One after A2A scope validation."""
-    token = (x_consent_token or "").strip()
-    if not token:
-        raise HTTPException(status_code=401, detail="Missing X-Consent-Token")
+    consent_token = (x_consent_token or "").strip()
+    if not consent_token:
+        return await _create_or_report_consent_request(
+            body=body,
+            request=request,
+            authorization=authorization,
+            developer_token=token,
+        )
 
-    validation = validate_a2a_consent_token("agent_one", token)
+    validation = validate_a2a_consent_token("agent_one", consent_token)
     if not validation.ok or not validation.user_id:
         logger.warning("agent_one_a2a.request_rejected_invalid_token")
         raise HTTPException(status_code=403, detail="Invalid consent token")
@@ -103,7 +343,7 @@ async def agent_one_a2a_message(
         result = get_orchestrator().handle_message(
             message=body.message,
             user_id=user_id,
-            consent_token=token,
+            consent_token=consent_token,
             persona=body.persona,
         )
     except Exception:
@@ -116,5 +356,6 @@ async def agent_one_a2a_message(
         userId=user_id,
         response=str(result.get("response") or ""),
         delegation=result.get("delegation") if isinstance(result.get("delegation"), dict) else None,
+        consent=None,
         isComplete=True,
     )

--- a/consent-protocol/api/routes/one/a2a.py
+++ b/consent-protocol/api/routes/one/a2a.py
@@ -1,0 +1,120 @@
+"""Agent One A2A endpoint.
+
+This route exposes Agent One over the existing Hussh A2A consent boundary.
+It does not mint tokens and does not grant specialist execution authority; the
+caller must present a consent token scoped to ``agent.one.orchestrate``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from hushh_mcp.adk_bridge.delegation import validate_a2a_consent_token
+from hushh_mcp.agents.one.manifest import get_manifest
+from hushh_mcp.agents.orchestrator.agent import get_orchestrator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/one/a2a", tags=["Agent One A2A"])
+
+
+class AgentOneA2AMessageRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    message: str = Field(..., min_length=1, max_length=8192)
+    user_id: str | None = Field(default=None, alias="userId", min_length=1, max_length=128)
+    conversation_id: str | None = Field(default=None, alias="conversationId", max_length=128)
+    persona: str = Field(default="investor", min_length=1, max_length=32)
+
+
+class AgentOneA2AMessageResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    agent_id: str = Field(alias="agentId")
+    conversation_id: str | None = Field(default=None, alias="conversationId")
+    user_id: str = Field(alias="userId")
+    response: str
+    delegation: dict[str, Any] | None = None
+    is_complete: bool = Field(default=True, alias="isComplete")
+
+
+def _agent_card() -> dict[str, Any]:
+    manifest = get_manifest()
+    return {
+        "agentId": manifest["agent_id"],
+        "legacyIds": list(manifest.get("legacy_ids") or []),
+        "name": manifest["name"],
+        "version": manifest["version"],
+        "description": manifest["description"],
+        "requiredScopes": [
+            str(scope.value if hasattr(scope, "value") else scope)
+            for scope in manifest["required_scopes"]
+        ],
+        "optionalScopes": [
+            str(scope.value if hasattr(scope, "value") else scope)
+            for scope in manifest.get("optional_scopes", [])
+        ],
+        "specialists": list(manifest.get("specialists") or []),
+        "capabilities": dict(manifest.get("capabilities") or {}),
+        "compliance": dict(manifest.get("compliance") or {}),
+        "endpoints": {
+            "message": "/api/one/a2a/message",
+            "card": "/api/one/a2a/card",
+        },
+        "protocol": {
+            "transport": "https",
+            "consentHeader": "X-Consent-Token",
+            "requiredScope": "agent.one.orchestrate",
+        },
+    }
+
+
+@router.get("/card")
+async def agent_one_a2a_card() -> dict[str, Any]:
+    """Return Agent One capability metadata from the checked-in manifest."""
+    return _agent_card()
+
+
+@router.post("/message", response_model=AgentOneA2AMessageResponse)
+async def agent_one_a2a_message(
+    body: AgentOneA2AMessageRequest,
+    x_consent_token: str | None = Header(default=None, alias="X-Consent-Token"),
+) -> AgentOneA2AMessageResponse:
+    """Route a caller request through Agent One after A2A scope validation."""
+    token = (x_consent_token or "").strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing X-Consent-Token")
+
+    validation = validate_a2a_consent_token("agent_one", token)
+    if not validation.ok or not validation.user_id:
+        logger.warning("agent_one_a2a.request_rejected_invalid_token")
+        raise HTTPException(status_code=403, detail="Invalid consent token")
+
+    user_id = str(validation.user_id)
+    if body.user_id is not None and body.user_id != user_id:
+        logger.warning("agent_one_a2a.request_rejected_user_mismatch")
+        raise HTTPException(status_code=403, detail="Token user does not match request user")
+
+    try:
+        result = get_orchestrator().handle_message(
+            message=body.message,
+            user_id=user_id,
+            consent_token=token,
+            persona=body.persona,
+        )
+    except Exception:
+        logger.exception("agent_one_a2a.orchestrator_failed")
+        raise HTTPException(status_code=500, detail="Agent One could not process the request")
+
+    return AgentOneA2AMessageResponse(
+        agentId="agent_one",
+        conversationId=body.conversation_id,
+        userId=user_id,
+        response=str(result.get("response") or ""),
+        delegation=result.get("delegation") if isinstance(result.get("delegation"), dict) else None,
+        isComplete=True,
+    )

--- a/consent-protocol/docs/reference/consent-protocol.md
+++ b/consent-protocol/docs/reference/consent-protocol.md
@@ -341,10 +341,13 @@ fun chat(call: PluginCall) {
 | **PKM** | `pkm.read` | Read PKM attributes |
 | | `pkm.write` | Write PKM attributes |
 | | `pkm.metadata` | Access PKM metadata |
+| **Agent One** | `agent.one.orchestrate` | Coordinate user intent and specialist handoff framing |
 | **Agent Kai** | `agent.kai.analyze` | Run Kai analysis pipelines |
 | | `agent.kai.debate` | Run Kai debate/reasoning |
 | | `agent.kai.infer` | Run Kai inference |
 | | `agent.kai.chat` | Kai chat interactions |
+| **Agent Nav** | `agent.nav.review` | Review consent, privacy, vault, and scope decisions |
+| **Agent KYC** | `agent.kyc.process` | Process identity workflow requirements inside the granted scope |
 | **External** | `external.sec.filings` | Access SEC filing data |
 | | `external.news.api` | Access news API data |
 | | `external.market.data` | Access market data feeds |

--- a/consent-protocol/tests/test_agent_one_a2a_routes.py
+++ b/consent-protocol/tests/test_agent_one_a2a_routes.py
@@ -15,6 +15,7 @@ from hushh_mcp.constants import ConsentScope
 def _client() -> TestClient:
     app = FastAPI()
     app.include_router(a2a.router)
+    app.include_router(a2a.well_known_router)
     return TestClient(app)
 
 
@@ -36,6 +37,15 @@ def test_agent_card_is_manifest_backed():
     assert payload["protocol"]["consentHeader"] == "X-Consent-Token"
     assert payload["endpoints"]["message"] == "/api/one/a2a/message"
     assert payload["capabilities"]["specialist_delegation"] is True
+
+
+def test_standard_well_known_agent_card_matches_manifest_card():
+    client = _client()
+    standard = client.get("/.well-known/agent-card.json")
+    compat = client.get("/api/one/a2a/card")
+
+    assert standard.status_code == 200
+    assert standard.json() == compat.json()
 
 
 def test_message_requires_consent_token_or_developer_auth():

--- a/consent-protocol/tests/test_agent_one_a2a_routes.py
+++ b/consent-protocol/tests/test_agent_one_a2a_routes.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.routes.one import a2a
-from hushh_mcp.consent.token import issue_token
+from hushh_mcp.consent.token import issue_token, validate_token
 from hushh_mcp.constants import ConsentScope
 
 
@@ -22,8 +22,31 @@ def _client() -> TestClient:
 def _token(
     scope: ConsentScope = ConsentScope.AGENT_ONE_ORCHESTRATE,
     user_id: str = "user-one",
+    agent_id: str = "developer:brand-agent",
 ) -> str:
-    return issue_token(user_id, "calling_agent", scope).token
+    return issue_token(user_id, agent_id, scope).token
+
+
+def _principal(agent_id: str = "developer:brand-agent") -> SimpleNamespace:
+    return SimpleNamespace(
+        app_id="app_brand",
+        agent_id=agent_id,
+        display_name="Brand Agent",
+        allowed_tool_groups=("core_consent",),
+        brand_image_url=None,
+        website_url=None,
+    )
+
+
+def _patch_developer_auth(monkeypatch, *, agent_id: str = "developer:brand-agent") -> None:
+    monkeypatch.setattr(a2a, "authenticate_developer_principal", lambda **_: _principal(agent_id))
+
+
+def _patch_db_token_validation(monkeypatch) -> None:
+    async def _validate(token, expected_scope=None, **kwargs):
+        return validate_token(token, expected_scope, **kwargs)
+
+    monkeypatch.setattr(a2a, "validate_token_with_db", _validate)
 
 
 def test_agent_card_is_manifest_backed():
@@ -34,6 +57,7 @@ def test_agent_card_is_manifest_backed():
     assert payload["agentId"] == "agent_one"
     assert payload["name"] == "Agent One"
     assert payload["requiredScopes"] == ["agent.one.orchestrate"]
+    assert payload["protocol"]["developerAuth"] == "Authorization: Bearer <developer-token>"
     assert payload["protocol"]["consentHeader"] == "X-Consent-Token"
     assert payload["endpoints"]["message"] == "/api/one/a2a/message"
     assert payload["capabilities"]["specialist_delegation"] is True
@@ -100,14 +124,7 @@ def test_message_without_consent_token_creates_pending_consent_request(monkeypat
     monkeypatch.setattr(
         a2a,
         "authenticate_developer_principal",
-        lambda **_: SimpleNamespace(
-            app_id="app_brand",
-            agent_id="developer:brand-agent",
-            display_name="Brand Agent",
-            allowed_tool_groups=("core_consent",),
-            brand_image_url=None,
-            website_url=None,
-        ),
+        lambda **_: _principal(),
     )
     monkeypatch.setattr(a2a, "_resolve_consent_user_id", _resolve_user)
     monkeypatch.setattr(a2a, "ConsentDBService", _FakeConsentDBService)
@@ -158,14 +175,7 @@ def test_message_without_consent_token_reports_existing_pending_request(monkeypa
     monkeypatch.setattr(
         a2a,
         "authenticate_developer_principal",
-        lambda **_: SimpleNamespace(
-            app_id="app_brand",
-            agent_id="developer:brand-agent",
-            display_name="Brand Agent",
-            allowed_tool_groups=("core_consent",),
-            brand_image_url=None,
-            website_url=None,
-        ),
+        lambda **_: _principal(),
     )
     monkeypatch.setattr(a2a, "_resolve_consent_user_id", _resolve_user)
     monkeypatch.setattr(a2a, "ConsentDBService", _FakeConsentDBService)
@@ -183,33 +193,122 @@ def test_message_without_consent_token_reports_existing_pending_request(monkeypa
     assert payload["consent"]["requestId"] == "req_pending"
 
 
-def test_message_rejects_wrong_scope():
+def test_message_with_consent_token_requires_developer_auth():
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Who are you?"},
+        headers={"X-Consent-Token": _token()},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error_code"] == "DEVELOPER_TOKEN_REQUIRED"
+
+
+def test_message_rejects_wrong_scope(monkeypatch):
+    _patch_developer_auth(monkeypatch)
+    _patch_db_token_validation(monkeypatch)
+
     response = _client().post(
         "/api/one/a2a/message",
         json={"message": "Analyze my portfolio"},
-        headers={"X-Consent-Token": _token(ConsentScope.AGENT_KAI_ANALYZE)},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(ConsentScope.AGENT_KAI_ANALYZE),
+        },
     )
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Invalid consent token"
 
 
-def test_message_rejects_user_mismatch():
+def test_message_rejects_developer_app_mismatch(monkeypatch):
+    _patch_developer_auth(monkeypatch, agent_id="developer:other-agent")
+    _patch_db_token_validation(monkeypatch)
+
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Who are you?"},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(agent_id="developer:brand-agent"),
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Token app does not match caller"
+
+
+def test_message_rejects_db_revoked_token(monkeypatch):
+    _patch_developer_auth(monkeypatch)
+
+    async def _revoked(*args, **kwargs):
+        return False, "Token has been revoked (DB check)", None
+
+    monkeypatch.setattr(a2a, "validate_token_with_db", _revoked)
+
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Who are you?"},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(),
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid consent token"
+
+
+def test_message_rejects_user_mismatch(monkeypatch):
+    _patch_developer_auth(monkeypatch)
+    _patch_db_token_validation(monkeypatch)
+
     response = _client().post(
         "/api/one/a2a/message",
         json={"message": "Who are you?", "userId": "other-user"},
-        headers={"X-Consent-Token": _token(user_id="user-one")},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(user_id="user-one"),
+        },
     )
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Token user does not match request user"
 
 
-def test_message_routes_general_turn_to_one():
+def test_message_rejects_email_target_mismatch(monkeypatch):
+    _patch_developer_auth(monkeypatch)
+    _patch_db_token_validation(monkeypatch)
+
+    async def _resolve_user(body):
+        return "other-user"
+
+    monkeypatch.setattr(a2a, "_resolve_consent_user_id", _resolve_user)
+
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Who are you?", "email": "other@example.com"},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(user_id="user-one"),
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Token user does not match request user"
+
+
+def test_message_routes_general_turn_to_one(monkeypatch):
+    _patch_developer_auth(monkeypatch)
+    _patch_db_token_validation(monkeypatch)
+
     response = _client().post(
         "/api/one/a2a/message",
         json={"message": "Who are you?", "userId": "user-one", "conversationId": "conv-1"},
-        headers={"X-Consent-Token": _token(user_id="user-one")},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(user_id="user-one"),
+        },
     )
 
     assert response.status_code == 200
@@ -221,11 +320,17 @@ def test_message_routes_general_turn_to_one():
     assert "One" in payload["response"]
 
 
-def test_message_surfaces_specialist_delegation():
+def test_message_surfaces_specialist_delegation(monkeypatch):
+    _patch_developer_auth(monkeypatch)
+    _patch_db_token_validation(monkeypatch)
+
     response = _client().post(
         "/api/one/a2a/message",
         json={"message": "Please review my portfolio allocation"},
-        headers={"X-Consent-Token": _token(user_id="user-one")},
+        headers={
+            "Authorization": "Bearer hdk_demo",
+            "X-Consent-Token": _token(user_id="user-one"),
+        },
     )
 
     assert response.status_code == 200

--- a/consent-protocol/tests/test_agent_one_a2a_routes.py
+++ b/consent-protocol/tests/test_agent_one_a2a_routes.py
@@ -1,0 +1,96 @@
+"""Agent One A2A route contract tests."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes.one import a2a
+from hushh_mcp.consent.token import issue_token
+from hushh_mcp.constants import ConsentScope
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(a2a.router)
+    return TestClient(app)
+
+
+def _token(
+    scope: ConsentScope = ConsentScope.AGENT_ONE_ORCHESTRATE,
+    user_id: str = "user-one",
+) -> str:
+    return issue_token(user_id, "calling_agent", scope).token
+
+
+def test_agent_card_is_manifest_backed():
+    response = _client().get("/api/one/a2a/card")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["agentId"] == "agent_one"
+    assert payload["name"] == "Agent One"
+    assert payload["requiredScopes"] == ["agent.one.orchestrate"]
+    assert payload["protocol"]["consentHeader"] == "X-Consent-Token"
+    assert payload["endpoints"]["message"] == "/api/one/a2a/message"
+    assert payload["capabilities"]["specialist_delegation"] is True
+
+
+def test_message_requires_consent_token():
+    response = _client().post("/api/one/a2a/message", json={"message": "Who are you?"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing X-Consent-Token"
+
+
+def test_message_rejects_wrong_scope():
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Analyze my portfolio"},
+        headers={"X-Consent-Token": _token(ConsentScope.AGENT_KAI_ANALYZE)},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid consent token"
+
+
+def test_message_rejects_user_mismatch():
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Who are you?", "userId": "other-user"},
+        headers={"X-Consent-Token": _token(user_id="user-one")},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Token user does not match request user"
+
+
+def test_message_routes_general_turn_to_one():
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Who are you?", "userId": "user-one", "conversationId": "conv-1"},
+        headers={"X-Consent-Token": _token(user_id="user-one")},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["agentId"] == "agent_one"
+    assert payload["userId"] == "user-one"
+    assert payload["conversationId"] == "conv-1"
+    assert payload["delegation"] is None
+    assert "One" in payload["response"]
+
+
+def test_message_surfaces_specialist_delegation():
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Please review my portfolio allocation"},
+        headers={"X-Consent-Token": _token(user_id="user-one")},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["userId"] == "user-one"
+    assert payload["delegation"]["delegated"] is True
+    assert payload["delegation"]["target_agent"] == "agent_kai"
+    assert payload["delegation"]["domain"] == "finance"

--- a/consent-protocol/tests/test_agent_one_a2a_routes.py
+++ b/consent-protocol/tests/test_agent_one_a2a_routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -36,11 +38,139 @@ def test_agent_card_is_manifest_backed():
     assert payload["capabilities"]["specialist_delegation"] is True
 
 
-def test_message_requires_consent_token():
+def test_message_requires_consent_token_or_developer_auth():
     response = _client().post("/api/one/a2a/message", json={"message": "Who are you?"})
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Missing X-Consent-Token"
+    assert response.json()["detail"]["error_code"] == "DEVELOPER_TOKEN_REQUIRED"
+
+
+def test_message_without_consent_token_creates_pending_consent_request(monkeypatch):
+    inserted: dict[str, object] = {}
+    orchestrator_called = False
+
+    async def _resolve_user(body):
+        return "user-one"
+
+    class _FakeConsentDBService:
+        async def get_covering_active_tokens(
+            self,
+            user_id: str,
+            *,
+            agent_id: str | None = None,
+            requested_scope: str,
+        ):
+            assert user_id == "user-one"
+            assert agent_id == "developer:brand-agent"
+            assert requested_scope == "agent.one.orchestrate"
+            return []
+
+        async def get_pending_request_for_scope(
+            self,
+            user_id: str,
+            *,
+            agent_id: str,
+            scope: str,
+        ):
+            assert user_id == "user-one"
+            assert agent_id == "developer:brand-agent"
+            assert scope == "agent.one.orchestrate"
+            return None
+
+        async def insert_event(self, **kwargs):
+            inserted.update(kwargs)
+            return 1
+
+    class _FailingOrchestrator:
+        def handle_message(self, **kwargs):
+            nonlocal orchestrator_called
+            orchestrator_called = True
+            raise AssertionError("orchestrator must not execute before consent")
+
+    monkeypatch.setattr(
+        a2a,
+        "authenticate_developer_principal",
+        lambda **_: SimpleNamespace(
+            app_id="app_brand",
+            agent_id="developer:brand-agent",
+            display_name="Brand Agent",
+            allowed_tool_groups=("core_consent",),
+            brand_image_url=None,
+            website_url=None,
+        ),
+    )
+    monkeypatch.setattr(a2a, "_resolve_consent_user_id", _resolve_user)
+    monkeypatch.setattr(a2a, "ConsentDBService", _FakeConsentDBService)
+    monkeypatch.setattr(a2a, "get_orchestrator", lambda: _FailingOrchestrator())
+
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={
+            "message": "Please coordinate my task",
+            "email": "user@example.com",
+            "conversationId": "conv-1",
+        },
+        headers={"Authorization": "Bearer hdk_demo"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["isComplete"] is False
+    assert payload["userId"] == "user-one"
+    assert payload["consent"]["status"] == "pending"
+    assert payload["consent"]["requiredScope"] == "agent.one.orchestrate"
+    assert payload["consent"]["tokenRequired"] is True
+    assert inserted["action"] == "REQUESTED"
+    assert inserted["scope"] == "agent.one.orchestrate"
+    assert inserted["agent_id"] == "developer:brand-agent"
+    assert inserted["metadata"]["request_source"] == "agent_one_a2a_consent_v1"
+    assert inserted["metadata"]["requester_actor_type"] == "a2a_agent"
+    assert "connector_public_key" not in inserted["metadata"]
+    assert orchestrator_called is False
+
+
+def test_message_without_consent_token_reports_existing_pending_request(monkeypatch):
+    async def _resolve_user(body):
+        return "user-one"
+
+    class _FakeConsentDBService:
+        async def get_covering_active_tokens(self, *args, **kwargs):
+            return []
+
+        async def get_pending_request_for_scope(self, *args, **kwargs):
+            return {
+                "id": "req_pending",
+                "requestUrl": "http://localhost:3000/consents?tab=pending&requestId=req_pending",
+                "pollTimeoutAt": 123456,
+                "approvalTimeoutAt": 123456,
+            }
+
+    monkeypatch.setattr(
+        a2a,
+        "authenticate_developer_principal",
+        lambda **_: SimpleNamespace(
+            app_id="app_brand",
+            agent_id="developer:brand-agent",
+            display_name="Brand Agent",
+            allowed_tool_groups=("core_consent",),
+            brand_image_url=None,
+            website_url=None,
+        ),
+    )
+    monkeypatch.setattr(a2a, "_resolve_consent_user_id", _resolve_user)
+    monkeypatch.setattr(a2a, "ConsentDBService", _FakeConsentDBService)
+
+    response = _client().post(
+        "/api/one/a2a/message",
+        json={"message": "Please coordinate my task", "userId": "user-one"},
+        headers={"Authorization": "Bearer hdk_demo"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["isComplete"] is False
+    assert payload["consent"]["status"] == "pending"
+    assert payload["consent"]["requestId"] == "req_pending"
 
 
 def test_message_rejects_wrong_scope():

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -1580,7 +1580,8 @@ def test_developer_consent_event_stream_rejects_other_developer(monkeypatch):
 
     client = TestClient(_build_app())
     response = client.get(
-        "/api/v1/consent-events?token=hdk_demo&user_id=user_123&request_id=req_pending"
+        "/api/v1/consent-events?user_id=user_123&request_id=req_pending",
+        headers={"Authorization": "Bearer hdk_demo"},
     )
 
     assert response.status_code == 404
@@ -1609,11 +1610,13 @@ def test_developer_consent_event_stream_returns_terminal_snapshot(monkeypatch):
 
     client = TestClient(_build_app())
     response = client.get(
-        "/api/v1/consent-events?token=hdk_demo&user_id=user_123&request_id=req_granted"
+        "/api/v1/consent-events?user_id=user_123&request_id=req_granted",
+        headers={"Authorization": "Bearer hdk_demo"},
     )
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/event-stream")
+    assert "no-store" in response.headers["cache-control"].lower()
     body = response.text
     assert "event: snapshot" in body
     assert '"status": "granted"' in body

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -1477,6 +1478,183 @@ def test_get_consent_status_uses_covering_active_token(monkeypatch):
     assert payload["coverage_kind"] == "superset"
     assert payload["export_revision"] == 5
     assert payload["export_refresh_status"] == "current"
+
+
+def test_get_consent_status_pending_request_does_not_return_event_token(monkeypatch):
+    class _FakeConsentDBService:
+        async def get_covering_active_tokens(
+            self,
+            user_id: str,
+            *,
+            requested_scope: str,
+            agent_id: str | None = None,
+        ):
+            return []
+
+        async def get_request_status(self, user_id: str, request_id: str):
+            assert user_id == "user_123"
+            assert request_id == "req_pending"
+            return {
+                "action": "REQUESTED",
+                "agent_id": "developer:app_demo_123",
+                "scope": "agent.one.orchestrate",
+                "request_id": "req_pending",
+                "token_id": "evt_internal_row_id",
+                "poll_timeout_at": 123456789,
+                "metadata": {
+                    "approval_timeout_minutes": 60,
+                    "expiry_hours": 24,
+                    "requester_label": "Demo App",
+                },
+            }
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBService)
+    monkeypatch.setattr(
+        developer, "authenticate_developer_principal", lambda **_: _fake_principal()
+    )
+
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/v1/consent-status?token=hdk_demo&user_id=user_123&request_id=req_pending"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "pending"
+    assert payload["consent_token"] is None
+
+
+def test_developer_consent_status_payload_only_returns_token_after_grant():
+    principal = _fake_principal()
+
+    pending = developer._developer_consent_status_payload(
+        latest={
+            "action": "REQUESTED",
+            "scope": "agent.one.orchestrate",
+            "token_id": "evt_internal",
+            "metadata": {"requester_label": "Demo App"},
+        },
+        user_id="user_123",
+        request_id="req_pending",
+        principal=principal,
+    )
+    granted = developer._developer_consent_status_payload(
+        latest={
+            "action": "CONSENT_GRANTED",
+            "scope": "agent.one.orchestrate",
+            "token_id": "HCT:granted",
+            "expires_at": 123456789,
+            "metadata": {"requester_label": "Demo App"},
+        },
+        user_id="user_123",
+        request_id="req_pending",
+        principal=principal,
+    )
+
+    assert pending["status"] == "pending"
+    assert pending["consent_token"] is None
+    assert pending["terminal"] is False
+    assert granted["status"] == "granted"
+    assert granted["consent_token"] == "HCT:granted"
+    assert granted["terminal"] is True
+
+
+def test_developer_consent_event_stream_rejects_other_developer(monkeypatch):
+    class _FakeConsentDBService:
+        async def get_request_status(self, user_id: str, request_id: str):
+            return {
+                "action": "REQUESTED",
+                "agent_id": "developer:other_app",
+                "scope": "agent.one.orchestrate",
+                "request_id": request_id,
+            }
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBService)
+    monkeypatch.setattr(
+        developer, "authenticate_developer_principal", lambda **_: _fake_principal()
+    )
+
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/v1/consent-events?token=hdk_demo&user_id=user_123&request_id=req_pending"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error_code"] == "CONSENT_REQUEST_NOT_FOUND"
+
+
+def test_developer_consent_event_stream_returns_terminal_snapshot(monkeypatch):
+    class _FakeConsentDBService:
+        async def get_request_status(self, user_id: str, request_id: str):
+            return {
+                "action": "CONSENT_GRANTED",
+                "agent_id": "developer:app_demo_123",
+                "scope": "agent.one.orchestrate",
+                "request_id": request_id,
+                "token_id": "HCT:granted",
+                "expires_at": 123456789,
+                "metadata": {"requester_label": "Demo App"},
+            }
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBService)
+    monkeypatch.setattr(
+        developer, "authenticate_developer_principal", lambda **_: _fake_principal()
+    )
+
+    client = TestClient(_build_app())
+    response = client.get(
+        "/api/v1/consent-events?token=hdk_demo&user_id=user_123&request_id=req_granted"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    body = response.text
+    assert "event: snapshot" in body
+    assert '"status": "granted"' in body
+    assert '"consent_token": "HCT:granted"' in body
+
+
+def test_developer_consent_subscribers_are_fanout_not_shared_queue():
+    from api import consent_listener
+
+    async def _run():
+        q1 = await consent_listener.subscribe_developer_consent_queue(
+            request_id="req_fanout",
+            agent_id="developer:app_demo_123",
+        )
+        q2 = await consent_listener.subscribe_developer_consent_queue(
+            request_id="req_fanout",
+            agent_id="developer:app_demo_123",
+        )
+        try:
+            await consent_listener._push_to_developer_consent_queues(
+                {
+                    "request_id": "req_fanout",
+                    "agent_id": "developer:app_demo_123",
+                    "action": "CONSENT_GRANTED",
+                }
+            )
+            assert (await asyncio.wait_for(q1.get(), timeout=1))["action"] == "CONSENT_GRANTED"
+            assert (await asyncio.wait_for(q2.get(), timeout=1))["action"] == "CONSENT_GRANTED"
+        finally:
+            await consent_listener.unsubscribe_developer_consent_queue(
+                request_id="req_fanout",
+                agent_id="developer:app_demo_123",
+                queue=q1,
+            )
+            await consent_listener.unsubscribe_developer_consent_queue(
+                request_id="req_fanout",
+                agent_id="developer:app_demo_123",
+                queue=q2,
+            )
+
+    asyncio.run(_run())
 
 
 def test_default_available_export_returns_safe_projection_and_audits(monkeypatch):

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -46,6 +46,7 @@ def test_list_scopes_returns_dynamic_catalog(monkeypatch):
     names = [item["name"] for item in payload["scopes"]]
     assert payload["scopes_are_dynamic"] is True
     assert "pkm.read" in names
+    assert "agent.one.orchestrate" in names
     assert all("world" not in name for name in names)
     assert "attr.{domain}.*" in names
     assert payload["request_endpoint"] == "/api/v1/request-consent"
@@ -686,6 +687,119 @@ def test_request_consent_creates_pending_request(monkeypatch):
     assert inserted["metadata"]["developer_app_display_name"] == "Demo App"
     assert inserted["metadata"]["connector_public_key"] == _CONNECTOR_PUBLIC_KEY
     assert inserted["metadata"]["connector_key_id"] == _CONNECTOR_KEY_ID
+    assert inserted["metadata"]["connector_wrapping_alg"] == _CONNECTOR_WRAPPING_ALG
+
+
+def test_request_consent_creates_pending_agent_one_orchestration_request(monkeypatch):
+    inserted: dict[str, object] = {}
+
+    class _FakeScopeGenerator:
+        async def get_available_scopes(self, user_id: str) -> list[str]:
+            assert user_id == "user_123"
+            return []
+
+        async def get_available_scope_entries(self, user_id: str) -> list[dict]:
+            assert user_id == "user_123"
+            return []
+
+    class _FakeIndex:
+        available_domains: list[str] = []
+
+    class _FakePkmService:
+        scope_generator = _FakeScopeGenerator()
+
+        async def resolve_metadata_index(self, user_id: str):
+            assert user_id == "user_123"
+            return _FakeIndex()
+
+    class _FakeConsentDBService:
+        async def get_covering_active_tokens(
+            self,
+            user_id: str,
+            *,
+            requested_scope: str,
+            agent_id: str | None = None,
+        ):
+            assert user_id == "user_123"
+            assert requested_scope == "agent.one.orchestrate"
+            assert agent_id == "developer:app_demo_123"
+            return []
+
+        async def get_pending_request_for_scope(
+            self,
+            user_id: str,
+            *,
+            agent_id: str,
+            scope: str,
+        ):
+            assert user_id == "user_123"
+            assert agent_id == "developer:app_demo_123"
+            assert scope == "agent.one.orchestrate"
+            return None
+
+        async def get_superseded_active_tokens(
+            self,
+            user_id: str,
+            *,
+            requested_scope: str,
+            agent_id: str | None = None,
+        ):
+            assert user_id == "user_123"
+            assert requested_scope == "agent.one.orchestrate"
+            assert agent_id == "developer:app_demo_123"
+            return []
+
+        async def was_recently_denied(
+            self,
+            user_id: str,
+            scope: str,
+            cooldown_seconds: int = 60,
+            agent_id: str | None = None,
+        ):
+            assert user_id == "user_123"
+            assert scope == "agent.one.orchestrate"
+            assert agent_id == "developer:app_demo_123"
+            return False
+
+        async def insert_event(self, **kwargs):
+            inserted.update(kwargs)
+            return 1
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
+    monkeypatch.setattr(developer, "get_pkm_service", lambda: _FakePkmService())
+    monkeypatch.setattr(developer, "ConsentDBService", _FakeConsentDBService)
+    monkeypatch.setattr(
+        developer, "authenticate_developer_principal", lambda **_: _fake_principal()
+    )
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/v1/request-consent?token=hdk_demo",
+        json={
+            "user_id": "user_123",
+            "scope": "agent.one.orchestrate",
+            "expiry_hours": 24,
+            "approval_timeout_minutes": 60,
+            "reason": "Coordinate this request through Agent One",
+            "connector_public_key": _CONNECTOR_PUBLIC_KEY,
+            "connector_key_id": _CONNECTOR_KEY_ID,
+            "connector_wrapping_alg": _CONNECTOR_WRAPPING_ALG,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "pending"
+    assert payload["scope"] == "agent.one.orchestrate"
+    assert payload["requested_scope"] == "agent.one.orchestrate"
+    assert payload["granted_scope"] is None
+    assert payload["agent_id"] == "developer:app_demo_123"
+    assert payload["approval_timeout_minutes"] == 60
+    assert inserted["action"] == "REQUESTED"
+    assert inserted["agent_id"] == "developer:app_demo_123"
+    assert inserted["scope"] == "agent.one.orchestrate"
+    assert inserted["metadata"]["reason"] == "Coordinate this request through Agent One"
     assert inserted["metadata"]["connector_wrapping_alg"] == _CONNECTOR_WRAPPING_ALG
 
 
@@ -1872,6 +1986,10 @@ def test_is_supported_scope_accepts_pkm_read():
 
 def test_is_supported_scope_accepts_pkm_write():
     assert _is_supported_scope("pkm.write") is True
+
+
+def test_is_supported_scope_accepts_agent_one_orchestrate():
+    assert _is_supported_scope("agent.one.orchestrate") is True
 
 
 def test_is_supported_scope_accepts_dynamic_attr_scope():

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -76,7 +76,7 @@ Client surfaces
 | GET | `/api/v1/tool-catalog` | Public-beta or app-filtered tool visibility |
 | GET | `/api/v1/user-scopes/{user_id}` | Discover dynamic user scopes for one user (requires `?token=<developer-token>`) |
 | GET | `/api/v1/consent-status` | Check app-scoped consent status by scope or request id |
-| POST | `/api/v1/request-consent` | Create or reuse consent for one discovered scope (requires `?token=<developer-token>`) |
+| POST | `/api/v1/request-consent` | Create or reuse consent for one discovered `attr.*` scope or approved static scope such as `agent.one.orchestrate` (requires `?token=<developer-token>`) |
 | POST | `/api/v1/default-available-export` | Read a user-published safe projection for a `default_available` scope; records audit metadata and never returns raw PKM |
 | POST | `/api/v1/scoped-export` | Fetch encrypted consent export metadata and ciphertext for an approved developer grant |
 

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -33,7 +33,7 @@ POST /api/consent/vault-owner-token  (Firebase Bearer)
 | Firebase ID Token     | Identity verification only       | 1 hour   | `Bearer <firebase-id-token>`   |
 | VAULT_OWNER Token     | Consent + identity for all data  | 24 hours | `Bearer <vault-owner-token>`   |
 | Agent Scoped Token    | Delegated MCP agent access       | 7 days   | `Bearer <consent-token>`       |
-| Developer Token       | External API and remote MCP access | N/A    | `?token=<developer-token>`     |
+| Developer Token       | External API and remote MCP access | N/A    | `Bearer <developer-token>` preferred; `?token=` legacy-compatible |
 
 ---
 
@@ -199,9 +199,11 @@ endpoint is `/.well-known/agent-card.json`; `/api/one/a2a/card` remains a Hussh
 compatibility alias. Both return manifest-backed metadata. The message endpoint
 has two paths:
 
-1. With `X-Consent-Token`, the token must validate for `agent_one` with
-   `agent.one.orchestrate`; the route derives `userId` from the signed token,
-   rejects a mismatched request body `userId`, and invokes Agent One.
+1. With `X-Consent-Token`, the caller must also authenticate as the developer
+   app with `Authorization: Bearer <developer-token>`; the consent token is
+   DB-validated for `agent.one.orchestrate`, must belong to that same app, and
+   the route derives `userId` from the signed token. Any mismatched body
+   `userId`, `email`, or `phoneNumber` is rejected before Agent One runs.
 2. Without `X-Consent-Token`, an authenticated developer caller can create or
    check a pending `agent.one.orchestrate` consent request for a resolved
    `userId`, `email`, or `phoneNumber`. This path does not execute Agent One
@@ -213,7 +215,7 @@ Specialist work still validates at the specialist boundary.
 | ------ | ---- | ---- | ----------- |
 | GET | `/.well-known/agent-card.json` | Public metadata | Standard A2A Agent Card discovery endpoint for Agent One |
 | GET | `/api/one/a2a/card` | Public metadata | Return Agent One manifest, required scope, specialists, and endpoint metadata |
-| POST | `/api/one/a2a/message` | `X-Consent-Token` scoped `agent.one.orchestrate` | Invoke Agent One as the coordinator for a user request; returns either a direct One response or a specialist delegation payload |
+| POST | `/api/one/a2a/message` | Developer bearer token plus `X-Consent-Token` scoped `agent.one.orchestrate` | Invoke Agent One as the coordinator for a user request; returns either a direct One response or a specialist delegation payload |
 | POST | `/api/one/a2a/message` | Developer `Authorization: Bearer <token>` or legacy `?token=` | Create or report pending Agent One orchestration consent for a resolved user; returns consent request metadata only |
 
 ### VAULT_OWNER (Consent-Gated)
@@ -457,7 +459,7 @@ Security invariant:
 | ------ | ---- | ----------- |
 | GET | `/api/consent/events/{user_id}` | Disabled in production unless `CONSENT_SSE_ENABLED=true` |
 | GET | `/api/consent/events/{user_id}/poll/{request_id}` | Deprecated and disabled (`410`, `CONSENT_POLL_DEPRECATED`) |
-| GET | `/api/v1/consent-events?user_id={user_id}&request_id={request_id}` | Developer-authenticated SSE for the outside agent; emits `snapshot`, `consent_update`, and `heartbeat`; scoped to the developer app that owns the consent request |
+| GET | `/api/v1/consent-events?user_id={user_id}&request_id={request_id}` | Developer-authenticated SSE for the outside agent; prefer `Authorization: Bearer <developer-token>`; emits `snapshot`, `consent_update`, and `heartbeat`; scoped to the developer app that owns the consent request |
 
 ### Deprecated (410 Gone)
 
@@ -588,12 +590,15 @@ External developers (MCP agents, third-party apps) use the `/api/v1` endpoints:
    → If the scope is already default-available, returns { status: "already_available", coverage_kind: "default_available_projection" }.
 
 4. Optional realtime wait: GET /api/v1/consent-events
-   Query: ?token=<developer-token>&user_id=<user_id>&request_id=<request_id>
+   Header: Authorization: Bearer <developer-token>
+   Query: ?user_id=<user_id>&request_id=<request_id>
    → SSE events:
      - `snapshot`: current request state
      - `consent_update`: request state change, including `consent_token` only when `status="granted"`
      - `heartbeat`: keepalive while waiting
    → The stream is bound to the authenticated developer app and closes on terminal consent states.
+   → Query-token auth remains legacy-compatible, but bearer auth is preferred
+     because URLs are commonly logged by proxies and developer tools.
 
 5. User receives FCM notification → approves in app
 

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -195,15 +195,23 @@ not the product owner for live location.
 ### Agent One A2A
 
 Agent One exposes a scoped A2A coordination surface. The card endpoint is
-manifest-backed metadata. The message endpoint requires `X-Consent-Token`; the
-token must validate for `agent_one` with `agent.one.orchestrate`. The route
-derives `userId` from the signed token and rejects a mismatched request body
-`userId`. Specialist work still validates at the specialist boundary.
+manifest-backed metadata. The message endpoint has two paths:
+
+1. With `X-Consent-Token`, the token must validate for `agent_one` with
+   `agent.one.orchestrate`; the route derives `userId` from the signed token,
+   rejects a mismatched request body `userId`, and invokes Agent One.
+2. Without `X-Consent-Token`, an authenticated developer caller can create or
+   check a pending `agent.one.orchestrate` consent request for a resolved
+   `userId`, `email`, or `phoneNumber`. This path does not execute Agent One
+   and does not return a consent token.
+
+Specialist work still validates at the specialist boundary.
 
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
 | GET | `/api/one/a2a/card` | Public metadata | Return Agent One manifest, required scope, specialists, and endpoint metadata |
 | POST | `/api/one/a2a/message` | `X-Consent-Token` scoped `agent.one.orchestrate` | Invoke Agent One as the coordinator for a user request; returns either a direct One response or a specialist delegation payload |
+| POST | `/api/one/a2a/message` | Developer `Authorization: Bearer <token>` or legacy `?token=` | Create or report pending Agent One orchestration consent for a resolved user; returns consent request metadata only |
 
 ### VAULT_OWNER (Consent-Gated)
 
@@ -446,6 +454,7 @@ Security invariant:
 | ------ | ---- | ----------- |
 | GET | `/api/consent/events/{user_id}` | Disabled in production unless `CONSENT_SSE_ENABLED=true` |
 | GET | `/api/consent/events/{user_id}/poll/{request_id}` | Deprecated and disabled (`410`, `CONSENT_POLL_DEPRECATED`) |
+| GET | `/api/v1/consent-events?user_id={user_id}&request_id={request_id}` | Developer-authenticated SSE for the outside agent; emits `snapshot`, `consent_update`, and `heartbeat`; scoped to the developer app that owns the consent request |
 
 ### Deprecated (410 Gone)
 
@@ -575,9 +584,21 @@ External developers (MCP agents, third-party apps) use the `/api/v1` endpoints:
      { requested_scope, granted_scope, coverage_kind, covered_by_existing_grant }.
    → If the scope is already default-available, returns { status: "already_available", coverage_kind: "default_available_projection" }.
 
-4. User receives FCM notification → approves in app
+4. Optional realtime wait: GET /api/v1/consent-events
+   Query: ?token=<developer-token>&user_id=<user_id>&request_id=<request_id>
+   → SSE events:
+     - `snapshot`: current request state
+     - `consent_update`: request state change, including `consent_token` only when `status="granted"`
+     - `heartbeat`: keepalive while waiting
+   → The stream is bound to the authenticated developer app and closes on terminal consent states.
 
-5. POST /api/validate-token
+5. User receives FCM notification → approves in app
+
+6. Poll fallback: GET /api/v1/consent-status
+   Query: ?token=<developer-token>&user_id=<user_id>&request_id=<request_id>
+   → Returns pending/granted/denied/expired status. `consent_token` is null until granted.
+
+7. POST /api/validate-token
    Body: { token: "<consent-token>" }
    → Returns: { valid, user_id, scope, expires_at }
 

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -194,8 +194,10 @@ not the product owner for live location.
 
 ### Agent One A2A
 
-Agent One exposes a scoped A2A coordination surface. The card endpoint is
-manifest-backed metadata. The message endpoint has two paths:
+Agent One exposes a scoped A2A coordination surface. The standard A2A discovery
+endpoint is `/.well-known/agent-card.json`; `/api/one/a2a/card` remains a Hussh
+compatibility alias. Both return manifest-backed metadata. The message endpoint
+has two paths:
 
 1. With `X-Consent-Token`, the token must validate for `agent_one` with
    `agent.one.orchestrate`; the route derives `userId` from the signed token,
@@ -209,6 +211,7 @@ Specialist work still validates at the specialist boundary.
 
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
+| GET | `/.well-known/agent-card.json` | Public metadata | Standard A2A Agent Card discovery endpoint for Agent One |
 | GET | `/api/one/a2a/card` | Public metadata | Return Agent One manifest, required scope, specialists, and endpoint metadata |
 | POST | `/api/one/a2a/message` | `X-Consent-Token` scoped `agent.one.orchestrate` | Invoke Agent One as the coordinator for a user request; returns either a direct One response or a specialist delegation payload |
 | POST | `/api/one/a2a/message` | Developer `Authorization: Bearer <token>` or legacy `?token=` | Create or report pending Agent One orchestration consent for a resolved user; returns consent request metadata only |

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -192,6 +192,19 @@ not the product owner for live location.
 | POST | `/api/one/location/grants/{grant_id}/refer` | VAULT_OWNER Bearer | Recipient refers another verified user into a request flow; no access is forwarded |
 | POST | `/api/one/location/retention/purge?older_than_hours=12` | `X-Hushh-Maintenance-Token` backed by dedicated `ONE_LOCATION_RETENTION_TOKEN` | Delete terminal expired/revoked location grants, ciphertext envelopes, terminal requests, referrals, public request-link submissions, Invite to One links, and related events after the retention window |
 
+### Agent One A2A
+
+Agent One exposes a scoped A2A coordination surface. The card endpoint is
+manifest-backed metadata. The message endpoint requires `X-Consent-Token`; the
+token must validate for `agent_one` with `agent.one.orchestrate`. The route
+derives `userId` from the signed token and rejects a mismatched request body
+`userId`. Specialist work still validates at the specialist boundary.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/api/one/a2a/card` | Public metadata | Return Agent One manifest, required scope, specialists, and endpoint metadata |
+| POST | `/api/one/a2a/message` | `X-Consent-Token` scoped `agent.one.orchestrate` | Invoke Agent One as the coordinator for a user request; returns either a direct One response or a specialist delegation payload |
+
 ### VAULT_OWNER (Consent-Gated)
 
 #### Consent Management

--- a/docs/reference/iam/consent-scope-catalog.md
+++ b/docs/reference/iam/consent-scope-catalog.md
@@ -133,6 +133,22 @@ Denied selected scopes block external reply-all. Missing fields inside an
 approved export are described in the client-generated draft; the backend never
 decrypts or drafts from the scoped data.
 
+## Agent Coordination Scopes
+
+Agent coordination scopes authorize bounded agent entrypoints. They do not
+replace specialist scopes or PKM/data scopes.
+
+| Scope | Intended Use |
+| --- | --- |
+| `agent.one.orchestrate` | Invoke Agent One as the coordinator for intent routing and specialist handoff framing |
+| `agent.kai.analyze` | Invoke Kai for finance, portfolio, market, and RIA/investor analysis |
+| `agent.nav.review` | Invoke Nav for privacy, consent, vault, deletion, and scope-review guidance |
+| `agent.kyc.process` | Invoke KYC for identity workflow state and approval-gated KYC processing |
+
+Specialist execution remains scoped at the specialist boundary. A caller using
+Agent One over A2A presents `agent.one.orchestrate`; any delegated specialist
+entrypoint validates its own required scope before doing specialist work.
+
 ## Duration Policy
 
 1. Presets: `24h`, `7d`, `30d`, `90d`


### PR DESCRIPTION
## Summary
- require developer authentication when executing Agent One via external A2A with X-Consent-Token
- DB-validate A2A consent tokens and bind token agent_id to the authenticated developer app
- harden developer consent SSE cache headers and document bearer-token usage

## Verification
- uv run python -m pytest tests/test_agent_one_a2a_routes.py tests/test_developer_api_routes.py -q
- uv run python -m pytest tests/test_granular_scopes.py -q
- ./bin/hushh docs verify