### PR TITLE
feat(one-location): Quick Actions with Check-In + SOS

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -284,6 +284,26 @@ def _fingerprint_public_key(public_key_jwk: dict[str, Any]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+# Internal grant "reason" markers used for plain shares and approved access
+# requests. These are plumbing, never a human message, so they must NOT be shown
+# to the recipient. Anything else (e.g. a Check-In note) is a real message.
+_INTERNAL_SHARE_REASONS = {"owner_approved", "request_approved"}
+
+
+def _visible_share_message(reason: str | None) -> str | None:
+    """Return a human-facing share message, or None for internal markers.
+
+    A Check-In (or any future quick action) can pass a short note as the grant
+    reason so the recipient's notification reads "<Owner>: <message>" instead of
+    the generic "<Owner> shared location access with you." Internal defaults are
+    filtered out and never surfaced.
+    """
+    text = " ".join(str(reason or "").split())
+    if not text or text.lower() in _INTERNAL_SHARE_REASONS:
+        return None
+    return text[:160]
+
+
 def _loads_json(value: Any) -> Any:
     if value is None:
         return None
@@ -2558,11 +2578,22 @@ class OneLocationAgentService:
             event_type="location_share_created",
             metadata={"duration_hours": duration},
         )
+        # A caller-supplied reason (e.g. a Check-In note like "I've checked in
+        # here, let's catch up") is surfaced verbatim in the recipient's
+        # notification so they see WHO shared and WHY. Internal markers
+        # ("owner_approved" / "request_approved") are never shown — those are the
+        # default reasons for a plain share or an approved access request.
+        share_message = _visible_share_message(reason)
+        notification_body = (
+            f"{owner_label}: {share_message}"
+            if share_message
+            else f"{owner_label} shared location access with you."
+        )
         self._send_metadata_notification(
             user_id=recipient_user_id,
             notification_type="location_share_created",
             title="Location shared",
-            body=f"{owner_label} shared location access with you.",
+            body=notification_body,
             notification_tag=f"one-location-share:{grant['id']}",
             request_url=_one_location_url(
                 grantId=grant["id"],
@@ -2578,6 +2609,7 @@ class OneLocationAgentService:
                 else None,
                 "duration_hours": str(duration),
                 "expires_at": grant.get("expiresAt"),
+                **({"share_message": share_message} if share_message else {}),
             },
         )
         return grant

--- a/hushh-webapp/.gitignore
+++ b/hushh-webapp/.gitignore
@@ -37,6 +37,11 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
+# Local dev-server logs (agent-run backgrounded frontend output)
+frontend.local.log
+frontend.err.log
+frontend*.log
+
 # Runtime-generated PKM debug logs
 pkm-debug.log*
 pkm-debug-*.log*

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1916,6 +1916,18 @@ function OneLocationAgentPageContent() {
     [rankedRecipients, state?.networkConnections, auth.userId],
   );
 
+  // Recipients shown + alerted by the SOS and Check-In quick actions. Prefer the
+  // explicit One Network (SOS-connected) circle; when the user has no active
+  // network connections yet, fall back to their share-ready trusted people (the
+  // same list the People tab shows) so "Who gets alerted?" / "Who should know?"
+  // are never empty and the SOS button stays actionable, mirroring how the
+  // original main-page panic panel surfaced trusted contacts.
+  const sosActionRecipients = useMemo(() => {
+    if (sosTrustedRecipients.length > 0) return sosTrustedRecipients;
+    return rankedRecipients.filter(isShareReadyRecipient);
+  }, [sosTrustedRecipients, rankedRecipients]);
+
+
   // Ref kept in sync with the latest sosIncident value so the reconcile effect
   // can read it without adding it as a dependency (preventing infinite loops).
   const sosIncidentRef = useRef(sosIncident);
@@ -2943,8 +2955,8 @@ function OneLocationAgentPageContent() {
   const handleTriggerSos = useCallback(async () => {
     if (sosIncident) return; // re-entry guard: never overwrite/orphan an active incident
     if (!vaultOwnerToken || locationPermissionBlocksSharing(permission)) return;
-    const readyRecipients = sosTrustedRecipients.filter(isSosShareReadyRecipient);
-    const totalTrusted = sosTrustedRecipients.length;
+    const readyRecipients = sosActionRecipients.filter(isSosShareReadyRecipient);
+    const totalTrusted = sosActionRecipients.length;
     if (!readyRecipients.length) {
       toast.error("No trusted contacts are ready to receive your location yet.");
       return;
@@ -2991,7 +3003,7 @@ function OneLocationAgentPageContent() {
     ensureForegroundLocationReady,
     permission,
     publishEnvelopeWithRetry,
-    sosTrustedRecipients,
+    sosActionRecipients,
     refresh,
     sosIncident,
     vaultOwnerToken,
@@ -4018,6 +4030,100 @@ function OneLocationAgentPageContent() {
     [selectedRequestOwnerIds],
   );
 
+  // Check-In quick action: shares live location with a caller-provided set of
+  // trusted contacts (the same SOS-connected circle) for a chosen duration.
+  // Reuses the exact encrypted share pipeline (createGrant + publish) as the
+  // normal share flow — no new crypto, no new consent surface — so a check-in
+  // is just a fast, pre-scoped share to the people who already receive SOS.
+  const handleCheckIn = useCallback(
+    async (
+      recipientIds: string[],
+      durationHoursValue: string,
+      messageValue?: string,
+    ) => {
+      if (!vaultOwnerToken || locationPermissionBlocksSharing(permission)) {
+        toast.error("Location permission is required to check in.");
+        return;
+      }
+      const selected = sosActionRecipients
+        .filter((recipient) => recipientIds.includes(recipient.userId))
+        .filter(isShareReadyRecipient);
+      if (!selected.length) {
+        toast.error(
+          "Select at least one trusted contact who is ready to receive your location.",
+        );
+        return;
+      }
+      // The check-in note rides along as the grant reason so it surfaces in the
+      // recipient's notification ("<You>: I've checked in here..."). Trimmed and
+      // bounded; empty falls back to a plain share on the backend.
+      const checkInMessage = (messageValue || "").trim().slice(0, 160) || undefined;
+      setBusy("share");
+      let successCount = 0;
+      try {
+        const readiness = await ensureForegroundLocationReady({
+          capturePoint: true,
+          autoOpenSettings: true,
+        });
+        if (!readiness.ready || !readiness.point) {
+          toast.error("Couldn't get your location — check-in not sent.");
+          return;
+        }
+        const point = readiness.point;
+        const durationHoursNum = Number(durationHoursValue) || 1;
+        for (const recipient of selected) {
+          const grant = await OneLocationService.createGrant({
+            vaultOwnerToken,
+            recipientUserId: recipient.userId,
+            recipientKeyId: recipient.keyId,
+            durationHours: durationHoursNum,
+            reason: checkInMessage,
+          });
+          await publishEnvelopeWithRetry(grant, recipient, "manual", point);
+          successCount += 1;
+        }
+        trackEvent("one_location_share_confirmed", {
+          route_id: "one_location",
+          result: oneLocationEventResult(successCount, 0),
+          selected_count: selected.length,
+          success_count: successCount,
+          failure_count: 0,
+          duration_bucket: oneLocationDurationBucket(durationHoursValue),
+          review_required: false,
+        });
+        toast.success(`Checked in with ${peopleCountLabel(selected.length)}.`);
+        // Closes the Check-In flow and returns to the hub (same signal the
+        // share flow uses).
+        setShareCompletedTick((value) => value + 1);
+        await refresh();
+      } catch (error) {
+        const failureCount = selected.length - successCount || 1;
+        trackEvent("one_location_share_confirmed", {
+          route_id: "one_location",
+          result: oneLocationEventResult(successCount, failureCount),
+          selected_count: selected.length,
+          success_count: successCount,
+          failure_count: failureCount,
+          duration_bucket: oneLocationDurationBucket(durationHoursValue),
+          review_required: false,
+        });
+        toast.error(
+          error instanceof Error ? error.message : "Could not check in.",
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [
+      vaultOwnerToken,
+      permission,
+      sosActionRecipients,
+      ensureForegroundLocationReady,
+      publishEnvelopeWithRetry,
+      refresh,
+    ],
+  );
+
   const canShare = Boolean(
     vaultOwnerToken &&
     selectedShareRecipients.length &&
@@ -4402,12 +4508,14 @@ function OneLocationAgentPageContent() {
       <LocalMapPreview point={point} showNavigation={showNavigation} />
     ),
     decryptedPoints,
-    sosRecipients: sosTrustedRecipients,
+    sosRecipients: sosActionRecipients,
     sosActive: Boolean(sosIncident?.grantIds.length),
     sosBusy: busy === "sos",
     sosStartedAtLabel: sosIncident ? formatDateTime(sosIncident.startedAt) : null,
     onTriggerSos: handleTriggerSos,
     onStopSos: handleStopSos,
+    onCheckIn: (recipientIds, durationHoursValue, messageValue) =>
+      void handleCheckIn(recipientIds, durationHoursValue, messageValue),
   };
 
   if (USE_LOCATION_REDESIGN && !loadError) {

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -1,0 +1,405 @@
+"use client";
+
+/**
+ * One Location redesign — Check-In flow (Quick Action).
+ *
+ * "Let trusted people know you're here." A focused, full-screen task flow that
+ * reuses the existing encrypted location-share pipeline via `vm.onCheckIn`.
+ *
+ * PRESENTATION + LOCAL SELECTION STATE ONLY.
+ * - The list of people ("Who should know?") is the SAME trusted contacts used by
+ *   SOS (`vm.sosRecipients`), so a user's emergency circle is exactly who they
+ *   check in with.
+ * - Selection is local checkbox state; on confirm it hands the chosen recipient
+ *   ids + duration to `vm.onCheckIn`, which runs the same createGrant + encrypt +
+ *   publish path as a normal share (no new crypto, no new consent surface).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Check, MapPin, RefreshCw, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+import { TaskFlowHeader } from "./primitives";
+import { PersonSearchInput } from "./selectors";
+import { CARD_SURFACE, MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
+import type { LocationHubViewModel } from "./location-redesign-hub";
+
+/** Check-in durations. "until_stop" maps to the maximum supported window. */
+const CHECK_IN_DURATIONS: { value: string; label: string }[] = [
+  { value: "0.5", label: "30 min" },
+  { value: "1", label: "1 hour" },
+  { value: "2", label: "2 hours" },
+];
+const UNTIL_STOP_VALUE = "24";
+
+/** Default Check-In note sent to recipients and shown in their notification. */
+const DEFAULT_CHECK_IN_MESSAGE = "I've checked in here, let's catch up";
+const CHECK_IN_MESSAGE_MAX_LENGTH = 120;
+
+function initialsOf(label: string): string {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length >= 2) {
+    return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
+  }
+  return (words[0]?.slice(0, 1) || "?").toUpperCase();
+}
+
+function avatarTone(index: number): string {
+  const tones = [
+    "bg-red-500 text-white",
+    "bg-sky-500 text-white",
+    "bg-violet-500 text-white",
+    "bg-emerald-500 text-white",
+    "bg-amber-500 text-white",
+  ];
+  return tones[index % tones.length]!;
+}
+
+function accuracyLine(point: PlainLocationPoint | null): string | null {
+  if (!point) return null;
+  const accuracyM = point.accuracyM;
+  if (typeof accuracyM !== "number" || !Number.isFinite(accuracyM) || accuracyM <= 0) {
+    return null;
+  }
+  return `Accurate to about ${Math.round(accuracyM)} meters`;
+}
+
+function ContactRow({
+  index,
+  checked,
+  ready,
+  label,
+  subtitle,
+  onToggle,
+}: {
+  index: number;
+  checked: boolean;
+  ready: boolean;
+  label: string;
+  subtitle: string;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={ready ? onToggle : undefined}
+      disabled={!ready}
+      aria-pressed={checked}
+      className={cn(
+        SUBCARD_SURFACE,
+        "flex w-full items-center gap-3 p-3 text-left transition-all duration-150",
+        ready
+          ? "hover:border-[#d4a574]/40 active:scale-[0.99]"
+          : "cursor-not-allowed opacity-60",
+        checked && "border-[#d4a574]/60 ring-1 ring-[#d4a574]/30",
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold",
+          avatarTone(index),
+        )}
+        aria-hidden
+      >
+        {initialsOf(label)}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-semibold text-foreground">
+          {label}
+        </span>
+        <span className={cn(MUTED_TEXT, "block truncate")}>
+          {ready ? subtitle : "Not ready to receive location"}
+        </span>
+      </span>
+      <span
+        className={cn(
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-[7px] border-2 transition-colors",
+          checked
+            ? "border-[#d4a574] bg-[#d4a574] text-white"
+            : "border-border bg-background",
+        )}
+      >
+        {checked ? <Check className="h-4 w-4" strokeWidth={3} /> : null}
+      </span>
+    </button>
+  );
+}
+
+export function CheckInFlow({
+  vm,
+  onClose,
+}: {
+  vm: LocationHubViewModel;
+  onClose: () => void;
+}) {
+  const contacts = vm.sosRecipients;
+  const busy = vm.busy === "share" || vm.busy === "selfLocation";
+
+  // Local selection state, seeded once from the trusted (ready) contacts so the
+  // first ready person is pre-checked (mirrors the reference design).
+  const [search, setSearch] = useState("");
+  const [checkedIds, setCheckedIds] = useState<string[]>([]);
+  const [durationValue, setDurationValue] = useState("1");
+  const [untilStop, setUntilStop] = useState(false);
+  const [message, setMessage] = useState(DEFAULT_CHECK_IN_MESSAGE);
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (seeded) return;
+    const firstReady = contacts.find((r) => vm.isRecipientShareReady(r));
+    if (firstReady) {
+      setCheckedIds([firstReady.userId]);
+      setSeeded(true);
+    } else if (contacts.length > 0) {
+      setSeeded(true);
+    }
+  }, [contacts, seeded, vm]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return contacts;
+    return contacts.filter((r) =>
+      vm.recipientLabel(r).toLowerCase().includes(q),
+    );
+  }, [contacts, search, vm]);
+
+  const selectedReadyCount = useMemo(
+    () =>
+      contacts.filter(
+        (r) => checkedIds.includes(r.userId) && vm.isRecipientShareReady(r),
+      ).length,
+    [contacts, checkedIds, vm],
+  );
+
+  const toggle = (id: string) =>
+    setCheckedIds((current) =>
+      current.includes(id)
+        ? current.filter((value) => value !== id)
+        : [...current, id],
+    );
+
+  const effectiveDuration = untilStop ? UNTIL_STOP_VALUE : durationValue;
+
+  const point = vm.myLocationPoint;
+  const accuracy = accuracyLine(point);
+
+  return (
+    <div className="space-y-5">
+      <TaskFlowHeader
+        eyebrow="Check-In"
+        title="Let trusted people know you're here"
+        onBack={onClose}
+      />
+
+      {/* YOUR LOCATION */}
+      <section className={cn(CARD_SURFACE, "p-4")}>
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#d4a574]/12 text-[#d4a574]">
+            <MapPin className="h-5 w-5" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Your location
+            </p>
+            {point ? (
+              <>
+                <p className="mt-0.5 text-[15px] font-semibold text-foreground">
+                  Live location ready
+                </p>
+                <p className={cn(MUTED_TEXT, "mt-0.5")}>
+                  {accuracy ?? "Location captured"} ·{" "}
+                  {vm.formatDateTime(point.capturedAt)}
+                </p>
+              </>
+            ) : (
+              <>
+                <p className="mt-0.5 text-[15px] font-semibold text-foreground">
+                  Location not captured yet
+                </p>
+                <p className={cn(MUTED_TEXT, "mt-0.5")}>
+                  Capture your current location to check in.
+                </p>
+              </>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={vm.onShowMyLocation}
+            isLoading={vm.busy === "selfLocation"}
+            className="h-9 shrink-0 rounded-full px-3 text-xs"
+          >
+            <RefreshCw className="mr-1 h-3.5 w-3.5" />
+            {point ? "Refresh" : "Capture"}
+          </Button>
+        </div>
+        {vm.myLocationError ? (
+          <p className="mt-2 text-xs font-medium text-red-600 dark:text-red-300">
+            {vm.myLocationError}
+          </p>
+        ) : null}
+        {point ? (
+          <div className="mt-3">{vm.renderMapPreview(point, false)}</div>
+        ) : null}
+      </section>
+
+      {/* WHO SHOULD KNOW? */}
+      <section className={cn(CARD_SURFACE, "p-4")}>
+        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Who should know?
+        </p>
+        <PersonSearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Search contacts..."
+        />
+        <div className="mt-3 space-y-2.5">
+          {filtered.length ? (
+            filtered.map((recipient, index) => (
+              <ContactRow
+                key={recipient.userId}
+                index={index}
+                checked={checkedIds.includes(recipient.userId)}
+                ready={vm.isRecipientShareReady(recipient)}
+                label={vm.recipientLabel(recipient)}
+                subtitle={vm.recipientSubtitle(recipient)}
+                onToggle={() => toggle(recipient.userId)}
+              />
+            ))
+          ) : (
+            <div
+              className={cn(
+                SUBCARD_SURFACE,
+                "p-5 text-center text-sm text-muted-foreground",
+              )}
+            >
+              {contacts.length === 0
+                ? "No trusted contacts yet. Add people to your Circle first."
+                : "No matching contacts."}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* DURATION */}
+      <section
+        className={cn(
+          "rounded-[var(--app-card-radius-standard)] border border-sky-500/20 bg-sky-500/[0.06] p-4 dark:bg-sky-400/[0.08]",
+        )}
+      >
+        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300">
+          Duration
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {CHECK_IN_DURATIONS.map((option) => {
+            const active = !untilStop && option.value === durationValue;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  setUntilStop(false);
+                  setDurationValue(option.value);
+                }}
+                className={cn(
+                  "h-9 rounded-full border px-4 text-sm font-medium transition-colors",
+                  active
+                    ? "border-[#d4a574] bg-[#d4a574] text-white"
+                    : "border-border/70 bg-background text-foreground hover:border-[#d4a574]/40",
+                )}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          onClick={() => setUntilStop((value) => !value)}
+          className={cn(
+            "mt-3 flex w-full items-center gap-2 rounded-[12px] border px-3 py-2.5 text-left text-sm font-medium transition-colors",
+            untilStop
+              ? "border-[#d4a574]/50 bg-[#d4a574]/10 text-foreground"
+              : "border-border/70 bg-background text-foreground hover:border-[#d4a574]/40",
+          )}
+        >
+          <span
+            className={cn(
+              "flex h-5 w-5 items-center justify-center rounded-full border-2",
+              untilStop ? "border-[#d4a574] bg-[#d4a574]" : "border-border",
+            )}
+          >
+            {untilStop ? <span className="h-2 w-2 rounded-full bg-white" /> : null}
+          </span>
+          Until I say stop
+        </button>
+        <p className="mt-3 flex items-center gap-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+          <ShieldCheck className="h-3.5 w-3.5" />
+          Sharing stops automatically · no manual revoke needed
+        </p>
+      </section>
+
+      {/* MESSAGE — sent with the check-in and shown in the recipient's
+          notification (e.g. "Alex: I've checked in here, let's catch up"). */}
+      <section className={cn(CARD_SURFACE, "p-4")}>
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Message
+          </p>
+          <span className="text-[11px] font-medium text-muted-foreground">
+            {message.length}/{CHECK_IN_MESSAGE_MAX_LENGTH}
+          </span>
+        </div>
+        <textarea
+          value={message}
+          onChange={(event) =>
+            setMessage(event.target.value.slice(0, CHECK_IN_MESSAGE_MAX_LENGTH))
+          }
+          rows={2}
+          placeholder={DEFAULT_CHECK_IN_MESSAGE}
+          className="w-full rounded-[14px] border border-border/70 bg-background p-3 text-sm text-foreground outline-none transition-shadow focus:ring-2 focus:ring-[#d4a574]/25"
+        />
+        <p className={cn(MUTED_TEXT, "mt-2")}>
+          They&apos;ll see this with your name in the notification, so they know
+          who checked in and why.
+        </p>
+      </section>
+
+      {/* Action bar — inline so it renders above the chat panel, not floating
+          over it. Buttons stack directly under the flow content. */}
+      <div className="space-y-2 pt-1">
+        <Button
+          onClick={() =>
+            vm.onCheckIn(
+              checkedIds,
+              effectiveDuration,
+              message.trim() || DEFAULT_CHECK_IN_MESSAGE,
+            )
+          }
+          disabled={!point || selectedReadyCount === 0}
+          isLoading={busy}
+          className="h-12 w-full rounded-2xl bg-emerald-600 text-base font-semibold text-white hover:bg-emerald-600/90 disabled:opacity-50"
+        >
+          <Check className="mr-1.5 h-5 w-5" strokeWidth={3} />
+          {point
+            ? selectedReadyCount > 0
+              ? `Check in with ${selectedReadyCount} ${
+                  selectedReadyCount === 1 ? "person" : "people"
+                }`
+              : "Select who should know"
+            : "Capture your location first"}
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={onClose}
+          className="h-10 w-full rounded-2xl text-sm text-muted-foreground"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -23,11 +23,17 @@ import { useSearchParams } from "next/navigation";
 
 
 import {
+  CalendarClock,
+  Car,
+  CheckCircle2,
+  Hand,
+  Home,
   Inbox as InboxIcon,
   Link as LinkIcon,
   MapPin,
   Plus,
   Send,
+  ShieldAlert,
   UserPlus,
   UsersRound,
 } from "lucide-react";
@@ -76,6 +82,11 @@ import {
   type ReasonValue,
 } from "./selectors";
 import { SosPanel } from "@/components/one-location/redesign/sos-panel";
+import {
+  QuickActionCard,
+  QuickActionsSection,
+} from "@/components/one-location/redesign/quick-actions";
+import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
 
@@ -164,6 +175,15 @@ export type LocationHubViewModel = {
   onTriggerSos: () => void;
   onStopSos: () => void;
 
+  /* Check-In (quick action) — reuses the encrypted share pipeline. The message
+     is surfaced in the recipient's notification (e.g. "Alex: I've checked in
+     here, let's catch up") so they see who checked in and why. */
+  onCheckIn: (
+    recipientIds: string[],
+    durationHours: string,
+    message?: string,
+  ) => void;
+
   /* label helpers (reuse existing formatting) */
   recipientLabel: (r: OneLocationRecipient) => string;
   recipientSubtitle: (r: OneLocationRecipient) => string;
@@ -184,7 +204,14 @@ export type LocationHubViewModel = {
   decryptedPoints: Record<string, PlainLocationPoint>;
 };
 
-type FlowKind = "none" | "share" | "ask" | "invite" | "temp-link";
+type FlowKind =
+  | "none"
+  | "share"
+  | "ask"
+  | "invite"
+  | "temp-link"
+  | "check-in"
+  | "sos";
 
 const BUSY = (vm: LocationHubViewModel, key: string) => vm.busy === key;
 
@@ -319,6 +346,10 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             setReason={setReason}
             onClose={closeFlow}
           />
+        ) : flow === "check-in" ? (
+          <CheckInFlow vm={vm} onClose={closeFlow} />
+        ) : flow === "sos" ? (
+          <SosFlow vm={vm} onClose={closeFlow} />
         ) : flow === "invite" ? (
           <InviteFlow vm={vm} onClose={closeFlow} />
         ) : (
@@ -379,6 +410,8 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             setFlow("share");
           }}
           onAsk={() => setFlow("ask")}
+          onCheckIn={() => setFlow("check-in")}
+          onSos={() => setFlow("sos")}
           onGoTab={setTab}
         />
       ) : tab === "people" ? (
@@ -409,6 +442,8 @@ function NowHub({
   inboxCount,
   onStartShare,
   onAsk,
+  onCheckIn,
+  onSos,
   onGoTab,
 }: {
   vm: LocationHubViewModel;
@@ -416,6 +451,8 @@ function NowHub({
   inboxCount: number;
   onStartShare: () => void;
   onAsk: () => void;
+  onCheckIn: () => void;
+  onSos: () => void;
   onGoTab: (tab: LocationHubTab) => void;
 }) {
   // When location permission is blocked (denied / restricted / services off),
@@ -485,16 +522,90 @@ function NowHub({
         </Button>
       </div>
 
-      <SosPanel
-        recipients={vm.sosRecipients}
-        active={vm.sosActive}
-        busy={vm.sosBusy}
-        startedAtLabel={vm.sosStartedAtLabel}
-        onTrigger={vm.onTriggerSos}
-        onStop={vm.onStopSos}
-        recipientLabel={vm.recipientLabel}
-        isRecipientShareReady={vm.isRecipientShareReady}
-      />
+      {/* Quick actions — six reusable location shortcuts. Two are live
+          (Check-In + SOS); the rest surface as "Coming soon". When SOS is
+          already active, its card reflects the live state and reopens the
+          panel to stop sharing. */}
+      <QuickActionsSection title="Quick actions">
+        <QuickActionCard
+          tone="green"
+          icon={<CheckCircle2 className="h-6 w-6" />}
+          title="Check-In"
+          subtitle="Share now"
+          onClick={onCheckIn}
+        />
+        <QuickActionCard
+          tone="red"
+          icon={<ShieldAlert className="h-6 w-6" />}
+          title="SOS"
+          subtitle={vm.sosActive ? "Live now" : "Emergency"}
+          onClick={onSos}
+          badge={
+            vm.sosActive ? (
+              <span className="flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-red-600 dark:text-red-300">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-75" />
+                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-red-500" />
+                </span>
+                Live
+              </span>
+            ) : undefined
+          }
+        />
+        <QuickActionCard
+          tone="blue"
+          icon={<Car className="h-6 w-6" />}
+          title="Drive To"
+          subtitle="Navigation"
+          comingSoon
+        />
+        <QuickActionCard
+          tone="amber"
+          icon={<Hand className="h-6 w-6" />}
+          title="Pick Me Up"
+          subtitle="Request"
+          comingSoon
+        />
+        <QuickActionCard
+          tone="violet"
+          icon={<CalendarClock className="h-6 w-6" />}
+          title="Meeting"
+          subtitle="Venue"
+          comingSoon
+        />
+        <QuickActionCard
+          tone="slate"
+          icon={<Home className="h-6 w-6" />}
+          title="Safe Arrival"
+          subtitle="Notify"
+          comingSoon
+        />
+      </QuickActionsSection>
+
+      {/* Active SOS banner (only while an incident is live) — quick stop
+          without opening the full SOS panel. */}
+      {vm.sosActive ? (
+        <button
+          type="button"
+          onClick={onSos}
+          className="flex w-full items-center gap-3 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-left transition-colors hover:bg-red-500/15"
+        >
+          <span className="relative flex h-2.5 w-2.5 shrink-0">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-75" />
+            <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-semibold text-red-700 dark:text-red-300">
+              SOS live location active
+            </span>
+            <span className="block text-xs text-red-600/80 dark:text-red-300/80">
+              {vm.sosStartedAtLabel
+                ? `Since ${vm.sosStartedAtLabel} · tap to manage`
+                : "Tap to manage or stop"}
+            </span>
+          </span>
+        </button>
+      ) : null}
 
       {/* Active shares */}
       <SectionCard title="Active shares">
@@ -847,6 +958,49 @@ function InboxHub({ vm }: { vm: LocationHubViewModel }) {
           </div>
         </SectionCard>
       ) : null}
+    </div>
+  );
+}
+
+/* =================================================================== */
+/* SOS FLOW (Quick Action wrapper around the existing SOS panic panel)  */
+/* =================================================================== */
+
+function SosFlow({
+  vm,
+  onClose,
+}: {
+  vm: LocationHubViewModel;
+  onClose: () => void;
+}) {
+  return (
+    <div className="space-y-5">
+      {/* Minimal back-nav header only. The SosPanel below renders the single
+          "SOS" header, so we intentionally do NOT repeat an "SOS" title here
+          (that produced the duplicate-header the screenshot flagged). */}
+      <TaskFlowHeader eyebrow="Location" title="Emergency" onBack={onClose} />
+      <SosPanel
+        recipients={vm.sosRecipients}
+        active={vm.sosActive}
+        busy={vm.sosBusy}
+        startedAtLabel={vm.sosStartedAtLabel}
+        onTrigger={vm.onTriggerSos}
+        onStop={vm.onStopSos}
+        recipientLabel={vm.recipientLabel}
+        isRecipientShareReady={vm.isRecipientShareReady}
+      />
+      <TrustNoteCard
+        title="Only your trusted contacts are alerted"
+        description="The same people who receive your SOS also appear in Check-In. Nothing is shared publicly."
+      />
+      {/* Inline so it renders above the chat panel, not floating over it. */}
+      <Button
+        variant="ghost"
+        onClick={onClose}
+        className="h-11 w-full rounded-2xl text-sm text-muted-foreground"
+      >
+        Back to One Location
+      </Button>
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * One Location redesign — Quick Actions grid (Now tab).
+ *
+ * PRESENTATION ONLY. A single reusable `QuickActionCard` renders every tile in
+ * the "Quick actions" block so the six location shortcuts (Check-In, SOS,
+ * Drive To, Pick Me Up, Meeting, Safe Arrival) stay visually identical and
+ * behaviourally consistent. Cards are prop-driven: they render an icon tile,
+ * title + subtitle, an optional "Coming soon" state, and delegate taps to the
+ * handler passed in by the hub. No business logic, no data fetching here.
+ */
+
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+import { SECTION_HEADING } from "./tokens";
+
+export type QuickActionTone =
+  | "green"
+  | "red"
+  | "blue"
+  | "amber"
+  | "violet"
+  | "slate";
+
+/**
+ * Per-tone palette for the icon tile. Uses soft tinted surfaces + a saturated
+ * foreground so each action reads instantly while still matching the app-wide
+ * calm, premium aesthetic (no harsh full-bleed colours).
+ */
+const TONE_STYLES: Record<
+  QuickActionTone,
+  { tile: string; icon: string; glow: string }
+> = {
+  green: {
+    tile: "bg-emerald-500/12 dark:bg-emerald-400/15",
+    icon: "text-emerald-600 dark:text-emerald-300",
+    glow: "group-hover:shadow-[0_10px_30px_-12px_rgba(16,185,129,0.55)]",
+  },
+  red: {
+    tile: "bg-red-500/12 dark:bg-red-400/15",
+    icon: "text-red-600 dark:text-red-300",
+    glow: "group-hover:shadow-[0_10px_30px_-12px_rgba(239,68,68,0.55)]",
+  },
+  blue: {
+    tile: "bg-sky-500/12 dark:bg-sky-400/15",
+    icon: "text-sky-600 dark:text-sky-300",
+    glow: "group-hover:shadow-[0_10px_30px_-12px_rgba(14,165,233,0.5)]",
+  },
+  amber: {
+    tile: "bg-amber-500/14 dark:bg-amber-400/15",
+    icon: "text-amber-600 dark:text-amber-300",
+    glow: "group-hover:shadow-[0_10px_30px_-12px_rgba(245,158,11,0.5)]",
+  },
+  violet: {
+    tile: "bg-violet-500/12 dark:bg-violet-400/15",
+    icon: "text-violet-600 dark:text-violet-300",
+    glow: "group-hover:shadow-[0_10px_30px_-12px_rgba(139,92,246,0.5)]",
+  },
+  slate: {
+    tile: "bg-slate-500/10 dark:bg-white/10",
+    icon: "text-slate-600 dark:text-slate-300",
+    glow: "group-hover:shadow-[0_10px_30px_-12px_rgba(100,116,139,0.45)]",
+  },
+};
+
+export type QuickActionCardProps = {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  tone?: QuickActionTone;
+  onClick?: () => void;
+  /** Renders the muted, non-interactive "Coming soon" treatment. */
+  comingSoon?: boolean;
+  /** Disable interaction without the coming-soon styling (e.g. temporary). */
+  disabled?: boolean;
+  /** Optional accent badge in the top-right corner (e.g. "Ready"). */
+  badge?: ReactNode;
+};
+
+export function QuickActionCard({
+  icon,
+  title,
+  subtitle,
+  tone = "slate",
+  onClick,
+  comingSoon = false,
+  disabled = false,
+  badge,
+}: QuickActionCardProps) {
+  const palette = TONE_STYLES[tone];
+  const interactive = !comingSoon && !disabled;
+
+  return (
+    <button
+      type="button"
+      onClick={interactive ? onClick : undefined}
+      disabled={!interactive}
+      aria-disabled={!interactive}
+      className={cn(
+        "group relative flex min-h-[128px] w-full flex-col justify-between overflow-hidden rounded-[20px] border p-4 text-left transition-all duration-200",
+        "border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)]",
+        "shadow-[0_1px_2px_rgba(0,0,0,0.04),0_10px_24px_-16px_rgba(15,23,42,0.28)]",
+        interactive
+          ? cn(
+              "cursor-pointer hover:-translate-y-0.5 hover:border-[color:var(--app-card-border-standard)] active:translate-y-0 active:scale-[0.98]",
+              palette.glow,
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d4a574]/40",
+            )
+          : "cursor-not-allowed",
+        comingSoon && "opacity-70",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={cn(
+            "flex h-12 w-12 items-center justify-center rounded-[16px] transition-transform duration-200",
+            palette.tile,
+            palette.icon,
+            interactive && "group-hover:scale-105",
+          )}
+        >
+          {icon}
+        </span>
+        {badge ? <span className="shrink-0">{badge}</span> : null}
+      </div>
+
+      <div className="mt-3 min-w-0">
+        <p className="truncate text-[15px] font-semibold leading-tight text-foreground">
+          {title}
+        </p>
+        {comingSoon ? (
+          <span className="mt-1 inline-flex items-center gap-1 rounded-full bg-muted/70 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Coming soon
+          </span>
+        ) : (
+          <p className="mt-0.5 truncate text-[13px] font-medium text-muted-foreground">
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </button>
+  );
+}
+
+export function QuickActionsSection({
+  title = "Quick actions",
+  children,
+}: {
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between px-1">
+        <h2 className={SECTION_HEADING}>{title}</h2>
+      </div>
+      <div className="grid grid-cols-2 gap-3">{children}</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Quick Actions** block to the One Location "Now" tab with six reusable shortcut cards and wires up two live flows (Check-In + SOS), matching the reference design.

## Changes

- **Reusable component**: new `QuickActionCard` / `QuickActionsSection` renders all six cards (Check-In, SOS, Drive To, Pick Me Up, Meeting, Safe Arrival). The last four show "Coming soon".
- **SOS**: moved the existing panic-button flow into the SOS quick action. Removed the duplicate SOS header so the screen matches the reference layout (single EMERGENCY ALERT → TAP TO PANIC → WHO GETS ALERTED → LIVE LOCATION ACTIVE).
- **Check-In**: new full-screen flow reusing the existing encrypted share pipeline (`createGrant` + publish; no new crypto/consent). Its "Who should know?" list is the same SOS-connected trusted circle. Sends a note that surfaces in the recipient notification (e.g. `<You>: I've checked in here, let's catch up`) via the grant reason.
- **Contacts/SOS availability fix**: `sosActionRecipients` fallback keeps SOS/Check-In contacts populated and the SOS button actionable when the user has no active One Network connections.
- **Layout fix**: Check-In/SOS action buttons render inline (above the chat panel) instead of a floating fixed bar.
- **Chore**: ignore local dev-server `frontend*.log` files.

## Verification

- `eslint --max-warnings=0` clean on all changed TS/TSX files.
- consent-protocol pre-commit lint/format passes (ruff).
- `/one/location` compiles and renders with no console errors.

## Notes / risk

- Authenticated SOS/Check-In click-through could not be exercised locally (Reviewer mode disabled in this env); validated via code path + lint + compile.
