### PR TITLE
feat(marketplace): real anonymized cross-account demand + proactive opportunity nudges

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,11 +3,18 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: unknown
-last_updated: "2026-06-25T16:55:07.838Z"
+stopped_at: context exhaustion at 75% (2026-07-05)
+last_updated: "2026-07-05T17:50:44.149Z"
 progress:
-  total_phases: 3
-  completed_phases: 1
-  total_plans: 11
-  completed_plans: 6
-  percent: 33
+  total_phases: 1
+  completed_phases: 0
+  total_plans: 4
+  completed_plans: 0
+  percent: 0
 ---
+
+## Session
+
+**Last session:** 2026-07-05T17:50:44.144Z
+**Stopped at:** context exhaustion at 75% (2026-07-05)
+**Resume file:** None

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -9,6 +9,7 @@ from .email_chat import router as email_chat_router
 from .information_chat import router as information_chat_router
 from .location import router as location_router
 from .location_chat import router as location_chat_router
+from .marketplace_catalog import router as marketplace_catalog_router
 from .marketplace_requests import router as marketplace_requests_router
 from .opportunity_signals import router as opportunity_signals_router
 from .voice import router as voice_router
@@ -21,6 +22,7 @@ router.include_router(email_chat_router)
 router.include_router(location_router)
 router.include_router(location_chat_router)
 router.include_router(information_chat_router)
+router.include_router(marketplace_catalog_router)
 router.include_router(marketplace_requests_router)
 router.include_router(opportunity_signals_router)
 router.include_router(voice_router)

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -10,6 +10,7 @@ from .information_chat import router as information_chat_router
 from .location import router as location_router
 from .location_chat import router as location_chat_router
 from .marketplace_requests import router as marketplace_requests_router
+from .opportunity_signals import router as opportunity_signals_router
 from .voice import router as voice_router
 
 router = APIRouter()
@@ -21,6 +22,7 @@ router.include_router(location_router)
 router.include_router(location_chat_router)
 router.include_router(information_chat_router)
 router.include_router(marketplace_requests_router)
+router.include_router(opportunity_signals_router)
 router.include_router(voice_router)
 
 __all__ = ["router"]

--- a/consent-protocol/api/routes/one/marketplace_catalog.py
+++ b/consent-protocol/api/routes/one/marketplace_catalog.py
@@ -1,0 +1,104 @@
+"""Anonymized Buyer directory + real cross-account access requests.
+
+The Buyer tab browses everyone else's published slices (anonymized) and files a
+real request into the *owner's* durable inbox — not the buyer's own. This is what
+makes marketplace demand real and two-account:
+
+  GET  /api/one/marketplace/available
+       -> the caller (a browsing buyer) sees other users' published slices,
+          owner identity hidden behind an opaque ref.
+  POST /api/one/marketplace/available/{listing_id}/request
+       -> resolve the listing to its real owner server-side, then create a pending
+          access request with buyer_user_id = the caller. The owner approves it in
+          their opportunity stack / marketplace inbox exactly as before.
+
+Consent-first: a request never grants access; only the owner's approve does, and
+only the safe summary is ever involved.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+
+from api.middleware import require_vault_owner_token
+from hushh_mcp.services.actor_identity_service import ActorIdentityService
+from hushh_mcp.services.marketplace_catalog_service import MarketplaceCatalogService
+from hushh_mcp.services.marketplace_request_service import MarketplaceRequestService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/one/marketplace", tags=["One Information Marketplace Catalog"])
+
+
+def _catalog() -> MarketplaceCatalogService:
+    return MarketplaceCatalogService()
+
+
+def _requests() -> MarketplaceRequestService:
+    return MarketplaceRequestService()
+
+
+async def _buyer_label(buyer_user_id: str) -> str:
+    """Best-effort display name for the buyer, shown to the owner in their inbox.
+    Falls back to a short opaque buyer ref so a request is never blocked on (or
+    leaks) real identity when the actor-identity cache has no name."""
+    try:
+        identities = await ActorIdentityService().get_many([buyer_user_id])
+        name = (identities.get(buyer_user_id) or {}).get("display_name")
+        if name:
+            return str(name)
+    except Exception:
+        logger.debug("catalog.buyer_label_lookup_failed buyer=%s", buyer_user_id)
+    digest = hashlib.sha256((buyer_user_id or "").encode("utf-8")).hexdigest()
+    return f"Buyer {digest[:6]}"
+
+
+@router.get("/available")
+async def list_available_listings(
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    """Anonymized directory of other users' published slices for the caller."""
+    try:
+        listings = await _catalog().list_available_listings(viewer_user_id=token_data["user_id"])
+        return {"listings": listings}
+    except Exception:
+        logger.exception("marketplace.list_available_failed")
+        raise HTTPException(status_code=500, detail="Could not load the marketplace directory")
+
+
+@router.post("/available/{listing_id}/request")
+async def request_available_listing(
+    listing_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    """File a real cross-account access request against a listing's true owner."""
+    buyer_user_id = token_data["user_id"]
+    listing = await _catalog().resolve_listing(listing_id=listing_id)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found or no longer available")
+
+    owner_user_id = listing["ownerUserId"]
+    # Not-self is enforced by the DB CHECK too, but guard here for a clean 400.
+    if owner_user_id == buyer_user_id:
+        raise HTTPException(status_code=400, detail="You can't request access to your own slice")
+
+    buyer_label = await _buyer_label(buyer_user_id)
+    try:
+        request = await _requests().create_request(
+            owner_user_id=owner_user_id,
+            buyer_user_id=buyer_user_id,
+            buyer_label=buyer_label,
+            slice_label=listing["sliceLabel"],
+            domain=listing["domain"],
+            scope_handle=listing.get("scopeHandle"),
+            price_cents=int(listing.get("priceCents") or 0),
+            currency=listing.get("currency") or "USD",
+        )
+        return {"request": request}
+    except Exception:
+        logger.exception("marketplace.request_available_failed")
+        raise HTTPException(status_code=500, detail="Could not file the request")

--- a/consent-protocol/api/routes/one/opportunity_signals.py
+++ b/consent-protocol/api/routes/one/opportunity_signals.py
@@ -19,6 +19,9 @@ from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, ConfigDict, Field
 
 from api.middleware import require_vault_owner_token
+from hushh_mcp.services.opportunity_signal_derivation_service import (
+    OpportunitySignalDerivationService,
+)
 from hushh_mcp.services.opportunity_signal_service import OpportunitySignalService
 
 logger = logging.getLogger(__name__)
@@ -58,8 +61,16 @@ class AuthorSignalBody(BaseModel):
 async def list_due_opportunities(
     token_data: dict = Depends(require_vault_owner_token),
 ) -> dict[str, Any]:
+    user_id = token_data["user_id"]
+    # Derive-on-read: refresh server-derivable `intent` signals from the owner's
+    # publishable slices before listing. Best-effort — a derivation hiccup must not
+    # break the read of already-persisted signals.
     try:
-        opportunities = await _service().list_due(user_id=token_data["user_id"])
+        await OpportunitySignalDerivationService().derive_for_user(user_id=user_id)
+    except Exception:
+        logger.exception("opportunities.derive_failed")
+    try:
+        opportunities = await _service().list_due(user_id=user_id)
         return {"opportunities": opportunities}
     except Exception:
         logger.exception("opportunities.list_due_failed")

--- a/consent-protocol/api/routes/one/opportunity_signals.py
+++ b/consent-protocol/api/routes/one/opportunity_signals.py
@@ -1,0 +1,134 @@
+"""Information Marketplace opportunity-signal routes (durable, owner-scoped).
+
+Proactive flashcards for Agent One. Unlike the derived-fresh nudges elsewhere in
+the app, these signals are real records (migration 077) with a persisted lifecycle:
+they can be snoozed ("remind me later" → reappears the next day), dismissed, or
+marked published, and that state survives reloads and days.
+
+Consent-first: no route here publishes anything. `POST /{id}/publish` only records
+that the owner acted on the signal; the actual publish runs through the existing
+consent-first posture flow. All routes are owner-token gated.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Path
+from pydantic import BaseModel, ConfigDict, Field
+
+from api.middleware import require_vault_owner_token
+from hushh_mcp.services.opportunity_signal_service import OpportunitySignalService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/api/one/marketplace/opportunities",
+    tags=["One Information Marketplace Opportunities"],
+)
+
+
+def _service() -> OpportunitySignalService:
+    return OpportunitySignalService()
+
+
+class SnoozeBody(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    until_days: int = Field(default=1, alias="untilDays", ge=1, le=365)
+
+
+class AuthorSignalBody(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: str = Field(max_length=16)
+    domain: str = Field(max_length=128)
+    title: str = Field(max_length=200)
+    dedupe_key: str = Field(alias="dedupeKey", max_length=256)
+    scope_handle: str | None = Field(default=None, alias="scopeHandle", max_length=256)
+    body: str | None = Field(default=None, max_length=2000)
+    event_date: str | None = Field(default=None, alias="eventDate", max_length=32)
+    suggested_price_cents: int = Field(default=0, alias="suggestedPriceCents", ge=0, le=100_000_000)
+    currency: str = Field(default="USD", max_length=8)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+@router.get("")
+async def list_due_opportunities(
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    try:
+        opportunities = await _service().list_due(user_id=token_data["user_id"])
+        return {"opportunities": opportunities}
+    except Exception:
+        logger.exception("opportunities.list_due_failed")
+        raise HTTPException(status_code=500, detail="Could not load opportunities")
+
+
+@router.post("")
+async def author_opportunity(
+    body: AuthorSignalBody,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    try:
+        signal = await _service().create_signal(
+            user_id=token_data["user_id"],
+            kind=body.kind,
+            domain=body.domain,
+            title=body.title,
+            dedupe_key=body.dedupe_key,
+            source="authored",
+            scope_handle=body.scope_handle,
+            body=body.body,
+            event_date=body.event_date,
+            suggested_price_cents=body.suggested_price_cents,
+            currency=body.currency,
+            metadata=body.metadata,
+        )
+        return {"opportunity": signal}
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    except Exception:
+        logger.exception("opportunities.author_failed")
+        raise HTTPException(status_code=500, detail="Could not create opportunity")
+
+
+@router.post("/{signal_id}/snooze")
+async def snooze_opportunity(
+    body: SnoozeBody | None = None,
+    signal_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    result: dict[str, Any] = await _service().snooze(
+        user_id=token_data["user_id"], signal_id=signal_id
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail="Opportunity not found")
+    return result
+
+
+@router.post("/{signal_id}/dismiss")
+async def dismiss_opportunity(
+    signal_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    result: dict[str, Any] = await _service().dismiss(
+        user_id=token_data["user_id"], signal_id=signal_id
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail="Opportunity not found")
+    return result
+
+
+@router.post("/{signal_id}/publish")
+async def mark_opportunity_published(
+    signal_id: str = Path(..., min_length=1, max_length=128),
+    token_data: dict = Depends(require_vault_owner_token),
+) -> dict[str, Any]:
+    result: dict[str, Any] = await _service().mark_published(
+        user_id=token_data["user_id"], signal_id=signal_id
+    )
+    if not result.get("ok"):
+        raise HTTPException(status_code=404, detail="Opportunity not found")
+    return result

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 76,
+  "expected_migration_version": 77,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/077_marketplace_opportunity_signals.sql
+++ b/consent-protocol/db/migrations/077_marketplace_opportunity_signals.sql
@@ -1,0 +1,64 @@
+BEGIN;
+
+-- Durable, proactive "opportunity signals" for the Information Marketplace.
+--
+-- Until now every nudge/flashcard in the app (Gmail, Location) was derived fresh
+-- on load and lived only in the browser — no dismiss, no snooze, nothing survived
+-- a reload, let alone the next day. This table makes an opportunity a real record:
+-- "your insurance expires soon — publish this so buyers can reach you", or an
+-- offer-worthy unpublished slice worth listing. The card can be published (via the
+-- existing consent-first posture flow), snoozed ("remind me later" → reappears the
+-- next day), or dismissed, and that state persists.
+--
+-- Consent-first: a signal NEVER publishes anything on its own. It only surfaces the
+-- suggestion; publishing runs the normal owner-driven, server-side posture change,
+-- and this row merely records that the signal was acted on.
+--
+-- Two producers converge on this one store:
+--   * server-side derivation of dateless "intent" signals (offer-worthy unpublished
+--     slices), which needs no vault key; and
+--   * client-side derivation of dated "expiry" signals (insurance renewal, trip
+--     date), which are only decryptable with the owner's vault key and are written
+--     through the author endpoint.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS marketplace_opportunity_signals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  -- 'expiry' carries an event_date (dated, client-derived); 'intent' is dateless
+  -- (server-derived from offer-worthy unpublished slices).
+  kind TEXT NOT NULL
+    CHECK (kind IN ('expiry', 'intent')),
+  domain TEXT NOT NULL,
+  -- The PKM slice this maps to, so the publish CTA can target the right section.
+  scope_handle TEXT,
+  title TEXT NOT NULL,
+  body TEXT,
+  event_date DATE,
+  suggested_price_cents INTEGER NOT NULL DEFAULT 0,
+  currency TEXT NOT NULL DEFAULT 'USD',
+  source TEXT NOT NULL
+    CHECK (source IN ('derived', 'authored')),
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'snoozed', 'published', 'dismissed', 'expired')),
+  -- "Remind me later" sets snoozed_until to the start of the next day; list_due
+  -- surfaces the card again once now() passes it.
+  snoozed_until TIMESTAMPTZ,
+  -- Stable identity so re-derivation on every open is idempotent (no duplicates).
+  dedupe_key TEXT NOT NULL,
+  show_count INTEGER NOT NULL DEFAULT 0,
+  -- Carries topLevelScopePath/label/domainTitle/sensitivityTier so the publish CTA
+  -- can call the consent-first posture flow without a second lookup.
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_opportunity_signals_dedupe UNIQUE (user_id, dedupe_key)
+);
+
+-- The "due now" query: active signals, or snoozed ones whose snooze has elapsed,
+-- for a given owner. event_date included so dated cards can order/expire cheaply.
+CREATE INDEX IF NOT EXISTS idx_marketplace_opportunity_signals_due
+  ON marketplace_opportunity_signals (user_id, status, snoozed_until, event_date);
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -54,7 +54,8 @@
     "073_crm_registry_mulesoft_simplify.sql",
     "074_pkm_scope_registry_owner_consent_override.sql",
     "075_agent_chat_message_metadata.sql",
-    "076_marketplace_access_requests.sql"
+    "076_marketplace_access_requests.sql",
+    "077_marketplace_opportunity_signals.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/hushh_mcp/agents/personal_information/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/personal_information/agent.yaml
@@ -50,12 +50,15 @@ system_instruction: |
   string — use them to explain how a number was reached. You DO have the formula;
   never say you lack access to it.
 
-  BE HONEST ABOUT MONEY. There is no payment rail and no settled money. Earnings
-  are POTENTIAL only: a suggested monthly price if a buyer subscribes. Nothing is
-  accrued. When the user asks how much they have made, say clearly that nothing
-  is accrued yet and give the potential figure, labeled as such. Never invent a
-  sale or a settled amount. (A pending request in the inbox is a buyer asking for
-  access — not a settled purchase; the owner still approves and no money moves.)
+  BE HONEST ABOUT MONEY, BUT SURFACE REAL DEMAND. Payments are coming soon —
+  there is no payment rail and no settled money yet (payoutsEnabled is False,
+  accrued is 0). What can be real is buyer DEMAND: get_earnings_summary returns
+  pendingRequestCount / approvedBuyerCount / interestedBuyerCount. When the user
+  asks how much they have made, cite that real interest if any ("N buyers have
+  access, M are waiting"), give the potential monthly figure labeled as such, and
+  ALWAYS add that payments are coming soon and nothing has been paid out. Never
+  invent a sale or a settled amount. (A pending request is a buyer asking for
+  access — not a purchase; the owner still approves and no money moves yet.)
 
   Do NOT invent slices, prices, requests, or numbers. Always call a tool to get
   real values; if a tool returns nothing published, tell the user plainly that
@@ -76,7 +79,7 @@ tools:
     py_func: hushh_mcp.agents.personal_information.tools.list_published_slices
     required_scope: cap.pkm.marketplace.view
   - name: get_earnings_summary
-    description: Summarize POTENTIAL monthly earnings across published slices, with per-slice show-math factors and the pricing formula. No buyers or payment rail yet; nothing is accrued.
+    description: Summarize real buyer demand (pending/approved/interested counts) + POTENTIAL monthly earnings across published slices, with per-slice show-math factors and the pricing formula. Payments coming soon; payouts disabled and nothing accrued.
     py_func: hushh_mcp.agents.personal_information.tools.get_earnings_summary
     required_scope: cap.pkm.marketplace.view
   - name: propose_publish

--- a/consent-protocol/hushh_mcp/agents/personal_information/tools.py
+++ b/consent-protocol/hushh_mcp/agents/personal_information/tools.py
@@ -52,11 +52,14 @@ async def get_earnings_summary(
     power: str = "affluent",
     mood: str = "affinity",
 ) -> dict[str, Any]:
-    """Summarize potential monthly earnings across the user's published slices.
+    """Summarize buyer demand + potential monthly earnings for published slices.
 
-    Read-only. Earnings are POTENTIAL only — there is no payment rail and no buyer
-    yet, so accruedCents is always 0. Use this to answer 'how much money have I
-    made / what are my slices worth'. Always be honest that nothing is accrued yet.
+    Read-only. Reports REAL buyer demand (pendingRequestCount, approvedBuyerCount,
+    interestedBuyerCount) alongside each slice's potential monthly price. But
+    payments are NOT enabled yet (payoutsEnabled is False, accruedCents is always
+    0). Use this to answer 'how much have I made / what are my slices worth / who
+    wants my data'. Be honest: cite real buyer interest if any, but always say
+    payments are coming soon and nothing has been paid out yet.
     """
     context = _ctx()
     return await _service().earnings_summary(user_id=context.user_id, power=power, mood=mood)

--- a/consent-protocol/hushh_mcp/services/information_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/information_chat_service.py
@@ -101,11 +101,14 @@ def _function_declarations(types: Any) -> list:
         types.FunctionDeclaration(
             name="get_earnings_summary",
             description=(
-                "Summarize POTENTIAL monthly earnings across the user's published "
-                "slices. Returns each slice's price plus its `math` factors (floor, "
-                "data value, buyer fit, freshness, exclusivity, geo) and the pricing "
-                "`formula` — use these to explain 'show math'. There is no buyer or "
-                "payment rail yet, so nothing is accrued (accruedCents is 0). Read-only."
+                "Summarize buyer demand + POTENTIAL monthly earnings for the user's "
+                "published slices. Returns real demand (pendingRequestCount, "
+                "approvedBuyerCount, interestedBuyerCount) plus each slice's price and "
+                "its `math` factors (floor, data value, buyer fit, freshness, "
+                "exclusivity, geo) and the pricing `formula` — use these to explain "
+                "'show math'. Payments are NOT enabled yet (payoutsEnabled False, "
+                "accruedCents 0): cite real buyer interest but always say payments are "
+                "coming soon and nothing has been paid out. Read-only."
             ),
             parameters=schema(
                 type=kind.OBJECT,

--- a/consent-protocol/hushh_mcp/services/marketplace_catalog_service.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_catalog_service.py
@@ -97,6 +97,82 @@ def _presentation_attribute_count(presentation: dict[str, Any]) -> int:
     return max(1, count)
 
 
+def _attribute_count_for(entry: dict[str, Any] | None, presentation: dict[str, Any]) -> int:
+    """The number of attributes in a slice, used for both display and pricing.
+
+    A registry entry's `segment_ids` is authoritative for a *segment* scope (the
+    owner hand-picked those attributes). But a *subtree* scope stores a single
+    marker (`["root"]`), so its length is 1 regardless of how many leaf fields the
+    subtree actually holds — that undercounts (and underprices) the slice. For
+    subtrees (or a missing entry) we fall back to the published preview's field
+    count, which reflects the real leaves.
+    """
+    presentation_count = _presentation_attribute_count(presentation)
+    if entry is None:
+        return presentation_count
+    segment_ids = entry.get("segment_ids") or []
+    is_subtree = entry.get("scope_kind") == "subtree" or segment_ids in ([], ["root"])
+    if is_subtree:
+        return max(presentation_count, len(segment_ids), 1)
+    return max(1, len(segment_ids))
+
+
+def _safe_preview(presentation: dict[str, Any]) -> dict[str, Any]:
+    """Buyer-safe projection of an owner's published presentation.
+
+    CRITICAL PRIVACY BOUNDARY. The presentation stored in
+    `pkm_default_available_projections` is the OWNER's own preview and embeds raw
+    saved VALUES (e.g. a home address, a postal code). A browsing buyer must never
+    see those — only the *shape* of the slice: its title, which field names it
+    contains, and how many items each group holds. This rebuilds a preview that
+    keeps labels and aggregate counts and drops every value-bearing key.
+    """
+    if not isinstance(presentation, dict):
+        return {}
+    safe: dict[str, Any] = {"title": presentation.get("title") or "Data slice", "stats": []}
+    if presentation.get("description"):
+        safe["description"] = presentation["description"]
+    # stats are aggregate counts (e.g. "Fields: 5") — no raw values, safe to keep.
+    stats = presentation.get("stats")
+    if isinstance(stats, list):
+        safe["stats"] = [
+            {"label": s.get("label"), "value": s.get("value")}
+            for s in stats
+            if isinstance(s, dict) and s.get("label") is not None
+        ]
+
+    field_names: list[str] = []
+    for group in presentation.get("groups") or []:
+        if not isinstance(group, dict):
+            continue
+        kind = group.get("kind")
+        if kind == "fields":
+            for field in group.get("fields") or []:
+                if isinstance(field, dict) and field.get("label"):
+                    field_names.append(str(field["label"]))
+        elif kind == "entities":
+            # Entity titles/subtitles/section items are raw values → never surface.
+            # Only the field *names* inside entities describe the slice shape.
+            for entity in group.get("items") or []:
+                if not isinstance(entity, dict):
+                    continue
+                for field in entity.get("fields") or []:
+                    if isinstance(field, dict) and field.get("label"):
+                        field_names.append(str(field["label"]))
+        # chips / list groups are pure values (e.g. saved preferences) — dropped
+        # entirely; the count already lives in `stats`.
+
+    # De-duplicate while preserving order so the buyer sees each field name once.
+    seen: set[str] = set()
+    unique_names = [n for n in field_names if not (n in seen or seen.add(n))]
+
+    groups: list[dict[str, Any]] = []
+    if unique_names:
+        groups.append({"kind": "chips", "title": "Included fields", "items": unique_names})
+    safe["groups"] = groups
+    return safe
+
+
 class MarketplaceCatalogService:
     """Read model for the anonymized cross-user Buyer directory + listing resolution."""
 
@@ -151,22 +227,21 @@ class MarketplaceCatalogService:
         cache[key] = index
         return index
 
-    def _price_for(
-        self, entry: dict[str, Any] | None, *, fallback_attributes: int
-    ) -> tuple[int, str]:
+    def _price_for(self, entry: dict[str, Any] | None, *, attribute_count: int) -> tuple[int, str]:
         """Suggested 30-day price for a slice. Uses the owner's real registry entry
-        (sensitivity tier, scope kind, attribute count) when matched; otherwise a
-        conservative demographics default with the preview-derived attribute count.
-        Band is the neutral affluent/affinity default the owner-side read model uses.
+        for the sensitivity category when matched; otherwise a conservative
+        demographics default. The attribute count is computed by the caller (see
+        `_attribute_count_for`, which handles subtree scopes) and passed in so
+        display and price never disagree. Band is the neutral affluent/affinity
+        default the owner-side read model uses.
         """
         if entry is not None:
             category = category_from_sensitivity(
                 entry.get("sensitivity_tier"), entry.get("scope_kind")
             )
-            attribute_count = max(1, len(entry.get("segment_ids") or []))
         else:
             category = "demographics_lifestyle"
-            attribute_count = max(1, int(fallback_attributes or 1))
+        attribute_count = max(1, int(attribute_count or 1))
         try:
             breakdown = compute_suggested_price(
                 SlicePricingInput(
@@ -212,12 +287,8 @@ class MarketplaceCatalogService:
             entry = registry.get(f"h:{row.get('scope_handle')}") or registry.get(
                 f"p:{top_level_scope_path}"
             )
-            attribute_count = (
-                max(1, len(entry.get("segment_ids") or []))
-                if entry is not None
-                else _presentation_attribute_count(presentation)
-            )
-            price_cents, currency = self._price_for(entry, fallback_attributes=attribute_count)
+            attribute_count = _attribute_count_for(entry, presentation)
+            price_cents, currency = self._price_for(entry, attribute_count=attribute_count)
             listings.append(
                 {
                     "listingId": str(row.get("id")),
@@ -227,7 +298,9 @@ class MarketplaceCatalogService:
                     "label": label,
                     "topLevelScopePath": top_level_scope_path,
                     "attributeCount": attribute_count,
-                    "preview": presentation,
+                    # NEVER send the raw presentation to a buyer — it embeds saved
+                    # values. Only the value-stripped, names-only shape crosses the wire.
+                    "preview": _safe_preview(presentation),
                     "suggestedPriceCents": price_cents,
                     "currency": currency,
                 }
@@ -270,12 +343,8 @@ class MarketplaceCatalogService:
         entry = registry.get(f"h:{row.get('scope_handle')}") or registry.get(
             f"p:{top_level_scope_path}"
         )
-        attribute_count = (
-            max(1, len(entry.get("segment_ids") or []))
-            if entry is not None
-            else _presentation_attribute_count(presentation)
-        )
-        price_cents, currency = self._price_for(entry, fallback_attributes=attribute_count)
+        attribute_count = _attribute_count_for(entry, presentation)
+        price_cents, currency = self._price_for(entry, attribute_count=attribute_count)
         return {
             "listingId": str(row.get("id")),
             "ownerUserId": owner_user_id,

--- a/consent-protocol/hushh_mcp/services/marketplace_catalog_service.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_catalog_service.py
@@ -1,0 +1,288 @@
+"""Anonymized cross-user catalog of published data slices (the Buyer directory).
+
+The Information Marketplace's Buyer tab shows a browsing buyer *everyone else's*
+published slices — the same safe-summary preview the owner published, priced by
+the deterministic engine — but with the owner's identity hidden behind an opaque
+ref. This makes demand real and two-account: a buyer files a request into the
+owner's durable inbox (migration 076), not against themselves.
+
+Discovery source is `pkm_default_available_projections` (migration 063): every
+active row (`revoked_at IS NULL`) is a slice its owner set to `default_available`
+and published a safe summary for. We read that table cross-user, exclude the
+viewer's own rows, and never expose the real owner user_id or name — only a
+stable hash (`ownerRef`) and an opaque `listingId` (the projection row id). The
+server keeps the listingId -> owner map internal (see `resolve_listing`).
+
+Consent safety mirrors the owner-side read model: we surface only the published
+safe-summary projection plus scope-registry *metadata* (label, sensitivity tier,
+attribute count) — never raw PKM values, and never another user's identity.
+Pricing is the same pure engine the owner sees (`hushh_mcp.pricing`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Any
+
+from db.db_client import get_db
+from hushh_mcp.pricing import (
+    SlicePricingInput,
+    category_from_sensitivity,
+    compute_suggested_price,
+)
+from hushh_mcp.services.personal_knowledge_model_service import (
+    PersonalKnowledgeModelService,
+)
+
+logger = logging.getLogger(__name__)
+
+# Columns we read from the projection table — never select the whole row into a
+# response; the mapping to owner identity stays server-side.
+_PROJECTION_COLUMNS = (
+    "id,user_id,domain,scope,scope_handle,top_level_scope_path,projection_payload,updated_at"
+)
+
+
+def _domain_title(domain: str) -> str:
+    """Human-readable title for a domain key (mirrors MarketplaceInformationService)."""
+    return (domain or "").replace(".", " ").replace("_", " ").strip().title() or "Data"
+
+
+def _owner_ref(user_id: str) -> str:
+    """Stable, opaque reference for an owner — a truncated SHA-256 of the user id.
+
+    Same owner always maps to the same ref (so a buyer can tell two listings come
+    from one seller), but the real id/name can never be recovered from it.
+    """
+    digest = hashlib.sha256((user_id or "").encode("utf-8")).hexdigest()
+    return f"own_{digest[:16]}"
+
+
+def _coerce_payload(value: Any) -> dict[str, Any]:
+    """Projection payloads are JSONB but can come back as a str depending on the
+    driver; coerce to a dict, degrading to {} rather than raising."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _presentation_attribute_count(presentation: dict[str, Any]) -> int:
+    """Best-effort attribute count from a published preview presentation, used only
+    when the owner's live manifest can't be matched. Counts visible fields, list/
+    chip items, and entity fields so the price still reflects slice richness."""
+    if not isinstance(presentation, dict):
+        return 1
+    count = 0
+    for group in presentation.get("groups") or []:
+        if not isinstance(group, dict):
+            continue
+        kind = group.get("kind")
+        if kind == "fields":
+            count += len(group.get("fields") or [])
+        elif kind in ("chips", "list"):
+            count += len(group.get("items") or [])
+        elif kind == "entities":
+            for entity in group.get("items") or []:
+                if isinstance(entity, dict):
+                    count += max(1, len(entity.get("fields") or []))
+    return max(1, count)
+
+
+class MarketplaceCatalogService:
+    """Read model for the anonymized cross-user Buyer directory + listing resolution."""
+
+    def __init__(
+        self,
+        pkm_service: PersonalKnowledgeModelService | None = None,
+    ) -> None:
+        self._pkm = pkm_service or PersonalKnowledgeModelService()
+        self._supabase = None
+
+    @property
+    def supabase(self):
+        if self._supabase is None:
+            self._supabase = get_db()
+        return self._supabase
+
+    async def _execute_query(self, query):
+        return await asyncio.to_thread(query.execute)
+
+    # --- pricing metadata -------------------------------------------------
+
+    async def _registry_index(
+        self, *, owner_user_id: str, domain: str, cache: dict[tuple[str, str], dict]
+    ) -> dict[str, dict[str, Any]]:
+        """Load the owner's scope-registry entries for a domain, indexed by both
+        scope_handle and top_level_scope_path so a projection row can find its
+        entry (for real sensitivity/attribute pricing inputs). Memoized per call;
+        best-effort — a missing manifest degrades to an empty index (default price).
+        """
+        key = (owner_user_id, domain)
+        if key in cache:
+            return cache[key]
+        index: dict[str, dict[str, Any]] = {}
+        try:
+            manifest = await self._pkm.get_domain_manifest(owner_user_id, domain)
+        except Exception:
+            logger.debug("catalog.manifest_load_failed owner=%s domain=%s", owner_user_id, domain)
+            manifest = None
+        if manifest:
+            for entry in manifest.get("scope_registry") or []:
+                if not isinstance(entry, dict):
+                    continue
+                handle = entry.get("scope_handle")
+                if handle:
+                    index[f"h:{handle}"] = entry
+                projection = entry.get("summary_projection")
+                top = (
+                    projection.get("top_level_scope_path") if isinstance(projection, dict) else None
+                )
+                if top:
+                    index[f"p:{top}"] = entry
+        cache[key] = index
+        return index
+
+    def _price_for(
+        self, entry: dict[str, Any] | None, *, fallback_attributes: int
+    ) -> tuple[int, str]:
+        """Suggested 30-day price for a slice. Uses the owner's real registry entry
+        (sensitivity tier, scope kind, attribute count) when matched; otherwise a
+        conservative demographics default with the preview-derived attribute count.
+        Band is the neutral affluent/affinity default the owner-side read model uses.
+        """
+        if entry is not None:
+            category = category_from_sensitivity(
+                entry.get("sensitivity_tier"), entry.get("scope_kind")
+            )
+            attribute_count = max(1, len(entry.get("segment_ids") or []))
+        else:
+            category = "demographics_lifestyle"
+            attribute_count = max(1, int(fallback_attributes or 1))
+        try:
+            breakdown = compute_suggested_price(
+                SlicePricingInput(
+                    category=category,
+                    attribute_count=attribute_count,
+                    power="affluent",
+                    mood="affinity",
+                )
+            )
+        except KeyError:
+            return 0, "USD"
+        return breakdown.suggested_price_cents, breakdown.currency
+
+    # --- directory --------------------------------------------------------
+
+    async def list_available_listings(self, *, viewer_user_id: str) -> list[dict[str, Any]]:
+        """Every active published slice from OTHER users, anonymized. The viewer's
+        own listings are excluded (you don't buy your own data)."""
+        query = (
+            self.supabase.table("pkm_default_available_projections")
+            .select(_PROJECTION_COLUMNS)
+            .is_("revoked_at", None)
+            .neq("user_id", viewer_user_id)
+            .order("updated_at", desc=True)
+        )
+        result = await self._execute_query(query)
+        rows = getattr(result, "data", None) or []
+        registry_cache: dict[tuple[str, str], dict] = {}
+        listings: list[dict[str, Any]] = []
+        for row in rows:
+            owner_user_id = str(row.get("user_id") or "")
+            if not owner_user_id or owner_user_id == viewer_user_id:
+                continue
+            domain = row.get("domain") or ""
+            payload = _coerce_payload(row.get("projection_payload"))
+            presentation = payload.get("presentation")
+            presentation = presentation if isinstance(presentation, dict) else {}
+            label = payload.get("label") or row.get("scope") or "Data slice"
+            top_level_scope_path = payload.get("section") or row.get("top_level_scope_path") or ""
+            registry = await self._registry_index(
+                owner_user_id=owner_user_id, domain=domain, cache=registry_cache
+            )
+            entry = registry.get(f"h:{row.get('scope_handle')}") or registry.get(
+                f"p:{top_level_scope_path}"
+            )
+            attribute_count = (
+                max(1, len(entry.get("segment_ids") or []))
+                if entry is not None
+                else _presentation_attribute_count(presentation)
+            )
+            price_cents, currency = self._price_for(entry, fallback_attributes=attribute_count)
+            listings.append(
+                {
+                    "listingId": str(row.get("id")),
+                    "ownerRef": _owner_ref(owner_user_id),
+                    "domain": domain,
+                    "domainTitle": _domain_title(domain),
+                    "label": label,
+                    "topLevelScopePath": top_level_scope_path,
+                    "attributeCount": attribute_count,
+                    "preview": presentation,
+                    "suggestedPriceCents": price_cents,
+                    "currency": currency,
+                }
+            )
+        return listings
+
+    async def resolve_listing(self, *, listing_id: str) -> dict[str, Any] | None:
+        """Resolve an opaque listingId back to the real owner + slice descriptor +
+        suggested price. Internal only — the owner user_id here is never returned to
+        a buyer's browser; it is used server-side to file the access request."""
+        try:
+            numeric_id = int(str(listing_id).strip())
+        except (TypeError, ValueError):
+            return None
+        query = (
+            self.supabase.table("pkm_default_available_projections")
+            .select(_PROJECTION_COLUMNS)
+            .eq("id", numeric_id)
+            .is_("revoked_at", None)
+            .limit(1)
+        )
+        result = await self._execute_query(query)
+        rows = getattr(result, "data", None) or []
+        if not rows:
+            return None
+        row = rows[0]
+        owner_user_id = str(row.get("user_id") or "")
+        if not owner_user_id:
+            return None
+        domain = row.get("domain") or ""
+        payload = _coerce_payload(row.get("projection_payload"))
+        presentation = payload.get("presentation")
+        presentation = presentation if isinstance(presentation, dict) else {}
+        label = payload.get("label") or row.get("scope") or "Data slice"
+        top_level_scope_path = payload.get("section") or row.get("top_level_scope_path") or ""
+        registry_cache: dict[tuple[str, str], dict] = {}
+        registry = await self._registry_index(
+            owner_user_id=owner_user_id, domain=domain, cache=registry_cache
+        )
+        entry = registry.get(f"h:{row.get('scope_handle')}") or registry.get(
+            f"p:{top_level_scope_path}"
+        )
+        attribute_count = (
+            max(1, len(entry.get("segment_ids") or []))
+            if entry is not None
+            else _presentation_attribute_count(presentation)
+        )
+        price_cents, currency = self._price_for(entry, fallback_attributes=attribute_count)
+        return {
+            "listingId": str(row.get("id")),
+            "ownerUserId": owner_user_id,
+            "domain": domain,
+            "scopeHandle": row.get("scope_handle"),
+            "sliceLabel": label,
+            "topLevelScopePath": top_level_scope_path,
+            "priceCents": price_cents,
+            "currency": currency,
+        }

--- a/consent-protocol/hushh_mcp/services/marketplace_information_service.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_information_service.py
@@ -10,10 +10,13 @@ projection. It never returns raw PKM values or another user's data. Pricing is
 computed by the pure, deterministic backend engine (hushh_mcp.pricing), so the
 agent cannot fabricate a number.
 
-Honesty about "earnings": there is NO payment rail and NO buyers yet. Published
-slices have a *potential* monthly price only; nothing is accrued or settled. The
-summary makes that explicit (accrued_cents is always 0) so the agent never
-implies money that does not exist.
+Honesty about "earnings": there is NO payment rail yet, so nothing is ever
+accrued or settled (accrued_cents is always 0, payouts_enabled is always False).
+What IS real is buyer *demand* — durable access requests (migration 076) that
+buyers file against published slices. The summary reports that real demand
+(pending/approved counts) alongside a *potential* monthly price tag, and says
+payments are "coming soon" — so the agent surfaces genuine interest without ever
+implying money has changed hands.
 """
 
 from __future__ import annotations
@@ -26,6 +29,7 @@ from hushh_mcp.pricing import (
     category_from_sensitivity,
     compute_suggested_price,
 )
+from hushh_mcp.services.marketplace_request_service import MarketplaceRequestService
 from hushh_mcp.services.personal_knowledge_model_service import (
     PersonalKnowledgeModelService,
 )
@@ -41,6 +45,32 @@ def _domain_title(domain: str) -> str:
 def _attribute_count(entry: dict) -> int:
     segments = entry.get("segment_ids") or []
     return max(1, len(segments))
+
+
+def _plural(n: int, singular: str, plural: str) -> str:
+    return singular if n == 1 else plural
+
+
+def _earnings_note(demand: dict[str, Any]) -> str:
+    """Honest one-liner for the summary: report real buyer demand but never imply
+    money — payouts are not enabled yet ("payments coming soon")."""
+    approved = demand.get("approvedBuyerCount", 0)
+    pending = demand.get("pendingRequestCount", 0)
+    if approved or pending:
+        parts: list[str] = []
+        if approved:
+            parts.append(f"{approved} {_plural(approved, 'buyer has', 'buyers have')} access")
+        if pending:
+            parts.append(f"{pending} {_plural(pending, 'request is', 'requests are')} waiting")
+        lead = " and ".join(parts)
+        return (
+            f"{lead}. Payments are coming soon — no payout has been made yet, so "
+            "nothing is accrued or settled."
+        )
+    return (
+        "Potential only. No buyer has requested access yet and payments are coming "
+        "soon (no payment rail), so nothing is accrued or settled."
+    )
 
 
 # Commercial-intent / life-event cues that make an unpublished slice worth offers
@@ -124,8 +154,44 @@ def _matches_topic(topic: str, label: str, domain_title: str) -> bool:
 class MarketplaceInformationService:
     """Read-only view over the owner's published marketplace slices + pricing."""
 
-    def __init__(self, pkm_service: PersonalKnowledgeModelService | None = None) -> None:
+    def __init__(
+        self,
+        pkm_service: PersonalKnowledgeModelService | None = None,
+        request_service: MarketplaceRequestService | None = None,
+    ) -> None:
         self._pkm = pkm_service or PersonalKnowledgeModelService()
+        self._requests = request_service or MarketplaceRequestService()
+
+    async def _demand_snapshot(self, *, user_id: str) -> dict[str, Any]:
+        """Real buyer demand for this owner from the durable access-request inbox
+        (migration 076). Best-effort: a broken inbox degrades to zero demand
+        rather than breaking the earnings summary."""
+        empty = {
+            "pendingRequestCount": 0,
+            "approvedBuyerCount": 0,
+            "interestedBuyerCount": 0,
+            "hasBuyers": False,
+        }
+        try:
+            requests = await self._requests.list_requests(owner_user_id=user_id)
+        except Exception:
+            logger.exception("marketplace.earnings_demand_read_failed")
+            return empty
+        pending = [r for r in requests if r.get("status") == "pending"]
+        approved = [r for r in requests if r.get("status") == "approved"]
+
+        def _buyer_key(r: dict) -> str:
+            # Prefer a real account id; fall back to the label, then the request id
+            # so an anonymous request still counts as one distinct interested buyer.
+            return r.get("buyerUserId") or r.get("buyerLabel") or str(r.get("id"))
+
+        interested = {_buyer_key(r) for r in (pending + approved)}
+        return {
+            "pendingRequestCount": len(pending),
+            "approvedBuyerCount": len(approved),
+            "interestedBuyerCount": len(interested),
+            "hasBuyers": len(approved) > 0,
+        }
 
     async def list_published_slices(self, *, user_id: str) -> list[dict[str, Any]]:
         """Every scope the owner has set to `default_available` (published), across
@@ -234,10 +300,12 @@ class MarketplaceInformationService:
         power: str = "affluent",
         mood: str = "affinity",
     ) -> dict[str, Any]:
-        """Potential (never accrued) monthly earnings across the owner's published
-        slices. `accruedCents` is always 0 — there is no payment rail or buyer yet.
+        """Real buyer demand + potential (never accrued) monthly price across the
+        owner's published slices. `accruedCents` is always 0 and `payoutsEnabled`
+        is always False — there is no payment rail yet ("payments coming soon").
         """
         slices = await self.list_published_slices(user_id=user_id)
+        demand = await self._demand_snapshot(user_id=user_id)
         per_slice: list[dict[str, Any]] = []
         total_potential_cents = 0
         currency = "USD"
@@ -295,11 +363,14 @@ class MarketplaceInformationService:
                 "Exclusivity: sold to everyone = base, one buyer = worth more."
             ),
             "band": {"power": power, "mood": mood},
-            # Explicit honesty flags the agent's prompt relies on.
-            "hasBuyers": False,
+            # Real buyer demand from the durable access-request inbox (migration 076).
+            "pendingRequestCount": demand["pendingRequestCount"],
+            "approvedBuyerCount": demand["approvedBuyerCount"],
+            "interestedBuyerCount": demand["interestedBuyerCount"],
+            # Explicit honesty flags the agent's prompt relies on. Demand can be
+            # real, but money never is yet: nothing is accrued and payouts are off.
+            "hasBuyers": demand["hasBuyers"],
             "hasPaymentRail": False,
-            "note": (
-                "Potential only. No buyer has subscribed and no payment rail exists "
-                "yet, so nothing is accrued or settled."
-            ),
+            "payoutsEnabled": False,
+            "note": _earnings_note(demand),
         }

--- a/consent-protocol/hushh_mcp/services/marketplace_information_service.py
+++ b/consent-protocol/hushh_mcp/services/marketplace_information_service.py
@@ -207,12 +207,19 @@ class MarketplaceInformationService:
                 except KeyError:
                     price_cents = 0
                     currency = "USD"
+                # The section path the publish flow targets (slice-publishing.ts
+                # matches on `summary_projection.top_level_scope_path`). Surfacing it
+                # here lets the opportunity card publish the slice without a second
+                # manifest lookup to rediscover the section.
+                projection = entry.get("summary_projection") or {}
+                top_level_scope_path = projection.get("top_level_scope_path")
                 out.append(
                     {
                         "domain": entry.get("domain") or domain,
                         "domainTitle": domain_title,
                         "label": label,
                         "scopeHandle": entry.get("scope_handle"),
+                        "topLevelScopePath": top_level_scope_path,
                         "attributeCount": _attribute_count(entry),
                         "suggestedPriceCents": price_cents,
                         "currency": currency,

--- a/consent-protocol/hushh_mcp/services/opportunity_signal_derivation_service.py
+++ b/consent-protocol/hushh_mcp/services/opportunity_signal_derivation_service.py
@@ -1,0 +1,92 @@
+"""Server-side producer of `intent`-kind opportunity signals.
+
+Bridges the read model (what the owner *could* publish) to the durable signal
+store (the proactive flashcards on Agent One). It reuses
+`MarketplaceInformationService.list_publishable_slices` — the same offer-worthy,
+unpublished-slice source the inline chat card uses — and persists each as an
+`intent` signal via `OpportunitySignalService`.
+
+Why intent-only, server-side: PKM attribute values are BYOK-encrypted, so the
+server can see labels/metadata but not raw dates. It can therefore derive dateless
+"you could publish this for offers" (`intent`) signals with no vault key. Dated
+"this expires soon" (`expiry`) signals must be authored client-side where the vault
+is unlocked (phase 4) — both kinds converge on the one signal store.
+
+Idempotent: dedupe_key `derived:intent:{domain}:{scope_handle|label}` means running
+this on every Agent One open refreshes display fields on still-active signals and
+never resurrects ones the owner already dismissed, published, or snoozed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hushh_mcp.services.marketplace_information_service import (
+    MarketplaceInformationService,
+)
+from hushh_mcp.services.opportunity_signal_service import OpportunitySignalService
+
+logger = logging.getLogger(__name__)
+
+
+def _dedupe_key(domain: str, scope_handle: str | None, label: str) -> str:
+    """Stable per-slice identity so re-derivation upserts rather than duplicates."""
+    return f"derived:intent:{domain}:{scope_handle or label}"
+
+
+class OpportunitySignalDerivationService:
+    """Derives durable `intent` signals from the owner's publishable slices."""
+
+    def __init__(
+        self,
+        *,
+        info_service: MarketplaceInformationService | None = None,
+        signal_service: OpportunitySignalService | None = None,
+    ) -> None:
+        self._info = info_service or MarketplaceInformationService()
+        self._signals = signal_service or OpportunitySignalService()
+
+    async def derive_for_user(self, *, user_id: str) -> list[dict[str, Any]]:
+        """Upsert one `intent` signal per offer-worthy unpublished slice.
+
+        Returns the signals as persisted (shaped camelCase). Safe to call on every
+        open: creation is idempotent on `(user_id, dedupe_key)` and never revives a
+        signal the owner has already handled.
+        """
+        slices = await self._info.list_publishable_slices(user_id=user_id)
+        out: list[dict[str, Any]] = []
+        for sl in slices:
+            domain = sl.get("domain") or ""
+            label = sl.get("label") or "Data slice"
+            scope_handle = sl.get("scopeHandle")
+            domain_title = sl.get("domainTitle") or domain
+            price_cents = int(sl.get("suggestedPriceCents") or 0)
+            currency = sl.get("currency") or "USD"
+
+            signal = await self._signals.create_signal(
+                user_id=user_id,
+                kind="intent",
+                domain=domain,
+                title=f"Publish your {label} for offers",
+                dedupe_key=_dedupe_key(domain, scope_handle, label),
+                source="derived",
+                scope_handle=scope_handle,
+                body=(
+                    f"Your {label} ({domain_title}) isn't published yet. Publishing it "
+                    "lets buyers reach you with offers — you stay in control and approve "
+                    "each request."
+                ),
+                suggested_price_cents=price_cents,
+                currency=currency,
+                # Everything the publish CTA needs to target the section without a
+                # second manifest lookup (see slice-publishing.ts applySlicePosture).
+                metadata={
+                    "topLevelScopePath": sl.get("topLevelScopePath"),
+                    "scopeHandle": scope_handle,
+                    "label": label,
+                    "domainTitle": domain_title,
+                },
+            )
+            out.append(signal)
+        return out

--- a/consent-protocol/hushh_mcp/services/opportunity_signal_service.py
+++ b/consent-protocol/hushh_mcp/services/opportunity_signal_service.py
@@ -1,0 +1,275 @@
+"""Durable persistence for Information Marketplace opportunity signals.
+
+An "opportunity signal" is a proactive, monetizable nudge surfaced on Agent One:
+"your insurance expires soon — publish this so buyers can reach you", or an
+offer-worthy unpublished slice worth listing. Unlike every other nudge in the app
+(Gmail, Location), which is derived fresh on load and forgotten on reload, a signal
+is a real record in `marketplace_opportunity_signals` (migration 077) with a
+persisted lifecycle: it can be snoozed ("remind me later" → reappears the next day),
+dismissed, or marked published, and that state survives reloads and days.
+
+Consent-first: a signal never publishes anything on its own. The card's publish CTA
+runs the normal owner-driven, server-side posture change; `mark_published` here only
+records that the signal was acted on.
+
+Re-derivation on every open is idempotent via `(user_id, dedupe_key)`: creating a
+signal that already exists refreshes its display fields only while it is still
+`active`, and never resurrects a `dismissed`/`published` row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from db.db_client import get_db
+
+logger = logging.getLogger(__name__)
+
+_STATUSES = {"active", "snoozed", "published", "dismissed", "expired"}
+_KINDS = {"expiry", "intent"}
+_SOURCES = {"derived", "authored"}
+
+# Display fields refreshed on idempotent re-derivation of a still-active signal.
+_REFRESHABLE = ("title", "body", "event_date", "suggested_price_cents", "metadata")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Coerce UUID/datetime/date to a JSON-safe string (chat path uses json.dumps)."""
+    return None if value is None else str(value)
+
+
+def _row_to_signal(row: dict) -> dict[str, Any]:
+    """Shape a DB row into the JSON-safe camelCase contract the frontend consumes."""
+    return {
+        "id": _str_or_none(row.get("id")),
+        "userId": _str_or_none(row.get("user_id")),
+        "kind": row.get("kind"),
+        "domain": row.get("domain"),
+        "scopeHandle": row.get("scope_handle"),
+        "title": row.get("title"),
+        "body": row.get("body"),
+        "eventDate": _str_or_none(row.get("event_date")),
+        "suggestedPriceCents": row.get("suggested_price_cents"),
+        "currency": row.get("currency"),
+        "source": row.get("source"),
+        "status": row.get("status"),
+        "snoozedUntil": _str_or_none(row.get("snoozed_until")),
+        "dedupeKey": row.get("dedupe_key"),
+        "showCount": row.get("show_count"),
+        "metadata": row.get("metadata") or {},
+        "createdAt": _str_or_none(row.get("created_at")),
+        "updatedAt": _str_or_none(row.get("updated_at")),
+    }
+
+
+def _start_of_next_day(now: datetime) -> datetime:
+    """Start of tomorrow (UTC) — the default 'remind me later' target."""
+    tomorrow = (now + timedelta(days=1)).date()
+    return datetime(tomorrow.year, tomorrow.month, tomorrow.day, tzinfo=UTC)
+
+
+class OpportunitySignalService:
+    """CRUD + lifecycle for durable opportunity signals (owner-scoped)."""
+
+    def __init__(self) -> None:
+        self._supabase = None
+
+    @property
+    def supabase(self):
+        if self._supabase is None:
+            self._supabase = get_db()
+        return self._supabase
+
+    async def _execute_query(self, query):
+        return await asyncio.to_thread(query.execute)
+
+    async def _find_by_dedupe(self, *, user_id: str, dedupe_key: str) -> dict[str, Any] | None:
+        result = await self._execute_query(
+            self.supabase.table("marketplace_opportunity_signals")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("dedupe_key", dedupe_key)
+            .limit(1)
+        )
+        rows = getattr(result, "data", None) or []
+        return rows[0] if rows else None
+
+    async def create_signal(
+        self,
+        *,
+        user_id: str,
+        kind: str,
+        domain: str,
+        title: str,
+        dedupe_key: str,
+        source: str = "derived",
+        scope_handle: str | None = None,
+        body: str | None = None,
+        event_date: str | None = None,
+        suggested_price_cents: int = 0,
+        currency: str = "USD",
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create a signal, idempotent on (user_id, dedupe_key).
+
+        If a signal with the same dedupe_key already exists: refresh its display
+        fields only while it is still `active`; never resurrect a dismissed/published
+        signal (so a re-derivation on every open doesn't nag about handled items).
+        """
+        if kind not in _KINDS:
+            raise ValueError(f"kind must be one of {_KINDS}")
+        if source not in _SOURCES:
+            raise ValueError(f"source must be one of {_SOURCES}")
+
+        existing = await self._find_by_dedupe(user_id=user_id, dedupe_key=dedupe_key)
+        if existing is not None:
+            if existing.get("status") != "active":
+                # Handled already (snoozed/published/dismissed/expired) — leave it be.
+                return _row_to_signal(existing)
+            update = {
+                "title": title,
+                "body": body,
+                "event_date": event_date,
+                "suggested_price_cents": int(suggested_price_cents or 0),
+                "metadata": metadata or {},
+                "updated_at": _now_iso(),
+            }
+            result = await self._execute_query(
+                self.supabase.table("marketplace_opportunity_signals")
+                .update(update)
+                .eq("id", existing["id"])
+                .eq("user_id", user_id)
+                .eq("status", "active")
+            )
+            rows = getattr(result, "data", None) or []
+            return _row_to_signal(rows[0]) if rows else _row_to_signal({**existing, **update})
+
+        payload = {
+            "user_id": user_id,
+            "kind": kind,
+            "domain": domain,
+            "scope_handle": scope_handle,
+            "title": title,
+            "body": body,
+            "event_date": event_date,
+            "suggested_price_cents": int(suggested_price_cents or 0),
+            "currency": currency or "USD",
+            "source": source,
+            "status": "active",
+            "dedupe_key": dedupe_key,
+            "metadata": metadata or {},
+        }
+        result = await self._execute_query(
+            self.supabase.table("marketplace_opportunity_signals").insert(payload)
+        )
+        rows = getattr(result, "data", None) or []
+        return _row_to_signal(rows[0]) if rows else _row_to_signal(payload)
+
+    async def list_due(self, *, user_id: str, now: datetime | None = None) -> list[dict[str, Any]]:
+        """Signals due to show now: active, or snoozed with snooze elapsed.
+
+        Expired dated signals are self-cleaned first. Returned rows get their
+        show_count bumped so we can reason about repeated exposure later.
+        """
+        now = now or _now()
+        await self.expire_past(user_id=user_id, now=now)
+
+        result = await self._execute_query(
+            self.supabase.table("marketplace_opportunity_signals")
+            .select("*")
+            .eq("user_id", user_id)
+            .in_("status", ["active", "snoozed"])
+            .order("created_at", desc=True)
+        )
+        rows = getattr(result, "data", None) or []
+        now_iso = now.isoformat()
+        due = [
+            r
+            for r in rows
+            if r.get("status") == "active"
+            or (r.get("snoozed_until") is not None and str(r["snoozed_until"]) <= now_iso)
+        ]
+
+        for r in due:
+            await self._execute_query(
+                self.supabase.table("marketplace_opportunity_signals")
+                .update(
+                    {
+                        "show_count": int(r.get("show_count") or 0) + 1,
+                        "updated_at": now_iso,
+                    }
+                )
+                .eq("id", r["id"])
+                .eq("user_id", user_id)
+            )
+        return [_row_to_signal(r) for r in due]
+
+    async def _owner_update(
+        self, *, user_id: str, signal_id: str, update: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Owner-scoped update; only a signal the owner owns can be mutated."""
+        update = {**update, "updated_at": _now_iso()}
+        result = await self._execute_query(
+            self.supabase.table("marketplace_opportunity_signals")
+            .update(update)
+            .eq("id", signal_id)
+            .eq("user_id", user_id)
+        )
+        rows = getattr(result, "data", None) or []
+        if not rows:
+            return {"ok": False, "reason": "not_found", "signalId": signal_id}
+        return {"ok": True, "signal": _row_to_signal(rows[0])}
+
+    async def snooze(
+        self,
+        *,
+        user_id: str,
+        signal_id: str,
+        until: datetime | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Remind me later: hide until the given time (default start of tomorrow)."""
+        target = until or _start_of_next_day(now or _now())
+        return await self._owner_update(
+            user_id=user_id,
+            signal_id=signal_id,
+            update={"status": "snoozed", "snoozed_until": target.isoformat()},
+        )
+
+    async def dismiss(self, *, user_id: str, signal_id: str) -> dict[str, Any]:
+        return await self._owner_update(
+            user_id=user_id, signal_id=signal_id, update={"status": "dismissed"}
+        )
+
+    async def mark_published(self, *, user_id: str, signal_id: str) -> dict[str, Any]:
+        """Record that the owner published the slice this signal pointed at.
+
+        The actual publish runs through the consent-first posture flow client-side;
+        this only transitions the signal so it stops resurfacing.
+        """
+        return await self._owner_update(
+            user_id=user_id, signal_id=signal_id, update={"status": "published"}
+        )
+
+    async def expire_past(self, *, user_id: str, now: datetime | None = None) -> int:
+        """Flip active/snoozed dated signals whose event_date has passed to expired."""
+        today: date = (now or _now()).date()
+        result = await self._execute_query(
+            self.supabase.table("marketplace_opportunity_signals")
+            .update({"status": "expired", "updated_at": _now_iso()})
+            .eq("user_id", user_id)
+            .in_("status", ["active", "snoozed"])
+            .lt("event_date", today.isoformat())
+        )
+        return len(getattr(result, "data", None) or [])

--- a/consent-protocol/tests/test_marketplace_catalog.py
+++ b/consent-protocol/tests/test_marketplace_catalog.py
@@ -11,7 +11,9 @@ import pytest
 
 from hushh_mcp.services.marketplace_catalog_service import (
     MarketplaceCatalogService,
+    _attribute_count_for,
     _owner_ref,
+    _safe_preview,
 )
 
 
@@ -128,6 +130,107 @@ async def test_list_excludes_viewer_via_neq_and_anonymizes():
     assert listing["label"] == "Insurance renewal"
     assert listing["preview"]["title"] == "Insurance renewal"
     assert listing["suggestedPriceCents"] > 0
+
+
+async def test_buyer_preview_never_leaks_raw_values():
+    # Regression: the stored projection is the OWNER's own preview and embeds raw
+    # saved VALUES. A browsing buyer must see field *names* only, never the values.
+    row = _row(
+        projection_payload={
+            "label": "Address",
+            "section": "address",
+            "presentation": {
+                "title": "Address",
+                "stats": [{"label": "Fields", "value": "2"}],
+                "groups": [
+                    {
+                        "kind": "fields",
+                        "title": "Saved values",
+                        "fields": [
+                            {"label": "Line1", "value": "123 Test Street"},
+                            {"label": "Postal Code", "value": "94016"},
+                        ],
+                    },
+                    # Pure-value groups (e.g. saved preferences) must be dropped whole.
+                    {
+                        "kind": "chips",
+                        "title": "Preferences",
+                        "items": ["Vegetarian", "Aisle seat"],
+                    },
+                ],
+            },
+        }
+    )
+    svc, _ = _service_with([row])
+
+    listings = await svc.list_available_listings(viewer_user_id="viewer-B")
+    preview = listings[0]["preview"]
+    blob = str(preview)
+
+    # No raw value ever appears in the buyer-facing payload.
+    for leaked in ("123 Test Street", "94016", "Vegetarian", "Aisle seat"):
+        assert leaked not in blob
+    # Field names DO appear so the buyer can judge the slice shape.
+    assert preview["groups"][0]["kind"] == "chips"
+    assert preview["groups"][0]["items"] == ["Line1", "Postal Code"]
+    assert preview["title"] == "Address"
+
+
+def test_safe_preview_strips_entity_values_keeps_field_names():
+    # Entity titles/subtitles/section items are raw values; only field names survive.
+    presentation = {
+        "title": "Receipts",
+        "stats": [{"label": "Purchases", "value": "1"}],
+        "groups": [
+            {
+                "kind": "entities",
+                "title": "Recent purchases",
+                "items": [
+                    {
+                        "title": "Whole Foods Market",
+                        "subtitle": "Groceries",
+                        "fields": [
+                            {"label": "Amount", "value": "$42.10"},
+                            {"label": "Merchant", "value": "Whole Foods Market"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    safe = _safe_preview(presentation)
+    blob = str(safe)
+    for leaked in ("Whole Foods Market", "$42.10", "Groceries"):
+        assert leaked not in blob
+    assert safe["groups"][0]["items"] == ["Amount", "Merchant"]
+
+
+def test_attribute_count_subtree_uses_preview_field_count():
+    # A subtree scope stores a single "root" marker; segment length would undercount
+    # (and underprice) the slice. The real leaf count comes from the preview.
+    presentation = {
+        "groups": [
+            {
+                "kind": "fields",
+                "fields": [
+                    {"label": f, "value": "x"}
+                    for f in ("Line1", "City", "Region", "Postal", "Country")
+                ],
+            }
+        ]
+    }
+    subtree_entry = {"scope_kind": "subtree", "segment_ids": ["root"]}
+    assert _attribute_count_for(subtree_entry, presentation) == 5
+    # A segment scope's hand-picked segment_ids stay authoritative.
+    segment_entry = {"scope_kind": "segment", "segment_ids": ["a", "b"]}
+    assert _attribute_count_for(segment_entry, presentation) == 2
+    # No registry entry → preview count.
+    assert _attribute_count_for(None, presentation) == 5
+
+
+def test_safe_preview_handles_empty_and_non_dict():
+    assert _safe_preview({}) == {"title": "Data slice", "stats": [], "groups": []}
+    assert _safe_preview(None) == {}  # type: ignore[arg-type]
 
 
 async def test_list_drops_viewer_owned_rows_defensively():

--- a/consent-protocol/tests/test_marketplace_catalog.py
+++ b/consent-protocol/tests/test_marketplace_catalog.py
@@ -1,0 +1,258 @@
+"""Tests for the anonymized cross-user Buyer directory + cross-account requests.
+
+Injects a fake Supabase client (chainable query stub) and a stub PKM service so
+the anonymization, viewer-exclusion, listing resolution, and cross-account
+request wiring are covered without a real database.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hushh_mcp.services.marketplace_catalog_service import (
+    MarketplaceCatalogService,
+    _owner_ref,
+)
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    """Records the chained filters and returns a preset result on execute()."""
+
+    def __init__(self, result):
+        self._result = result
+        self.eqs: list[tuple] = []
+        self.neqs: list[tuple] = []
+        self.selected = None
+
+    def select(self, cols):
+        self.selected = cols
+        return self
+
+    def is_(self, *_a):
+        return self
+
+    def neq(self, key, value):
+        self.neqs.append((key, value))
+        return self
+
+    def eq(self, key, value):
+        self.eqs.append((key, value))
+        return self
+
+    def order(self, *_a, **_k):
+        return self
+
+    def limit(self, *_a):
+        return self
+
+    def execute(self):
+        return self._result
+
+
+class _FakeTable:
+    def __init__(self, query):
+        self._query = query
+
+    def select(self, cols):
+        return self._query.select(cols)
+
+
+class _FakeDB:
+    def __init__(self, result):
+        self.query = _FakeQuery(result)
+
+    def table(self, _name):
+        return _FakeTable(self.query)
+
+
+class _StubPkm:
+    """Manifest is unavailable -> catalog falls back to preview-derived pricing."""
+
+    async def get_domain_manifest(self, _user_id, _domain):
+        return None
+
+
+def _service_with(rows) -> tuple[MarketplaceCatalogService, _FakeDB]:
+    svc = MarketplaceCatalogService(pkm_service=_StubPkm())
+    fake = _FakeDB(_FakeResult(rows))
+    svc._supabase = fake
+    return svc, fake
+
+
+def _row(**over):
+    row = {
+        "id": 7,
+        "user_id": "owner-A",
+        "domain": "personal_data",
+        "scope": "personal_data.insurance",
+        "scope_handle": "h-ins",
+        "top_level_scope_path": "insurance",
+        "projection_payload": {
+            "label": "Insurance renewal",
+            "section": "insurance",
+            "presentation": {
+                "title": "Insurance renewal",
+                "stats": [],
+                "groups": [
+                    {"kind": "fields", "fields": [{"label": "Carrier", "value": "Acme"}]},
+                ],
+            },
+        },
+        "updated_at": "2026-07-05T00:00:00Z",
+    }
+    row.update(over)
+    return row
+
+
+async def test_list_excludes_viewer_via_neq_and_anonymizes():
+    svc, fake = _service_with([_row()])
+
+    listings = await svc.list_available_listings(viewer_user_id="viewer-B")
+
+    # Viewer's own rows are excluded at the query layer.
+    assert ("user_id", "viewer-B") in fake.query.neqs
+    assert len(listings) == 1
+    listing = listings[0]
+    # Anonymized: opaque refs only, never the raw owner id or a name.
+    assert listing["ownerRef"] == _owner_ref("owner-A")
+    assert listing["ownerRef"].startswith("own_")
+    assert "owner-A" not in str(listing)
+    assert "ownerUserId" not in listing
+    assert "userId" not in listing
+    assert listing["listingId"] == "7"
+    assert listing["label"] == "Insurance renewal"
+    assert listing["preview"]["title"] == "Insurance renewal"
+    assert listing["suggestedPriceCents"] > 0
+
+
+async def test_list_drops_viewer_owned_rows_defensively():
+    # Even if the DB filter somehow returned a viewer-owned row, code drops it.
+    svc, _ = _service_with([_row(user_id="viewer-B"), _row(id=8, user_id="owner-A")])
+
+    listings = await svc.list_available_listings(viewer_user_id="viewer-B")
+
+    assert [item["listingId"] for item in listings] == ["8"]
+
+
+async def test_resolve_listing_returns_internal_owner_and_price():
+    svc, fake = _service_with([_row()])
+
+    resolved = await svc.resolve_listing(listing_id="7")
+
+    assert ("id", 7) in fake.query.eqs
+    assert resolved is not None
+    # Internal descriptor keeps the real owner (server-side only) for filing.
+    assert resolved["ownerUserId"] == "owner-A"
+    assert resolved["sliceLabel"] == "Insurance renewal"
+    assert resolved["domain"] == "personal_data"
+    assert resolved["scopeHandle"] == "h-ins"
+    assert resolved["priceCents"] > 0
+
+
+async def test_resolve_listing_missing_returns_none():
+    svc, _ = _service_with([])
+    assert await svc.resolve_listing(listing_id="999") is None
+
+
+async def test_resolve_listing_non_numeric_returns_none():
+    svc, _ = _service_with([_row()])
+    assert await svc.resolve_listing(listing_id="not-a-number") is None
+
+
+async def test_owner_ref_is_stable_and_opaque():
+    assert _owner_ref("owner-A") == _owner_ref("owner-A")
+    assert _owner_ref("owner-A") != _owner_ref("owner-B")
+    assert "owner-A" not in _owner_ref("owner-A")
+
+
+# --- cross-account request endpoint wiring --------------------------------
+
+
+class _RecordingRequests:
+    def __init__(self):
+        self.kwargs = None
+
+    async def create_request(self, **kwargs):
+        self.kwargs = kwargs
+        return {"id": "req-1", "status": "pending", **kwargs}
+
+
+async def test_request_endpoint_files_cross_account_request(monkeypatch):
+    from api.routes.one import marketplace_catalog as mod
+
+    resolved = {
+        "ownerUserId": "owner-A",
+        "domain": "personal_data",
+        "scopeHandle": "h-ins",
+        "sliceLabel": "Insurance renewal",
+        "priceCents": 250,
+        "currency": "USD",
+    }
+
+    class _Catalog:
+        async def resolve_listing(self, *, listing_id):
+            assert listing_id == "7"
+            return resolved
+
+    async def _fake_label(buyer_user_id):
+        return "Buyer abc123"
+
+    recorder = _RecordingRequests()
+    monkeypatch.setattr(mod, "_catalog", lambda: _Catalog())
+    monkeypatch.setattr(mod, "_requests", lambda: recorder)
+    monkeypatch.setattr(mod, "_buyer_label", _fake_label)
+
+    out = await mod.request_available_listing(listing_id="7", token_data={"user_id": "buyer-B"})
+
+    assert out["request"]["status"] == "pending"
+    # Owner is the resolved listing owner; buyer is the caller.
+    assert recorder.kwargs["owner_user_id"] == "owner-A"
+    assert recorder.kwargs["buyer_user_id"] == "buyer-B"
+    assert recorder.kwargs["slice_label"] == "Insurance renewal"
+    assert recorder.kwargs["price_cents"] == 250
+    # Buyer label is best-effort and never the raw buyer id.
+    assert "buyer-B" not in str(recorder.kwargs["buyer_label"])
+
+
+async def test_request_endpoint_rejects_self_request(monkeypatch):
+    from fastapi import HTTPException
+
+    from api.routes.one import marketplace_catalog as mod
+
+    class _Catalog:
+        async def resolve_listing(self, *, listing_id):
+            return {
+                "ownerUserId": "buyer-B",  # same as caller
+                "domain": "d",
+                "scopeHandle": None,
+                "sliceLabel": "s",
+                "priceCents": 0,
+                "currency": "USD",
+            }
+
+    monkeypatch.setattr(mod, "_catalog", lambda: _Catalog())
+
+    with pytest.raises(HTTPException) as exc:
+        await mod.request_available_listing(listing_id="7", token_data={"user_id": "buyer-B"})
+    assert exc.value.status_code == 400
+
+
+async def test_request_endpoint_404_when_listing_missing(monkeypatch):
+    from fastapi import HTTPException
+
+    from api.routes.one import marketplace_catalog as mod
+
+    class _Catalog:
+        async def resolve_listing(self, *, listing_id):
+            return None
+
+    monkeypatch.setattr(mod, "_catalog", lambda: _Catalog())
+
+    with pytest.raises(HTTPException) as exc:
+        await mod.request_available_listing(listing_id="404", token_data={"user_id": "buyer-B"})
+    assert exc.value.status_code == 404

--- a/consent-protocol/tests/test_marketplace_earnings_accrual.py
+++ b/consent-protocol/tests/test_marketplace_earnings_accrual.py
@@ -1,0 +1,110 @@
+"""Tests for the earnings summary's real-demand accrual + payout honesty.
+
+`earnings_summary` folds the durable access-request inbox (migration 076) into
+its response so it reports genuine buyer demand — but it must NEVER imply money.
+These tests fake both collaborators (a PKM that has published nothing and a
+request service returning a fixed mix) so the demand math and the core honesty
+guarantee are covered without a database.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hushh_mcp.services.marketplace_information_service import MarketplaceInformationService
+
+
+class _FakePkm:
+    """No published slices — earnings then depends only on buyer demand."""
+
+    async def get_index_v2(self, _user_id: str):
+        return None
+
+
+class _FakeRequestService:
+    def __init__(self, requests: list[dict[str, Any]], *, raise_on_list: bool = False):
+        self._requests = requests
+        self._raise = raise_on_list
+
+    async def list_requests(self, *, owner_user_id: str, status: str | None = None):
+        if self._raise:
+            raise RuntimeError("inbox unavailable")
+        return self._requests
+
+
+def _service(requests, *, raise_on_list=False) -> MarketplaceInformationService:
+    return MarketplaceInformationService(
+        pkm_service=_FakePkm(),
+        request_service=_FakeRequestService(requests, raise_on_list=raise_on_list),
+    )
+
+
+def _req(status: str, *, buyer_id=None, label=None, req_id="r"):
+    return {"id": req_id, "status": status, "buyerUserId": buyer_id, "buyerLabel": label}
+
+
+async def test_earnings_reports_real_buyer_demand():
+    requests = [
+        _req("pending", buyer_id="b1", req_id="r1"),
+        _req("pending", buyer_id="b1", req_id="r2"),  # same buyer, still 2 requests
+        _req("approved", buyer_id="b2", req_id="r3"),
+        _req("denied", buyer_id="b3", req_id="r4"),  # denied is neither pending nor approved
+    ]
+    summary = await _service(requests).earnings_summary(user_id="owner")
+
+    assert summary["pendingRequestCount"] == 2
+    assert summary["approvedBuyerCount"] == 1
+    # distinct buyers across pending+approved: b1 (x2 → 1) + b2 = 2
+    assert summary["interestedBuyerCount"] == 2
+    assert summary["hasBuyers"] is True
+
+
+async def test_has_buyers_is_false_without_an_approved_request():
+    # Pending interest alone is demand, not an approved buyer.
+    summary = await _service([_req("pending", buyer_id="b1", req_id="r1")]).earnings_summary(
+        user_id="owner"
+    )
+    assert summary["pendingRequestCount"] == 1
+    assert summary["approvedBuyerCount"] == 0
+    assert summary["hasBuyers"] is False
+
+
+async def test_payouts_disabled_and_nothing_accrued_always():
+    # The core honesty guarantee: even with an approved buyer, no money exists.
+    summary = await _service([_req("approved", buyer_id="b2", req_id="r3")]).earnings_summary(
+        user_id="owner"
+    )
+    assert summary["accruedCents"] == 0
+    assert summary["payoutsEnabled"] is False
+    assert summary["hasPaymentRail"] is False
+    assert "coming soon" in summary["note"].lower()
+
+
+async def test_anonymous_requests_each_count_as_a_distinct_buyer():
+    # No buyerUserId and no label → fall back to request id so they don't collapse.
+    requests = [
+        _req("pending", req_id="r1"),
+        _req("pending", req_id="r2"),
+    ]
+    summary = await _service(requests).earnings_summary(user_id="owner")
+    assert summary["interestedBuyerCount"] == 2
+
+
+async def test_no_demand_summary_is_honest():
+    summary = await _service([]).earnings_summary(user_id="owner")
+    assert summary["pendingRequestCount"] == 0
+    assert summary["approvedBuyerCount"] == 0
+    assert summary["interestedBuyerCount"] == 0
+    assert summary["hasBuyers"] is False
+    assert summary["payoutsEnabled"] is False
+    assert "coming soon" in summary["note"].lower()
+
+
+async def test_inbox_failure_degrades_to_zero_demand():
+    # A broken inbox must not break the earnings summary — demand degrades to zero.
+    summary = await _service([], raise_on_list=True).earnings_summary(user_id="owner")
+    assert summary["pendingRequestCount"] == 0
+    assert summary["approvedBuyerCount"] == 0
+    assert summary["hasBuyers"] is False
+    assert summary["accruedCents"] == 0
+    assert summary["payoutsEnabled"] is False

--- a/consent-protocol/tests/test_opportunity_signal_derivation.py
+++ b/consent-protocol/tests/test_opportunity_signal_derivation.py
@@ -1,0 +1,112 @@
+"""Tests for server-side `intent`-signal derivation.
+
+Uses fakes for both collaborators — a stub read model (list_publishable_slices)
+and a recording signal service — so the derivation's mapping and idempotency
+contract are covered without a database or a real PKM.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hushh_mcp.services.opportunity_signal_derivation_service import (
+    OpportunitySignalDerivationService,
+    _dedupe_key,
+)
+
+
+class _FakeInfoService:
+    def __init__(self, slices: list[dict[str, Any]]):
+        self._slices = slices
+        self.called_with: str | None = None
+
+    async def list_publishable_slices(self, *, user_id: str, **_kw) -> list[dict[str, Any]]:
+        self.called_with = user_id
+        return self._slices
+
+
+class _FakeSignalService:
+    """Records create_signal calls and echoes back a shaped-ish row."""
+
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
+    async def create_signal(self, **kwargs) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"id": f"sig-{len(self.calls)}", "status": "active", **kwargs}
+
+
+def _derivation(slices):
+    info = _FakeInfoService(slices)
+    signals = _FakeSignalService()
+    svc = OpportunitySignalDerivationService(info_service=info, signal_service=signals)
+    return svc, info, signals
+
+
+async def test_derive_maps_each_slice_to_intent_signal():
+    slices = [
+        {
+            "domain": "travel",
+            "domainTitle": "Travel",
+            "label": "Upcoming trip",
+            "scopeHandle": "h-travel",
+            "topLevelScopePath": "travel.trip",
+            "suggestedPriceCents": 250,
+            "currency": "USD",
+        },
+        {
+            "domain": "insurance",
+            "domainTitle": "Insurance",
+            "label": "Auto renewal",
+            "scopeHandle": None,
+            "topLevelScopePath": "insurance.auto",
+            "suggestedPriceCents": 400,
+            "currency": "USD",
+        },
+    ]
+    svc, info, signals = _derivation(slices)
+
+    out = await svc.derive_for_user(user_id="owner")
+
+    assert info.called_with == "owner"
+    assert len(out) == 2
+    assert len(signals.calls) == 2
+
+    first = signals.calls[0]
+    assert first["kind"] == "intent"
+    assert first["source"] == "derived"
+    assert first["domain"] == "travel"
+    assert first["scope_handle"] == "h-travel"
+    assert first["suggested_price_cents"] == 250
+    assert "Upcoming trip" in first["title"]
+    assert first["dedupe_key"] == "derived:intent:travel:h-travel"
+    assert first["metadata"]["topLevelScopePath"] == "travel.trip"
+    assert first["metadata"]["label"] == "Upcoming trip"
+
+
+async def test_dedupe_key_falls_back_to_label_when_no_handle():
+    # A slice with no scope_handle must still get a stable, distinct key.
+    assert _dedupe_key("insurance", None, "Auto renewal") == "derived:intent:insurance:Auto renewal"
+    slices = [
+        {
+            "domain": "insurance",
+            "domainTitle": "Insurance",
+            "label": "Auto renewal",
+            "scopeHandle": None,
+            "topLevelScopePath": "insurance.auto",
+            "suggestedPriceCents": 400,
+            "currency": "USD",
+        }
+    ]
+    svc, _info, signals = _derivation(slices)
+
+    await svc.derive_for_user(user_id="owner")
+
+    assert signals.calls[0]["dedupe_key"] == "derived:intent:insurance:Auto renewal"
+
+
+async def test_derive_with_no_publishable_slices_creates_nothing():
+    svc, _info, signals = _derivation([])
+    out = await svc.derive_for_user(user_id="owner")
+    assert out == []
+    assert signals.calls == []

--- a/consent-protocol/tests/test_opportunity_signal_service.py
+++ b/consent-protocol/tests/test_opportunity_signal_service.py
@@ -1,0 +1,249 @@
+"""Tests for durable opportunity-signal persistence.
+
+Injects a fake Supabase client (chainable query stub) so shaping, idempotent
+re-derivation, owner-scoped lifecycle, and the due-now logic are covered without a
+real database. Unlike the marketplace-request stub, this one queues a result per
+execute() because the service issues several queries per call (find-by-dedupe then
+insert/update; list_due does expire + select + per-row show_count bumps).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from hushh_mcp.services.opportunity_signal_service import (
+    OpportunitySignalService,
+    _start_of_next_day,
+)
+
+
+class _FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    """Chainable stub; records the call shape and pops the next queued result."""
+
+    def __init__(self, db):
+        self._db = db
+        self.inserted = None
+        self.updated = None
+        self.eqs: list[tuple] = []
+        self.ins: list[tuple] = []
+        self.lts: list[tuple] = []
+
+    def insert(self, payload):
+        self.inserted = payload
+        return self
+
+    def select(self, *_a):
+        return self
+
+    def update(self, payload):
+        self.updated = payload
+        return self
+
+    def eq(self, key, value):
+        self.eqs.append((key, value))
+        return self
+
+    def in_(self, key, values):
+        self.ins.append((key, tuple(values)))
+        return self
+
+    def lt(self, key, value):
+        self.lts.append((key, value))
+        return self
+
+    def limit(self, *_a):
+        return self
+
+    def order(self, *_a, **_k):
+        return self
+
+    def execute(self):
+        self._db.calls.append(self)
+        return self._db.next_result()
+
+
+class _FakeTable:
+    def __init__(self, db):
+        self._db = db
+
+    def __getattr__(self, name):
+        query = _FakeQuery(self._db)
+        return getattr(query, name)
+
+
+class _FakeDB:
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls: list[_FakeQuery] = []
+
+    def next_result(self):
+        return self._results.pop(0) if self._results else _FakeResult([])
+
+    def table(self, _name):
+        return _FakeTable(self)
+
+
+def _service_with(*results) -> tuple[OpportunitySignalService, _FakeDB]:
+    svc = OpportunitySignalService()
+    fake = _FakeDB([_FakeResult(r) for r in results])
+    svc._supabase = fake
+    return svc, fake
+
+
+async def test_create_new_signal_inserts_and_shapes():
+    # 1st query: find_by_dedupe (none) → 2nd: insert returns the row.
+    row = {
+        "id": "sig-1",
+        "user_id": "owner",
+        "kind": "intent",
+        "domain": "travel",
+        "scope_handle": "h1",
+        "title": "List your travel intent",
+        "suggested_price_cents": 120,
+        "currency": "USD",
+        "source": "derived",
+        "status": "active",
+        "dedupe_key": "derived:intent:travel:h1",
+        "show_count": 0,
+        "metadata": {"topLevelScopePath": "travel.intent"},
+    }
+    svc, fake = _service_with([], [row])
+
+    out = await svc.create_signal(
+        user_id="owner",
+        kind="intent",
+        domain="travel",
+        title="List your travel intent",
+        dedupe_key="derived:intent:travel:h1",
+        scope_handle="h1",
+        suggested_price_cents=120,
+        metadata={"topLevelScopePath": "travel.intent"},
+    )
+
+    assert out["id"] == "sig-1"
+    assert out["kind"] == "intent"
+    assert out["suggestedPriceCents"] == 120
+    assert out["metadata"]["topLevelScopePath"] == "travel.intent"
+    # Second call was the insert with status active.
+    assert fake.calls[1].inserted["status"] == "active"
+    assert fake.calls[1].inserted["dedupe_key"] == "derived:intent:travel:h1"
+
+
+async def test_create_refreshes_existing_active_signal():
+    existing = {
+        "id": "sig-1",
+        "user_id": "owner",
+        "status": "active",
+        "dedupe_key": "k",
+        "title": "old",
+    }
+    updated = {**existing, "title": "new", "suggested_price_cents": 200}
+    # find_by_dedupe → existing active; then update returns refreshed row.
+    svc, fake = _service_with([existing], [updated])
+
+    out = await svc.create_signal(
+        user_id="owner",
+        kind="intent",
+        domain="travel",
+        title="new",
+        dedupe_key="k",
+        suggested_price_cents=200,
+    )
+
+    assert out["title"] == "new"
+    assert out["suggestedPriceCents"] == 200
+    # It was an update (guarded to still-active), not a second insert.
+    assert fake.calls[1].updated["title"] == "new"
+    assert ("status", "active") in fake.calls[1].eqs
+
+
+async def test_create_does_not_resurrect_dismissed_signal():
+    existing = {
+        "id": "sig-1",
+        "user_id": "owner",
+        "status": "dismissed",
+        "dedupe_key": "k",
+        "title": "old",
+    }
+    svc, fake = _service_with([existing])  # only the find query runs
+
+    out = await svc.create_signal(
+        user_id="owner",
+        kind="intent",
+        domain="travel",
+        title="new",
+        dedupe_key="k",
+    )
+
+    assert out["status"] == "dismissed"
+    assert out["title"] == "old"  # untouched
+    assert len(fake.calls) == 1  # no insert/update issued
+
+
+async def test_list_due_returns_active_and_elapsed_snoozed_only():
+    now = datetime(2026, 7, 5, 12, 0, tzinfo=UTC)
+    rows = [
+        {"id": "a", "user_id": "o", "status": "active", "show_count": 0},
+        {
+            "id": "b",
+            "user_id": "o",
+            "status": "snoozed",
+            "snoozed_until": "2026-07-04T00:00:00+00:00",  # elapsed
+            "show_count": 1,
+        },
+        {
+            "id": "c",
+            "user_id": "o",
+            "status": "snoozed",
+            "snoozed_until": "2026-07-06T00:00:00+00:00",  # still snoozed
+            "show_count": 0,
+        },
+    ]
+    # 1st query: expire_past update (no rows). 2nd: the select. Then per-due-row bumps.
+    svc, _ = _service_with([], rows, [], [])
+
+    out = await svc.list_due(user_id="o", now=now)
+
+    ids = {r["id"] for r in out}
+    assert ids == {"a", "b"}  # c is still snoozed into the future
+
+
+async def test_snooze_defaults_to_start_of_tomorrow():
+    now = datetime(2026, 7, 5, 15, 30, tzinfo=UTC)
+    row = {"id": "sig-1", "user_id": "o", "status": "snoozed"}
+    svc, fake = _service_with([row])
+
+    result = await svc.snooze(user_id="o", signal_id="sig-1", now=now)
+
+    assert result["ok"] is True
+    expected = _start_of_next_day(now).isoformat()
+    assert fake.calls[0].updated["snoozed_until"] == expected
+    assert fake.calls[0].updated["status"] == "snoozed"
+    assert ("user_id", "o") in fake.calls[0].eqs
+
+
+async def test_dismiss_and_publish_are_owner_scoped():
+    row = {"id": "sig-1", "user_id": "o", "status": "dismissed"}
+    svc, fake = _service_with([row])
+    result = await svc.dismiss(user_id="o", signal_id="sig-1")
+    assert result["ok"] is True
+    assert fake.calls[0].updated["status"] == "dismissed"
+    assert ("user_id", "o") in fake.calls[0].eqs
+
+    row2 = {"id": "sig-1", "user_id": "o", "status": "published"}
+    svc2, fake2 = _service_with([row2])
+    result2 = await svc2.mark_published(user_id="o", signal_id="sig-1")
+    assert result2["ok"] is True
+    assert fake2.calls[0].updated["status"] == "published"
+
+
+async def test_owner_update_not_found_returns_not_ok():
+    svc, _ = _service_with([])  # no row matched
+    result = await svc.dismiss(user_id="o", signal_id="missing")
+    assert result["ok"] is False
+    assert result["reason"] == "not_found"

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -319,6 +319,21 @@
       "expected_row_growth": "medium_per_user_request"
     },
     {
+      "id": "information_marketplace_opportunity_signals",
+      "owner": "iam-consent-governance",
+      "data_class": "workflow_state",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "marketplace_opportunity_signals"
+      ],
+      "primary_access_path": "One Information Marketplace proactive opportunity nudges: the server derives dateless intent signals from the owner's publishable-slice metadata (and the client may post dated expiry signals), surfaced as flashcards on Agent One where the owner publishes, snoozes, or dismisses them; state is read and mutated server-side per owner.",
+      "retention_policy": "One durable row per owner+dedupe_key; snoozed rows reappear the next day, published/dismissed/expired rows are retained for lifecycle idempotency and bounded operational review before compaction.",
+      "deletion_behavior": "Delete rows where the deleting account is the owner (user_id); no cross-account references exist.",
+      "trust_boundary": "Backend stores only safe signal metadata (title, body, domain, scope handle, suggested price, nudge lifecycle state, timestamps) derived from summary projections. It never stores raw PKM values; dated expiry details are client-derived and posted as safe summaries only.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "low_per_user_signal"
+    },
+    {
       "id": "market_reference_and_cache",
       "owner": "backend-runtime-governance",
       "data_class": "reference",

--- a/hushh-webapp/__tests__/services/unlock-warm-orchestrator.test.ts
+++ b/hushh-webapp/__tests__/services/unlock-warm-orchestrator.test.ts
@@ -130,6 +130,15 @@ vi.mock("@/lib/utils/portfolio-normalize", () => ({
   normalizeStoredPortfolio: vi.fn((raw: unknown) => raw),
 }));
 
+// Mock the One Location recipient key bootstrap: run() fires this fire-and-forget
+// (queueLocationRecipientKeyBootstrap). Left unmocked, the real implementation
+// rejects with "Location key storage is unavailable on this device." after the
+// test completes, and its console.warn lands during worker teardown -> Vitest
+// EnvironmentTeardownError ("Closing rpc while onUserConsoleLog was pending").
+vi.mock("@/lib/one-location/key-bootstrap", () => ({
+  bootstrapCurrentUserLocationRecipientKey: vi.fn(() => Promise.resolve()),
+}));
+
 import {
   UnlockWarmOrchestrator,
 } from "@/lib/services/unlock-warm-orchestrator";

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -43,6 +43,7 @@ import {
 import { MarketplaceChatPanel } from "@/components/one-marketplace/marketplace-chat-panel";
 import {
   OneMarketplaceService,
+  type AvailableListing,
   type MarketplaceRequest,
   type PublishableSlice,
 } from "@/lib/one-marketplace/service";
@@ -378,6 +379,24 @@ function PriceLine({
   );
 }
 
+/** Expander for an anonymized listing's published safe-summary preview. Renders
+ * the owner's own published presentation payload — no owner identity, no raw data. */
+function ListingPreviewToggle({ presentation }: { presentation: PkmSectionPreviewPresentation }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-3">
+      <Button type="button" size="sm" variant="none" effect="fade" onClick={() => setOpen((v) => !v)}>
+        {open ? "Hide preview" : "Preview safe summary"}
+      </Button>
+      {open ? (
+        <div className="mt-2">
+          <PkmSectionPreview presentation={presentation} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export default function OneMarketplacePage() {
   const router = useRouter();
   const { user } = useAuth();
@@ -387,7 +406,11 @@ export default function OneMarketplacePage() {
   const [view, setView] = useState<MarketplaceView>("owner");
   const [power, setPower] = useState<PricingPower>("affluent");
   const [mood, setMood] = useState<PricingMood>("affinity");
-  const [purchaseSection, setPurchaseSection] = useState<Section | null>(null);
+  // Buyer directory — the anonymized cross-user catalog of published slices. The
+  // listing the buyer is about to request (consent-first confirm), or null.
+  const [listings, setListings] = useState<AvailableListing[]>([]);
+  const [listingsLoading, setListingsLoading] = useState(false);
+  const [requestListing, setRequestListing] = useState<AvailableListing | null>(null);
   // Owner is about to publish this section to the marketplace and must explicitly
   // consent first (consent-first). Null when no confirmation is pending.
   const [confirmPublish, setConfirmPublish] = useState<Section | null>(null);
@@ -414,6 +437,24 @@ export default function OneMarketplacePage() {
   useEffect(() => {
     void loadRequests();
   }, [loadRequests, refreshToken]);
+
+  // Load the anonymized cross-user Buyer directory (other users' published slices).
+  const loadListings = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    setListingsLoading(true);
+    try {
+      const rows = await OneMarketplaceService.listAvailable({ vaultOwnerToken });
+      setListings(rows);
+    } catch {
+      // Non-fatal: keep the current directory until the next refresh.
+    } finally {
+      setListingsLoading(false);
+    }
+  }, [vaultOwnerToken]);
+
+  useEffect(() => {
+    if (view === "buyer") void loadListings();
+  }, [view, loadListings, refreshToken]);
 
   // Load the owner's real PKM domains + manifests. The scope registry on each
   // manifest is the source of shareable sections and their consent posture.
@@ -663,10 +704,6 @@ export default function OneMarketplacePage() {
     [runPosture]
   );
 
-  const availableSections = sections.filter(
-    (s) => s.permission.visibilityPosture === "default_available"
-  );
-
   const pendingRequestCount = requests.filter((r) => r.status === "pending").length;
 
   // Identity keys of slices already published — the chat publish card filters
@@ -696,46 +733,30 @@ export default function OneMarketplacePage() {
     [sections, onTogglePosture]
   );
 
-  // File a real, durable access request (server-side). The buyer is simulated by
-  // the owner in this tab; the record persists and survives refresh.
-  const confirmPurchase = useCallback(() => {
-    const current = purchaseSection;
-    if (!current || !vaultOwnerToken) {
-      setPurchaseSection(null);
+  // File a REAL cross-account access request against the listing's true owner
+  // (resolved server-side from the opaque listingId). The record lands in the
+  // owner's inbox — this is a two-account request, not a simulated one.
+  const confirmRequestListing = useCallback(() => {
+    const listing = requestListing;
+    if (!listing || !vaultOwnerToken) {
+      setRequestListing(null);
       return;
     }
-    setPurchaseSection(null);
+    setRequestListing(null);
     void (async () => {
-      let priceCents = 0;
-      let currency = "USD";
       try {
-        const price = await SlicePricingService.getSuggestedPrice(
-          priceInput(current),
-          vaultOwnerToken
-        );
-        priceCents = price.suggestedPriceCents;
-        currency = price.currency;
-      } catch {
-        // Price is best-effort; the request still files at the floor.
-      }
-      try {
-        await OneMarketplaceService.createRequest({
+        await OneMarketplaceService.requestListing({
           vaultOwnerToken,
-          sliceName: current.permission.label,
-          domain: current.domainKey,
-          scopeHandle: current.permission.scopeHandle,
-          buyerLabel: "Buyer",
-          priceCents,
-          currency,
+          listingId: listing.listingId,
         });
         await loadRequests();
         setView("flow");
-        toast.success("Request filed — see Flow & requests.");
+        toast.success("Request filed — the owner will approve or deny it.");
       } catch {
         toast.error("Couldn't file the request. Try again.");
       }
     })();
-  }, [purchaseSection, vaultOwnerToken, priceInput, loadRequests]);
+  }, [requestListing, vaultOwnerToken, loadRequests]);
 
   const approveRequest = useCallback(
     async (id: string) => {
@@ -963,38 +984,46 @@ export default function OneMarketplacePage() {
             </div>
           ) : null}
 
-          {/* BUYER — available slices, purchasable */}
+          {/* BUYER — the anonymized cross-user directory of published slices */}
           {view === "buyer" ? (
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                Slices available to buy — only the safe summary, never raw data. Purchase grants 30-day
-                scoped access, and it is only ever delivered after the owner approves your request.
+                Slices other people have published — only the safe summary, never raw data, and the
+                seller stays anonymous. Requesting access files a request the owner must approve;
+                nothing is delivered until they say yes.
               </p>
-              {availableSections.length === 0 ? (
+              {listingsLoading && listings.length === 0 ? (
+                <div className="rounded-2xl border p-6 text-center text-sm text-muted-foreground">
+                  Loading the marketplace directory…
+                </div>
+              ) : listings.length === 0 ? (
                 <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
                   <Store className="mx-auto mb-2 h-6 w-6 opacity-60" aria-hidden />
-                  Nothing on the market yet. In the <span className="font-medium text-foreground">Owner</span>{" "}
-                  tab, set a section to <span className="font-medium text-foreground">Available</span> and it
-                  will list here to buy.
+                  Nothing on the market yet. When other people set a section to{" "}
+                  <span className="font-medium text-foreground">Available</span>, their anonymized slice
+                  lists here to request.
                 </div>
               ) : (
                 <div className="grid gap-4 sm:grid-cols-2">
-                  {availableSections.map((section) => (
-                    <div key={section.key} className="flex flex-col rounded-2xl border p-5">
+                  {listings.map((listing) => (
+                    <div key={listing.listingId} className="flex flex-col rounded-2xl border p-5">
                       <div className="flex items-center gap-2">
                         <span className="rounded-full bg-emerald-500/12 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
                           available
                         </span>
-                        <span className="text-xs text-muted-foreground">{section.domainTitle}</span>
+                        <span className="text-xs text-muted-foreground">{listing.domainTitle}</span>
                       </div>
-                      <div className="mt-2 text-lg font-semibold">{section.permission.label}</div>
+                      <div className="mt-2 text-lg font-semibold">{listing.label}</div>
                       <div className="mt-0.5 text-sm text-muted-foreground">
-                        {attributeCountFor(section.manifest, section.permission.scopeHandle)} attribute
-                        {attributeCountFor(section.manifest, section.permission.scopeHandle) === 1 ? "" : "s"}{" "}
-                        · safe summary
+                        {listing.attributeCount} attribute{listing.attributeCount === 1 ? "" : "s"} · safe
+                        summary · seller{" "}
+                        <span className="font-mono text-xs">{listing.ownerRef}</span>
                       </div>
-                      <div className="mt-4 border-t pt-4">
-                        <PriceLine input={priceInput(section)} token={token} showMath />
+                      <div className="mt-4 flex items-center justify-between gap-3 border-t pt-4">
+                        <div className="text-2xl font-semibold tracking-tight">
+                          {formatCents(listing.suggestedPriceCents, listing.currency)}{" "}
+                          <span className="text-sm font-medium text-muted-foreground">/ 30 days</span>
+                        </div>
                       </div>
                       <Button
                         type="button"
@@ -1002,21 +1031,13 @@ export default function OneMarketplacePage() {
                         variant="none"
                         effect="fade"
                         className="mt-4 self-start"
-                        onClick={() => setPurchaseSection(section)}
+                        onClick={() => setRequestListing(listing)}
                       >
-                        Purchase 30-day access
+                        Request 30-day access
                       </Button>
-                      <PreviewToggle
-                        columnsOnly
-                        userId={user?.uid}
-                        vaultKey={vaultKey}
-                        token={token}
-                        domainKey={section.domainKey}
-                        domainTitle={section.domainTitle}
-                        topLevelScopePath={section.permission.topLevelScopePath}
-                        label={section.permission.label}
-                        description={section.permission.description}
-                      />
+                      {listing.preview ? (
+                        <ListingPreviewToggle presentation={listing.preview} />
+                      ) : null}
                     </div>
                   ))}
                 </div>
@@ -1154,28 +1175,28 @@ export default function OneMarketplacePage() {
         </>
       )}
 
-      {/* PURCHASE CONFIRM MODAL */}
-      {purchaseSection ? (
+      {/* REQUEST ACCESS CONFIRM MODAL — real cross-account request */}
+      {requestListing ? (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
           onClick={(e) => {
-            if (e.target === e.currentTarget) setPurchaseSection(null);
+            if (e.target === e.currentTarget) setRequestListing(null);
           }}
         >
           <div className="w-full max-w-md rounded-2xl border bg-background p-6 shadow-xl">
             <div className="text-lg font-semibold">
-              Purchase — {purchaseSection.permission.label}
+              Request access — {requestListing.label}
             </div>
             <p className="mt-2 text-sm text-muted-foreground">
-              You’re buying <span className="font-medium text-foreground">30-day scoped access</span> to the
-              safe summary of{" "}
-              <span className="font-medium text-foreground">{purchaseSection.permission.label}</span>. This
-              files a request the owner must approve — nothing is shared until they say yes.
+              You’re requesting <span className="font-medium text-foreground">30-day scoped access</span> to
+              the safe summary of{" "}
+              <span className="font-medium text-foreground">{requestListing.label}</span> from seller{" "}
+              <span className="font-mono text-xs">{requestListing.ownerRef}</span>. This files a request the
+              owner must approve — nothing is shared until they say yes.
             </p>
             <p className="mt-2 text-xs text-muted-foreground">
-              Consent-first by design. The request appears under{" "}
-              <span className="font-medium text-foreground">Flow &amp; requests</span>. No money moves —
-              payment settlement is a later phase.
+              Consent-first by design. The request lands in the owner’s inbox. No money moves — payment
+              settlement is a later phase.
             </p>
             <div className="mt-4 flex justify-end gap-2">
               <Button
@@ -1183,11 +1204,17 @@ export default function OneMarketplacePage() {
                 size="sm"
                 variant="none"
                 effect="fade"
-                onClick={() => setPurchaseSection(null)}
+                onClick={() => setRequestListing(null)}
               >
                 Cancel
               </Button>
-              <Button type="button" size="sm" variant="none" effect="fade" onClick={confirmPurchase}>
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                onClick={confirmRequestListing}
+              >
                 Confirm request
               </Button>
             </div>

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -46,6 +46,7 @@ import {
   type SpecialistPendingConsentRequestItem,
 } from "@/components/agent/specialist-directive-card";
 import { MarketplacePublishDirectiveCard } from "@/components/agent/marketplace-publish-directive-card";
+import { OpportunityNudgeStack } from "@/components/agent/opportunity-nudge-card";
 import { SelectionChip } from "@/components/agent/selection-chip";
 import { describeSelection } from "@/lib/agent/describe-selection";
 import type { PublishableSlice } from "@/lib/one-marketplace/service";
@@ -4166,6 +4167,15 @@ export function AgentChatWorkspace({
                   onDismiss={() => handleDismissPkmReview(review.id)}
                 />
               ))}
+
+              {hasChatAccess ? (
+                <OpportunityNudgeStack
+                  userId={user?.uid ?? null}
+                  vaultOwnerToken={vaultOwnerToken}
+                  vaultKey={vaultKey}
+                  onRequireUnlock={() => setVaultDialogOpen(true)}
+                />
+              ) : null}
 
               {pendingSpecialistDirective ? (
                 getConsentRequiredPayload(pendingSpecialistDirective) ? (

--- a/hushh-webapp/components/agent/opportunity-nudge-card.tsx
+++ b/hushh-webapp/components/agent/opportunity-nudge-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CalendarClock, Sparkles } from "lucide-react";
+import { CalendarClock, Inbox, Sparkles } from "lucide-react";
 
 import { Button, morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { formatCents } from "@/lib/services/slice-pricing-service";
@@ -11,6 +11,19 @@ import {
   OneOpportunityService,
   type OpportunitySignal,
 } from "@/lib/one-marketplace/opportunity-service";
+import {
+  OneMarketplaceService,
+  type MarketplaceRequest,
+} from "@/lib/one-marketplace/service";
+
+/** Honest posture until a payment rail exists: approving grants access, not money. */
+function PaymentsComingSoonChip() {
+  return (
+    <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+      Payments coming soon
+    </span>
+  );
+}
 
 /**
  * Proactive Information Marketplace flashcards on Agent One. Unlike the derived-
@@ -107,9 +120,74 @@ function OpportunityNudgeCard({
 }
 
 /**
- * On-open stack of due opportunity signals. Self-fetching (like GmailNudgesSection)
- * so the workspace only has to render it; renders nothing until there is at least
- * one due signal. Vault-token gated — no Firebase id-token.
+ * A real buyer asking to access a published slice (durable request, migration
+ * 076). This is the demand half of the loop: publish → a buyer requests → the
+ * owner approves here. Consent-first — approving grants scoped access to the safe
+ * summary only, and NO money moves (payments are coming soon), so the card never
+ * promises a payout.
+ */
+function BuyerRequestCard({
+  request,
+  busy,
+  onApprove,
+  onDecline,
+}: {
+  request: MarketplaceRequest;
+  busy: boolean;
+  onApprove: (request: MarketplaceRequest) => void;
+  onDecline: (request: MarketplaceRequest) => void;
+}) {
+  const buyer = request.buyerLabel?.trim() || "A buyer";
+  const price = request.priceCents
+    ? formatCents(request.priceCents, request.currency ?? "USD")
+    : null;
+
+  return (
+    <div className="rounded-2xl border border-sky-300/50 bg-sky-50/50 p-3 dark:border-sky-900/40 dark:bg-sky-950/15">
+      <div className="mb-1 flex items-center gap-2 text-sm font-semibold text-sky-900 dark:text-sky-200">
+        <Inbox className="h-4 w-4 shrink-0" aria-hidden />
+        <span className="min-w-0">{buyer} wants access</span>
+      </div>
+      <p className="mb-2 text-xs text-sky-900/80 dark:text-sky-200/70">
+        {request.sliceName}
+        {request.message ? <span className="italic"> — “{request.message}”</span> : null}
+      </p>
+      <div className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+        {price ? <span>suggested ~{price}/mo</span> : null}
+        <PaymentsComingSoonChip />
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          size="sm"
+          variant="none"
+          effect="fade"
+          disabled={busy}
+          onClick={() => onApprove(request)}
+        >
+          {busy ? "Approving…" : "Approve access"}
+        </Button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onDecline(request)}
+          className="text-xs font-medium text-muted-foreground hover:underline disabled:opacity-50"
+        >
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * On-open stack of due opportunity signals plus pending buyer requests.
+ * Self-fetching (like GmailNudgesSection) so the workspace only has to render it;
+ * renders nothing until there is at least one buyer request or due signal.
+ * Vault-token gated — no Firebase id-token.
+ *
+ * Order: buyer requests first (real demand to act on), then publish
+ * opportunities (things to put up for offers).
  */
 export function OpportunityNudgeStack({
   userId,
@@ -124,6 +202,7 @@ export function OpportunityNudgeStack({
   onRequireUnlock: () => void;
 }) {
   const [signals, setSignals] = useState<OpportunitySignal[]>([]);
+  const [requests, setRequests] = useState<MarketplaceRequest[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
   const loadKeyRef = useRef<string | null>(null);
 
@@ -131,13 +210,21 @@ export function OpportunityNudgeStack({
 
   const load = useCallback(async () => {
     if (!vaultOwnerToken) return;
-    try {
-      const due = await OneOpportunityService.listDue({ vaultOwnerToken });
-      setSignals(due.filter((s) => s.status === "active" || s.status === "snoozed"));
-    } catch {
-      // A nudge fetch failing is non-fatal — just show nothing this open.
-      setSignals([]);
-    }
+    // Fetch both halves independently so one failing doesn't blank the other.
+    const [dueResult, requestResult] = await Promise.allSettled([
+      OneOpportunityService.listDue({ vaultOwnerToken }),
+      OneMarketplaceService.listRequests({ vaultOwnerToken, status: "pending" }),
+    ]);
+    setSignals(
+      dueResult.status === "fulfilled"
+        ? dueResult.value.filter((s) => s.status === "active" || s.status === "snoozed")
+        : [],
+    );
+    setRequests(
+      requestResult.status === "fulfilled"
+        ? requestResult.value.filter((r) => r.status === "pending")
+        : [],
+    );
   }, [vaultOwnerToken]);
 
   useEffect(() => {
@@ -155,6 +242,48 @@ export function OpportunityNudgeStack({
       void load();
     },
     [load],
+  );
+
+  const removeRequestAndRefresh = useCallback(
+    (requestId: string) => {
+      setRequests((current) => current.filter((r) => r.id !== requestId));
+      void load();
+    },
+    [load],
+  );
+
+  const handleApproveRequest = useCallback(
+    async (request: MarketplaceRequest) => {
+      if (!vaultOwnerToken) return;
+      setBusyId(request.id);
+      try {
+        await OneMarketplaceService.approveRequest({ vaultOwnerToken, requestId: request.id });
+        // Honest: access is granted, but no money moves yet.
+        toast.success("Approved — buyer now has access. Payouts are coming soon.");
+        removeRequestAndRefresh(request.id);
+      } catch {
+        toast.error("Couldn't approve this request.");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [vaultOwnerToken, removeRequestAndRefresh],
+  );
+
+  const handleDeclineRequest = useCallback(
+    async (request: MarketplaceRequest) => {
+      if (!vaultOwnerToken) return;
+      setBusyId(request.id);
+      try {
+        await OneMarketplaceService.denyRequest({ vaultOwnerToken, requestId: request.id });
+        removeRequestAndRefresh(request.id);
+      } catch {
+        toast.error("Couldn't decline this request.");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [vaultOwnerToken, removeRequestAndRefresh],
   );
 
   const handlePublish = useCallback(
@@ -252,13 +381,22 @@ export function OpportunityNudgeStack({
     [vaultOwnerToken, removeAndRefresh],
   );
 
-  if (signals.length === 0) return null;
+  if (signals.length === 0 && requests.length === 0) return null;
 
   return (
     <div className="space-y-2">
       <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
         Marketplace opportunities
       </p>
+      {requests.map((request) => (
+        <BuyerRequestCard
+          key={request.id}
+          request={request}
+          busy={busyId === request.id}
+          onApprove={handleApproveRequest}
+          onDecline={handleDeclineRequest}
+        />
+      ))}
       {signals.map((signal) => (
         <OpportunityNudgeCard
           key={signal.id}

--- a/hushh-webapp/components/agent/opportunity-nudge-card.tsx
+++ b/hushh-webapp/components/agent/opportunity-nudge-card.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CalendarClock, Sparkles } from "lucide-react";
+
+import { Button, morphyToast as toast } from "@/lib/morphy-ux/morphy";
+import { formatCents } from "@/lib/services/slice-pricing-service";
+import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge-model-service";
+import { applySlicePosture } from "@/lib/personal-knowledge-model/slice-publishing";
+import {
+  OneOpportunityService,
+  type OpportunitySignal,
+} from "@/lib/one-marketplace/opportunity-service";
+
+/**
+ * Proactive Information Marketplace flashcards on Agent One. Unlike the derived-
+ * fresh nudges elsewhere (Gmail, Location), these are durable signals (migration
+ * 077) with a persisted lifecycle: "Remind me later" snoozes to tomorrow, Dismiss
+ * hides for good, and "Publish for offers" runs the real consent-first posture
+ * flow then records the signal as published — all surviving reloads and days.
+ *
+ * The whole loop the Information Marketplace promises starts here: open Agent One
+ * → a card greets you → publish → buyers can reach you.
+ */
+
+function relativeDay(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const days = Math.round((then - Date.now()) / 86_400_000);
+  if (days <= 0) return "soon";
+  if (days === 1) return "tomorrow";
+  if (days < 30) return `in ${days} days`;
+  const months = Math.round(days / 30);
+  return months === 1 ? "in a month" : `in ${months} months`;
+}
+
+function OpportunityNudgeCard({
+  signal,
+  busy,
+  onPublish,
+  onSnooze,
+  onDismiss,
+}: {
+  signal: OpportunitySignal;
+  busy: boolean;
+  onPublish: (signal: OpportunitySignal) => void;
+  onSnooze: (signal: OpportunitySignal) => void;
+  onDismiss: (signal: OpportunitySignal) => void;
+}) {
+  const isExpiry = signal.kind === "expiry";
+  const when = isExpiry ? relativeDay(signal.eventDate) : null;
+  const price = signal.suggestedPriceCents
+    ? formatCents(signal.suggestedPriceCents, signal.currency ?? "USD")
+    : null;
+
+  return (
+    <div className="rounded-2xl border border-emerald-300/50 bg-emerald-50/50 p-3 dark:border-emerald-900/40 dark:bg-emerald-950/15">
+      <div className="mb-1 flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+        {isExpiry ? (
+          <CalendarClock className="h-4 w-4 shrink-0" aria-hidden />
+        ) : (
+          <Sparkles className="h-4 w-4 shrink-0" aria-hidden />
+        )}
+        <span className="min-w-0">{signal.title}</span>
+      </div>
+      {signal.body ? (
+        <p className="mb-2 text-xs text-emerald-900/80 dark:text-emerald-200/70">{signal.body}</p>
+      ) : null}
+      <div className="mb-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">
+          {signal.metadata?.domainTitle ?? signal.domain}
+        </span>
+        {when ? <span>· {when}</span> : null}
+        {price ? <span>· ~{price}/mo</span> : null}
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          size="sm"
+          variant="none"
+          effect="fade"
+          disabled={busy}
+          onClick={() => onPublish(signal)}
+        >
+          {busy ? "Publishing…" : "Publish for offers"}
+        </Button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onSnooze(signal)}
+          className="text-xs font-medium text-emerald-700/80 hover:underline disabled:opacity-50 dark:text-emerald-300/80"
+        >
+          Remind me later
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => onDismiss(signal)}
+          className="text-xs font-medium text-muted-foreground hover:underline disabled:opacity-50"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * On-open stack of due opportunity signals. Self-fetching (like GmailNudgesSection)
+ * so the workspace only has to render it; renders nothing until there is at least
+ * one due signal. Vault-token gated — no Firebase id-token.
+ */
+export function OpportunityNudgeStack({
+  userId,
+  vaultOwnerToken,
+  vaultKey,
+  onRequireUnlock,
+}: {
+  userId: string | null;
+  vaultOwnerToken: string | null;
+  vaultKey: string | null;
+  /** Just-in-time vault unlock when a publish is requested while the vault is locked. */
+  onRequireUnlock: () => void;
+}) {
+  const [signals, setSignals] = useState<OpportunitySignal[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const loadKeyRef = useRef<string | null>(null);
+
+  const canLoad = Boolean(userId && vaultOwnerToken);
+
+  const load = useCallback(async () => {
+    if (!vaultOwnerToken) return;
+    try {
+      const due = await OneOpportunityService.listDue({ vaultOwnerToken });
+      setSignals(due.filter((s) => s.status === "active" || s.status === "snoozed"));
+    } catch {
+      // A nudge fetch failing is non-fatal — just show nothing this open.
+      setSignals([]);
+    }
+  }, [vaultOwnerToken]);
+
+  useEffect(() => {
+    if (!canLoad || !userId || !vaultOwnerToken) return;
+    const key = `${userId}:${vaultOwnerToken.slice(0, 12)}`;
+    if (loadKeyRef.current === key) return;
+    loadKeyRef.current = key;
+    void load();
+  }, [canLoad, userId, vaultOwnerToken, load]);
+
+  // Optimistically drop a handled card, then refetch to reconcile with the server.
+  const removeAndRefresh = useCallback(
+    (signalId: string) => {
+      setSignals((current) => current.filter((s) => s.id !== signalId));
+      void load();
+    },
+    [load],
+  );
+
+  const handlePublish = useCallback(
+    async (signal: OpportunitySignal) => {
+      if (!userId || !vaultOwnerToken) return;
+      if (!vaultKey) {
+        // Vault locked — bounce to the just-in-time unlock; the card stays put so
+        // the user can retry publishing once unlocked.
+        onRequireUnlock();
+        return;
+      }
+      const topLevelScopePath = signal.metadata?.topLevelScopePath;
+      if (!topLevelScopePath) {
+        toast.error("This opportunity can't be published automatically yet.");
+        return;
+      }
+      setBusyId(signal.id);
+      try {
+        const previousManifest = await PersonalKnowledgeModelService.getDomainManifest(
+          userId,
+          signal.domain,
+          vaultOwnerToken,
+          true,
+        );
+        if (!previousManifest) {
+          throw new Error("Couldn't load your data to publish this section.");
+        }
+        await applySlicePosture({
+          userId,
+          domain: signal.domain,
+          domainTitle: signal.metadata?.domainTitle ?? signal.domain,
+          permission: {
+            scopeHandle: signal.scopeHandle ?? signal.metadata?.scopeHandle ?? null,
+            label: signal.metadata?.label ?? signal.title,
+            description: null,
+            topLevelScopePath,
+          },
+          nextPosture: "default_available",
+          previousManifest,
+          vaultKey,
+          vaultOwnerToken,
+          source: "opportunity_nudge",
+          // The card IS the owner's explicit consent to publish; forward it so the
+          // backend can expose restricted-tier personal data (structural keys are
+          // still hard-blocked server-side).
+          ownerConsentOverride: true,
+        });
+        // Record the transition so this signal stops resurfacing. Best-effort —
+        // the publish already succeeded, so don't fail the flow if this hiccups.
+        await OneOpportunityService.markPublished({
+          vaultOwnerToken,
+          signalId: signal.id,
+        }).catch(() => {});
+        toast.success("Published — buyers can now reach you with offers.");
+        removeAndRefresh(signal.id);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Couldn't publish this section.");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [userId, vaultOwnerToken, vaultKey, onRequireUnlock, removeAndRefresh],
+  );
+
+  const handleSnooze = useCallback(
+    async (signal: OpportunitySignal) => {
+      if (!vaultOwnerToken) return;
+      setBusyId(signal.id);
+      try {
+        await OneOpportunityService.snooze({ vaultOwnerToken, signalId: signal.id });
+        toast.success("Reminder set — this will come back tomorrow.");
+        removeAndRefresh(signal.id);
+      } catch {
+        toast.error("Couldn't snooze this reminder.");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [vaultOwnerToken, removeAndRefresh],
+  );
+
+  const handleDismiss = useCallback(
+    async (signal: OpportunitySignal) => {
+      if (!vaultOwnerToken) return;
+      setBusyId(signal.id);
+      try {
+        await OneOpportunityService.dismiss({ vaultOwnerToken, signalId: signal.id });
+        removeAndRefresh(signal.id);
+      } catch {
+        toast.error("Couldn't dismiss this.");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [vaultOwnerToken, removeAndRefresh],
+  );
+
+  if (signals.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        Marketplace opportunities
+      </p>
+      {signals.map((signal) => (
+        <OpportunityNudgeCard
+          key={signal.id}
+          signal={signal}
+          busy={busyId === signal.id}
+          onPublish={handlePublish}
+          onSnooze={handleSnooze}
+          onDismiss={handleDismiss}
+        />
+      ))}
+    </div>
+  );
+}

--- a/hushh-webapp/components/agent/opportunity-nudge-card.tsx
+++ b/hushh-webapp/components/agent/opportunity-nudge-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CalendarClock, Inbox, Sparkles } from "lucide-react";
+import { CalendarClock, Inbox } from "lucide-react";
 
 import { Button, morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { formatCents } from "@/lib/services/slice-pricing-service";
@@ -70,11 +70,7 @@ function OpportunityNudgeCard({
   return (
     <div className="rounded-2xl border border-emerald-300/50 bg-emerald-50/50 p-3 dark:border-emerald-900/40 dark:bg-emerald-950/15">
       <div className="mb-1 flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
-        {isExpiry ? (
-          <CalendarClock className="h-4 w-4 shrink-0" aria-hidden />
-        ) : (
-          <Sparkles className="h-4 w-4 shrink-0" aria-hidden />
-        )}
+        {isExpiry ? <CalendarClock className="h-4 w-4 shrink-0" aria-hidden /> : null}
         <span className="min-w-0">{signal.title}</span>
       </div>
       {signal.body ? (

--- a/hushh-webapp/components/one-marketplace/marketplace-chat-panel.tsx
+++ b/hushh-webapp/components/one-marketplace/marketplace-chat-panel.tsx
@@ -16,7 +16,6 @@ import { MarketplaceSuggestionChips } from "./marketplace-chat-suggestions";
 import { useMarketplaceChat } from "./use-marketplace-chat";
 import type { PublishableSlice } from "@/lib/one-marketplace/service";
 import { formatCents } from "@/lib/services/slice-pricing-service";
-import { Sparkles } from "lucide-react";
 
 /**
  * The Information Marketplace chat panel — the marketplace's conversational
@@ -126,7 +125,6 @@ export function MarketplaceChatPanel(props: {
           className="mb-3 rounded-2xl border border-emerald-300/50 bg-emerald-50/50 p-3 dark:border-emerald-900/40 dark:bg-emerald-950/15"
         >
           <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
-            <Sparkles className="h-4 w-4" aria-hidden />
             {chat.publishCard.topic
               ? `Publish your ${chat.publishCard.topic} data for offers?`
               : "Publish these for offers?"}

--- a/hushh-webapp/lib/one-marketplace/opportunity-service.ts
+++ b/hushh-webapp/lib/one-marketplace/opportunity-service.ts
@@ -1,0 +1,147 @@
+import { apiJson } from "@/lib/services/api-client";
+
+/**
+ * A durable Information Marketplace opportunity signal (migration 077).
+ *
+ * Unlike every other nudge in the app (Gmail, Location), which is derived fresh
+ * on load and forgotten on reload, a signal is a real server record with a
+ * persisted lifecycle: snooze ("remind me later" → reappears next day), dismiss,
+ * or mark published — and that state survives reloads and days.
+ */
+export interface OpportunitySignal {
+  id: string;
+  userId?: string;
+  kind: "expiry" | "intent";
+  domain: string;
+  scopeHandle?: string | null;
+  title: string;
+  body?: string | null;
+  eventDate?: string | null;
+  suggestedPriceCents?: number;
+  currency?: string;
+  source: "derived" | "authored";
+  status: "active" | "snoozed" | "published" | "dismissed" | "expired";
+  snoozedUntil?: string | null;
+  dedupeKey?: string;
+  showCount?: number;
+  /** Publish-CTA targeting data persisted by the server (topLevelScopePath, etc.). */
+  metadata?: {
+    topLevelScopePath?: string | null;
+    scopeHandle?: string | null;
+    label?: string | null;
+    domainTitle?: string | null;
+    [key: string]: unknown;
+  };
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function jsonAuthHeaders(vaultOwnerToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${vaultOwnerToken}`,
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * Client for durable opportunity signals — the proactive Information Marketplace
+ * flashcards surfaced on Agent One. Owner-scoped: every call is gated on the
+ * vault-owner token (no Firebase id-token). The lifecycle mutations mirror the
+ * server routes at /api/one/marketplace/opportunities.
+ */
+export class OneOpportunityService {
+  /**
+   * Signals due to show now (active, or snoozed with the snooze elapsed). The
+   * server also derives fresh `intent` signals and expires past-dated ones on
+   * this read, so the caller just gets the current, honest set.
+   */
+  static async listDue(params: {
+    vaultOwnerToken: string;
+  }): Promise<OpportunitySignal[]> {
+    const res = await apiJson<{ opportunities: OpportunitySignal[] }>(
+      "/api/one/marketplace/opportunities",
+      { headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+    return res.opportunities ?? [];
+  }
+
+  /** Remind me later: hide the signal until the given day count (default tomorrow). */
+  static async snooze(params: {
+    vaultOwnerToken: string;
+    signalId: string;
+    untilDays?: number;
+  }): Promise<void> {
+    await apiJson(
+      `/api/one/marketplace/opportunities/${encodeURIComponent(params.signalId)}/snooze`,
+      {
+        method: "POST",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({ untilDays: params.untilDays ?? 1 }),
+      },
+    );
+  }
+
+  static async dismiss(params: {
+    vaultOwnerToken: string;
+    signalId: string;
+  }): Promise<void> {
+    await apiJson(
+      `/api/one/marketplace/opportunities/${encodeURIComponent(params.signalId)}/dismiss`,
+      { method: "POST", headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+  }
+
+  /**
+   * Record that the owner published the slice this signal pointed at. Consent-first:
+   * this only transitions the signal so it stops resurfacing — the actual publish
+   * runs through the normal owner-driven posture flow (applySlicePosture) first.
+   */
+  static async markPublished(params: {
+    vaultOwnerToken: string;
+    signalId: string;
+  }): Promise<void> {
+    await apiJson(
+      `/api/one/marketplace/opportunities/${encodeURIComponent(params.signalId)}/publish`,
+      { method: "POST", headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+  }
+
+  /**
+   * Author a signal directly (source="authored"). Used to seed a "save a memory"
+   * opportunity and, later, for client-derived dated `expiry` signals.
+   */
+  static async author(params: {
+    vaultOwnerToken: string;
+    kind: "expiry" | "intent";
+    domain: string;
+    title: string;
+    dedupeKey: string;
+    scopeHandle?: string | null;
+    body?: string | null;
+    eventDate?: string | null;
+    suggestedPriceCents?: number;
+    currency?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<OpportunitySignal> {
+    const res = await apiJson<{ opportunity: OpportunitySignal }>(
+      "/api/one/marketplace/opportunities",
+      {
+        method: "POST",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({
+          kind: params.kind,
+          domain: params.domain,
+          title: params.title,
+          dedupeKey: params.dedupeKey,
+          scopeHandle: params.scopeHandle ?? null,
+          body: params.body ?? null,
+          eventDate: params.eventDate ?? null,
+          suggestedPriceCents: params.suggestedPriceCents ?? 0,
+          currency: params.currency ?? "USD",
+          metadata: params.metadata ?? {},
+        }),
+      },
+    );
+    return res.opportunity;
+  }
+}

--- a/hushh-webapp/lib/one-marketplace/service.ts
+++ b/hushh-webapp/lib/one-marketplace/service.ts
@@ -1,4 +1,5 @@
 import { apiJson } from "@/lib/services/api-client";
+import { type PkmSectionPreviewPresentation } from "@/lib/profile/pkm-section-preview";
 
 /** A durable Information Marketplace access request (migration 075). */
 export interface MarketplaceRequest {
@@ -26,6 +27,25 @@ export interface PublishableSlice {
   scopeHandle?: string | null;
   suggestedPriceCents?: number;
   currency?: string;
+}
+
+/**
+ * One anonymized listing in the cross-user Buyer directory. The owner's identity
+ * is never sent — only a stable opaque `ownerRef` and an opaque `listingId` the
+ * server maps back to the real owner when a request is filed.
+ */
+export interface AvailableListing {
+  listingId: string;
+  ownerRef: string;
+  domain: string;
+  domainTitle: string;
+  label: string;
+  topLevelScopePath: string;
+  attributeCount: number;
+  /** The owner's published safe-summary preview — same detail shown on the owner side. */
+  preview: PkmSectionPreviewPresentation | null;
+  suggestedPriceCents: number;
+  currency: string;
 }
 
 /** Inline "publish for offers?" card the agent can surface in chat. */
@@ -84,6 +104,29 @@ export class OneMarketplaceService {
       { headers: jsonAuthHeaders(params.vaultOwnerToken) },
     );
     return res.requests ?? [];
+  }
+
+  /** Anonymized directory of other users' published slices (Buyer tab). */
+  static async listAvailable(params: {
+    vaultOwnerToken: string;
+  }): Promise<AvailableListing[]> {
+    const res = await apiJson<{ listings: AvailableListing[] }>(
+      "/api/one/marketplace/available",
+      { headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+    return res.listings ?? [];
+  }
+
+  /** File a real cross-account access request against a listing's true owner. */
+  static async requestListing(params: {
+    vaultOwnerToken: string;
+    listingId: string;
+  }): Promise<MarketplaceRequest> {
+    const res = await apiJson<{ request: MarketplaceRequest }>(
+      `/api/one/marketplace/available/${encodeURIComponent(params.listingId)}/request`,
+      { method: "POST", headers: jsonAuthHeaders(params.vaultOwnerToken) },
+    );
+    return res.request;
   }
 
   static async createRequest(params: {


### PR DESCRIPTION
## What & why
Makes the Information Marketplace demand **real and two-account** (no simulated buyer), adds a **proactive opportunity nudge loop** on Agent One, and keeps earnings **honest** (shows real buyer demand, payouts "coming soon"). Includes two correctness fixes found during local verification.

## Highlights
- **Anonymized Buyer directory** — cross-user published slices, opaque `listingId`/`ownerRef`, viewer excluded; real cross-account access requests into the owner's durable inbox (migration 076).
- **Opportunity nudge loop** — migration 077 signal store + server derivation; self-fetching `OpportunityNudgeStack` (Publish / Snooze / Dismiss + buyer-request Approve/Decline).
- **Honest earnings** — `earnings_summary` folds real demand; `payoutsEnabled:false` ("payments coming soon").

## Fixes (from local verification)
- **Privacy:** buyer directory previously shipped the owner's raw published presentation (embedded saved values, e.g. a home address). Now emits field **names + counts only** via a whitelist sanitizer. Regression-tested.
- **Pricing:** subtree scopes (`segment_ids:['root']`) were counted/priced as 1 attribute; now use the published leaf-field count.

## Testing
- `python -m pytest tests/test_marketplace_catalog.py -q` → 13 passed
- Ran locally (proxy + backend + web); all new endpoints 200; verified no raw values leak against the DB.

## Notes
- All commits DCO signed-off. No schema changes beyond migrations 076/077 (077 already applied on UAT).