### PR TITLE
[codex] polish connected systems mobile UI

### DIFF
--- a/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
@@ -110,7 +110,7 @@ describe("ConnectedSystemsPanel", () => {
     );
     expect(screen.getByRole("searchbox", { name: /Search CRM systems/i })).toBeTruthy();
     expect(screen.getByText(/Macy's \/ Contact \/ External CRM MCP/)).toBeTruthy();
-    expect(screen.getByText("5 MCP tools")).toBeTruthy();
+    expect(screen.queryByText(/MCP tools/i)).toBeNull();
     expect(screen.getByAltText("Macy's logo")).toBeTruthy();
     expect(screen.getByAltText("CRM platform logo")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Refresh from Macy's/i })).toBeNull();
@@ -138,7 +138,7 @@ describe("ConnectedSystemsPanel", () => {
     expect(screen.getByAltText("Macy's logo")).toBeTruthy();
     expect(screen.getByAltText("CRM platform logo")).toBeTruthy();
     expect(screen.getByText(/Connected through External CRM MCP/)).toBeTruthy();
-    expect(screen.getByText(/5 MCP tools/)).toBeTruthy();
+    expect(screen.queryByText(/MCP tools/i)).toBeNull();
     expect(screen.queryByText("Registry backed")).toBeNull();
     expect(screen.queryByText(/My Macy's Contact/i)).toBeNull();
     expect(screen.queryByText(/No CRM record is connected/i)).toBeNull();

--- a/hushh-webapp/app/one/connected-systems/[systemId]/connected-system-detail-client.tsx
+++ b/hushh-webapp/app/one/connected-systems/[systemId]/connected-system-detail-client.tsx
@@ -44,7 +44,7 @@ export function ConnectedSystemDetailClient({ systemId }: { systemId: string }) 
     <AppPageShell
       as="main"
       width="standard"
-      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      className="pb-[calc(var(--app-bottom-inset)+var(--kai-command-fixed-ui,82px)+1.25rem)] sm:pb-10 md:pb-8"
       nativeTest={{
         routeId: "/one/connected-systems/[systemId]",
         marker: "native-route-connected-system-detail",

--- a/hushh-webapp/app/one/connected-systems/page.tsx
+++ b/hushh-webapp/app/one/connected-systems/page.tsx
@@ -24,7 +24,7 @@ export default function ConnectedSystemsPage() {
     <AppPageShell
       as="main"
       width="standard"
-      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      className="pb-[calc(var(--app-bottom-inset)+var(--kai-command-fixed-ui,82px)+1.25rem)] sm:pb-10 md:pb-8"
       nativeTest={{
         routeId: "/one/connected-systems",
         marker: "native-route-connected-systems",

--- a/hushh-webapp/components/app-ui/settings-ui.tsx
+++ b/hushh-webapp/components/app-ui/settings-ui.tsx
@@ -186,7 +186,7 @@ export function SettingsRow({
 }) {
   const resolvedAsChild = asChild && isValidElement(children);
   const isInteractive = !disabled && (typeof onClick === "function" || resolvedAsChild);
-  const shouldStackTrailing = stackTrailingOnMobile && Boolean(trailing) && !chevron;
+  const shouldStackTrailing = stackTrailingOnMobile && Boolean(trailing);
   const hasInteractiveTrailing = containsInteractiveNode(trailing);
   const splitPrimaryAction = Boolean(!asChild && onClick && hasInteractiveTrailing);
   const Comp = resolvedAsChild ? Slot.Root : onClick && !splitPrimaryAction ? "button" : "div";
@@ -239,7 +239,7 @@ export function SettingsRow({
         className={cn(
           "relative z-0 flex max-w-full shrink-0 items-center justify-end self-center gap-2.5 pr-0.5 sm:pr-1",
           shouldStackTrailing &&
-            "w-full justify-start pl-[2.65rem] pt-1 sm:w-auto sm:justify-end sm:pl-0 sm:pt-0"
+            "w-full min-w-0 justify-between pl-[var(--settings-row-stack-indent,2.65rem)] pt-1 sm:w-auto sm:justify-end sm:pl-0 sm:pt-0"
         )}
     >
       {trailing}

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -316,7 +316,7 @@ function CrmTypeLogoBadge({ system }: { system?: ConnectedSystemSummary | null }
   const logoSrc = crmTypeLogoSrc(system);
   if (!logoSrc) return null;
   return (
-    <span className="inline-flex h-7 w-20 items-center justify-center rounded-md border border-border/60 bg-white px-2 py-1 shadow-sm">
+    <span className="hidden h-7 w-20 items-center justify-center rounded-md border border-border/60 bg-white px-2 py-1 shadow-sm sm:inline-flex">
       <Image
         src={logoSrc}
         alt="CRM platform logo"
@@ -1479,11 +1479,30 @@ export function ConnectedSystemsPanel({
               <span>
                 {filteredSystems.length} CRM system{filteredSystems.length === 1 ? "" : "s"}
               </span>
-              {filteredSystems.length > CRM_LIST_PAGE_SIZE ? (
-                <span>
-                  Page {normalizedListPage} of {listPageCount}
-                </span>
-              ) : null}
+              <div className="flex items-center gap-2">
+                {filteredSystems.length > CRM_LIST_PAGE_SIZE ? (
+                  <span>
+                    Page {normalizedListPage} of {listPageCount}
+                  </span>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="none"
+                  effect="fade"
+                  size="sm"
+                  disabled={busy !== null}
+                  onClick={() => void refreshSystems()}
+                  aria-label="Refresh CRM systems"
+                  className="h-7 px-2 text-xs"
+                >
+                  <Icon
+                    icon={RefreshCw}
+                    size="xs"
+                    className={busy === "systems" ? "mr-1.5 animate-spin" : "mr-1.5"}
+                  />
+                  Refresh
+                </Button>
+              </div>
             </div>
           </div>
           {systems.length === 0 && busy === "systems" ? (
@@ -1534,18 +1553,16 @@ export function ConnectedSystemsPanel({
                 key={system.systemId}
                 asChild
                 leading={<ConnectedSystemLogo system={system} />}
+                className="[--settings-row-stack-indent:4.75rem]"
                 title={system.displayName || "CRM system"}
                 description={`${systemCustomer} / ${
                   system.objectTypeDefault || "Contact"
                 } / ${system.transportLabel || "External CRM MCP"}`}
                 trailing={
-                  <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
+                  <div className="flex min-w-0 max-w-[calc(100%-1.75rem)] flex-wrap items-center justify-start gap-2 sm:max-w-none sm:justify-end">
                     <CrmTypeLogoBadge system={system} />
                     <Badge variant="secondary">{statusBadge(system.status)}</Badge>
                     {typeLabel ? <Badge variant="secondary">{typeLabel}</Badge> : null}
-                    {system.toolCatalog?.length ? (
-                      <Badge variant="secondary">{system.toolCatalog.length} MCP tools</Badge>
-                    ) : null}
                   </div>
                 }
                 chevron
@@ -1592,17 +1609,6 @@ export function ConnectedSystemsPanel({
             {error}
           </SurfaceInset>
         ) : null}
-
-        <SettingsGroup title="Actions">
-          <SettingsRow
-            icon={RefreshCw}
-            title="Refresh CRM systems"
-            description="Reload the connected-system registry and status from the backend."
-            disabled={busy !== null}
-            chevron
-            onClick={() => void refreshSystems()}
-          />
-        </SettingsGroup>
       </div>
     );
   }
@@ -1631,9 +1637,6 @@ export function ConnectedSystemsPanel({
             <div className="mt-2">
               {statusBadge(selectedSystem?.status || "connected")} through{" "}
               {selectedSystem?.transportLabel || "External CRM MCP"}
-              {selectedSystem?.toolCatalog?.length
-                ? ` / ${selectedSystem.toolCatalog.length} MCP tools`
-                : ""}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- branch from latest origin/main with only the connected-systems UI/UX polish
- hide the CRM/Salesforce platform badge on mobile while preserving the Macy's brand logo
- remove user-facing MCP tool-count copy and tighten connected-systems mobile bottom spacing

## Verification
- bash scripts/ci/check-dco-signoff.sh origin/main HEAD
- cd hushh-webapp && npm test -- --run __tests__/components/connected-systems-panel.test.tsx
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:design-system

## Scope guard
- This PR intentionally avoids the long-lived kai-voice-level3 stack and carries only 5 changed files.