### PR TITLE
fix(location): chat disambiguation, false-failure, and expiry-hint bug fixes

### DIFF
--- a/consent-protocol/hushh_mcp/agents/location/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/location/agent.yaml
@@ -23,7 +23,9 @@ system_instruction: |
 
   Platform-aware sharing: when the user asks to share with a person, resolve them
   with list_location_recipients. If exactly one verified recipient matches and can
-  receive location, create the share. If the match is ambiguous, ask which person.
+  receive location, create the share. If more than one recipient matches the name
+  (e.g. two "Neelesh Meena"), call request_recipient_choice with that name so the
+  picker shows only those matches — never dump the whole directory to disambiguate.
   If they are on Hushh but cannot receive location yet, offer to send a request or
   make a public link. If they are not found, offer a public link.
 

--- a/consent-protocol/hushh_mcp/agents/location/tools.py
+++ b/consent-protocol/hushh_mcp/agents/location/tools.py
@@ -256,29 +256,54 @@ def _expiry_hint(expires_at: Any) -> str | None:
 
 
 @hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_recipient_choice")
-async def request_recipient_choice() -> dict[str, Any]:
+async def request_recipient_choice(name: str | None = None) -> dict[str, Any]:
     """Ask the user to pick who to share with. Returns a coordinate-free select
-    prompt whose options carry real recipient ids. Call this when the user wants to
-    share but did not name a (single, unambiguous) recipient."""
+    prompt whose options carry real recipient ids.
+
+    Pass ``name`` when the user named a person but it matched more than one contact
+    (e.g. two "Neelesh Meena"): the options are then limited to just the contacts
+    whose display name matches, so the picker shows only the ambiguous matches
+    instead of the whole directory. Omit ``name`` only when the user has not named
+    anyone at all — then the picker lists everyone plus a public-link option.
+    """
     context = _ctx()
     recipients = _service().list_verified_recipients(owner_user_id=context.user_id)
+    needle = (name or "").strip().lower()
+    matches = (
+        [r for r in recipients if needle in str(r.get("displayName") or "").strip().lower()]
+        if needle
+        else recipients
+    )
+    # Disambiguation mode: only when a name was given AND it matched someone. A
+    # name that matches nothing falls back to the full directory so a typo can't
+    # strand the user with an empty picker.
+    disambiguating = bool(needle) and bool(matches)
+    chosen = matches if matches else recipients
     options = [
         {
             "label": r.get("displayName") or "Someone",
             "ref": {"recipientUserId": r.get("userId"), "recipientKeyId": r.get("keyId")},
             "hint": None if r.get("canReceiveLocation") else "hasn't set up location yet",
         }
-        for r in recipients
+        for r in chosen
     ]
-    options.append({"label": "Public link (anyone)", "ref": {"publicLink": True}, "hint": None})
+    if not disambiguating:
+        # The user named a specific person, so a public link is not a valid
+        # disambiguation answer — only offer it in the open "who?" case.
+        options.append({"label": "Public link (anyone)", "ref": {"publicLink": True}, "hint": None})
+    question = (
+        f"Which “{name}” do you want to share your location with?"
+        if disambiguating
+        else "Who do you want to share your location with?"
+    )
     return {
         "prompt": {
             "kind": "select",
             "purpose": "select_recipient",
-            "question": "Who do you want to share your location with?",
+            "question": question,
             "options": options,
             "minSelections": 1,
-            "maxSelections": None,
+            "maxSelections": 1 if disambiguating else None,
             "allowFreeText": True,
         }
     }

--- a/consent-protocol/hushh_mcp/agents/location/tools.py
+++ b/consent-protocol/hushh_mcp/agents/location/tools.py
@@ -6,6 +6,7 @@ OneLocationAgentService and scope checks inside @hushh_tool.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
@@ -251,8 +252,34 @@ async def revoke_public_link(invite_id: str) -> dict[str, Any]:
     return _service().revoke_public_invite(owner_user_id=context.user_id, invite_id=invite_id)
 
 
-def _expiry_hint(expires_at: Any) -> str | None:
-    return f"expires {expires_at}" if expires_at else None
+def _expiry_hint(expires_at: Any, *, now: datetime | None = None) -> str | None:
+    """Human-friendly relative expiry for chat option hints.
+
+    Renders "expires in N hours" (rounded to the nearest hour), or
+    "expires in N minutes" when under an hour, since these hints are shown inline
+    in the chat picker where a raw ISO timestamp is unreadable. Returns None when
+    there is no timestamp, "expired" when it is already past, and preserves the
+    raw value if it can't be parsed.
+    """
+    if not expires_at:
+        return None
+    if isinstance(expires_at, datetime):
+        when = expires_at
+    else:
+        try:
+            when = datetime.fromisoformat(str(expires_at).replace("Z", "+00:00"))
+        except ValueError:
+            return f"expires {expires_at}"
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    total_minutes = int((when - current).total_seconds() // 60)
+    if total_minutes <= 0:
+        return "expired"
+    if total_minutes < 60:
+        return f"expires in {total_minutes} minute{'s' if total_minutes != 1 else ''}"
+    hours = int(total_minutes / 60 + 0.5)
+    return f"expires in {hours} hour{'s' if hours != 1 else ''}"
 
 
 @hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_recipient_choice")

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -295,8 +295,26 @@ def _function_declarations_v2(types: Any) -> list:
             ),
             types.FunctionDeclaration(
                 name="request_recipient_choice",
-                description="Ask the user to choose who to share with (returns selectable options). Call when no single recipient was named.",
-                parameters=schema(type=kind.OBJECT, properties={}, required=[]),
+                description=(
+                    "Ask the user to choose who to share with (returns selectable options). "
+                    "Call when no single recipient was named. When the user DID name a person "
+                    "but more than one contact matches that name (e.g. two 'Neelesh Meena'), "
+                    "pass `name` with the name they gave so the options are limited to just "
+                    "those matches instead of the whole directory."
+                ),
+                parameters=schema(
+                    type=kind.OBJECT,
+                    properties={
+                        "name": schema(
+                            type=kind.STRING,
+                            description=(
+                                "The name the user gave, used to limit the choices to matching "
+                                "contacts. Omit only when the user named no one."
+                            ),
+                        )
+                    },
+                    required=[],
+                ),
             ),
             types.FunctionDeclaration(
                 name="request_active_share_choice",

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -567,12 +567,26 @@ class LocationChatService:
         prompts: list[dict] = []
         with HushhContext(user_id=user_id, consent_token=consent_token, vault_keys={}):
             for _ in range(_MAX_TOOL_STEPS):
-                response = await self._model_call(contents, config)
-                calls = list(getattr(response, "function_calls", None) or [])
+                try:
+                    calls, reply = await self._model_step(contents, config)
+                except Exception:
+                    # A model/transport failure (e.g. the follow-up summarization
+                    # call times out). If a mutating tool has ALREADY committed a
+                    # change this turn, do NOT report total failure: the grant /
+                    # revoke is real, so surface the accumulated state (state_changed
+                    # + any clientAction) with a deterministic reply. Only a failure
+                    # BEFORE any side effect is a truthful "temporarily unavailable",
+                    # so re-raise in that case for the caller's fallback.
+                    if state_changed or directives or prompts:
+                        logger.warning(
+                            "Location model step failed after side effects; "
+                            "returning partial turn result",
+                            exc_info=True,
+                        )
+                        break
+                    raise
                 if not calls:
-                    reply = (getattr(response, "text", "") or "").strip()
                     break
-                contents.append(response.candidates[0].content)
                 for call in calls:
                     result, mutated, directive, prompt = await self._run_tool(
                         call.name, dict(call.args or {})
@@ -594,6 +608,21 @@ class LocationChatService:
                 reply = _GAVE_UP_MESSAGE
                 errored = True
         return reply, errored, state_changed, directives, prompts
+
+    async def _model_step(self, contents: list, config: Any) -> tuple[list, str]:
+        """Run one model turn. Returns (function_calls, reply_text).
+
+        When the model requests tool calls, its content is appended to ``contents``
+        and reply_text is "". When it answers, calls is empty and reply_text holds
+        the text. Isolating the throwing model interaction here lets the loop treat
+        a post-mutation model failure as recoverable (see _run_tool_loop).
+        """
+        response = await self._model_call(contents, config)
+        calls = list(getattr(response, "function_calls", None) or [])
+        if not calls:
+            return [], (getattr(response, "text", "") or "").strip()
+        contents.append(response.candidates[0].content)
+        return calls, ""
 
     async def _run_tool(self, name: str, args: dict) -> tuple[dict, bool, dict | None, dict | None]:
         """Execute one tool inside the active HushhContext.

--- a/consent-protocol/tests/test_location_chat_service.py
+++ b/consent-protocol/tests/test_location_chat_service.py
@@ -232,3 +232,142 @@ async def test_first_turn_sends_user_message_to_model():
     assert "earlier answer" in texts
     assert first_contents[-1].role == "user"
     assert first_contents[-1].parts[0].text == "latest message"
+
+
+def _scripted_model_call_with_failures(responses: list, captured: list):
+    """Like _scripted_model_call, but any Exception item in `responses` is raised
+    when that step is reached (simulates a timed-out / transient model call)."""
+    seq = iter(responses)
+
+    async def _call(contents, config):
+        captured.append(list(contents))
+        item = next(seq)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    return _call
+
+
+async def test_mutation_survives_followup_model_failure():
+    # Regression (ll1/ll2): the grant is created, then the follow-up summarization
+    # model call fails (timeout / transient error). The turn must NOT report
+    # "temporarily unavailable" — the mutation already committed, so it must report
+    # success, keep stateChanged=True, and still surface the clientAction so the
+    # browser publishes the encrypted envelope.
+    store = _FakeStore()
+    calls: list[dict] = []
+    tools = [
+        _fake_tool(
+            "create_location_share",
+            calls,
+            result={
+                "id": "grant-1",
+                "recipientUserId": "u-neel-1",
+                "recipientKeyId": "k2",
+                "recipientDisplayName": "Neelesh Meena",
+            },
+        )
+    ]
+    captured: list = []
+    service = LocationChatService(
+        chat_store=store,
+        model_call=_scripted_model_call_with_failures(
+            [
+                _fc_response(
+                    "create_location_share",
+                    {
+                        "recipient_user_id": "u-neel-1",
+                        "recipient_key_id": "k2",
+                        "duration_hours": 2.5,
+                    },
+                ),
+                TimeoutError("gemini summarization timed out"),
+            ],
+            captured,
+        ),
+        genai_types=types,
+        ready=lambda: True,
+        tools=tools,
+        system_prompt="test-system-prompt",
+    )
+
+    out = await service.handle_turn(
+        user_id="u",
+        message="grant to Neelesh Meena for 2.5 hours",
+        consent_token="t",  # noqa: S106
+    )
+
+    # the grant WAS created
+    assert len(calls) == 1
+    assert calls[0]["args"]["duration_hours"] == 2.5
+    # ...so the turn must not claim it failed
+    assert "unavailable" not in out["response"].lower()
+    assert out["isComplete"] is True
+    assert store.added[-1]["status"] == "complete"
+    # and the browser still gets the publish directive, which drives the encrypted
+    # publish + the follow-up action_result that reports "Done" and refreshes the
+    # list — exactly like a normal successful share (hence stateChanged is False
+    # here, deferred to the round-trip, not the false-failure it used to be).
+    assert out["clientAction"]["type"] == "publish_share"
+    assert out["clientAction"]["shares"][0]["grantId"] == "grant-1"
+    assert out["stateChanged"] is False
+
+
+async def test_server_side_mutation_survives_followup_model_failure():
+    # A pure server-side mutation (revoke) has no browser round-trip, so when the
+    # follow-up model call fails the turn must report success AND stateChanged=True
+    # so the UI refreshes — rather than the old false "temporarily unavailable".
+    store = _FakeStore()
+    calls: list[dict] = []
+    tools = [_fake_tool("revoke_location_share", calls, result={"status": "revoked"})]
+    captured: list = []
+    service = LocationChatService(
+        chat_store=store,
+        model_call=_scripted_model_call_with_failures(
+            [
+                _fc_response("revoke_location_share", {"grant_id": "g1"}),
+                TimeoutError("gemini summarization timed out"),
+            ],
+            captured,
+        ),
+        genai_types=types,
+        ready=lambda: True,
+        tools=tools,
+        system_prompt="test-system-prompt",
+    )
+
+    out = await service.handle_turn(
+        user_id="u",
+        message="revoke access from Abdul",
+        consent_token="t",  # noqa: S106
+    )
+
+    assert len(calls) == 1
+    assert "unavailable" not in out["response"].lower()
+    assert out["isComplete"] is True
+    assert out["stateChanged"] is True
+    assert "clientAction" not in out
+    assert store.added[-1]["status"] == "complete"
+
+
+async def test_model_failure_before_any_mutation_still_unavailable():
+    # Contrast: if the model fails BEFORE any tool commits a change, there is no
+    # side effect to preserve, so the truthful answer is still "unavailable".
+    store = _FakeStore()
+    captured: list = []
+    service = LocationChatService(
+        chat_store=store,
+        model_call=_scripted_model_call_with_failures([TimeoutError("down")], captured),
+        genai_types=types,
+        ready=lambda: True,
+        tools=[_fake_tool("create_location_share", [])],
+        system_prompt="test-system-prompt",
+    )
+
+    out = await service.handle_turn(user_id="u", message="grant to Mom", consent_token="t")  # noqa: S106
+
+    assert "unavailable" in out["response"].lower()
+    assert out["isComplete"] is False
+    assert out["stateChanged"] is False
+    assert store.added[-1]["status"] == "error"

--- a/consent-protocol/tests/test_location_chat_tools_behavior.py
+++ b/consent-protocol/tests/test_location_chat_tools_behavior.py
@@ -11,6 +11,8 @@ exercised directly.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from google.genai import types
 
@@ -222,6 +224,44 @@ async def test_request_active_share_choice_includes_stop_all(monkeypatch):
     refs = [o["ref"] for o in out["prompt"]["options"]]
     assert {"grantId": "g1"} in refs
     assert {"all": True} in refs
+
+
+_NOW = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("expires_at", "expected"),
+    [
+        # ISO timestamps (what the service actually emits) -> relative time
+        ("2026-07-06T15:00:00+00:00", "expires in 3 hours"),
+        ("2026-07-06T12:45:00+00:00", "expires in 45 minutes"),
+        ("2026-07-06T12:01:00+00:00", "expires in 1 minute"),  # singular
+        ("2026-07-06T13:00:00+00:00", "expires in 1 hour"),  # singular
+        ("2026-07-06T12:00:00+00:00", "expired"),  # boundary / already past
+        ("2026-07-06T11:30:00+00:00", "expired"),
+        # 'Z' suffix is accepted too
+        ("2026-07-06T14:00:00Z", "expires in 2 hours"),
+        # no timestamp -> no hint
+        (None, None),
+        ("", None),
+    ],
+)
+def test_expiry_hint_is_relative_and_human_friendly(expires_at, expected):
+    assert loc_tools._expiry_hint(expires_at, now=_NOW) == expected
+
+
+def test_expiry_hint_accepts_datetime_objects():
+    assert loc_tools._expiry_hint(_NOW + timedelta(hours=6), now=_NOW) == "expires in 6 hours"
+
+
+def test_expiry_hint_hours_round_to_nearest():
+    # 2h30m rounds up to 3 hours; 1h20m rounds down to 1 hour.
+    assert loc_tools._expiry_hint(_NOW + timedelta(hours=2, minutes=30), now=_NOW) == (
+        "expires in 3 hours"
+    )
+    assert loc_tools._expiry_hint(_NOW + timedelta(hours=1, minutes=20), now=_NOW) == (
+        "expires in 1 hour"
+    )
 
 
 async def test_request_confirmation_returns_confirm_prompt():

--- a/consent-protocol/tests/test_location_chat_tools_behavior.py
+++ b/consent-protocol/tests/test_location_chat_tools_behavior.py
@@ -155,6 +155,66 @@ async def test_request_recipient_choice_options_carry_real_ids_and_public_link(m
     assert "latitude" not in blob and "longitude" not in blob and "lat" not in blob.split("late")[0]
 
 
+class _DupNameSvc:
+    """Directory with two contacts sharing the same display name."""
+
+    def list_verified_recipients(self, *, owner_user_id, limit=50):
+        return [
+            {
+                "userId": "u-abdul",
+                "displayName": "Abdul Zalil",
+                "keyId": "k1",
+                "canReceiveLocation": True,
+            },
+            {
+                "userId": "u-neel-1",
+                "displayName": "Neelesh Meena",
+                "keyId": "k2",
+                "canReceiveLocation": True,
+            },
+            {
+                "userId": "u-gautam",
+                "displayName": "Gautam Ahuja",
+                "keyId": "k3",
+                "canReceiveLocation": True,
+            },
+            {
+                "userId": "u-neel-2",
+                "displayName": "Neelesh Meena",
+                "keyId": "k4",
+                "canReceiveLocation": True,
+            },
+        ]
+
+
+async def test_request_recipient_choice_filters_to_named_matches(monkeypatch):
+    # Disambiguation bug: when the user named a person that matches >1 contact,
+    # the picker must show ONLY those matches, not the whole directory, and must
+    # not offer a public link (the user named a specific person).
+    monkeypatch.setattr(loc_tools, "_service", lambda: _DupNameSvc())
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_recipient_choice.__wrapped__(name="Neelesh Meena")
+    prompt = out["prompt"]
+    labels = [o["label"] for o in prompt["options"]]
+    assert labels == ["Neelesh Meena", "Neelesh Meena"]
+    refs = [o["ref"] for o in prompt["options"]]
+    assert {"recipientUserId": "u-neel-1", "recipientKeyId": "k2"} in refs
+    assert {"recipientUserId": "u-neel-2", "recipientKeyId": "k4"} in refs
+    assert all("publicLink" not in o["ref"] for o in prompt["options"])
+    assert "Neelesh Meena" in prompt["question"]
+
+
+async def test_request_recipient_choice_falls_back_when_name_unmatched(monkeypatch):
+    # A name that matches nothing must not strand the user with an empty picker:
+    # fall back to the full directory (with the public-link escape hatch).
+    monkeypatch.setattr(loc_tools, "_service", lambda: _DupNameSvc())
+    with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106
+        out = await loc_tools.request_recipient_choice.__wrapped__(name="Nobody Here")
+    options = out["prompt"]["options"]
+    assert len(options) == 5  # 4 contacts + public link
+    assert options[-1]["ref"] == {"publicLink": True}
+
+
 async def test_request_active_share_choice_includes_stop_all(monkeypatch):
     monkeypatch.setattr(loc_tools, "_service", lambda: _FakeSvc())
     with HushhContext(user_id="u1", consent_token="t", vault_keys={}):  # noqa: S106


### PR DESCRIPTION
# Description

Three fixes to the One Location chat agent surfaced during manual testing. All three are backend-only and land in the shared `LocationChatService` / location tools, so they fix **both** the inline location chat and the central One agent (A2A) paths at once.

1. **Disambiguation picker showed the whole directory.** When a name matched >1 contact (e.g. two "Neelesh Meena"), `request_recipient_choice` dumped every verified recipient instead of the matches. It now accepts a `name`, filters to matching contacts, drops the public-link option in disambiguation mode, and single-selects. Falls back to the full list if nothing matches. Mirrors the existing Trusted Connections selection pattern.

2. **"Temporarily unavailable" after the action already succeeded.** A mutating tool (e.g. `create_location_share` → grant INSERT) commits mid-loop; if the follow-up summarization model call then timed out / errored, a turn-wide `except` reported failure with `state_changed=False` even though the grant existed. The throwing model interaction is now isolated in `_model_step`; a post-mutation failure surfaces the real state + `clientAction` instead of a false failure, while a pre-mutation failure still reports "unavailable".

3. **Raw ISO expiry in chat pickers.** The stop-sharing / view-incoming pickers showed `expires 2026-07-06T13:25:02.164084+00:00`. `_expiry_hint` now renders "expires in N hours" (rounded) or "expires in N minutes" under an hour; "expired" when past.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None

- API / schema / type changes:
  - [x] Listed below:
  - `request_recipient_choice` tool gains an optional `name` argument (Gemini `FunctionDeclaration` + tool signature). Backwards compatible (defaults to prior behavior when omitted).

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — backend only; the frontend renders whatever options/hints the backend supplies (unchanged contract).

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

## Testing

- New/updated tests (all green locally):
  - `tests/test_location_chat_tools_behavior.py` — name-filtered disambiguation, unmatched fallback, relative `_expiry_hint` (parametrized).
  - `tests/test_location_chat_service.py` — mutation survives follow-up model failure (create keeps `clientAction`; revoke keeps `stateChanged=True`); pre-mutation failure still "unavailable".
- Ruff lint clean on all changed files.
- Pre-existing unrelated failure noted: `test_location_agent_yaml_declares_callable_tools` (agent.yaml tool list vs `LOCATION_AGENT_TOOLS` drift) fails on `main` too; not gated by CI (latest main smoke is green) and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)