### PR TITLE
fix(ui): remove debate stream cancel run console warning leak

### DIFF
--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -814,8 +814,8 @@ export function DebateStreamView({
           userId,
           vaultOwnerToken,
         });
-      } catch (cancelError) {
-        console.warn("[DebateStreamView] Failed to cancel run:", cancelError);
+      } catch (_cancelError) {
+        // Silently ignore cancellation failures when closing
       }
     }
     setBusyOperation("stock_analysis_stream", false);


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `DebateStreamView` run cancellation handler. If the background run cancellation API fails when the user closes the dialog (e.g. if the run had already finished), the UI already gracefully proceeds to close and clear its state anyway. Removing this log keeps the client console clean without needing environment checks, and the catch variable is appropriately prefixed with an underscore to satisfy TypeScript linters.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] `components/kai/debate-stream-view.tsx`

- Trust boundary touched:
  - [x] none (purely client UI logging removal)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] This PR changes a current reachable app/backend/package/docs surface.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/kai/debate-stream-view.tsx`)
- [ ] **iOS**: N/A (Web UI only)
- [ ] **Android**: N/A (Web UI only)

## 🧪 Testing

- [x] Tested on Web (Code inspection, TypeScript linters)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Sensitive surface touched: none (internal logging only, non-trust boundary)
- [x] Error path, rollback, or safe-failure behavior proved: N/A - purely a logging chore fix.