### PR TITLE
fix(ui): remove debate stream profile context load console warning leak

### DIFF
--- a/hushh-webapp/components/kai/debate-stream-view.tsx
+++ b/hushh-webapp/components/kai/debate-stream-view.tsx
@@ -1328,8 +1328,7 @@ export function DebateStreamView({
             },
             financial_profile: profile,
           };
-        } catch (profileError) {
-          console.warn("[DebateStreamView] Failed to load Kai profile context:", profileError);
+        } catch (_profileError) {
         }
       }
 


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `DebateStreamView` profile context load handler. If the local database read for the user's Kai preferences fails (e.g., if it doesn't exist yet), the application already gracefully degrades by continuing the agent debate with a default context. Removing this log keeps the client console clean without needing environment checks, and the catch variable is appropriately prefixed with an underscore to satisfy TypeScript linters.