### PR TITLE
fix(ui): silence profile kai preferences error logging leak

### DIFF
--- a/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
+++ b/hushh-webapp/components/profile/profile-kai-preferences-panel.tsx
@@ -139,10 +139,7 @@ export function ProfileKaiPreferencesPanel({
             });
             setProfile(refreshed);
             toast.success("Preferences updated");
-          } catch (error) {
-            if (process.env.NODE_ENV !== "production") {
-              console.error("[ProfileKaiPreferencesPanel] Save failed:", error);
-            }
+          } catch {
             toast.error("Couldn't save preferences. Please retry.");
           } finally {
             setLoading(false);


### PR DESCRIPTION
### Description

Silences an explicit `console.error` trace leak in `components/profile/profile-kai-preferences-panel.tsx`. This error log was firing unconditionally whenever saving Kai profile preferences failed. Since the component natively catches this exception and handles it securely by displaying a user-friendly fallback UI toast to the user and resetting the loading state, the explicit `console.error` log was unnecessary and merely leaked backend trace noise into the browser console.
