### PR TITLE
fix(location): stop double public-link confirmation and make shared links clickable

### DIFF
--- a/consent-protocol/hushh_mcp/agents/location/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/location/agent.yaml
@@ -35,11 +35,14 @@ system_instruction: |
   request_duration_choice, request_request_choice, or request_incoming_choice.
   Then act only on the exact ids the user picks.
 
-  Before any irreversible or bulk action — creating a public link, sharing with
+  Before any irreversible or bulk action that runs server-side — sharing with
   everyone, or stopping all shares — call request_confirmation with a short
-  summary and proceed only if the user confirms. SOS is high-stakes: always call
-  request_confirmation before propose_sos_panic and proceed only after the user
-  explicitly confirms.
+  summary and proceed only if the user confirms. Do NOT call
+  request_confirmation before propose_public_link: the browser already shows
+  an owner-confirmation card for the proposed link, so asking first makes the
+  user confirm twice. Once the duration is known, call propose_public_link
+  directly. SOS is high-stakes: always call request_confirmation before
+  propose_sos_panic and proceed only after the user explicitly confirms.
 
   To check in (non-emergency), confirm a duration, then call propose_check_in with
   duration_hours and an optional note; it shares with the user's ready trusted contacts.

--- a/consent-protocol/hushh_mcp/agents/location/tools.py
+++ b/consent-protocol/hushh_mcp/agents/location/tools.py
@@ -474,8 +474,10 @@ async def request_incoming_choice() -> dict[str, Any]:
 @hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="request_confirmation")
 async def request_confirmation(summary: str, destructive: bool = True) -> dict[str, Any]:
     """Ask the user to confirm an irreversible or bulk action before it runs. Returns
-    a coordinate-free yes/no confirm prompt. Use before creating a public link,
-    sharing with everyone, or stopping all shares."""
+    a coordinate-free yes/no confirm prompt. Use before sharing with everyone or
+    stopping all shares. Do NOT use before propose_public_link — the browser shows
+    its own owner-confirmation card for the link, so confirming here would make
+    the user confirm twice."""
     _ctx()
     return {
         "prompt": {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -127,6 +127,7 @@ import {
   type OneLocationNotificationSection,
   type OneLocationWorkflowNotificationType,
 } from "@/lib/one-location/notifications";
+import { publicInviteUrlLabel } from "@/lib/one-location/public-invite-url";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
   syncOneLocationContactSignals,
@@ -613,21 +614,6 @@ function publicSubmissionLabel(
   submission: OneLocationPublicInviteSubmission,
 ): string {
   return safePersonLabel(submission.visitorDisplayName, "Public request");
-}
-
-function publicInviteUrlLabel(value: string): string {
-  if (!value) return "";
-  const configuredOrigin = String(process.env.NEXT_PUBLIC_APP_URL || "")
-    .trim()
-    .replace(/\/+$/, "");
-  if (/^https?:\/\//i.test(value)) return value;
-  const origin =
-    /^https?:\/\//i.test(configuredOrigin) ||
-    typeof window === "undefined"
-      ? configuredOrigin
-      : String(window.location.origin || "").trim().replace(/\/+$/, "");
-  if (!/^https?:\/\//i.test(origin)) return value;
-  return new URL(value, origin).toString();
 }
 
 function publicInviteUrlPreview(value: string): string {

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -57,6 +57,10 @@ import {
   type MarketplaceRequest,
   type PublishableSlice,
 } from "@/lib/one-marketplace/service";
+import {
+  ChatMarkdownLink,
+  copyTextToClipboard,
+} from "@/components/agent/chat-markdown-link";
 import { SelectionChip } from "@/components/agent/selection-chip";
 import {
   AgentTurnStreamPanel,
@@ -611,26 +615,6 @@ function formatAgentDisplayName(displayName?: string | null, email?: string | nu
   return firstName.charAt(0).toUpperCase() + firstName.slice(1);
 }
 
-async function copyTextToClipboard(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.setAttribute("readonly", "");
-  textarea.style.position = "fixed";
-  textarea.style.left = "-9999px";
-  document.body.appendChild(textarea);
-  textarea.select();
-  try {
-    document.execCommand("copy");
-  } finally {
-    document.body.removeChild(textarea);
-  }
-}
-
 function AgentWelcomePanel({
   name,
   disabled,
@@ -714,14 +698,7 @@ function AgentMarkdown({ text }: { text: string }) {
           ),
           li: ({ children }) => <li className="pl-1">{children}</li>,
           a: ({ children, href }) => (
-            <a
-              href={href || "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary underline-offset-4 hover:underline"
-            >
-              {children}
-            </a>
+            <ChatMarkdownLink href={href}>{children}</ChatMarkdownLink>
           ),
           code: ({ children, className }) => {
             const inline = !className;

--- a/hushh-webapp/components/agent/chat-markdown-link.tsx
+++ b/hushh-webapp/components/agent/chat-markdown-link.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Check, Copy } from "lucide-react";
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export function ChatMarkdownLink({
+  href,
+  children,
+}: {
+  href?: string;
+  children?: ReactNode;
+}) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const url = href ?? "";
+  const copyable = /^https?:\/\//i.test(url);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  const handleCopy = async () => {
+    try {
+      await copyTextToClipboard(url);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopied(false), 2000);
+  };
+
+  const anchor = (
+    <a
+      href={url || "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="break-all font-medium text-primary underline decoration-primary/40 underline-offset-4 transition-colors hover:decoration-primary"
+    >
+      {children}
+    </a>
+  );
+
+  if (!copyable) return anchor;
+
+  return (
+    <span className="inline-flex max-w-full items-baseline gap-1.5">
+      {anchor}
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Link copied" : "Copy link"}
+        title={copied ? "Copied" : "Copy link"}
+        className="relative inline-flex h-5 w-5 shrink-0 translate-y-[3px] cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 after:absolute after:-inset-2.5 after:content-[''] hover:bg-muted hover:text-foreground active:scale-95"
+      >
+        {copied ? (
+          <Check aria-hidden className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+        ) : (
+          <Copy aria-hidden className="h-3.5 w-3.5" />
+        )}
+        <span aria-live="polite" className="sr-only">
+          {copied ? "Link copied to clipboard" : ""}
+        </span>
+      </button>
+    </span>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-chat-message-list.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
+import { ChatMarkdownLink } from "@/components/agent/chat-markdown-link";
 import { SelectionChip } from "@/components/agent/selection-chip";
 import type { ChatMessage } from "./use-location-chat";
 import { BotAvatar, StateChangedNote, TypingIndicator } from "./location-chat-atoms";
@@ -43,7 +44,14 @@ export function ChatMessageList(props: {
                   message.errored && "text-muted-foreground",
                 )}
               >
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    a: ({ children, href }) => (
+                      <ChatMarkdownLink href={href}>{children}</ChatMarkdownLink>
+                    ),
+                  }}
+                >
                   {message.text}
                 </ReactMarkdown>
               </div>

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from "react";
 
+import { publicInviteUrlLabel } from "@/lib/one-location/public-invite-url";
 import { OneLocationService } from "@/lib/one-location/service";
 import {
   decryptLocationEnvelope,
@@ -274,7 +275,12 @@ export function useLocationChat(params: {
           durationHours: action.durationHours ?? 1,
           locationSnapshot,
         });
-        await report({ id: action.id, type: action.type, status: "completed", publicUrl });
+        await report({
+          id: action.id,
+          type: action.type,
+          status: "completed",
+          publicUrl: publicInviteUrlLabel(publicUrl),
+        });
       } else if (action.type === "sos_panic") {
         const state = await OneLocationService.getState(vaultOwnerToken);
         const connected = selectSosConnectedRecipients(

--- a/hushh-webapp/lib/agent/specialist-directive-runtime.ts
+++ b/hushh-webapp/lib/agent/specialist-directive-runtime.ts
@@ -1,3 +1,4 @@
+import { publicInviteUrlLabel } from "@/lib/one-location/public-invite-url";
 import { OneLocationService } from "@/lib/one-location/service";
 import { encryptLocationForRecipient } from "@/lib/one-location/encryption";
 import {
@@ -126,7 +127,7 @@ export async function runLocationDirective(
         id,
         type,
         status: "completed",
-        publicUrl,
+        publicUrl: publicInviteUrlLabel(publicUrl),
       };
     }
 

--- a/hushh-webapp/lib/one-location/public-invite-url.ts
+++ b/hushh-webapp/lib/one-location/public-invite-url.ts
@@ -1,0 +1,20 @@
+/**
+ * The backend returns public-invite URLs as app-relative paths
+ * (e.g. /one/location/request/<token>). Resolve them against the configured
+ * app origin (NEXT_PUBLIC_APP_URL) or the current window origin so they can
+ * be shared, copied, and autolinked outside the app.
+ */
+export function publicInviteUrlLabel(value: string): string {
+  if (!value) return "";
+  const configuredOrigin = String(process.env.NEXT_PUBLIC_APP_URL || "")
+    .trim()
+    .replace(/\/+$/, "");
+  if (/^https?:\/\//i.test(value)) return value;
+  const origin =
+    /^https?:\/\//i.test(configuredOrigin) ||
+    typeof window === "undefined"
+      ? configuredOrigin
+      : String(window.location.origin || "").trim().replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(origin)) return value;
+  return new URL(value, origin).toString();
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the Location Agent sharing flow, affecting both the **inline location agent chat** and the **central A2A agent chat** (they share the same `LocationChatService` backend).

### 1. Double confirmation when creating a public link
Selecting **"public / anyone"** asked the user to confirm **twice**. Two independent confirmation layers were both firing:
- **LLM-level:** the agent's system prompt mandated `request_confirmation` before creating any public link.
- **Client-level:** `propose_public_link` becomes a client action that is deliberately never auto-executed (the browser must capture and encrypt coordinates), rendered as a second confirm card.

Recipient-bound shares only ever showed one confirm (the action card), confirming that card is the intended owner-consent gate. The agent is now instructed to **skip `request_confirmation` before `propose_public_link`**, leaving the browser's action card as the single gate. Confirmation is still required for share-with-everyone, stop-all-shares, and SOS. The security boundary is unchanged — every public link still passes through the structural browser confirmation.

### 2. Public link rendered as plain, unclickable text
The shared link appeared as raw text with no way to open or copy it. Two causes:
- The backend returns the invite as an **app-relative path** (`/one/location/request/<token>`). Markdown autolinking only fires on absolute `http(s)` URLs, so no anchor was produced. Both chat flows now run `publicUrl` through the shared `publicInviteUrlLabel()` helper (extracted from the location page) before reporting the completed action.
- The inline chat markdown had no link styling and the central chat only underlined on hover. A shared `ChatMarkdownLink` component now renders every agent-message URL as a styled, new-tab link with an **accessible inline copy-to-clipboard button** (expanded ≥44px hit area, copied ✓ state, `aria-live` announcement).

## Changes
- `consent-protocol/.../location/agent.yaml`, `tools.py` — drop the redundant public-link confirmation instruction.
- `hushh-webapp/lib/one-location/public-invite-url.ts` — new shared URL absolutizer (deduped from `app/one/location/page.tsx`).
- `hushh-webapp/components/agent/chat-markdown-link.tsx` — new clickable link + copy component.
- `use-location-chat.ts`, `specialist-directive-runtime.ts` — absolutize `publicUrl` before reporting.
- `location-chat-message-list.tsx`, `agent-chat-workspace.tsx` — use `ChatMarkdownLink` for markdown links.

## Testing
- Backend: `test_location_chat_service_v2.py` + `test_location_agent_a2a.py` — 14/14 pass.
- Frontend: `tsc --noEmit` clean, ESLint clean on all touched files, 60 tests across the location chat hook, specialist directive runtime, location page, and one-location/agent components pass.

## Notes
- Messages already saved in chat history keep the old relative-path text; only newly created links get the fix.
- If the app runs in a webview whose origin is not `http(s)` (e.g. Capacitor) and `NEXT_PUBLIC_APP_URL` is unset, the helper falls back to the relative path — same behavior the location page already had. Ensure `NEXT_PUBLIC_APP_URL` is set in the mobile build.
