### PR TITLE
fix(agent-dropdown): fix Popover crash and icon contrast on select

### DIFF
--- a/hushh-webapp/__tests__/components/agent-section-dropdown.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-section-dropdown.test.tsx
@@ -21,17 +21,23 @@ describe("AgentSectionDropdown", () => {
     useKaiSession.getState().clear();
   });
 
-  it("shows the active agent section from the current route", async () => {
+  it("shows the active agent section from the current route and opens the searchable list", async () => {
     render(<AgentSectionDropdown pathname={ROUTES.KAI_ANALYSIS} />);
 
-    const trigger = screen.getByRole("button", {
+    const trigger = screen.getByRole("combobox", {
       name: "Switch agent section",
     });
-    expect(trigger.textContent).toContain("Finance");
+    expect(trigger.textContent).toContain("Investor");
 
-    fireEvent.keyDown(trigger, { key: "ArrowDown", code: "ArrowDown" });
+    // Regression: PopoverContent previously passed the conditional scrim +
+    // Radix Content as two JSX siblings, which crashed every popover on open
+    // with "React.Children.only expected to receive a single React element
+    // child." Opening this dropdown must never throw.
+    expect(() => fireEvent.click(trigger)).not.toThrow();
 
-    expect(await screen.findByTestId("top_agent_section_finance")).toBeTruthy();
+    expect(await screen.findByTestId("agent-section-search")).toBeTruthy();
+    expect(screen.getByTestId("top_agent_section_finance")).toBeTruthy();
+    expect(screen.getByTestId("top_agent_section_ria")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_gmail")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_consent")).toBeTruthy();
   });
@@ -39,10 +45,9 @@ describe("AgentSectionDropdown", () => {
   it("navigates through the shared agent section registry", async () => {
     render(<AgentSectionDropdown pathname={ROUTES.ONE_HOME} />);
 
-    fireEvent.keyDown(screen.getByRole("button", { name: "Switch agent section" }), {
-      key: "ArrowDown",
-      code: "ArrowDown",
-    });
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Switch agent section" }),
+    );
     fireEvent.click(await screen.findByTestId("top_agent_section_gmail"));
 
     await waitFor(() =>
@@ -61,7 +66,8 @@ describe("AgentSectionDropdown", () => {
     render(<AgentSectionDropdown pathname={ROUTES.PROFILE} />);
 
     expect(
-      screen.getByRole("button", { name: "Switch agent section" }).textContent,
-    ).toContain("Finance");
+      screen.getByRole("combobox", { name: "Switch agent section" })
+        .textContent,
+    ).toContain("Investor");
   });
 });

--- a/hushh-webapp/__tests__/setup.ts
+++ b/hushh-webapp/__tests__/setup.ts
@@ -37,6 +37,25 @@ if (typeof window !== "undefined") {
   });
 }
 
+// JSDOM has no ResizeObserver. cmdk (used by the Command/CommandList
+// primitives) observes its list element on mount, so any test that renders a
+// cmdk-based component needs this polyfill or React logs an unhandled
+// ReferenceError from the passive effect.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  class ResizeObserverMock {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+  }
+  globalThis.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+}
+
+// JSDOM also has no scrollIntoView. cmdk calls this on the selected item's
+// layout effect to keep it in view, which throws in JSDOM without a stub.
+if (typeof window !== "undefined" && !window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+}
+
 /**
  * Reset all mocks between tests to prevent state leakage.
  * This ensures each test starts with a clean slate.

--- a/hushh-webapp/components/app-ui/agent-section-icon.tsx
+++ b/hushh-webapp/components/app-ui/agent-section-icon.tsx
@@ -4,7 +4,13 @@ import type { OneCapabilityTone } from "@/lib/onboarding/one-capabilities";
 import { cn } from "@/lib/utils";
 
 const AGENT_ICON_SURFACE_CLASSNAME =
-  "bg-[#f1f1f3] text-[#1d1d1f] dark:bg-white/[0.14] dark:text-white";
+  // Solid neutral chip in both themes. The `group-data-[selected=true]` variant
+  // keeps this readable when the icon sits on an accent/amber cmdk highlight
+  // row (see components/ui/command.tsx CommandItem): the default translucent
+  // dark tint (white/0.14) is nearly invisible against that highlight, so the
+  // selected state forces the same solid chip used everywhere else instead of
+  // blending into the highlight color.
+  "bg-[#f1f1f3] text-[#1d1d1f] dark:bg-white/[0.14] dark:text-white group-data-[selected=true]:bg-white group-data-[selected=true]:text-[#1d1d1f] dark:group-data-[selected=true]:bg-[#2c2c2e] dark:group-data-[selected=true]:text-white";
 
 const ICON_SIZE_CLASS = {
   launcher: {

--- a/hushh-webapp/components/ui/popover.tsx
+++ b/hushh-webapp/components/ui/popover.tsx
@@ -38,23 +38,34 @@ function PopoverContent({
 }) {
   return (
     <PopoverPrimitive.Portal>
-      {withBackdrop ? (
-        <div
-          data-slot="popover-scrim"
-          aria-hidden
-          className="fixed inset-0 z-[499] touch-none bg-black/22 backdrop-blur-[8px] [-webkit-backdrop-filter:blur(8px)]"
+      {/*
+        Radix's Portal forwards its children through React.Children.only, so it
+        must receive exactly ONE React element. Passing the scrim and the
+        content as two JSX siblings (even with the scrim as `null`) produces a
+        children ARRAY and crashes every popover with
+        "React.Children.only expected to receive a single React element
+        child." Wrapping both in one Fragment keeps Portal's single-child
+        contract while still conditionally rendering the scrim.
+      */}
+      <>
+        {withBackdrop ? (
+          <div
+            data-slot="popover-scrim"
+            aria-hidden
+            className="fixed inset-0 z-[499] touch-none bg-black/22 backdrop-blur-[8px] [-webkit-backdrop-filter:blur(8px)]"
+          />
+        ) : null}
+        <PopoverPrimitive.Content
+          data-slot="popover-content"
+          align={align}
+          sideOffset={sideOffset}
+          className={cn(
+            "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:data-[state=closed]:slide-out-to-top-2 data-[side=left]:data-[state=closed]:slide-out-to-right-2 data-[side=right]:data-[state=closed]:slide-out-to-left-2 data-[side=top]:data-[state=closed]:slide-out-to-bottom-2 z-[500] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+            className
+          )}
+          {...props}
         />
-      ) : null}
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:data-[state=closed]:slide-out-to-top-2 data-[side=left]:data-[state=closed]:slide-out-to-right-2 data-[side=right]:data-[state=closed]:slide-out-to-left-2 data-[side=top]:data-[state=closed]:slide-out-to-bottom-2 z-[500] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className
-        )}
-        {...props}
-      />
+      </>
     </PopoverPrimitive.Portal>
   )
 }


### PR DESCRIPTION
## Summary
- Fixed a crash: opening the top-bar agent dropdown threw `React.Children.only expected to receive a single React element child` because `PopoverContent` passed the conditional scrim div and Radix's `PopoverPrimitive.Content` as two JSX siblings inside `PopoverPrimitive.Portal`. Wrapped both in a single Fragment.
- Fixed icon contrast: `AgentSectionIcon`'s translucent dark-mode chip was nearly invisible on the cmdk-highlighted (amber/gold `bg-accent`) row. Added a `group-data-[selected=true]` variant forcing a solid neutral chip in both themes.
- Rewrote the stale `agent-section-dropdown.test.tsx` (still asserted the old DropdownMenu API / "Finance" label) to match the current Popover+Command implementation, and added a regression assertion that opening the dropdown never throws.
- Added `ResizeObserver`/`scrollIntoView` JSDOM polyfills to the shared test setup (required by cmdk's Command primitives).

## Verification
- `npm run typecheck` — pass
- `npx eslint` on touched files — pass
- `npx vitest run __tests__/components/agent-section-dropdown.test.tsx` — 3/3 pass
- `npx vitest run` (full suite) — 1777 passed / 1 pre-existing unrelated failure (confirmed via git stash it exists on main too, stale "Finance" label assertion in `one-dashboard-page.test.tsx`, out of scope here)
- Live browser verification (Playwright): dropdown opens with zero console/page errors; icon on highlighted row shows solid contrast chip in dark mode (screenshot confirmed)


---
Closes #4472
(retroactive board-linkage backfill, 2026-07-14)