### PR TITLE
fix(one-location): recover from expired vault token on app resume (no dead-end banner)

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -576,6 +576,28 @@ describe("OneLocationAgentPage", () => {
     expect(mockSyncCurrentUser).toHaveBeenCalledWith({ uid: "user_a" });
   });
 
+  it("requests vault re-unlock instead of showing a stale-token error", async () => {
+    const lockReasons: string[] = [];
+    const handleLockRequest = (event: Event) => {
+      lockReasons.push(
+        (event as CustomEvent<{ reason?: string }>).detail?.reason ?? "",
+      );
+    };
+    window.addEventListener("vault-lock-requested", handleLockRequest);
+    mockGetState.mockRejectedValue(new Error("Token validation failed."));
+
+    try {
+      render(<OneLocationAgentPage />);
+
+      await waitFor(() => {
+        expect(lockReasons).toContain("one_location_token_invalid");
+      });
+      expect(screen.queryByText(/Token validation failed/i)).toBeNull();
+    } finally {
+      window.removeEventListener("vault-lock-requested", handleLockRequest);
+    }
+  });
+
   it("scrolls Active shares only when more than three shares are present", async () => {
     const baseGrant = locationState().ownerGrants[0]!;
     mockGetState.mockResolvedValueOnce({

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -576,26 +576,15 @@ describe("OneLocationAgentPage", () => {
     expect(mockSyncCurrentUser).toHaveBeenCalledWith({ uid: "user_a" });
   });
 
-  it("requests vault re-unlock instead of showing a stale-token error", async () => {
-    const lockReasons: string[] = [];
-    const handleLockRequest = (event: Event) => {
-      lockReasons.push(
-        (event as CustomEvent<{ reason?: string }>).detail?.reason ?? "",
-      );
-    };
-    window.addEventListener("vault-lock-requested", handleLockRequest);
-    mockGetState.mockRejectedValue(new Error("Token validation failed."));
+  it("suppresses the stale-token banner while vault re-unlock is requested", async () => {
+    mockGetState.mockRejectedValue(
+      Object.assign(new Error("Token validation failed."), { status: 401 }),
+    );
 
-    try {
-      render(<OneLocationAgentPage />);
+    render(<OneLocationAgentPage />);
 
-      await waitFor(() => {
-        expect(lockReasons).toContain("one_location_token_invalid");
-      });
-      expect(screen.queryByText(/Token validation failed/i)).toBeNull();
-    } finally {
-      window.removeEventListener("vault-lock-requested", handleLockRequest);
-    }
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+    expect(screen.queryByText(/Token validation failed/i)).toBeNull();
   });
 
   it("scrolls Active shares only when more than three shares are present", async () => {

--- a/hushh-webapp/__tests__/lib/vault/vault-context-resume.test.tsx
+++ b/hushh-webapp/__tests__/lib/vault/vault-context-resume.test.tsx
@@ -1,0 +1,218 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  nativePlatform: false,
+  appStateListener: null as ((state: { isActive: boolean }) => void) | null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  pausePkmUpgrade: vi.fn().mockResolvedValue(undefined),
+  pauseConsentExport: vi.fn(),
+  invalidateVaultState: vi.fn(),
+  resetSessionUnlocked: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => (mocks.nativePlatform ? "android" : "web"),
+    isNativePlatform: () => mocks.nativePlatform,
+  },
+}));
+
+vi.mock("@capacitor/app", () => ({
+  App: {
+    addListener: mocks.addListener,
+  },
+}));
+
+vi.mock("@/lib/firebase/auth-context", () => ({
+  useAuth: () => ({
+    user: {
+      uid: "vault-owner",
+      displayName: "Vault Owner",
+      email: "owner@example.test",
+      photoURL: null,
+    },
+  }),
+}));
+
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: { onVaultStateChanged: vi.fn() },
+}));
+
+vi.mock("@/lib/capacitor", () => ({
+  HushhConsent: {
+    clearIMessageSession: vi.fn().mockResolvedValue(undefined),
+    publishIMessageSession: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  trackGrowthFunnelStepCompleted: vi.fn(),
+}));
+
+vi.mock("@/lib/services/auth-service", () => ({
+  AuthService: { getIdToken: vi.fn().mockResolvedValue("firebase-token") },
+}));
+
+vi.mock("@/lib/services/consent-export-refresh-orchestrator", () => ({
+  ConsentExportRefreshOrchestrator: {
+    ensureRunning: vi.fn().mockResolvedValue(undefined),
+    pauseForLocalAuthResume: mocks.pauseConsentExport,
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {
+    invalidateSessionStateAfterVaultRekey: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/pkm-upgrade-orchestrator", () => ({
+  PkmUpgradeOrchestrator: {
+    ensureRunning: vi.fn().mockResolvedValue(undefined),
+    pauseForLocalAuthResume: mocks.pausePkmUpgrade,
+  },
+}));
+
+vi.mock("@/lib/services/unlock-warm-orchestrator", () => ({
+  UnlockWarmOrchestrator: { run: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("@/lib/services/vault-service", () => ({
+  VaultService: { invalidateVaultStateCache: mocks.invalidateVaultState },
+}));
+
+vi.mock("@/lib/vault/vault-session-latch", () => ({
+  markSessionUnlocked: vi.fn(),
+  resetSessionUnlocked: mocks.resetSessionUnlocked,
+}));
+
+vi.mock("@/lib/kai/kai-financial-resource", () => ({
+  KaiFinancialResourceService: {
+    hydrateFromSecureCache: vi.fn().mockResolvedValue(null),
+    invalidate: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/pkm/pkm-domain-resource", () => ({
+  PkmDomainResourceService: {
+    hydrateFromSecureCache: vi.fn().mockResolvedValue(null),
+    invalidateDomain: vi.fn(),
+  },
+}));
+
+import { VaultProvider, useVault } from "@/lib/vault/vault-context";
+
+const NOW = 1_800_000_000_000;
+
+function VaultHarness() {
+  const vault = useVault();
+  return (
+    <div>
+      <span data-testid="vault-status">
+        {vault.isVaultUnlocked ? "unlocked" : "locked"}
+      </span>
+      <span data-testid="vault-token">{vault.vaultOwnerToken ?? "none"}</span>
+      <span data-testid="vault-key">{vault.vaultKey ?? "none"}</span>
+      <button
+        type="button"
+        onClick={() => vault.unlockVault("vault-key", "vault-token", NOW)}
+      >
+        Unlock expired
+      </button>
+      <button
+        type="button"
+        onClick={() => vault.unlockVault("vault-key", "vault-token", NOW + 60_000)}
+      >
+        Unlock valid
+      </button>
+    </div>
+  );
+}
+
+function renderVault() {
+  return render(
+    <VaultProvider>
+      <VaultHarness />
+    </VaultProvider>,
+  );
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: state,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.nativePlatform = false;
+  mocks.appStateListener = null;
+  mocks.addListener.mockImplementation(
+    async (
+      _event: string,
+      listener: (state: { isActive: boolean }) => void,
+    ) => {
+      mocks.appStateListener = listener;
+      return { remove: mocks.removeListener };
+    },
+  );
+  vi.spyOn(Date, "now").mockReturnValue(NOW);
+  setVisibility("hidden");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("VaultProvider app-resume expiry recovery", () => {
+  it("relocks and clears memory-only credentials when an expired token resumes on web", async () => {
+    renderVault();
+    fireEvent.click(screen.getByRole("button", { name: "Unlock expired" }));
+    expect(screen.getByTestId("vault-status").textContent).toBe("unlocked");
+
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("vault-status").textContent).toBe("locked");
+    });
+    expect(screen.getByTestId("vault-token").textContent).toBe("none");
+    expect(screen.getByTestId("vault-key").textContent).toBe("none");
+    expect(mocks.resetSessionUnlocked).toHaveBeenCalled();
+    expect(mocks.invalidateVaultState).toHaveBeenCalled();
+  });
+
+  it("keeps a still-valid token unlocked when the web app resumes", () => {
+    renderVault();
+    fireEvent.click(screen.getByRole("button", { name: "Unlock valid" }));
+
+    setVisibility("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    expect(screen.getByTestId("vault-status").textContent).toBe("unlocked");
+    expect(screen.getByTestId("vault-token").textContent).toBe("vault-token");
+    expect(mocks.resetSessionUnlocked).not.toHaveBeenCalled();
+  });
+
+  it("relocks only when the native app becomes active and removes its listener", async () => {
+    mocks.nativePlatform = true;
+    const view = renderVault();
+    await waitFor(() => expect(mocks.addListener).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "Unlock expired" }));
+    await waitFor(() => expect(mocks.appStateListener).not.toBeNull());
+
+    act(() => mocks.appStateListener?.({ isActive: false }));
+    expect(screen.getByTestId("vault-status").textContent).toBe("unlocked");
+
+    act(() => mocks.appStateListener?.({ isActive: true }));
+    await waitFor(() => {
+      expect(screen.getByTestId("vault-status").textContent).toBe("locked");
+    });
+
+    view.unmount();
+    await waitFor(() => expect(mocks.removeListener).toHaveBeenCalled());
+  });
+});

--- a/hushh-webapp/__tests__/lib/vault/vault-context-resume.test.tsx
+++ b/hushh-webapp/__tests__/lib/vault/vault-context-resume.test.tsx
@@ -197,6 +197,26 @@ describe("VaultProvider app-resume expiry recovery", () => {
     expect(mocks.resetSessionUnlocked).not.toHaveBeenCalled();
   });
 
+  it("relocks and clears credentials when API validation requests a vault lock", async () => {
+    renderVault();
+    fireEvent.click(screen.getByRole("button", { name: "Unlock valid" }));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("vault-lock-requested", {
+          detail: { reason: "Token validation failed." },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("vault-status").textContent).toBe("locked");
+    });
+    expect(screen.getByTestId("vault-token").textContent).toBe("none");
+    expect(screen.getByTestId("vault-key").textContent).toBe("none");
+    expect(mocks.resetSessionUnlocked).toHaveBeenCalled();
+  });
+
   it("relocks only when the native app becomes active and removes its listener", async () => {
     mocks.nativePlatform = true;
     const view = renderVault();

--- a/hushh-webapp/__tests__/services/api-service-fetch.test.ts
+++ b/hushh-webapp/__tests__/services/api-service-fetch.test.ts
@@ -1,15 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const capacitorMocks = vi.hoisted(() => ({
+  isNativePlatform: vi.fn(() => false),
+  getPlatform: vi.fn(() => "web"),
+  request: vi.fn(),
+}));
+
 // ---------------------------------------------------------------------------
 // Mocks – declared before any import that touches them
 // ---------------------------------------------------------------------------
 
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
-    isNativePlatform: () => false,
-    getPlatform: () => "web",
+    isNativePlatform: capacitorMocks.isNativePlatform,
+    getPlatform: capacitorMocks.getPlatform,
   },
-  CapacitorHttp: { request: vi.fn() },
+  CapacitorHttp: { request: capacitorMocks.request },
 }));
 
 vi.mock("@/lib/capacitor", () => ({
@@ -84,6 +90,9 @@ describe("ApiService.apiFetch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetch.mockReset();
+    capacitorMocks.isNativePlatform.mockReturnValue(false);
+    capacitorMocks.getPlatform.mockReturnValue("web");
+    capacitorMocks.request.mockReset();
   });
 
   // 1 – Web platform: calls fetch with relative path (no base URL)
@@ -236,6 +245,68 @@ describe("ApiService.apiFetch", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toEqual(payload);
+  });
+
+  it("requests a vault lock when web rejects an HCT token after validation", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ detail: "Token validation failed." }, 401)
+    );
+    const lockReasons: string[] = [];
+    const handleLock = (event: Event) => {
+      lockReasons.push(
+        String((event as CustomEvent<{ reason?: string }>).detail?.reason || "")
+      );
+    };
+    window.addEventListener("vault-lock-requested", handleLock);
+
+    try {
+      const response = await ApiService.apiFetch("/api/one/location/state", {
+        headers: { Authorization: "Bearer HCT:expired-vault-owner" },
+      });
+
+      expect(response.status).toBe(401);
+      expect(lockReasons).toEqual(["Token validation failed."]);
+      expect(AuthService.getIdToken).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("vault-lock-requested", handleLock);
+    }
+  });
+
+  it("requests the same vault lock when native rejects an HCT token", async () => {
+    capacitorMocks.isNativePlatform.mockReturnValue(true);
+    capacitorMocks.getPlatform.mockReturnValue("ios");
+    capacitorMocks.request.mockResolvedValueOnce({
+      status: 401,
+      headers: { "content-type": "application/json" },
+      data: { detail: "Token validation failed." },
+      url: "https://uat.example/api/one/location/state",
+    });
+    const previousBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+    process.env.NEXT_PUBLIC_BACKEND_URL = "https://uat.example";
+    const lockReasons: string[] = [];
+    const handleLock = (event: Event) => {
+      lockReasons.push(
+        String((event as CustomEvent<{ reason?: string }>).detail?.reason || "")
+      );
+    };
+    window.addEventListener("vault-lock-requested", handleLock);
+
+    try {
+      const response = await ApiService.apiFetch("/api/one/location/state", {
+        headers: { Authorization: "Bearer HCT:expired-vault-owner" },
+      });
+
+      expect(response.status).toBe(401);
+      expect(lockReasons).toEqual(["Token validation failed."]);
+      expect(capacitorMocks.request).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("vault-lock-requested", handleLock);
+      if (previousBackendUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_BACKEND_URL;
+      } else {
+        process.env.NEXT_PUBLIC_BACKEND_URL = previousBackendUrl;
+      }
+    }
   });
 
   it("fetches baseline market insights with Firebase auth", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -2275,10 +2275,31 @@ function OneLocationAgentPageContent() {
 
       } catch (error) {
         suppressAutoRecipientSelectionRef.current = false;
-        setLoadError(
-          oneLocationErrorMessage(error, "Could not load location sharing."),
+        // A stale/expired VAULT_OWNER token (e.g. the app was backgrounded while
+        // the phone was locked, then resumed) makes the backend reject the load
+        // with "Token validation failed". Rather than dead-ending on a scary
+        // banner that only an app restart clears, fail closed to the standard
+        // re-unlock sheet: dispatch the vault-lock event the VaultProvider
+        // listens for, so Face ID / passphrase re-unlock appears and a fresh
+        // token is issued. Everything else still surfaces the normal message.
+        const message = oneLocationErrorMessage(
+          error,
+          "Could not load location sharing.",
         );
+        if (
+          typeof window !== "undefined" &&
+          /token validation failed|vault_owner|unauthor/i.test(message)
+        ) {
+          window.dispatchEvent(
+            new CustomEvent("vault-lock-requested", {
+              detail: { reason: "one_location_token_invalid" },
+            }),
+          );
+        } else {
+          setLoadError(message);
+        }
       } finally {
+
         refreshInFlightRef.current = null;
         setBusy(null);
       }

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -652,6 +652,12 @@ function isTransientOneApiError(error: unknown): boolean {
   return status === 502 || status === 503 || status === 504;
 }
 
+function isVaultOwnerAuthError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const status = (error as { status?: unknown }).status;
+  return status === 401;
+}
+
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
@@ -2275,31 +2281,15 @@ function OneLocationAgentPageContent() {
 
       } catch (error) {
         suppressAutoRecipientSelectionRef.current = false;
-        // A stale/expired VAULT_OWNER token (e.g. the app was backgrounded while
-        // the phone was locked, then resumed) makes the backend reject the load
-        // with "Token validation failed". Rather than dead-ending on a scary
-        // banner that only an app restart clears, fail closed to the standard
-        // re-unlock sheet: dispatch the vault-lock event the VaultProvider
-        // listens for, so Face ID / passphrase re-unlock appears and a fresh
-        // token is issued. Everything else still surfaces the normal message.
-        const message = oneLocationErrorMessage(
-          error,
-          "Could not load location sharing.",
-        );
-        if (
-          typeof window !== "undefined" &&
-          /token validation failed|vault_owner|unauthor/i.test(message)
-        ) {
-          window.dispatchEvent(
-            new CustomEvent("vault-lock-requested", {
-              detail: { reason: "one_location_token_invalid" },
-            }),
+        // ApiService handles rejected VAULT_OWNER tokens for web and native by
+        // locking the vault. Do not briefly render the backend auth message
+        // while VaultLockGuard switches to the standard re-unlock flow.
+        if (!isVaultOwnerAuthError(error)) {
+          setLoadError(
+            oneLocationErrorMessage(error, "Could not load location sharing."),
           );
-        } else {
-          setLoadError(message);
         }
       } finally {
-
         refreshInFlightRef.current = null;
         setBusy(null);
       }

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -324,7 +324,8 @@ async function classifyVaultOwnerAuthFailure(
       return {
         shouldLockVault:
           normalized.includes("token has been revoked") ||
-          normalized.includes("invalid token"),
+          normalized.includes("invalid token") ||
+          normalized.includes("token validation failed"),
         reason,
       };
     }
@@ -334,7 +335,8 @@ async function classifyVaultOwnerAuthFailure(
     return {
       shouldLockVault:
         normalized.includes("token has been revoked") ||
-        normalized.includes("invalid token"),
+        normalized.includes("invalid token") ||
+        normalized.includes("token validation failed"),
       reason: raw || null,
     };
   } catch {
@@ -419,6 +421,22 @@ async function apiFetch(
         detail: { reason, path },
       })
     );
+  };
+
+  const handleVaultOwnerAuthFailure = async (response: Response) => {
+    if (
+      (response.status !== 401 && response.status !== 403) ||
+      !getAuthorizationBearer().startsWith("HCT:")
+    ) {
+      return;
+    }
+
+    const failure = await classifyVaultOwnerAuthFailure(response.clone());
+    if (failure.shouldLockVault) {
+      dispatchVaultLockRequested(
+        failure.reason || "Vault access token is no longer valid"
+      );
+    }
   };
 
   const retryWithFreshFirebaseToken = async (): Promise<Response | null> => {
@@ -567,6 +585,7 @@ async function apiFetch(
 
       const nativeResponse = await CapacitorHttp.request(request);
       const response = toResponse(nativeResponse);
+      await handleVaultOwnerAuthFailure(response);
       recordApiRequestMetric(response.status);
       return response;
     }
@@ -576,14 +595,7 @@ async function apiFetch(
       credentials: "include",
       headers: mergedHeaders,
     });
-    if ((response.status === 401 || response.status === 403) && getAuthorizationBearer().startsWith("HCT:")) {
-      const failure = await classifyVaultOwnerAuthFailure(response.clone());
-      if (failure.shouldLockVault) {
-        dispatchVaultLockRequested(
-          failure.reason || "Vault access token is no longer valid"
-        );
-      }
-    }
+    await handleVaultOwnerAuthFailure(response);
     if (response.status === 401 && !(await responseLooksLikeAuthServiceUnavailable(response))) {
       const retryResponse = await retryWithFreshFirebaseToken();
       if (retryResponse) {

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -160,16 +160,10 @@ export function VaultProvider({ children }: VaultProviderProps) {
     }
   }, [user, vaultKey, lockVault]);
 
-  // App-resume expiry guard (iOS/Android + web).
-  // The VAULT_OWNER token is memory-only with a fixed TTL and is never
-  // auto-refreshed. When the OS backgrounds the app (e.g. the user locks their
-  // phone) and later foregrounds it, the token can already be past its expiry.
-  // Any request made with that stale token fails backend validation and the
-  // location screen surfaced a dead-end "Token validation failed." banner that
-  // only a full app restart cleared. Instead, fail CLOSED: if the token is
-  // expired on resume, lock the vault so the standard VaultLockGuard re-unlock
-  // sheet (Face ID / passphrase) appears — a one-tap recovery, no restart, no
-  // scary error, and no weakening of the memory-only security model.
+  // App-resume expiry guard (iOS/Android + web). Proactively lock when the
+  // memory-only VAULT_OWNER token has reached its known expiry. Other backend
+  // validation failures are handled by ApiService's shared web/native response
+  // path, which requests the same fail-closed re-unlock flow.
   useEffect(() => {
     let removeListener: (() => void) | null = null;
     let cancelled = false;

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -178,7 +178,7 @@ export function VaultProvider({ children }: VaultProviderProps) {
       const expiresAt = tokenExpiresAtRef.current;
       // Only act when a token exists AND is actually past expiry. A missing
       // token means the vault is already locked (guard handles it).
-      if (expiresAt !== null && Date.now() > expiresAt) {
+      if (expiresAt !== null && Date.now() >= expiresAt) {
         console.warn(
           "🔒 [VaultProvider] VAULT_OWNER token expired while backgrounded — locking to prompt re-unlock.",
         );
@@ -467,7 +467,7 @@ export function VaultProvider({ children }: VaultProviderProps) {
 
   const getVaultOwnerToken = useCallback(() => {
     // Check expiry
-    if (tokenExpiresAt && Date.now() > tokenExpiresAt) {
+    if (tokenExpiresAt && Date.now() >= tokenExpiresAt) {
       console.warn("⚠️ VAULT_OWNER token expired");
       return null;
     }

--- a/hushh-webapp/lib/vault/vault-context.tsx
+++ b/hushh-webapp/lib/vault/vault-context.tsx
@@ -102,6 +102,13 @@ export function VaultProvider({ children }: VaultProviderProps) {
   const [vaultOwnerToken, setVaultOwnerToken] = useState<string | null>(null);
   const [tokenExpiresAt, setTokenExpiresAt] = useState<number | null>(null);
   const lastUpgradeKickoffKeyRef = useRef<string | null>(null);
+  // Mirror of tokenExpiresAt so the app-resume listener can read the latest
+  // expiry without re-subscribing every time the token changes.
+  const tokenExpiresAtRef = useRef<number | null>(null);
+  useEffect(() => {
+    tokenExpiresAtRef.current = tokenExpiresAt;
+  }, [tokenExpiresAt]);
+
 
   const lockVault = useCallback(() => {
     resetSessionUnlocked();
@@ -153,10 +160,67 @@ export function VaultProvider({ children }: VaultProviderProps) {
     }
   }, [user, vaultKey, lockVault]);
 
+  // App-resume expiry guard (iOS/Android + web).
+  // The VAULT_OWNER token is memory-only with a fixed TTL and is never
+  // auto-refreshed. When the OS backgrounds the app (e.g. the user locks their
+  // phone) and later foregrounds it, the token can already be past its expiry.
+  // Any request made with that stale token fails backend validation and the
+  // location screen surfaced a dead-end "Token validation failed." banner that
+  // only a full app restart cleared. Instead, fail CLOSED: if the token is
+  // expired on resume, lock the vault so the standard VaultLockGuard re-unlock
+  // sheet (Face ID / passphrase) appears — a one-tap recovery, no restart, no
+  // scary error, and no weakening of the memory-only security model.
+  useEffect(() => {
+    let removeListener: (() => void) | null = null;
+    let cancelled = false;
+
+    const relockIfTokenExpired = () => {
+      const expiresAt = tokenExpiresAtRef.current;
+      // Only act when a token exists AND is actually past expiry. A missing
+      // token means the vault is already locked (guard handles it).
+      if (expiresAt !== null && Date.now() > expiresAt) {
+        console.warn(
+          "🔒 [VaultProvider] VAULT_OWNER token expired while backgrounded — locking to prompt re-unlock.",
+        );
+        lockVault();
+      }
+    };
+
+    if (Capacitor.isNativePlatform()) {
+      void import("@capacitor/app")
+        .then(({ App }) => App.addListener("appStateChange", ({ isActive }) => {
+          if (isActive) relockIfTokenExpired();
+        }))
+        .then((handle) => {
+          if (cancelled) {
+            void handle.remove();
+            return;
+          }
+          removeListener = () => void handle.remove();
+        })
+        .catch((error) => {
+          console.warn("[VaultProvider] Failed to register app-resume expiry guard:", error);
+        });
+    } else if (typeof document !== "undefined") {
+      const onVisible = () => {
+        if (document.visibilityState === "visible") relockIfTokenExpired();
+      };
+      document.addEventListener("visibilitychange", onVisible);
+      removeListener = () =>
+        document.removeEventListener("visibilitychange", onVisible);
+    }
+
+    return () => {
+      cancelled = true;
+      if (removeListener) removeListener();
+    };
+  }, [lockVault]);
+
   // Listen for vault-lock-requested events (e.g., when VAULT_OWNER token is revoked)
   useEffect(() => {
     const handleLockRequest = (event: Event) => {
       const customEvent = event as CustomEvent<{ reason: string }>;
+
       console.log(
         `🔒 [VaultProvider] Lock requested: ${customEvent.detail?.reason}`
       );


### PR DESCRIPTION
## Description

Fixes the iOS/Android/web resume failure where One Location could show a dead-end **Token validation failed.** banner after the app returned from the background.

## Root Cause

The backend deliberately returns the same generic `401` message for several VAULT_OWNER validation failures, so the screenshot alone cannot distinguish expiry, revocation, signature, or scope rejection.

Two client gaps made that rejection terminal:

1. `ApiService` processed HCT validation failures on web only; the native Capacitor HTTP path returned before that recovery logic.
2. The existing classifier did not recognize the backend's exact generic `Token validation failed.` response. The page-level fallback covered only the initial state load and depended on message matching.

Closing and reopening worked because vault bootstrap issued or recovered a valid token in a fresh app session.

## Fix

1. `VaultProvider` watches native `appStateChange` and web `visibilitychange` and proactively re-locks when a retained memory-only token has reached its known expiry.
2. A shared HCT auth-failure handler now runs for both web `fetch` and native `CapacitorHttp` responses.
3. The handler recognizes the backend's exact generic validation response and emits one `vault-lock-requested` event.
4. `VaultProvider` consumes that event, clears the in-memory vault key/token/expiry, and `VaultLockGuard` presents the standard Face ID/passphrase re-unlock flow.
5. One Location suppresses the rejected-token `401` banner while that secure recovery transition occurs; unrelated errors remain visible.
6. Expiry uses `now >= expiresAt`, matching the backend validity boundary.

No token or vault key is persisted, and no auth or consent boundary is weakened.

## Impact Map

- Routes touched: `/one/location`
- Shared runtime touched: platform-aware API auth-failure handling and vault lifecycle
- API/schema/data changes: none
- Cache/PKM changes: none; existing pause/invalidation paths run during re-lock
- Mobile parity: the same response handler now covers web, iOS, and Android
- Rollback: revert the three PR commits
- Error fallback: standard vault re-unlock sheet; unrelated failures keep normal messaging

## Verification

- [x] 44 focused transport, One Location, and VaultProvider recovery tests
- [x] Simulated iOS native `401` emits exactly one vault-lock event
- [x] Web `401` follows the same event contract and does not attempt Firebase refresh for HCT
- [x] VaultProvider event consumption clears the memory-only key and token
- [x] Web visible resume re-locks an expired token and preserves a valid token
- [x] Native inactive event does not re-lock; active event does and listener cleanup is verified
- [x] One Location does not render the terminal validation banner during recovery
- [x] Exact expiry boundary (`now === expiresAt`) fails closed
- [x] 53 related API client, One Location service, and chat tests
- [x] TypeScript typecheck
- [x] ESLint on all changed runtime and test files
- [x] Capacitor static parity
- [x] Capacitor production build
- [x] Branch freshness against `origin/main`
- [x] DCO sign-offs

## Known Unrelated Baseline

`verify:capacitor:plugins` reports the same pre-existing Android `HushhLocation` method drift on unchanged `main`; this PR does not modify that plugin contract.

Physical iOS lock/resume remains a post-merge/UAT device smoke test because this Windows environment cannot run an iOS simulator.
