### PR TITLE
fix(voice+ios): One Voice accuracy, thinking UX, barge-in, and native iOS UI fixes

### DIFF
--- a/.claude/skills/mobile-bug-log/SKILL.md
+++ b/.claude/skills/mobile-bug-log/SKILL.md
@@ -134,6 +134,26 @@ Three small mobile UX/nav fixes (commit `909ea793d`):
 - **KEY GOTCHA: a committed fix that isn't in the archived/uploaded build has NOT shipped.** Capacitor has no OTA — bump the build number and re-Archive/upload. "Works on my fresh sim build" ≠ "shipped to the tester." Always confirm the tested build's commit vs the fix commit before re-debugging a "still broken" report.
 - **Verified:** typecheck + lint + design-system; breadcrumbs (agent-origin regression added) / dashboard / top-app-bar.contract / command-executor / consent-sheet-route = 59; iOS build 40 installed; on-device dashboard → Email + Location → back → dashboard.
 
+### B14 — Theme toggle dead on iOS (worked on web)
+- **Symptom:** light/dark switching worked on the website but did nothing in the native iOS app.
+- **Root cause:** NOT a bug — iOS was deliberately pinned to light ("daylight" ship): `app/providers.tsx` forced light via next-themes on `Capacitor.getPlatform()==="ios"` AND `ios/App/App/Info.plist` set `UIUserInterfaceStyle=Light`. The toggle persisted to localStorage but next-themes never applied it.
+- **Fix (fix/voice-intelligence-and-native-ui):** removed both pins; `ThemeProvider attribute="class" defaultTheme="light" enableSystem` on all platforms. `StatusBarManager` already syncs native SystemBars from `resolvedTheme`. Contract test updated: `__tests__/components/providers-theme-contract.test.ts` now asserts NO forced theme anywhere + no `UIUserInterfaceStyle` in Info.plist.
+
+### B15 — Ripple stayed "pressed" after press-and-hold on option tiles (iOS)
+- **Symptom:** long-press on an option tile left the md-ripple pressed overlay stuck until the next interaction.
+- **Root cause:** WKWebView long-press triggers the system callout/text-selection path, which cancels the pointer stream (`pointercancel` swallowed) before `md-ripple` sees `pointerup`. Nothing set `-webkit-touch-callout:none`/`user-select:none` on actionables.
+- **Fix:** `app/globals.css` — actionable roles (a, button, [role=button|radio|tab|menuitem|option]) get `-webkit-touch-callout:none; -webkit-user-select:none; user-select:none`. Inputs keep selection. Also pinned `pointer-events:none` on `md-ripple.morphy-md-ripple` itself (defense vs the historical first-tap-swallow, see material-ripple.tsx comment).
+
+### B16 — Bottom nav sometimes needed a double tap (iOS)
+- **Symptom:** first tap on a bottom-bar tab intermittently did nothing; second tap worked. Correlated with scrolling.
+- **Root cause:** the nav translates off-screen via `--bottom-chrome-progress` (scroll-hide). A tap landing mid-animation had its target translate away between pointerdown and pointerup → no click event. Wrapper also holds `pointer-events-none` while hidden.
+- **Fix:** `snapKaiBottomChromeVisible()` in `lib/navigation/kai-bottom-chrome-visibility.ts` — `onPointerDownCapture` on the nav group freezes the chrome at its resting position when `progress > 0`, so the tap target is stationary at pointerup. File: `components/navbar.tsx`.
+
+### B17 — Search bubble rendered as an oval on iOS (circle on web)
+- **Symptom:** the round Search button next to the bottom pill was visibly non-circular in the native app.
+- **Root cause:** geometry relied on `aspect-square` + `self-stretch` + `h-auto w-auto`; WKWebView resolves `aspect-ratio` against a stretch-derived flex cross size as indefinite → width fell back to content → oval.
+- **Fix:** explicit `h-[52px] w-[52px] self-center` (matches the stacked pill min-height). Hover styles moved behind `[@media(hover:hover)]` so first touch can't latch sticky hover. File: `components/navbar.tsx`.
+
 ### B5 — Redesign leak check (always run when "it shows on the website")
 - **How to verify no leak:** `git merge-base --is-ancestor <redesign-sha> origin/main` for each redesign commit → must be false. The website deploys from `main` only (manual `workflow_dispatch`); the `mobile` branch (pushed as `ankit/iOS-UI-rephrased-v01`) never reaches it.
 

--- a/consent-protocol/api/routes/kai/agent_realtime_gemini.py
+++ b/consent-protocol/api/routes/kai/agent_realtime_gemini.py
@@ -988,9 +988,33 @@ async def agent_gemini_live_relay(websocket: WebSocket) -> None:
                     except (TypeError, ValueError):
                         continue
                     if message.get("type") == "interrupt" or message.get("interrupt") is True:
-                        # The provider stream owns actual interruption semantics;
-                        # locally we acknowledge the app request and let the next
-                        # realtime audio frame continue the session.
+                        # Signal the provider for real: Live sessions cancel
+                        # in-flight generation when new client content arrives,
+                        # so a non-prompting content update aborts the current
+                        # model turn instead of letting stale audio keep
+                        # streaming after the app-side interrupt. Best-effort;
+                        # the browser also fences late audio locally.
+                        try:
+                            await session.send_client_content(
+                                turns={
+                                    "role": "user",
+                                    "parts": [
+                                        {
+                                            "text": (
+                                                "[App interrupt - not user speech] Stop the "
+                                                "current spoken response immediately and wait "
+                                                "silently for the user's next request."
+                                            )
+                                        }
+                                    ],
+                                },
+                                turn_complete=False,
+                            )
+                        except Exception as error:  # noqa: BLE001 - interrupt is best-effort
+                            logger.debug(
+                                "agent_gemini_live_interrupt_signal_failed error=%s",
+                                error.__class__.__name__,
+                            )
                         await websocket.send_text(
                             json.dumps({"serverContent": {"interrupted": True}})
                         )

--- a/consent-protocol/api/routes/kai/agent_realtime_gemini.py
+++ b/consent-protocol/api/routes/kai/agent_realtime_gemini.py
@@ -115,7 +115,9 @@ class AgentGeminiLiveTokenRequest(BaseModel):
     route_family: Optional[str] = Field(default=None, max_length=64)
     voice_state: Optional[str] = Field(default=None, max_length=32)
     access_tier: Optional[str] = Field(default=None, max_length=32)
-    available_action_ids: list[str] = Field(default_factory=list, max_length=10)
+    # 18 = screen-ranked segment (10) + reserved global navigation segment (8).
+    # Mirrors AVAILABLE_ACTION_IDS_CAP in hushh-webapp screen-context-builder.ts.
+    available_action_ids: list[str] = Field(default_factory=list, max_length=18)
     visible_modules: list[str] = Field(default_factory=list, max_length=10)
     cache_freshness: Optional[str] = Field(default=None, max_length=32)
     vault_ready: Optional[bool] = None
@@ -199,13 +201,16 @@ def _compact_persona_hints(raw: RelayPersonaHints) -> RelayPersonaHints:
         value = raw.get(key)
         if isinstance(value, bool):
             hints[key] = value
-    for key in ("available_action_ids", "visible_modules"):
+    # available_action_ids carries the screen segment plus the reserved global
+    # navigation segment (mirrors frontend AVAILABLE_ACTION_IDS_CAP = 18).
+    _hint_list_limits = {"available_action_ids": 18, "visible_modules": 10}
+    for key, item_limit in _hint_list_limits.items():
         value = raw.get(key)
         if not isinstance(value, list):
             continue
         clean_items = [
             item.strip()[:96] for item in value if isinstance(item, str) and item.strip()
-        ][:10]
+        ][:item_limit]
         if clean_items:
             hints[key] = clean_items
     return hints
@@ -601,9 +606,16 @@ def _compose_app_context_update(hints: RelayPersonaHints, *, proactive: bool) ->
             sanitize_action_id(action_id) for action_id in _hint_list(hints, "available_action_ids")
         )
         if clean
-    ][:10]
+    ][:18]
     if action_ids:
-        parts.append("Available app action contracts here: " + ", ".join(action_ids) + ".")
+        # "here" previously implied these were the ONLY contracts anywhere,
+        # which made the model refuse cross-screen navigation ("go to
+        # profile"). The list now includes a global navigation segment, so the
+        # wording must say navigation contracts work from any screen.
+        parts.append(
+            "Available app action contracts (route.* navigation contracts work "
+            "from any screen): " + ", ".join(action_ids) + "."
+        )
     vault_ready = _hint_bool(hints, "vault_ready")
     if vault_ready is not None:
         parts.append("Vault is ready." if vault_ready else "Vault is not ready.")
@@ -817,8 +829,15 @@ def _build_action_proposal_tools(genai_types: Any) -> Optional[list[Any]]:
         declaration = genai_types.FunctionDeclaration(
             name=_ONE_VOICE_ACTION_PROPOSAL_TOOL,
             description=(
-                "Proposal-only signal for Hussh One Voice. Provide a generated "
-                "action_id, slots, confidence, and reason. Never execute the action."
+                "Propose an app action for Hussh One to run, exactly like "
+                "calling a tool: pick the action_id from the available action "
+                "contracts and fill slots from what the user said plus the "
+                "contract's stated defaults. The app validates and executes; "
+                "you only propose. Set confidence honestly: 0.9+ only when the "
+                "user's words map directly onto one contract, 0.6-0.8 when you "
+                "inferred the mapping, below 0.6 when guessing. Do not ask the "
+                "user for an input whose contract line shows a default; pass "
+                "the default in slots instead."
             ),
             parameters={
                 "type": "object",
@@ -829,7 +848,7 @@ def _build_action_proposal_tools(genai_types: Any) -> Optional[list[Any]]:
                     "reason": {"type": "string"},
                     "needs_confirmation": {"type": "boolean"},
                 },
-                "required": ["action_id"],
+                "required": ["action_id", "confidence"],
             },
         )
         return [genai_types.Tool(function_declarations=[declaration])]
@@ -840,14 +859,23 @@ def _build_action_proposal_tools(genai_types: Any) -> Optional[list[Any]]:
 def _with_live_proposal_instructions(instructions: str) -> str:
     return (
         f"{instructions}\n\n"
-        "Gemini Live action bridge: operate Agent First. Use the system "
-        "instruction, active app state, and generated action contracts to infer "
-        "the user's goal. When the user asks for an app action, you may call "
-        f"{_ONE_VOICE_ACTION_PROPOSAL_TOOL} with a generated action id, slots, "
-        "confidence, and reason as a proposal only. The provider must never claim "
-        "execution. Hussh One will validate guards, confirmation policy, A2A "
+        "Gemini Live action bridge: treat the available app action contracts "
+        "like a tool catalog. Each contract line reads "
+        "'action_id (Label; inputs: slot=<resolver>, slot default value)'. "
+        "When the user asks for something an action covers, call "
+        f"{_ONE_VOICE_ACTION_PROPOSAL_TOOL} naturally in your flow, the way an "
+        "agent calls a tool: choose the single best-matching action_id, fill "
+        "slots from the user's words, and use contract defaults for anything "
+        "the user did not specify instead of asking a clarifying question. "
+        "Only ask the user when a required input has no default and cannot be "
+        "inferred. route.* navigation contracts work from any screen, so "
+        "requests like 'go to profile' always map to their route action even "
+        "when the user is elsewhere in the app. You never execute anything "
+        "yourself: Hussh One validates guards, confirmation policy, A2A "
         "delegation, and route settlement through the generated gateway before "
-        "any action occurs."
+        "any action occurs, and it will tell the user if something is blocked. "
+        "If no contract fits, just answer conversationally; never invent an "
+        "action_id."
     )
 
 

--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -78,6 +78,64 @@ def _normalize_ticker_or_422(raw_ticker: str) -> str:
     return ticker
 
 
+def _require_known_ticker_or_422(ticker: str) -> str:
+    """Reject debate/analysis requests for symbols the symbol master does not know.
+
+    Format validation alone let misheard STT tokens (e.g. "YOUR") start a full
+    multi-agent debate that produced a score from fallback defaults while every
+    agent reported no data. classify() cannot be used directly as the gate
+    because its ticker_pattern_fallback deliberately treats pattern-valid
+    unknowns as tradable for portfolio flows; a debate run demands a real
+    symbol-master match. When the ticker cache is unavailable (cold start,
+    DB miss) we cannot verify membership and let the request through rather
+    than blocking all analysis on infrastructure state.
+    """
+    from hushh_mcp.services.ticker_cache import ticker_cache
+
+    symbol_master = get_symbol_master_service()
+    classification = symbol_master.classify(ticker)
+    if classification.reason == "symbol_master_match":
+        if not classification.tradable:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "ANALYZE_TICKER_NOT_TRADABLE",
+                    "message": f"'{ticker}' is a known identifier but not a tradable equity.",
+                    "ticker": ticker,
+                },
+            )
+        return ticker
+    if classification.reason in {"trade_action_token", "cash_equivalent"}:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "ANALYZE_TICKER_UNKNOWN",
+                "message": f"'{ticker}' is not an analyzable equity symbol.",
+                "ticker": ticker,
+            },
+        )
+    # classify() already attempted ticker_cache.load_from_db(); a loaded cache
+    # with no match means the symbol genuinely does not exist.
+    if ticker_cache.loaded:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": "ANALYZE_TICKER_UNKNOWN",
+                "message": (
+                    f"'{ticker}' is not a recognized ticker symbol. "
+                    "Check the spelling or say the company name."
+                ),
+                "ticker": ticker,
+            },
+        )
+    logger.warning(
+        "stream.ticker_gate_unverifiable ticker=%s reason=%s (ticker cache empty)",
+        ticker,
+        classification.reason,
+    )
+    return ticker
+
+
 async def _require_vault_owner_token(
     *,
     user_id: str,
@@ -2489,6 +2547,9 @@ async def analyze_stream(
 
     # Auth uses validate_token_with_db inside _require_vault_owner_token().
     consent_token = await _require_vault_owner_token(user_id=user_id, authorization=authorization)
+    # Membership gate runs after auth so unauthenticated callers cannot probe
+    # which symbols exist.
+    ticker = _require_known_ticker_or_422(ticker)
 
     # Log operation for audit trail (shows what vault.owner token was used for)
     consent_service = ConsentDBService()
@@ -2530,6 +2591,12 @@ async def analyze_stream_post(
         user_id=body.user_id,
         authorization=authorization,
     )
+
+    if not body.run_id:
+        # Resume requests attach to an already-validated run; only fresh
+        # analysis starts go through the symbol-master membership gate. Runs
+        # after auth so unauthenticated callers cannot probe symbol existence.
+        ticker = _require_known_ticker_or_422(ticker)
 
     if body.run_id:
         run = await _RUN_MANAGER.get_run(body.run_id)
@@ -2601,6 +2668,9 @@ async def analyze_run_start(
         user_id=body.user_id,
         authorization=authorization,
     )
+    # Membership gate runs after auth so unauthenticated callers cannot probe
+    # which symbols exist.
+    ticker = _require_known_ticker_or_422(ticker)
     consent_service = ConsentDBService()
     next_context = dict(body.context or {})
     if body.pick_source:

--- a/consent-protocol/hushh_mcp/services/agent_persona.py
+++ b/consent-protocol/hushh_mcp/services/agent_persona.py
@@ -197,7 +197,9 @@ def build_persona_context(
         persona=normalize_persona(persona),
         route_family=sanitize_screen(route_family),
         voice_state=normalized_voice_state or None,
-        available_action_ids=_sanitize_sequence(available_action_ids, sanitize_action_id),
+        # 18 mirrors the frontend AVAILABLE_ACTION_IDS_CAP: screen segment (10)
+        # plus the reserved global navigation segment (8).
+        available_action_ids=_sanitize_sequence(available_action_ids, sanitize_action_id, limit=18),
         visible_modules=_sanitize_sequence(visible_modules, sanitize_label),
         cache_freshness=(normalized_cache_freshness or None),  # type: ignore[arg-type]
         vault_ready=vault_ready if isinstance(vault_ready, bool) else None,
@@ -253,13 +255,49 @@ _PERSONA_LENS: dict[AgentPersona, str] = {
 }
 
 
+def _describe_action_inputs(manifest_action: dict) -> str:
+    """Render a compact MCP-tool-style parameter signature for one action.
+
+    Mirrors how tool schemas read to coding agents: each required input shows
+    its slot name, and defaults are stated inline so the model knows it never
+    needs to ask a clarifying question for an input the contract already
+    answers. Example: "inputs: symbol=<ticker>, pickSource default 'default'".
+    """
+    goal = manifest_action.get("goal")
+    if not isinstance(goal, dict):
+        return ""
+    required_inputs = goal.get("required_inputs")
+    if not isinstance(required_inputs, list) or not required_inputs:
+        return ""
+    rendered: list[str] = []
+    for entry in required_inputs:
+        if not isinstance(entry, dict):
+            continue
+        slot = sanitize_label(str(entry.get("slot") or entry.get("name") or ""))
+        if not slot:
+            continue
+        default_value = sanitize_label(str(entry.get("default_value") or ""))
+        if default_value:
+            rendered.append(f"{slot} default '{default_value}'")
+            continue
+        resolver = sanitize_label(str(entry.get("resolver") or ""))
+        rendered.append(f"{slot}=<{resolver or 'value'}>")
+        if len(rendered) >= 4:
+            break
+    if not rendered:
+        return ""
+    return "; inputs: " + ", ".join(rendered)
+
+
 def _describe_action_contract(action_id: str, ctx: AgentPersonaContext) -> str:
-    """Render one action id with its manifest label and a coarse lock hint.
+    """Render one action id like an MCP tool doc: label, param signature, lock.
 
     The manifest load is process-cached (lru_cache), so this adds no I/O on the
-    hot token/relay path. Labels give the model semantics beyond bare ids, and
-    the lock hint keeps tier prose and the action list from contradicting each
-    other (the app still enforces every guard at execution time).
+    hot token/relay path. Labels + input signatures give the model the same
+    affordance a coding agent gets from a tool schema: it can propose the
+    action with slots filled (using contract defaults) instead of guessing
+    from a bare id or asking questions the contract already answers. The app
+    still enforces every guard at execution time.
     """
     try:
         from hushh_mcp.services.voice_action_manifest import get_voice_manifest_action
@@ -283,8 +321,9 @@ def _describe_action_contract(action_id: str, ctx: AgentPersonaContext) -> str:
         "anon_browsing",
     }:
         locked_hint = " [requires sign-in]"
+    inputs_hint = _describe_action_inputs(manifest_action)
     if label:
-        return f"{action_id} ({label}){locked_hint}"
+        return f"{action_id} ({label}{inputs_hint}){locked_hint}"
     return f"{action_id}{locked_hint}"
 
 
@@ -300,7 +339,10 @@ def _context_clause(ctx: AgentPersonaContext) -> str:
         described = [
             _describe_action_contract(action_id, ctx) for action_id in ctx.available_action_ids
         ]
-        parts.append("Available app action contracts: " + ", ".join(described) + ".")
+        parts.append(
+            "Available app action contracts (route.* navigation contracts work "
+            "from any screen): " + ", ".join(described) + "."
+        )
     if ctx.voice_state:
         parts.append(f"The current voice transition state is '{ctx.voice_state}'.")
     cache_parts: list[str] = []

--- a/consent-protocol/tests/test_kai_stream_ticker_gate.py
+++ b/consent-protocol/tests/test_kai_stream_ticker_gate.py
@@ -1,0 +1,111 @@
+# tests/test_kai_stream_ticker_gate.py
+"""
+Unit tests for the symbol-master membership gate on analysis-starting routes.
+
+Regression context: voice STT misheard "Nvidia" as "YOUR". "YOUR" passes the
+format-only _normalize_ticker_or_422 check, so a full multi-agent debate ran
+against a nonexistent company and produced a composite score from fallback
+defaults while every agent reported no coverage.
+
+_require_known_ticker_or_422 closes that hole: a fresh debate/analysis start
+now requires a real symbol-master match. The gate deliberately:
+  - allows symbols when the ticker cache is empty (infra state must not block
+    all analysis; classify() falls back to pattern acceptance)
+  - rejects known-but-non-tradable identifiers
+  - rejects unknown symbols when the cache is loaded
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.kai.stream import _require_known_ticker_or_422
+
+
+def _classification(reason: str, tradable: bool) -> SimpleNamespace:
+    return SimpleNamespace(reason=reason, tradable=tradable)
+
+
+class TestKnownTickerGate:
+    def test_symbol_master_match_tradable_passes(self):
+        with (
+            patch("api.routes.kai.stream.get_symbol_master_service") as service,
+            patch("hushh_mcp.services.ticker_cache.ticker_cache") as cache,
+        ):
+            service.return_value.classify.return_value = _classification(
+                "symbol_master_match", tradable=True
+            )
+            cache.loaded = True
+            assert _require_known_ticker_or_422("NVDA") == "NVDA"
+
+    def test_symbol_master_match_non_tradable_rejected(self):
+        with (
+            patch("api.routes.kai.stream.get_symbol_master_service") as service,
+            patch("hushh_mcp.services.ticker_cache.ticker_cache") as cache,
+        ):
+            service.return_value.classify.return_value = _classification(
+                "symbol_master_match", tradable=False
+            )
+            cache.loaded = True
+            with pytest.raises(HTTPException) as exc:
+                _require_known_ticker_or_422("XXII")
+            assert exc.value.status_code == 422
+            assert exc.value.detail["code"] == "ANALYZE_TICKER_NOT_TRADABLE"
+
+    def test_unknown_symbol_with_loaded_cache_rejected(self):
+        """The exact 'YOUR' regression: pattern-valid, not a real symbol."""
+        with (
+            patch("api.routes.kai.stream.get_symbol_master_service") as service,
+            patch("hushh_mcp.services.ticker_cache.ticker_cache") as cache,
+        ):
+            service.return_value.classify.return_value = _classification(
+                "ticker_pattern_fallback", tradable=True
+            )
+            cache.loaded = True
+            with pytest.raises(HTTPException) as exc:
+                _require_known_ticker_or_422("YOUR")
+            assert exc.value.status_code == 422
+            assert exc.value.detail["code"] == "ANALYZE_TICKER_UNKNOWN"
+
+    def test_trade_action_token_rejected(self):
+        with (
+            patch("api.routes.kai.stream.get_symbol_master_service") as service,
+            patch("hushh_mcp.services.ticker_cache.ticker_cache") as cache,
+        ):
+            service.return_value.classify.return_value = _classification(
+                "trade_action_token", tradable=False
+            )
+            cache.loaded = True
+            with pytest.raises(HTTPException) as exc:
+                _require_known_ticker_or_422("BUY")
+            assert exc.value.status_code == 422
+            assert exc.value.detail["code"] == "ANALYZE_TICKER_UNKNOWN"
+
+    def test_cash_equivalent_rejected(self):
+        with (
+            patch("api.routes.kai.stream.get_symbol_master_service") as service,
+            patch("hushh_mcp.services.ticker_cache.ticker_cache") as cache,
+        ):
+            service.return_value.classify.return_value = _classification(
+                "cash_equivalent", tradable=False
+            )
+            cache.loaded = True
+            with pytest.raises(HTTPException) as exc:
+                _require_known_ticker_or_422("CASH")
+            assert exc.value.status_code == 422
+
+    def test_unverifiable_when_cache_empty_passes_through(self):
+        """Cold-start/DB-miss must not turn into a hard analysis outage."""
+        with (
+            patch("api.routes.kai.stream.get_symbol_master_service") as service,
+            patch("hushh_mcp.services.ticker_cache.ticker_cache") as cache,
+        ):
+            service.return_value.classify.return_value = _classification(
+                "ticker_pattern_fallback", tradable=True
+            )
+            cache.loaded = False
+            assert _require_known_ticker_or_422("NVDA") == "NVDA"

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -61,7 +61,9 @@ describe("OneDashboardPage", () => {
     // when the href already has a query) so the surface's top-bar back button
     // returns to the dashboard, not Profile. See resolveTopShellBreadcrumb.
     const fromOne = `from=${ROUTES.ONE_HOME}`;
-    const financeLink = screen.getByRole("link", { name: "Open Finance" });
+    // "Finance" was renamed to "Investor" when Investor/RIA became standalone
+    // top-level agents.
+    const financeLink = screen.getByRole("link", { name: "Open Investor" });
     expect(financeLink.getAttribute("href")).toBe(`${ROUTES.KAI_HOME}?${fromOne}`);
     expect(financeLink.className).not.toContain("translate");
     expect(screen.getByTestId("one-agent-tile-finance").className).toContain(

--- a/hushh-webapp/__tests__/components/providers-theme-contract.test.ts
+++ b/hushh-webapp/__tests__/components/providers-theme-contract.test.ts
@@ -10,13 +10,20 @@ function read(relativePath: string) {
 }
 
 describe("Providers theme contract", () => {
-  it("does not force light theme on web while preserving iOS daylight mode", () => {
+  it("never forces a theme on any platform (iOS daylight pin removed)", () => {
     const source = read("app/providers.tsx");
 
-    expect(source).toContain("const forceNativeDaylight");
-    expect(source).toContain("Capacitor.isNativePlatform() && Capacitor.getPlatform() === \"ios\"");
-    expect(source).toContain('forcedTheme={forceNativeDaylight ? "light" : undefined}');
-    expect(source).toContain("enableSystem={!forceNativeDaylight}");
-    expect(source).not.toContain('forcedTheme="light"');
+    // The earlier "daylight" ship pinned iOS to light via forcedTheme +
+    // Info.plist UIUserInterfaceStyle=Light. Both pins are removed: the theme
+    // toggle must work identically on web and native iOS.
+    expect(source).not.toContain("forcedTheme");
+    expect(source).not.toContain("forceNativeDaylight");
+    expect(source).toContain('attribute="class"');
+    expect(source).toContain("enableSystem");
+  });
+
+  it("keeps Info.plist free of a UIUserInterfaceStyle pin", () => {
+    const plist = read("ios/App/App/Info.plist");
+    expect(plist).not.toContain("UIUserInterfaceStyle");
   });
 });

--- a/hushh-webapp/__tests__/one-goal/one-goal-planner.test.ts
+++ b/hushh-webapp/__tests__/one-goal/one-goal-planner.test.ts
@@ -3,19 +3,36 @@ import { describe, expect, it } from "vitest";
 import { planOneGoal } from "@/lib/one-goal/one-goal-planner";
 
 describe("planOneGoal", () => {
-  it("asks for the next blocking source input for Analyze TSLA", () => {
+  it("fills contract defaults instead of asking for pick source on Analyze TSLA", () => {
     const plan = planOneGoal({
       transcript: "Analyze TSLA",
       entrypoint: "voice",
     });
 
-    expect(plan.status).toBe("input_needed");
-    if (plan.status !== "input_needed") return;
+    // pick_source declares default_value "default" with a single option; a
+    // natural agent flow uses the declared default rather than interrupting
+    // the user with "Which list should Kai use for this debate?".
+    expect(plan.status).toBe("ready");
+    if (plan.status !== "ready") return;
     expect(plan.goalId).toBe("goal.analysis.start_debate");
     expect(plan.action.action_id).toBe("analysis.start");
     expect(plan.slots.symbol).toBe("TSLA");
-    expect(plan.prompt.slot).toBe("pickSource");
-    expect(plan.prompt.prompt).toMatch(/Which list/i);
+    expect(plan.slots.pickSource).toBe("default");
+  });
+
+  it("still asks when a required input has no contract default", () => {
+    const plan = planOneGoal({
+      actionId: "analysis.start",
+      // Every token here is a stop word or contract-dictionary token, so no
+      // ticker can be resolved and the symbol prompt must fire.
+      transcript: "start the stock debate",
+      entrypoint: "voice",
+    });
+
+    expect(plan.status).toBe("input_needed");
+    if (plan.status !== "input_needed") return;
+    expect(plan.prompt.slot).toBe("symbol");
+    expect(plan.prompt.prompt).toMatch(/Which stock/i);
   });
 
   it("plans Analyze TSLA using default as a ready governed goal", () => {
@@ -79,5 +96,35 @@ describe("planOneGoal", () => {
     expect(plan.status).toBe("input_needed");
     if (plan.status !== "input_needed") return;
     expect(plan.prompt.slot).toBe("symbol");
+  });
+
+  it("does not treat possessive pronouns from STT as ticker symbols", () => {
+    // Regression: "stock analysis for Nvidia" was misheard as "stock for
+    // YOUR"; "YOUR" matched the 1-5 uppercase ticker pattern and started a
+    // real debate against a nonexistent company.
+    const plan = planOneGoal({
+      actionId: "analysis.start",
+      transcript: "stock for your",
+      entrypoint: "voice",
+    });
+
+    expect(plan.status).toBe("input_needed");
+    if (plan.status !== "input_needed") return;
+    expect(plan.prompt.slot).toBe("symbol");
+    expect(plan.slots.symbol).toBeUndefined();
+  });
+
+  it("never overrides an explicit navigation intent with a ticker action", () => {
+    // Regression: "navigate to Investor" was hijacked into analysis.start,
+    // which then asked "Which list should Kai use for this debate?".
+    const plan = planOneGoal({
+      transcript: "navigate and take me to Investor",
+      candidateActionId: "route.kai_home",
+      entrypoint: "voice",
+    });
+
+    expect(plan.status).toBe("ready");
+    if (plan.status !== "ready") return;
+    expect(plan.action.action_id).toBe("route.kai_home");
   });
 });

--- a/hushh-webapp/__tests__/one-goal/one-goal-planner.test.ts
+++ b/hushh-webapp/__tests__/one-goal/one-goal-planner.test.ts
@@ -114,6 +114,49 @@ describe("planOneGoal", () => {
     expect(plan.slots.symbol).toBeUndefined();
   });
 
+  it("explains the real prerequisite when state gating blocks the matched intent", () => {
+    const plan = planOneGoal({
+      transcript: "Analyze TSLA",
+      entrypoint: "voice",
+      appRuntimeState: {
+        auth: { signed_in: true, user_id: "user_1" },
+        vault: { unlocked: true, token_available: true, token_valid: true },
+        route: { pathname: "/one/kai", screen: "kai_market", subview: null },
+        runtime: {
+          analysis_active: true,
+          analysis_ticker: "NVDA",
+          analysis_run_id: "run_1",
+          import_active: false,
+          import_run_id: null,
+          busy_operations: [],
+        },
+        portfolio: { has_portfolio_data: false },
+        persona: {
+          active: "investor",
+          primary_nav: "investor",
+          available: ["investor"],
+          transition_target: null,
+          ria_switch_available: false,
+          ria_setup_available: false,
+        },
+        voice: {
+          available: true,
+          tts_playing: false,
+          last_tool_name: null,
+          last_ticker: null,
+        },
+      },
+    });
+
+    // A debate is already running, so analysis_idle_required blocks a new
+    // start. The plan must carry the matched intent and the true prerequisite
+    // instead of a generic "could not map that request".
+    expect(plan.status).toBe("blocked");
+    if (plan.status !== "blocked") return;
+    expect(plan.action?.action_id).toBe("analysis.start");
+    expect(plan.reason).toMatch(/active analysis/i);
+  });
+
   it("never overrides an explicit navigation intent with a ticker action", () => {
     // Regression: "navigate to Investor" was hijacked into analysis.start,
     // which then asked "Which list should Kai use for this debate?".

--- a/hushh-webapp/__tests__/voice/one-intelligence-eval.test.ts
+++ b/hushh-webapp/__tests__/voice/one-intelligence-eval.test.ts
@@ -22,11 +22,13 @@ type EvalCase =
     };
 
 const EVAL_CASES: EvalCase[] = [
-  { kind: "goal", transcript: "Analyze TSLA", expectedStatus: "input_needed", expectedActionId: "analysis.start", expectedSymbol: "TSLA" },
+  // Contract defaults satisfy pick_source without a clarifying question, so a
+  // plain "Analyze TSLA" is immediately ready (MCP-tool-style default filling).
+  { kind: "goal", transcript: "Analyze TSLA", expectedStatus: "ready", expectedActionId: "analysis.start", expectedSymbol: "TSLA", expectedPickSource: "default" },
   { kind: "goal", transcript: "Analyze TSLA using default", expectedStatus: "ready", expectedActionId: "analysis.start", expectedSymbol: "TSLA", expectedPickSource: "default" },
   { kind: "goal", transcript: "analyzing nvidia using default", expectedStatus: "ready", expectedActionId: "analysis.start", expectedSymbol: "NVDA", expectedPickSource: "default" },
   { kind: "goal", transcript: "start the debate for Microsoft with the default list", candidateActionId: "analysis.start", slots: { symbol: "MSFT", pickSource: "default" }, expectedStatus: "ready", expectedActionId: "analysis.start", expectedSymbol: "MSFT", expectedPickSource: "default" },
-  { kind: "goal", transcript: "start the debate for Tesla", candidateActionId: "analysis.start", slots: { symbol: "TSLA" }, expectedStatus: "input_needed", expectedActionId: "analysis.start", expectedSymbol: "TSLA" },
+  { kind: "goal", transcript: "start the debate for Tesla", candidateActionId: "analysis.start", slots: { symbol: "TSLA" }, expectedStatus: "ready", expectedActionId: "analysis.start", expectedSymbol: "TSLA", expectedPickSource: "default" },
   { kind: "goal", transcript: "use default for the pending stock debate", candidateActionId: "analysis.start", slots: { pickSource: "default" }, expectedStatus: "input_needed", expectedActionId: "analysis.start", expectedPickSource: "default" },
   { kind: "goal", transcript: "open analysis", candidateActionId: "route.kai_analysis", expectedStatus: "ready", expectedActionId: "route.kai_analysis" },
   { kind: "goal", transcript: "show analysis history", candidateActionId: "route.analysis_history", expectedStatus: "ready", expectedActionId: "route.analysis_history" },

--- a/hushh-webapp/__tests__/voice/one-voice-live-action-bridge.test.ts
+++ b/hushh-webapp/__tests__/voice/one-voice-live-action-bridge.test.ts
@@ -107,15 +107,22 @@ describe("OneVoiceLiveActionBridge", () => {
       openChatHandoff: vi.fn(),
     });
 
-    await bridge.processTranscript({ transcript: "Analyze TSLA" });
-    expect(speak.mock.lastCall?.[0].text).toContain("Which list");
-    expect(speak.mock.lastCall?.[0].text).toContain("default");
-
-    await bridge.processTranscript({ transcript: "which lists are available" });
-    expect(speak.mock.lastCall?.[0].text).toContain("Available options: default");
+    // The ticker input has no contract default, so a debate request without a
+    // symbol still produces a pending clarification turn.
+    await bridge.processTranscript({
+      transcript: "start the stock debate",
+      candidate: {
+        action_id: "analysis.start",
+        needs_confirmation: false,
+        confidence: 0.9,
+        slots: {},
+        reason: "Debate requested without a symbol.",
+      },
+    });
+    expect(speak.mock.lastCall?.[0].text).toContain("Which stock");
     expect(runOneGoal).not.toHaveBeenCalled();
 
-    await bridge.processTranscript({ transcript: "use default" });
+    await bridge.processTranscript({ transcript: "Tesla please" });
     expect(runOneGoal).toHaveBeenCalledTimes(1);
     expect(vi.mocked(runOneGoal).mock.calls[0]?.[0].plan).toMatchObject({
       status: "ready",
@@ -130,11 +137,7 @@ describe("OneVoiceLiveActionBridge", () => {
     expect(vi.mocked(runOneGoal).mock.calls[0]?.[0].waitForCompletion).toBe(false);
   });
 
-  it.each([
-    "which lists are available",
-    "what sources can I choose",
-    "show available choices",
-  ])("answers option questions during a pending Gemini Live goal: %s", async (optionQuestion) => {
+  it("runs Analyze TSLA immediately using the contract default pick source", async () => {
     const speak = vi.fn().mockResolvedValue(undefined);
     const bridge = new OneVoiceLiveActionBridge({
       userId: "user_1",
@@ -147,10 +150,20 @@ describe("OneVoiceLiveActionBridge", () => {
     });
 
     await bridge.processTranscript({ transcript: "Analyze TSLA" });
-    await bridge.processTranscript({ transcript: optionQuestion });
 
-    expect(speak.mock.lastCall?.[0].text).toContain("Available options: default");
-    expect(runOneGoal).not.toHaveBeenCalled();
+    // No "Which list should Kai use" interruption: pick_source has a declared
+    // contract default, so the goal is dispatched in the same turn.
+    expect(runOneGoal).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runOneGoal).mock.calls[0]?.[0].plan).toMatchObject({
+      status: "ready",
+      action: {
+        action_id: "analysis.start",
+      },
+      slots: {
+        symbol: "TSLA",
+        pickSource: "default",
+      },
+    });
   });
 
   it("preserves pending Gemini Live goal state across bridge config refreshes", async () => {
@@ -166,36 +179,41 @@ describe("OneVoiceLiveActionBridge", () => {
     };
     const bridge = new OneVoiceLiveActionBridge(baseConfig);
 
-    await bridge.processTranscript({ transcript: "Analyze TSLA" });
+    // Symbol has no default, so this parks a pending goal turn.
+    await bridge.processTranscript({
+      transcript: "start the stock debate",
+      candidate: {
+        action_id: "analysis.start",
+        needs_confirmation: false,
+        confidence: 0.9,
+        slots: {},
+        reason: "Debate requested without a symbol.",
+      },
+    });
+    expect(speak.mock.lastCall?.[0].text).toContain("Which stock");
     bridge.updateConfig({
       ...baseConfig,
       getVoiceContext: () => ({ refreshed: true }),
     });
-    await bridge.processTranscript({ transcript: "which lists are available" });
+    await bridge.processTranscript({ transcript: "Tesla" });
 
-    expect(speak.mock.lastCall?.[0].text).toContain("Available options: default");
-    expect(runOneGoal).not.toHaveBeenCalled();
+    expect(runOneGoal).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runOneGoal).mock.calls[0]?.[0].plan).toMatchObject({
+      status: "ready",
+      slots: {
+        symbol: "TSLA",
+        pickSource: "default",
+      },
+    });
   });
 
   it.each([
-    {
-      start: "Analyze TSLA",
-      question: "which lists are available",
-      selection: "use default",
-    },
-    {
-      start: "please research TSLA",
-      question: "what sources can I choose",
-      selection: "default list",
-    },
-    {
-      start: "start a TSLA stock debate",
-      question: "show available choices",
-      selection: "the default one",
-    },
+    "Analyze TSLA",
+    "please research TSLA",
+    "start a TSLA stock debate",
   ])(
-    "chains natural-language Gemini Live goal turns without hardcoded transcript branches: $start",
-    async ({ start, question, selection }) => {
+    "dispatches natural-language debate requests in one turn using contract defaults: %s",
+    async (start) => {
       const speak = vi.fn().mockResolvedValue(undefined);
       const bridge = new OneVoiceLiveActionBridge({
         userId: "user_1",
@@ -208,13 +226,7 @@ describe("OneVoiceLiveActionBridge", () => {
       });
 
       await bridge.processTranscript({ transcript: start });
-      expect(speak.mock.lastCall?.[0].text).toContain("Which list");
 
-      await bridge.processTranscript({ transcript: question });
-      expect(speak.mock.lastCall?.[0].text).toContain("Available options: default");
-      expect(runOneGoal).not.toHaveBeenCalled();
-
-      await bridge.processTranscript({ transcript: selection });
       expect(runOneGoal).toHaveBeenCalledTimes(1);
       expect(vi.mocked(runOneGoal).mock.calls[0]?.[0].plan).toMatchObject({
         status: "ready",

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -212,6 +212,26 @@ describe("buildStructuredScreenContext", () => {
     );
   });
 
+  it("always includes global navigation contracts regardless of screen", () => {
+    // Regression: "go to profile" from the Connect tab failed because
+    // route.profile was screen-filtered out of available_action_ids, so the
+    // model was never told the contract existed.
+    window.history.pushState({}, "", "/marketplace");
+    document.body.innerHTML = "<h1>Connect</h1>";
+
+    const context = buildStructuredScreenContext({
+      appRuntimeState: makeRuntimeState("/marketplace", "marketplace"),
+      voiceContext: {},
+    });
+
+    const availableIds = (
+      context.screen_metadata as { available_action_ids: string[] }
+    ).available_action_ids;
+    expect(availableIds).toEqual(
+      expect.arrayContaining(["route.profile", "route.kai_home", "route.ria_home"])
+    );
+  });
+
   it("caps multi-source context arrays before they enter the voice planner payload", () => {
     const oversizedActions = Array.from({ length: 12 }, (_, index) => ({
       id: `action_${index}`,

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -15,6 +15,24 @@ input[type="reset"],
   touch-action: manipulation;
 }
 
+/* iOS WKWebView: a press-and-hold on an interactive element triggers the
+ * system callout/text-selection path, which cancels the pointer stream with
+ * pointercancel BEFORE md-ripple sees pointerup. The ripple's pressed layer
+ * then sticks until the next interaction. Suppressing the callout and text
+ * selection on actionables keeps the pointer stream intact so the press state
+ * always clears. Inputs keep selection/callout for copy-paste. */
+a,
+button,
+[role="button"],
+[role="radio"],
+[role="tab"],
+[role="menuitem"],
+[role="option"] {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 /* Remove default iOS tap highlight flash */
 * {
   -webkit-tap-highlight-color: transparent;
@@ -1387,7 +1405,11 @@ html.native-ios {
   -webkit-backdrop-filter: blur(24px);
 }
 
-/* Material Web ripple: ensure it fills its host and clips with border-radius. */
+/* Material Web ripple: ensure it fills its host and clips with border-radius.
+ * pointer-events:none belongs on the ripple element itself, not only the host:
+ * the injected <md-ripple> child previously relied on md-ripple's internal
+ * styles staying opaque to hits; a regression there re-introduces the iOS
+ * "first tap swallowed / needs double tap" bug on the bottom nav. */
 md-ripple.morphy-md-ripple {
   position: absolute;
   inset: 0;
@@ -1395,6 +1417,7 @@ md-ripple.morphy-md-ripple {
   width: 100%;
   height: 100%;
   border-radius: inherit;
+  pointer-events: none;
 }
 
 .morphy-ripple-host {

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -506,10 +506,10 @@ function AppShellFrame({ children }: ProvidersProps) {
 
 export function Providers({ children }: ProvidersProps) {
   // Theme switching now works on every platform, including native iOS. The
-  // earlier "daylight" ship pinned iOS to light (forcedTheme + Info.plist
-  // UIUserInterfaceStyle=Light); both pins are removed so the in-app theme
-  // toggle behaves identically on web and native, with StatusBarManager
-  // keeping the native chrome in sync with resolvedTheme.
+  // earlier "daylight" ship pinned iOS to light (a next-themes forced theme
+  // plus Info.plist UIUserInterfaceStyle=Light); both pins are removed so the
+  // in-app theme toggle behaves identically on web and native, with
+  // StatusBarManager keeping the native chrome in sync with resolvedTheme.
   return (
     <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
       <ObservabilityRouteObserver />

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -505,19 +505,13 @@ function AppShellFrame({ children }: ProvidersProps) {
 }
 
 export function Providers({ children }: ProvidersProps) {
-  // iOS ships in forced LIGHT ("daylight") mode: the native side is pinned via
-  // Info.plist UIUserInterfaceStyle=Light, and next-themes is pinned here so no
-  // persisted/system "dark" can re-apply the .dark class.
-  const forceNativeDaylight =
-    Capacitor.isNativePlatform() && Capacitor.getPlatform() === "ios";
-
+  // Theme switching now works on every platform, including native iOS. The
+  // earlier "daylight" ship pinned iOS to light (forcedTheme + Info.plist
+  // UIUserInterfaceStyle=Light); both pins are removed so the in-app theme
+  // toggle behaves identically on web and native, with StatusBarManager
+  // keeping the native chrome in sync with resolvedTheme.
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="light"
-      forcedTheme={forceNativeDaylight ? "light" : undefined}
-      enableSystem={!forceNativeDaylight}
-    >
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
       <ObservabilityRouteObserver />
       <StepProgressProvider>
         <StatusBarManager />

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -36,7 +36,10 @@ import {
   SegmentedPill,
   type SegmentedPillOption,
 } from "@/lib/morphy-ux/ui";
-import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
+import {
+  snapKaiBottomChromeVisible,
+  useKaiBottomChromeVisibility,
+} from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
@@ -432,6 +435,13 @@ export const Navbar = () => {
         )}
         style={{ width: bottomNavGroupWidth }}
         ref={pillRef}
+        // iOS first-tap fix: if the hide/reveal animation is mid-flight when
+        // a finger lands, the buttons translate away before pointerup and the
+        // tap is lost (felt as "need to tap twice"). Snapping the chrome to
+        // its resting position on pointerdown keeps the tap target still.
+        onPointerDownCapture={() => {
+          if (hideBottomChromeProgress > 0) snapKaiBottomChromeVisible();
+        }}
       >
         <div
           className="min-w-0 pointer-events-auto"
@@ -462,12 +472,17 @@ export const Navbar = () => {
           data-native-voice-control-id="one_voice_open_command_search"
           data-testid="one-voice-open-command-search"
           className={cn(
-            // Stretch to the pill height and stay a perfect circle so the search
-            // bubble and the bottom-nav pill read as one symmetric row.
-            "pointer-events-auto relative z-20 inline-flex aspect-square h-auto w-auto self-stretch shrink-0 items-center justify-center overflow-hidden rounded-full",
+            // A perfect circle matching the stacked pill's 52px min-height.
+            // Explicit equal h/w instead of aspect-square + self-stretch:
+            // WKWebView resolves aspect-ratio against a stretch-derived flex
+            // cross size as indefinite, which rendered this button as an oval
+            // on iOS while web looked fine.
+            "pointer-events-auto relative z-20 inline-flex h-[52px] w-[52px] shrink-0 self-center items-center justify-center overflow-hidden rounded-full",
             "kai-bottom-search-action",
             "transition-[color,transform,background-color] duration-200 ease-[cubic-bezier(0.25,1,0.5,1)]",
-            "hover:bg-black/[0.08] hover:text-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:hover:bg-white/[0.1] active:scale-90 chrome-bottom-foreground",
+            // Hover styles behind (hover:hover) so iOS taps never latch a
+            // sticky hover background on the first touch.
+            "[@media(hover:hover)]:hover:bg-black/[0.08] [@media(hover:hover)]:hover:text-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background [@media(hover:hover)]:dark:hover:bg-white/[0.1] active:scale-90 chrome-bottom-foreground",
           )}
           onClick={() => {
             if (busyOperations["portfolio_save"]) {

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -83,8 +83,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts
+++ b/hushh-webapp/lib/navigation/kai-bottom-chrome-visibility.ts
@@ -203,6 +203,23 @@ export function resetKaiBottomChromeVisibility(): void {
 }
 
 /**
+ * Snap the bottom chrome fully visible with NO animation. Called on
+ * pointerdown inside the bottom nav: when a tap lands while the hide/reveal
+ * animation is mid-flight, the buttons translate away between pointerdown and
+ * pointerup and the browser registers no click, which surfaced on iOS as
+ * "sometimes I have to tap the bottom bar twice". Freezing the chrome at its
+ * mean position for the press guarantees the target is stationary at
+ * pointerup.
+ */
+export function snapKaiBottomChromeVisible(): void {
+  cancelAnimation();
+  state.progress = 0;
+  state.targetProgress = 0;
+  state.lastY = readActiveScrollY();
+  emit();
+}
+
+/**
  * Re-seed the singleton from the ACTUAL current scroll position of the active
  * target and animate toward the matching mean/hidden target.
  *

--- a/hushh-webapp/lib/one-goal/one-goal-planner.ts
+++ b/hushh-webapp/lib/one-goal/one-goal-planner.ts
@@ -21,9 +21,13 @@ const STOP_WORDS = new Set([
   "CAN",
   "DO",
   "FOR",
+  "GO",
+  "HER",
+  "HIS",
   "I",
   "IN",
   "IT",
+  "ITS",
   "KAI",
   "ME",
   "MY",
@@ -31,13 +35,21 @@ const STOP_WORDS = new Set([
   "ON",
   "ONE",
   "OR",
+  "OUR",
   "PLEASE",
+  "SHOW",
   "START",
+  "TAKE",
+  "THAT",
   "THE",
+  "THEIR",
+  "THIS",
   "TO",
   "USE",
+  "WHAT",
   "WITH",
   "YOU",
+  "YOUR",
 ]);
 
 function readString(value: unknown): string | null {
@@ -159,6 +171,17 @@ function rankActionsForTranscript(
     .sort((left, right) => right.score - left.score || left.action.action_id.localeCompare(right.action.action_id));
 }
 
+const NAVIGATION_INTENT_PATTERN =
+  /\b(?:go(?:\s+back)?\s+to|navigate\s+to|take\s+me\s+(?:to|back)|open|switch\s+to|show\s+me\s+the|back\s+to)\b/i;
+
+/**
+ * When the user utters an explicit navigation verb ("navigate to Investor",
+ * "take me to profile"), a route candidate must never be displaced by a
+ * higher-scoring input-collecting action. The old behavior let a ticker false
+ * positive (misheard STT tokens matching the 1-5 letter pattern) hijack a
+ * plain navigation request into an analysis flow that then asked unrelated
+ * clarifying questions.
+ */
 function shouldOverrideCandidate(input: {
   candidate: KaiActionDefinition;
   top: { action: KaiActionDefinition; score: number } | undefined;
@@ -170,6 +193,8 @@ function shouldOverrideCandidate(input: {
   const candidateIsRouteOnly =
     candidate.action_id.startsWith("route.") &&
     candidate.goal.required_inputs.length === 0;
+  const explicitNavigationIntent = NAVIGATION_INTENT_PATTERN.test(transcript);
+  if (candidateIsRouteOnly && explicitNavigationIntent) return false;
   const topResolvesTicker =
     top.action.goal.input_resolvers.includes("ticker_symbol") &&
     Boolean(resolveTickerFromTranscript(transcript, top.action));
@@ -271,6 +296,26 @@ function isInputSatisfied(slotValue: unknown): boolean {
   return typeof slotValue === "string" ? slotValue.trim().length > 0 : slotValue !== undefined && slotValue !== null;
 }
 
+/**
+ * Contract-declared defaults satisfy an input without a spoken clarifying
+ * question. This is what stops the planner from asking "Which list should Kai
+ * use for this debate?" when the contract already says pick_source defaults
+ * to "default" and offers no other option.
+ */
+function applyDefaultValue(
+  input: KaiActionDefinition["goal"]["required_inputs"][number],
+  slots: Record<string, unknown>,
+  slot: string
+): boolean {
+  const defaultValue = readString(input.default_value);
+  if (!defaultValue) return false;
+  slots[slot] = defaultValue;
+  if (slot === "pickSource") {
+    slots.pickSource = defaultValue;
+  }
+  return true;
+}
+
 function nextMissingInput(
   action: KaiActionDefinition,
   slots: Record<string, unknown>
@@ -279,6 +324,7 @@ function nextMissingInput(
     if (input.required === false) continue;
     const slot = input.slot || input.name;
     if (isInputSatisfied(slots[slot])) continue;
+    if (applyDefaultValue(input, slots, slot)) continue;
     return {
       inputName: input.name,
       slot,

--- a/hushh-webapp/lib/one-goal/one-goal-planner.ts
+++ b/hushh-webapp/lib/one-goal/one-goal-planner.ts
@@ -228,6 +228,40 @@ function inferAction(input: OneGoalPlannerInput): KaiActionDefinition | null {
   return ranked[0]?.action ?? null;
 }
 
+/**
+ * When state gating removed every viable match, find the action the user most
+ * likely MEANT (pure lexical ranking, no availability filter) and explain the
+ * real prerequisite. "Unlock your vault to start the stock debate" is a
+ * useful answer; "One could not map that request" reads as a hallucinating
+ * agent that did not listen.
+ */
+function explainBlockedIntent(input: OneGoalPlannerInput): {
+  action: KaiActionDefinition;
+  reason: string;
+} | null {
+  const appRuntimeState = input.appRuntimeState;
+  if (!appRuntimeState) return null;
+  const transcript = input.transcript || "";
+  if (!transcript.trim()) return null;
+  const lexical = KAI_ACTION_GATEWAY.actions
+    .map((action) => ({ action, score: scoreActionForTranscript(action, transcript) }))
+    .filter((entry) => entry.score >= 6)
+    .sort((left, right) => right.score - left.score);
+  const top = lexical[0];
+  if (!top) return null;
+  const availability = evaluateKaiActionAvailability({
+    action: top.action,
+    appRuntimeState,
+    allowPersonaRouteSettlement: true,
+  });
+  if (availability.status === "available") return null;
+  const reason =
+    availability.reason ||
+    availability.blocked_guidance ||
+    `${top.action.label} is not available right now.`;
+  return { action: top.action, reason };
+}
+
 function resolveTickerFromTranscript(
   transcript: string,
   action: KaiActionDefinition
@@ -338,6 +372,16 @@ function nextMissingInput(
 export function planOneGoal(input: OneGoalPlannerInput): OneGoalPlan {
   const action = inferAction(input);
   if (!action) {
+    const blockedIntent = explainBlockedIntent(input);
+    if (blockedIntent) {
+      return {
+        status: "blocked",
+        goalId: blockedIntent.action.goal.goal_id,
+        action: blockedIntent.action,
+        slots: { ...(input.slots || {}) },
+        reason: blockedIntent.reason,
+      };
+    }
     return {
       status: "blocked",
       goalId: null,

--- a/hushh-webapp/lib/one-goal/stock-target-resolver.ts
+++ b/hushh-webapp/lib/one-goal/stock-target-resolver.ts
@@ -84,10 +84,27 @@ function extractStockTarget(transcript: string): string {
   return sanitizeStockTarget(normalized);
 }
 
+/**
+ * Bare uppercase tokens are only trusted as ticker symbols when they exist in
+ * the cached ticker universe. STT output like "YOUR" matches the 1-5 letter
+ * ticker pattern but is not a listed security; without this membership gate a
+ * misheard word starts a full analysis run against a nonexistent company.
+ * When the universe has not loaded yet (null snapshot) we fall back to
+ * accepting the token: the backend symbol-master gate rejects unknown tickers
+ * before any run starts, so the failure mode is a clean refusal, not a fake
+ * debate.
+ */
+function isKnownUniverseTicker(candidate: string): boolean {
+  const rows = getTickerUniverseSnapshot();
+  if (!rows?.length) return true;
+  return rows.some((row) => row.ticker === candidate);
+}
+
 function tickerFromText(value: string, ignoredTokens: ReadonlySet<string>): string | null {
   for (const match of value.toUpperCase().matchAll(TICKER_PATTERN)) {
     const candidate = match[1];
     if (!candidate || ignoredTokens.has(candidate)) continue;
+    if (!isKnownUniverseTicker(candidate)) continue;
     return candidate;
   }
   return null;
@@ -139,12 +156,16 @@ export function resolveStockTargetSymbol(input: {
   const target = extractStockTarget(input.transcript);
   if (!target) return null;
 
-  const targetTicker = tickerFromText(target, ignoredTokens);
-  if (targetTicker) return targetTicker;
-
+  // Alias resolution runs BEFORE bare-token extraction: a spoken company name
+  // like "Tesla" uppercases into a pattern-valid token ("TESLA") that is not
+  // the real symbol. The alias map is the authoritative mapping for common
+  // company names, so it must win over the raw-token heuristic.
   const key = normalizeCompanyLookupKey(target);
   const alias = STOCK_ALIAS_TO_TICKER[key] || STOCK_ALIAS_TO_TICKER[target.toLowerCase()];
   if (alias) return alias;
+
+  const targetTicker = tickerFromText(target, ignoredTokens);
+  if (targetTicker) return targetTicker;
 
   return tickerFromUniverse(target);
 }

--- a/hushh-webapp/lib/services/gemini-live-client.ts
+++ b/hushh-webapp/lib/services/gemini-live-client.ts
@@ -231,6 +231,18 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
   private state: GeminiLiveVoiceState = "idle";
   private sessionId: string | null = null;
   private sourceSeq = 0;
+  /**
+   * Turn fence: after a local interrupt we drop any late model audio still in
+   * flight until the provider closes the interrupted turn (turnComplete) or
+   * the app starts a new turn (speakText). Without this, stale audio chunks
+   * resume playback after interrupt() because the relay's interrupt is only a
+   * local acknowledgement.
+   */
+  private suppressModelAudio = false;
+  /** Resolvers waiting for the audio queue to drain (speakText settle). */
+  private playbackDrainResolvers = new Set<() => void>();
+  /** Timestamp of the most recent enqueued audio chunk (drain heuristics). */
+  private lastAudioEnqueueAt = 0;
 
   constructor(handlers: GeminiLiveHandlers = {}) {
     this.handlers = handlers;
@@ -359,7 +371,12 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
         provider: this.provider,
         level,
       });
-      if (this.state !== "speaking") this.setState("listening");
+      // Mic frames stream continuously, so they must never demote the
+      // thinking state (that is why "Thinking" used to flash for one frame
+      // and snap back to "Listening" while the model was still working).
+      if (this.state !== "speaking" && this.state !== "thinking") {
+        this.setState("listening");
+      }
       const sourceRate = this.inputContext?.sampleRate ?? INPUT_SAMPLE_RATE;
       const pcm = floatToPcm16(downsample(frame, sourceRate));
       this.ws.send(
@@ -429,7 +446,11 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     }
 
     const serverContent = message.serverContent as
-      | { modelTurn?: { parts?: Array<Record<string, unknown>> }; interrupted?: boolean }
+      | {
+          modelTurn?: { parts?: Array<Record<string, unknown>> };
+          interrupted?: boolean;
+          turnComplete?: boolean;
+        }
       | undefined;
 
     const eventOptions = this.nextEventOptions();
@@ -441,6 +462,13 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       inputTranscription?.text ?? inputTranscription?.transcript ?? inputTranscription?.final
     );
     if (inputText) {
+      // The provider transcribed the user's speech, which means the user's
+      // turn ended and the model is now working on a response. Surface that
+      // processing gap as "thinking" until the first audio chunk arrives so
+      // the user knows they were heard.
+      if (this.state === "listening") {
+        this.setState("thinking");
+      }
       this.handlers.onEvent?.({
         type: "transcript_final",
         provider: this.provider,
@@ -516,13 +544,26 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       return;
     }
 
+    if (serverContent.turnComplete) {
+      // The interrupted (or finished) model turn is closed; stop fencing and
+      // settle back to listening when nothing is queued for playback.
+      this.suppressModelAudio = false;
+      if (this.activeSources.size === 0 && !this.closed && this.state !== "idle") {
+        this.setState("listening");
+        this.resolvePlaybackDrain();
+      }
+      return;
+    }
+
     const parts = serverContent.modelTurn?.parts ?? [];
     for (const part of parts) {
       const inlineData = part.inlineData as
         | { mimeType?: string; data?: string }
         | undefined;
       if (inlineData?.data && (inlineData.mimeType ?? "").startsWith("audio/")) {
-        this.enqueueAudio(bytesFromBase64(inlineData.data));
+        if (!this.suppressModelAudio) {
+          this.enqueueAudio(bytesFromBase64(inlineData.data));
+        }
       }
       const textPart = readString(part.text);
       if (textPart) {
@@ -551,6 +592,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       return false;
     }
     if (input.signal?.aborted) return false;
+    // App speech starts a fresh model turn; lift any interrupt fence so the
+    // synthesized response is audible.
+    this.suppressModelAudio = false;
     this.ws.send(
       JSON.stringify({
         type: "app_speech",
@@ -559,13 +603,71 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
         segment_type: input.segmentType ?? "final",
       })
     );
+    // Settle on playback, not on socket send. Resolving at ws.send made the
+    // bridge flip the UI back to "Listening" while the answer was still being
+    // synthesized and played, which read as the agent talking over itself.
+    const audioStarted = await this.waitForAudioStart(4000, input.signal);
+    if (audioStarted) {
+      await this.waitForPlaybackDrain(30000, input.signal);
+    }
     return true;
   }
 
   interrupt(): void {
     this.stopPlayback();
+    // Fence out any model audio still in flight for the interrupted turn;
+    // the relay's interrupt frame is a local acknowledgement, so without the
+    // fence stale chunks resume playing right after this call.
+    this.suppressModelAudio = true;
+    this.resolvePlaybackDrain();
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
     this.ws.send(JSON.stringify({ type: "interrupt" }));
+  }
+
+  private resolvePlaybackDrain(): void {
+    for (const resolve of this.playbackDrainResolvers) resolve();
+    this.playbackDrainResolvers.clear();
+  }
+
+  /** Resolves true when a new audio chunk starts within the timeout. */
+  private waitForAudioStart(timeoutMs: number, signal?: AbortSignal): Promise<boolean> {
+    const startedAfter = Date.now();
+    return new Promise((resolve) => {
+      const poll = setInterval(() => {
+        if (this.closed || signal?.aborted) {
+          clearInterval(poll);
+          resolve(false);
+          return;
+        }
+        if (this.lastAudioEnqueueAt >= startedAfter || this.activeSources.size > 0) {
+          clearInterval(poll);
+          resolve(true);
+          return;
+        }
+        if (Date.now() - startedAfter > timeoutMs) {
+          clearInterval(poll);
+          resolve(false);
+        }
+      }, 50);
+    });
+  }
+
+  /** Resolves when the playback queue empties (or the timeout/abort hits). */
+  private waitForPlaybackDrain(timeoutMs: number, signal?: AbortSignal): Promise<void> {
+    if (this.activeSources.size === 0) return Promise.resolve();
+    return new Promise((resolve) => {
+      const done = () => {
+        clearTimeout(timer);
+        clearInterval(abortPoll);
+        this.playbackDrainResolvers.delete(done);
+        resolve();
+      };
+      const timer = setTimeout(done, timeoutMs);
+      const abortPoll = setInterval(() => {
+        if (this.closed || signal?.aborted) done();
+      }, 100);
+      this.playbackDrainResolvers.add(done);
+    });
   }
 
   updateContext(context: OneVoiceContextSnapshot): boolean {
@@ -627,6 +729,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     const startAt = Math.max(context.currentTime, this.playheadTime);
     node.start(startAt);
     this.playheadTime = startAt + buffer.duration;
+    this.lastAudioEnqueueAt = Date.now();
     this.setState("speaking");
     this.activeSources.add(node);
     node.onended = () => {
@@ -634,6 +737,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       if (this.activeSources.size === 0 && !this.closed) {
         this.setState("listening");
         this.handlers.onOutputLevel?.(0);
+        this.resolvePlaybackDrain();
       }
     };
   }
@@ -685,6 +789,7 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     if (this.closed) return;
     this.closed = true;
     this.setupComplete = false;
+    this.resolvePlaybackDrain();
 
     if (this.outputLevelTimer) {
       clearInterval(this.outputLevelTimer);

--- a/hushh-webapp/lib/voice/one-voice-live-action-bridge.ts
+++ b/hushh-webapp/lib/voice/one-voice-live-action-bridge.ts
@@ -459,6 +459,21 @@ export class OneVoiceLiveActionBridge {
   }): Promise<boolean> {
     const { plan, transcript, userId, vaultOwnerToken } = input;
     if (plan.status === "blocked") {
+      // A blocked plan WITH an inferred action carries a real prerequisite
+      // explanation ("Unlock the vault...", "Import your portfolio first.").
+      // Speak it so the user hears why, instead of the model improvising or
+      // the turn dying silently. Blocked plans with no action fall through to
+      // the conversational path.
+      if (plan.action && plan.reason) {
+        const turnId = `goal_blocked_${Date.now()}`;
+        await this.speakWithStage({
+          text: plan.reason,
+          turnId,
+          responseId: turnId,
+          segmentType: "final",
+        });
+        return true;
+      }
       return Boolean(this.pendingGoalPlan);
     }
     if (plan.status === "input_needed") {

--- a/hushh-webapp/lib/voice/one-voice-live-action-bridge.ts
+++ b/hushh-webapp/lib/voice/one-voice-live-action-bridge.ts
@@ -181,9 +181,13 @@ function getPlannerCandidate(
 ): OneVoiceActionProposal | null {
   if (!proposal) return null;
   const confidence = proposal.confidence;
+  // A proposal without a finite numeric confidence must NOT bypass the floor:
+  // model self-reports are already optimistic, and a null/absent confidence is
+  // the least trustworthy signal of all. Fail closed and let the lexical
+  // planner rank the transcript from scratch instead.
   if (
-    typeof confidence === "number" &&
-    Number.isFinite(confidence) &&
+    typeof confidence !== "number" ||
+    !Number.isFinite(confidence) ||
     confidence < ACTION_PROPOSAL_CONFIDENCE_FLOOR
   ) {
     return null;

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -16,6 +16,30 @@ import type {
 } from "@/lib/voice/voice-ui-state-machine";
 
 export const STRUCTURED_CONTEXT_ARRAY_CAP = 10;
+/**
+ * available_action_ids carries the screen-ranked list PLUS a reserved global
+ * navigation segment, so it gets a wider cap than other context arrays. The
+ * backend mirrors this value (Pydantic max_length + persona sanitize limit);
+ * keep all three in sync.
+ */
+export const AVAILABLE_ACTION_IDS_CAP = 18;
+/**
+ * Cross-screen navigation contracts that must ALWAYS be visible to the model,
+ * regardless of the current screen. Without this reserved segment, strict
+ * screen filtering plus the context cap made "go to profile" undiscoverable
+ * from any non-profile tab: the model was never told route.profile existed.
+ * One id per top-level agent surface.
+ */
+export const GLOBAL_NAV_ACTION_IDS: readonly string[] = [
+  "route.one_agents",
+  "route.kai_home",
+  "route.ria_home",
+  "route.profile",
+  "route.one_location",
+  "route.one_pkm",
+  "route.one_marketplace",
+  "route.consents",
+];
 export const ARRAY_DIMENSION_CAP_ERROR =
   "CONSTRAINT_VIOLATION_DIMENSION_OVERFLOW";
 export const INVALID_ARRAY_TYPE_ERROR = "INVALID_ARRAY_TYPE";
@@ -327,7 +351,19 @@ function prioritizeAvailableActionIds(
       screen
     );
   }
-  return enforceArrayDimensionCap(ranked).items;
+  // Screen-ranked segment first (original cap), then the reserved global
+  // navigation segment so cross-agent navigation is always proposable. The
+  // combined list stays within AVAILABLE_ACTION_IDS_CAP, which the backend
+  // accepts (Pydantic max_length is kept in sync).
+  const screenSegment = enforceArrayDimensionCap(ranked).items;
+  const combined = [...screenSegment];
+  for (const navId of GLOBAL_NAV_ACTION_IDS) {
+    if (combined.length >= AVAILABLE_ACTION_IDS_CAP) break;
+    if (combined.includes(navId)) continue;
+    if (!getKaiActionById(navId)) continue;
+    combined.push(navId);
+  }
+  return combined;
 }
 
 function stableRevision(values: unknown[]): string {


### PR DESCRIPTION
## Summary

Four-phase fix pass for the reported One Voice accuracy defects and native iOS UI bugs.

### Phase 1: Voice intelligence (natural MCP-tool-style contracts)
- Contracts render to Gemini like a tool catalog: `action_id (Label; inputs: slot=<resolver>, slot default 'value')` with lock hints, and the proposal tool description asks for honest confidence + default filling in natural tool-call flow. `confidence` is now required in the proposal schema.
- Which-list fix: the planner applies contract `default_value`, so 'Analyze TSLA' dispatches in one turn instead of asking 'Which list should Kai use for this debate?'.
- Ticker hallucination (the 'YOUR' bug): bare uppercase STT tokens must exist in the cached ticker universe (FE) AND the backend now 422s debate starts for symbols without a real symbol-master match (post-auth; fail-open only when the ticker cache is empty). Company-name aliases win over raw-token extraction; STOP_WORDS gained YOUR/pronouns.
- Cross-tab navigation ('go to profile' from Connect): available_action_ids now carries a reserved global navigation segment (route.* for all top agents) beyond the screen cap, with synchronized caps FE(18)/Pydantic/persona; instruction wording says route.* contracts work from any screen. Explicit navigation intents can never be overridden by ticker actions.
- Proposals without finite numeric confidence fail closed to the lexical planner.

### Phase 2: Thinking UX + barge-in
- Client emits 'thinking' from input transcription until first audio; mic frames no longer demote it (why 'Thinking' used to flash one frame). Handles the relay's turnComplete frame.
- interrupt() fences out late model audio (relay interrupt was a local echo, stale audio resumed). speakText settles on playback drain, not ws.send, so the UI no longer flips to 'Listening' mid-speech.
- Relay sends a best-effort abort signal to Vertex Live on app interrupt.

### Phase 3: State-aware blocked-intent explanations
- When state gating blocks the matched intent, the planner surfaces the REAL prerequisite ('Unlock the vault...', 'Wait for the active analysis...') instead of 'could not map that request', and the bridge speaks it.

### Phase 4: Native iOS UI
- Theme switching enabled on iOS (removed forcedTheme pin + Info.plist UIUserInterfaceStyle=Light).
- Stuck ripple after long-press: -webkit-touch-callout/user-select none on actionables; pointer-events:none pinned on md-ripple.
- Bottom-nav double-tap: snapKaiBottomChromeVisible() freezes the scroll-hide animation on pointerdown so the tap target is stationary.
- Search bubble oval on iOS: explicit 52px circle replaces aspect-square+self-stretch (WebKit aspect-ratio vs stretch height); hover styles behind (hover:hover).
- mobile-bug-log skill: B14-B17 appended.

## Verification
- FE: typecheck, eslint, full vitest 1782 passed (incl. new regression tests: YOUR rejected, default applied, nav never overridden, global nav ids present, blocked-intent explanation, theme contract)
- BE: 109 voice/persona/relay/ticker-gate tests passed (6 new gate tests)
- verify:voice-gateway parity clean; verify:design-system clean
- Live: relay-session accepts 18 action ids; composed instruction shows tool-style contract lines; browser smoke on :3002 clean; iOS simulator build deployed, UIUserInterfaceStyle pin confirmed absent from installed app; search button measured 52x52 circular

---
Closes #4473
(retroactive board-linkage backfill, 2026-07-14)