### PR TITLE
fix(dependabot): target integration/pr-train instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/hushh-webapp"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -26,6 +27,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/hushh-mcp"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -50,6 +52,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/consent-protocol"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -74,6 +77,7 @@ updates:
 
   - package-ecosystem: "swift"
     directory: "/apps/one-mac"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -99,6 +103,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "thursday"


### PR DESCRIPTION
## Why
[Run 28919027856](https://github.com/hushh-labs/hushh-research/actions/runs/28919027856) (dependabot PR #2276) failed **PR Base Policy**: `Direct PRs into main are blocked for non-maintainers.`

Dependabot opens PRs against the repo **default branch** unless told otherwise — and `dependabot[bot]` is (rightly) not a governed maintainer, so every dependabot PR into `main` dies at the governance gate before any real validation runs.

## Fix
`target-branch: integration/pr-train` on all 5 ecosystems — dependency bumps now ride the train like all other inbound work and reach `main` only via the governed promotion flow.

## Verification
- YAML validated; 5/5 update blocks carry the target-branch key
- Policy self-check: train-branch PRs pass `verify-pr-base-policy.py` (base=train is always allowed)

## Follow-up (this PR doesn't do it)
Existing open dependabot PRs against `main` (#2276) need `@dependabot rebase` after merge, or close and let the next weekly cycle reopen against the train.

---
Closes #4489
(retroactive board-linkage backfill, 2026-07-14)