### PR TITLE
test(utils): characterize formatCompleteJson on deeply nested circular references

### DIFF
--- a/hushh-webapp/__tests__/utils/format-circular-references.test.ts
+++ b/hushh-webapp/__tests__/utils/format-circular-references.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson in lib/utils/json-to-human.ts,
+// focused on self-referential (circular) input objects.
+//
+// Truth-first note on the real implementation:
+//
+// formatCompleteJson is NOT recursive and has NO explicit cycle detection.
+// It walks a FIXED, bounded structure — at most three levels deep:
+//
+//   level 0: Object.entries(json)                 -> section
+//   level 1: Object.entries(sectionValue)         -> field
+//   level 2: Object.entries(value)                -> nested field
+//
+// At level 2, each nested value is rendered through formatValue(), which for a
+// non-null, non-primitive value falls through to String(value) and yields the
+// literal "[object Object]". Because the walk never descends past level 2, a
+// cycle (obj.self = obj, or a parent/child back-reference) is simply printed as
+// "[object Object]" at the leaf — it can never trigger unbounded recursion or a
+// RangeError: Maximum call stack size exceeded.
+//
+// IMPORTANT: this is safety by bounded depth, NOT by deliberate cycle
+// "decoupling". These tests pin that real behavior so any future change (e.g.
+// introducing real recursion, a WeakSet seen-guard, or a "[Circular]" marker)
+// becomes a visible, deliberate contract change rather than silent drift.
+//
+// These tests never call JSON.stringify on the cyclic objects (which WOULD
+// throw), so no exception blocks or loop lockups are involved.
+
+describe("formatCompleteJson — circular reference bounds", () => {
+  it("does not throw or loop on a direct self-reference (obj.self = obj)", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+
+    expect(() => formatCompleteJson(obj)).not.toThrow();
+  });
+
+  it("renders a direct self-reference leaf as the literal '[object Object]'", () => {
+    const obj: Record<string, unknown> = {};
+    obj.self = obj;
+
+    const output = formatCompleteJson(obj);
+    expect(typeof output).toBe("string");
+    // Section header derived from the key, then the bounded leaf stringification.
+    expect(output).toContain("--- Self ---");
+    expect(output).toContain("[object Object]");
+  });
+
+  it("does not throw on a two-node parent/child back-reference cycle", () => {
+    const parent: Record<string, unknown> = { label: "root" };
+    const child: Record<string, unknown> = { parent };
+    parent.child = child;
+
+    expect(() => formatCompleteJson(parent)).not.toThrow();
+    const output = formatCompleteJson(parent);
+    expect(output).toContain("--- Child ---");
+    // The cycle back to `parent` is flattened at the bounded leaf depth.
+    expect(output).toContain("[object Object]");
+  });
+
+  it("does not throw on a cycle routed through an array container", () => {
+    const node: Record<string, unknown> = {};
+    node.items = [node];
+
+    expect(() => formatCompleteJson(node)).not.toThrow();
+    const output = formatCompleteJson(node);
+    // Array section header uses the (length) suffix; content is bounded.
+    expect(output).toContain("--- Items (1 items) ---");
+  });
+
+  it("terminates deterministically and returns a finite string for a self-cycle", () => {
+    const obj: Record<string, unknown> = { note: "cyclic" };
+    obj.self = obj;
+
+    const output = formatCompleteJson(obj);
+    // Bounded output: no runaway growth from the cycle.
+    expect(output.length).toBeLessThan(500);
+    expect(output).toContain("Note: cyclic");
+  });
+
+  it("keeps sibling primitive fields intact alongside a self-reference", () => {
+    const obj: Record<string, unknown> = { total_value: 1000 };
+    obj.self = obj;
+
+    const output = formatCompleteJson(obj);
+    // The scalar sibling is still formatted normally (currency field).
+    expect(output).toContain("Total Portfolio Value: $1,000.00");
+    // And the cyclic branch is still safely flattened.
+    expect(output).toContain("[object Object]");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **characterization test only** for the existing `formatCompleteJson` in `hushh-webapp/lib/utils/json-to-human.ts`. It pins the current, verified behavior when the input object contains self-referential (circular) property graphs. **Zero production runtime change.**

## Truth-First Note on Real Behavior

The task premise implied `formatCompleteJson` performs deliberate cycle "decoupling" to avoid recursive stack exhaustion. I verified the source first — that is **not** how it works:

- `formatCompleteJson` is **not recursive** and has **no cycle-detection** (no `WeakSet`, no `[Circular]` marker).
- It walks a **fixed, bounded structure — at most three levels** (`section -> field -> nested field`).
- At the leaf, non-primitive values fall through to `String(value)` and render as the literal `"[object Object]"`.

So a cycle (`obj.self = obj`, or a parent/child back-reference) is **safe by bounded depth, not by intentional decoupling**. It can never trigger `RangeError: Maximum call stack size exceeded`, because the walk simply never descends into the cycle.

## Literal Contract Characterized

- **Direct self-reference** (`obj.self = obj`) -> does not throw; leaf renders as `"[object Object]"`.
- **Two-node parent/child back-reference** -> flattened at bounded leaf depth; no recursion.
- **Cycle routed through an array container** (`node.items = [node]`) -> bounded array header, no lockup.
- **Deterministic termination** -> finite, bounded output length for a self-cycle.
- **Sibling integrity** -> primitive siblings (e.g. `total_value`) still format normally alongside the cyclic branch.

The tests never call `JSON.stringify` on the cyclic objects (which *would* throw), so no exception blocks or loop lockups are involved. This makes any future cycle-handling change (real recursion, seen-guard, or `[Circular]` marker) a deliberate, visible contract change rather than silent drift.

## Proofs & Verification

- **Execution:** `npm test -- hushh-webapp/__tests__/utils/format-circular-references.test.ts`
- **Local runner caveat (reported honestly):** the environment's `vitest` v4 install fails to bootstrap its runner for **every** test file (identical `Vitest failed to find the runner` error at `__tests__/setup.ts:84`, including already-merged sibling suites). This is a machine-level toolchain defect, not a defect in this test — the config and `@/` alias resolve correctly. **CI is the authoritative gate.**
- **Workspace Isolation:** verified single new file via `git status`.

## CI Gate Checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified — commit signed off (`-s`)
- [x] Test Only Surface Change
