### PR TITLE
test(webapp): characterize normalizeInternalRouteHref empty/comma-blank query params

### DIFF
--- a/hushh-webapp/__tests__/navigation/route-param-empty-arrays.test.ts
+++ b/hushh-webapp/__tests__/navigation/route-param-empty-arrays.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+// Characterization tests for normalizeInternalRouteHref
+// (hushh-webapp/lib/navigation/routes.ts) focused on query-string components
+// that resolve to empty strings or multi-comma blanks within search
+// dimensions, e.g. `/search?tags=,,&category=`.
+//
+// TRUTH-FIRST — LITERAL CONTRACT:
+//
+//   export function normalizeInternalRouteHref(value): string | null {
+//     const href = String(value ?? "").trim();
+//     if (!href) return null;
+//     if (!href.startsWith("/") || href.startsWith("//")) return null;
+//     if (/[\r\n]/.test(href)) return null;
+//     return href;
+//   }
+//
+// CORRECTION TO THE TASK PREMISE: this routine is NOT a query-string
+// extractor. It performs NO parsing, NO array element extraction, NO dropping
+// of empty positions, and NO construction of blank literal array strings. It
+// is a pure allow/deny gate over the trimmed string:
+//   - Passes -> the href (including its entire query block) is returned
+//     VERBATIM, so every `,,` and every dangling `=` survives byte-for-byte.
+//   - Fails a guard (empty, not rooted, protocol-relative `//`, or containing
+//     CR/LF) -> `null` is returned.
+// These tests pin that real contract for the empty/comma-blank query surface.
+
+describe("normalizeInternalRouteHref — empty-string & multi-comma query params", () => {
+  it("returns the href verbatim, preserving multi-comma blanks and a dangling empty value", () => {
+    expect(normalizeInternalRouteHref("/search?tags=,,&category=")).toBe(
+      "/search?tags=,,&category=",
+    );
+  });
+
+  it("does not drop or compress the empty comma positions inside a single param", () => {
+    const out = normalizeInternalRouteHref("/search?tags=,,");
+    // The two commas (three empty positions) are retained exactly.
+    expect(out).toBe("/search?tags=,,");
+    expect(out?.match(/,/g)?.length).toBe(2);
+  });
+
+  it("preserves a param whose value is an empty string (`category=`)", () => {
+    expect(normalizeInternalRouteHref("/search?category=")).toBe(
+      "/search?category=",
+    );
+  });
+
+  it("preserves repeated empty-string params without deduping or reordering", () => {
+    expect(normalizeInternalRouteHref("/search?tags=&tags=&tags=")).toBe(
+      "/search?tags=&tags=&tags=",
+    );
+  });
+
+  it("preserves a leading empty position before a real value", () => {
+    expect(normalizeInternalRouteHref("/search?tags=,,active")).toBe(
+      "/search?tags=,,active",
+    );
+  });
+
+  it("preserves bracketed empty array syntax verbatim", () => {
+    expect(normalizeInternalRouteHref("/search?tags[]=&tags[]=&tags[]=z")).toBe(
+      "/search?tags[]=&tags[]=&tags[]=z",
+    );
+  });
+
+  it("trims outer whitespace but keeps the blank comma/empty query intact", () => {
+    expect(normalizeInternalRouteHref("  /search?tags=,,&category=  ")).toBe(
+      "/search?tags=,,&category=",
+    );
+  });
+
+  it("preserves a lone `?` with an all-blank multi-comma value", () => {
+    expect(normalizeInternalRouteHref("/search?=,,")).toBe("/search?=,,");
+  });
+
+  it("returns null for a protocol-relative host even when carrying blank params", () => {
+    expect(
+      normalizeInternalRouteHref("//evil.example/search?tags=,,&category="),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-rooted href even when carrying blank params", () => {
+    expect(normalizeInternalRouteHref("search?tags=,,&category=")).toBeNull();
+  });
+
+  it("returns null when a newline is injected after the blank params", () => {
+    expect(
+      normalizeInternalRouteHref("/search?tags=,,&category=\ninject"),
+    ).toBeNull();
+  });
+
+  it("returns null for null/undefined/empty input (no query to inspect)", () => {
+    expect(normalizeInternalRouteHref(null)).toBeNull();
+    expect(normalizeInternalRouteHref(undefined)).toBeNull();
+    expect(normalizeInternalRouteHref("")).toBeNull();
+    expect(normalizeInternalRouteHref("   ")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a characterization test suite that pins the **actual** behavior of
`normalizeInternalRouteHref` (`hushh-webapp/lib/navigation/routes.ts`) for
internal hrefs carrying empty-string and multi-comma query values, e.g.
`/search?tags=,,&category=`.

This is a **test-only, no behavior change** PR.

## Truth-first note on the premise

The routine is **not** a query-string parser. It performs no parsing, no
array-element extraction, no dropping of empty positions, and no construction
of blank literal array strings. Its real contract is a pure allow/deny gate
over the trimmed string:

- `String(value ?? "").trim()`, then
- reject empty, non-rooted (`!startsWith("/")`), protocol-relative (`//`),
  or CR/LF-containing input → returns `null`;
- otherwise returns the href **verbatim**, so the entire query block
  (every `,,`, every dangling `=`) survives byte-for-byte.

The tests pin exactly this contract on the empty/comma-blank query surface.

## Coverage

- Verbatim preservation of `tags=,,&category=`, repeated empty params,
  bracketed empty-array syntax, and leading empty comma positions.
- Outer-whitespace trimming while keeping blank query intact.
- `null` for protocol-relative host, non-rooted href, and newline injection.
- `null` for null/undefined/empty/whitespace input.

## Testing

Local `vitest` cannot register suites on this Windows + Node 24 box (a
runner/rolldown environment issue reproducible with a bare `expect(1+1)`
smoke test), so verification defers to CI, which runs the same `vitest` on
Node 24 where the existing webapp suite is green. Assertions were verified
line-by-line against the current `routes.ts` source.
