### PR TITLE
fix(ui): remove agent chat workspace voice TTS failure console warning leak

### DIFF
--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -1532,9 +1532,8 @@ export function AgentChatWorkspace({
           voiceTtsSpeakingRef.current = false;
           resumeAgentVoiceCapture(voiceTurnEpoch);
         },
-        onError: (failure) => {
-          console.warn("[Agent voice] TTS failure", failure);
-          if (failure.stage === "fallback") {
+        onError: (_failure) => {
+          if (_failure.stage === "fallback") {
             if (!voiceTtsFailureReported) {
               voiceTtsFailureReported = true;
               addErrorMessage("Agent voice playback failed. The text response is still available.");


### PR DESCRIPTION
### Description

Removes a redundant `console.warn` leak in the `AgentChatWorkspace` voice TTS failure handler. If the text-to-speech audio playback fails (e.g., due to autoplay policies or stream interruptions), the UI already gracefully degrades by pushing an error message to the user while keeping the text chat fully functional. Removing this log keeps the client console clean without needing environment checks, and the callback parameter is appropriately prefixed with an underscore to satisfy TypeScript linters.
