### PR TITLE
fix(dependabot): target integration/pr-train (config must live on main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/hushh-webapp"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -26,6 +27,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/packages/hushh-mcp"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -50,6 +52,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/consent-protocol"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -74,6 +77,7 @@ updates:
 
   - package-ecosystem: "swift"
     directory: "/apps/one-mac"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "wednesday"
@@ -99,6 +103,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "integration/pr-train"
     schedule:
       interval: "weekly"
       day: "thursday"


### PR DESCRIPTION
## Why #4354 wasn't enough
Dependabot reads `.github/dependabot.yml` from the **default branch** (`main`). #4354 merged the fix to `integration/pr-train` only — so new dependabot PRs (e.g. #4369, opened after the recreate) still target `main` and still fail PR Base Policy.

## This PR
Identical 5-line change, landed on `main` via the governed-maintainer direct path (PR Base Policy allows governed maintainers into main; CI Status Gate + merge queue still apply).

## Effect
Next weekly cycles (npm Mon / npm+MCP Tue / pip+swift Wed / actions Thu, 15:00 UTC) open against `integration/pr-train` and pass the governance gates.

---
Closes #4489
(retroactive board-linkage backfill, 2026-07-14)