### PR TITLE
test(navigation): characterize route param bracket notation array bounds

### DIFF
--- a/hushh-webapp/__tests__/navigation/route-param-bracket-arrays.test.ts
+++ b/hushh-webapp/__tests__/navigation/route-param-bracket-arrays.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeInternalRouteHref } from "@/lib/navigation/routes";
+
+/**
+ * Characterization tests for `normalizeInternalRouteHref` from
+ * `hushh-webapp/lib/navigation/routes.ts`.
+ *
+ * Scope: pin down the exact contract when an internal href carries PHP/Rails
+ * style bracket-array query notation, e.g. `/search?ids[]=10&ids[]=20`.
+ *
+ * Truth-first note (premise correction): this routine is NOT a query-string
+ * parser. Reading the implementation, it performs only:
+ *   1. `String(value ?? "").trim()`
+ *   2. reject empty
+ *   3. reject if it does not start with "/" OR starts with "//"
+ *   4. reject if it contains CR/LF
+ *   5. otherwise return the href VERBATIM
+ *
+ * Therefore it does NOT "map brackets as keys" and it does NOT "condense them
+ * into a native string array". Bracket-array notation is never interpreted at
+ * all — the entire query block (including `[]`, `&`, repeated keys, and any
+ * pre-encoded `%5B%5D`) is preserved byte-for-byte in the returned string.
+ * These tests document that real pass-through contract, not an aspirational
+ * parsing one.
+ */
+describe("normalizeInternalRouteHref — bracket-array query notation", () => {
+  it("returns repeated bracket-array params verbatim without parsing into an array", () => {
+    const href = "/search?ids[]=10&ids[]=20";
+
+    const out = normalizeInternalRouteHref(href);
+
+    // Verbatim string, not a parsed structure.
+    expect(out).toBe(href);
+    expect(typeof out).toBe("string");
+    // Repeated key is preserved (no de-duplication / condensing).
+    expect(out?.match(/ids\[\]=/g)?.length).toBe(2);
+    // Literal bracket tokens survive; they are not turned into an array key.
+    expect(out).toContain("ids[]=10");
+    expect(out).toContain("ids[]=20");
+  });
+
+  it("preserves indexed bracket notation (ids[0], ids[1]) as literal characters", () => {
+    const href = "/search?ids[0]=10&ids[1]=20";
+
+    expect(normalizeInternalRouteHref(href)).toBe(href);
+  });
+
+  it("preserves nested/associative bracket notation (filter[status]) verbatim", () => {
+    const href = "/search?filter[status]=active&filter[tag]=x";
+
+    expect(normalizeInternalRouteHref(href)).toBe(href);
+  });
+
+  it("does not decode pre-encoded brackets (%5B%5D) — no query-level decoding", () => {
+    const href = "/search?ids%5B%5D=10&ids%5B%5D=20";
+
+    const out = normalizeInternalRouteHref(href);
+
+    expect(out).toBe(href);
+    expect(out).toContain("%5B%5D");
+    expect(out).not.toContain("[]");
+  });
+
+  it("trims surrounding whitespace but leaves the bracket query block intact", () => {
+    const href = "   /search?ids[]=10&ids[]=20   ";
+
+    expect(normalizeInternalRouteHref(href)).toBe("/search?ids[]=10&ids[]=20");
+  });
+
+  it("still rejects protocol-relative hrefs even when they carry bracket arrays", () => {
+    expect(normalizeInternalRouteHref("//evil.example?ids[]=10")).toBeNull();
+  });
+
+  it("rejects CRLF-injected bracket-array hrefs (returns null, not a sanitized string)", () => {
+    expect(normalizeInternalRouteHref("/search?ids[]=10\n&ids[]=20")).toBeNull();
+  });
+});


### PR DESCRIPTION
### Summary

Adds a characterization test pinning down `normalizeInternalRouteHref`
(`hushh-webapp/lib/navigation/routes.ts`) when an internal href carries
PHP/Rails-style bracket-array query notation, e.g. `/search?ids[]=10&ids[]=20`.

Test-only, single-file, no production behavior change.

### Truth-first note (premise correction)

The framing "does it map brackets as literal keys, or condense them into a native
string array?" assumes this function parses query strings. It does not. Reading
the implementation, `normalizeInternalRouteHref` only:

1. `String(value ?? "").trim()`
2. returns `null` if empty
3. returns `null` if the href does not start with `/`, or starts with `//`
4. returns `null` if it contains CR/LF
5. otherwise returns the href **verbatim**

So brackets are **never interpreted** — neither mapped to keys nor condensed into
an array. The entire query block (literal `[]`, `&`, repeated keys, and any
pre-encoded `%5B%5D`) is preserved byte-for-byte. This is a security-oriented
same-origin href guard, not a query parser. The test documents that real
pass-through contract rather than the aspirational parsing one.

### Literal contract characterized

- `/search?ids[]=10&ids[]=20` → returned verbatim; repeated `ids[]=` count stays 2 (no condensing)
- `/search?ids[0]=10&ids[1]=20` → indexed brackets preserved literally
- `/search?filter[status]=active&filter[tag]=x` → associative brackets preserved
- `/search?ids%5B%5D=10...` → pre-encoded brackets NOT decoded (no `[]` introduced)
- Leading/trailing whitespace trimmed; interior query untouched
- `//evil.example?ids[]=10` → `null` (protocol-relative guard still fires)
- `/search?ids[]=10\n&ids[]=20` → `null` (CRLF guard still fires)

### Proofs & verification

- Static analysis against `lib/navigation/routes.ts` confirms every asserted output.
- Import path (`@/lib/navigation/routes`) matches the already-merged sibling suite
  `__tests__/navigation/normalize-internal-route-href.test.ts` verbatim.
- Local `npx vitest run` could **not** execute: the local vitest v4.1.10 runner
  aborts with "Vitest failed to find the runner" **before any test file loads**.
  This is an environment-wide defect, not specific to this file — merged sibling
  suites (e.g. `format-complete-json-bounds.test.ts`) fail identically with
  `no tests`. CI is the authoritative execution gate; I did not fabricate a
  local pass.

### CI Gate Checklist

- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified (commit signed off)
- [x] Test Only Surface Change (`git status` clean; 1 file, +78)
