### PR TITLE
fix(planning-board): flag unlinked merged PRs in board sync + codify Closes-#NNNN SOP

### DIFF
--- a/.codex/skills/planning-board/references/engineering-core-board.md
+++ b/.codex/skills/planning-board/references/engineering-core-board.md
@@ -34,6 +34,8 @@ This reference documents the canonical GitHub board workflow for this repo.
 5. When the user asks for labels, update them explicitly and verify the final label set on the issue.
 6. If a task is duplicate or redundant, consolidate its remaining scope into the canonical issue, add a traceability comment, and remove the duplicate project item from the board. Preserve GitHub issue history unless the user explicitly asks for destructive issue deletion.
 7. Do not mark duplicate or redundant tasks as `Done` unless the duplicated task itself was actually delivered and accepted.
+8. Every PR that ships owner-scoped work MUST reference at least one issue via `Closes #NNNN` / `Fixes #NNNN` / `#NNNN` in the PR body (or branch name) — one reference per logical unit of work for multi-workstream PRs. This is what lets the daily board sync auto-complete the linked issue; a PR with no issue reference is invisible to that automation and the board silently drifts behind real shipped work (see 2026-07-09 incident: PR #4376 shipped 7 workstreams with zero issue links; board sync correctly reported nothing to do). Create the issue(s) BEFORE or WHILE opening the PR, not after merge.
+9. `board_sync_cycle.py` flags (does not silently skip) any owned merged/closed PR with zero issue references in its "Completion & Delivery" report section. Treat that warning as an action item: backfill an issue, edit the PR body to add `Closes #NNNN`, and re-run the sync so the board catches up.
 
 ## Board hygiene SOP
 

--- a/.codex/skills/planning-board/scripts/board_sync_cycle.py
+++ b/.codex/skills/planning-board/scripts/board_sync_cycle.py
@@ -505,6 +505,27 @@ def sync_board_cycle(dry_run: bool = False) -> tuple[str, bool]:
         refs = set(extract_referenced_issues(pr.get("body", "")))
         refs.update(extract_referenced_issues(pr.get("headRefName", "")))
         r = pr["repo"]
+
+        # Unlinked-merge guard (Hussh Research SOP gap, 2026-07-09): a merged/
+        # closed owned PR with ZERO issue references cannot drive any board
+        # item to Done -- the completion is invisible to this sync. Flag it in
+        # the report instead of silently reporting a clean "no changes" run,
+        # so the operator notices and backfills issues/Closes-# links rather
+        # than the board silently drifting behind real shipped work.
+        unlinked_key = f"{r}-pr#{pr['number']}-unlinked"
+        if not refs:
+            if prev_state.get(unlinked_key) != "flagged":
+                pr_title = pr.get("title", "")
+                out.append(
+                    f"- \u26a0\ufe0f **{r}#{pr['number']}** ({pr_title!r}) merged/closed with "
+                    f"NO issue references -- board not updated. Add `Closes #NNNN` to the PR body "
+                    f"and re-run sync, or backfill an issue for this work."
+                )
+                has_changes = True
+            cur_state[unlinked_key] = "flagged"
+        else:
+            cur_state[unlinked_key] = "linked"
+
         for num in refs:
             try:
                 details = board_ops.get_issue_json(r, num)


### PR DESCRIPTION
## Summary
Root cause of 2026-07-09 incident: PR #4376 shipped 7 real workstreams (WS1-4, voice/consent fixes, memory rename, subtree gate) with zero `#issue` references in its body. The daily "Hushh Core Board Sync" cron correctly found nothing to link and reported a clean run — silently masking real shipped work from the Hushh Engineering Core board.

## What changed
- **Backfilled** issues #4380-4387 for the untracked PR #4376 workstreams (all marked Done, verified via `board_ops.py audit-state`) and retroactively linked PR #4376's body with `Closes #NNNN`.
- **`board_sync_cycle.py`**: added an unlinked-merged-PR guard — any owned merged/closed PR with zero issue references now surfaces a ⚠️ warning in the Completion & Delivery report instead of being silently invisible. State-cache deduped so it only fires once per PR, not every tick.
- **`engineering-core-board.md`**: codified the `Closes #NNNN` requirement as SOP items 8-9 under Task shape, plus the operational contract for handling the new warning.
- Mirrored the `board_sync_cycle.py` change into `~/.hermes/scripts/board_lib/` (the stable cron-owned copy the scheduled job actually runs) so the daily 9am cron picks this up immediately, per the mirroring convention documented in `board_sync.py`'s wrapper docstring.

## Verification
- `python3 -m py_compile .codex/skills/planning-board/scripts/board_sync_cycle.py`
- `python3 .codex/skills/planning-board/scripts/board_ops.py audit-state` → `closed_not_done: [], open_done: []`
- Dry-run against live board correctly flagged 20 pre-existing unlinked merged PRs (historical, pre-dating this fix) without mutating anything.
- Real run persisted state cache; second consecutive run correctly suppressed the now-acknowledged warnings (no daily spam).

Closes #4390