### PR TITLE
feat(ops): hosted dev environment (UAT replica) — deploy pipeline, tooling, doctor, runbook

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,17 +27,19 @@ env:
   GCP_REGION: us-central1
   BACKEND_SERVICE: consent-protocol
   FRONTEND_SERVICE: hushh-webapp
-  APP_FRONTEND_ORIGIN: https://dev.kai.hushh.ai
+  # TEMPORARY: deterministic Cloud Run URL until dev.kai.hushh.ai DNS exists.
+  # Flip to https://dev.kai.hushh.ai once the domain mapping + DNS record land,
+  # then redeploy (secret sync propagates origin/CORS automatically).
+  APP_FRONTEND_ORIGIN: https://hushh-webapp-621416509462.us-central1.run.app
   DEV_CLOUDSQL_INSTANCE: hushh-pda-dev:us-central1:hushh-dev-pg
   DEV_DB_UNIX_SOCKET: /cloudsql/hushh-pda-dev:us-central1:hushh-dev-pg
   # One Email KYC runs in dev via topic fanout: dev consumes the SAME UAT
-  # Pub/Sub topic through its own push subscription. UAT remains the single
-  # owner of the Gmail watch; never schedule watch renewal against dev.
-  # Update the audience to the dev backend Cloud Run URL after the first
-  # backend deploy and create the matching push subscription (see
-  # consent-protocol/docs/reference/dev-environment-setup.md).
+  # Pub/Sub topic through its own push subscription
+  # (one-email-kyc-dev-push in hushh-pda, provisioned 2026-07-10). UAT remains
+  # the single owner of the Gmail watch; never schedule watch renewal against
+  # dev. See consent-protocol/docs/reference/dev-environment-setup.md.
   DEV_ONE_EMAIL_PUBSUB_TOPIC: projects/hushh-pda/topics/one-email-kyc-uat
-  DEV_ONE_EMAIL_WEBHOOK_AUDIENCE: https://consent-protocol-REPLACE_WITH_DEV_HASH-uc.a.run.app/api/one/email/webhook
+  DEV_ONE_EMAIL_WEBHOOK_AUDIENCE: https://consent-protocol-621416509462.us-central1.run.app/api/one/email/webhook
   CLOUD_RUN_REVISION_RETENTION: "10"
   PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,960 @@
+name: Deploy to Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Auto-detect deploy lane, or force backend/frontend/all"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - all
+          - backend
+          - frontend
+      sha:
+        description: "Exact green main SHA to deploy (blank defaults to latest origin/main)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  checks: read
+
+env:
+  GCP_PROJECT_ID: hushh-pda-dev
+  GCP_REGION: us-central1
+  BACKEND_SERVICE: consent-protocol
+  FRONTEND_SERVICE: hushh-webapp
+  APP_FRONTEND_ORIGIN: https://dev.kai.hushh.ai
+  DEV_CLOUDSQL_INSTANCE: hushh-pda-dev:us-central1:hushh-dev-pg
+  DEV_DB_UNIX_SOCKET: /cloudsql/hushh-pda-dev:us-central1:hushh-dev-pg
+  CLOUD_RUN_REVISION_RETENTION: "10"
+  PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Dev Scope
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing dev deploy from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Assert manual dev dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface dev --actor "${GITHUB_ACTOR}"
+
+      - name: Capture deployment timing start
+        id: timing-start
+        shell: bash
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve deployment SHA
+        id: resolve-sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.sha }}" ]; then
+            DEPLOY_SHA="${{ github.event.inputs.sha }}"
+          else
+            git fetch --no-tags origin main
+            DEPLOY_SHA="$(git rev-parse origin/main)"
+          fi
+          echo "sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Validate deployment SHA against main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIRED_BRANCH: main
+          REQUIRE_CI_SUCCESS: "1"
+          REQUIRED_CHECK_NAME: "Main Post-Merge Smoke Gate"
+        run: bash scripts/ci/require-deploy-sha-on-main.sh "${{ steps.resolve-sha.outputs.sha }}"
+
+      - name: Checkout deployment SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --detach "${{ steps.resolve-sha.outputs.sha }}"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set GCP project context
+        run: gcloud config set project "${{ env.GCP_PROJECT_ID }}"
+
+      - name: Assert GCP project scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null)"
+          if [ "$ACTIVE_PROJECT" != "${{ env.GCP_PROJECT_ID }}" ]; then
+            echo "Refusing deploy: expected project '${{ env.GCP_PROJECT_ID }}' but got '$ACTIVE_PROJECT'."
+            exit 1
+          fi
+
+      - name: Set up Python + uv runtime
+        uses: ./consent-protocol/.github/actions/setup-python-uv
+        with:
+          python-version: "3.13"
+          protocol-dir: ./consent-protocol
+
+      - name: Capture predeploy Cloud Run state
+        id: predeploy-state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+
+          backend_sha=""
+          if [ -n "${backend_revision}" ]; then
+            backend_sha="$(gcloud run revisions describe "${backend_revision}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --format='value(metadata.labels.deploy-sha)' 2>/dev/null || true)"
+          fi
+          frontend_sha=""
+          if [ -n "${frontend_revision}" ]; then
+            frontend_sha="$(gcloud run revisions describe "${frontend_revision}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --format='value(metadata.labels.deploy-sha)' 2>/dev/null || true)"
+          fi
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "backend_sha=${backend_sha}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_sha=${frontend_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve deployment scope
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/resolve-deploy-scope.py \
+            --requested-scope "${{ github.event.inputs.scope }}" \
+            --target-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --backend-base-sha "${{ steps.predeploy-state.outputs.backend_sha }}" \
+            --frontend-base-sha "${{ steps.predeploy-state.outputs.frontend_sha }}" \
+            --github-output "$GITHUB_OUTPUT" \
+            --json
+
+      - name: Sync canonical hosted runtime secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_backend_runtime_secrets.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --environment uat \
+            --app-frontend-origin "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --db-host "cloudsql-socket" \
+            --db-port "5432" \
+            --db-name "postgres" \
+            --db-unix-socket "${{ env.DEV_DB_UNIX_SOCKET }}" \
+            --cloudsql-instance-connection-name "${{ env.DEV_CLOUDSQL_INSTANCE }}" \
+            --consent-sse-enabled "true" \
+            --sync-remote-enabled "false" \
+            --developer-api-enabled "true" \
+            --remote-mcp-enabled "true" \
+            --crm-registry-db-enabled "true" \
+            --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --obs-data-stale-ratio-threshold "0.25" \
+            --passkey-allowed-rp-ids "localhost,127.0.0.1,kai.hushh.ai,dev.kai.hushh.ai" \
+            --plaid-env "production" \
+            --plaid-client-name "Hushh Kai" \
+            --plaid-country-codes "US" \
+            --plaid-webhook-url "${{ env.APP_FRONTEND_ORIGIN }}/api/kai/plaid/webhook" \
+            --plaid-redirect-path "/kai/plaid/oauth/return" \
+            --plaid-tx-history-days "730" \
+            > /tmp/dev-runtime-secret-sync.json
+
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --environment dev \
+            > /tmp/dev-frontend-runtime-secret-sync.json
+
+      - name: Install Cloud SQL Auth Proxy
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
+            -o /usr/local/bin/cloud-sql-proxy
+          chmod +x /usr/local/bin/cloud-sql-proxy
+
+      - name: Apply dev DB migrations and predeploy schema gate
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
+          DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"
+          echo "::add-mask::${DB_USER}"
+          echo "::add-mask::${DB_PASSWORD}"
+
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 6543 \
+            ${GOOGLE_GHA_CREDS_PATH:+--credentials-file="${GOOGLE_GHA_CREDS_PATH}"} \
+            "${{ env.DEV_CLOUDSQL_INSTANCE }}" >/tmp/cloud-sql-proxy-dev.log 2>&1 &
+          PROXY_PID=$!
+          trap 'kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
+
+          python3 - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 20
+          while time.time() < deadline:
+              with socket.socket() as sock:
+                  sock.settimeout(0.5)
+                  if sock.connect_ex(("127.0.0.1", 6543)) == 0:
+                      raise SystemExit(0)
+              time.sleep(0.25)
+          raise SystemExit("Cloud SQL proxy did not bind 127.0.0.1:6543 in time")
+          PY
+
+          export DB_HOST=127.0.0.1
+          export DB_PORT=6543
+          export DB_NAME=postgres
+          export DB_USER
+          export DB_PASSWORD
+
+          (
+            cd consent-protocol
+            "${{ env.PROTOCOL_PYTHON }}" db/migrate.py --release
+          )
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
+            --contract-file consent-protocol/db/contracts/uat_integrated_schema.json \
+            --report-path /tmp/dev-db-migration-guard-predeploy.json
+
+      - name: Deploy backend using Cloud Build
+        id: deploy-backend
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="$(date +%s)"
+          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.DEV_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_APP_REVIEW_MODE=true##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=dev##_DEPLOY_SOURCE=deploy-dev##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          gcloud builds submit \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --config=deploy/backend.cloudbuild.yaml \
+            "--substitutions=^##^${SUBSTITUTIONS}"
+          finished_at="$(date +%s)"
+          echo "started_at_epoch=${started_at}" >> "$GITHUB_OUTPUT"
+          echo "finished_at_epoch=${finished_at}" >> "$GITHUB_OUTPUT"
+          echo "duration_seconds=$((finished_at - started_at))" >> "$GITHUB_OUTPUT"
+
+      - name: Retain latest backend revisions
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+
+      - name: Deploy frontend using Cloud Build
+        id: deploy-frontend
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="$(date +%s)"
+          gcloud builds submit \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --config=deploy/frontend.cloudbuild.yaml \
+            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_APP_ENV=uat,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }},_DEPLOY_ENV=dev,_DEPLOY_SOURCE=deploy-dev,_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+          finished_at="$(date +%s)"
+          echo "started_at_epoch=${started_at}" >> "$GITHUB_OUTPUT"
+          echo "finished_at_epoch=${finished_at}" >> "$GITHUB_OUTPUT"
+          echo "duration_seconds=$((finished_at - started_at))" >> "$GITHUB_OUTPUT"
+
+      - name: Retain latest frontend revisions
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+
+      - name: Resolve deployed candidate revisions
+        id: candidate-state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestCreatedRevisionName)')"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestCreatedRevisionName)')"
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+
+      - name: Promote deployed revisions to dev traffic
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
+            gcloud run services update-traffic "${{ env.BACKEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --to-revisions="${{ steps.candidate-state.outputs.backend_revision }}=100"
+          fi
+
+          if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
+            gcloud run services update-traffic "${{ env.FRONTEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --to-revisions="${{ steps.candidate-state.outputs.frontend_revision }}=100"
+          fi
+
+      - name: Resolve current deployed Cloud Run state
+        id: current-state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)')"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)')"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)')"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)')"
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify backend deployment provenance
+        id: verify-backend-provenance
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ci/verify-cloudrun-revision-provenance.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --service "${{ env.BACKEND_SERVICE }}" \
+            --expected-env dev \
+            --expected-source deploy-dev \
+            --expected-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --expected-run-id "${{ github.run_id }}" \
+            --report-path /tmp/dev-backend-provenance.json
+
+      - name: Verify frontend deployment provenance
+        id: verify-frontend-provenance
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ci/verify-cloudrun-revision-provenance.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --service "${{ env.FRONTEND_SERVICE }}" \
+            --expected-env dev \
+            --expected-source deploy-dev \
+            --expected-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --expected-run-id "${{ github.run_id }}" \
+            --report-path /tmp/dev-frontend-provenance.json
+
+      - name: Verify dev runtime env parity
+        id: verify-parity-1
+        continue-on-error: true
+        run: |
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify-env-secrets-parity.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --backend-service "${{ env.BACKEND_SERVICE }}" \
+            --frontend-service "${{ env.FRONTEND_SERVICE }}" \
+            --require-plaid \
+            --require-market-data \
+            --require-gmail \
+            --require-voice \
+            --require-reviewer-smoke \
+            --assert-runtime-env-contract \
+            --report-path /tmp/dev-runtime-parity-attempt-1.json
+
+      - name: Verify dev runtime env parity retry
+        id: verify-parity-2
+        if: steps.verify-parity-1.outcome == 'failure'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          sleep 20
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify-env-secrets-parity.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --backend-service "${{ env.BACKEND_SERVICE }}" \
+            --frontend-service "${{ env.FRONTEND_SERVICE }}" \
+            --require-plaid \
+            --require-market-data \
+            --require-gmail \
+            --require-voice \
+            --require-reviewer-smoke \
+            --assert-runtime-env-contract \
+            --report-path /tmp/dev-runtime-parity-attempt-2.json
+
+      - name: Post-deploy dev schema contract gate
+        id: postdeploy-db-gate
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
+          DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"
+          echo "::add-mask::${DB_USER}"
+          echo "::add-mask::${DB_PASSWORD}"
+
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 6543 \
+            ${GOOGLE_GHA_CREDS_PATH:+--credentials-file="${GOOGLE_GHA_CREDS_PATH}"} \
+            "${{ env.DEV_CLOUDSQL_INSTANCE }}" >/tmp/cloud-sql-proxy-dev-postdeploy.log 2>&1 &
+          PROXY_PID=$!
+          trap 'kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
+
+          python3 - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 20
+          while time.time() < deadline:
+              with socket.socket() as sock:
+                  sock.settimeout(0.5)
+                  if sock.connect_ex(("127.0.0.1", 6543)) == 0:
+                      raise SystemExit(0)
+              time.sleep(0.25)
+          raise SystemExit("Cloud SQL proxy did not bind 127.0.0.1:6543 in time")
+          PY
+
+          export DB_HOST=127.0.0.1
+          export DB_PORT=6543
+          export DB_NAME=postgres
+          export DB_USER
+          export DB_PASSWORD
+
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
+            --contract-file consent-protocol/db/contracts/uat_integrated_schema.json \
+            --report-path /tmp/dev-db-migration-guard-postdeploy.json
+
+      - name: Bootstrap dev runtime files for semantic verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          BOOTSTRAP_FOCUS_PROFILE=dev bash scripts/env/bootstrap_profiles.sh --strict
+          bash scripts/env/use_profile.sh dev
+
+      - name: Load maintainer smoke overlay
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_user_id="$(gcloud secrets versions access latest \
+            --secret=UAT_SMOKE_USER_ID \
+            --project="${{ env.GCP_PROJECT_ID }}")"
+          smoke_passphrase="$(gcloud secrets versions access latest \
+            --secret=UAT_SMOKE_PASSPHRASE \
+            --project="${{ env.GCP_PROJECT_ID }}")"
+          echo "::add-mask::$smoke_user_id"
+          echo "::add-mask::$smoke_passphrase"
+          {
+            echo "UAT_SMOKE_USER_ID<<EOF"
+            printf '%s\n' "$smoke_user_id"
+            echo "EOF"
+            echo "UAT_SMOKE_PASSPHRASE<<EOF"
+            printf '%s\n' "$smoke_passphrase"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Semantic dev verification
+        id: verify-dev-1
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify_uat_release.py \
+            --backend-url "${{ steps.current-state.outputs.backend_url }}" \
+            --frontend-url "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --protocol-env consent-protocol/.env \
+            --web-env hushh-webapp/.env.local \
+            --report-path /tmp/dev-release-verify-attempt-1.json
+
+      - name: Semantic dev verification retry
+        id: verify-dev-2
+        if: steps.verify-dev-1.outcome == 'failure'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          sleep 20
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify_uat_release.py \
+            --backend-url "${{ steps.current-state.outputs.backend_url }}" \
+            --frontend-url "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --protocol-env consent-protocol/.env \
+            --web-env hushh-webapp/.env.local \
+            --report-path /tmp/dev-release-verify-attempt-2.json
+
+      - name: Classify dev release outcome
+        if: always()
+        id: classify-dev-release
+        shell: bash
+        env:
+          DEPLOY_BACKEND: ${{ steps.scope.outputs.deploy_backend }}
+          DEPLOY_FRONTEND: ${{ steps.scope.outputs.deploy_frontend }}
+          PARITY_ATTEMPT_1: ${{ steps.verify-parity-1.outcome }}
+          PARITY_ATTEMPT_2: ${{ steps.verify-parity-2.outcome }}
+          BACKEND_PROVENANCE_OUTCOME: ${{ steps.verify-backend-provenance.outcome }}
+          FRONTEND_PROVENANCE_OUTCOME: ${{ steps.verify-frontend-provenance.outcome }}
+          DB_OUTCOME: ${{ steps.postdeploy-db-gate.outcome }}
+          SEMANTIC_ATTEMPT_1: ${{ steps.verify-dev-1.outcome }}
+          SEMANTIC_ATTEMPT_2: ${{ steps.verify-dev-2.outcome }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          def load_json(path: str) -> dict:
+              candidate = Path(path)
+              if not candidate.exists():
+                  return {}
+              try:
+                  parsed = json.loads(candidate.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  return {}
+              return parsed if isinstance(parsed, dict) else {}
+
+          def has_runtime_failures(entries: list[dict]) -> bool:
+              return any(str(entry.get("status")) in {"missing", "legacy"} for entry in entries)
+
+          def append_unique(target: list[str], values: list[str]) -> None:
+              for value in values:
+                  if value and value not in target:
+                      target.append(value)
+
+          parity_report = load_json("/tmp/dev-runtime-parity-attempt-2.json") or load_json(
+              "/tmp/dev-runtime-parity-attempt-1.json"
+          )
+          backend_provenance_report = load_json("/tmp/dev-backend-provenance.json")
+          frontend_provenance_report = load_json("/tmp/dev-frontend-provenance.json")
+          semantic_report = load_json("/tmp/dev-release-verify-attempt-2.json") or load_json(
+              "/tmp/dev-release-verify-attempt-1.json"
+          )
+
+          parity_success = os.environ.get("PARITY_ATTEMPT_1") == "success" or os.environ.get("PARITY_ATTEMPT_2") == "success"
+          backend_provenance_success = (
+              os.environ.get("DEPLOY_BACKEND") != "true"
+              or os.environ.get("BACKEND_PROVENANCE_OUTCOME") == "success"
+          )
+          frontend_provenance_success = (
+              os.environ.get("DEPLOY_FRONTEND") != "true"
+              or os.environ.get("FRONTEND_PROVENANCE_OUTCOME") == "success"
+          )
+          semantic_success = os.environ.get("SEMANTIC_ATTEMPT_1") == "success" or os.environ.get("SEMANTIC_ATTEMPT_2") == "success"
+          db_outcome = os.environ.get("DB_OUTCOME", "")
+
+          blocking: list[str] = []
+          backend_failure = False
+          frontend_failure = False
+
+          required = parity_report.get("required") or {}
+          missing_secrets = set(parity_report.get("missing_secrets") or [])
+          backend_secret_names = set(
+              required.get("backend", [])
+              + required.get("gmail", [])
+              + required.get("one_email", [])
+              + required.get("voice", [])
+              + required.get("plaid", [])
+              + required.get("market", [])
+          )
+          frontend_secret_names = set(required.get("frontend", []))
+
+          runtime_contract = parity_report.get("runtime_contract") or {}
+          frontend_runtime_entries = runtime_contract.get("frontend") or []
+          backend_runtime_entries = (
+              (runtime_contract.get("backend") or [])
+              + (runtime_contract.get("backend_gmail") or [])
+              + (runtime_contract.get("backend_one_email") or [])
+              + (runtime_contract.get("backend_voice") or [])
+          )
+
+          if not parity_success:
+              append_unique(blocking, list(parity_report.get("classifications") or ["runtime_mount_missing"]))
+          if missing_secrets & backend_secret_names:
+              backend_failure = True
+          if missing_secrets & frontend_secret_names:
+              frontend_failure = True
+          if has_runtime_failures(frontend_runtime_entries):
+              frontend_failure = True
+          if has_runtime_failures(backend_runtime_entries):
+              backend_failure = True
+
+          if not backend_provenance_success:
+              append_unique(
+                  blocking,
+                  list(backend_provenance_report.get("classifications") or ["deploy_authority_drift"]),
+              )
+              backend_failure = True
+          if not frontend_provenance_success:
+              append_unique(
+                  blocking,
+                  list(frontend_provenance_report.get("classifications") or ["deploy_authority_drift"]),
+              )
+              frontend_failure = True
+
+          semantic_failures = set(semantic_report.get("failures") or [])
+          advisory_semantic_failures = sorted(
+              item for item in semantic_failures if item.startswith("signed_in_routes:")
+          )
+          blocking_semantic_failures = {
+              item for item in semantic_failures if not item.startswith("signed_in_routes:")
+          }
+          if not semantic_success:
+              if blocking_semantic_failures:
+                  append_unique(blocking, ["runtime_behavior_failed"])
+              if "smoke_auth" in blocking_semantic_failures:
+                  append_unique(blocking, ["smoke_overlay_dependency_leak"])
+              if blocking_semantic_failures & {"backend_health", "smoke_auth", "gmail_status", "voice_capability", "voice_realtime_session"}:
+                  backend_failure = True
+              if "frontend_login" in blocking_semantic_failures:
+                  frontend_failure = True
+
+          if db_outcome == "failure":
+              append_unique(blocking, ["db_contract_drift"])
+              backend_failure = True
+
+          blocking = list(dict.fromkeys(blocking))
+          release_failed = bool(blocking)
+
+          payload = {
+              "status": "blocked" if release_failed else "healthy",
+              "release_failed": release_failed,
+              "blocking_classifications": blocking,
+              "backend_failure": backend_failure,
+              "frontend_failure": frontend_failure,
+              "parity": {
+                  "attempt_1": os.environ.get("PARITY_ATTEMPT_1", ""),
+                  "attempt_2": os.environ.get("PARITY_ATTEMPT_2", ""),
+                  "success": parity_success,
+              },
+              "provenance": {
+                  "backend": {
+                      "outcome": os.environ.get("BACKEND_PROVENANCE_OUTCOME", ""),
+                      "success": backend_provenance_success,
+                      "report": backend_provenance_report,
+                  },
+                  "frontend": {
+                      "outcome": os.environ.get("FRONTEND_PROVENANCE_OUTCOME", ""),
+                      "success": frontend_provenance_success,
+                      "report": frontend_provenance_report,
+                  },
+              },
+              "semantic": {
+                  "attempt_1": os.environ.get("SEMANTIC_ATTEMPT_1", ""),
+                  "attempt_2": os.environ.get("SEMANTIC_ATTEMPT_2", ""),
+                  "success": semantic_success,
+                  "failures": sorted(semantic_failures),
+                  "blocking_failures": sorted(blocking_semantic_failures),
+                  "advisory_failures": advisory_semantic_failures,
+              },
+              "db_contract": {
+                  "outcome": db_outcome,
+              },
+          }
+
+          Path("/tmp/dev-release-classification.json").write_text(
+              json.dumps(payload, indent=2), encoding="utf-8"
+          )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"release_failed={'true' if release_failed else 'false'}\n")
+              handle.write(f"backend_failure={'true' if backend_failure else 'false'}\n")
+              handle.write(f"frontend_failure={'true' if frontend_failure else 'false'}\n")
+              handle.write(f"blocking_classifications={','.join(blocking)}\n")
+              handle.write(f"parity_success={'true' if parity_success else 'false'}\n")
+              handle.write(f"provenance_success={'true' if backend_provenance_success and frontend_provenance_success else 'false'}\n")
+              handle.write(f"semantic_success={'true' if semantic_success else 'false'}\n")
+          PY
+
+      - name: Roll back backend revision
+        id: rollback-backend
+        if: always() && steps.classify-dev-release.outputs.release_failed == 'true' && steps.classify-dev-release.outputs.backend_failure == 'true' && steps.scope.outputs.deploy_backend == 'true' && steps.predeploy-state.outputs.backend_revision != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.backend_revision }}"
+
+      - name: Roll back frontend revision
+        id: rollback-frontend
+        if: always() && steps.classify-dev-release.outputs.release_failed == 'true' && steps.classify-dev-release.outputs.frontend_failure == 'true' && steps.scope.outputs.deploy_frontend == 'true' && steps.predeploy-state.outputs.frontend_revision != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.frontend_revision }}"
+
+      - name: Resolve final Cloud Run state
+        if: always()
+        id: final-state
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Write dev release status artifact
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          BACKEND_ROLLBACK_REQUIRED=false
+          FRONTEND_ROLLBACK_REQUIRED=false
+          BACKEND_ROLLBACK_DONE=true
+          FRONTEND_ROLLBACK_DONE=true
+
+          if [ "${{ steps.classify-dev-release.outputs.release_failed }}" != "true" ]; then
+            STATUS="healthy"
+          else
+            if [ "${{ steps.classify-dev-release.outputs.backend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ] && [ "${{ steps.predeploy-state.outputs.backend_revision }}" != "" ]; then
+              BACKEND_ROLLBACK_REQUIRED=true
+              if [ "${{ steps.rollback-backend.outcome }}" != "success" ]; then
+                BACKEND_ROLLBACK_DONE=false
+              fi
+            fi
+            if [ "${{ steps.classify-dev-release.outputs.frontend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ] && [ "${{ steps.predeploy-state.outputs.frontend_revision }}" != "" ]; then
+              FRONTEND_ROLLBACK_REQUIRED=true
+              if [ "${{ steps.rollback-frontend.outcome }}" != "success" ]; then
+                FRONTEND_ROLLBACK_DONE=false
+              fi
+            fi
+
+            if { [ "$BACKEND_ROLLBACK_REQUIRED" = true ] || [ "$FRONTEND_ROLLBACK_REQUIRED" = true ]; } && [ "$BACKEND_ROLLBACK_DONE" = true ] && [ "$FRONTEND_ROLLBACK_DONE" = true ]; then
+              STATUS="rolled_back"
+            else
+              STATUS="blocked"
+            fi
+          fi
+
+          export STATUS
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              "status": os.environ["STATUS"],
+              "sha": "${{ steps.resolve-sha.outputs.sha }}",
+              "scope": "${{ steps.scope.outputs.scope }}",
+              "app_frontend_origin": "${{ env.APP_FRONTEND_ORIGIN }}",
+              "predeploy": {
+                  "backend_revision": "${{ steps.predeploy-state.outputs.backend_revision }}",
+                  "backend_url": "${{ steps.predeploy-state.outputs.backend_url }}",
+                  "frontend_revision": "${{ steps.predeploy-state.outputs.frontend_revision }}",
+                  "frontend_url": "${{ steps.predeploy-state.outputs.frontend_url }}",
+              },
+              "current": {
+                  "backend_candidate_revision": "${{ steps.candidate-state.outputs.backend_revision }}",
+                  "backend_revision": "${{ steps.current-state.outputs.backend_revision }}",
+                  "backend_url": "${{ steps.current-state.outputs.backend_url }}",
+                  "frontend_candidate_revision": "${{ steps.candidate-state.outputs.frontend_revision }}",
+                  "frontend_revision": "${{ steps.current-state.outputs.frontend_revision }}",
+                  "frontend_url": "${{ steps.current-state.outputs.frontend_url }}",
+              },
+              "final": {
+                  "backend_revision": "${{ steps.final-state.outputs.backend_revision }}",
+                  "backend_url": "${{ steps.final-state.outputs.backend_url }}",
+                  "frontend_revision": "${{ steps.final-state.outputs.frontend_revision }}",
+                  "frontend_url": "${{ steps.final-state.outputs.frontend_url }}",
+              },
+              "verification": {
+                  "parity_attempt_1": "${{ steps.verify-parity-1.outcome }}",
+                  "parity_attempt_2": "${{ steps.verify-parity-2.outcome }}",
+                  "parity_success": "${{ steps.classify-dev-release.outputs.parity_success }}",
+                  "backend_provenance": "${{ steps.verify-backend-provenance.outcome }}",
+                  "frontend_provenance": "${{ steps.verify-frontend-provenance.outcome }}",
+                  "provenance_success": "${{ steps.classify-dev-release.outputs.provenance_success }}",
+                  "attempt_1": "${{ steps.verify-dev-1.outcome }}",
+                  "attempt_2": "${{ steps.verify-dev-2.outcome }}",
+                  "semantic_success": "${{ steps.classify-dev-release.outputs.semantic_success }}",
+                  "db_contract": "${{ steps.postdeploy-db-gate.outcome }}",
+                  "blocking_classifications": "${{ steps.classify-dev-release.outputs.blocking_classifications }}",
+              },
+              "rollback_targets": {
+                  "backend_revision": "${{ steps.predeploy-state.outputs.backend_revision }}",
+                  "frontend_revision": "${{ steps.predeploy-state.outputs.frontend_revision }}",
+              },
+              "timing_seconds": {
+                  "backend_cloud_build": "${{ steps.deploy-backend.outputs.duration_seconds || '0' }}",
+                  "frontend_cloud_build": "${{ steps.deploy-frontend.outputs.duration_seconds || '0' }}",
+              },
+          }
+          Path("/tmp/dev-release-status.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+          PY
+
+      - name: Upload dev deploy artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dev-release-${{ github.run_id }}
+          if-no-files-found: ignore
+          path: |
+            /tmp/dev-runtime-secret-sync.json
+            /tmp/dev-frontend-runtime-secret-sync.json
+            /tmp/dev-runtime-parity-attempt-1.json
+            /tmp/dev-runtime-parity-attempt-2.json
+            /tmp/dev-backend-provenance.json
+            /tmp/dev-frontend-provenance.json
+            /tmp/dev-db-migration-guard-predeploy.json
+            /tmp/dev-db-migration-guard-postdeploy.json
+            /tmp/cloud-sql-proxy-dev.log
+            /tmp/cloud-sql-proxy-dev-postdeploy.log
+            /tmp/dev-release-verify-attempt-1.json
+            /tmp/dev-release-verify-attempt-2.json
+            /tmp/dev-release-classification.json
+            /tmp/dev-release-status.json
+
+      - name: Deployment summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            total_seconds=$(( $(date +%s) - ${{ steps.timing-start.outputs.epoch || '0' }} ))
+            if [ "${{ steps.timing-start.outputs.epoch || '' }}" = "" ]; then
+              total_seconds=0
+            fi
+            backend_build_seconds="${{ steps.deploy-backend.outputs.duration_seconds || '0' }}"
+            frontend_build_seconds="${{ steps.deploy-frontend.outputs.duration_seconds || '0' }}"
+            build_seconds=$(( backend_build_seconds + frontend_build_seconds ))
+            non_build_seconds=$(( total_seconds - build_seconds ))
+            if [ "$non_build_seconds" -lt 0 ]; then
+              non_build_seconds=0
+            fi
+            echo "## Dev Release"
+            echo ""
+            echo "- SHA: \`${{ steps.resolve-sha.outputs.sha }}\`"
+            echo "- Requested scope: \`${{ github.event.inputs.scope }}\`"
+            echo "- Scope: \`${{ steps.scope.outputs.scope }}\`"
+            echo "- Scope reason: \`${{ steps.scope.outputs.reason }}\`"
+            echo "- Backend deployed SHA before run: \`${{ steps.predeploy-state.outputs.backend_sha || 'unknown' }}\`"
+            echo "- Frontend deployed SHA before run: \`${{ steps.predeploy-state.outputs.frontend_sha || 'unknown' }}\`"
+            echo "- Status: \`$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/dev-release-status.json').read_text(encoding='utf-8'))['status'])")\`"
+            echo "- Blocking classifications: \`${{ steps.classify-dev-release.outputs.blocking_classifications || 'none' }}\`"
+            echo "- Backend URL: \`${{ steps.final-state.outputs.backend_url }}\`"
+            echo "- Frontend URL: \`${{ env.APP_FRONTEND_ORIGIN }}\`"
+            echo "- Backend revision: \`${{ steps.final-state.outputs.backend_revision }}\`"
+            echo "- Frontend revision: \`${{ steps.final-state.outputs.frontend_revision }}\`"
+            echo "- Parity attempt 1: \`${{ steps.verify-parity-1.outcome }}\`"
+            echo "- Parity attempt 2: \`${{ steps.verify-parity-2.outcome }}\`"
+            echo "- Backend provenance: \`${{ steps.verify-backend-provenance.outcome }}\`"
+            echo "- Frontend provenance: \`${{ steps.verify-frontend-provenance.outcome }}\`"
+            echo "- Post-deploy DB contract: \`${{ steps.postdeploy-db-gate.outcome }}\`"
+            echo "- Verify attempt 1: \`${{ steps.verify-dev-1.outcome }}\`"
+            echo "- Verify attempt 2: \`${{ steps.verify-dev-2.outcome }}\`"
+            echo "- Backend rollback: \`${{ steps.rollback-backend.outcome }}\`"
+            echo "- Frontend rollback: \`${{ steps.rollback-frontend.outcome }}\`"
+            echo ""
+            echo "### Deploy Timing"
+            echo ""
+            echo "- Total job time so far: \`${total_seconds}s\`"
+            echo "- Backend Cloud Build: \`${backend_build_seconds}s\`"
+            echo "- Frontend Cloud Build: \`${frontend_build_seconds}s\`"
+            echo "- Non-build gates and verification: \`${non_build_seconds}s\`"
+            echo ""
+            echo "### Auto Scope Evidence"
+            echo ""
+            echo "- Backend changed files: \`${{ steps.scope.outputs.backend_changed_files || 'none' }}\`"
+            echo "- Frontend changed files: \`${{ steps.scope.outputs.frontend_changed_files || 'none' }}\`"
+            echo "- Shared changed files: \`${{ steps.scope.outputs.shared_changed_files || 'none' }}\`"
+            echo "- Neutral changed files: \`${{ steps.scope.outputs.neutral_changed_files || 'none' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail workflow when dev release did not end healthy
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          STATUS="$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/dev-release-status.json').read_text(encoding='utf-8'))['status'])")"
+          if [ "$STATUS" != "healthy" ]; then
+            echo "Dev release finished with status: $STATUS"
+            exit 1
+          fi

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,6 +30,14 @@ env:
   APP_FRONTEND_ORIGIN: https://dev.kai.hushh.ai
   DEV_CLOUDSQL_INSTANCE: hushh-pda-dev:us-central1:hushh-dev-pg
   DEV_DB_UNIX_SOCKET: /cloudsql/hushh-pda-dev:us-central1:hushh-dev-pg
+  # One Email KYC runs in dev via topic fanout: dev consumes the SAME UAT
+  # Pub/Sub topic through its own push subscription. UAT remains the single
+  # owner of the Gmail watch; never schedule watch renewal against dev.
+  # Update the audience to the dev backend Cloud Run URL after the first
+  # backend deploy and create the matching push subscription (see
+  # consent-protocol/docs/reference/dev-environment-setup.md).
+  DEV_ONE_EMAIL_PUBSUB_TOPIC: projects/hushh-pda/topics/one-email-kyc-uat
+  DEV_ONE_EMAIL_WEBHOOK_AUDIENCE: https://consent-protocol-REPLACE_WITH_DEV_HASH-uc.a.run.app/api/one/email/webhook
   CLOUD_RUN_REVISION_RETENTION: "10"
   PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
 
@@ -280,7 +288,7 @@ jobs:
         run: |
           set -euo pipefail
           started_at="$(date +%s)"
-          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.DEV_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_APP_REVIEW_MODE=true##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=dev##_DEPLOY_SOURCE=deploy-dev##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.DEV_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=${{ env.DEV_ONE_EMAIL_PUBSUB_TOPIC }}##_ONE_EMAIL_WEBHOOK_AUDIENCE=${{ env.DEV_ONE_EMAIL_WEBHOOK_AUDIENCE }}##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=dev##_DEPLOY_SOURCE=deploy-dev##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/backend.cloudbuild.yaml \
@@ -427,6 +435,7 @@ jobs:
             --require-plaid \
             --require-market-data \
             --require-gmail \
+            --require-one-email \
             --require-voice \
             --require-reviewer-smoke \
             --assert-runtime-env-contract \
@@ -448,6 +457,7 @@ jobs:
             --require-plaid \
             --require-market-data \
             --require-gmail \
+            --require-one-email \
             --require-voice \
             --require-reviewer-smoke \
             --assert-runtime-env-contract \

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,10 +27,7 @@ env:
   GCP_REGION: us-central1
   BACKEND_SERVICE: consent-protocol
   FRONTEND_SERVICE: hushh-webapp
-  # TEMPORARY: deterministic Cloud Run URL until dev.kai.hushh.ai DNS exists.
-  # Flip to https://dev.kai.hushh.ai once the domain mapping + DNS record land,
-  # then redeploy (secret sync propagates origin/CORS automatically).
-  APP_FRONTEND_ORIGIN: https://hushh-webapp-621416509462.us-central1.run.app
+  APP_FRONTEND_ORIGIN: https://dev.kai.hushh.ai
   DEV_CLOUDSQL_INSTANCE: hushh-pda-dev:us-central1:hushh-dev-pg
   DEV_DB_UNIX_SOCKET: /cloudsql/hushh-pda-dev:us-central1:hushh-dev-pg
   # One Email KYC runs in dev via topic fanout: dev consumes the SAME UAT

--- a/bin/hushh
+++ b/bin/hushh
@@ -15,11 +15,11 @@ Usage:
   ./bin/hushh <command> [subcommand] [options]
 
 Core commands:
-  bootstrap [--mode <local|uat|prod>]
-  doctor --mode <local|uat|prod> [--json]
+  bootstrap [--mode <local|uat|dev|prod>]
+  doctor --mode <local|uat|dev|prod> [--json]
   proxy --mode local
   terminal <proxy|web|backend> [...]
-  web [--mode <local|uat|prod|offline>] [-- <next-dev args>]
+  web [--mode <local|uat|dev|prod|offline>] [-- <next-dev args>]
   backend [--mode <local|offline>] [--reload|--no-reload]
 
 Local runtime uses three separate terminals (one component each):
@@ -27,7 +27,7 @@ Local runtime uses three separate terminals (one component each):
   2. ./bin/hushh backend --mode local --reload
   3. ./bin/hushh web     --mode local
   compose <init|up|down|nuke|logs|ps|config|health>
-  native <ios|android> [--mode <local|uat|prod>] [--fresh]
+  native <ios|android> [--mode <local|uat|dev|prod>] [--fresh]
   native mac <build|run|test>
   lint
   test
@@ -37,11 +37,12 @@ Local runtime uses three separate terminals (one component each):
 Operational commands:
   docs verify
   env bootstrap
-  env use --mode <local|uat|prod> [--dry-run]
+  env use --mode <local|uat|dev|prod> [--dry-run]
   db init-iam
   db verify-iam-schema
   db verify-release-contract
   db verify-uat-schema
+  db verify-dev-schema
   db report-prod-posture [--json]
   compose <subcommand>
   protocol <subcommand>
@@ -144,7 +145,7 @@ run_web() {
       -h|--help)
         cat <<'EOF'
 Usage:
-  ./bin/hushh web [--mode <local|uat|prod>] [-- <next-dev args>]
+  ./bin/hushh web [--mode <local|uat|dev|prod>] [-- <next-dev args>]
 
 Defaults to: --mode local
 EOF
@@ -213,7 +214,7 @@ EOF
           -h|--help)
             cat <<'EOF'
 Usage:
-  ./bin/hushh terminal web [--mode <local|uat|prod>] [-- <next-dev args>]
+  ./bin/hushh terminal web [--mode <local|uat|dev|prod>] [-- <next-dev args>]
 
 Defaults to: --mode local
 EOF
@@ -265,7 +266,7 @@ EOF
       cat <<'EOF'
 Usage:
   ./bin/hushh terminal proxy [--mode local]
-  ./bin/hushh terminal web [--mode <local|uat|prod>] [-- <next-dev args>]
+  ./bin/hushh terminal web [--mode <local|uat|dev|prod>] [-- <next-dev args>]
   ./bin/hushh terminal backend [--mode local] [--reload|--no-reload]
 
 Opens a visible OS terminal window and runs the canonical Hushh command there.
@@ -338,7 +339,7 @@ run_native() {
       -h|--help)
         cat <<'EOF'
 Usage:
-  ./bin/hushh native <ios|android> [--mode <local|uat|prod>] [--fresh]
+  ./bin/hushh native <ios|android> [--mode <local|uat|dev|prod>] [--fresh]
   ./bin/hushh native mac <build|run|test>
 EOF
         exit 0
@@ -601,7 +602,7 @@ run_env() {
           -h|--help)
             cat <<'EOF'
 Usage:
-  ./bin/hushh env use --mode <local|uat|prod> [--dry-run]
+  ./bin/hushh env use --mode <local|uat|dev|prod> [--dry-run]
 EOF
             exit 0
             ;;
@@ -665,6 +666,37 @@ EOF
       done
       cmd=(bash "$REPO_ROOT/scripts/ops/verify_runtime_db_contract.sh" \
         --project hushh-pda-uat \
+        --region us-central1 \
+        --service consent-protocol \
+        --contract-file "$REPO_ROOT/consent-protocol/db/contracts/uat_integrated_schema.json")
+      if [ -n "$report_path" ]; then
+        cmd+=(--report-path "$report_path")
+      fi
+      exec "${cmd[@]}"
+      ;;
+    verify-dev-schema)
+      shift
+      report_path=""
+      while [ "$#" -gt 0 ]; do
+        case "${1:-}" in
+          --report-path)
+            report_path="${2:-}"
+            shift 2
+            ;;
+          -h|--help)
+            cat <<'EOF'
+Usage:
+  ./bin/hushh db verify-dev-schema [--report-path <path>]
+EOF
+            exit 0
+            ;;
+          *)
+            die "Unknown option for db verify-dev-schema: $1"
+            ;;
+        esac
+      done
+      cmd=(bash "$REPO_ROOT/scripts/ops/verify_runtime_db_contract.sh" \
+        --project "${DEV_PROJECT_ID:-hushh-pda-dev}" \
         --region us-central1 \
         --service consent-protocol \
         --contract-file "$REPO_ROOT/consent-protocol/db/contracts/uat_integrated_schema.json")
@@ -760,7 +792,7 @@ case "$COMMAND" in
         -h|--help)
           cat <<'EOF'
 Usage:
-  ./bin/hushh doctor --mode <local|uat|prod> [--json]
+  ./bin/hushh doctor --mode <local|uat|dev|prod> [--json]
 EOF
           exit 0
           ;;

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -15,7 +15,6 @@
     "allow_auto_merge": true
   },
   "main": {
-
     "required_status_check": "CI Status Gate",
     "required_approving_reviews": 1,
     "require_last_push_approval": true,
@@ -86,6 +85,19 @@
     "merge_queue_bypass_team_name": "Allowed Maintainers to Approve",
     "merge_queue_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_bypass_users": [
+      "kushaltrivedi5",
+      "RGlodAkshat",
+      "ankitkumarsingh1702",
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh",
+      "ahujagautam024",
+      "rohansharma4050"
+    ]
+  },
+  "dev": {
+    "environment": "dev",
+    "manual_dispatch_users": [
       "kushaltrivedi5",
       "RGlodAkshat",
       "ankitkumarsingh1702",

--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -42,22 +42,18 @@ the governed operator service account. Current live facts:
 | Runtime SAs | compute + cloudbuild SAs granted UAT-parity roles |
 | APIs | full UAT parity (92 enabled; doctor-audited) |
 | **Deployed services** | `consent-protocol` + `hushh-webapp` live and healthy (first deploy 2026-07-10, `deploy-env=dev`, public invoker enabled — note: org-fresh projects drop the `--allow-unauthenticated` binding silently; re-add `allUsers` → `roles/run.invoker` if a new service 403s) |
-| Schedulers | `one-email-kyc-retention-purge-dev` daily 09:37 PT |
+| Schedulers | full UAT parity: `one-email-kyc-retention-purge-dev` (daily 09:37 PT), `marketplace-investor-replenisher-every-8h`, `obs-supabase-data-health-every-30m` (+ their Cloud Run jobs and invoker SAs) |
 | Database | full UAT data replica (102 tables, parity-verified) |
-| Doctor status | 0 failures, 2 warnings (domain mapping, Cloud Run job schedulers) |
+| Domain | `dev.kai.hushh.ai` mapped to `hushh-webapp` + DNS CNAME live; origin flipped in secrets/workflow; TLS cert provisioning in flight |
+| Doctor status | 0 failures, 1 warning (TLS cert provisioning — self-resolving) |
 
-Still pending (human-gated):
+Known parity notes:
 
-1. **Domain**: `dev.kai.hushh.ai` — (a) a verified Search Console owner of
-   `kai.hushh.ai` either adds the operator SA as an additional owner or runs
-   `gcloud beta run domain-mappings create --service hushh-webapp --domain dev.kai.hushh.ai --region us-central1 --project hushh-pda-dev`,
-   and (b) add `dev.kai.hushh.ai CNAME ghs.googlehosted.com.` at the external DNS host
-   (same pattern as `uat.kai.hushh.ai`; no Cloud DNS zone exists in the org). Then flip
-   `APP_FRONTEND_ORIGIN` in `deploy-dev.yml` to `https://dev.kai.hushh.ai` and redeploy.
-2. **GitHub**: environment `dev` + secret `GCP_SA_KEY_DEV` so the governed
-   `Deploy to Dev` workflow can take over from manual bootstrap deploys.
-3. Cloud Run job schedulers (`marketplace-investor-replenisher`,
-   `obs-supabase-data-health`) if those lanes are wanted in dev.
+- `obs-supabase-data-health` exits 1 in dev with `pkm_coherence_mismatch` — the SAME
+  anomaly its UAT runs currently fail with (data-shape issue inherited via the clone,
+  not an environment defect).
+- GitHub environment `dev` + secret `GCP_SA_KEY_DEV` still pending so the governed
+  `Deploy to Dev` workflow can take over from manual bootstrap deploys.
 
 ## Identity Model (read this first)
 

--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -10,6 +10,22 @@ Canonical visual owner: [consent-protocol](../README.md). Use that map for the t
 
 ---
 
+## End-to-End Audit (run this first)
+
+The dev environment has a dedicated doctor that derives its baseline live from UAT
+(APIs, secret names, SQL shape and users, runtime-SA roles, Cloud Run services,
+scheduler jobs) and audits the dev project against it, printing a remediation command
+for every failure:
+
+```bash
+python3 scripts/ops/dev_environment_doctor.py \
+  --dev-project hushh-pda-dev --uat-project hushh-pda-uat \
+  --report-path /tmp/dev-doctor.json
+```
+
+Exit 0 = healthy, 1 = failures. Run it after any environment change and before
+declaring dev ready.
+
 ## Provisioned State (as of 2026-07-10)
 
 Phases 1–3, the IAM plumbing, and the One Email fanout subscription were executed via
@@ -17,7 +33,7 @@ the governed operator service account. Current live facts:
 
 | Item | Value |
 | --- | --- |
-| Project | `hushh-pda-dev` (number `621416509462`, folder shared with UAT, billing `014D7F-FD970D-D2459E`) |
+| Project | `hushh-pda-dev`, display name **consent-protocol dev** (number `621416509462`, folder shared with UAT, billing `014D7F-FD970D-D2459E`) |
 | Cloud SQL | `hushh-pda-dev:us-central1:hushh-dev-pg` (POSTGRES_15, db-custom-1-3840, 20GB SSD), user `hushh_uat_app` (new password in dev `DB_PASSWORD`) |
 | Secrets | all 144 UAT secrets replicated; overrides: `APP_FRONTEND_ORIGIN`, `BACKEND_URL`, `DB_PASSWORD` |
 | Backend URL (deterministic) | `https://consent-protocol-621416509462.us-central1.run.app` |
@@ -254,10 +270,15 @@ gcloud pubsub subscriptions create one-email-kyc-dev-push \
 
 Ongoing schedulers to replicate (after first deploy):
 
+- One KYC retention purge (Phase 6b above; UAT runs it daily at 09:37 PT).
 - One Location retention purge: `POST /api/one/location/retention/purge?older_than_hours=12`
-  with `X-Hushh-Maintenance-Token: $ONE_LOCATION_RETENTION_TOKEN` (Cloud Scheduler,
-  same cadence as UAT).
-- One KYC retention purge (Phase 6b above).
+  with `X-Hushh-Maintenance-Token: $ONE_LOCATION_RETENTION_TOKEN` (note: UAT itself has
+  no such job today — parity means matching UAT, so treat this as optional until UAT
+  adds it).
+- `marketplace-investor-replenisher-every-8h` and `obs-supabase-data-health-every-30m`
+  trigger Cloud Run *jobs* that must first be created in dev
+  (`deploy/marketplace/setup_investor_replenisher_scheduler.sh`,
+  `deploy/observability/`); the doctor reports them as warnings until then.
 - Do NOT schedule One Email watch renewal in dev — watch ownership stays with UAT
   (see divergences above).
 

--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -40,12 +40,24 @@ the governed operator service account. Current live facts:
 | Frontend URL (deterministic) | `https://hushh-webapp-621416509462.us-central1.run.app` |
 | One Email fanout | subscription `one-email-kyc-dev-push` in `hushh-pda` on topic `one-email-kyc-uat`, OIDC audience = dev backend webhook |
 | Runtime SAs | compute + cloudbuild SAs granted UAT-parity roles |
+| APIs | full UAT parity (92 enabled; doctor-audited) |
+| **Deployed services** | `consent-protocol` + `hushh-webapp` live and healthy (first deploy 2026-07-10, `deploy-env=dev`, public invoker enabled — note: org-fresh projects drop the `--allow-unauthenticated` binding silently; re-add `allUsers` → `roles/run.invoker` if a new service 403s) |
+| Schedulers | `one-email-kyc-retention-purge-dev` daily 09:37 PT |
+| Database | full UAT data replica (102 tables, parity-verified) |
+| Doctor status | 0 failures, 2 warnings (domain mapping, Cloud Run job schedulers) |
 
-Still pending: `dev.kai.hushh.ai` DNS + domain mapping (origin temporarily set to the
-deterministic frontend Cloud Run URL in `deploy-dev.yml`; passkey unlock is unavailable
-on the temporary origin because the RP id is `kai.hushh.ai` — passphrase unlock works),
-GitHub environment `dev` + `GCP_SA_KEY_DEV`, first deploy, and the post-deploy
-schedulers below.
+Still pending (human-gated):
+
+1. **Domain**: `dev.kai.hushh.ai` — (a) a verified Search Console owner of
+   `kai.hushh.ai` either adds the operator SA as an additional owner or runs
+   `gcloud beta run domain-mappings create --service hushh-webapp --domain dev.kai.hushh.ai --region us-central1 --project hushh-pda-dev`,
+   and (b) add `dev.kai.hushh.ai CNAME ghs.googlehosted.com.` at the external DNS host
+   (same pattern as `uat.kai.hushh.ai`; no Cloud DNS zone exists in the org). Then flip
+   `APP_FRONTEND_ORIGIN` in `deploy-dev.yml` to `https://dev.kai.hushh.ai` and redeploy.
+2. **GitHub**: environment `dev` + secret `GCP_SA_KEY_DEV` so the governed
+   `Deploy to Dev` workflow can take over from manual bootstrap deploys.
+3. Cloud Run job schedulers (`marketplace-investor-replenisher`,
+   `obs-supabase-data-health`) if those lanes are wanted in dev.
 
 ## Identity Model (read this first)
 

--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -1,0 +1,220 @@
+# Dev Environment Setup (UAT Replica)
+
+> Operator runbook for standing up and operating the hosted `dev` environment: a full
+> infrastructure replica of the UAT GCP project, deployed from green `main` SHAs through
+> `.github/workflows/deploy-dev.yml` — the same pipeline shape as UAT.
+
+## Visual Context
+
+Canonical visual owner: [consent-protocol](../README.md). Use that map for the top-down system view; this page is the narrower detail beneath it.
+
+---
+
+## Identity Model (read this first)
+
+The dev environment splits infrastructure identity from runtime identity on purpose:
+
+| Layer | Value | Why |
+| --- | --- | --- |
+| GCP project | `hushh-pda-dev` | isolation from UAT |
+| Cloud SQL instance | `hushh-pda-dev:us-central1:hushh-dev-pg` | own database |
+| Frontend origin | `https://dev.kai.hushh.ai` | own domain |
+| Deploy labels / provenance | `deploy-env=dev`, `deploy-source=deploy-dev` | auditability |
+| Runtime identity | `ENVIRONMENT=uat`, `NEXT_PUBLIC_APP_ENV=uat` | exact UAT behavior parity |
+
+Backend behavior gates (UAT phone test numbers, webhook auth defaults, SSE defaults,
+review-alias verification, non-production CORS) all key off `ENVIRONMENT`. Keeping the
+`uat` runtime identity is what makes dev a true replica. The string `dev` must NOT be
+used as `ENVIRONMENT` or `NEXT_PUBLIC_APP_ENV`: existing code treats `dev` as local
+development and would silently change behavior (auth defaults off, debug routes on).
+
+The deploy pipeline enforces this through the `_RUNTIME_ENVIRONMENT=uat` Cloud Build
+substitution (backend) and `_APP_ENV=uat` (frontend), while `_DEPLOY_ENV=dev` drives
+labels and provenance verification.
+
+## Intentional divergences from UAT
+
+1. **One Email KYC intake is disabled in dev.** `one@hushh.ai` is a single real
+   Workspace mailbox; per [env-and-secrets.md](../../../docs/reference/operations/env-and-secrets.md),
+   two environments must not independently renew Gmail watches for the same mailbox.
+   The dev deploy omits all `ONE_EMAIL_*` wiring and the parity gate runs without
+   `--require-one-email`. If dev ever needs email intake, it needs its own mailbox and
+   Pub/Sub topic first.
+2. Everything else (voice, Plaid, market data, Gmail receipts OAuth, Maps, reviewer
+   smoke, phone test numbers) replicates UAT, using secret values copied into the dev
+   project.
+
+---
+
+## Phase 1 — GCP project bootstrap (operator, requires org access)
+
+```bash
+# 1. Create the project and link billing
+gcloud projects create hushh-pda-dev --name="Hussh PDA Dev"
+gcloud billing projects link hushh-pda-dev --billing-account=<BILLING_ACCOUNT_ID>
+gcloud config set project hushh-pda-dev
+
+# 2. Enable the same APIs as UAT
+gcloud services enable \
+  cloudbuild.googleapis.com \
+  run.googleapis.com \
+  containerregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  sqladmin.googleapis.com \
+  aiplatform.googleapis.com \
+  cloudscheduler.googleapis.com
+```
+
+## Phase 2 — Cloud SQL replica
+
+```bash
+# Mirror the UAT instance shape (check current UAT tier before running)
+gcloud sql instances describe hushh-uat-pg --project=hushh-pda-uat \
+  --format='value(settings.tier, databaseVersion, region)'
+
+gcloud sql instances create hushh-dev-pg \
+  --project=hushh-pda-dev \
+  --region=us-central1 \
+  --database-version=<same-as-uat> \
+  --tier=<same-as-uat>
+
+# Create the runtime DB user (new credentials — do NOT reuse UAT DB credentials)
+gcloud sql users create <dev-db-user> --instance=hushh-dev-pg --password=<generated>
+```
+
+Seed the schema, choosing one of:
+
+- **Recommended — data replica:** export the UAT database and import it into
+  `hushh-dev-pg` (`gcloud sql export sql` from UAT → GCS → `gcloud sql import sql`).
+  This carries the reviewer smoke identities and marketplace fixtures with it, so
+  post-deploy semantic verification works on day one.
+- **Schema-only:** run `consent-protocol/db/migrate.py --release` against the empty
+  dev DB (the deploy workflow does this anyway) and recreate the reviewer smoke
+  fixture manually.
+
+The schema contract for dev is the UAT contract by definition:
+`consent-protocol/db/contracts/uat_integrated_schema.json` (dev replicates UAT; do not
+fork a dev contract file unless dev is allowed to drift, which it is not).
+
+## Phase 3 — Secret Manager population
+
+Copy the UAT secret values into the dev project, then override the environment-specific
+ones. From an operator machine with access to both projects:
+
+```bash
+# Copy every UAT secret name/value into hushh-pda-dev
+for secret in $(gcloud secrets list --project=hushh-pda-uat --format='value(name)'); do
+  value="$(gcloud secrets versions access latest --secret="$secret" --project=hushh-pda-uat)"
+  gcloud secrets create "$secret" --replication-policy=automatic --project=hushh-pda-dev 2>/dev/null || true
+  printf '%s' "$value" | gcloud secrets versions add "$secret" --data-file=- --project=hushh-pda-dev
+done
+```
+
+Then override the values that must differ in dev:
+
+| Secret | Dev value |
+| --- | --- |
+| `DB_USER` / `DB_PASSWORD` | the new dev Cloud SQL credentials |
+| `APP_FRONTEND_ORIGIN` | `https://dev.kai.hushh.ai` |
+| `BACKEND_URL` | dev backend Cloud Run URL (set after the first deploy) |
+| `GMAIL_OAUTH_REDIRECT_URI` | dev origin redirect (only if Gmail receipts should run in dev) |
+
+Notes:
+
+- `APP_SIGNING_KEY` / `VAULT_DATA_KEY`: copying UAT values makes dev able to read a
+  cloned UAT database (tokens and ciphertext stay valid). If you seed schema-only,
+  prefer generating fresh values instead.
+- Firebase identity plane is shared across environments by policy, so
+  `FIREBASE_ADMIN_CREDENTIALS_JSON` and all `NEXT_PUBLIC_FIREBASE_*` values are copied
+  as-is.
+- The deploy workflow's secret-sync step
+  (`scripts/ops/sync_backend_runtime_secrets.py --environment uat`,
+  `scripts/ops/sync_frontend_runtime_secrets.py --environment dev`) maintains
+  `BACKEND_RUNTIME_CONFIG_JSON`, CORS, passkey RP ids
+  (`localhost,127.0.0.1,kai.hushh.ai,dev.kai.hushh.ai`), and analytics ids on every
+  deploy — do not hand-maintain those.
+- Verify parity when done:
+
+```bash
+python3 scripts/ops/verify-env-secrets-parity.py \
+  --project hushh-pda-dev \
+  --region us-central1 \
+  --backend-service consent-protocol \
+  --frontend-service hushh-webapp \
+  --require-plaid --require-market-data --require-gmail --require-voice \
+  --require-reviewer-smoke
+```
+
+## Phase 4 — Deploy service account + GitHub wiring
+
+```bash
+# Service account with the same roles as the UAT deployer
+gcloud iam service-accounts create github-deployer \
+  --project=hushh-pda-dev --display-name="GitHub Actions dev deployer"
+
+for role in roles/cloudbuild.builds.editor roles/run.admin roles/iam.serviceAccountUser \
+            roles/secretmanager.admin roles/cloudsql.client roles/storage.admin \
+            roles/viewer; do
+  gcloud projects add-iam-policy-binding hushh-pda-dev \
+    --member="serviceAccount:github-deployer@hushh-pda-dev.iam.gserviceaccount.com" \
+    --role="$role"
+done
+
+gcloud iam service-accounts keys create dev-deployer-key.json \
+  --iam-account=github-deployer@hushh-pda-dev.iam.gserviceaccount.com
+```
+
+In GitHub (`hushh-labs/hushh-research` → Settings → Environments):
+
+1. Create environment **`dev`** (mirror any reviewer/branch protections from `uat`).
+2. Add environment secret **`GCP_SA_KEY_DEV`** = contents of `dev-deployer-key.json`.
+3. Delete the local key file after upload.
+
+Dispatch governance is already wired: `config/ci-governance.json` has a `dev` surface
+with the same governed actor list as UAT, enforced by
+`scripts/ci/assert-governed-actor.py --surface dev`.
+
+## Phase 5 — Domain mapping (optional for first deploy)
+
+```bash
+gcloud beta run domain-mappings create --service hushh-webapp \
+  --domain dev.kai.hushh.ai --region us-central1 --project hushh-pda-dev
+# then add the DNS records it prints to the kai.hushh.ai zone
+```
+
+Until the domain is live you can leave `APP_FRONTEND_ORIGIN` pointing at the frontend
+Cloud Run URL; the deploy pipeline reads the secret, so update it and redeploy when the
+domain lands.
+
+## Phase 6 — First deploy and verification
+
+1. Merge the branch that adds `deploy-dev.yml` to `main` (the workflow must exist on
+   `main` because dev deploys are dispatched from `main` only, same as UAT).
+2. GitHub → Actions → **Deploy to Dev** → Run workflow (branch `main`, scope `all`,
+   optionally an exact green SHA).
+3. The pipeline then does what the UAT one does: governed-actor gate → SHA-on-main gate
+   (requires the "Main Post-Merge Smoke Gate" check) → secret sync → DB migrations +
+   schema-contract gate → backend/frontend Cloud Build → traffic promotion →
+   provenance + parity + semantic verification → auto-rollback on failure.
+4. After the first successful backend deploy, set the `BACKEND_URL` secret in
+   `hushh-pda-dev` to the backend Cloud Run URL so frontend builds and contributor
+   profile bootstrap resolve it.
+
+Ongoing schedulers to replicate (after first deploy):
+
+- One Location retention purge: `POST /api/one/location/retention/purge?older_than_hours=12`
+  with `X-Hushh-Maintenance-Token: $ONE_LOCATION_RETENTION_TOKEN` (Cloud Scheduler,
+  same cadence as UAT).
+- Do NOT schedule One Email watch renewal in dev (see divergences above).
+
+## Contributor usage once dev is live
+
+```bash
+./bin/hushh bootstrap                 # hydrates hushh-webapp/.env.dev.local from hushh-pda-dev
+./bin/hushh web --mode dev            # local frontend against the dev backend
+./bin/hushh doctor --mode dev
+./bin/hushh db verify-dev-schema      # dev DB vs the UAT schema contract
+```
+
+Non-default project id? Export `DEV_PROJECT_ID=<project>` before running the tooling;
+`bootstrap_profiles.sh` also accepts `--dev-project <project>`.

--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -34,12 +34,19 @@ labels and provenance verification.
 
 ## Intentional divergences from UAT
 
-1. **One Email KYC intake is disabled in dev.** `one@hushh.ai` is a single real
-   Workspace mailbox; per [env-and-secrets.md](../../../docs/reference/operations/env-and-secrets.md),
-   two environments must not independently renew Gmail watches for the same mailbox.
-   The dev deploy omits all `ONE_EMAIL_*` wiring and the parity gate runs without
-   `--require-one-email`. If dev ever needs email intake, it needs its own mailbox and
-   Pub/Sub topic first.
+1. **One Email KYC runs in dev through topic fanout (founder-approved 2026-07).**
+   `one@hushh.ai` is a single real Workspace mailbox, and two environments must never
+   independently renew Gmail watches for it. The approved pattern:
+   - **One watch, owned by UAT.** The existing UAT scheduler remains the only caller of
+     `POST /api/one/email/watch/renew`. Never point a scheduler at the dev renewal
+     endpoint.
+   - **One topic, two subscriptions.** The watch keeps publishing to
+     `projects/hushh-pda/topics/one-email-kyc-uat`; dev gets its own push subscription
+     on that topic targeting the dev backend webhook (setup in Phase 6b below).
+   - **Caveat:** both environments see every inbound email, so the same message can
+     open a pending KYC workflow in UAT and dev. Sends stay user-approval-gated per
+     environment, but approvers should expect duplicates and treat dev as the testing
+     lane.
 2. Everything else (voice, Plaid, market data, Gmail receipts OAuth, Maps, reviewer
    smoke, phone test numbers) replicates UAT, using secret values copied into the dev
    project.
@@ -141,8 +148,8 @@ python3 scripts/ops/verify-env-secrets-parity.py \
   --region us-central1 \
   --backend-service consent-protocol \
   --frontend-service hushh-webapp \
-  --require-plaid --require-market-data --require-gmail --require-voice \
-  --require-reviewer-smoke
+  --require-plaid --require-market-data --require-gmail --require-one-email \
+  --require-voice --require-reviewer-smoke
 ```
 
 ## Phase 4 — Deploy service account + GitHub wiring
@@ -200,12 +207,38 @@ domain lands.
    `hushh-pda-dev` to the backend Cloud Run URL so frontend builds and contributor
    profile bootstrap resolve it.
 
+### Phase 6b — One Email fanout subscription (after first backend deploy)
+
+With the dev backend Cloud Run URL in hand:
+
+1. Update `DEV_ONE_EMAIL_WEBHOOK_AUDIENCE` in `.github/workflows/deploy-dev.yml` to
+   `https://<dev-backend-run-url>/api/one/email/webhook` and redeploy the backend so
+   the runtime audience matches.
+2. Create the dev push subscription on the shared UAT topic (topic lives in the
+   `hushh-pda` project):
+
+```bash
+gcloud pubsub subscriptions create one-email-kyc-dev-push \
+  --project=hushh-pda \
+  --topic=one-email-kyc-uat \
+  --push-endpoint="https://<dev-backend-run-url>/api/one/email/webhook" \
+  --push-auth-service-account=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com \
+  --push-auth-token-audience="https://<dev-backend-run-url>/api/one/email/webhook"
+```
+
+3. KYC retention purge for dev: schedule
+   `POST /api/one/kyc/retention/purge?older_than_days=30` with
+   `X-Hushh-Maintenance-Token: $ONE_EMAIL_WATCH_RENEW_TOKEN`
+   (`deploy/one-email/setup_kyc_retention_scheduler.sh` shows the UAT shape).
+
 Ongoing schedulers to replicate (after first deploy):
 
 - One Location retention purge: `POST /api/one/location/retention/purge?older_than_hours=12`
   with `X-Hushh-Maintenance-Token: $ONE_LOCATION_RETENTION_TOKEN` (Cloud Scheduler,
   same cadence as UAT).
-- Do NOT schedule One Email watch renewal in dev (see divergences above).
+- One KYC retention purge (Phase 6b above).
+- Do NOT schedule One Email watch renewal in dev — watch ownership stays with UAT
+  (see divergences above).
 
 ## Contributor usage once dev is live
 

--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -10,6 +10,27 @@ Canonical visual owner: [consent-protocol](../README.md). Use that map for the t
 
 ---
 
+## Provisioned State (as of 2026-07-10)
+
+Phases 1–3, the IAM plumbing, and the One Email fanout subscription were executed via
+the governed operator service account. Current live facts:
+
+| Item | Value |
+| --- | --- |
+| Project | `hushh-pda-dev` (number `621416509462`, folder shared with UAT, billing `014D7F-FD970D-D2459E`) |
+| Cloud SQL | `hushh-pda-dev:us-central1:hushh-dev-pg` (POSTGRES_15, db-custom-1-3840, 20GB SSD), user `hushh_uat_app` (new password in dev `DB_PASSWORD`) |
+| Secrets | all 144 UAT secrets replicated; overrides: `APP_FRONTEND_ORIGIN`, `BACKEND_URL`, `DB_PASSWORD` |
+| Backend URL (deterministic) | `https://consent-protocol-621416509462.us-central1.run.app` |
+| Frontend URL (deterministic) | `https://hushh-webapp-621416509462.us-central1.run.app` |
+| One Email fanout | subscription `one-email-kyc-dev-push` in `hushh-pda` on topic `one-email-kyc-uat`, OIDC audience = dev backend webhook |
+| Runtime SAs | compute + cloudbuild SAs granted UAT-parity roles |
+
+Still pending: `dev.kai.hushh.ai` DNS + domain mapping (origin temporarily set to the
+deterministic frontend Cloud Run URL in `deploy-dev.yml`; passkey unlock is unavailable
+on the temporary origin because the RP id is `kai.hushh.ai` — passphrase unlock works),
+GitHub environment `dev` + `GCP_SA_KEY_DEV`, first deploy, and the post-deploy
+schedulers below.
+
 ## Identity Model (read this first)
 
 The dev environment splits infrastructure identity from runtime identity on purpose:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -279,9 +279,10 @@ Manual dispatch now supports `scope`:
 
 **For seamless deployment:**
 
-1. **GitHub secret:** add `GCP_SA_KEY` (and optionally `GCP_SA_KEY_UAT`) with Cloud Build + Cloud Run + Secret Manager permissions.
+1. **GitHub secret:** add `GCP_SA_KEY` (and optionally `GCP_SA_KEY_UAT` and `GCP_SA_KEY_DEV`) with Cloud Build + Cloud Run + Secret Manager permissions.
 2. **Branch flow:** merge to `main` for UAT rollout; use manual dispatch for production rollout from a green `main` SHA.
 3. **Environment policy:** keep only the canonical deploy environments in active use:
+   - `dev` (UAT infrastructure replica; see [consent-protocol/docs/reference/dev-environment-setup.md](../consent-protocol/docs/reference/dev-environment-setup.md))
    - `uat`
    - `production`
    Legacy unused production environments should not remain as parallel approval lanes.

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -87,8 +87,16 @@ steps:
         append_optional_secret "${_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET}" "RIA_INTELLIGENCE_VERIFY_BASE_URL"
         append_optional_secret "${_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET}" "ONE_EMAIL_WATCH_RENEW_TOKEN"
 
+        # Runtime identity may differ from deploy identity: the dev environment
+        # deploys with _DEPLOY_ENV=dev (labels, provenance) but runs with
+        # ENVIRONMENT=uat so behavior gates replicate UAT exactly.
+        runtime_environment="${_RUNTIME_ENVIRONMENT}"
+        if [[ -z "${runtime_environment}" ]]; then
+          runtime_environment="${_DEPLOY_ENV}"
+        fi
+
         env_vars=(
-          "ENVIRONMENT=${_DEPLOY_ENV}"
+          "ENVIRONMENT=${runtime_environment}"
           "HUSHH_DEPLOY_ENV=${_DEPLOY_ENV}"
           "HUSHH_DEPLOY_SOURCE=${_DEPLOY_SOURCE}"
           "HUSHH_DEPLOY_SHA=${_DEPLOY_SHA}"
@@ -207,6 +215,7 @@ substitutions:
   _ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED: "true"
   _APP_REVIEW_MODE: ""
   _CLOUD_RUN_NO_TRAFFIC: "false"
+  _RUNTIME_ENVIRONMENT: ""
   _IMAGE_TAG: v2.1.0
   _DEPLOY_ENV: manual
   _DEPLOY_SOURCE: manual

--- a/docs/guides/environment-model.md
+++ b/docs/guides/environment-model.md
@@ -5,15 +5,18 @@
 
 Canonical visual owner: [Guides Index](README.md). Use that map for the top-down system view; this page is the narrower detail beneath it.
 
-This repo supports exactly three contributor runtime modes:
+This repo supports exactly four contributor runtime modes:
 
 - `local`
 - `uat`
+- `dev`
 - `prod`
 
 Anything outside that list is legacy or unsupported for normal onboarding.
 
-Those supported backend and frontend profile files now share one canonical key shape. The files are allowed to differ by value, but not by “which keys exist,” except for legacy unsupported env variants outside this three-profile model.
+`dev` is the founder-approved hosted development environment (added 2026-07): an infrastructure replica of UAT in its own GCP project (`hushh-pda-dev`). It deliberately keeps the `uat` runtime identity so behavior gates match UAT exactly; only the infrastructure identity (GCP project, Cloud SQL instance, deploy labels, origin) is `dev`.
+
+Those supported backend and frontend profile files now share one canonical key shape. The files are allowed to differ by value, but not by “which keys exist,” except for legacy unsupported env variants outside this four-profile model.
 
 ## Profile Matrix
 
@@ -21,6 +24,7 @@ Those supported backend and frontend profile files now share one canonical key s
 | --- | --- | --- | --- | --- |
 | `local` | local | local | `development` | full-stack development with UAT-backed DB/resources |
 | `uat` | local | deployed UAT | `uat` | reproduce UAT behavior from a local frontend |
+| `dev` | local | deployed dev (UAT replica) | `uat` (by design) | develop against the dev environment without touching UAT |
 | `prod` | local | deployed production | `production` | validate production behavior safely |
 
 ## Active Files
@@ -30,6 +34,7 @@ The supported local files are:
 - `consent-protocol/.env.example`
 - `hushh-webapp/.env.local.local.example`
 - `hushh-webapp/.env.uat.local.example`
+- `hushh-webapp/.env.dev.local.example`
 - `hushh-webapp/.env.prod.local.example`
 
 The active runtime files remain:
@@ -43,6 +48,7 @@ Seeded contributor files:
 - generated frontend profile files beside:
   `hushh-webapp/.env.local.local.example`
   `hushh-webapp/.env.uat.local.example`
+  `hushh-webapp/.env.dev.local.example`
   `hushh-webapp/.env.prod.local.example`
 
 Activate a profile with:
@@ -74,6 +80,8 @@ Every profile must keep these keys aligned:
 - frontend: `NEXT_PUBLIC_APP_ENV=development|uat|production`
 - both: `APP_RUNTIME_PROFILE=<profile>`
 
+The `dev` profile intentionally reuses the `uat` identity values (`ENVIRONMENT=uat`, `NEXT_PUBLIC_APP_ENV=uat`); it is distinguished by `APP_RUNTIME_PROFILE=dev`, its backend/app URLs, and its GCP project.
+
 `./bin/hushh doctor --mode <mode>` is the quickest way to verify that alignment.
 
 Doctor status meanings:
@@ -87,12 +95,13 @@ Doctor status meanings:
 - Local development may default to `http://127.0.0.1:8000` only when the selected environment is `development`
 - Hosted Next.js route handlers must receive an explicit runtime backend origin
 - UAT frontend runtime must talk only to the UAT backend
+- Dev frontend runtime must talk only to the dev backend
 - Production frontend runtime must talk only to the production backend
 - Hosted runtimes must fail fast if the backend origin is missing instead of guessing
 
 ## Contributor Rules
 
-- Never create a fourth profile for convenience
+- Never create additional profiles for convenience; `local`, `uat`, `dev`, and `prod` are the only supported modes, and adding one requires founder approval plus a full tooling/docs pass
 - Never teach a new contributor to hand-wire `.env.local` manually
 - Never rely on `DATABASE_URL`; this repo uses the `DB_*` contract
 - Never use the old `*remote*` or `local-uatdb` runtime names as onboarding truth
@@ -104,6 +113,7 @@ Doctor status meanings:
 ./bin/hushh bootstrap
 ./bin/hushh doctor --mode local
 ./bin/hushh doctor --mode uat
+./bin/hushh doctor --mode dev
 ./bin/hushh doctor --mode prod
 python3 scripts/ops/verify-runtime-profile-env-shape.py --include-runtime
 ```

--- a/docs/reference/operations/cli.md
+++ b/docs/reference/operations/cli.md
@@ -58,6 +58,7 @@ Use package-local commands only when you are working inside a package on purpose
 <repo-root>/bin/hushh db verify-iam-schema
 <repo-root>/bin/hushh db verify-release-contract
 <repo-root>/bin/hushh db verify-uat-schema
+<repo-root>/bin/hushh db verify-dev-schema
 <repo-root>/bin/hushh db report-prod-posture
 <repo-root>/bin/hushh compose init
 <repo-root>/bin/hushh compose up backend
@@ -78,13 +79,13 @@ Use package-local commands only when you are working inside a package on purpose
 - Do not document `make`.
 - Keep helper output and runbooks aligned with this CLI.
 - Contributor and agent onboarding should start with `./bin/hushh codex onboard`, not direct internal script paths.
-- `./bin/hushh web` defaults to `local`; use `--mode uat` or `--mode prod` only when you explicitly want a hosted backend target.
+- `./bin/hushh web` defaults to `local`; use `--mode uat`, `--mode dev`, or `--mode prod` only when you explicitly want a hosted backend target.
 - Local runtime uses three separate terminals (one component each): `./bin/hushh proxy --mode local`, `./bin/hushh backend --mode local --reload`, and `./bin/hushh web --mode local`. There is no combined `stack` command.
 - Use `./bin/hushh terminal proxy|backend|web --mode <mode>` only when you explicitly want visible OS terminal windows instead of in-session terminals.
 - Use `./bin/hushh compose ...` only for opt-in local container support. It does not replace the default frontend/backend development flow.
 - The `dev` compose profile starts backend + Redis + Mailhog. The local Postgres profile is standalone unless an operator explicitly changes backend env values.
 - Use `uv` as the canonical Python install surface for `consent-protocol`; `requirements*.txt` are generated compatibility artifacts, not contributor commands.
-- Treat `./bin/hushh db verify-release-contract`, `./bin/hushh db verify-uat-schema`, and `./bin/hushh db report-prod-posture` as the authoritative DB governance surface.
+- Treat `./bin/hushh db verify-release-contract`, `./bin/hushh db verify-uat-schema`, `./bin/hushh db verify-dev-schema`, and `./bin/hushh db report-prod-posture` as the authoritative DB governance surface.
 - Use `./bin/hushh codex data-model-audit` before treating new tables, durable caches, or runtime DB family changes as production-ready.
 - Use `./bin/hushh codex rca --surface runtime|uat|ci` as the canonical machine-readable RCA surface for core runtime, CI, and UAT release failures.
 - Use `./bin/hushh codex pre-pr` as the canonical pre-PR local mirror of `PR Validation` and `CI Status Gate`; add `--include-advisory` only when you intentionally want the wider readiness lane.

--- a/docs/reference/operations/env-and-secrets.md
+++ b/docs/reference/operations/env-and-secrets.md
@@ -16,7 +16,7 @@ See also: [deploy/README.md](../../../deploy/README.md), [consent-protocol/.env.
 
 - **Local:** `.env` (backend) and `.env.local` (frontend) must contain exactly the keys the application code reads. Use the repo `.env.example` files as the template; they are audited to match the code.
 - **Production:** GCP Secret Manager must hold **exactly** the secrets the code expects — no more, no less. The Cloud Build config (`deploy/*.cloudbuild.yaml`) injects only these; do not add secrets that are not read by the code, and do not remove any that are.
-- **Canonical runtime modes:** the supported frontend `local`, `uat`, and `prod` files must share one frontend key shape. The backend contributor runtime stays local-only in `consent-protocol/.env`.
+- **Canonical runtime modes:** the supported frontend `local`, `uat`, `dev`, and `prod` files must share one frontend key shape. The backend contributor runtime stays local-only in `consent-protocol/.env`. The hosted `dev` environment is a UAT infrastructure replica that keeps the `uat` runtime identity; see [consent-protocol/docs/reference/dev-environment-setup.md](../../../consent-protocol/docs/reference/dev-environment-setup.md).
 
 ## Canonical 3-environment contract
 
@@ -27,7 +27,7 @@ See also: [deploy/README.md](../../../deploy/README.md), [consent-protocol/.env.
 - `NEXT_PUBLIC_ENVIRONMENT_MODE`
 4. Local runtime-mode model (non-committed):
 - backend template/source: `consent-protocol/.env.example` -> `consent-protocol/.env`
-- frontend templates: `hushh-webapp/.env.local.local.example`, `hushh-webapp/.env.uat.local.example`, `hushh-webapp/.env.prod.local.example`
+- frontend templates: `hushh-webapp/.env.local.local.example`, `hushh-webapp/.env.uat.local.example`, `hushh-webapp/.env.dev.local.example`, `hushh-webapp/.env.prod.local.example`
 - local source files are created from templates and kept uncommitted
 - active files: `consent-protocol/.env`, `hushh-webapp/.env.local`
 - PKM rehearsal toggles, maintainer smoke identities, and review/bypass overlays belong in maintainer-only overlays, not in the canonical contributor runtime files.
@@ -132,10 +132,12 @@ It checks that:
 These are not Cloud Run runtime secrets.
 
 - Required: `GCP_SA_KEY` (used by production deploy and backup posture workflows to call GCP APIs)
+- Required for dev deploys: `GCP_SA_KEY_DEV` on the `dev` GitHub environment (used by `.github/workflows/deploy-dev.yml`)
 
 Used by:
 - `.github/workflows/deploy-production.yml`
 - `.github/workflows/prod-supabase-backup-posture.yml`
+- `.github/workflows/deploy-dev.yml`
 
 ---
 

--- a/hushh-webapp/.env.dev.local.example
+++ b/hushh-webapp/.env.dev.local.example
@@ -5,7 +5,7 @@
 
 APP_RUNTIME_PROFILE=dev
 NEXT_PUBLIC_APP_ENV=uat
-NEXT_PUBLIC_BACKEND_URL=https://consent-protocol-<dev-hash>-uc.a.run.app
+NEXT_PUBLIC_BACKEND_URL=https://consent-protocol-621416509462.us-central1.run.app
 NEXT_PUBLIC_APP_URL=https://dev.kai.hushh.ai
 NEXT_PUBLIC_PASSKEY_RP_ID=kai.hushh.ai
 

--- a/hushh-webapp/.env.dev.local.example
+++ b/hushh-webapp/.env.dev.local.example
@@ -1,0 +1,31 @@
+# Frontend runtime mode: dev
+# Local frontend pointed at the deployed dev backend (infrastructure replica of UAT
+# in its own GCP project). Runtime identity stays uat so behavior gates match UAT;
+# Firebase identity stays shared.
+
+APP_RUNTIME_PROFILE=dev
+NEXT_PUBLIC_APP_ENV=uat
+NEXT_PUBLIC_BACKEND_URL=https://consent-protocol-<dev-hash>-uc.a.run.app
+NEXT_PUBLIC_APP_URL=https://dev.kai.hushh.ai
+NEXT_PUBLIC_PASSKEY_RP_ID=kai.hushh.ai
+
+NEXT_PUBLIC_FIREBASE_API_KEY=replace_with_shared_firebase_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=replace_with_shared_firebase_auth_domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=replace_with_shared_firebase_project_id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=replace_with_shared_firebase_storage_bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=replace_with_shared_firebase_sender_id
+NEXT_PUBLIC_FIREBASE_APP_ID=replace_with_shared_firebase_app_id
+NEXT_PUBLIC_FIREBASE_VAPID_KEY=replace_with_shared_firebase_vapid_key
+
+FIREBASE_ADMIN_CREDENTIALS_JSON=replace_with_shared_firebase_service_account_json
+
+NEXT_PUBLIC_FIREBASE_PHONE_AUTH_DISABLE_APP_VERIFICATION=false
+
+NEXT_PUBLIC_OBSERVABILITY_ENABLED=true
+NEXT_PUBLIC_OBSERVABILITY_DEBUG=false
+NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_dev_measurement_id
+NEXT_PUBLIC_GTM_ID=replace_with_dev_gtm_id
+
+# Maintainer-only overlay values such as app-review, native signing,
+# REVIEWER_UID / REVIEWER_VAULT_PASSPHRASE, and rehearsal toggles should live in an untracked overlay file.

--- a/scripts/ci/assert-governed-actor.py
+++ b/scripts/ci/assert-governed-actor.py
@@ -17,7 +17,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Assert that a GitHub actor is allowed to dispatch a governed workflow."
     )
-    parser.add_argument("--surface", choices=("uat", "production"), required=True)
+    parser.add_argument("--surface", choices=("dev", "uat", "production"), required=True)
     parser.add_argument("--actor", required=True)
     args = parser.parse_args()
 

--- a/scripts/env/bootstrap.sh
+++ b/scripts/env/bootstrap.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/runtime_profile_lib.sh"
 usage() {
   cat <<'USAGE'
 Usage:
-  scripts/env/bootstrap.sh [--mode <local|uat|prod>] [--profile <local|uat|prod>]
+  scripts/env/bootstrap.sh [--mode <local|uat|dev|prod>] [--profile <local|uat|dev|prod>]
 
 Description:
   Canonical contributor bootstrap for the monorepo.
@@ -106,7 +106,6 @@ warn_legacy_envs() {
     "$REPO_ROOT/consent-protocol/.env.local-uatdb.local" \
     "$REPO_ROOT/consent-protocol/.env.uat-remote.local" \
     "$REPO_ROOT/consent-protocol/.env.prod-remote.local" \
-    "$REPO_ROOT/hushh-webapp/.env.dev.local" \
     "$REPO_ROOT/hushh-webapp/.env.local-uatdb.local" \
     "$REPO_ROOT/hushh-webapp/.env.uat-remote.local" \
     "$REPO_ROOT/hushh-webapp/.env.prod-remote.local"

--- a/scripts/env/bootstrap_profiles.sh
+++ b/scripts/env/bootstrap_profiles.sh
@@ -15,6 +15,7 @@ Options:
   --backend-service <name>           Backend service name (default: consent-protocol)
   --frontend-service <name>          Frontend service name (default: hushh-webapp)
   --uat-project <project-id>         UAT project id (default: hushh-pda-uat)
+  --dev-project <project-id>         Dev project id (default: hushh-pda-dev)
   --prod-project <project-id>        Prod project id (default: hushh-pda)
   --force                            Re-copy templates before hydration
   --strict                           Exit non-zero if required cloud values are missing
@@ -25,11 +26,13 @@ Description:
     consent-protocol/.env
     hushh-webapp/.env.local.local
     hushh-webapp/.env.uat.local
+    hushh-webapp/.env.dev.local
     hushh-webapp/.env.prod.local
 
   Runtime mode model:
   - local : local frontend + local backend, backed by UAT resources
   - uat   : local frontend only, pointed at deployed UAT backend
+  - dev   : local frontend only, pointed at deployed dev backend (UAT replica)
   - prod  : local frontend only, pointed at deployed production backend
 
   Notes:
@@ -45,6 +48,7 @@ REGION="${REGION:-us-central1}"
 BACKEND_SERVICE="${BACKEND_SERVICE:-consent-protocol}"
 FRONTEND_SERVICE="${FRONTEND_SERVICE:-hushh-webapp}"
 UAT_PROJECT_ID="${UAT_PROJECT_ID:-hushh-pda-uat}"
+DEV_PROJECT_ID="${DEV_PROJECT_ID:-hushh-pda-dev}"
 PROD_PROJECT_ID="${PROD_PROJECT_ID:-hushh-pda}"
 FORCE=false
 STRICT=false
@@ -70,6 +74,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --uat-project)
       UAT_PROJECT_ID="${2:-}"
+      shift 2
+      ;;
+    --dev-project)
+      DEV_PROJECT_ID="${2:-}"
       shift 2
       ;;
     --prod-project)
@@ -1078,7 +1086,7 @@ sync_active_frontend_profile_if_present() {
   SUMMARY+=("synced hushh-webapp/.env.local from ${source_file#$REPO_ROOT/}")
 }
 
-profiles=(local uat prod)
+profiles=(local uat dev prod)
 
 copy_template_if_needed "$BACKEND_DIR/.env.example" "$BACKEND_DIR/.env"
 for profile in "${profiles[@]}"; do
@@ -1088,6 +1096,9 @@ done
 hydrate_backend_local_uatdb "$BACKEND_DIR/.env" "$UAT_PROJECT_ID"
 hydrate_frontend_local_uatdb "$FRONTEND_DIR/.env.local.local" "$UAT_PROJECT_ID"
 hydrate_frontend_cloud "$FRONTEND_DIR/.env.uat.local" "uat" "$UAT_PROJECT_ID" "uat"
+# dev keeps the uat runtime identity (NEXT_PUBLIC_APP_ENV=uat); it is an
+# infrastructure replica of UAT living in its own GCP project.
+hydrate_frontend_cloud "$FRONTEND_DIR/.env.dev.local" "dev" "$DEV_PROJECT_ID" "uat"
 hydrate_frontend_cloud "$FRONTEND_DIR/.env.prod.local" "prod" "$PROD_PROJECT_ID" "production"
 
 ensure_shape_from_template "$BACKEND_DIR/.env.example" "$BACKEND_DIR/.env"
@@ -1104,7 +1115,7 @@ for path in \
   "$BACKEND_DIR/.env" \
   "$FRONTEND_DIR/.env.local.local" "$FRONTEND_DIR/.env.uat.local" "$FRONTEND_DIR/.env.prod.local" \
   "$BACKEND_DIR/.env.dev.local" "$BACKEND_DIR/.env.uat.local" "$BACKEND_DIR/.env.prod.local" \
-  "$FRONTEND_DIR/.env.dev.local" "$FRONTEND_DIR/.env.uat.local" "$FRONTEND_DIR/.env.prod.local"
+  "$FRONTEND_DIR/.env.dev.local"
 do
   normalize_env_json_values "$path"
 done
@@ -1123,6 +1134,12 @@ validate_canonical_keys "uat" \
   "development" \
   "uat"
 
+validate_canonical_keys "dev" \
+  "$BACKEND_DIR/.env" \
+  "$FRONTEND_DIR/.env.dev.local" \
+  "development" \
+  "uat"
+
 validate_canonical_keys "prod" \
   "$BACKEND_DIR/.env" \
   "$FRONTEND_DIR/.env.prod.local" \
@@ -1131,7 +1148,7 @@ validate_canonical_keys "prod" \
 
 for path in \
   "$BACKEND_DIR/.env" \
-  "$FRONTEND_DIR/.env.local.local" "$FRONTEND_DIR/.env.uat.local" "$FRONTEND_DIR/.env.prod.local"
+  "$FRONTEND_DIR/.env.local.local" "$FRONTEND_DIR/.env.uat.local" "$FRONTEND_DIR/.env.dev.local" "$FRONTEND_DIR/.env.prod.local"
 do
   key_count="$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$path" | wc -l | tr -d ' ')"
   SUMMARY+=("hydrated ${path#$REPO_ROOT/} (${key_count} keys)")
@@ -1173,4 +1190,4 @@ if [ -f "$REPO_ROOT/scripts/ops/verify-runtime-profile-env-shape.py" ]; then
 fi
 echo ""
 echo "Done. Use a runtime mode with:"
-echo "  bash scripts/env/use_profile.sh local|uat|prod"
+echo "  bash scripts/env/use_profile.sh local|uat|dev|prod"

--- a/scripts/env/doctor.sh
+++ b/scripts/env/doctor.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/runtime_profile_lib.sh"
 usage() {
   cat <<'USAGE'
 Usage:
-  scripts/env/doctor.sh <local|uat|prod> [--json]
+  scripts/env/doctor.sh <local|uat|dev|prod> [--json]
 
 Description:
   Verify that a runtime mode is coherent and runnable.
@@ -352,6 +352,14 @@ case "$PROFILE" in
       add_check "backend_target_shape" "pass" "uat points at a remote backend"
     fi
     ;;
+  dev)
+    if [[ "$FRONTEND_BACKEND_TARGET" == http://localhost:* || "$FRONTEND_BACKEND_TARGET" == http://127.0.0.1:* ]]; then
+      add_check "backend_target_shape" "fail" "dev must not point at localhost"
+      SOURCE_READY=false
+    else
+      add_check "backend_target_shape" "pass" "dev points at a remote backend"
+    fi
+    ;;
   prod)
     if [[ "$FRONTEND_BACKEND_TARGET" == http://localhost:* || "$FRONTEND_BACKEND_TARGET" == http://127.0.0.1:* ]]; then
       add_check "backend_target_shape" "fail" "prod must not point at localhost"
@@ -370,7 +378,6 @@ for path in \
   "$REPO_ROOT/consent-protocol/.env.local-uatdb.local" \
   "$REPO_ROOT/consent-protocol/.env.uat-remote.local" \
   "$REPO_ROOT/consent-protocol/.env.prod-remote.local" \
-  "$REPO_ROOT/hushh-webapp/.env.dev.local" \
   "$REPO_ROOT/hushh-webapp/.env.local-uatdb.local" \
   "$REPO_ROOT/hushh-webapp/.env.uat-remote.local" \
   "$REPO_ROOT/hushh-webapp/.env.prod-remote.local"

--- a/scripts/env/runtime_profile_lib.sh
+++ b/scripts/env/runtime_profile_lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 runtime_modes() {
-  printf '%s\n' "local" "uat" "prod"
+  printf '%s\n' "local" "uat" "dev" "prod"
 }
 
 runtime_profiles() {
@@ -9,7 +9,7 @@ runtime_profiles() {
 }
 
 runtime_profiles_csv() {
-  printf 'local, uat, prod'
+  printf 'local, uat, dev, prod'
 }
 
 normalize_runtime_mode() {
@@ -18,11 +18,14 @@ normalize_runtime_mode() {
   normalized="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | xargs)"
 
   case "$normalized" in
-    local|development|dev|local-uatdb)
+    local|development|local-uatdb)
       printf 'local'
       ;;
     uat|uat-remote)
       printf 'uat'
+      ;;
+    dev|dev-remote)
+      printf 'dev'
       ;;
     prod|production|prod-remote)
       printf 'prod'
@@ -40,14 +43,14 @@ normalize_runtime_profile() {
 runtime_profile_backend_mode() {
   case "${1:-}" in
     local) printf 'local' ;;
-    uat|prod) printf 'remote' ;;
+    uat|dev|prod) printf 'remote' ;;
     *) return 1 ;;
   esac
 }
 
 runtime_profile_frontend_mode() {
   case "${1:-}" in
-    local|uat|prod) printf 'local' ;;
+    local|uat|dev|prod) printf 'local' ;;
     *) return 1 ;;
   esac
 }
@@ -56,6 +59,10 @@ runtime_profile_backend_environment() {
   case "${1:-}" in
     local) printf 'development' ;;
     uat) printf 'uat' ;;
+    # dev is an infrastructure replica of UAT; it keeps the uat runtime
+    # identity so behavior gates match UAT exactly. The dev-ness lives in
+    # the GCP project, deploy labels, and profile name.
+    dev) printf 'uat' ;;
     prod) printf 'production' ;;
     *) return 1 ;;
   esac
@@ -68,6 +75,7 @@ runtime_profile_frontend_environment() {
 runtime_profile_resource_target() {
   case "${1:-}" in
     local|uat) printf 'uat' ;;
+    dev) printf 'dev' ;;
     prod) printf 'production' ;;
     *) return 1 ;;
   esac
@@ -80,6 +88,9 @@ runtime_profile_description() {
       ;;
     uat)
       printf 'local frontend only, pointed at deployed UAT backend'
+      ;;
+    dev)
+      printf 'local frontend only, pointed at deployed dev backend (UAT replica)'
       ;;
     prod)
       printf 'local frontend only, pointed at deployed production backend'
@@ -94,6 +105,7 @@ runtime_profile_frontend_source() {
   case "${1:-}" in
     local) printf '.env.local.local' ;;
     uat) printf '.env.uat.local' ;;
+    dev) printf '.env.dev.local' ;;
     prod) printf '.env.prod.local' ;;
     *) return 1 ;;
   esac

--- a/scripts/env/use_profile.sh
+++ b/scripts/env/use_profile.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/runtime_profile_lib.sh"
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/env/use_profile.sh <local|uat|prod> [--dry-run]
+  scripts/env/use_profile.sh <local|uat|dev|prod> [--dry-run]
 
 Description:
   Activates the selected frontend runtime mode by copying:
@@ -45,7 +45,7 @@ done
 
 if ! PROFILE="$(normalize_runtime_profile "$RAW_PROFILE")"; then
   echo "Invalid profile: $RAW_PROFILE" >&2
-  echo "Expected one of: local, uat, prod" >&2
+  echo "Expected one of: local, uat, dev, prod" >&2
   exit 1
 fi
 
@@ -194,6 +194,9 @@ gcp_project_for_profile() {
     local|uat)
       printf 'hushh-pda-uat'
       ;;
+    dev)
+      printf '%s' "${DEV_PROJECT_ID:-hushh-pda-dev}"
+      ;;
     prod)
       printf 'hushh-pda'
       ;;
@@ -208,14 +211,17 @@ legacy_frontend_sources_for_profile() {
     local)
       printf '%s\n%s\n' \
         "$REPO_ROOT/hushh-webapp/.env.local-uatdb.local" \
-        "$REPO_ROOT/hushh-webapp/.env.uat.local" \
-        "$REPO_ROOT/hushh-webapp/.env.dev.local"
+        "$REPO_ROOT/hushh-webapp/.env.uat.local"
       ;;
     uat)
       printf '%s\n%s\n' \
         "$REPO_ROOT/hushh-webapp/.env.uat-remote.local" \
-        "$REPO_ROOT/hushh-webapp/.env.uat.local" \
-        "$REPO_ROOT/hushh-webapp/.env.dev.local"
+        "$REPO_ROOT/hushh-webapp/.env.uat.local"
+      ;;
+    dev)
+      # dev is a first-class profile; .env.dev.local is its real source file,
+      # not a legacy alias.
+      :
       ;;
     prod)
       printf '%s\n%s\n' \
@@ -351,6 +357,9 @@ echo "Frontend source: $FRONTEND_SOURCE"
 echo "Backend runtime file: $BACKEND_TARGET"
 if [ "$PROFILE" = "prod" ]; then
   echo "WARNING: prod points the local frontend at production services."
+fi
+if [ "$PROFILE" = "dev" ]; then
+  echo "Note: dev points the local frontend at the deployed dev backend (UAT replica)."
 fi
 if [ "$DRY_RUN" = "true" ]; then
   echo "Dry run: no files were copied."

--- a/scripts/ops/dev_environment_doctor.py
+++ b/scripts/ops/dev_environment_doctor.py
@@ -247,6 +247,51 @@ def check_runtime_sa_iam(dev: str, uat: str, dev_number: str | None) -> None:
             record(f"iam-{kind}-sa", "pass", f"role set covers UAT parity ({len(dev_roles)} roles)")
 
 
+RUNTIME_SPEC_FIELDS = (
+    ("min instances", ("spec", "template", "metadata", "annotations", "autoscaling.knative.dev/minScale")),
+    ("max instances", ("spec", "template", "metadata", "annotations", "autoscaling.knative.dev/maxScale")),
+    ("memory", ("spec", "template", "spec", "containers", 0, "resources", "limits", "memory")),
+    ("cpu", ("spec", "template", "spec", "containers", 0, "resources", "limits", "cpu")),
+    ("timeout", ("spec", "template", "spec", "timeoutSeconds")),
+    ("concurrency", ("spec", "template", "spec", "containerConcurrency")),
+    ("session affinity", ("spec", "template", "metadata", "annotations", "run.googleapis.com/sessionAffinity")),
+)
+
+
+def _dig(obj: Any, path: tuple) -> Any:
+    for key in path:
+        try:
+            obj = obj[key]
+        except (KeyError, IndexError, TypeError):
+            return None
+    return obj
+
+
+def check_runtime_spec_parity(dev: str, uat: str, region: str) -> None:
+    for service in (BACKEND_SERVICE, FRONTEND_SERVICE):
+        dev_info = gcloud_json(["run", "services", "describe", service,
+                                f"--project={dev}", f"--region={region}"])
+        uat_info = gcloud_json(["run", "services", "describe", service,
+                                f"--project={uat}", f"--region={region}"])
+        if not dev_info or not uat_info:
+            continue  # deployment presence handled by check_cloud_run
+        drift = []
+        for label, path in RUNTIME_SPEC_FIELDS:
+            dev_val, uat_val = _dig(dev_info, path), _dig(uat_info, path)
+            if str(dev_val) != str(uat_val):
+                drift.append(f"{label}: dev={dev_val} uat={uat_val}")
+        min_scale = _dig(dev_info, RUNTIME_SPEC_FIELDS[0][1])
+        if str(min_scale) != "1":
+            drift.append(f"min instances must be 1 to avoid cold boots (found {min_scale})")
+        if drift:
+            record(f"runtime-spec:{service}", "fail", "; ".join(drift),
+                   f"gcloud run services update {service} --project={dev} --region={region} "
+                   "--min-instances=1 <plus the drifted flags>")
+        else:
+            record(f"runtime-spec:{service}", "pass",
+                   "matches UAT (min=1 warm, max/memory/cpu/timeout/concurrency/affinity)")
+
+
 def check_cloud_run(dev: str, region: str) -> dict[str, str]:
     urls: dict[str, str] = {}
     for service in (BACKEND_SERVICE, FRONTEND_SERVICE):
@@ -366,6 +411,7 @@ def main() -> int:
     check_sql(args.dev_project, args.uat_project)
     check_runtime_sa_iam(args.dev_project, args.uat_project, dev_number)
     urls = check_cloud_run(args.dev_project, args.region)
+    check_runtime_spec_parity(args.dev_project, args.uat_project, args.region)
     check_health(urls)
     check_pubsub_fanout(dev_number)
     check_domain_mapping(args.dev_project, args.region)

--- a/scripts/ops/dev_environment_doctor.py
+++ b/scripts/ops/dev_environment_doctor.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""End-to-end dev-environment doctor: audits the hosted dev GCP project against UAT.
+
+The baseline is derived LIVE from the UAT project (enabled APIs, secret names,
+Cloud SQL shape and users, runtime service-account roles, Cloud Run services,
+scheduler jobs), so the audit stays correct as UAT evolves. Dev-specific
+expectations (override secrets, runtime identity, Pub/Sub fanout, domain
+mapping) are asserted explicitly.
+
+Each failed check prints a remediation command. Exit codes: 0 = healthy,
+1 = failures present. Warnings never fail the run.
+
+Usage:
+  python3 scripts/ops/dev_environment_doctor.py \
+    --dev-project hushh-pda-dev --uat-project hushh-pda-uat \
+    [--region us-central1] [--report-path /tmp/dev-doctor.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.request
+from typing import Any
+
+CHECKS: list[dict[str, Any]] = []
+
+# Secrets whose values MUST differ from UAT in dev (environment-specific).
+OVERRIDE_SECRETS = ("APP_FRONTEND_ORIGIN", "BACKEND_URL", "DB_PASSWORD")
+
+# APIs dev needs beyond whatever UAT reports (UAT may predate the API split).
+REQUIRED_DEV_APIS = (
+    "cloudbuild.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "sqladmin.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "aiplatform.googleapis.com",
+)
+
+RUNTIME_SA_KINDS = {
+    "compute": "-compute@developer.gserviceaccount.com",
+    "cloudbuild": "@cloudbuild.gserviceaccount.com",
+}
+
+FANOUT_SUBSCRIPTION = "one-email-kyc-dev-push"
+FANOUT_TOPIC_PROJECT = "hushh-pda"
+FANOUT_TOPIC = "one-email-kyc-uat"
+
+DEV_DOMAIN = "dev.kai.hushh.ai"
+BACKEND_SERVICE = "consent-protocol"
+FRONTEND_SERVICE = "hushh-webapp"
+DEV_SQL_INSTANCE = "hushh-dev-pg"
+UAT_SQL_INSTANCE = "hushh-uat-pg"
+
+
+def run(args: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    return proc.returncode, proc.stdout.strip()
+
+
+def gcloud_json(args: list[str]) -> Any:
+    code, out = run(["gcloud", *args, "--format=json"])
+    if code != 0:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def record(name: str, status: str, detail: str, fix: str = "") -> None:
+    CHECKS.append({"check": name, "status": status, "detail": detail, "fix": fix})
+    symbol = {"pass": "PASS", "warn": "WARN", "fail": "FAIL"}[status]
+    print(f"[{symbol}] {name}: {detail}")
+    if fix and status != "pass":
+        print(f"       fix: {fix}")
+
+
+def check_project(dev: str, uat: str) -> str | None:
+    dev_info = gcloud_json(["projects", "describe", dev])
+    uat_info = gcloud_json(["projects", "describe", uat])
+    if not dev_info:
+        record("project", "fail", f"{dev} is not accessible",
+               f"gcloud projects create {dev} --folder=<uat-folder>")
+        return None
+    if dev_info.get("lifecycleState") != "ACTIVE":
+        record("project", "fail", f"{dev} lifecycleState={dev_info.get('lifecycleState')}")
+        return None
+    detail = f"{dev} ACTIVE (name: {dev_info.get('name')})"
+    if uat_info and dev_info.get("parent") != uat_info.get("parent"):
+        record("project", "warn", detail + "; parent folder differs from UAT")
+    else:
+        record("project", "pass", detail)
+
+    dev_billing = gcloud_json(["billing", "projects", "describe", dev])
+    uat_billing = gcloud_json(["billing", "projects", "describe", uat])
+    if not dev_billing or not dev_billing.get("billingEnabled"):
+        record("billing", "fail", f"billing disabled on {dev}",
+               f"gcloud billing projects link {dev} --billing-account=<account>")
+    elif uat_billing and dev_billing.get("billingAccountName") != uat_billing.get("billingAccountName"):
+        record("billing", "warn",
+               f"dev bills to {dev_billing.get('billingAccountName')}, UAT to {uat_billing.get('billingAccountName')}")
+    else:
+        record("billing", "pass", f"billing enabled ({dev_billing.get('billingAccountName')})")
+    return str(dev_info.get("projectNumber"))
+
+
+def check_apis(dev: str, uat: str) -> None:
+    dev_apis = {s["config"]["name"] for s in gcloud_json(["services", "list", "--enabled", f"--project={dev}"]) or []}
+    uat_apis = {s["config"]["name"] for s in gcloud_json(["services", "list", "--enabled", f"--project={uat}"]) or []}
+    if not dev_apis:
+        record("apis", "fail", f"could not list enabled services on {dev}")
+        return
+    required = set(REQUIRED_DEV_APIS) | uat_apis
+    missing = sorted(required - dev_apis)
+    if missing:
+        record("apis", "fail", f"missing {len(missing)} API(s): {', '.join(missing)}",
+               f"gcloud services enable {' '.join(missing)} --project={dev}")
+    else:
+        record("apis", "pass", f"{len(dev_apis)} APIs enabled; covers UAT set + dev requirements")
+
+
+def check_secrets(dev: str, uat: str) -> None:
+    dev_names = {s["name"].split("/")[-1] for s in gcloud_json(["secrets", "list", f"--project={dev}"]) or []}
+    uat_names = {s["name"].split("/")[-1] for s in gcloud_json(["secrets", "list", f"--project={uat}"]) or []}
+    if not uat_names:
+        record("secrets", "fail", f"could not list UAT secrets in {uat}")
+        return
+    missing = sorted(uat_names - dev_names)
+    if missing:
+        record("secrets", "fail", f"{len(missing)} UAT secret(s) missing in dev: {', '.join(missing[:10])}",
+               "replicate via consent-protocol/docs/reference/dev-environment-setup.md Phase 3")
+    else:
+        record("secrets", "pass", f"all {len(uat_names)} UAT secret names present in dev")
+
+    def secret_value(project: str, name: str) -> str | None:
+        code, out = run(["gcloud", "secrets", "versions", "access", "latest",
+                         f"--secret={name}", f"--project={project}"])
+        return out if code == 0 else None
+
+    for name in OVERRIDE_SECRETS:
+        dev_val, uat_val = secret_value(dev, name), secret_value(uat, name)
+        if dev_val is None:
+            record(f"secret-override:{name}", "fail", "missing in dev",
+                   f"gcloud secrets create {name} --project={dev} && add a dev-specific version")
+        elif uat_val is not None and dev_val == uat_val:
+            record(f"secret-override:{name}", "fail", "dev value equals UAT value (must be dev-specific)",
+                   f"add a dev-specific version: gcloud secrets versions add {name} --project={dev}")
+        else:
+            record(f"secret-override:{name}", "pass", "present and differs from UAT")
+
+    runtime_cfg = secret_value(dev, "BACKEND_RUNTIME_CONFIG_JSON")
+    if runtime_cfg:
+        try:
+            cfg = json.loads(runtime_cfg)
+        except json.JSONDecodeError:
+            cfg = {}
+        socket = str(cfg.get("db_unix_socket") or cfg.get("cloudsql_instance_connection_name") or "")
+        if dev.split("-")[0] not in socket and DEV_SQL_INSTANCE not in socket:
+            record("runtime-config-db", "fail",
+                   f"BACKEND_RUNTIME_CONFIG_JSON does not reference the dev Cloud SQL instance ({socket or 'unset'})",
+                   "re-run scripts/ops/sync_backend_runtime_secrets.py with dev parameters")
+        else:
+            record("runtime-config-db", "pass", "runtime config points at the dev Cloud SQL instance")
+        rp_ids = str(cfg.get("passkey_allowed_rp_ids", ""))
+        env_identity = str(cfg.get("environment", ""))
+        if env_identity != "uat":
+            record("runtime-identity", "fail",
+                   f"runtime config environment={env_identity!r}; dev must keep the uat runtime identity",
+                   "re-run sync_backend_runtime_secrets.py with --environment uat")
+        else:
+            record("runtime-identity", "pass", "runtime identity is uat (behavior parity by design)")
+        if DEV_DOMAIN not in rp_ids:
+            record("runtime-config-passkeys", "warn",
+                   f"passkey RP ids do not include {DEV_DOMAIN} ({rp_ids or 'unset'})")
+        else:
+            record("runtime-config-passkeys", "pass", f"passkey RP ids include {DEV_DOMAIN}")
+
+
+def check_sql(dev: str, uat: str) -> None:
+    dev_inst = gcloud_json(["sql", "instances", "describe", DEV_SQL_INSTANCE, f"--project={dev}"])
+    uat_inst = gcloud_json(["sql", "instances", "describe", UAT_SQL_INSTANCE, f"--project={uat}"])
+    if not dev_inst:
+        record("cloudsql-instance", "fail", f"{DEV_SQL_INSTANCE} not found in {dev}",
+               f"gcloud sql instances create {DEV_SQL_INSTANCE} --project={dev} "
+               "--region=us-central1 --database-version=<uat-version> --tier=<uat-tier>")
+        return
+    state = dev_inst.get("state")
+    if state != "RUNNABLE":
+        record("cloudsql-instance", "fail", f"{DEV_SQL_INSTANCE} state={state}")
+        return
+    detail = f"{DEV_SQL_INSTANCE} RUNNABLE ({dev_inst.get('databaseVersion')}, {dev_inst['settings'].get('tier')})"
+    if uat_inst and (dev_inst.get("databaseVersion") != uat_inst.get("databaseVersion")
+                     or dev_inst["settings"].get("tier") != uat_inst["settings"].get("tier")):
+        record("cloudsql-instance", "warn", detail + "; version/tier differs from UAT")
+    else:
+        record("cloudsql-instance", "pass", detail)
+
+    dev_users = {u["name"] for u in gcloud_json(
+        ["sql", "users", "list", f"--instance={DEV_SQL_INSTANCE}", f"--project={dev}"]) or []}
+    code, uat_app_user = run(["gcloud", "secrets", "versions", "access", "latest",
+                              "--secret=DB_USER", f"--project={dev}"])
+    required_users = {u for u in (uat_app_user if code == 0 else "", "mulesoft_crm_registry") if u}
+    missing_users = sorted(required_users - dev_users)
+    if missing_users:
+        record("cloudsql-users", "fail", f"missing DB user(s): {', '.join(missing_users)}",
+               f"gcloud sql users create <user> --instance={DEV_SQL_INSTANCE} --project={dev} --password=<generated>")
+    else:
+        record("cloudsql-users", "pass", f"required DB users present ({', '.join(sorted(required_users))})")
+
+
+def check_runtime_sa_iam(dev: str, uat: str, dev_number: str | None) -> None:
+    if not dev_number:
+        record("iam-runtime-sas", "warn", "skipped (dev project number unknown)")
+        return
+    uat_number = None
+    uat_info = gcloud_json(["projects", "describe", uat])
+    if uat_info:
+        uat_number = str(uat_info.get("projectNumber"))
+
+    def roles_for(project: str, member_suffix: str) -> set[str]:
+        policy = gcloud_json(["projects", "get-iam-policy", project])
+        roles: set[str] = set()
+        for binding in (policy or {}).get("bindings", []):
+            for member in binding.get("members", []):
+                if member.endswith(member_suffix):
+                    roles.add(binding["role"])
+        return roles
+
+    for kind, suffix in RUNTIME_SA_KINDS.items():
+        uat_roles = roles_for(uat, f"{uat_number}{suffix}") if uat_number else set()
+        dev_roles = roles_for(dev, f"{dev_number}{suffix}")
+        missing = sorted(uat_roles - dev_roles)
+        if missing:
+            member = f"serviceAccount:{dev_number}{suffix}"
+            fixes = " && ".join(
+                f"gcloud projects add-iam-policy-binding {dev} --member='{member}' --role='{r}'" for r in missing)
+            record(f"iam-{kind}-sa", "fail", f"missing role(s) vs UAT: {', '.join(missing)}", fixes)
+        else:
+            record(f"iam-{kind}-sa", "pass", f"role set covers UAT parity ({len(dev_roles)} roles)")
+
+
+def check_cloud_run(dev: str, region: str) -> dict[str, str]:
+    urls: dict[str, str] = {}
+    for service in (BACKEND_SERVICE, FRONTEND_SERVICE):
+        info = gcloud_json(["run", "services", "describe", service,
+                            f"--project={dev}", f"--region={region}"])
+        if not info:
+            record(f"cloudrun:{service}", "fail", f"service not deployed in {dev}/{region}",
+                   "run the Deploy to Dev workflow (or deploy/*.cloudbuild.yaml manually)")
+            continue
+        url = info.get("status", {}).get("url", "")
+        ready = next((c.get("status") for c in info.get("status", {}).get("conditions", [])
+                      if c.get("type") == "Ready"), "Unknown")
+        labels = info.get("metadata", {}).get("labels", {})
+        env_label = labels.get("deploy-env", "")
+        urls[service] = url
+        if ready != "True":
+            record(f"cloudrun:{service}", "fail", f"deployed but not Ready (Ready={ready})")
+        elif env_label != "dev":
+            record(f"cloudrun:{service}", "warn", f"Ready, but deploy-env label is {env_label!r} (expected dev)")
+        else:
+            record(f"cloudrun:{service}", "pass", f"Ready at {url} (deploy-env=dev)")
+    return urls
+
+
+def check_health(urls: dict[str, str]) -> None:
+    probes = []
+    if BACKEND_SERVICE in urls:
+        probes.append(("backend-health", f"{urls[BACKEND_SERVICE]}/health"))
+    if FRONTEND_SERVICE in urls:
+        probes.append(("frontend-health", f"{urls[FRONTEND_SERVICE]}/login"))
+    for name, url in probes:
+        try:
+            with urllib.request.urlopen(url, timeout=30) as resp:
+                status = resp.status
+        except Exception as exc:  # noqa: BLE001 - report any probe failure
+            record(name, "fail", f"{url} unreachable: {exc}")
+            continue
+        if 200 <= status < 400:
+            record(name, "pass", f"{url} -> {status}")
+        else:
+            record(name, "fail", f"{url} -> {status}")
+
+
+def check_pubsub_fanout(dev_number: str | None) -> None:
+    sub = gcloud_json(["pubsub", "subscriptions", "describe",
+                       f"projects/{FANOUT_TOPIC_PROJECT}/subscriptions/{FANOUT_SUBSCRIPTION}"])
+    if not sub:
+        record("one-email-fanout", "fail",
+               f"subscription {FANOUT_SUBSCRIPTION} missing in {FANOUT_TOPIC_PROJECT}",
+               "see runbook Phase 6b (gcloud pubsub subscriptions create ...)")
+        return
+    topic_ok = sub.get("topic", "").endswith(FANOUT_TOPIC)
+    endpoint = sub.get("pushConfig", {}).get("pushEndpoint", "")
+    endpoint_ok = dev_number is None or dev_number in endpoint
+    if topic_ok and endpoint_ok:
+        record("one-email-fanout", "pass", f"{FANOUT_SUBSCRIPTION} on {FANOUT_TOPIC} -> {endpoint}")
+    else:
+        record("one-email-fanout", "fail",
+               f"subscription misconfigured (topic ok: {topic_ok}, endpoint: {endpoint})",
+               "recreate per runbook Phase 6b with the dev backend webhook URL")
+
+
+def check_domain_mapping(dev: str, region: str) -> None:
+    mappings = gcloud_json(["beta", "run", "domain-mappings", "list",
+                            f"--project={dev}", f"--region={region}"]) or []
+    entry = next((m for m in mappings
+                  if m.get("metadata", {}).get("name") == DEV_DOMAIN), None)
+    if not entry:
+        record("domain-mapping", "warn", f"{DEV_DOMAIN} not mapped yet",
+               f"gcloud beta run domain-mappings create --service {FRONTEND_SERVICE} "
+               f"--domain {DEV_DOMAIN} --region {region} --project {dev}")
+        return
+    ready = next((c.get("status") for c in entry.get("status", {}).get("conditions", [])
+                  if c.get("type") == "Ready"), "Unknown")
+    records = entry.get("status", {}).get("resourceRecords", [])
+    dns_hint = "; ".join(f"{r.get('name', DEV_DOMAIN)} {r.get('type')} {r.get('rrdata')}" for r in records)
+    if ready == "True":
+        record("domain-mapping", "pass", f"{DEV_DOMAIN} mapped and Ready")
+    else:
+        record("domain-mapping", "warn",
+               f"{DEV_DOMAIN} mapping exists but not Ready (usually waiting on DNS): {dns_hint}")
+
+
+def _normalize_job_name(name: str) -> str:
+    return name.replace("-uat", "").replace("-dev", "")
+
+
+def check_schedulers(dev: str, uat: str, region: str) -> None:
+    dev_jobs = {_normalize_job_name(j["name"].split("/")[-1]) for j in gcloud_json(
+        ["scheduler", "jobs", "list", f"--project={dev}", f"--location={region}"]) or []}
+    uat_jobs = {_normalize_job_name(j["name"].split("/")[-1]) for j in gcloud_json(
+        ["scheduler", "jobs", "list", f"--project={uat}", f"--location={region}"]) or []}
+    # Watch renewal is deliberately UAT-only (single Gmail watch owner).
+    expected = {j for j in uat_jobs if "watch" not in j.lower()}
+    missing = sorted(expected - dev_jobs)
+    if missing:
+        record("schedulers", "warn", f"missing scheduler job(s) vs UAT: {', '.join(missing)}",
+               "replicate with gcloud scheduler jobs create http ... (see runbook; exclude watch renewal)")
+    elif expected:
+        record("schedulers", "pass", f"dev has UAT-parity scheduler jobs ({len(expected)})")
+    else:
+        record("schedulers", "pass", "UAT defines no replicable scheduler jobs in this region")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dev-project", default="hushh-pda-dev")
+    parser.add_argument("--uat-project", default="hushh-pda-uat")
+    parser.add_argument("--region", default="us-central1")
+    parser.add_argument("--report-path", default="")
+    args = parser.parse_args()
+
+    print(f"Dev environment doctor: {args.dev_project} vs baseline {args.uat_project}\n")
+    dev_number = check_project(args.dev_project, args.uat_project)
+    check_apis(args.dev_project, args.uat_project)
+    check_secrets(args.dev_project, args.uat_project)
+    check_sql(args.dev_project, args.uat_project)
+    check_runtime_sa_iam(args.dev_project, args.uat_project, dev_number)
+    urls = check_cloud_run(args.dev_project, args.region)
+    check_health(urls)
+    check_pubsub_fanout(dev_number)
+    check_domain_mapping(args.dev_project, args.region)
+    check_schedulers(args.dev_project, args.uat_project, args.region)
+
+    fails = [c for c in CHECKS if c["status"] == "fail"]
+    warns = [c for c in CHECKS if c["status"] == "warn"]
+    summary = {
+        "dev_project": args.dev_project,
+        "uat_project": args.uat_project,
+        "status": "blocked" if fails else ("degraded" if warns else "healthy"),
+        "failures": len(fails),
+        "warnings": len(warns),
+        "checks": CHECKS,
+    }
+    if args.report_path:
+        with open(args.report_path, "w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2)
+    print(f"\nStatus: {summary['status']} ({len(fails)} failure(s), {len(warns)} warning(s))")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/sync_frontend_runtime_secrets.py
+++ b/scripts/ops/sync_frontend_runtime_secrets.py
@@ -101,7 +101,7 @@ def main() -> int:
     parser.add_argument(
         "--environment",
         required=True,
-        choices=("uat", "production"),
+        choices=("dev", "uat", "production"),
         help="Deploy environment used to resolve legacy measurement/GTM secret names.",
     )
     args = parser.parse_args()

--- a/scripts/ops/verify-runtime-profile-env-shape.py
+++ b/scripts/ops/verify-runtime-profile-env-shape.py
@@ -18,6 +18,7 @@ BACKEND_TEMPLATE_FILES = (
 FRONTEND_TEMPLATE_FILES = (
     Path("hushh-webapp/.env.local.local.example"),
     Path("hushh-webapp/.env.uat.local.example"),
+    Path("hushh-webapp/.env.dev.local.example"),
     Path("hushh-webapp/.env.prod.local.example"),
 )
 
@@ -28,6 +29,7 @@ BACKEND_RUNTIME_FILES = (
 FRONTEND_RUNTIME_FILES = (
     Path("hushh-webapp/.env.local.local"),
     Path("hushh-webapp/.env.uat.local"),
+    Path("hushh-webapp/.env.dev.local"),
     Path("hushh-webapp/.env.prod.local"),
 )
 


### PR DESCRIPTION
# Description

Adds the founder-approved hosted **dev** environment: a full infrastructure replica of the UAT GCP project (`hushh-pda-dev`, display name `consent-protocol dev`) with a mirrored governed deploy pipeline, contributor tooling, an end-to-end dev-vs-UAT audit doctor, and the operator runbook. The environment itself is already provisioned, deployed, and doctor-verified (0 failures); this PR lands the repo-side contracts so future deploys run through the governed `Deploy to Dev` workflow.

Design decision: dev keeps the **uat runtime identity** (`ENVIRONMENT=uat`, `NEXT_PUBLIC_APP_ENV=uat`) so every behavior gate matches UAT exactly; the infrastructure identity (project, Cloud SQL, deploy labels/provenance, origin `dev.kai.hushh.ai`) is `dev`. A new `_RUNTIME_ENVIRONMENT` Cloud Build substitution implements the split.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None (dev DB is an operator-side UAT clone; no migrations added)
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] Listed below:
    - `consent-protocol/docs/reference/dev-environment-setup.md` (new runbook)
    - `docs/guides/environment-model.md` (four-mode contract)
    - `docs/reference/operations/env-and-secrets.md`
    - `docs/reference/operations/cli.md`
    - `deploy/README.md`
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `.github/workflows/deploy-dev.yml` (new; mirror of `deploy-uat.yml`)
    - `deploy/backend.cloudbuild.yaml` (`_RUNTIME_ENVIRONMENT` substitution; used by deploy-dev)
    - `config/ci-governance.json` + `scripts/ci/assert-governed-actor.py` (dev dispatch surface, same actor cohort as uat)
    - `scripts/ops/sync_frontend_runtime_secrets.py` (dev choice), `scripts/ops/verify-runtime-profile-env-shape.py` (dev template)
    - `scripts/ops/dev_environment_doctor.py` (new; audits dev vs live UAT baseline)
    - `scripts/env/*` + `bin/hushh` (dev runtime mode; `db verify-dev-schema`)
    - `hushh-webapp/.env.dev.local.example` (new profile template)
- Trust boundary touched:
  - [x] Deploy / public ingress listed below:
    - New deploy lane `Deploy to Dev` gated by the same governed-actor cohort as UAT (`assert-governed-actor.py --surface dev`), same SHA-on-green-main gate, provenance/parity/semantic verification, auto-rollback.
    - One Email KYC in dev via shared-topic fanout; Gmail watch ownership stays UAT-only (documented in runbook).
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below: deploy-dev.yml mirrors UAT's classify→rollback lane (predeploy revision capture, per-service rollback on blocking classifications).
- UI browser or Playwright proof:
  - [x] Not applicable
- Verification commands executed:
  - [x] `python3 scripts/ops/verify-runtime-profile-env-shape.py` (pass)
  - [x] `node scripts/verify-doc-brand.cjs` + `node scripts/verify-shareable-links.cjs` (pass)
  - [x] `bash -n` on all touched shell scripts; `python3 -m py_compile` on all touched Python; YAML parse on both workflows/cloudbuild
  - [x] `python3 scripts/ops/dev_environment_doctor.py` against the live environment (0 failures)
  - [x] Live deploy proof: backend `/health` 200 (`one/kai/nav/kyc`), frontend `/login` 200, dev DB = 102/102 UAT tables

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: no prior dev-environment lane exists (deploy-uat/deploy-production only).
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `.github/workflows/deploy-dev.yml` (workflow_dispatch from main), `./bin/hushh` mode surface, `scripts/ops/dev_environment_doctor.py`.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file. (No new tests; ops tooling verified against the live environment.)
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: dev environment live and doctor-audited (0 failures); Cloud Run spec parity with UAT including min-instances=1.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] If this is one PR in a stack, the predecessor PR is linked here: standalone.
- [x] If this responds to requested changes, the new commit or material explanation is described here: n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4481
(retroactive board-linkage backfill, 2026-07-14)