### PR TITLE
fix(deploy-dev): pin project_id at auth (scope assert tripped by SA home project)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -126,6 +126,13 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
+          # Pin the SDK project explicitly. Without this, the auth action
+          # exports CLOUDSDK_CORE_PROJECT/GOOGLE_CLOUD_PROJECT from the key's
+          # HOME project (the SA lives in hussh-developer-platform), which
+          # silently overrides `gcloud config set project` and trips the
+          # project-scope assertion below.
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          export_environment_variables: true
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
First governed **Deploy to Dev** run ([29073352239](https://github.com/hushh-labs/hushh-research/actions/runs/29073352239)) failed its own project-scope assertion:

`Refusing deploy: expected project 'hushh-pda-dev' but got 'hussh-developer-platform'.`

**RCA:** `google-github-actions/auth@v2` exports `CLOUDSDK_CORE_PROJECT`/`GOOGLE_CLOUD_PROJECT` derived from the SA key's home project (`hussh-developer-platform`, where claude-code-gcp-operator lives). Env vars take precedence over `gcloud config set project`, so the workflow's later project pin silently lost.

**Fix:** pass `project_id: ${{ env.GCP_PROJECT_ID }}` to the auth action so exported env agrees with the intended target. The scope assertion stays — it did its job.

Verification plan: merge → dispatch Deploy to Dev with a CI-green train SHA → expect full deploy + healthy release.

---
Closes #4483
(retroactive board-linkage backfill, 2026-07-14)