### PR TITLE
fix(deploy-dev): feature-probe sync flags (main-workflow vs train-tree skew)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -218,6 +218,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # The workflow file runs from main, but the deployed tree is the
+          # requested (train) SHA. Newer flags in this workflow may not exist
+          # in the checked-out script yet — feature-probe --help and pass
+          # newer flags only when the script supports them (version-skew
+          # guard; first governed run failed on exactly this).
+          SYNC_HELP="$("${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_backend_runtime_secrets.py --help 2>/dev/null || true)"
+          EXTRA_ARGS=()
+          if grep -q -- '--crm-registry-db-enabled' <<<"$SYNC_HELP"; then
+            EXTRA_ARGS+=(--crm-registry-db-enabled "true")
+          fi
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_backend_runtime_secrets.py \
             --project "${{ env.GCP_PROJECT_ID }}" \
             --environment uat \
@@ -231,7 +241,7 @@ jobs:
             --sync-remote-enabled "false" \
             --developer-api-enabled "true" \
             --remote-mcp-enabled "true" \
-            --crm-registry-db-enabled "true" \
+            "${EXTRA_ARGS[@]}" \
             --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
             --obs-data-stale-ratio-threshold "0.25" \
             --passkey-allowed-rp-ids "localhost,127.0.0.1,kai.hushh.ai,dev.kai.hushh.ai" \


### PR DESCRIPTION
Second governed **Deploy to Dev** run ([29073634458](https://github.com/hushh-labs/hushh-research/actions/runs/29073634458)) got past auth+scope (thanks to #4398) and failed at secret sync:

`sync_backend_runtime_secrets.py: error: unrecognized arguments: --crm-registry-db-enabled true`

**RCA — structural version skew:** the workflow file executes from `main`, but the checked-out tree is the requested train SHA. `main` is currently 654 ahead / 1758 behind `integration/pr-train`, so flags added on main can predate/postdate the train script arbitrarily. Any hardcoded newer flag will keep breaking dev deploys of train SHAs.

**Fix:** probe `--help` and append newer optional flags only when the deployed script supports them. Older SHAs deploy with their own defaults; newer SHAs get the flag.

Verification: merge → re-dispatch with train SHA a26adae → expect healthy release end-to-end.

---
Closes #4483
(retroactive board-linkage backfill, 2026-07-14)