### PR TITLE
test(utils): characterize native symbol lookup and value serialization invariants

### DIFF
--- a/hushh-webapp/__tests__/utils/formatter-symbol-invariants.test.ts
+++ b/hushh-webapp/__tests__/utils/formatter-symbol-invariants.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for formatCompleteJson
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on the EXACT runtime
+// invariants for native JavaScript `Symbol` inputs.
+//
+// Truth-first, verified against the source:
+//   - formatCompleteJson iterates with `Object.entries(json)` (line 233) and
+//     hand-builds output lines. It NEVER calls JSON.stringify. `Object.entries`
+//     only returns enumerable, own, STRING-keyed properties — symbol keys are
+//     excluded by the language spec, not by any formatter branch. So a
+//     symbol-keyed property contributes no output line.
+//   - A symbol VALUE attached to a mapped string key routes through
+//     formatValue, which is a typeof-cascade (number/string/boolean) whose final
+//     fallback is `return String(value)` (line 202). `String(Symbol("x"))`
+//     yields "Symbol(x)" and does NOT throw, unlike the `${sym}` template form.
+// These tests pin those two invariants precisely. They document existing
+// behavior only; no production code is changed.
+
+describe("formatCompleteJson — native Symbol invariants", () => {
+  it("drops symbol-keyed properties via Object.entries enumeration rules", () => {
+    const sym = Symbol("hidden");
+    const input: Record<string, unknown> = { custom_status: "active" };
+    // Attach a symbol-keyed property alongside a normal string key.
+    (input as Record<symbol, unknown>)[sym] = "should-not-appear";
+
+    const out = formatCompleteJson(input);
+
+    // The string key is emitted...
+    expect(out).toContain("Custom Status: active");
+    // ...but the symbol-keyed entry is never enumerated by Object.entries,
+    // so its value contributes nothing to the output.
+    expect(out).not.toContain("should-not-appear");
+  });
+
+  it("emits nothing at all for an object whose only keys are symbols", () => {
+    const symA = Symbol("a");
+    const symB = Symbol("b");
+    const input: Record<string, unknown> = {};
+    (input as Record<symbol, unknown>)[symA] = "alpha";
+    (input as Record<symbol, unknown>)[symB] = "beta";
+
+    // No enumerable string keys -> Object.entries returns [] -> empty output.
+    expect(formatCompleteJson(input)).toBe("");
+  });
+
+  it("renders a top-level symbol value as String(sym) without throwing", () => {
+    // `symbol_cusip` is a mapped field label ("Symbol"), but the top-level
+    // scalar branch (line 239) only fires for number|string. A symbol is
+    // neither number/string, not an array, and typeof symbol !== "object",
+    // so a TOP-LEVEL symbol value matches no branch and is silently skipped.
+    const out = formatCompleteJson({ description: Symbol("AAPL") });
+    expect(out).toBe("");
+  });
+
+  it("renders a symbol value on a mapped key inside an object as 'Symbol(x)'", () => {
+    // Inside a named object section, a non-null value that is not an object and
+    // not an array reaches formatValue, whose final branch is String(value).
+    // String(Symbol("AAPL")) === "Symbol(AAPL)".
+    const out = formatCompleteJson({
+      holdings_detail: { description: Symbol("AAPL") },
+    });
+    expect(out).toContain("--- Holdings Detail ---");
+    expect(out).toContain("Security: Symbol(AAPL)");
+  });
+
+  it("does not throw for symbol values nested inside an object section", () => {
+    expect(() =>
+      formatCompleteJson({
+        account_metadata: { account_type: Symbol("IRA") },
+      })
+    ).not.toThrow();
+
+    const out = formatCompleteJson({
+      account_metadata: { account_type: Symbol("IRA") },
+    });
+    expect(out).toContain("Account Type: Symbol(IRA)");
+  });
+});


### PR DESCRIPTION
### Summary

Adds a **test-only** characterization suite that pins the exact runtime behavior of `formatCompleteJson` (`hushh-webapp/lib/utils/json-to-human.ts`) when native JavaScript `Symbol` values or symbol-keyed properties are present in the input object.

No production code is changed. This locks down two language-level invariants so future refactors of the formatter cannot silently regress them.

### Why this matters

`formatCompleteJson` renders Gemini-parsed document JSON into human-readable text. It builds output by iterating with `Object.entries(...)` and routing scalar values through a `formatValue` `typeof` cascade — it does **not** use `JSON.stringify`. There was no explicit test documenting how `Symbol` inputs behave through this path, even though a sibling suite (`format-json-primitives.test.ts`) already characterizes booleans and other primitives. This PR closes that documentation gap.

### Literal contract characterized (verified against source)

1. **Symbol keys are dropped by enumeration rules.**
   `Object.entries` returns only enumerable, own, **string**-keyed properties. Symbol-keyed properties are excluded by the ECMAScript spec, not by any formatter branch — so a symbol-keyed entry contributes no output line. An object whose only keys are symbols formats to `""`.

2. **Symbol values stringify via the `String()` fallback without throwing.**
   Inside a named object section, a value that is not null/undefined, not an object, and not an array reaches `formatValue`, whose final branch is `return String(value)`. `String(Symbol("AAPL"))` yields `"Symbol(AAPL)"` and does **not** throw (unlike the `${sym}` template form). A **top-level** symbol value matches no branch in the top-level scalar guard (`typeof === "number" | "string"` only) and is silently skipped, producing `""`.

### Tests added

`hushh-webapp/__tests__/utils/formatter-symbol-invariants.test.ts` (5 cases):
- drops a symbol-keyed property while still emitting sibling string keys
- emits `""` for an object whose only keys are symbols
- skips a top-level symbol value (`""`)
- renders a symbol value on a mapped key inside an object as `Security: Symbol(AAPL)`
- does not throw for symbol values nested in an object section

### Proof / Verification

- **Scope:** `git status` showed exactly one added file, nothing else modified. Diff is `1 file changed, 81 insertions(+)`.
- **DCO:** commit created with `git commit -s` (Signed-off-by trailer present).
- **Source cross-check:** assertions were derived directly from the current `json-to-human.ts` (`Object.entries` at the section loop; `String(value)` fallback in `formatValue`).
- **Local test run caveat (honest disclosure):** the Vitest runner in my local environment aborts with `Vitest failed to find the runner` before loading any spec (this reproduces even against already-merged suites), so I could **not** produce a local green run. CI is the authoritative gate for the pass/fail signal here.

### CI Gate Checklist
- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified (`-s`)
- [x] Test Only Surface Change (single new spec, no production edits)
