### PR TITLE
fix(deploy-dev): frontend secret-sync env probe (same skew class as #4399)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -253,9 +253,18 @@ jobs:
             --plaid-tx-history-days "730" \
             > /tmp/dev-runtime-secret-sync.json
 
+          # Same main-workflow vs train-tree skew guard as the backend sync:
+          # newer trees accept --environment dev; older train SHAs only know
+          # uat|production. Probe --help and fall back to uat (dev's runtime
+          # identity IS uat — see dev-environment-setup.md Identity Model).
+          FE_HELP="$("${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py --help 2>/dev/null || true)"
+          FE_ENV="uat"
+          if grep -q "'dev'" <<<"$FE_HELP" || grep -q 'dev,' <<<"$FE_HELP" || grep -qE '\bdev\b.*production' <<<"$FE_HELP"; then
+            FE_ENV="dev"
+          fi
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \
             --project "${{ env.GCP_PROJECT_ID }}" \
-            --environment dev \
+            --environment "$FE_ENV" \
             > /tmp/dev-frontend-runtime-secret-sync.json
 
       - name: Install Cloud SQL Auth Proxy


### PR DESCRIPTION
Run [29074180644](https://github.com/hushh-labs/hushh-research/actions/runs/29074180644): backend sync now passes (flag probe from #4399 worked), frontend sync failed:

`sync_frontend_runtime_secrets.py: error: argument --environment: invalid choice: 'dev' (choose from 'uat', 'production')`

Same structural skew: workflow-from-main passes `--environment dev`; the train SHA's script predates that choice. Probe `--help` and fall back to `uat` — which per docs/reference/dev-environment-setup.md Identity Model is dev's runtime identity anyway (`ENVIRONMENT=uat` by design; only labels/provenance say dev).

Verification: merge → re-dispatch train SHA a26adae → expect healthy release.

---
Closes #4483
(retroactive board-linkage backfill, 2026-07-14)