### PR TITLE
fix(deploy-dev): DB contract-file fallback (third instance of main/train skew)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -320,8 +320,16 @@ jobs:
             cd consent-protocol
             "${{ env.PROTOCOL_PYTHON }}" db/migrate.py --release
           )
+          # Skew guard (same class as the secret-sync probes): the dev
+          # contract file may not exist on older train SHAs. Fall back to the
+          # UAT contract, which dev replicates by design.
+          CONTRACT_FILE="consent-protocol/db/contracts/dev_minimum_schema.json"
+          if [ ! -f "$CONTRACT_FILE" ]; then
+            CONTRACT_FILE="consent-protocol/db/contracts/uat_integrated_schema.json"
+            echo "dev contract missing on this SHA; falling back to $CONTRACT_FILE"
+          fi
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
-            --contract-file consent-protocol/db/contracts/dev_minimum_schema.json \
+            --contract-file "$CONTRACT_FILE" \
             --report-path /tmp/dev-db-migration-guard-predeploy.json
 
       - name: Deploy backend using Cloud Build
@@ -547,8 +555,16 @@ jobs:
           export DB_USER
           export DB_PASSWORD
 
+          # Skew guard (same class as the secret-sync probes): the dev
+          # contract file may not exist on older train SHAs. Fall back to the
+          # UAT contract, which dev replicates by design.
+          CONTRACT_FILE="consent-protocol/db/contracts/dev_minimum_schema.json"
+          if [ ! -f "$CONTRACT_FILE" ]; then
+            CONTRACT_FILE="consent-protocol/db/contracts/uat_integrated_schema.json"
+            echo "dev contract missing on this SHA; falling back to $CONTRACT_FILE"
+          fi
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
-            --contract-file consent-protocol/db/contracts/dev_minimum_schema.json \
+            --contract-file "$CONTRACT_FILE" \
             --report-path /tmp/dev-db-migration-guard-postdeploy.json
 
       - name: Bootstrap dev runtime files for semantic verification


### PR DESCRIPTION
Run [29074500536](https://github.com/hushh-labs/hushh-research/actions/runs/29074500536) got past auth, scope, and both secret syncs — failed at the predeploy schema gate:

`contract_file_missing: consent-protocol/db/contracts/dev_minimum_schema.json`

The contract exists on `main` but not on the deployed train SHA (a26adae). Third instance of the same class (#4398 → auth env, #4399 → backend sync flag, #4401 → frontend sync env). Fallback: `uat_integrated_schema.json` — dev is a UAT replica by design, so the UAT contract is the correct minimum bar on trees that predate the dev contract.

Applied to both predeploy and postdeploy gates.

Verification: merge → re-dispatch train SHA a26adae → healthy release expected.

---
Closes #4483
(retroactive board-linkage backfill, 2026-07-14)