### PR TITLE
fix(deploy-dev): substitution skew guard for Cloud Build (5th skew instance)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -340,6 +340,20 @@ jobs:
           set -euo pipefail
           started_at="$(date +%s)"
           SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.DEV_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=${{ env.DEV_ONE_EMAIL_PUBSUB_TOPIC }}##_ONE_EMAIL_WEBHOOK_AUDIENCE=${{ env.DEV_ONE_EMAIL_WEBHOOK_AUDIENCE }}##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=dev##_DEPLOY_SOURCE=deploy-dev##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          # Skew guard (same class as #4399/#4401/#4402): the workflow file
+          # (from main) may pass substitutions the train SHA's cloudbuild
+          # template doesn't declare — gcloud rejects unmatched keys. Filter
+          # SUBSTITUTIONS down to keys actually present in the template.
+          FILTERED=""
+          while IFS= read -r pair; do
+            key="${pair%%=*}"
+            if grep -qF "\${${key}}" deploy/backend.cloudbuild.yaml; then
+              FILTERED="${FILTERED:+${FILTERED}##}${pair}"
+            else
+              echo "skew guard: dropping substitution ${key} (not in template on this SHA)"
+            fi
+          done < <(printf '%s' "${SUBSTITUTIONS//##/$'\n'}" | awk 'NF')
+          SUBSTITUTIONS="$FILTERED"
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/backend.cloudbuild.yaml \


### PR DESCRIPTION
Run [29074838463](https://github.com/hushh-labs/hushh-research/actions/runs/29074838463) got past auth, scope, both secret syncs, and the DB gate — failed at backend Cloud Build:

`INVALID_ARGUMENT: key \"_RUNTIME_ENVIRONMENT\" in the substitution data is not matched in the template; key \"_GOOGLE_MAPS_API_KEY_SECRET\" ...`

Same structural class as #4398/#4399/#4401/#4402: workflow-from-main passes substitutions the train SHA's `deploy/backend.cloudbuild.yaml` doesn't declare, and gcloud hard-rejects unmatched keys.

**Guard:** filter `SUBSTITUTIONS` to keys whose `${_KEY}` placeholder exists in the checked-out template, logging every dropped key. Newer trees pass everything; older trees deploy with what they understand.

Filter verified locally (exact-brace matching; `_REGION` vs `_BACKEND_REGION` prefix collision safe).

Verification: merge → re-dispatch train SHA a26adae → expect healthy release (or the NEXT skew instance, which is the point of doing this end-to-end).

---
Closes #4483
(retroactive board-linkage backfill, 2026-07-14)