### PR TITLE
fix(ops): dev fast-lane gate accepts per-commit-kind authoritative checks

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -105,15 +105,16 @@ jobs:
           echo "sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
 
       # Dev correctness gate: the SHA must be reachable from the requested
-      # ref AND carry a green CI Status Gate (the same authoritative check
-      # required to land on the train). No Main Post-Merge Smoke here by
+      # ref AND carry a green authoritative full-CI check. The check name
+      # differs by commit kind (PR head / merge-queue train head / main
+      # merge commit), so this is an any-of list. No signoff gate here by
       # design — dev does not route through main.
       - name: Validate deployment SHA against requested ref
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REQUIRED_BRANCH: ${{ steps.resolve-sha.outputs.ref }}
           REQUIRE_CI_SUCCESS: "1"
-          REQUIRED_CHECK_NAME: "CI Status Gate"
+          REQUIRED_CHECK_NAME: "CI Status Gate,Queue Validation,Main Post-Merge Smoke Gate"
         run: bash scripts/ci/require-deploy-sha-on-main.sh "${{ steps.resolve-sha.outputs.sha }}"
 
       - name: Checkout deployment SHA

--- a/docs/reference/operations/dev-fast-lane.md
+++ b/docs/reference/operations/dev-fast-lane.md
@@ -51,7 +51,7 @@ flowchart LR
 
 | Gate | Where it runs | What it guarantees |
 | --- | --- | --- |
-| `CI Status Gate` on the exact SHA | before every dev deploy | code is test-, type-, secret-, DCO-, and governance-clean — the same bar required to merge anywhere |
+| Authoritative full-CI check on the exact SHA (`CI Status Gate` for PR heads, `Queue Validation` for train heads, `Main Post-Merge Smoke Gate` for main merges — any-of) | before every dev deploy | code is test-, type-, secret-, DCO-, and governance-clean — the same bar required to merge anywhere |
 | Governed-actor dispatch (`assert-governed-actor.py --surface dev`) | dispatch time | only the maintainer cohort can deploy |
 | Workflow definition pinned to `main` | dispatch time | the pipeline itself cannot be mutated from a feature branch; only the deployed *content* comes from the requested ref |
 | Secret sync + runtime identity assertions | every deploy | dev cannot silently drift to wrong DB/CORS/identity |

--- a/scripts/ci/require-deploy-sha-on-main.sh
+++ b/scripts/ci/require-deploy-sha-on-main.sh
@@ -50,22 +50,32 @@ import sys
 sha, branch, check_name, payload_json = sys.argv[1:]
 payload = json.loads(payload_json)
 
+# REQUIRED_CHECK_NAME accepts a comma-separated any-of list because the
+# authoritative full-CI check differs by commit kind: PR heads carry
+# "CI Status Gate", merge-queue train heads carry "Queue Validation", and
+# main merge commits carry "Main Post-Merge Smoke Gate". A single-name
+# value keeps the historical exact-match behavior.
+accepted_names = [name.strip() for name in check_name.split(",") if name.strip()]
+
 check_runs = payload.get("check_runs", [])
-matches = [run for run in check_runs if run.get("name") == check_name]
+matches = [run for run in check_runs if run.get("name") in accepted_names]
 if not matches:
     available = ", ".join(sorted({str(run.get("name")) for run in check_runs if run.get("name")})) or "<none>"
     raise SystemExit(
-        f"Refusing deploy: required check '{check_name}' not found for {sha} on {branch}. "
+        f"Refusing deploy: none of the required checks {accepted_names} found for {sha} on {branch}. "
         f"Available checks: {available}"
     )
 
 successful = [run for run in matches if run.get("conclusion") == "success"]
 if not successful:
-    conclusions = ", ".join(str(run.get("conclusion") or "unknown") for run in matches)
+    conclusions = ", ".join(
+        f"{run.get('name')}={run.get('conclusion') or 'unknown'}" for run in matches
+    )
     raise SystemExit(
-        f"Refusing deploy: required check '{check_name}' is not successful for {sha} on {branch}. "
-        f"Observed conclusions: {conclusions}"
+        f"Refusing deploy: no required check in {accepted_names} is successful for {sha} on {branch}. "
+        f"Observed: {conclusions}"
     )
 
-print(f"Deploy SHA preflight passed: {sha} is on origin/{branch} and '{check_name}' succeeded.")
+passed = sorted({str(run.get("name")) for run in successful})
+print(f"Deploy SHA preflight passed: {sha} is on origin/{branch}; successful check(s): {', '.join(passed)}.")
 PY


### PR DESCRIPTION
# Description

Follow-up fix to the dev fast lane (#4395): `CI Status Gate` only attaches to PR heads, so the gate as merged would refuse the fast lane's own *default* deploy target (the `integration/pr-train` head, a merge-queue commit). The gate now accepts a comma-separated **any-of** list of authoritative full-CI checks — `CI Status Gate` (PR heads), `Queue Validation` (merge-queue train heads), `Main Post-Merge Smoke Gate` (main merge commits). Single-name values keep the historical exact-match behavior, so `deploy-uat.yml` is unaffected.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] Listed below:
    - `docs/reference/operations/dev-fast-lane.md` (gate table names the per-commit-kind checks)
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `scripts/ci/require-deploy-sha-on-main.sh` — `REQUIRED_CHECK_NAME` now splits on commas (any-of); backward compatible
    - `.github/workflows/deploy-dev.yml` — passes the three-name list
- Trust boundary touched:
  - [x] Deploy listed below: gate semantics unchanged in strength — every accepted name is a full authoritative CI signal on the exact SHA; UAT/production gates untouched.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable (gate remains fail-closed: no matching successful check → refuse deploy)
- UI browser or Playwright proof:
  - [x] Not applicable
- Verification commands executed:
  - [x] `bash -n scripts/ci/require-deploy-sha-on-main.sh`; YAML parse of `deploy-dev.yml`
  - [x] `node scripts/verify-doc-links.cjs` + `node scripts/verify-doc-brand.cjs` (pass)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: amends #4395's gate.
- [x] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [x] Reachable production attach point: `Deploy to Dev` workflow SHA gate.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file. (No new tests; verified via check-run attachment evidence: smoke runs attach to main merge SHAs, queue validation to merge-group SHAs.)
- [x] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [x] Production surface proved: gate behavior verified against live check-run data for all three commit kinds.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] If this is one PR in a stack, the predecessor PR is linked here: follows #4395.
- [x] If this responds to requested changes, the new commit or material explanation is described here: n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4483
(retroactive board-linkage backfill, 2026-07-14)