### PR TITLE
fix(one-location): preserve dismissed shared locations

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -608,6 +608,29 @@ describe("OneLocationAgentPage", () => {
     expect(mockSyncCurrentUser).toHaveBeenCalledWith({ uid: "user_a" });
   });
 
+  it("scrolls Active shares only when more than three shares are present", async () => {
+    const baseGrant = locationState().ownerGrants[0]!;
+    mockGetState.mockResolvedValueOnce({
+      ...locationState(),
+      ownerGrants: Array.from({ length: 4 }, (_, index) => ({
+        ...baseGrant,
+        id: `grant_${index + 1}`,
+        recipientUserId: `user_${index + 1}`,
+        recipientDisplayName: `Trusted ${index + 1}`,
+      })),
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    const activeShares = await screen.findByRole("list", {
+      name: "Active shares",
+    });
+    expect(activeShares.className).toContain("max-h-[470px]");
+    expect(activeShares.className).toContain("overflow-y-auto");
+    expect(activeShares.querySelectorAll('[role="listitem"]')).toHaveLength(4);
+  });
+
   it("does not render the removed onboarding tour", async () => {
     render(<OneLocationAgentPage />);
 
@@ -931,6 +954,31 @@ describe("OneLocationAgentPage", () => {
     expect(directionsLink.getAttribute("href")).toContain(
       "https://www.google.com/maps/dir/?api=1&destination=28.613900%2C77.209000&travelmode=driving",
     );
+
+    const openMapLink = screen.getByRole("link", {
+      name: "Open shared location in Google Maps",
+    });
+    expect(openMapLink.getAttribute("target")).toBe("_blank");
+    expect(openMapLink.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(openMapLink.getAttribute("href")).toContain(
+      "https://www.google.com/maps/search/?api=1&query=28.613900%2C77.209000",
+    );
+
+    const viewCallsBeforeCollapse = mockViewEnvelope.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByTitle("Live location map preview")).toBeNull();
+    expect(screen.getByText("Trusted A is sharing with you")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "View location" }),
+    ).toBeTruthy();
+    expect(
+      window.localStorage.getItem("one_location_unwatched_grants_v1:user_b"),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "View location" }));
+    expect(await screen.findByTitle("Live location map preview")).toBeTruthy();
+    expect(mockViewEnvelope).toHaveBeenCalledTimes(viewCallsBeforeCollapse);
 
     // The duplicate "Start" navigation button was removed from location
     // previews (it opened the same Google Maps navigation as "Directions").

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -791,6 +791,11 @@ function locationCoordinateQuery(point: PlainLocationPoint): string {
   ].join(",");
 }
 
+function googleMapsLocationUrl(point: PlainLocationPoint): string {
+  const query = encodeURIComponent(locationCoordinateQuery(point));
+  return `https://www.google.com/maps/search/?api=1&query=${query}`;
+}
+
 function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
   const destination = encodeURIComponent(locationCoordinateQuery(point));
   return `https://www.google.com/maps/dir/?api=1&destination=${destination}&travelmode=driving`;
@@ -1932,15 +1937,20 @@ function OneLocationAgentPageContent() {
   // convenience deep-link, NOT a requirement. Shares the recipient explicitly
   // "unwatched" are hidden. Terminal (revoked/expired) grants are never listed
   // here (the backend keeps them for ~12h for history only).
+  const activeReceivedGrants = useMemo(
+    () =>
+      (state?.receivedGrants ?? []).filter(
+        (grant) => grant.status === "active",
+      ),
+    [state?.receivedGrants],
+  );
   const visibleReceivedGrants = useMemo(() => {
     void openedGrantTick;
     void unwatchedTick;
-    return (state?.receivedGrants ?? []).filter(
-      (grant) =>
-        grant.status === "active" &&
-        !isOneLocationGrantUnwatched(auth.userId, grant.id),
+    return activeReceivedGrants.filter(
+      (grant) => !isOneLocationGrantUnwatched(auth.userId, grant.id),
     );
-  }, [auth.userId, openedGrantTick, unwatchedTick, state?.receivedGrants]);
+  }, [activeReceivedGrants, auth.userId, openedGrantTick, unwatchedTick]);
   const activeOwnerGrants = useMemo(
     () =>
       (state?.ownerGrants ?? []).filter((grant) => grant.status === "active"),
@@ -1995,7 +2005,12 @@ function OneLocationAgentPageContent() {
     }
   }, [state, activeOwnerGrants]);
 
-  const activeVisibleReceivedGrants = visibleReceivedGrants;
+  // The redesigned Inbox keeps every active share live-refreshing even when a
+  // legacy build previously persisted an "unwatched" id. In the redesigned
+  // UX, Dismiss owns preview presentation only and never changes grant reachability.
+  const activeVisibleReceivedGrants = USE_LOCATION_REDESIGN
+    ? activeReceivedGrants
+    : visibleReceivedGrants;
   // Active shares the recipient unwatched (hidden locally). Used only to tailor
   // the empty-state copy.
   const unwatchedActiveReceivedGrantCount = useMemo(() => {
@@ -5056,7 +5071,10 @@ function OneLocationAgentPageContent() {
     recipients: rankedRecipients,
     visibleRecipients,
     activeOwnerGrants,
-    receivedGrants: visibleReceivedGrants,
+    // The redesigned Inbox always keeps active received grants reachable.
+    // Its Dismiss action collapses only the decrypted map preview; legacy
+    // recipient-side "unwatch" state must not remove the durable row.
+    receivedGrants: activeReceivedGrants,
     pendingOwnerRequests,
     requestedByMe,
     latestActivePublicInvite,
@@ -5092,7 +5110,6 @@ function OneLocationAgentPageContent() {
     onApprove: (request) => void handleApprove(request),
     onDeny: (requestId) => void handleDeny(requestId),
     onViewGrant: (grant) => void handleView(grant),
-    onUnwatchGrant: (grant) => handleUnwatch(grant),
     onStopGrant: (grantId) => void handleRevoke(grantId),
     onCreatePublicInvite: () => void handleCreatePublicInvite(),
     onCopyPublicInvite: () => void handleCopyPublicInvite(),
@@ -5116,6 +5133,7 @@ function OneLocationAgentPageContent() {
     renderMapPreview: (point, showNavigation) => (
       <LocalMapPreview point={point} showNavigation={showNavigation} />
     ),
+    mapLocationHref: googleMapsLocationUrl,
     decryptedPoints,
     sosRecipients: sosActionRecipients,
     sosActive: Boolean(sosIncident?.grantIds.length),

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -246,8 +246,9 @@ export function SharedWithMeCard({
   metaLine,
   onView,
   onDismiss,
+  mapHref,
   viewBusy,
-  viewed,
+  previewExpanded,
   children,
 }: {
   name: string;
@@ -255,10 +256,14 @@ export function SharedWithMeCard({
   metaLine?: string;
   onView: () => void;
   onDismiss?: () => void;
+  mapHref?: string;
   viewBusy?: boolean;
-  viewed?: boolean;
+  previewExpanded?: boolean;
   children?: ReactNode;
 }) {
+  const canOpenMap = Boolean(previewExpanded && mapHref);
+  const canDismissPreview = Boolean(previewExpanded && onDismiss);
+
   return (
     <div className={cn(SUBCARD_SURFACE, "space-y-3 p-3.5")}>
       <div className="flex items-center gap-3">
@@ -273,17 +278,36 @@ export function SharedWithMeCard({
       </div>
       {metaLine ? <p className={MUTED_TEXT}>{metaLine}</p> : null}
       {children}
-      <div className="grid grid-cols-2 gap-2">
-        <Button
-          size="sm"
-          onClick={onView}
-          isLoading={viewBusy}
-          className="h-9 rounded-full text-sm"
-        >
-          <MapPin className="mr-1.5 h-3.5 w-3.5" />
-          {viewed ? "Open map" : "View"}
-        </Button>
-        {onDismiss ? (
+      <div
+        className={cn(
+          "grid gap-2",
+          canDismissPreview ? "grid-cols-2" : "grid-cols-1",
+        )}
+      >
+        {canOpenMap ? (
+          <Button asChild size="sm" className="h-9 rounded-full text-sm">
+            <a
+              href={mapHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open shared location in Google Maps"
+            >
+              <MapPin className="mr-1.5 h-3.5 w-3.5" />
+              Open map
+            </a>
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            onClick={onView}
+            isLoading={viewBusy}
+            className="h-9 rounded-full text-sm"
+          >
+            <MapPin className="mr-1.5 h-3.5 w-3.5" />
+            View location
+          </Button>
+        )}
+        {canDismissPreview ? (
           <Button
             variant="outline"
             size="sm"

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -161,7 +161,6 @@ export type LocationHubViewModel = {
   onApprove: (request: OneLocationAccessRequest) => void;
   onDeny: (requestId: string) => void;
   onViewGrant: (grant: OneLocationGrant) => void;
-  onUnwatchGrant: (grant: OneLocationGrant) => void;
   onStopGrant: (grantId: string) => void;
   onCreatePublicInvite: () => void;
   onCopyPublicInvite: () => void;
@@ -238,6 +237,7 @@ export type LocationHubViewModel = {
     point: PlainLocationPoint,
     showNavigation?: boolean,
   ) => ReactNode;
+  mapLocationHref: (point: PlainLocationPoint) => string;
   decryptedPoints: Record<string, PlainLocationPoint>;
 };
 
@@ -263,11 +263,16 @@ const BUSY = (vm: LocationHubViewModel, key: string) => vm.busy === key;
 const PEOPLE_LIST_SCROLL_CLASS =
   "max-h-[340px] space-y-2.5 overflow-y-auto overscroll-contain pr-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/20";
 
+const ACTIVE_SHARE_LIST_SCROLL_CLASS =
+  "max-h-[470px] overflow-y-auto overscroll-contain pr-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/20";
 
 export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const searchParams = useSearchParams();
   const [tab, setTab] = useState<LocationHubTab>("now");
   const [flow, setFlow] = useState<FlowKind>("none");
+  const [collapsedGrantIds, setCollapsedGrantIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   // Deep-link routing: notification "Open" buttons land here with a `section`
   // (or requestId/grantId/submissionId) query param. The page-level tabs are
   // compose/activity, but the ACTIVE UI is this hub (now/people/links/inbox),
@@ -478,7 +483,29 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       ) : tab === "links" ? (
         <LinksHub vm={vm} onCreateTempLink={() => setFlow("temp-link")} />
       ) : (
-        <InboxHub vm={vm} />
+        <InboxHub
+          vm={vm}
+          collapsedGrantIds={collapsedGrantIds}
+          onCollapseGrant={(grantId) =>
+            setCollapsedGrantIds((current) => {
+              if (current.has(grantId)) return current;
+              const next = new Set(current);
+              next.add(grantId);
+              return next;
+            })
+          }
+          onExpandGrant={(grant) => {
+            setCollapsedGrantIds((current) => {
+              if (!current.has(grant.id)) return current;
+              const next = new Set(current);
+              next.delete(grant.id);
+              return next;
+            });
+            if (!vm.decryptedPoints[grant.id]) {
+              vm.onViewGrant(grant);
+            }
+          }}
+        />
       )}
     </div>
   );
@@ -671,17 +698,25 @@ function NowHub({
       {/* Active shares */}
       <SectionCard title="Active shares">
         {hasActiveShare ? (
-          <div className="space-y-2.5">
+          <div
+            role="list"
+            aria-label="Active shares"
+            className={cn(
+              "space-y-2.5",
+              vm.activeOwnerGrants.length > 3 &&
+                ACTIVE_SHARE_LIST_SCROLL_CLASS,
+            )}
+          >
             {vm.activeOwnerGrants.map((grant) => (
-              <ActiveShareCard
-                key={grant.id}
-                name={vm.grantRecipientLabel(grant)}
-                expiryLabel={vm.expiresCountdownLabel(grant.expiresAt)}
-                metaLabel={`Started ${vm.formatDateTime(grant.createdAt)}`}
-                onStop={() => vm.onStopGrant(grant.id)}
-                stopBusy={vm.revokingGrantId === grant.id}
-
-              />
+              <div key={grant.id} role="listitem">
+                <ActiveShareCard
+                  name={vm.grantRecipientLabel(grant)}
+                  expiryLabel={vm.expiresCountdownLabel(grant.expiresAt)}
+                  metaLabel={`Started ${vm.formatDateTime(grant.createdAt)}`}
+                  onStop={() => vm.onStopGrant(grant.id)}
+                  stopBusy={vm.revokingGrantId === grant.id}
+                />
+              </div>
             ))}
           </div>
         ) : (
@@ -905,7 +940,17 @@ function LinksHub({
 /* INBOX HUB                                                            */
 /* =================================================================== */
 
-function InboxHub({ vm }: { vm: LocationHubViewModel }) {
+function InboxHub({
+  vm,
+  collapsedGrantIds,
+  onCollapseGrant,
+  onExpandGrant,
+}: {
+  vm: LocationHubViewModel;
+  collapsedGrantIds: Set<string>;
+  onCollapseGrant: (grantId: string) => void;
+  onExpandGrant: (grant: OneLocationGrant) => void;
+}) {
   const received = vm.receivedGrants;
   return (
     <div className="space-y-5">
@@ -951,6 +996,8 @@ function InboxHub({ vm }: { vm: LocationHubViewModel }) {
           <div className="space-y-2.5">
             {received.map((grant) => {
               const point = vm.decryptedPoints[grant.id];
+              const previewExpanded =
+                Boolean(point) && !collapsedGrantIds.has(grant.id);
               return (
                 <SharedWithMeCard
                   key={grant.id}
@@ -961,12 +1008,15 @@ function InboxHub({ vm }: { vm: LocationHubViewModel }) {
                       ? `Updated ${vm.formatDateTime(point.capturedAt)}`
                       : undefined
                   }
-                  viewed={Boolean(point)}
-                  onView={() => vm.onViewGrant(grant)}
-                  onDismiss={() => vm.onUnwatchGrant(grant)}
+                  previewExpanded={previewExpanded}
+                  mapHref={point ? vm.mapLocationHref(point) : undefined}
+                  onView={() => onExpandGrant(grant)}
+                  onDismiss={() => onCollapseGrant(grant.id)}
                   viewBusy={vm.busy === "view"}
                 >
-                  {point ? vm.renderMapPreview(point, true) : null}
+                  {previewExpanded && point
+                    ? vm.renderMapPreview(point, true)
+                    : null}
                 </SharedWithMeCard>
               );
             })}


### PR DESCRIPTION
## Summary

- keep received location shares reachable after the map preview is dismissed
- collapse the preview into a compact row with a `View location` action and reuse the decrypted point when re-expanded
- make `Open map` a real Google Maps link and constrain Active shares to a three-card scroll viewport when more than three are present

## Root cause

The redesigned Inbox reused the legacy recipient `unwatch` action for `Dismiss`. That persisted the grant id locally, filtered the complete share row out of the Inbox, and stopped the redesigned live-refresh path. The apparent `Open map` control also called the in-app decrypt/view handler instead of opening an external map.

### Impact Map

- Routes touched:
  - `/one/location`

- API/schema/type changes:
  - Frontend-only `LocationHubViewModel` presentation contract changes.
  - No HTTP API, backend schema, or generated contract changes.

- Runtime DB data-plane changes:
  - Table families changed: none.
  - Data class / retention / deletion policy updated: no.
  - `./bin/hushh codex data-model-audit` run: not applicable; no data-model change.

- Cache keys touched:
  - No cache schema changes.
  - Redesigned Inbox dismissal no longer writes or relies on `one_location_unwatched_grants_v1` to hide an active share; legacy UI compatibility remains unchanged.

- PKM effects:
  - Domain(s): none.
  - Summary fields changed: none.
  - Reconciliation required: no.

- Mobile parity impacts:
  - Route parity: the responsive `/one/location` web surface gains the same collapse/re-expand and scrolling behavior in mobile layouts.
  - Plugin/bridge contract: unchanged.
  - Web-only behavior changes: external Google Maps link uses a standard HTTPS URL and works in browser contexts.

- Trust boundary touched:
  - Active location grant presentation only; auth, consent issuance/revocation, vault, PKM, finance, voice, KYC, deploy, and public ingress are unchanged.
  - Privacy or secret exposure impact: none. Coordinates are placed only in the user-invoked Google Maps URL, matching the existing Directions behavior.

- Caller/proxy/backend pairing:
  - Caller changed: One Location redesigned Inbox and Now views.
  - Backend/proxy changed: none.
  - Contract proof: Dismiss now mutates only component preview state; backend revoke/delete handlers are untouched. Behavior tests assert the row remains, no legacy unwatch key is written, and cached decrypted data is reused.

- Rollback or safe-failure behavior:
  - Rollback path: revert this PR; no database or grant migration is required.
  - Error/fallback path: if the external map cannot open, the durable share row and in-app preview remain available; Dismiss never revokes or deletes the share.

- UI browser or Playwright proof:
  - Behavior-level Vitest/Testing Library interaction test covers map display, working external link, dismiss-to-row, `View location`, cached re-expand, and four-share scrolling.
  - Live local smoke: `/one/location` returned HTTP 200 on Next.js 16.2.4 with no frontend stderr.
  - Authenticated route verifier was not run because `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE` are unavailable locally.

- Docs updated:
  - None; no public/runtime contract documentation changed.

- Verification run:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] focused ESLint on all four changed files
  - [x] focused One Location Vitest scenarios: 2 passed
  - [x] cache contract suites: 51 passed across isolated runs after one Vitest fork startup timeout
  - [x] `cd hushh-webapp && npm run verify:design-system`
  - [x] `cd hushh-webapp && npm run verify:docs`
  - [x] live HTTP smoke for frontend root, `/one/location`, backend docs, and local PostgreSQL listener
  - [ ] native iOS/Android checks: not applicable; no plugin or native bridge change