### PR TITLE
fix(one-location): no default contact selection in Drive To, Pick Me Up, Safe Arrival

### DIFF
--- a/hushh-webapp/components/one-location/redesign/drive-to-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/drive-to-flow.tsx
@@ -62,18 +62,9 @@ export function DriveToFlow({
   const [destination, setDestination] = useState<DriveDestination | null>(null);
   const [checkedIds, setCheckedIds] = useState<string[]>([]);
   const [durationValue, setDurationValue] = useState("2");
-  const [seeded, setSeeded] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
 
-  // Pre-select the whole ready trusted circle (narrowable), per the spec.
-  useEffect(() => {
-    if (seeded) return;
-    const ready = contacts.filter((r) => vm.isRecipientShareReady(r));
-    if (contacts.length > 0) {
-      setCheckedIds(ready.map((r) => r.userId));
-      setSeeded(true);
-    }
-  }, [contacts, seeded, vm]);
+  // No default selection: the user explicitly chooses who to share with.
 
   // Debounced Places autocomplete via the backend proxy.
   useEffect(() => {

--- a/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
@@ -19,7 +19,7 @@
  *   you until they arrive.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Check, Clock, Hand, MapPin, Navigation, RefreshCw, ShieldCheck } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -196,19 +196,8 @@ export function PickMeUpFlow({
   const [untilPickedUp, setUntilPickedUp] = useState(true);
   const [urgency, setUrgency] = useState<UrgencyValue>("soon");
   const [note, setNote] = useState("");
-  const [seeded, setSeeded] = useState(false);
 
-  // Pre-select the first ready contact so a single tap can send help.
-  useEffect(() => {
-    if (seeded) return;
-    const firstReady = contacts.find((r) => vm.isRecipientShareReady(r));
-    if (firstReady) {
-      setCheckedIds([firstReady.userId]);
-      setSeeded(true);
-    } else if (contacts.length > 0) {
-      setSeeded(true);
-    }
-  }, [contacts, seeded, vm]);
+  // No default selection: the user explicitly chooses who can come get them.
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/hushh-webapp/components/one-location/redesign/safe-arrival-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/safe-arrival-flow.tsx
@@ -155,18 +155,9 @@ export function SafeArrivalFlow({
   const [checkedIds, setCheckedIds] = useState<string[]>([]);
   const [durationValue, setDurationValue] = useState("1");
   const [note, setNote] = useState("");
-  const [seeded, setSeeded] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
 
-  // Pre-select the whole ready trusted circle (narrowable).
-  useEffect(() => {
-    if (seeded) return;
-    const ready = contacts.filter((r) => vm.isRecipientShareReady(r));
-    if (contacts.length > 0) {
-      setCheckedIds(ready.map((r) => r.userId));
-      setSeeded(true);
-    }
-  }, [contacts, seeded, vm]);
+  // No default selection: the user explicitly chooses who should know.
 
   // Debounced Places autocomplete via the backend proxy (same as Drive To).
   useEffect(() => {


### PR DESCRIPTION
## Summary

The One Location quick-action flows pre-selected trusted contacts on open, which is poor UX for a consent-first location share:

- **Drive To** and **Safe Arrival** pre-checked the entire ready trusted circle
- **Pick Me Up** pre-checked the first ready contact

This change removes the seeding logic so **no contact is selected initially** — the user explicitly chooses who to share with.

## Changes

- Removed the seeding `useEffect` + `seeded` state from `drive-to-flow.tsx`, `pick-me-up-flow.tsx`, and `safe-arrival-flow.tsx` so `checkedIds` starts empty.
- Dropped the now-unused `useEffect` import in `pick-me-up-flow.tsx`.
- Existing action-button gating (`selectedReadyCount > 0`, with "Select who…" labels + disabled state) already handles the zero-selection start, so no behavioral gaps.

## Scope

- The separate **Check-In** flow still pre-selects by design and was intentionally left untouched.

## Verification

- `npm run typecheck` — pass (exit 0)
- `npm run lint` (`--max-warnings=0`) — pass (exit 0)
- `vitest run __tests__/components/one-location-agent-page.test.tsx` — 28/28 passed
