### PR TITLE
fix(migrations): 079 allow source='connection' so UAT release re-apply passes

### DIFF
--- a/consent-protocol/db/migrations/079_unify_location_connections.sql
+++ b/consent-protocol/db/migrations/079_unify_location_connections.sql
@@ -12,12 +12,18 @@ BEGIN;
 -- once all code stops referencing it. Idempotent: ON CONFLICT DO NOTHING + IF
 -- EXISTS guards.
 
--- 1. Widen the source CHECK to include circle_invite.
+-- 1. Widen the source CHECK to include circle_invite (and 'connection').
+-- NOTE: the release manifest re-applies EVERY migration file on every deploy
+-- (db/migrate.py apply_migration_files runs in explicit mode, no skip). Once
+-- 086 shipped, the live app writes trusted_connections rows with
+-- source='connection'; if this ADD CONSTRAINT omitted 'connection' it would
+-- re-narrow the set mid-deploy and fail validation on those rows before 086
+-- re-widens it. Keep this superset in sync with 086_connections.sql.
 ALTER TABLE trusted_connections
   DROP CONSTRAINT IF EXISTS trusted_connections_source_check;
 ALTER TABLE trusted_connections
   ADD CONSTRAINT trusted_connections_source_check
-  CHECK (source IN ('agent_one', 'seed', 'import', 'circle_invite'));
+  CHECK (source IN ('agent_one', 'seed', 'import', 'circle_invite', 'connection'));
 
 -- 2a. Copy a -> b for every real active pair.
 INSERT INTO trusted_connections (


### PR DESCRIPTION
## Summary

Fixes a deterministic UAT deploy failure: the release schema gate fails at `079_unify_location_connections.sql` with

```
CheckViolationError: check constraint "trusted_connections_source_check" is violated by some row
```

## Root cause
The release manifest re-applies **every** migration file on every deploy (`db/migrate.py` `apply_migration_files`, explicit mode — no skip-if-applied). `079` re-created `trusted_connections_source_check` as `CHECK (source IN ('agent_one','seed','import','circle_invite'))` — **without `'connection'`**. Once `086_connections.sql` shipped, the live app began writing `trusted_connections` rows with `source='connection'` (connection accept + circle-invite link mirror). On the next deploy, `079` runs before `086`, `DROP`s the (correct, wide) constraint and re-`ADD`s the narrow one, which re-validates existing rows and fails on the `'connection'` rows — before `086` can re-widen.

## Fix
Align `079`'s CHECK with `086`'s superset so re-applying it is idempotent against live data:
`CHECK (source IN ('agent_one','seed','import','circle_invite','connection'))`.
No new migration is added (a later migration can't help — `079` fails first in the same run). Final schema is unchanged (086 already defines this set).

## Testing
- Local lint/format clean.
- Verified mechanism against `db/migrate.py` (re-applies all manifest files) and the failing UAT deploy log (re-running 070…079 then CheckViolationError).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
