### PR TITLE
feat(one-voice): onboarding voice/UI parity + proactive prompting

### DIFF
--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -73,6 +73,22 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/one/adk", tags=["One ADK"])
 
+# Screens where a person is actively moving through account setup. On these
+# screens a screen change is a hand-off moment (they just landed somewhere
+# new mid-flow), so the injected note instructs a concrete spoken next-step
+# question instead of staying silent - the rest of the app gets the neutral
+# silent note so One does not narrate ordinary browsing.
+_ONBOARDING_SCREENS = frozenset(
+    {
+        "getting_started",
+        "login",
+        "register_phone",
+        "one_setup",
+        "one_setup_hub",
+        "kai_setup_wizard",
+    }
+)
+
 _INPUT_MIME_DEFAULT = "audio/pcm;rate=16000"
 _OUTPUT_MIME = "audio/pcm;rate=24000"
 
@@ -256,18 +272,25 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                     changed = clean_screen != last_injected_screen
                     last_injected_screen = clean_screen
                     if changed and not is_first:
+                        if clean_screen in _ONBOARDING_SCREENS:
+                            note_text = (
+                                "[App state update - not user speech] The user is "
+                                f"now on the '{clean_screen}' screen while finishing "
+                                "account setup. Briefly name the one next thing they "
+                                "can do here, and if it needs an answer from them "
+                                "(a question, a phone number), ask for it directly "
+                                "in the same breath."
+                            )
+                        else:
+                            note_text = (
+                                "[App state update - not user speech] The user is "
+                                f"now on the '{clean_screen}' screen. Use this "
+                                "silently."
+                            )
                         queue.send_content(
                             genai_types.Content(
                                 role="user",
-                                parts=[
-                                    genai_types.Part(
-                                        text=(
-                                            "[App state update - not user speech] The "
-                                            f"user is now on the '{clean_screen}' "
-                                            "screen. Use this silently."
-                                        )
-                                    )
-                                ],
+                                parts=[genai_types.Part(text=note_text)],
                             )
                         )
                 first_app_context_seen = True

--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -149,7 +149,20 @@ async def run_app_action(
         "kind": "action",
         "payload": directive_payload,
     }
-    return {"status": "ok", "message": f"Running {label}.", "action_id": clean_id}
+    return {
+        "status": "ok",
+        "message": f"Running {label}.",
+        "action_id": clean_id,
+        # Proactive-prompting: like open_screen, this text is the tool
+        # RESULT the model reads on its next turn - there is no separate
+        # server-injected system turn after a tool call. Nudging here means
+        # One offers a next step after every governed action it runs, not
+        # only after an onboarding screen change.
+        "next_step": (
+            f"After {label} completes, briefly confirm what happened and, if "
+            "there's an obvious next step, offer it before waiting to be asked."
+        ),
+    }
 
 
 async def list_app_actions(query: str, tool_context: ToolContext) -> dict[str, Any]:

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -136,7 +136,18 @@ ONE_IDENTITY_INSTRUCTION = (
     "it cannot act (missing consent, locked vault, no data), relay that "
     "honestly and tell the user what would unlock it. You never execute "
     "sensitive actions directly: specialists validate consent and the app "
-    "confirms every state change."
+    "confirms every state change.\n\n"
+    "Guiding a new user through account setup is your job, the same way any "
+    "other app action is: the welcome screen, sign-in, phone verification, "
+    "the setup hub, and the Finance preferences wizard are all reachable "
+    "through run_app_action (list_app_actions first when unsure of the exact "
+    "id). While someone is still finishing setup, be proactive rather than "
+    "waiting to be asked: after you open a screen or complete a step, briefly "
+    "name ONE next thing they could do there and, if that next step needs an "
+    "answer from them (a wizard question, a phone number), ask for it "
+    "directly instead of just describing it. Never invent what setup has or "
+    "has not been completed; rely on the action result or the app state you "
+    "are given."
 )
 
 
@@ -242,7 +253,22 @@ async def open_screen(screen: str, tool_context: ToolContext) -> dict[str, Any]:
         "kind": "navigate",
         "payload": {"route": route, "screen": key},
     }
-    return {"status": "ok", "message": f"Opening {key.replace('_', ' ')}.", "route": route}
+    return {
+        "status": "ok",
+        "message": f"Opening {key.replace('_', ' ')}.",
+        "route": route,
+        # Proactive-prompting: this text becomes the tool RESULT the model
+        # reads on its next turn (there is no separate server-injected
+        # system turn for tool results, unlike the greeting/screen-change
+        # notes in adk_live.py). Nudging here means One offers a next step
+        # after every screen it opens, not only after onboarding-tagged
+        # screen changes.
+        "next_step": (
+            f"Once you land on {key.replace('_', ' ')}, briefly say what the "
+            "person can do here and, if there's an obvious next action, offer "
+            "it before waiting for them to ask."
+        ),
+    }
 
 
 async def ask_email_agent(request: str, tool_context: ToolContext) -> dict[str, Any]:

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -26,7 +26,7 @@ from typing import Any, Optional
 from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from google.adk.sessions.in_memory_session_service import InMemorySessionService
-from google.adk.tools import google_search
+from google.adk.tools.google_search_tool import GoogleSearchTool
 from google.adk.tools.tool_context import ToolContext
 
 from hushh_mcp.adk_bridge.contract import A2ATask
@@ -358,11 +358,25 @@ def _one_roster_tools() -> list:
     consult them as tools; the dispatch-backed specialists (email, location,
     connections, marketplace, connected systems, consent) are plain function
     tools that call the existing governed adk_bridge handlers.
+
+    Uses GoogleSearchTool(bypass_multi_tools_limit=True) rather than the bare
+    google_search function-tool. Binding Gemini's native google_search
+    directly alongside this many custom function/agent tools in the SAME
+    LlmAgent.tools=[...] list is unstable on google-adk 2.4.0 (verified in
+    hushh-search-console's adk_runtime.py via 15+ live trials: redundant
+    tool calls, intermittent TaskGroup errors, occasional full timeouts).
+    bypass_multi_tools_limit=True makes LlmAgent's own tool conversion wrap
+    google_search as an isolated per-call sub-agent turn (a
+    GoogleSearchAgentTool with propagate_grounding_metadata=True), which ADK
+    itself maintains and which still propagates real grounding metadata
+    (search queries + grounding chunks with real URLs) back onto One's own
+    event stream - so voice/chat answers keep real citations, not just a
+    plain summarized string.
     """
     from google.adk.tools.agent_tool import AgentTool
 
     return [
-        google_search,
+        GoogleSearchTool(bypass_multi_tools_limit=True),
         open_screen,
         run_app_action,
         list_app_actions,

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -3997,7 +3997,8 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
-          "one_setup_connected-systems"
+          "one_setup_connected-systems",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -4103,7 +4104,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -4220,7 +4222,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -4339,7 +4342,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -4459,7 +4463,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -5789,7 +5794,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -5904,7 +5910,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -10630,7 +10637,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -10733,7 +10741,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -10835,7 +10844,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -10938,7 +10948,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11042,7 +11053,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11145,7 +11157,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11248,7 +11261,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11355,7 +11369,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -9,8 +9,11 @@
     "hushh-webapp/app/one/kyc/page.voice-action-contract.json",
     "hushh-webapp/app/one/marketplace/page.voice-action-contract.json",
     "hushh-webapp/app/one/page.voice-action-contract.json",
+    "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+    "hushh-webapp/app/one/setup/kai/page.voice-action-contract.json",
     "hushh-webapp/app/profile/page.voice-action-contract.json",
     "hushh-webapp/app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
+    "hushh-webapp/app/register-phone/page.voice-action-contract.json",
     "hushh-webapp/app/ria/clients/page.voice-action-contract.json",
     "hushh-webapp/app/ria/onboarding/page.voice-action-contract.json",
     "hushh-webapp/app/ria/page.voice-action-contract.json",
@@ -23,6 +26,7 @@
     "hushh-webapp/components/kai/kai-command-bar-global.voice-action-contract.json",
     "hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json",
     "hushh-webapp/components/kai/views/kai-market-preview-view.voice-action-contract.json",
+    "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
     "hushh-webapp/components/ria/ria-client-account-detail.voice-action-contract.json",
     "hushh-webapp/components/ria/ria-client-request-detail.voice-action-contract.json",
     "hushh-webapp/components/ria/ria-client-workspace.voice-action-contract.json"
@@ -163,6 +167,49 @@
     },
     {
       "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_setup_capability_step",
+      "surface_title": "One Setup Capability Step",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_setup_wizard",
+      "surface_title": "Kai Investor Preferences Wizard",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/app/one/setup/kai/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
+          ]
+        },
+        "speaker_persona": "kai",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
       "surface_id": "profile_account",
       "surface_title": "Profile Workspace",
       "docs_references": [
@@ -193,6 +240,28 @@
             "ria"
           ]
         }
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "phone_mandate",
+      "surface_title": "Phone Verification",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/app/register-phone/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
       }
     },
     {
@@ -401,6 +470,28 @@
             "investor"
           ]
         }
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_setup_hub",
+      "surface_title": "One Setup Hub",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
       }
     },
     {
@@ -3871,6 +3962,589 @@
       }
     },
     {
+      "action_id": "setup.capability_continue",
+      "surface_id": "one_setup_capability_step",
+      "label": "Continue Capability Setup",
+      "aliases": [
+        "continue",
+        "unlock and continue",
+        "got it",
+        "next"
+      ],
+      "search_keywords": [
+        "continue",
+        "next",
+        "got it",
+        "unlock"
+      ],
+      "meaning": "Advances past the current capability setup step to its next destination (workspace, wizard, or explore acknowledgement). Applies to whichever capability route is currently open.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/finance",
+          "/one/setup/gmail",
+          "/one/setup/email",
+          "/one/setup/location",
+          "/one/setup/pkm",
+          "/one/setup/consent",
+          "/one/setup/connected-systems"
+        ],
+        "screens": [
+          "one_setup_finance",
+          "one_setup_gmail",
+          "one_setup_email",
+          "one_setup_location",
+          "one_setup_pkm",
+          "one_setup_consent",
+          "one_setup_connected-systems"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.capability_continue"
+      },
+      "control_ids": [
+        "one_setup_capability_primary"
+      ],
+      "state_exposure": [
+        "capability seen/explored signal"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/finance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.capability_continue",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.capability_continue",
+            "label": "Continue Capability Setup",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_finance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_horizon",
+      "surface_id": "kai_setup_wizard",
+      "label": "Answer Investment Horizon",
+      "aliases": [
+        "less than 3 years",
+        "3 to 7 years",
+        "more than 7 years"
+      ],
+      "search_keywords": [
+        "horizon",
+        "how long",
+        "invested"
+      ],
+      "meaning": "Answers the investment horizon question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_horizon"
+      },
+      "control_ids": [
+        "kai_wizard_investment_horizon"
+      ],
+      "state_exposure": [
+        "current wizard step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_horizon",
+        "required_inputs": [
+          {
+            "name": "investment_horizon",
+            "prompt": "How long do you expect to keep this money invested: less than 3 years, 3 to 7 years, or more than 7 years?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "short_term",
+              "medium_term",
+              "long_term"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_horizon",
+            "label": "Answer Investment Horizon",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_drawdown",
+      "surface_id": "kai_setup_wizard",
+      "label": "Answer Drawdown Response",
+      "aliases": [
+        "reduce investments",
+        "stay invested",
+        "buy more"
+      ],
+      "search_keywords": [
+        "drawdown",
+        "drop",
+        "reaction"
+      ],
+      "meaning": "Answers the portfolio-drawdown-reaction question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Investment horizon must already be answered."
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_drawdown"
+      },
+      "control_ids": [
+        "kai_wizard_drawdown_response"
+      ],
+      "state_exposure": [
+        "current wizard step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_drawdown",
+        "required_inputs": [
+          {
+            "name": "drawdown_response",
+            "prompt": "If your portfolio drops 20 percent, would you reduce investments, stay invested, or buy more?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "reduce",
+              "stay",
+              "buy_more"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_drawdown",
+            "label": "Answer Drawdown Response",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_volatility",
+      "surface_id": "kai_setup_wizard",
+      "label": "Answer Volatility Preference",
+      "aliases": [
+        "smaller steadier returns",
+        "moderate ups and downs",
+        "larger swings"
+      ],
+      "search_keywords": [
+        "volatility",
+        "comfort",
+        "swings"
+      ],
+      "meaning": "Answers the volatility-comfort question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Drawdown response must already be answered."
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_volatility"
+      },
+      "control_ids": [
+        "kai_wizard_volatility_preference"
+      ],
+      "state_exposure": [
+        "current wizard step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_volatility",
+        "required_inputs": [
+          {
+            "name": "volatility_preference",
+            "prompt": "Which feels more comfortable: smaller steadier returns, moderate ups and downs, or larger swings for higher potential returns?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "small",
+              "moderate",
+              "large"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_volatility",
+            "label": "Answer Volatility Preference",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.launch_dashboard",
+      "surface_id": "kai_setup_wizard",
+      "label": "Launch Kai Dashboard",
+      "aliases": [
+        "launch my dashboard",
+        "looks good, continue",
+        "finish kai setup"
+      ],
+      "search_keywords": [
+        "launch",
+        "dashboard",
+        "finish",
+        "persona"
+      ],
+      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "All three preference questions must be answered."
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.launch_dashboard"
+      },
+      "control_ids": [
+        "kai_wizard_launch_dashboard"
+      ],
+      "state_exposure": [
+        "computed risk profile"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/kai/page.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.launch_dashboard",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.launch_dashboard",
+            "label": "Launch Kai Dashboard",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "route.profile",
       "surface_id": "profile_account",
       "label": "Open Profile",
@@ -5068,6 +5742,232 @@
             "settlement_target": {
               "route": "/profile/pkm-agent-lab",
               "screen": "profile_pkm_agent_lab"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "phone_mandate.submit_number",
+      "surface_id": "phone_mandate",
+      "label": "Submit Phone Number",
+      "aliases": [
+        "verify my phone",
+        "send me a code",
+        "my phone number is",
+        "add my phone number"
+      ],
+      "search_keywords": [
+        "phone",
+        "verify",
+        "code",
+        "sms"
+      ],
+      "meaning": "Sends a verification code to the phone number the user says.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "medium",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_number"
+      },
+      "control_ids": [
+        "phone-flow-number"
+      ],
+      "state_exposure": [
+        "masked phone number"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /register-phone"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_number",
+        "required_inputs": [
+          {
+            "name": "phone_number",
+            "prompt": "What's your phone number, including country code?",
+            "required": true,
+            "slot": "phoneNumber"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_number",
+            "label": "Submit Phone Number",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "phone_mandate.submit_code",
+      "surface_id": "phone_mandate",
+      "label": "Submit Verification Code",
+      "aliases": [
+        "the code is",
+        "verify my code",
+        "confirm my phone",
+        "submit the verification code"
+      ],
+      "search_keywords": [
+        "code",
+        "otp",
+        "verify",
+        "confirm"
+      ],
+      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "A verification code must already be sent."
+        ],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "manual_user_execution"
+      ],
+      "risk_level": "high",
+      "execution_policy": "manual_only",
+      "execution_target": {
+        "status": "unwired",
+        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
+        "intended_handler": "local_handler"
+      },
+      "control_ids": [
+        "phone-flow-code"
+      ],
+      "state_exposure": [
+        "verification step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /register-phone"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_code",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_code",
+            "label": "Submit Verification Code",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
             }
           }
         ],
@@ -9684,6 +10584,838 @@
             "settlement_target": {
               "route": "/one/kai",
               "screen": "kai_market"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_finance",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Finance",
+      "aliases": [
+        "set up finance",
+        "open finance setup",
+        "set up investing"
+      ],
+      "search_keywords": [
+        "finance",
+        "setup",
+        "investing",
+        "kai"
+      ],
+      "meaning": "Opens the Finance capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/finance"
+      },
+      "control_ids": [
+        "one_setup_tile_finance"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/finance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_finance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_finance",
+            "label": "Set Up Finance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_gmail",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Gmail",
+      "aliases": [
+        "set up gmail",
+        "open gmail setup",
+        "connect gmail"
+      ],
+      "search_keywords": [
+        "gmail",
+        "setup",
+        "receipts"
+      ],
+      "meaning": "Opens the Gmail capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/gmail"
+      },
+      "control_ids": [
+        "one_setup_tile_gmail"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/gmail"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_gmail",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_gmail",
+            "label": "Set Up Gmail",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/gmail",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_email",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Email",
+      "aliases": [
+        "set up email",
+        "open email setup"
+      ],
+      "search_keywords": [
+        "email",
+        "setup",
+        "approvals"
+      ],
+      "meaning": "Opens the Email capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/email"
+      },
+      "control_ids": [
+        "one_setup_tile_email"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/email"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_email",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_email",
+            "label": "Set Up Email",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/email",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_location",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Location",
+      "aliases": [
+        "set up location",
+        "open location setup",
+        "set up live sharing"
+      ],
+      "search_keywords": [
+        "location",
+        "setup",
+        "sharing"
+      ],
+      "meaning": "Opens the Location capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/location"
+      },
+      "control_ids": [
+        "one_setup_tile_location"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/location"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_location",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_location",
+            "label": "Set Up Location",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/location",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_personal_data",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Memory",
+      "aliases": [
+        "set up memory",
+        "open memory setup",
+        "set up personal data"
+      ],
+      "search_keywords": [
+        "memory",
+        "pkm",
+        "setup",
+        "personal data"
+      ],
+      "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/pkm"
+      },
+      "control_ids": [
+        "one_setup_tile_pkm"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/pkm"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_personal_data",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_personal_data",
+            "label": "Set Up Memory",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_consent",
+      "surface_id": "one_setup_hub",
+      "label": "Explore Consent",
+      "aliases": [
+        "set up consent",
+        "open consent setup",
+        "explore consent"
+      ],
+      "search_keywords": [
+        "consent",
+        "setup",
+        "approvals"
+      ],
+      "meaning": "Opens the Consent explore-only step from the setup hub.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/consent"
+      },
+      "control_ids": [
+        "one_setup_tile_consent"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/consent"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_consent",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_consent",
+            "label": "Explore Consent",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/consent",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_connected_systems",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Connected Systems",
+      "aliases": [
+        "set up connected systems",
+        "open connected systems setup",
+        "connect crm"
+      ],
+      "search_keywords": [
+        "connected systems",
+        "crm",
+        "setup"
+      ],
+      "meaning": "Opens the Connected Systems capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/connected-systems"
+      },
+      "control_ids": [
+        "one_setup_tile_connected-systems"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/connected-systems"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_connected_systems",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_connected_systems",
+            "label": "Set Up Connected Systems",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/connected-systems",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.hub_master_ack",
+      "surface_id": "one_setup_hub",
+      "label": "Finish Setup For Now",
+      "aliases": [
+        "skip setup",
+        "i'm done setting up",
+        "continue to home",
+        "finish setup",
+        "that's all for now"
+      ],
+      "search_keywords": [
+        "skip",
+        "continue",
+        "done",
+        "finish setup",
+        "home"
+      ],
+      "meaning": "Resolves the master setup gate: Skip when nothing is set up yet, or Continue once at least one capability is ready, then opens One's home.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.hub_master_ack"
+      },
+      "control_ids": [
+        "one-setup-master-ack"
+      ],
+      "state_exposure": [
+        "capabilities completed count"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/onboarding/setup/one-setup-hub.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.hub_master_ack",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.hub_master_ack",
+            "label": "Finish Setup For Now",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup",
+              "screen": "one_setup_hub"
             }
           }
         ],

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -2402,6 +2402,426 @@
       ]
     },
     {
+      "id": "setup.capability_continue",
+      "label": "Continue Capability Setup",
+      "meaning": "Advances past the current capability setup step to its next destination (workspace, wizard, or explore acknowledgement). Applies to whichever capability route is currently open.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "continue",
+        "unlock and continue",
+        "got it",
+        "next"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/finance",
+          "/one/setup/gmail",
+          "/one/setup/email",
+          "/one/setup/location",
+          "/one/setup/pkm",
+          "/one/setup/consent",
+          "/one/setup/connected-systems"
+        ],
+        "screens": [
+          "one_setup_finance",
+          "one_setup_gmail",
+          "one_setup_email",
+          "one_setup_location",
+          "one_setup_pkm",
+          "one_setup_consent",
+          "one_setup_connected-systems"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.capability_continue"
+      },
+      "goal": {
+        "goal_id": "goal.setup.capability_continue",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.capability_continue",
+            "label": "Continue Capability Setup",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_finance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.answer_horizon",
+      "label": "Answer Investment Horizon",
+      "meaning": "Answers the investment horizon question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "less than 3 years",
+        "3 to 7 years",
+        "more than 7 years"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_horizon"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_horizon",
+        "required_inputs": [
+          {
+            "name": "investment_horizon",
+            "prompt": "How long do you expect to keep this money invested: less than 3 years, 3 to 7 years, or more than 7 years?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "short_term",
+              "medium_term",
+              "long_term"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_horizon",
+            "label": "Answer Investment Horizon",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.answer_drawdown",
+      "label": "Answer Drawdown Response",
+      "meaning": "Answers the portfolio-drawdown-reaction question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "reduce investments",
+        "stay invested",
+        "buy more"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Investment horizon must already be answered."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_drawdown"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_drawdown",
+        "required_inputs": [
+          {
+            "name": "drawdown_response",
+            "prompt": "If your portfolio drops 20 percent, would you reduce investments, stay invested, or buy more?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "reduce",
+              "stay",
+              "buy_more"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_drawdown",
+            "label": "Answer Drawdown Response",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.answer_volatility",
+      "label": "Answer Volatility Preference",
+      "meaning": "Answers the volatility-comfort question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "smaller steadier returns",
+        "moderate ups and downs",
+        "larger swings"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Drawdown response must already be answered."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_volatility"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_volatility",
+        "required_inputs": [
+          {
+            "name": "volatility_preference",
+            "prompt": "Which feels more comfortable: smaller steadier returns, moderate ups and downs, or larger swings for higher potential returns?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "small",
+              "moderate",
+              "large"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_volatility",
+            "label": "Answer Volatility Preference",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.launch_dashboard",
+      "label": "Launch Kai Dashboard",
+      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "launch my dashboard",
+        "looks good, continue",
+        "finish kai setup"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "All three preference questions must be answered."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.launch_dashboard"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.launch_dashboard",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.launch_dashboard",
+            "label": "Launch Kai Dashboard",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/kai/page.tsx"
+      ]
+    },
+    {
       "id": "route.profile",
       "label": "Open Profile",
       "meaning": "Navigates to profile landing route.",
@@ -3271,6 +3691,164 @@
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "app/profile/pkm-agent-lab/page-client.tsx"
+      ]
+    },
+    {
+      "id": "phone_mandate.submit_number",
+      "label": "Submit Phone Number",
+      "meaning": "Sends a verification code to the phone number the user says.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "verify my phone",
+        "send me a code",
+        "my phone number is",
+        "add my phone number"
+      ],
+      "scope": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "medium",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_number"
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_number",
+        "required_inputs": [
+          {
+            "name": "phone_number",
+            "prompt": "What's your phone number, including country code?",
+            "required": true,
+            "slot": "phoneNumber"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_number",
+            "label": "Submit Phone Number",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
+      ]
+    },
+    {
+      "id": "phone_mandate.submit_code",
+      "label": "Submit Verification Code",
+      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "the code is",
+        "verify my code",
+        "confirm my phone",
+        "submit the verification code"
+      ],
+      "scope": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "A verification code must already be sent."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "manual_user_execution"
+      ],
+      "risk_level": "high",
+      "execution_policy": "manual_only",
+      "execution_hint": {
+        "status": "unwired",
+        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
+        "intended_handler": "local_handler"
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_code",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_code",
+            "label": "Submit Verification Code",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
       ]
     },
     {
@@ -6511,6 +7089,584 @@
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "docs/reference/one/one-voice-kai-compatibility-runtime.md"
+      ]
+    },
+    {
+      "id": "setup.open_finance",
+      "label": "Set Up Finance",
+      "meaning": "Opens the Finance capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up finance",
+        "open finance setup",
+        "set up investing"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/finance"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_finance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_finance",
+            "label": "Set Up Finance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_gmail",
+      "label": "Set Up Gmail",
+      "meaning": "Opens the Gmail capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up gmail",
+        "open gmail setup",
+        "connect gmail"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/gmail"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_gmail",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_gmail",
+            "label": "Set Up Gmail",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/gmail",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_email",
+      "label": "Set Up Email",
+      "meaning": "Opens the Email capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up email",
+        "open email setup"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/email"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_email",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_email",
+            "label": "Set Up Email",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/email",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_location",
+      "label": "Set Up Location",
+      "meaning": "Opens the Location capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up location",
+        "open location setup",
+        "set up live sharing"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/location"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_location",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_location",
+            "label": "Set Up Location",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/location",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_personal_data",
+      "label": "Set Up Memory",
+      "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up memory",
+        "open memory setup",
+        "set up personal data"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/pkm"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_personal_data",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_personal_data",
+            "label": "Set Up Memory",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_consent",
+      "label": "Explore Consent",
+      "meaning": "Opens the Consent explore-only step from the setup hub.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up consent",
+        "open consent setup",
+        "explore consent"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/consent"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_consent",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_consent",
+            "label": "Explore Consent",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/consent",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_connected_systems",
+      "label": "Set Up Connected Systems",
+      "meaning": "Opens the Connected Systems capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up connected systems",
+        "open connected systems setup",
+        "connect crm"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/connected-systems"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_connected_systems",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_connected_systems",
+            "label": "Set Up Connected Systems",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/connected-systems",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.hub_master_ack",
+      "label": "Finish Setup For Now",
+      "meaning": "Resolves the master setup gate: Skip when nothing is set up yet, or Continue once at least one capability is ready, then opens One's home.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "skip setup",
+        "i'm done setting up",
+        "continue to home",
+        "finish setup",
+        "that's all for now"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.hub_master_ack"
+      },
+      "goal": {
+        "goal_id": "goal.setup.hub_master_ack",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.hub_master_ack",
+            "label": "Finish Setup For Now",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/onboarding/setup/one-setup-hub.tsx"
       ]
     },
     {

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -2430,7 +2430,8 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
-          "one_setup_connected-systems"
+          "one_setup_connected-systems",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -2503,7 +2504,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -2588,7 +2590,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -2675,7 +2678,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -2762,7 +2766,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -3710,7 +3715,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -3791,7 +3797,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -7107,7 +7114,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7179,7 +7187,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7250,7 +7259,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7322,7 +7332,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7394,7 +7405,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7466,7 +7478,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7538,7 +7551,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7612,7 +7626,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []

--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -128,6 +128,64 @@ the event stream. The client executes it (`agent-bar.tsx` handles
 
 `open_screen` is allowlist-governed: `APP_ROUTES` in `agent_tree.py` maps
 screen ids to routes; anything outside the map is refused by construction.
+`run_app_action` is the broader governed-action lane: it looks up an exact
+`action_id` in the generated gateway (`contracts/kai/kai-action-gateway.vnext.json`,
+loaded via `hushh_mcp.services.voice_action_manifest`) and parks the same
+kind of client directive, or redirects to a specialist's `ask_*` tool when
+the action is delegate-owned, or refuses `manual_only` actions with
+where-to-do-it guidance.
+
+## Onboarding and Proactive Prompting
+
+Guiding a new user through account setup is an ordinary `run_app_action`/
+`open_screen` job, not a separate onboarding engine: `ONE_IDENTITY_INSTRUCTION`
+in `agent_tree.py` tells One that the welcome screen, sign-in, phone
+verification, the `/one/setup` hub, and the Finance preferences wizard are
+all reachable the same way as any other app surface, and that while someone
+is still finishing setup One should proactively name the next thing they can
+do and ask directly for anything that needs an answer (a wizard question, a
+phone number) instead of only describing it.
+
+Every previously tap-only onboarding control has a governed `action_id` so
+voice has full parity with tapping: `setup.open_finance`/`...gmail`/`...email`/
+`...location`/`...personal_data`/`...consent`/`...connected_systems` (hub
+tiles), `setup.hub_master_ack` (master Skip/Continue), `setup.capability_continue`
+(per-capability Continue), `kai.setup.answer_horizon`/`...answer_drawdown`/
+`...answer_volatility` (wizard questions, each carrying a real spoken
+`goal.required_inputs` prompt) and `kai.setup.launch_dashboard`, plus
+`phone_mandate.submit_number` (`phone_mandate.submit_code` stays
+`manual_only`, security-sensitive). Actions that change in-place component
+state rather than navigating use a fourth `execution_target.path`,
+`local_handler`: the owning component registers a small handler on mount via
+`useLocalOnboardingActionHandler` (`hushh-webapp/lib/agent/local-onboarding-actions.ts`,
+mirrors the `usePublishVoiceSurfaceMetadata` publish/clear lifecycle), and
+`executeAgentGatewayAction` resolves it by `action_id` for the text/chat
+execution path; the voice path already reaches the same client directive
+through `run_app_action`'s existing `{kind: "action"}` parking.
+
+Proactive prompting has two injection points, both in
+`consent-protocol/api/routes/one/adk_live.py` and `hushh_mcp/one_adk/`:
+
+- **Screen change**: the existing silent app-state note (`"...Use this
+  silently."`) upgrades to an explicit ask-a-question instruction whenever
+  the new screen is in `_ONBOARDING_SCREENS` (`getting_started`, `login`,
+  `register_phone`, `one_setup`, `one_setup_hub`, `kai_setup_wizard`); every
+  other screen keeps the original neutral/silent behavior.
+- **Tool result**: there is no separate server-injected system turn after a
+  tool call completes - the tool's own return dict is what the model reads
+  on its next turn. `open_screen` (`agent_tree.py`) and `run_app_action`
+  (`action_tools.py`) both add a `next_step` field to their success returns
+  so One offers a next step after every screen it opens and every governed
+  action it runs, not only after an onboarding-tagged screen change.
+
+Note: the generated gateway's `reachability.screens` is matched against the
+ROUTE-DERIVED screen id sent as `hushh:screen`
+(`deriveVoiceRouteScreen()` in `route-screen-derivation.ts`, e.g. `one_setup`,
+`register_phone`), not the custom `screenId` a component publishes via
+`usePublishVoiceSurfaceMetadata` (e.g. `one_setup_hub`, `kai_setup_wizard`).
+Onboarding contracts list both id sets in `reachability.screens` so
+`list_app_actions`' screen-based ranking still works; direct `run_app_action`
+execution by `action_id` is unaffected either way.
 
 ## Chat Runtime (parity path)
 

--- a/docs/reference/quality/one-onboarding-architecture.md
+++ b/docs/reference/quality/one-onboarding-architecture.md
@@ -228,3 +228,34 @@ gate, and a satisfied One gate never force‑completes a sub‑onboarding.
 6. Persist via `setup_*` / `nav_setup_*` columns and `hushh_setup_*` cookies;
    the KaiProfile blob uses `setup.*` keys (schema_version 3) with read‑compat
    for legacy `onboarding.*` / `nav_tour_*`.
+
+## 6. Voice/UI parity
+
+Every tap‑only control on the pre‑auth and setup surfaces (`/getting-started`
+→ `/login`, `/register-phone`, the `/one/setup` hub, per‑capability steps,
+the Kai preferences wizard) has a matching governed `action_id` in the
+generated gateway (`contracts/kai/kai-action-gateway.vnext.json`), authored
+via colocated `*.voice-action-contract.json` files next to each surface and
+regenerated with `npm run build:voice-gateway`. One's ADK agent tree treats
+guiding a new user through setup as an ordinary `run_app_action`/`open_screen`
+job (see [One Voice Runtime Architecture § Onboarding and Proactive
+Prompting](../one/one-voice-runtime-architecture.md#onboarding-and-proactive-prompting)
+for the full mechanism, including the new `local_handler` execution path for
+in‑place state changes like answering a wizard question).
+
+When adding a new setup screen or control:
+
+1. Author (or extend) a `*.voice-action-contract.json` next to the surface;
+   do not hand‑edit the generated gateway JSON.
+2. If the control is pure navigation, use `execution_target.path: "route"`.
+   If it changes in‑place component state (a radio answer, a form submit,
+   a master ack) with no direct route, use `"local_handler"` and register a
+   handler via `useLocalOnboardingActionHandler`
+   (`hushh-webapp/lib/agent/local-onboarding-actions.ts`).
+3. Set `reachability.screens` to BOTH the route‑derived screen id
+   (`deriveVoiceRouteScreen()` in `route-screen-derivation.ts`) and any
+   custom `screenId` the surface publishes via `usePublishVoiceSurfaceMetadata`
+   - the wire value sent to the backend as `hushh:screen` is always the
+   route‑derived one.
+4. Regenerate and verify: `npm run build:voice-gateway && npm run
+   verify:voice-gateway`.

--- a/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
@@ -131,6 +131,12 @@ vi.mock("@/lib/services/consent-center-service", () => ({
     getSummary: mocks.getSummary,
     listEntries: mocks.listEntries,
     lookupPendingRequests: mocks.lookupPendingRequests,
+    // Only ever called by HandshakeTimeline, which must NOT render for
+    // active_grant entries (see the "does not render a Consent timeline"
+    // regression test below). Left unmocked-but-present so an accidental
+    // regression that renders it fails loudly instead of throwing on an
+    // undefined method.
+    getHandshakeHistory: vi.fn().mockResolvedValue({ timeline: [] }),
   },
 }));
 
@@ -494,6 +500,48 @@ describe("ConsentCenterPage requestId deep links", () => {
     expect(row.className).not.toContain("border-accent-border");
   });
 
+  it("does not render a duplicate Consent timeline / history trail for an active_grant entry", async () => {
+    // Bug: Active Access shows a single live grant, but its detail panel
+    // also rendered the full HandshakeTimeline ("Consent timeline") with
+    // every historical grant/request/revoke event for that counterpart -
+    // an unrelated, duplicate history trail attached to a currently active
+    // item. That trail belongs on the History tab only.
+    mocks.search = "tab=active&requestId=req_active_1";
+    mocks.getSummary.mockResolvedValue({
+      ...summaryResponse(),
+      counts: { pending: 0, active: 1, previous: 0 },
+    });
+    mocks.listEntries.mockResolvedValue({
+      ...emptyListResponse(),
+      surface: "active",
+      total: 1,
+      items: [
+        {
+          id: "grant_active_1",
+          request_id: "req_active_1",
+          kind: "active_grant",
+          status: "active",
+          action: "CONSENT_GRANTED",
+          counterpart_type: "developer",
+          counterpart_id: "developer:app_kushaltrivedi",
+          counterpart_label: "Kushal Trivedi",
+          counterpart_email: "kushaltrivedi1711@gmail.com",
+          scope: "attr.financial.*",
+          issued_at: "2026-07-09T19:26:29.000Z",
+          expires_at: "2026-07-10T19:26:29.000Z",
+        },
+      ],
+    });
+
+    render(<ConsentCenterPage />);
+
+    expect(await screen.findByRole("dialog", { name: "Kushal Trivedi" })).toBeTruthy();
+    expect(screen.queryByText("Consent timeline")).toBeNull();
+    expect(
+      screen.queryByText("Full history of consent changes with this connection."),
+    ).toBeNull();
+  });
+
   it("keeps stale actor=ria links on the One lane unless the URL is the advisor outgoing route", async () => {
     mocks.search = "tab=pending&actor=ria";
 
@@ -550,6 +598,51 @@ describe("ConsentCenterPage requestId deep links", () => {
         expect.objectContaining({ force: true }),
       );
     });
+  });
+
+  it("does not force-refresh (and flicker) the list on a non-mutation consent-state-changed event", async () => {
+    // Regression: selecting any Requests/Active row calls
+    // acknowledgePendingConsent() (notification-provider.tsx), which POSTs
+    // /api/consent/pending/opened. The backend inserts a NOTIFICATION_OPENED
+    // audit event for still-pending rows, which echoes back to the same
+    // client as an "fcm_opened" consent-state-changed event carrying no
+    // `action`. The list-refresh listener used to force-refresh on ANY
+    // consent-state-changed event regardless of payload, so merely opening a
+    // request's detail panel made the whole list visibly flash "Refreshing
+    // consent state...". History rows are already resolved and never
+    // trigger that backend echo, which is why only Requests/Active flickered.
+    // Non-action bookkeeping events (fcm_opened, queued_pending,
+    // cached_pending, hydrated_pending, etc.) must NOT force a refresh.
+    // Counts must match the (empty) list so the unrelated list/count
+    // mismatch auto-retry effect does not also fire a background refresh
+    // and pollute this assertion.
+    mocks.getSummary.mockResolvedValue({
+      ...summaryResponse(),
+      counts: { pending: 0, active: 0, previous: 0 },
+    });
+    render(<ConsentCenterPage />);
+
+    await waitFor(() => {
+      expect(mocks.listEntries).toHaveBeenCalled();
+    });
+
+    const listCallsBefore = mocks.listEntries.mock.calls.length;
+    const summaryCallsBefore = mocks.getSummary.mock.calls.length;
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("consent-state-changed", {
+          detail: { source: "fcm_opened", requestId: "req_deep" },
+        }),
+      );
+    });
+
+    // Give any (incorrect) async refresh a chance to fire before asserting
+    // it did not.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.listEntries.mock.calls.length).toBe(listCallsBefore);
+    expect(mocks.getSummary.mock.calls.length).toBe(summaryCallsBefore);
   });
 
   it("keeps grouped history lifecycles out of the history list row", async () => {

--- a/hushh-webapp/__tests__/voice/voice-action-manifest.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-action-manifest.test.ts
@@ -56,6 +56,15 @@ function projectExecutionHint(action: InvestorKaiActionDefinition) {
     };
   }
 
+  if (binding.kind === "local_handler") {
+    return {
+      status: "wired" as const,
+      path: "local_handler" as const,
+      target: binding.actionId,
+      ...(binding.params ? { params: binding.params } : {}),
+    };
+  }
+
   return {
     status: "wired" as const,
     path: "route" as const,

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -983,6 +983,63 @@ html.native-ios {
   }
 }
 
+/* Per-connector traveling highlight for the 14a onboarding timeline (single
+ * gold tone, one short segment per icon pair, unlike the older tri-tone
+ * absolutely-positioned .intro-feature-rail which spanned the whole list).
+ * A bright pulse travels down each connector once on mount, then the
+ * connector settles back to its static faded-gold gradient. */
+.intro-feature-connector {
+  position: relative;
+  overflow: hidden;
+}
+
+.intro-feature-connector::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  /* Deep gold in light mode: the light cream used in dark mode reads as
+     near-white and disappears against the white sheet background here. */
+  background: linear-gradient(
+    180deg,
+    transparent,
+    #9c7434 45%,
+    transparent 90%
+  );
+  transform: translateY(-100%);
+  animation: intro-feature-connector-scan 1100ms var(--motion-ease-emphasized)
+    calc(var(--intro-feature-delay, 0ms) + 260ms) both;
+}
+
+.dark .intro-feature-connector::after {
+  background: linear-gradient(
+    180deg,
+    transparent,
+    #f4ead6 45%,
+    transparent 90%
+  );
+}
+
+@keyframes intro-feature-connector-scan {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  to {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .intro-feature-connector::after {
+    animation: none;
+    opacity: 0;
+  }
+}
+
 /* Hussh Brand Text */
 .text-hushh-brand {
   background: linear-gradient(135deg, #b8894d 0%, #d4a574 100%);

--- a/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx
+++ b/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
 import { OnboardingCapabilityStep } from "@/components/onboarding/setup/onboarding-capability-step";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { useVault } from "@/lib/vault/vault-context";
 import { getOneCapability } from "@/lib/onboarding/one-capabilities";
@@ -96,16 +97,7 @@ export function OneOnboardingCapabilityClient({
     }
   }, [capability, router]);
 
-  if (!capability) {
-    return <HushhLoader label="Opening…" />;
-  }
-
-  const handleBack = () => {
-    router.replace(ROUTES.ONE_SETUP);
-  };
-
-  const handlePrimary = () => {
-    if (busy) return;
+  const runPrimary = async () => {
     const userId = user?.uid ?? null;
 
     // Auth/lock guards own the unauthenticated path; if we somehow have no user,
@@ -117,40 +109,65 @@ export function OneOnboardingCapabilityClient({
 
     setBusy(true);
 
-    void (async () => {
-      try {
-        // Mark this visit as "seen" so the hub no longer treats it as a fresh,
-        // never-opened tile, and record the explore signal for explore-only
-        // capabilities.
-        OneSetupGateService.markSeen(userId);
+    try {
+      // Mark this visit as "seen" so the hub no longer treats it as a fresh,
+      // never-opened tile, and record the explore signal for explore-only
+      // capabilities.
+      OneSetupGateService.markSeen(userId);
 
-        if (capability?.isExploreOnly === true) {
-          await CapabilityTourService.markExplored(userId, capabilityId).catch(
-            () => undefined,
-          );
-          const explored = await CapabilityTourService.loadExploredIds(userId);
-          void PreVaultUserStateService.syncSetupCapabilities(userId, [
-            ...explored,
-          ]).catch(() => undefined);
-        }
-
-        // NOTE: we intentionally do NOT resolve the account-wide master setup
-        // gate here. Forwarding into a hard-gated `/one/*` surface is handled by
-        // the `?from=setup` marker on `target` (which `OneOnboardingGuard`
-        // allows through) — see the component doc comment. Marking
-        // `setupCompleted = true` on capability entry was the cause of the
-        // dashboard "Finish setup" bar clearing prematurely.
-      } catch (resolveError) {
-        console.warn(
-          "[OneOnboardingCapabilityClient] Failed to record capability signal:",
-          resolveError,
+      if (capability?.isExploreOnly === true) {
+        await CapabilityTourService.markExplored(userId, capabilityId).catch(
+          () => undefined,
         );
-        // Fail-open: still forward so the user is never stranded.
-      } finally {
-        router.replace(target);
-
+        const explored = await CapabilityTourService.loadExploredIds(userId);
+        void PreVaultUserStateService.syncSetupCapabilities(userId, [
+          ...explored,
+        ]).catch(() => undefined);
       }
-    })();
+
+      // NOTE: we intentionally do NOT resolve the account-wide master setup
+      // gate here. Forwarding into a hard-gated `/one/*` surface is handled by
+      // the `?from=setup` marker on `target` (which `OneOnboardingGuard`
+      // allows through) — see the component doc comment. Marking
+      // `setupCompleted = true` on capability entry was the cause of the
+      // dashboard "Finish setup" bar clearing prematurely.
+    } catch (resolveError) {
+      console.warn(
+        "[OneOnboardingCapabilityClient] Failed to record capability signal:",
+        resolveError,
+      );
+      // Fail-open: still forward so the user is never stranded.
+    } finally {
+      router.replace(target);
+    }
+  };
+
+  // Voice parity: "continue" / "got it" on this step drives the exact same
+  // forwarding logic as tapping the Continue/Unlock/Got it button. Registered
+  // before the `!capability` early return below to satisfy Rules of Hooks
+  // (this hook must run unconditionally on every render of this component).
+  useLocalOnboardingActionHandler("setup.capability_continue", async () => {
+    if (!capability) {
+      return { status: "blocked", summary: "This setup step isn't open yet." };
+    }
+    if (busy) {
+      return { status: "blocked", summary: "Already continuing, one moment." };
+    }
+    await runPrimary();
+    return { status: "succeeded", summary: `Continuing from ${capability.title} setup.` };
+  });
+
+  if (!capability) {
+    return <HushhLoader label="Opening…" />;
+  }
+
+  const handleBack = () => {
+    router.replace(ROUTES.ONE_SETUP);
+  };
+
+  const handlePrimary = () => {
+    if (busy) return;
+    void runPrimary();
   };
 
   return (

--- a/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json
+++ b/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json
@@ -29,7 +29,8 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
-          "one_setup_connected-systems"
+          "one_setup_connected-systems",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []

--- a/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json
+++ b/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "one_setup_capability_step",
+  "surface_title": "One Setup Capability Step",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md",
+    "docs/reference/quality/one-onboarding-architecture.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": ["investor", "ria"]
+    },
+    "speaker_persona": "one",
+    "guard_ids": ["auth_signed_in"]
+  },
+  "actions": [
+    {
+      "action_id": "setup.capability_continue",
+      "label": "Continue Capability Setup",
+      "meaning": "Advances past the current capability setup step to its next destination (workspace, wizard, or explore acknowledgement). Applies to whichever capability route is currently open.",
+      "aliases": ["continue", "unlock and continue", "got it", "next"],
+      "search_keywords": ["continue", "next", "got it", "unlock"],
+      "reachability": {
+        "routes": ["/one/setup/finance", "/one/setup/gmail", "/one/setup/email", "/one/setup/location", "/one/setup/pkm", "/one/setup/consent", "/one/setup/connected-systems"],
+        "screens": [
+          "one_setup_finance",
+          "one_setup_gmail",
+          "one_setup_email",
+          "one_setup_location",
+          "one_setup_pkm",
+          "one_setup_consent",
+          "one_setup_connected-systems"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.capability_continue"
+      },
+      "control_ids": ["one_setup_capability_primary"],
+      "state_exposure": ["capability seen/explored signal"],
+      "docs_references": [
+        "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx"
+      ]
+    }
+  ]
+}

--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -10,6 +10,7 @@ import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import { KaiPersonaScreen } from "@/components/kai/onboarding/KaiPersonaScreen";
 import { KaiPreferencesWizard } from "@/components/kai/onboarding/KaiPreferencesWizard";
 import { KaiInviteHandshake } from "@/components/kai/onboarding/kai-invite-handshake";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import {
   KaiProfileService,
   computeRiskScore,
@@ -302,6 +303,104 @@ function KaiOnboardingPageContent() {
     });
   }, [source, stage]);
 
+  const handleLaunchDashboard = async () => {
+    if (saving || !user) return;
+
+    try {
+      setSaving(true);
+      const riskScore = computeRiskScore(wizardAnswers as PreVaultOnboardingAnswers);
+
+      if (source === "vault") {
+        if (!vaultKey || !vaultOwnerToken) {
+          toast.error("Unlock your vault to continue.");
+          return;
+        }
+        const nextProfile = await KaiProfileService.setOnboardingCompleted({
+          userId: user.uid,
+          vaultKey,
+          vaultOwnerToken,
+          skippedPreferences: false,
+        });
+        // Await the server pre-vault sync BEFORE navigating (same rationale
+        // as the skip path) so the One gate is authoritative server-side the
+        // instant the user leaves onboarding. Error-swallowed to stay
+        // fail-open; vault profile remains the unlocked-path source.
+        await PreVaultUserStateService.syncKaiSetupState({
+          userId: user.uid,
+          completed: true,
+          skipped: false,
+          completedAt: nextProfile.setup.completed_at,
+        }).catch((syncError) => {
+          console.warn(
+            "[OneOnboardingPage] Failed vault->remote onboarding bridge after completion:",
+            syncError
+          );
+        });
+        setProfile(nextProfile);
+      } else {
+        const completedAt = Date.now();
+        await PreVaultUserStateService.updatePreVaultState(user.uid, {
+          setupCompleted: true,
+          setupSkipped: false,
+          setupCompletedAt: completedAt,
+        });
+        await PreVaultOnboardingService.markCompleted(user.uid, {
+          skipped: false,
+          answers: wizardAnswers,
+          risk_score: riskScore,
+          risk_profile: persona,
+        }).catch(() => null);
+        setPreVaultState((current) => {
+          if (!current) return current;
+          return {
+            ...current,
+            completed: true,
+            skipped: false,
+          };
+        });
+      }
+
+      toast.success("Preferences saved. Next step: connect your portfolio or Plaid.");
+      setOnboardingRequiredCookie(false);
+      setOnboardingFlowActiveCookie(true);
+      trackEvent("onboarding_completed", {
+        action: "complete",
+        result: "success",
+      });
+      trackGrowthFunnelStepCompleted({
+        journey: "investor",
+        step: "onboarding_completed",
+        dedupeKey: "growth:investor:onboarding_completed:complete",
+        dedupeWindowMs: 5_000,
+      });
+      router.replace(buildRouteWithFrom(ROUTES.KAI_IMPORT, onboardingSelfHref));
+    } catch (error) {
+      console.error("[OneOnboardingPage] Failed to finalize onboarding:", error);
+      trackEvent("onboarding_completed", {
+        action: "complete",
+        result: "error",
+      });
+      toast.error("Couldn't complete onboarding. Please retry.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Voice parity: "launch my dashboard" drives the exact same completion
+  // flow as tapping the persona screen's Launch dashboard button. Registered
+  // unconditionally (not just while stage === "persona") to satisfy Rules of
+  // Hooks; the handler itself is a no-op unless a user session exists.
+  useLocalOnboardingActionHandler("kai.setup.launch_dashboard", async () => {
+    if (!user) {
+      return { status: "blocked", summary: "Sign in to finish Kai setup." };
+    }
+    if (stage !== "persona") {
+      return { status: "blocked", summary: "Answer all three questions first." };
+    }
+    await handleLaunchDashboard();
+    return { status: "succeeded", summary: "Kai setup complete. Opening portfolio import." };
+  });
+
   if (authLoading) {
     return (
       <SetupKaiStageRegion>
@@ -409,88 +508,7 @@ function KaiOnboardingPageContent() {
         <KaiPersonaScreen
           riskProfile={persona}
           onEditAnswers={() => setStage("wizard")}
-          onLaunchDashboard={async () => {
-          if (saving) return;
-
-          try {
-            setSaving(true);
-            const riskScore = computeRiskScore(wizardAnswers as PreVaultOnboardingAnswers);
-
-            if (source === "vault") {
-              if (!vaultKey || !vaultOwnerToken) {
-                toast.error("Unlock your vault to continue.");
-                return;
-              }
-              const nextProfile = await KaiProfileService.setOnboardingCompleted({
-                userId: user.uid,
-                vaultKey,
-                vaultOwnerToken,
-                skippedPreferences: false,
-              });
-              // Await the server pre-vault sync BEFORE navigating (same rationale
-              // as the skip path) so the One gate is authoritative server-side the
-              // instant the user leaves onboarding. Error-swallowed to stay
-              // fail-open; vault profile remains the unlocked-path source.
-              await PreVaultUserStateService.syncKaiSetupState({
-                userId: user.uid,
-                completed: true,
-                skipped: false,
-                completedAt: nextProfile.setup.completed_at,
-              }).catch((syncError) => {
-                console.warn(
-                  "[OneOnboardingPage] Failed vault->remote onboarding bridge after completion:",
-                  syncError
-                );
-              });
-              setProfile(nextProfile);
-            } else {
-              const completedAt = Date.now();
-              await PreVaultUserStateService.updatePreVaultState(user.uid, {
-                setupCompleted: true,
-                setupSkipped: false,
-                setupCompletedAt: completedAt,
-              });
-              await PreVaultOnboardingService.markCompleted(user.uid, {
-                skipped: false,
-                answers: wizardAnswers,
-                risk_score: riskScore,
-                risk_profile: persona,
-              }).catch(() => null);
-              setPreVaultState((current) => {
-                if (!current) return current;
-                return {
-                  ...current,
-                  completed: true,
-                  skipped: false,
-                };
-              });
-            }
-
-            toast.success("Preferences saved. Next step: connect your portfolio or Plaid.");
-            setOnboardingRequiredCookie(false);
-            setOnboardingFlowActiveCookie(true);
-            trackEvent("onboarding_completed", {
-              action: "complete",
-              result: "success",
-            });
-            trackGrowthFunnelStepCompleted({
-              journey: "investor",
-              step: "onboarding_completed",
-              dedupeKey: "growth:investor:onboarding_completed:complete",
-              dedupeWindowMs: 5_000,
-            });
-            router.replace(buildRouteWithFrom(ROUTES.KAI_IMPORT, onboardingSelfHref));
-          } catch (error) {
-            console.error("[OneOnboardingPage] Failed to finalize onboarding:", error);
-            trackEvent("onboarding_completed", {
-              action: "complete",
-              result: "error",
-            });
-            toast.error("Couldn't complete onboarding. Please retry.");
-          } finally {
-            setSaving(false);
-          }
-          }}
+          onLaunchDashboard={handleLaunchDashboard}
         />
       </>
     );

--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -11,6 +11,7 @@ import { KaiPersonaScreen } from "@/components/kai/onboarding/KaiPersonaScreen";
 import { KaiPreferencesWizard } from "@/components/kai/onboarding/KaiPreferencesWizard";
 import { KaiInviteHandshake } from "@/components/kai/onboarding/kai-invite-handshake";
 import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import {
   KaiProfileService,
   computeRiskScore,
@@ -400,6 +401,53 @@ function KaiOnboardingPageContent() {
     await handleLaunchDashboard();
     return { status: "succeeded", summary: "Kai setup complete. Opening portfolio import." };
   });
+
+  // Publish the screen id the generated action contract expects
+  // (kai_setup_wizard) so voice grounding and reachability checks resolve
+  // against the same screen the wizard/persona actions declare, overriding
+  // the route-derived default of "one_setup" for this sub-route.
+  usePublishVoiceSurfaceMetadata(
+    stage === "wizard" || stage === "persona"
+      ? {
+          screenId: "kai_setup_wizard",
+          title: "Kai investor preferences",
+          purpose:
+            stage === "wizard"
+              ? "Three quick questions tune Kai to your investing style."
+              : "Review your computed investor persona and launch the dashboard.",
+          actions:
+            stage === "wizard"
+              ? [
+                  {
+                    id: "answer_horizon",
+                    actionId: "kai.setup.answer_horizon",
+                    label: "Investment horizon",
+                    purpose: "Answer how long you expect to stay invested.",
+                  },
+                  {
+                    id: "answer_drawdown",
+                    actionId: "kai.setup.answer_drawdown",
+                    label: "Drawdown response",
+                    purpose: "Answer how you'd react to a 20 percent drop.",
+                  },
+                  {
+                    id: "answer_volatility",
+                    actionId: "kai.setup.answer_volatility",
+                    label: "Volatility preference",
+                    purpose: "Answer how much volatility feels comfortable.",
+                  },
+                ]
+              : [
+                  {
+                    id: "launch_dashboard",
+                    actionId: "kai.setup.launch_dashboard",
+                    label: "Launch dashboard",
+                    purpose: "Confirm the persona and open portfolio import.",
+                  },
+                ],
+        }
+      : null
+  );
 
   if (authLoading) {
     return (

--- a/hushh-webapp/app/one/setup/kai/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/setup/kai/page.voice-action-contract.json
@@ -22,7 +22,7 @@
       "search_keywords": ["horizon", "how long", "invested"],
       "reachability": {
         "routes": ["/one/setup/kai"],
-        "screens": ["kai_setup_wizard"],
+        "screens": ["kai_setup_wizard", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -57,7 +57,7 @@
       "search_keywords": ["drawdown", "drop", "reaction"],
       "reachability": {
         "routes": ["/one/setup/kai"],
-        "screens": ["kai_setup_wizard"],
+        "screens": ["kai_setup_wizard", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": ["Investment horizon must already be answered."]
       },
@@ -92,7 +92,7 @@
       "search_keywords": ["volatility", "comfort", "swings"],
       "reachability": {
         "routes": ["/one/setup/kai"],
-        "screens": ["kai_setup_wizard"],
+        "screens": ["kai_setup_wizard", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": ["Drawdown response must already be answered."]
       },
@@ -127,7 +127,7 @@
       "search_keywords": ["launch", "dashboard", "finish", "persona"],
       "reachability": {
         "routes": ["/one/setup/kai"],
-        "screens": ["kai_setup_wizard"],
+        "screens": ["kai_setup_wizard", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": ["All three preference questions must be answered."]
       },

--- a/hushh-webapp/app/one/setup/kai/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/setup/kai/page.voice-action-contract.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "kai_setup_wizard",
+  "surface_title": "Kai Investor Preferences Wizard",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md",
+    "docs/reference/quality/one-onboarding-architecture.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": ["investor"]
+    },
+    "speaker_persona": "kai",
+    "guard_ids": ["auth_signed_in"]
+  },
+  "actions": [
+    {
+      "action_id": "kai.setup.answer_horizon",
+      "label": "Answer Investment Horizon",
+      "meaning": "Answers the investment horizon question in the Kai preferences wizard.",
+      "aliases": ["less than 3 years", "3 to 7 years", "more than 7 years"],
+      "search_keywords": ["horizon", "how long", "invested"],
+      "reachability": {
+        "routes": ["/one/setup/kai"],
+        "screens": ["kai_setup_wizard"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_horizon"
+      },
+      "control_ids": ["kai_wizard_investment_horizon"],
+      "state_exposure": ["current wizard step"],
+      "docs_references": ["hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"],
+      "goal": {
+        "required_inputs": [
+          {
+            "name": "investment_horizon",
+            "prompt": "How long do you expect to keep this money invested: less than 3 years, 3 to 7 years, or more than 7 years?",
+            "required": true,
+            "slot": "answer",
+            "options": ["short_term", "medium_term", "long_term"]
+          }
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_drawdown",
+      "label": "Answer Drawdown Response",
+      "meaning": "Answers the portfolio-drawdown-reaction question in the Kai preferences wizard.",
+      "aliases": ["reduce investments", "stay invested", "buy more"],
+      "search_keywords": ["drawdown", "drop", "reaction"],
+      "reachability": {
+        "routes": ["/one/setup/kai"],
+        "screens": ["kai_setup_wizard"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": ["Investment horizon must already be answered."]
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_drawdown"
+      },
+      "control_ids": ["kai_wizard_drawdown_response"],
+      "state_exposure": ["current wizard step"],
+      "docs_references": ["hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"],
+      "goal": {
+        "required_inputs": [
+          {
+            "name": "drawdown_response",
+            "prompt": "If your portfolio drops 20 percent, would you reduce investments, stay invested, or buy more?",
+            "required": true,
+            "slot": "answer",
+            "options": ["reduce", "stay", "buy_more"]
+          }
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_volatility",
+      "label": "Answer Volatility Preference",
+      "meaning": "Answers the volatility-comfort question in the Kai preferences wizard.",
+      "aliases": ["smaller steadier returns", "moderate ups and downs", "larger swings"],
+      "search_keywords": ["volatility", "comfort", "swings"],
+      "reachability": {
+        "routes": ["/one/setup/kai"],
+        "screens": ["kai_setup_wizard"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": ["Drawdown response must already be answered."]
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_volatility"
+      },
+      "control_ids": ["kai_wizard_volatility_preference"],
+      "state_exposure": ["current wizard step"],
+      "docs_references": ["hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"],
+      "goal": {
+        "required_inputs": [
+          {
+            "name": "volatility_preference",
+            "prompt": "Which feels more comfortable: smaller steadier returns, moderate ups and downs, or larger swings for higher potential returns?",
+            "required": true,
+            "slot": "answer",
+            "options": ["small", "moderate", "large"]
+          }
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.launch_dashboard",
+      "label": "Launch Kai Dashboard",
+      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "aliases": ["launch my dashboard", "looks good, continue", "finish kai setup"],
+      "search_keywords": ["launch", "dashboard", "finish", "persona"],
+      "reachability": {
+        "routes": ["/one/setup/kai"],
+        "screens": ["kai_setup_wizard"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": ["All three preference questions must be answered."]
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.launch_dashboard"
+      },
+      "control_ids": ["kai_wizard_launch_dashboard"],
+      "state_exposure": ["computed risk profile"],
+      "docs_references": ["hushh-webapp/app/one/setup/kai/page.tsx"]
+    }
+  ]
+}

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/services/onboarding-route-cookie";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-mandate-service";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
 function requiresVaultUnlockForRedirect(path?: string | null): boolean {
   const normalizedPath = String(path ?? "").trim();
@@ -119,6 +120,24 @@ function PhoneMandatePageContent() {
     }
     void continueToNextRoute(user);
   }, [continueToNextRoute, shouldBypassLocalPhoneMandate, user]);
+
+  usePublishVoiceSurfaceMetadata(
+    !loading && user && !shouldBypassLocalPhoneMandate
+      ? {
+          screenId: "phone_mandate",
+          title: "Verify your phone",
+          purpose:
+            "Adding a phone number keeps your account recoverable and secure before setup continues.",
+          actions: [
+            {
+              id: "phone_mandate.submit_number",
+              label: "Submit phone number",
+              purpose: "Send a verification code to the phone number you say.",
+            },
+          ],
+        }
+      : null
+  );
 
   if (loading || !user) {
     return <HushhLoader label="Loading phone verification..." variant="fullscreen" />;

--- a/hushh-webapp/app/register-phone/page.voice-action-contract.json
+++ b/hushh-webapp/app/register-phone/page.voice-action-contract.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "phone_mandate",
+  "surface_title": "Phone Verification",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md",
+    "docs/reference/quality/one-onboarding-architecture.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": ["investor", "ria"]
+    },
+    "speaker_persona": "one",
+    "guard_ids": ["auth_signed_in"]
+  },
+  "actions": [
+    {
+      "action_id": "phone_mandate.submit_number",
+      "label": "Submit Phone Number",
+      "meaning": "Sends a verification code to the phone number the user says.",
+      "aliases": [
+        "verify my phone",
+        "send me a code",
+        "my phone number is",
+        "add my phone number"
+      ],
+      "search_keywords": ["phone", "verify", "code", "sms"],
+      "reachability": {
+        "routes": ["/register-phone"],
+        "screens": ["phone_mandate"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "medium",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_number"
+      },
+      "control_ids": ["phone-flow-number"],
+      "state_exposure": ["masked phone number"],
+      "docs_references": ["hushh-webapp/components/auth/phone-verification-flow.tsx"],
+      "goal": {
+        "required_inputs": [
+          {
+            "name": "phone_number",
+            "prompt": "What's your phone number, including country code?",
+            "required": true,
+            "slot": "phoneNumber"
+          }
+        ]
+      }
+    },
+    {
+      "action_id": "phone_mandate.submit_code",
+      "label": "Submit Verification Code",
+      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "aliases": [
+        "the code is",
+        "verify my code",
+        "confirm my phone",
+        "submit the verification code"
+      ],
+      "search_keywords": ["code", "otp", "verify", "confirm"],
+      "reachability": {
+        "routes": ["/register-phone"],
+        "screens": ["phone_mandate"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": ["A verification code must already be sent."]
+      },
+      "guard_ids": ["auth_signed_in", "manual_user_execution"],
+      "risk_level": "high",
+      "execution_policy": "manual_only",
+      "execution_target": {
+        "status": "unwired",
+        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
+        "intended_handler": "local_handler"
+      },
+      "control_ids": ["phone-flow-code"],
+      "state_exposure": ["verification step"],
+      "docs_references": ["hushh-webapp/components/auth/phone-verification-flow.tsx"]
+    }
+  ]
+}

--- a/hushh-webapp/app/register-phone/page.voice-action-contract.json
+++ b/hushh-webapp/app/register-phone/page.voice-action-contract.json
@@ -27,7 +27,7 @@
       "search_keywords": ["phone", "verify", "code", "sms"],
       "reachability": {
         "routes": ["/register-phone"],
-        "screens": ["phone_mandate"],
+        "screens": ["phone_mandate", "register_phone"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -66,7 +66,7 @@
       "search_keywords": ["code", "otp", "verify", "confirm"],
       "reachability": {
         "routes": ["/register-phone"],
-        "screens": ["phone_mandate"],
+        "screens": ["phone_mandate", "register_phone"],
         "hidden_navigable": false,
         "navigation_prerequisites": ["A verification code must already be sent."]
       },

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -20,7 +20,7 @@ import React, {
   type MouseEvent,
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { AudioLines, X } from "lucide-react";
+import { AudioLines, MessageSquare, X } from "lucide-react";
 
 import { useOptionalAgentPopover } from "@/components/agent/agent-popover-provider";
 import { AgentVoiceWaveform } from "@/components/agent/agent-voice-waveform";
@@ -543,24 +543,48 @@ export function AgentBar() {
   //
   // The agent bar rides most surfaces, degrading gracefully by auth/vault level
   // (locked-vault users get an in-place unlock prompt; unlocked users get the
-  // full agent). EXCEPTION — the LOGGED-OUT welcome ("/"): an agent input has no
-  // meaning before sign-in and read as a confusing "backdoor" pinned under the
-  // CTA, so we unmount it there (signed-in users are redirected off "/", so the
-  // bar still shows on /one and every authed surface). We also unmount where an
-  // agent launcher genuinely must not exist (legacy dedicated agent route, phone
-  // mandate, appearance lab, developers) or on transient auth transitions
-  // (login, logout) where the app shell is not the host.
+  // full agent). We also unmount where an agent launcher genuinely must not
+  // exist (legacy dedicated agent route, phone mandate, appearance lab,
+  // developers) or on transient auth transitions (login, logout) where the
+  // app shell is not the host.
   const path = pathname ?? "";
   // The waveform action circle is white only on the 2c dark dashboard (where a
   // white circle pops); on every other surface (welcome, profile, kai, …) it is
   // the indigo accent, per design.md §5.5.
   const onDashboard = path === ROUTES.ONE_HOME || path === `${ROUTES.ONE_HOME}/`;
+  // The logged-out welcome ("/") now hosts the dogfooding onboarding voice
+  // greeter instead of unmounting the bar outright: it doubles as the
+  // pre-auth conversation starter and stays route-aware for whatever the
+  // signed-out flow visits next.
+  const onboardingGreeterMode = isHomeRoute && runtime?.tier === "anon_onboarding";
+
+  // Signed-out dogfooding: greet the person the moment the onboarding welcome
+  // ("/") loads, instead of waiting for a tap. This reuses the exact same
+  // startConversation() path as the manual mic button - same relay ticket,
+  // same ADK live session, same server-composed proactive greeting already
+  // documented in docs/reference/one/one-voice-runtime-architecture.md - so
+  // there is no new greeting mechanism, just an earlier call site. Guarded to
+  // fire once per mount and only for the anon_onboarding welcome tier. Must
+  // run before the unmountBar early return below (hooks cannot follow a
+  // conditional return).
+  const autoGreetedRef = useRef(false);
+  useEffect(() => {
+    if (!onboardingGreeterMode) {
+      autoGreetedRef.current = false;
+      return;
+    }
+    if (autoGreetedRef.current) return;
+    if (conversationActive || liveClientRef.current || erroredRef.current) return;
+    autoGreetedRef.current = true;
+    startConversation();
+    // Intentionally excludes startConversation/conversationActive from deps:
+    // this must fire exactly once per onboarding mount, not re-run whenever
+    // those identities change (they change on every voice status transition).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onboardingGreeterMode]);
+
   const unmountBar =
     !agentPopover ||
-    // Logged-out welcome ("/"): no agent before sign-in. On "/" an anonymous
-    // user is always the `anon_onboarding` tier; signed-in users are redirected
-    // off "/", so the bar still shows on /one and every authed surface.
-    (isHomeRoute && runtime?.tier === "anon_onboarding") ||
     // The One setup surface is a focused onboarding flow (like Apple's "Finish
     // Setting Up" in Settings): a centered translucent agent launcher reads
     // over the wide grouped-list rows on scroll (they show through it / beside
@@ -703,6 +727,52 @@ export function AgentBar() {
               )}
             >
               <X className="h-4 w-4" />
+            </button>
+          </>
+        ) : onboardingGreeterMode ? (
+          // Signed-out welcome ("/"): the bar itself IS the conversation
+          // starter (not a text hint that opens chat). Left = mic icon
+          // marker, whole body is the tap target, right = chat toggle that
+          // stays visually present but disabled - chat needs a signed-in,
+          // vault-capable session, which does not exist pre-auth.
+          <>
+            <button
+              type="button"
+              data-native-voice-control-id="one_voice_agent_bar_start"
+              data-testid="one-voice-agent-bar-start-icon"
+              onClick={handleVoiceStartClick}
+              aria-label="Start conversation with One"
+              title="Start conversation"
+              className={cn(
+                "flex min-w-0 flex-1 items-center gap-2.5 rounded-full pl-1 text-left",
+                "transition-colors duration-200 active:scale-[0.99]",
+              )}
+            >
+              <span
+                className={cn(
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+                  "bg-black/[0.05] text-accent-strong ring-1 ring-black/[0.04] dark:bg-white/[0.07] dark:ring-white/[0.08]",
+                )}
+              >
+                <AudioLines className="h-[16px] w-[16px]" />
+              </span>
+              <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-muted-foreground">
+                Talk to One
+              </span>
+            </button>
+            <button
+              type="button"
+              disabled
+              aria-disabled="true"
+              aria-label="Chat is available after you sign in"
+              title="Chat is available after you sign in"
+              className={cn(
+                "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+                "bg-black/[0.05] text-muted-foreground/50 ring-1 ring-black/[0.04] dark:bg-white/[0.07] dark:ring-white/[0.08]",
+                "cursor-not-allowed opacity-60",
+              )}
+            >
+              <MessageSquare className="h-[18px] w-[18px]" />
             </button>
           </>
         ) : (

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -55,6 +55,15 @@ type PrewarmedGeminiRelay = {
   accessTier: string;
 };
 
+// Precaution: if a live voice session sits idle (no user speech, no agent
+// speech, no tool/navigation activity) this long, close it automatically
+// instead of leaving an open mic/session hanging indefinitely. Mirrors the
+// idle-timeout pattern already used for the streamed voice turn watchdog in
+// `agent-chat-workspace.tsx` (`VOICE_AGENT_IDLE_TIMEOUT_MS`), but scoped to
+// the full ambient session rather than a single streamed turn since Gemini
+// Live has no per-turn stream to watch.
+const AGENT_BAR_VOICE_IDLE_TIMEOUT_MS = 90_000;
+
 // Screen-aware hint copy. First matching prefix wins, so order longest/most
 // specific routes before their parents. Falls back to a generic prompt.
 const AGENT_BAR_HINTS: ReadonlyArray<{ prefix: string; hint: string }> = [
@@ -115,6 +124,11 @@ export function AgentBar() {
   const liveClientRef = useRef<RealtimeVoiceTransport | null>(null);
   const lastTranscriptRef = useRef<{ text: string; atMs: number } | null>(null);
   const prewarmedRelayRef = useRef<PrewarmedGeminiRelay | null>(null);
+  // Idle-close precaution: any live-session activity (speech, thinking, tool
+  // results, navigation) reschedules this timer; if it ever fires, the
+  // session has been silent for AGENT_BAR_VOICE_IDLE_TIMEOUT_MS and is closed
+  // automatically so an ambient/onboarding session never lingers open.
+  const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Last SCREEN pushed into the live session. Deduping on snapshot_id was a
   // bug: snapshot_id churns with every voice state transition (voiceRevision
   // = transitionSeq), so each listening/speaking flip re-pushed app_context,
@@ -124,8 +138,42 @@ export function AgentBar() {
   // Tracks whether the active session ended with an error, so the bar can keep
   // showing the error status (instead of snapping shut) until it is dismissed.
   const erroredRef = useRef(false);
+  // Ref indirection lets the idle-timer callback always call the CURRENT
+  // stopConversation without needing it in handleTransportEvent's deps
+  // (stopConversation is declared further down, after handleTransportEvent).
+  const stopConversationRef = useRef<() => void>(() => {});
+
+  const clearVoiceIdleTimer = useCallback(() => {
+    if (idleTimeoutRef.current) {
+      clearTimeout(idleTimeoutRef.current);
+      idleTimeoutRef.current = null;
+    }
+  }, []);
+
+  // Precaution: reschedule on every real activity signal (state transition,
+  // final transcript, directive, handoff, error); if none arrive for
+  // AGENT_BAR_VOICE_IDLE_TIMEOUT_MS the session closes itself. input_level /
+  // output_level are intentionally excluded - they poll continuously on a
+  // fixed interval regardless of actual sound, so treating them as activity
+  // would make the idle timeout never fire.
+  const scheduleVoiceIdleTimer = useCallback(() => {
+    clearVoiceIdleTimer();
+    idleTimeoutRef.current = setTimeout(() => {
+      idleTimeoutRef.current = null;
+      stopConversationRef.current();
+    }, AGENT_BAR_VOICE_IDLE_TIMEOUT_MS);
+  }, [clearVoiceIdleTimer]);
 
   const handleTransportEvent = useCallback((event: OneVoiceSessionEvent) => {
+    if (
+      event.type === "state" ||
+      event.type === "transcript_final" ||
+      event.type === "assistant_text" ||
+      event.type === "client_directive" ||
+      event.type === "handoff"
+    ) {
+      scheduleVoiceIdleTimer();
+    }
     const eventOptions: AgentVoiceEventOptions = {
       sessionId: "sessionId" in event ? event.sessionId ?? null : null,
       sourceId: "sourceId" in event ? event.sourceId ?? null : event.provider,
@@ -313,6 +361,7 @@ export function AgentBar() {
       return;
     }
     if (event.type === "closed") {
+      clearVoiceIdleTimer();
       liveClientRef.current = null;
       if (erroredRef.current) return;
       setConversationActive(false);
@@ -321,9 +370,11 @@ export function AgentBar() {
     agentPopover,
     appendMirrorEvent,
     busyOperations,
+    clearVoiceIdleTimer,
     createHandoff,
     router,
     runtime,
+    scheduleVoiceIdleTimer,
     setAnalysisParams,
     setVoiceLevel,
     setVoiceStatus,
@@ -332,13 +383,18 @@ export function AgentBar() {
   ]);
 
   const stopConversation = useCallback(() => {
+    clearVoiceIdleTimer();
     erroredRef.current = false;
     liveClientRef.current?.stop();
     liveClientRef.current = null;
     prewarmedRelayRef.current = null;
     setConversationActive(false);
     resetVoice();
-  }, [resetVoice]);
+  }, [clearVoiceIdleTimer, resetVoice]);
+
+  useEffect(() => {
+    stopConversationRef.current = stopConversation;
+  }, [stopConversation]);
 
   const openAgentChat = useCallback(() => {
     if (conversationActive) return;
@@ -353,6 +409,7 @@ export function AgentBar() {
     }
     erroredRef.current = false;
     setConversationActive(true);
+    scheduleVoiceIdleTimer();
     const context = runtime?.oneVoiceContextSnapshot ?? null;
     const prewarmedRelay = prewarmedRelayRef.current;
     // The prewarmed ticket is context-free (context rides in app_context
@@ -384,6 +441,7 @@ export function AgentBar() {
     runtime?.tier,
     mirrorSessionId,
     handleTransportEvent,
+    scheduleVoiceIdleTimer,
     stopConversation,
     vaultOwnerToken,
   ]);
@@ -502,6 +560,10 @@ export function AgentBar() {
   // "listening") does not leak to other consumers after the bar is gone.
   useEffect(() => {
     return () => {
+      if (idleTimeoutRef.current) {
+        clearTimeout(idleTimeoutRef.current);
+        idleTimeoutRef.current = null;
+      }
       liveClientRef.current?.stop();
       liveClientRef.current = null;
       prewarmedRelayRef.current = null;

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/field";
 import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
 import { Button } from "@/lib/morphy-ux/button";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import {
   Combobox,
   ComboboxCollection,
@@ -251,8 +252,8 @@ export function PhoneVerificationFlow({
   }, []);
 
   const handleStartVerification = useCallback(
-    async (resendCode = false) => {
-      const normalizedPhone = normalizedPhoneInput.trim();
+    async (resendCode = false, phoneNumberOverride?: string) => {
+      const normalizedPhone = (phoneNumberOverride ?? normalizedPhoneInput).trim();
       if (!E164_PHONE_PATTERN.test(normalizedPhone)) {
         morphyToast.error("Enter a valid country code and phone number.");
         return;
@@ -307,6 +308,34 @@ export function PhoneVerificationFlow({
     },
     [currentPhoneNumber, mode, normalizedPhoneInput, onCompleted, startVerification]
   );
+
+  // Voice parity: "my phone number is +1 555 010 1234" fills the same fields
+  // a typed entry would, then runs the exact same start-verification flow as
+  // tapping the Send code button. The phone number is passed directly to
+  // `handleStartVerification` (not read back from `normalizedPhoneInput`)
+  // because the field-state updates below are async and would not be visible
+  // yet on this same tick. The confirmation-code step
+  // (`phone_mandate.submit_code`) stays `manual_only`/unwired by contract
+  // (see `app/register-phone/page.voice-action-contract.json`), so no
+  // handler is registered for it here.
+  useLocalOnboardingActionHandler("phone_mandate.submit_number", async (slots) => {
+    const rawPhoneNumber = String(slots.phoneNumber ?? "").trim();
+    if (!rawPhoneNumber) {
+      return { status: "blocked", summary: "What's your phone number, including country code?" };
+    }
+    const candidate = rawPhoneNumber.startsWith("+") ? rawPhoneNumber : `+${rawPhoneNumber}`;
+    if (!E164_PHONE_PATTERN.test(candidate)) {
+      return {
+        status: "blocked",
+        summary: "That doesn't look like a valid phone number with country code.",
+      };
+    }
+    const fields = derivePhoneFields(candidate);
+    setSelectedCountry(fields.countryValue);
+    setLocalPhoneNumber(fields.localPhoneNumber);
+    await handleStartVerification(false, candidate);
+    return { status: "succeeded", summary: "Verification code sent." };
+  });
 
   const handleConfirmVerification = useCallback(async () => {
     const normalizedCode = verificationCode.trim();

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1174,8 +1174,13 @@ function ConsentEntryDetail({
         </SettingsGroup>
       ) : null}
 
-      {/* Consent handshake timeline (Issue #122) */}
+      {/* Consent handshake timeline (Issue #122). Active Access entries cover
+          a single live grant, so the full historical trail (grants, denials,
+          revocations across time) belongs on the History tab, not here -
+          showing it in Active Access read as a duplicate/unrelated "history
+          trail" attached to a currently active item. */}
       {!hasGroupedHistory &&
+      entry.kind !== "active_grant" &&
       entry.counterpart_id &&
       entry.counterpart_type !== "self" ? (
         <SettingsGroup
@@ -1673,6 +1678,22 @@ export function ConsentCenterPage() {
       const detail =
         (event as CustomEvent<Partial<ConsentMutationDetail>>).detail || {};
       applyConfirmedConsentMutation(detail);
+      // CONSENT_STATE_CHANGED_EVENT is also dispatched for non-mutation
+      // bookkeeping (e.g. "fcm_opened" when a request is merely opened/
+      // acknowledged, "queued_pending"/"cached_pending"/"hydrated_pending"
+      // on vault unlock). Those carry no `action`, but selecting any pending
+      // or active row calls acknowledgePendingConsent() -> POST /pending/
+      // opened -> the backend inserts a NOTIFICATION_OPENED audit event,
+      // which echoes back over this same user's SSE/FCM channel as an
+      // "fcm_opened" state-changed event. Forcing a full list+summary
+      // refresh on that self-echo made every row click on Requests/Active
+      // (both surfaces list still-pending/live rows) visibly re-render with
+      // a "Refreshing..." flash. History rows are already resolved
+      // (status != REQUESTED) so the backend never inserts that event and
+      // never echoes back, which is why History never flickered. Only force
+      // a refresh for detail.action-bearing events (approve/deny/revoke/
+      // cancel), which are real state mutations.
+      if (!detail.action) return;
       setMutationTick((value) => value + 1);
     };
     window.addEventListener(CONSENT_ACTION_COMPLETE_EVENT, handleAction);

--- a/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
+++ b/hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx
@@ -9,6 +9,10 @@ import { RadioGroup } from "@/components/ui/radio-group";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { cn } from "@/lib/utils";
 import { Button } from "@/lib/morphy-ux/button";
+import {
+  useLocalOnboardingActionHandler,
+  type LocalOnboardingActionResult,
+} from "@/lib/agent/local-onboarding-actions";
 import type {
   DrawdownResponse,
   HorizonAnchorChoice,
@@ -135,6 +139,67 @@ export function KaiPreferencesWizard(props: {
     setHorizonAnchorChoice("from_now");
     setHorizonDialogOpen(true);
   }
+
+  // Voice parity: answering a question by voice sets the same answer state as
+  // tapping its radio option, then advances exactly like tapping the
+  // Next/Continue button would (or completes the wizard on the last
+  // question). If voice answers a question other than the one on screen, we
+  // jump there first rather than silently skipping ahead.
+  async function answerQuestionByVoice<K extends keyof WizardAnswers>(
+    questionId: K,
+    value: WizardAnswers[K]
+  ): Promise<LocalOnboardingActionResult> {
+    const questionIndex = QUESTIONS.findIndex((q) => q.id === questionId);
+    if (questionIndex === -1) {
+      return { status: "failed", summary: "Unknown wizard question." };
+    }
+    if (questionIndex !== step) {
+      setStep(questionIndex);
+      setAnswer(questionId, value);
+      return {
+        status: "succeeded",
+        summary: `Recorded ${String(questionId).replaceAll("_", " ")}.`,
+      };
+    }
+
+    setAnswer(questionId, value);
+    if (questionIndex === total - 1) {
+      const nextAnswers: WizardAnswers = { ...answers, [questionId]: value };
+      await Promise.resolve(
+        props.onComplete({
+          ...nextAnswers,
+          horizonAnchorChoice: props.mode === "edit" ? horizonAnchorChoice : undefined,
+        })
+      );
+      return { status: "succeeded", summary: "Preferences saved." };
+    }
+    setStep((s) => Math.min(total - 1, s + 1));
+    return { status: "succeeded", summary: "Moving to the next question." };
+  }
+
+  useLocalOnboardingActionHandler("kai.setup.answer_horizon", async (slots) => {
+    const value = String(slots.answer ?? "").trim();
+    if (value !== "short_term" && value !== "medium_term" && value !== "long_term") {
+      return { status: "blocked", summary: "That's not one of the horizon options." };
+    }
+    return answerQuestionByVoice("investment_horizon", value as InvestmentHorizon);
+  });
+
+  useLocalOnboardingActionHandler("kai.setup.answer_drawdown", async (slots) => {
+    const value = String(slots.answer ?? "").trim();
+    if (value !== "reduce" && value !== "stay" && value !== "buy_more") {
+      return { status: "blocked", summary: "That's not one of the drawdown options." };
+    }
+    return answerQuestionByVoice("drawdown_response", value as DrawdownResponse);
+  });
+
+  useLocalOnboardingActionHandler("kai.setup.answer_volatility", async (slots) => {
+    const value = String(slots.answer ?? "").trim();
+    if (value !== "small" && value !== "moderate" && value !== "large") {
+      return { status: "blocked", summary: "That's not one of the volatility options." };
+    }
+    return answerQuestionByVoice("volatility_preference", value as VolatilityPreference);
+  });
 
   async function handlePrimary() {
     if (!canContinue || isSubmitting) return;

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { ComponentType, SVGProps } from "react";
+import type { ComponentType, CSSProperties, SVGProps } from "react";
+import { Button } from "@/lib/morphy-ux/button";
 import { cn } from "@/lib/utils";
 
 /* ────────────────────────────────────────────────────────────
@@ -54,7 +55,10 @@ const INTRO_FEATURES: Array<{
   {
     icon: VaultLockIcon,
     title: "Your vault, guarded by consent",
-    subtitle: "Encrypted end to end, shared only when you say yes",
+    // Kept short (parity with the other two subtitles) so it stays on one
+    // line at narrow widths (e.g. iPhone 12 Pro, 390px logical width);
+    // the longer original phrasing wrapped to two lines there.
+    subtitle: "Encrypted, shared only with consent",
   },
   {
     icon: FinanceCapabilityIcon,
@@ -130,9 +134,18 @@ export function IntroStep({
                       <feature.icon className="h-[19px] w-[19px]" />
                     </span>
                     {!last ? (
+                      // Restores the original 14a "trail" connector: a soft
+                      // faded gradient line (reworked in the current gold/
+                      // cream theme) PLUS the traveling highlight animation
+                      // it originally had (.intro-feature-connector, ported
+                      // from the once-wired but since-orphaned
+                      // .intro-feature-rail-scan system in globals.css) -
+                      // a bright pulse that scans down the connector once on
+                      // mount, staggered per row via --intro-feature-delay.
                       <span
                         aria-hidden
-                        className="w-[1.5px] flex-1 bg-[rgba(156,116,52,0.18)] dark:bg-[rgba(212,175,106,0.22)]"
+                        className="intro-feature-connector w-[2px] flex-1 bg-gradient-to-b from-transparent via-[#D4AF6A] to-transparent dark:via-[#D4AF6A]"
+                        style={{ "--intro-feature-delay": `${index * 160}ms` } as CSSProperties}
                       />
                     ) : null}
                   </div>
@@ -156,15 +169,23 @@ export function IntroStep({
           </div>
 
           {/* Primary action — "Get Started" leads into sign-in / sign-up
-              (onLogin → /login → AuthStep, which handles both new + returning). */}
+              (onLogin → /login → AuthStep, which handles both new + returning).
+              Uses the shared morphy Button (variant="none" effect="fill") so
+              this CTA carries the same Material ripple/state-layer physics as
+              every other primary action in the app, per the frontend design
+              system skill, instead of a hand-rolled <button>. */}
           <div className="mt-6">
-            <button
+            <Button
               type="button"
+              variant="none"
+              effect="fill"
+              fullWidth
+              showRipple
               onClick={onLogin}
-              className="flex h-[54px] w-full items-center justify-center rounded-full border border-[rgba(214,175,106,0.55)] bg-[#F4EAD6] text-[17px] font-bold tracking-[-0.3px] text-[#17130C] shadow-[0_10px_24px_rgba(0,0,0,0.22)] transition-transform duration-150 hover:bg-[#F4EAD6] active:scale-[0.99] motion-reduce:active:scale-100 dark:bg-[#F4EAD6] dark:text-[#17130C] dark:hover:bg-[#F4EAD6]"
+              className="h-[54px] rounded-full border border-[rgba(214,175,106,0.55)] bg-[#F4EAD6] text-[17px] font-bold tracking-[-0.3px] text-[#17130C] shadow-[0_10px_24px_rgba(0,0,0,0.22)] hover:bg-[#F4EAD6] hover:text-[#17130C] dark:bg-[#F4EAD6] dark:text-[#17130C] dark:hover:bg-[#F4EAD6]"
             >
               Get Started
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/hushh-webapp/components/onboarding/setup/onboarding-capability-step.tsx
+++ b/hushh-webapp/components/onboarding/setup/onboarding-capability-step.tsx
@@ -94,6 +94,7 @@ export function OnboardingCapabilityStep({
           actions: [
             {
               id: "primary",
+              actionId: "setup.capability_continue",
               label: ctaLabel,
               purpose: isExploreOnly
                 ? "Acknowledge and continue."

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -27,6 +27,7 @@ import {
   type OneCapabilityTone,
 } from "@/lib/onboarding/one-capabilities";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { useCapabilitySetupStates } from "@/lib/onboarding/use-capability-setup-states";
 import {
   isCapabilitySetupActionable,
@@ -71,6 +72,13 @@ export function OneSetupHub() {
   const done = items.filter((item) => isCapabilitySetupComplete(item.status)).length;
   const remaining = total - done;
   const allReady = total > 0 && remaining === 0;
+  // The MASTER setup acknowledgement is owned by this single hub control:
+  //   - 0 capabilities done  -> "Skip"     (master skip-resolved)
+  //   - 1..n capabilities done -> "Continue" (master completed, not skipped)
+  // Computed here (ahead of the voice metadata publish below, which needs the
+  // label) rather than only near `handleMasterAck`.
+  const masterSkipped = done === 0;
+  const masterActionLabel = masterSkipped ? "Skip" : "Continue";
 
   // Publish screen context so the onboarding guide can describe the hub and
   // navigate the person to any capability they ask for.
@@ -79,26 +87,32 @@ export function OneSetupHub() {
     title: "Set up One",
     purpose:
       "This is your setup home. Each tile is one thing One can do for you. Set up the ones you want and skip the rest.",
-    actions: CAPABILITY_SETUP_COPY.map((cap) => ({
-      id: cap.id,
-      label: cap.title,
-      purpose: cap.setupBlurb,
-    })),
+    actions: [
+      ...CAPABILITY_SETUP_COPY.map((cap) => ({
+        id: cap.id,
+        actionId: `setup.open_${cap.id.replace(/-/g, "_")}`,
+        label: cap.title,
+        purpose: cap.setupBlurb,
+      })),
+      {
+        id: "master_ack",
+        actionId: "setup.hub_master_ack",
+        label: masterActionLabel,
+        purpose: masterSkipped
+          ? "Skip setup for now and go home."
+          : "Finish for now and go home.",
+      },
+    ],
   });
 
-  // The MASTER setup acknowledgement is owned by this single hub control:
-  //   - 0 capabilities done  -> "Skip"     (master skip-resolved)
-  //   - 1..n capabilities done -> "Continue" (master completed, not skipped)
-  // Either way it SATISFIES the root setup gate so the hard gate on /one/* does
-  // not bounce the user back here. Per-capability tiles never touch this gate;
-  // they only record their own signal. We mark the server pre-vault gate
-  // (authoritative for the gate and PostAuthRouteService); when the vault is
-  // unlocked we also flip the vault profile so the unlocked path agrees. Both
-  // are awaited before navigating so the gate is consistent on the very next
-  // route resolve. Failures stay fail-open (we still navigate home).
-  const masterSkipped = done === 0;
-  const masterActionLabel = masterSkipped ? "Skip" : "Continue";
-
+  // Either way, resolving the master ack SATISFIES the root setup gate so the
+  // hard gate on /one/* does not bounce the user back here. Per-capability
+  // tiles never touch this gate; they only record their own signal. We mark
+  // the server pre-vault gate (authoritative for the gate and
+  // PostAuthRouteService); when the vault is unlocked we also flip the vault
+  // profile so the unlocked path agrees. Both are awaited before navigating
+  // so the gate is consistent on the very next route resolve. Failures stay
+  // fail-open (we still navigate home).
   const handleMasterAck = async () => {
     if (dismissing) return;
     if (!user?.uid) {
@@ -121,6 +135,16 @@ export function OneSetupHub() {
       router.push(ROUTES.ONE_HOME);
     }
   };
+
+  // Voice parity: "skip setup" / "continue to home" drive the same master
+  // acknowledgement as tapping the hub's Skip/Continue button.
+  useLocalOnboardingActionHandler("setup.hub_master_ack", async () => {
+    await handleMasterAck();
+    return {
+      status: "succeeded",
+      summary: masterSkipped ? "Skipped setup for now." : "Setup acknowledged. Opening home.",
+    };
+  });
 
   const summary = isLoading
     ? "Checking what's set up…"

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
@@ -1,0 +1,189 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "one_setup_hub",
+  "surface_title": "One Setup Hub",
+  "docs_references": [
+    "docs/reference/kai/kai-action-gateway-vnext.md",
+    "docs/reference/quality/one-onboarding-architecture.md"
+  ],
+  "defaults": {
+    "reachability": {
+      "active_personas": ["investor", "ria"]
+    },
+    "speaker_persona": "one",
+    "guard_ids": ["auth_signed_in"]
+  },
+  "actions": [
+    {
+      "action_id": "setup.open_finance",
+      "label": "Set Up Finance",
+      "meaning": "Opens the Finance capability setup step from the setup hub.",
+      "aliases": ["set up finance", "open finance setup", "set up investing"],
+      "search_keywords": ["finance", "setup", "investing", "kai"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/finance" },
+      "control_ids": ["one_setup_tile_finance"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.open_gmail",
+      "label": "Set Up Gmail",
+      "meaning": "Opens the Gmail capability setup step from the setup hub.",
+      "aliases": ["set up gmail", "open gmail setup", "connect gmail"],
+      "search_keywords": ["gmail", "setup", "receipts"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/gmail" },
+      "control_ids": ["one_setup_tile_gmail"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.open_email",
+      "label": "Set Up Email",
+      "meaning": "Opens the Email capability setup step from the setup hub.",
+      "aliases": ["set up email", "open email setup"],
+      "search_keywords": ["email", "setup", "approvals"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/email" },
+      "control_ids": ["one_setup_tile_email"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.open_location",
+      "label": "Set Up Location",
+      "meaning": "Opens the Location capability setup step from the setup hub.",
+      "aliases": ["set up location", "open location setup", "set up live sharing"],
+      "search_keywords": ["location", "setup", "sharing"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/location" },
+      "control_ids": ["one_setup_tile_location"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.open_personal_data",
+      "label": "Set Up Memory",
+      "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
+      "aliases": ["set up memory", "open memory setup", "set up personal data"],
+      "search_keywords": ["memory", "pkm", "setup", "personal data"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/pkm" },
+      "control_ids": ["one_setup_tile_pkm"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.open_consent",
+      "label": "Explore Consent",
+      "meaning": "Opens the Consent explore-only step from the setup hub.",
+      "aliases": ["set up consent", "open consent setup", "explore consent"],
+      "search_keywords": ["consent", "setup", "approvals"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/consent" },
+      "control_ids": ["one_setup_tile_consent"],
+      "state_exposure": [],
+      "docs_references": [],
+      "speaker_persona": "nav"
+    },
+    {
+      "action_id": "setup.open_connected_systems",
+      "label": "Set Up Connected Systems",
+      "meaning": "Opens the Connected Systems capability setup step from the setup hub.",
+      "aliases": ["set up connected systems", "open connected systems setup", "connect crm"],
+      "search_keywords": ["connected systems", "crm", "setup"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/connected-systems"
+      },
+      "control_ids": ["one_setup_tile_connected-systems"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.hub_master_ack",
+      "label": "Finish Setup For Now",
+      "meaning": "Resolves the master setup gate: Skip when nothing is set up yet, or Continue once at least one capability is ready, then opens One's home.",
+      "aliases": [
+        "skip setup",
+        "i'm done setting up",
+        "continue to home",
+        "finish setup",
+        "that's all for now"
+      ],
+      "search_keywords": ["skip", "continue", "done", "finish setup", "home"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "local_handler", "target": "setup.hub_master_ack" },
+      "control_ids": ["one-setup-master-ack"],
+      "state_exposure": ["capabilities completed count"],
+      "docs_references": ["hushh-webapp/components/onboarding/setup/one-setup-hub.tsx"]
+    }
+  ]
+}

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
@@ -22,7 +22,7 @@
       "search_keywords": ["finance", "setup", "investing", "kai"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -42,7 +42,7 @@
       "search_keywords": ["gmail", "setup", "receipts"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -62,7 +62,7 @@
       "search_keywords": ["email", "setup", "approvals"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -82,7 +82,7 @@
       "search_keywords": ["location", "setup", "sharing"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -102,7 +102,7 @@
       "search_keywords": ["memory", "pkm", "setup", "personal data"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -122,7 +122,7 @@
       "search_keywords": ["consent", "setup", "approvals"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -143,7 +143,7 @@
       "search_keywords": ["connected systems", "crm", "setup"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
@@ -173,7 +173,7 @@
       "search_keywords": ["skip", "continue", "done", "finish setup", "home"],
       "reachability": {
         "routes": ["/one/setup"],
-        "screens": ["one_setup_hub"],
+        "screens": ["one_setup_hub", "one_setup"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -3997,7 +3997,8 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
-          "one_setup_connected-systems"
+          "one_setup_connected-systems",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -4103,7 +4104,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -4220,7 +4222,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -4339,7 +4342,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -4459,7 +4463,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -5789,7 +5794,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -5904,7 +5910,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -10630,7 +10637,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -10733,7 +10741,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -10835,7 +10844,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -10938,7 +10948,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11042,7 +11053,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11145,7 +11157,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11248,7 +11261,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11355,7 +11369,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -9,8 +9,11 @@
     "hushh-webapp/app/one/kyc/page.voice-action-contract.json",
     "hushh-webapp/app/one/marketplace/page.voice-action-contract.json",
     "hushh-webapp/app/one/page.voice-action-contract.json",
+    "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+    "hushh-webapp/app/one/setup/kai/page.voice-action-contract.json",
     "hushh-webapp/app/profile/page.voice-action-contract.json",
     "hushh-webapp/app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
+    "hushh-webapp/app/register-phone/page.voice-action-contract.json",
     "hushh-webapp/app/ria/clients/page.voice-action-contract.json",
     "hushh-webapp/app/ria/onboarding/page.voice-action-contract.json",
     "hushh-webapp/app/ria/page.voice-action-contract.json",
@@ -23,6 +26,7 @@
     "hushh-webapp/components/kai/kai-command-bar-global.voice-action-contract.json",
     "hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json",
     "hushh-webapp/components/kai/views/kai-market-preview-view.voice-action-contract.json",
+    "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
     "hushh-webapp/components/ria/ria-client-account-detail.voice-action-contract.json",
     "hushh-webapp/components/ria/ria-client-request-detail.voice-action-contract.json",
     "hushh-webapp/components/ria/ria-client-workspace.voice-action-contract.json"
@@ -163,6 +167,49 @@
     },
     {
       "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_setup_capability_step",
+      "surface_title": "One Setup Capability Step",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "kai_setup_wizard",
+      "surface_title": "Kai Investor Preferences Wizard",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/app/one/setup/kai/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor"
+          ]
+        },
+        "speaker_persona": "kai",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
       "surface_id": "profile_account",
       "surface_title": "Profile Workspace",
       "docs_references": [
@@ -193,6 +240,28 @@
             "ria"
           ]
         }
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "phone_mandate",
+      "surface_title": "Phone Verification",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/app/register-phone/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
       }
     },
     {
@@ -401,6 +470,28 @@
             "investor"
           ]
         }
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_setup_hub",
+      "surface_title": "One Setup Hub",
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "contract_file": "hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one",
+        "guard_ids": [
+          "auth_signed_in"
+        ]
       }
     },
     {
@@ -3871,6 +3962,589 @@
       }
     },
     {
+      "action_id": "setup.capability_continue",
+      "surface_id": "one_setup_capability_step",
+      "label": "Continue Capability Setup",
+      "aliases": [
+        "continue",
+        "unlock and continue",
+        "got it",
+        "next"
+      ],
+      "search_keywords": [
+        "continue",
+        "next",
+        "got it",
+        "unlock"
+      ],
+      "meaning": "Advances past the current capability setup step to its next destination (workspace, wizard, or explore acknowledgement). Applies to whichever capability route is currently open.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/finance",
+          "/one/setup/gmail",
+          "/one/setup/email",
+          "/one/setup/location",
+          "/one/setup/pkm",
+          "/one/setup/consent",
+          "/one/setup/connected-systems"
+        ],
+        "screens": [
+          "one_setup_finance",
+          "one_setup_gmail",
+          "one_setup_email",
+          "one_setup_location",
+          "one_setup_pkm",
+          "one_setup_consent",
+          "one_setup_connected-systems"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.capability_continue"
+      },
+      "control_ids": [
+        "one_setup_capability_primary"
+      ],
+      "state_exposure": [
+        "capability seen/explored signal"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/finance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.capability_continue",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.capability_continue",
+            "label": "Continue Capability Setup",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_finance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_horizon",
+      "surface_id": "kai_setup_wizard",
+      "label": "Answer Investment Horizon",
+      "aliases": [
+        "less than 3 years",
+        "3 to 7 years",
+        "more than 7 years"
+      ],
+      "search_keywords": [
+        "horizon",
+        "how long",
+        "invested"
+      ],
+      "meaning": "Answers the investment horizon question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_horizon"
+      },
+      "control_ids": [
+        "kai_wizard_investment_horizon"
+      ],
+      "state_exposure": [
+        "current wizard step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_horizon",
+        "required_inputs": [
+          {
+            "name": "investment_horizon",
+            "prompt": "How long do you expect to keep this money invested: less than 3 years, 3 to 7 years, or more than 7 years?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "short_term",
+              "medium_term",
+              "long_term"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_horizon",
+            "label": "Answer Investment Horizon",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_drawdown",
+      "surface_id": "kai_setup_wizard",
+      "label": "Answer Drawdown Response",
+      "aliases": [
+        "reduce investments",
+        "stay invested",
+        "buy more"
+      ],
+      "search_keywords": [
+        "drawdown",
+        "drop",
+        "reaction"
+      ],
+      "meaning": "Answers the portfolio-drawdown-reaction question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Investment horizon must already be answered."
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_drawdown"
+      },
+      "control_ids": [
+        "kai_wizard_drawdown_response"
+      ],
+      "state_exposure": [
+        "current wizard step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_drawdown",
+        "required_inputs": [
+          {
+            "name": "drawdown_response",
+            "prompt": "If your portfolio drops 20 percent, would you reduce investments, stay invested, or buy more?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "reduce",
+              "stay",
+              "buy_more"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_drawdown",
+            "label": "Answer Drawdown Response",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.answer_volatility",
+      "surface_id": "kai_setup_wizard",
+      "label": "Answer Volatility Preference",
+      "aliases": [
+        "smaller steadier returns",
+        "moderate ups and downs",
+        "larger swings"
+      ],
+      "search_keywords": [
+        "volatility",
+        "comfort",
+        "swings"
+      ],
+      "meaning": "Answers the volatility-comfort question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Drawdown response must already be answered."
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_volatility"
+      },
+      "control_ids": [
+        "kai_wizard_volatility_preference"
+      ],
+      "state_exposure": [
+        "current wizard step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_volatility",
+        "required_inputs": [
+          {
+            "name": "volatility_preference",
+            "prompt": "Which feels more comfortable: smaller steadier returns, moderate ups and downs, or larger swings for higher potential returns?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "small",
+              "moderate",
+              "large"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_volatility",
+            "label": "Answer Volatility Preference",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "kai.setup.launch_dashboard",
+      "surface_id": "kai_setup_wizard",
+      "label": "Launch Kai Dashboard",
+      "aliases": [
+        "launch my dashboard",
+        "looks good, continue",
+        "finish kai setup"
+      ],
+      "search_keywords": [
+        "launch",
+        "dashboard",
+        "finish",
+        "persona"
+      ],
+      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "All three preference questions must be answered."
+        ],
+        "active_personas": [
+          "investor"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.launch_dashboard"
+      },
+      "control_ids": [
+        "kai_wizard_launch_dashboard"
+      ],
+      "state_exposure": [
+        "computed risk profile"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/kai/page.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/kai"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.launch_dashboard",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.launch_dashboard",
+            "label": "Launch Kai Dashboard",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "route.profile",
       "surface_id": "profile_account",
       "label": "Open Profile",
@@ -5068,6 +5742,232 @@
             "settlement_target": {
               "route": "/profile/pkm-agent-lab",
               "screen": "profile_pkm_agent_lab"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "phone_mandate.submit_number",
+      "surface_id": "phone_mandate",
+      "label": "Submit Phone Number",
+      "aliases": [
+        "verify my phone",
+        "send me a code",
+        "my phone number is",
+        "add my phone number"
+      ],
+      "search_keywords": [
+        "phone",
+        "verify",
+        "code",
+        "sms"
+      ],
+      "meaning": "Sends a verification code to the phone number the user says.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "medium",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_number"
+      },
+      "control_ids": [
+        "phone-flow-number"
+      ],
+      "state_exposure": [
+        "masked phone number"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /register-phone"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_number",
+        "required_inputs": [
+          {
+            "name": "phone_number",
+            "prompt": "What's your phone number, including country code?",
+            "required": true,
+            "slot": "phoneNumber"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_number",
+            "label": "Submit Phone Number",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "phone_mandate.submit_code",
+      "surface_id": "phone_mandate",
+      "label": "Submit Verification Code",
+      "aliases": [
+        "the code is",
+        "verify my code",
+        "confirm my phone",
+        "submit the verification code"
+      ],
+      "search_keywords": [
+        "code",
+        "otp",
+        "verify",
+        "confirm"
+      ],
+      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "A verification code must already be sent."
+        ],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "manual_user_execution"
+      ],
+      "risk_level": "high",
+      "execution_policy": "manual_only",
+      "execution_target": {
+        "status": "unwired",
+        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
+        "intended_handler": "local_handler"
+      },
+      "control_ids": [
+        "phone-flow-code"
+      ],
+      "state_exposure": [
+        "verification step"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /register-phone"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_code",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_code",
+            "label": "Submit Verification Code",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
             }
           }
         ],
@@ -9684,6 +10584,838 @@
             "settlement_target": {
               "route": "/one/kai",
               "screen": "kai_market"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_finance",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Finance",
+      "aliases": [
+        "set up finance",
+        "open finance setup",
+        "set up investing"
+      ],
+      "search_keywords": [
+        "finance",
+        "setup",
+        "investing",
+        "kai"
+      ],
+      "meaning": "Opens the Finance capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/finance"
+      },
+      "control_ids": [
+        "one_setup_tile_finance"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/finance"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_finance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_finance",
+            "label": "Set Up Finance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_gmail",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Gmail",
+      "aliases": [
+        "set up gmail",
+        "open gmail setup",
+        "connect gmail"
+      ],
+      "search_keywords": [
+        "gmail",
+        "setup",
+        "receipts"
+      ],
+      "meaning": "Opens the Gmail capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/gmail"
+      },
+      "control_ids": [
+        "one_setup_tile_gmail"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/gmail"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_gmail",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_gmail",
+            "label": "Set Up Gmail",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/gmail",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_email",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Email",
+      "aliases": [
+        "set up email",
+        "open email setup"
+      ],
+      "search_keywords": [
+        "email",
+        "setup",
+        "approvals"
+      ],
+      "meaning": "Opens the Email capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/email"
+      },
+      "control_ids": [
+        "one_setup_tile_email"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/email"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_email",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_email",
+            "label": "Set Up Email",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/email",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_location",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Location",
+      "aliases": [
+        "set up location",
+        "open location setup",
+        "set up live sharing"
+      ],
+      "search_keywords": [
+        "location",
+        "setup",
+        "sharing"
+      ],
+      "meaning": "Opens the Location capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/location"
+      },
+      "control_ids": [
+        "one_setup_tile_location"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/location"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_location",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_location",
+            "label": "Set Up Location",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/location",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_personal_data",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Memory",
+      "aliases": [
+        "set up memory",
+        "open memory setup",
+        "set up personal data"
+      ],
+      "search_keywords": [
+        "memory",
+        "pkm",
+        "setup",
+        "personal data"
+      ],
+      "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/pkm"
+      },
+      "control_ids": [
+        "one_setup_tile_pkm"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/pkm"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_personal_data",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_personal_data",
+            "label": "Set Up Memory",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_consent",
+      "surface_id": "one_setup_hub",
+      "label": "Explore Consent",
+      "aliases": [
+        "set up consent",
+        "open consent setup",
+        "explore consent"
+      ],
+      "search_keywords": [
+        "consent",
+        "setup",
+        "approvals"
+      ],
+      "meaning": "Opens the Consent explore-only step from the setup hub.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/consent"
+      },
+      "control_ids": [
+        "one_setup_tile_consent"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/consent"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_consent",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_consent",
+            "label": "Explore Consent",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/consent",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_connected_systems",
+      "surface_id": "one_setup_hub",
+      "label": "Set Up Connected Systems",
+      "aliases": [
+        "set up connected systems",
+        "open connected systems setup",
+        "connect crm"
+      ],
+      "search_keywords": [
+        "connected systems",
+        "crm",
+        "setup"
+      ],
+      "meaning": "Opens the Connected Systems capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/connected-systems"
+      },
+      "control_ids": [
+        "one_setup_tile_connected-systems"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/connected-systems"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_connected_systems",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_connected_systems",
+            "label": "Set Up Connected Systems",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/connected-systems",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.hub_master_ack",
+      "surface_id": "one_setup_hub",
+      "label": "Finish Setup For Now",
+      "aliases": [
+        "skip setup",
+        "i'm done setting up",
+        "continue to home",
+        "finish setup",
+        "that's all for now"
+      ],
+      "search_keywords": [
+        "skip",
+        "continue",
+        "done",
+        "finish setup",
+        "home"
+      ],
+      "meaning": "Resolves the master setup gate: Skip when nothing is set up yet, or Continue once at least one capability is ready, then opens One's home.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.hub_master_ack"
+      },
+      "control_ids": [
+        "one-setup-master-ack"
+      ],
+      "state_exposure": [
+        "capabilities completed count"
+      ],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/onboarding/setup/one-setup-hub.tsx"
+      ],
+      "workflow": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.hub_master_ack",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.hub_master_ack",
+            "label": "Finish Setup For Now",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup",
+              "screen": "one_setup_hub"
             }
           }
         ],

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -2402,6 +2402,426 @@
       ]
     },
     {
+      "id": "setup.capability_continue",
+      "label": "Continue Capability Setup",
+      "meaning": "Advances past the current capability setup step to its next destination (workspace, wizard, or explore acknowledgement). Applies to whichever capability route is currently open.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "continue",
+        "unlock and continue",
+        "got it",
+        "next"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/finance",
+          "/one/setup/gmail",
+          "/one/setup/email",
+          "/one/setup/location",
+          "/one/setup/pkm",
+          "/one/setup/consent",
+          "/one/setup/connected-systems"
+        ],
+        "screens": [
+          "one_setup_finance",
+          "one_setup_gmail",
+          "one_setup_email",
+          "one_setup_location",
+          "one_setup_pkm",
+          "one_setup_consent",
+          "one_setup_connected-systems"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.capability_continue"
+      },
+      "goal": {
+        "goal_id": "goal.setup.capability_continue",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.capability_continue",
+            "label": "Continue Capability Setup",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_finance"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.answer_horizon",
+      "label": "Answer Investment Horizon",
+      "meaning": "Answers the investment horizon question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "less than 3 years",
+        "3 to 7 years",
+        "more than 7 years"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_horizon"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_horizon",
+        "required_inputs": [
+          {
+            "name": "investment_horizon",
+            "prompt": "How long do you expect to keep this money invested: less than 3 years, 3 to 7 years, or more than 7 years?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "short_term",
+              "medium_term",
+              "long_term"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_horizon",
+            "label": "Answer Investment Horizon",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.answer_drawdown",
+      "label": "Answer Drawdown Response",
+      "meaning": "Answers the portfolio-drawdown-reaction question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "reduce investments",
+        "stay invested",
+        "buy more"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Investment horizon must already be answered."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_drawdown"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_drawdown",
+        "required_inputs": [
+          {
+            "name": "drawdown_response",
+            "prompt": "If your portfolio drops 20 percent, would you reduce investments, stay invested, or buy more?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "reduce",
+              "stay",
+              "buy_more"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_drawdown",
+            "label": "Answer Drawdown Response",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.answer_volatility",
+      "label": "Answer Volatility Preference",
+      "meaning": "Answers the volatility-comfort question in the Kai preferences wizard.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "smaller steadier returns",
+        "moderate ups and downs",
+        "larger swings"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "Drawdown response must already be answered."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.answer_volatility"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.answer_volatility",
+        "required_inputs": [
+          {
+            "name": "volatility_preference",
+            "prompt": "Which feels more comfortable: smaller steadier returns, moderate ups and downs, or larger swings for higher potential returns?",
+            "required": true,
+            "slot": "answer",
+            "options": [
+              "small",
+              "moderate",
+              "large"
+            ]
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.answer_volatility",
+            "label": "Answer Volatility Preference",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/kai/onboarding/KaiPreferencesWizard.tsx"
+      ]
+    },
+    {
+      "id": "kai.setup.launch_dashboard",
+      "label": "Launch Kai Dashboard",
+      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "aliases": [
+        "launch my dashboard",
+        "looks good, continue",
+        "finish kai setup"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup/kai"
+        ],
+        "screens": [
+          "kai_setup_wizard"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "All three preference questions must be answered."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "kai.setup.launch_dashboard"
+      },
+      "goal": {
+        "goal_id": "goal.kai.setup.launch_dashboard",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "kai.setup.launch_dashboard",
+            "label": "Launch Kai Dashboard",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/kai",
+              "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/app/one/setup/kai/page.tsx"
+      ]
+    },
+    {
       "id": "route.profile",
       "label": "Open Profile",
       "meaning": "Navigates to profile landing route.",
@@ -3271,6 +3691,164 @@
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "app/profile/pkm-agent-lab/page-client.tsx"
+      ]
+    },
+    {
+      "id": "phone_mandate.submit_number",
+      "label": "Submit Phone Number",
+      "meaning": "Sends a verification code to the phone number the user says.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "verify my phone",
+        "send me a code",
+        "my phone number is",
+        "add my phone number"
+      ],
+      "scope": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "medium",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_number"
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_number",
+        "required_inputs": [
+          {
+            "name": "phone_number",
+            "prompt": "What's your phone number, including country code?",
+            "required": true,
+            "slot": "phoneNumber"
+          }
+        ],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_number",
+            "label": "Submit Phone Number",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
+      ]
+    },
+    {
+      "id": "phone_mandate.submit_code",
+      "label": "Submit Verification Code",
+      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "the code is",
+        "verify my code",
+        "confirm my phone",
+        "submit the verification code"
+      ],
+      "scope": {
+        "routes": [
+          "/register-phone"
+        ],
+        "screens": [
+          "phone_mandate"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [
+          "A verification code must already be sent."
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "manual_user_execution"
+      ],
+      "risk_level": "high",
+      "execution_policy": "manual_only",
+      "execution_hint": {
+        "status": "unwired",
+        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
+        "intended_handler": "local_handler"
+      },
+      "goal": {
+        "goal_id": "goal.phone_mandate.submit_code",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "phone_mandate.submit_code",
+            "label": "Submit Verification Code",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/register-phone",
+              "screen": "phone_mandate"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/auth/phone-verification-flow.tsx"
       ]
     },
     {
@@ -6511,6 +7089,584 @@
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "docs/reference/one/one-voice-kai-compatibility-runtime.md"
+      ]
+    },
+    {
+      "id": "setup.open_finance",
+      "label": "Set Up Finance",
+      "meaning": "Opens the Finance capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up finance",
+        "open finance setup",
+        "set up investing"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/finance"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_finance",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_finance",
+            "label": "Set Up Finance",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/finance",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_gmail",
+      "label": "Set Up Gmail",
+      "meaning": "Opens the Gmail capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up gmail",
+        "open gmail setup",
+        "connect gmail"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/gmail"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_gmail",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_gmail",
+            "label": "Set Up Gmail",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/gmail",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_email",
+      "label": "Set Up Email",
+      "meaning": "Opens the Email capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up email",
+        "open email setup"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/email"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_email",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_email",
+            "label": "Set Up Email",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/email",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_location",
+      "label": "Set Up Location",
+      "meaning": "Opens the Location capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up location",
+        "open location setup",
+        "set up live sharing"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/location"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_location",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_location",
+            "label": "Set Up Location",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/location",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_personal_data",
+      "label": "Set Up Memory",
+      "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up memory",
+        "open memory setup",
+        "set up personal data"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/pkm"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_personal_data",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_personal_data",
+            "label": "Set Up Memory",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_consent",
+      "label": "Explore Consent",
+      "meaning": "Opens the Consent explore-only step from the setup hub.",
+      "speaker_persona": "nav",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up consent",
+        "open consent setup",
+        "explore consent"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/consent"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_consent",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_consent",
+            "label": "Explore Consent",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/consent",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_connected_systems",
+      "label": "Set Up Connected Systems",
+      "meaning": "Opens the Connected Systems capability setup step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "set up connected systems",
+        "open connected systems setup",
+        "connect crm"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/connected-systems"
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_connected_systems",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_connected_systems",
+            "label": "Set Up Connected Systems",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/connected-systems",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.hub_master_ack",
+      "label": "Finish Setup For Now",
+      "meaning": "Resolves the master setup gate: Skip when nothing is set up yet, or Continue once at least one capability is ready, then opens One's home.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "skip setup",
+        "i'm done setting up",
+        "continue to home",
+        "finish setup",
+        "that's all for now"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "setup.hub_master_ack"
+      },
+      "goal": {
+        "goal_id": "goal.setup.hub_master_ack",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.hub_master_ack",
+            "label": "Finish Setup For Now",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md",
+        "hushh-webapp/components/onboarding/setup/one-setup-hub.tsx"
       ]
     },
     {

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -2430,7 +2430,8 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
-          "one_setup_connected-systems"
+          "one_setup_connected-systems",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -2503,7 +2504,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -2588,7 +2590,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -2675,7 +2678,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -2762,7 +2766,8 @@
           "/one/setup/kai"
         ],
         "screens": [
-          "kai_setup_wizard"
+          "kai_setup_wizard",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -3710,7 +3715,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -3791,7 +3797,8 @@
           "/register-phone"
         ],
         "screens": [
-          "phone_mandate"
+          "phone_mandate",
+          "register_phone"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [
@@ -7107,7 +7114,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7179,7 +7187,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7250,7 +7259,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7322,7 +7332,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7394,7 +7405,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7466,7 +7478,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7538,7 +7551,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7612,7 +7626,8 @@
           "/one/setup"
         ],
         "screens": [
-          "one_setup_hub"
+          "one_setup_hub",
+          "one_setup"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -2290,8 +2290,13 @@
         "shared_loader": true,
         "back_button_pattern": "route-local-check-required"
       },
-      "voice_action_contract_file": null,
-      "voice_action_contract_ids": [],
+      "voice_action_contract_file": "app/one/setup/kai/page.voice-action-contract.json",
+      "voice_action_contract_ids": [
+        "kai.setup.answer_drawdown",
+        "kai.setup.answer_horizon",
+        "kai.setup.answer_volatility",
+        "kai.setup.launch_dashboard"
+      ],
       "api_dependencies": [],
       "native_plugin_dependencies": [],
       "thread_and_consent_contract": null
@@ -3411,8 +3416,11 @@
         "shared_loader": true,
         "back_button_pattern": "shared-shell"
       },
-      "voice_action_contract_file": null,
-      "voice_action_contract_ids": [],
+      "voice_action_contract_file": "app/register-phone/page.voice-action-contract.json",
+      "voice_action_contract_ids": [
+        "phone_mandate.submit_code",
+        "phone_mandate.submit_number"
+      ],
       "api_dependencies": [],
       "native_plugin_dependencies": [],
       "thread_and_consent_contract": null

--- a/hushh-webapp/lib/agent/agent-action-runtime.ts
+++ b/hushh-webapp/lib/agent/agent-action-runtime.ts
@@ -1,5 +1,6 @@
 import { executeKaiCommand } from "@/lib/kai/command-executor";
 import type { KaiCommandAction } from "@/lib/kai/kai-command-types";
+import { resolveLocalOnboardingHandler } from "@/lib/agent/local-onboarding-actions";
 import { buildConnectedSystemRoute } from "@/lib/navigation/routes";
 import type { AnalysisParams } from "@/lib/stores/kai-session-store";
 import type { Persona } from "@/lib/services/ria-service";
@@ -266,6 +267,51 @@ export async function executeAgentGatewayAction(
       resultSummary: `${action.label} opened in Kai.`,
       data: { target: action.execution_target.target, goal_id: action.goal.goal_id },
     });
+  }
+
+  if (action.execution_target.path === "local_handler") {
+    const handler = resolveLocalOnboardingHandler(action.action_id);
+    if (!handler) {
+      return buildResult({
+        status: "blocked",
+        actionId: action.action_id,
+        label: action.label,
+        routeBefore: routeBefore.pathname,
+        screenBefore: routeBefore.screen,
+        resultSummary: `${action.label} isn't available on this screen right now.`,
+        reason: "local_handler_not_mounted",
+      });
+    }
+    try {
+      const handlerResult = await handler(input.slots || {});
+      return buildResult({
+        status:
+          handlerResult.status === "succeeded"
+            ? "succeeded"
+            : handlerResult.status === "blocked"
+              ? "blocked"
+              : "failed",
+        actionId: action.action_id,
+        label: action.label,
+        routeBefore: routeBefore.pathname,
+        screenBefore: routeBefore.screen,
+        resultSummary: handlerResult.summary,
+        data: { ...(handlerResult.data || {}), goal_id: action.goal.goal_id },
+      });
+    } catch (error) {
+      return buildResult({
+        status: "failed",
+        actionId: action.action_id,
+        label: action.label,
+        routeBefore: routeBefore.pathname,
+        screenBefore: routeBefore.screen,
+        resultSummary:
+          error instanceof Error && error.message
+            ? error.message
+            : `${action.label} failed to run.`,
+        reason: "local_handler_error",
+      });
+    }
   }
 
   if (action.execution_target.path !== "kai_command") {

--- a/hushh-webapp/lib/agent/local-onboarding-actions.ts
+++ b/hushh-webapp/lib/agent/local-onboarding-actions.ts
@@ -1,0 +1,78 @@
+/**
+ * Local-handler registry for governed actions whose `execution_target.path`
+ * is `"local_handler"`.
+ *
+ * The generated action gateway supports `"route"` (router.push) and
+ * `"kai_command"` (dispatch into `executeKaiCommand`) out of the box, but
+ * neither fits an in-place UI state change on a mounted component that has
+ * no route or Kai-command equivalent - for example answering an onboarding
+ * wizard question, tapping the setup hub's master Skip/Continue, or
+ * submitting a phone/OTP field. Those surfaces register a small handler here
+ * on mount (mirroring `usePublishVoiceSurfaceMetadata`'s publish/clear
+ * lifecycle in `voice-surface-metadata.ts`), and
+ * `executeAgentGatewayAction` (`agent-action-runtime.ts`) looks the handler
+ * up by `action_id` and invokes it with the action's resolved slots.
+ *
+ * A handler must be idempotent-safe to call from voice (no silent retries)
+ * and should return a short result summary string for the agent to relay.
+ */
+
+import { useEffect, useRef } from "react";
+
+export type LocalOnboardingActionResult = {
+  status: "succeeded" | "blocked" | "failed";
+  summary: string;
+  data?: Record<string, unknown>;
+};
+
+export type LocalOnboardingActionHandler = (
+  slots: Record<string, unknown>
+) => LocalOnboardingActionResult | Promise<LocalOnboardingActionResult>;
+
+const handlers = new Map<string, LocalOnboardingActionHandler>();
+
+/** Register a handler for a governed `action_id`. Last registration wins. */
+export function registerLocalOnboardingHandler(
+  actionId: string,
+  handler: LocalOnboardingActionHandler
+) {
+  handlers.set(actionId, handler);
+}
+
+/** Remove a handler only if it is still the one that registered it. */
+export function unregisterLocalOnboardingHandler(
+  actionId: string,
+  handler: LocalOnboardingActionHandler
+) {
+  if (handlers.get(actionId) === handler) {
+    handlers.delete(actionId);
+  }
+}
+
+export function resolveLocalOnboardingHandler(
+  actionId: string
+): LocalOnboardingActionHandler | null {
+  return handlers.get(actionId) ?? null;
+}
+
+/**
+ * Register a local onboarding handler for the lifetime of the calling
+ * component. Re-registers whenever `handler` changes identity so callers
+ * can close over fresh component state without stale closures.
+ */
+export function useLocalOnboardingActionHandler(
+  actionId: string,
+  handler: LocalOnboardingActionHandler
+) {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    const stableHandler: LocalOnboardingActionHandler = (slots) =>
+      handlerRef.current(slots);
+    registerLocalOnboardingHandler(actionId, stableHandler);
+    return () => {
+      unregisterLocalOnboardingHandler(actionId, stableHandler);
+    };
+  }, [actionId]);
+}

--- a/hushh-webapp/lib/agent/local-onboarding-actions.ts
+++ b/hushh-webapp/lib/agent/local-onboarding-actions.ts
@@ -65,7 +65,13 @@ export function useLocalOnboardingActionHandler(
   handler: LocalOnboardingActionHandler
 ) {
   const handlerRef = useRef(handler);
-  handlerRef.current = handler;
+  // Refs must not be written during render (react-hooks/refs); keep the ref
+  // fresh in an effect instead so the registered handler below never closes
+  // over a stale `handler` without needing `handler` itself in the
+  // registration effect's dependency array.
+  useEffect(() => {
+    handlerRef.current = handler;
+  });
 
   useEffect(() => {
     const stableHandler: LocalOnboardingActionHandler = (slots) =>

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -38,6 +38,7 @@ export const ROUTE_ID_VALUES = [
   "profile_gmail_oauth_return",
   "consents",
   "agent",
+  "connect",
   "marketplace",
   "marketplace_connections",
   "marketplace_connection_portfolio",
@@ -125,6 +126,7 @@ export function resolveRouteId(pathname: string): RouteId {
   }
   if (pathname === ROUTES.CONSENTS) return "consents";
   if (pathname === ROUTES.AGENT) return "agent";
+  if (pathname === ROUTES.CONNECT) return "connect";
   if (pathname === ROUTES.MARKETPLACE) return "marketplace";
   if (pathname === ROUTES.MARKETPLACE_CONNECTIONS) return "marketplace_connections";
   if (pathname === `${ROUTES.MARKETPLACE_CONNECTIONS}/portfolio`) {

--- a/hushh-webapp/lib/voice/investor-kai-action-registry.ts
+++ b/hushh-webapp/lib/voice/investor-kai-action-registry.ts
@@ -28,7 +28,7 @@ export type InvestorKaiBackendEffect = {
 export type InvestorKaiActionWiring =
   | {
       status: "wired";
-      handler: "executeKaiCommand" | "dispatchVoiceToolCall" | "router.push";
+      handler: "executeKaiCommand" | "dispatchVoiceToolCall" | "router.push" | "executeAgentGatewayAction.localHandler";
       binding:
         | {
             kind: "kai_command";
@@ -48,12 +48,17 @@ export type InvestorKaiActionWiring =
             kind: "route";
             href: string;
             params?: Record<string, unknown>;
+          }
+        | {
+            kind: "local_handler";
+            actionId: string;
+            params?: Record<string, unknown>;
           };
     }
   | {
       status: "unwired";
       reason: string;
-      intendedHandler?: "executeKaiCommand" | "dispatchVoiceToolCall" | "router.push";
+      intendedHandler?: "executeKaiCommand" | "dispatchVoiceToolCall" | "router.push" | "local_handler";
     }
   | {
       status: "dead";
@@ -169,7 +174,8 @@ function toWiring(executionTarget: KaiActionExecutionTarget): InvestorKaiActionW
       intendedHandler:
         executionTarget.intended_handler === "executeKaiCommand" ||
         executionTarget.intended_handler === "dispatchVoiceToolCall" ||
-        executionTarget.intended_handler === "router.push"
+        executionTarget.intended_handler === "router.push" ||
+        executionTarget.intended_handler === "local_handler"
           ? executionTarget.intended_handler
           : undefined,
     };
@@ -209,6 +215,18 @@ function toWiring(executionTarget: KaiActionExecutionTarget): InvestorKaiActionW
       binding: {
         kind: "voice_tool",
         toolName: executionTarget.target as VoiceToolCall["tool_name"],
+        params: executionTarget.params ? { ...executionTarget.params } : undefined,
+      },
+    };
+  }
+
+  if (executionTarget.path === "local_handler") {
+    return {
+      status: "wired",
+      handler: "executeAgentGatewayAction.localHandler",
+      binding: {
+        kind: "local_handler",
+        actionId: executionTarget.target,
         params: executionTarget.params ? { ...executionTarget.params } : undefined,
       },
     };
@@ -329,6 +347,15 @@ export function resolveInvestorKaiActionWiring(action: InvestorKaiActionDefiniti
       reason: KNOWN_VOICE_TOOLS.includes(binding.toolName)
         ? "resolved via dispatchVoiceToolCall"
         : "unknown voice tool binding",
+    };
+  }
+
+  if (binding.kind === "local_handler") {
+    return {
+      resolvable: binding.actionId.length > 0,
+      reason: binding.actionId.length > 0
+        ? "resolved via executeAgentGatewayAction.localHandler"
+        : "missing local handler action id",
     };
   }
 

--- a/hushh-webapp/lib/voice/kai-action-gateway.ts
+++ b/hushh-webapp/lib/voice/kai-action-gateway.ts
@@ -23,7 +23,7 @@ export type KaiActionDelegateAgentId =
 export type KaiActionExecutionTarget =
   | {
       status: "wired";
-      path: "kai_command" | "voice_tool" | "route";
+      path: "kai_command" | "voice_tool" | "route" | "local_handler";
       target: string;
       params?: Record<string, unknown>;
     }
@@ -271,7 +271,10 @@ function validateExecutionTarget(value: unknown): KaiActionExecutionTarget | nul
     const path = cleanString(value.path);
     const target = cleanString(value.target);
     if (
-      (path !== "kai_command" && path !== "voice_tool" && path !== "route") ||
+      (path !== "kai_command" &&
+        path !== "voice_tool" &&
+        path !== "route" &&
+        path !== "local_handler") ||
       !target
     ) {
       return null;

--- a/hushh-webapp/lib/voice/voice-action-manifest.ts
+++ b/hushh-webapp/lib/voice/voice-action-manifest.ts
@@ -2,7 +2,11 @@ import manifestJson from "@/contracts/kai/voice-action-manifest.v1.json";
 
 export type VoiceActionManifestRiskLevel = "low" | "medium" | "high";
 export type VoiceActionManifestExecutionPolicy = "allow_direct" | "confirm_required" | "manual_only";
-export type VoiceActionManifestExecutionPath = "kai_command" | "voice_tool" | "route";
+export type VoiceActionManifestExecutionPath =
+  | "kai_command"
+  | "voice_tool"
+  | "route"
+  | "local_handler";
 export type VoiceActionManifestSpeakerPersona = "one" | "kai" | "nav" | "kyc";
 export type VoiceActionManifestDelegateAgentId =
   | "one"
@@ -108,7 +112,8 @@ function validateExecutionHint(input: unknown): VoiceActionManifestExecutionHint
     if (
       path !== "kai_command" &&
       path !== "voice_tool" &&
-      path !== "route"
+      path !== "route" &&
+      path !== "local_handler"
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary

Full voice/UI parity for Agent One's onboarding and setup flow, plus proactive prompting during setup, plus a small batch of pre-existing onboarding/consents polish commits from earlier in this session.

### Commits
1. `fix(consents)`: stop list flicker on select + remove duplicate history trail
2. `fix(onboarding)`: restore animated trail + morphy ripple on root intro screen
3. `feat(agent)`: mount signed-out voice greeter on the root welcome bar
4. `fix(one-adk)`: stabilize `google_search` when mixed with One's full tool roster (ported empirically-verified fix from hushh-search-console for a google-adk 2.4.0 instability)
5. `feat(one-voice)`: full voice/UI parity for onboarding + setup flow. New `local_handler` execution path, 4 new `.voice-action-contract.json` sources (register-phone, one-setup-hub, capability-step, Kai wizard), idle-timeout precaution on live voice sessions
6. `feat(one-adk)`: onboarding ownership + proactive prompting in One's voice runtime. Persona instruction update, screen-change ask-a-question upgrade, per-tool-result `next_step` nudges
7. `docs(one)`: document onboarding action ownership + proactive prompting

## Verification
- Backend: `pytest tests/test_one_adk_agent_tree.py -q` (20/20), full `scripts/run-test-ci.sh` (330/330), `ruff check` + `mypy` clean
- Frontend: `npm run typecheck`, `npm run verify:voice-gateway`, `npm run verify:design-system` all clean; `npx vitest run __tests__/voice __tests__/one-goal` (220/220)
- Docs: `./bin/hushh docs verify` clean
- iOS: real `xcodebuild` build succeeded for the `App` scheme; installed + launched on a booted simulator, screenshotted showing correct render and live "Listening" voice state
- Live Playwright walkthrough (environment-limited: no real mic in headless Chromium) confirmed tap-driven navigation and bar state transitions

---
Closes #4475
(retroactive board-linkage backfill, 2026-07-14)