### PR TITLE
[codex] simplify Gmail receipt sync flow

### DIFF
--- a/consent-protocol/hushh_mcp/services/voice_app_knowledge.py
+++ b/consent-protocol/hushh_mcp/services/voice_app_knowledge.py
@@ -95,20 +95,31 @@ def _build_dynamic_control_entry(label: str) -> VoiceKnowledgeEntry:
         ),
         "add receipts to memory": VoiceKnowledgeEntry(
             key="add_receipts_to_memory",
-            summary="Add receipts to memory builds a compact receipts-memory preview from stored Gmail receipts.",
-            detail="It does not save to PKM yet. It prepares the preview first.",
+            summary=(
+                "Receipt memory is created automatically from stored Gmail receipts after sync."
+            ),
+            detail=(
+                "When your vault is unlocked, the private shopping summary is saved "
+                "automatically to PKM."
+            ),
             aliases=("add receipts to memory", "build receipts memory preview"),
         ),
         "refresh receipt memory": VoiceKnowledgeEntry(
             key="refresh_receipt_memory",
             summary="Refresh receipt memory rebuilds the current receipts-memory preview from stored receipts.",
-            detail="It refreshes merchants, patterns, highlights, and signals before save.",
+            detail=(
+                "It refreshes merchants, patterns, highlights, and signals before the "
+                "summary is saved automatically."
+            ),
             aliases=("refresh receipt memory",),
         ),
         "save receipts memory to pkm": VoiceKnowledgeEntry(
             key="save_receipts_memory_to_pkm",
-            summary="Save receipts memory to PKM writes the current receipts-memory preview into your shopping PKM domain.",
-            detail="It validates the prepared payload and persists the current preview as durable encrypted memory.",
+            summary="Gmail receipt summaries are saved automatically to your shopping PKM domain.",
+            detail=(
+                "There is no separate save action. One validates and stores the encrypted "
+                "summary after sync while your vault is unlocked."
+            ),
             aliases=("save receipts memory to pkm",),
         ),
         "generate pkm preview": VoiceKnowledgeEntry(
@@ -181,10 +192,13 @@ _GLOBAL_CONCEPTS: tuple[VoiceKnowledgeEntry, ...] = (
     ),
     VoiceKnowledgeEntry(
         key="gmail_connector",
-        summary="The Gmail receipts workflow links your inbox, syncs receipt data, and feeds the receipts-to-PKM flow.",
+        summary=(
+            "The Gmail receipts workflow links your inbox, syncs receipt data, and saves "
+            "a private shopping summary to PKM."
+        ),
         detail=(
-            "It manages Gmail connection state, receipt sync, and receipt-memory previews. Raw email bodies are "
-            "not saved into PKM."
+            "It manages Gmail connection state and receipt sync. When the vault is unlocked, it automatically "
+            "saves the compact summary to PKM; raw email bodies are not saved into PKM."
         ),
         aliases=(
             "gmail connector",
@@ -196,8 +210,14 @@ _GLOBAL_CONCEPTS: tuple[VoiceKnowledgeEntry, ...] = (
     ),
     VoiceKnowledgeEntry(
         key="receipt_memory",
-        summary="Receipt memory is a compact shopping-memory snapshot built from stored Gmail receipts.",
-        detail="It summarizes merchants, purchase patterns, recent highlights, and preference signals before save.",
+        summary=(
+            "Receipt memory is a compact shopping-memory snapshot built from stored Gmail "
+            "receipts and saved automatically to PKM."
+        ),
+        detail=(
+            "It summarizes merchants, purchase patterns, recent highlights, and preference "
+            "signals, then saves the private summary automatically when the vault is unlocked."
+        ),
         aliases=("receipt memory", "receipts memory", "receipts memory preview"),
     ),
     VoiceKnowledgeEntry(
@@ -351,11 +371,17 @@ _SURFACE_CONCEPTS: dict[str, VoiceKnowledgeEntry] = {
 
 _SECTION_CONCEPTS: dict[str, dict[str, VoiceKnowledgeEntry]] = {
     "profile_receipts": {
-        "receipt memory preview": VoiceKnowledgeEntry(
+        "shopping summary": VoiceKnowledgeEntry(
             key="receipt_memory_preview_section",
-            summary="Receipt Memory Preview shows the compact shopping memory derived from your stored receipts.",
-            detail="It surfaces merchants, purchase patterns, recent highlights, and preference signals before save.",
-            aliases=("receipt memory preview",),
+            summary=(
+                "Shopping Summary shows the compact private memory derived from your stored "
+                "receipts."
+            ),
+            detail=(
+                "It surfaces merchants, purchase patterns, recent highlights, and preference "
+                "signals and is saved automatically to PKM."
+            ),
+            aliases=("shopping summary", "receipt memory preview"),
         ),
         "latest sync": VoiceKnowledgeEntry(
             key="latest_sync_section",
@@ -564,7 +590,10 @@ def _resolve_section(
         )
     summary = entry.summary
     detail = entry.detail
-    if screen == "profile_receipts" and section_key == "receipt memory preview":
+    if screen == "profile_receipts" and section_key in {
+        "shopping summary",
+        "receipt memory preview",
+    }:
         connector = _coerce_text(
             screen_metadata.get("connector_badge_label") or screen_metadata.get("connector_state")
         )
@@ -573,12 +602,13 @@ def _resolve_section(
         preview_stale = _coerce_bool(screen_metadata.get("preview_stale"), default=False)
         if connector and receipt_count is not None:
             summary = (
-                "Receipt Memory Preview shows the compact shopping memory built from your stored "
+                "Shopping Summary shows the compact private memory built from your stored "
                 f"receipts. Gmail is {connector.lower()} with {receipt_count} stored receipts."
             )
             if preview_available:
                 summary = (
-                    f"{summary} The current preview is {'stale' if preview_stale else 'ready'}."
+                    f"{summary} The current shopping summary is "
+                    f"{'stale' if preview_stale else 'ready'}."
                 )
     elif screen == "profile_gmail_panel" and section_key == "gmail connector":
         inbox = _coerce_text(screen_metadata.get("google_email"))
@@ -640,10 +670,13 @@ def _resolve_surface(
         preview_available = _coerce_bool(screen_metadata.get("preview_available"), default=False)
         preview_stale = _coerce_bool(screen_metadata.get("preview_stale"), default=False)
         if connector and receipt_count is not None:
-            summary = f"Receipt Memory Preview is active. Gmail is {connector.lower()} with {receipt_count} stored receipts."
+            summary = (
+                "Shopping Summary is active. Gmail is "
+                f"{connector.lower()} with {receipt_count} stored receipts."
+            )
             if preview_available:
                 summary = (
-                    f"{summary} The current receipts-memory preview is "
+                    f"{summary} The current shopping summary is "
                     f"{'stale' if preview_stale else 'ready'}."
                 )
     elif screen == "profile_gmail_panel":
@@ -696,16 +729,20 @@ def _resolve_local_concept(
 
 def _resolve_global_concept(transcript: str) -> VoiceKnowledgeResolution | None:
     normalized = _normalize(transcript)
+    matches: list[tuple[int, VoiceKnowledgeEntry]] = []
     for entry in _GLOBAL_CONCEPTS:
         for alias in entry.aliases or (entry.key,):
             if _matches_phrase(normalized, alias):
-                return VoiceKnowledgeResolution(
-                    tier="global_concept",
-                    key=entry.key,
-                    summary=entry.summary,
-                    detail=entry.detail,
-                )
-    return None
+                matches.append((len(_normalize(alias)), entry))
+    if not matches:
+        return None
+    _, entry = max(matches, key=lambda match: match[0])
+    return VoiceKnowledgeResolution(
+        tier="global_concept",
+        key=entry.key,
+        summary=entry.summary,
+        detail=entry.detail,
+    )
 
 
 def resolve_voice_explain_knowledge(
@@ -843,11 +880,11 @@ _COMPAT_GLOBAL_CONCEPTS: dict[str, dict[str, Any]] = {
             "gmail integration",
         ],
         "short": (
-            "Gmail receipts connects your inbox, manages receipt sync, and feeds the governed receipts-to-PKM workflow."
+            "Gmail receipts connects your inbox, manages receipt sync, and automatically saves a private shopping summary to PKM."
         ),
         "detailed": (
-            "Gmail receipts links the selected inbox, manages receipt sync and backfill state, builds a "
-            "receipt-memory preview, and supports saving that governed summary into PKM instead of writing raw emails."
+            "Gmail receipts links the selected inbox, manages receipt sync and backfill state, builds a private "
+            "shopping summary, and saves it automatically to PKM instead of writing raw emails."
         ),
     },
     "portfolio": {
@@ -978,12 +1015,18 @@ _COMPAT_SURFACE_DEFINITIONS: dict[str, dict[str, Any]] = {
     "profile_receipts": {
         "screenId": "profile_receipts",
         "title": "Gmail receipts",
-        "purpose": "This page manages Gmail receipt sync, backfill state, stored receipts, and receipt-memory import into PKM.",
+        "purpose": (
+            "This page manages Gmail receipt sync, stored receipts, and an automatically "
+            "saved private shopping summary."
+        ),
         "sections": [
             {
                 "id": "receipt_memory",
-                "title": "Receipt memory",
-                "purpose": "This section previews and saves the compact receipt snapshot before it reaches PKM.",
+                "title": "Shopping summary",
+                "purpose": (
+                    "This section shows the private receipt summary that is saved "
+                    "automatically to PKM."
+                ),
             },
             {
                 "id": "stored_receipts",
@@ -991,24 +1034,7 @@ _COMPAT_SURFACE_DEFINITIONS: dict[str, dict[str, Any]] = {
                 "purpose": "This section lists normalized stored receipts from Gmail.",
             },
         ],
-        "controls": [
-            {
-                "id": "add_receipts_to_memory",
-                "label": "Add receipts to memory",
-                "purpose": "builds the receipts-memory preview from stored receipts.",
-                "action_id": "profile.receipts_memory.preview",
-                "role": "button",
-                "voice_aliases": ["add receipts to memory", "build receipts memory preview"],
-            },
-            {
-                "id": "save_receipts_memory",
-                "label": "Save receipts memory to PKM",
-                "purpose": "saves the current receipts-memory preview into shopping receipts memory.",
-                "action_id": "profile.receipts_memory.save",
-                "role": "button",
-                "voice_aliases": ["save receipts memory", "save receipts memory to pkm"],
-            },
-        ],
+        "controls": [],
         "concepts": [
             {
                 "id": "pkm",

--- a/consent-protocol/hushh_mcp/services/voice_intent_service.py
+++ b/consent-protocol/hushh_mcp/services/voice_intent_service.py
@@ -2916,9 +2916,9 @@ class VoiceIntentService:
 
         if _is_receipts_memory_intent(lowered):
             message = (
-                "Use Add receipts to memory here."
+                "Receipt memory is updated automatically after Gmail sync."
                 if current_screen == "profile_receipts"
-                else "Opening receipts. Use Add receipts to memory there."
+                else "Opening receipts. Receipt memory updates automatically after Gmail sync."
             )
             action_id_override = (
                 None if current_screen == "profile_receipts" else "route.profile_receipts"

--- a/consent-protocol/tests/test_kai_voice_contract.py
+++ b/consent-protocol/tests/test_kai_voice_contract.py
@@ -313,8 +313,8 @@ async def test_plan_voice_response_screen_explain_uses_receipts_surface_metadata
                     "screen": "profile_receipts",
                 },
                 "ui": {
-                    "active_section": "Receipt memory preview",
-                    "available_actions": ["Refresh receipt memory", "Save receipts memory to PKM"],
+                    "active_section": "Shopping summary",
+                    "available_actions": ["Sync Gmail receipts"],
                 },
                 "screen_metadata": {
                     "connector_badge_label": "Connected",
@@ -327,7 +327,7 @@ async def test_plan_voice_response_screen_explain_uses_receipts_surface_metadata
     )
 
     assert response["kind"] == "speak_only"
-    assert "Receipt Memory Preview" in response["message"]
+    assert "Shopping Summary" in response["message"]
     assert "12 stored receipts" in response["message"]
 
 
@@ -831,7 +831,7 @@ async def test_plan_voice_response_explains_control_with_deterministic_knowledge
 
     assert response["kind"] == "speak_only"
     assert response["execution_allowed"] is False
-    assert "writes the current receipts-memory preview" in response["message"].lower()
+    assert "saved automatically" in response["message"].lower()
     assert openai_http_ms == 0
     assert model == "deterministic"
 

--- a/consent-protocol/tests/test_voice_app_knowledge.py
+++ b/consent-protocol/tests/test_voice_app_knowledge.py
@@ -5,13 +5,13 @@ from hushh_mcp.services.voice_app_knowledge import (
 )
 
 
-def test_resolve_voice_explain_knowledge_prioritizes_control_over_section() -> None:
+def test_resolve_voice_explain_knowledge_explains_legacy_save_phrase() -> None:
     resolution = resolve_voice_explain_knowledge(
         transcript="What does Save receipts memory to PKM do?",
         screen="profile_receipts",
         pathname="/profile/receipts",
-        active_section="Receipt memory preview",
-        available_actions=["Save receipts memory to PKM", "Refresh receipt memory"],
+        active_section="Shopping summary",
+        available_actions=["Sync Gmail receipts"],
         screen_metadata={
             "connector_badge_label": "Connected",
             "receipt_count": 12,
@@ -20,9 +20,9 @@ def test_resolve_voice_explain_knowledge_prioritizes_control_over_section() -> N
         },
     )
 
-    assert resolution.tier == "control"
-    assert resolution.key == "save_receipts_memory_to_pkm"
-    assert "writes the current receipts-memory preview" in resolution.summary.lower()
+    assert resolution.tier == "global_concept"
+    assert resolution.key == "receipt_memory"
+    assert "saved automatically" in resolution.summary.lower()
 
 
 def test_resolve_voice_explain_knowledge_section_uses_receipts_metadata() -> None:
@@ -30,8 +30,8 @@ def test_resolve_voice_explain_knowledge_section_uses_receipts_metadata() -> Non
         transcript="What is on my screen?",
         screen="profile_receipts",
         pathname="/profile/receipts",
-        active_section="Receipt memory preview",
-        available_actions=["Refresh receipt memory", "Save receipts memory to PKM"],
+        active_section="Shopping summary",
+        available_actions=["Sync Gmail receipts"],
         screen_metadata={
             "connector_badge_label": "Connected",
             "receipt_count": 12,
@@ -42,7 +42,7 @@ def test_resolve_voice_explain_knowledge_section_uses_receipts_metadata() -> Non
 
     assert resolution.tier == "section"
     assert "12 stored receipts" in resolution.summary
-    assert "preview is ready" in resolution.summary.lower()
+    assert "shopping summary is ready" in resolution.summary.lower()
 
 
 def test_resolve_voice_explain_knowledge_resolves_local_concept() -> None:

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -1564,7 +1564,8 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
@@ -1645,11 +1646,10 @@
       "delegate_agent_id": null,
       "reachability": {
         "routes": [
-          "/profile",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -1666,8 +1666,8 @@
       "execution_policy": "confirm_required",
       "execution_target": {
         "status": "unwired",
-        "reason": "Only local component handler exists (handleConnectGmail in ProfilePage).",
-        "intended_handler": "router.push"
+        "reason": "Only local component handler exists (handleConnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleConnectGmail"
       },
       "control_ids": [
         "open_gmail_connector"
@@ -1675,12 +1675,12 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
         "state_changes": [
-          "current route becomes /profile"
+          "current route becomes /one/gmail"
         ],
         "backend_effects": [
           {
@@ -1710,8 +1710,8 @@
             "label": "Connect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -1752,12 +1752,10 @@
       "delegate_agent_id": null,
       "reachability": {
         "routes": [
-          "/one/gmail",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "gmail",
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -1783,8 +1781,7 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx",
-        "app/gmail/page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
@@ -1849,213 +1846,6 @@
       }
     },
     {
-      "action_id": "profile.receipts_memory.preview",
-      "surface_id": "gmail",
-      "label": "Build receipts memory preview",
-      "aliases": [
-        "preview receipts memory",
-        "generate receipts memory preview"
-      ],
-      "search_keywords": [
-        "receipts memory",
-        "preview receipts"
-      ],
-      "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [],
-        "active_personas": [
-          "investor",
-          "ria"
-        ],
-        "requires_persona_switch_confirmation": false
-      },
-      "guard_ids": [],
-      "risk_level": "medium",
-      "execution_policy": "allow_direct",
-      "execution_target": {
-        "status": "unwired",
-        "reason": "Implemented only in local receipts-page handlers; no shared voice/action adapter yet.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "control_ids": [
-        "edit_receipts_summary"
-      ],
-      "state_exposure": [],
-      "docs_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
-      ],
-      "workflow": null,
-      "expected_effects": {
-        "state_changes": [
-          "current route becomes /one/gmail"
-        ],
-        "backend_effects": [
-          {
-            "api": "POST /api/kai/gmail/receipts-memory/preview (proxied)",
-            "effect": "Builds or refreshes the receipts memory artifact preview."
-          }
-        ]
-      },
-      "trigger": {
-        "primary": "voice",
-        "supported": [
-          "voice",
-          "tap",
-          "keyboard",
-          "programmatic"
-        ]
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.preview",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.preview",
-            "label": "Build receipts memory preview",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      }
-    },
-    {
-      "action_id": "profile.receipts_memory.save",
-      "surface_id": "gmail",
-      "label": "Save receipts memory to PKM",
-      "aliases": [
-        "save receipts memory",
-        "save receipts to memory"
-      ],
-      "search_keywords": [
-        "save receipts memory"
-      ],
-      "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [
-          "receipt memory preview must exist before save"
-        ],
-        "active_personas": [
-          "investor",
-          "ria"
-        ],
-        "requires_persona_switch_confirmation": false
-      },
-      "guard_ids": [
-        "vault_unlocked",
-        "manual_user_execution"
-      ],
-      "risk_level": "medium",
-      "execution_policy": "manual_only",
-      "execution_target": {
-        "status": "unwired",
-        "reason": "Save to PKM is currently implemented only inside the receipts page.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "control_ids": [
-        "save_receipts_memory"
-      ],
-      "state_exposure": [],
-      "docs_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
-      ],
-      "workflow": null,
-      "expected_effects": {
-        "state_changes": [
-          "current route becomes /one/gmail"
-        ],
-        "backend_effects": []
-      },
-      "trigger": {
-        "primary": "voice",
-        "supported": [
-          "voice",
-          "tap",
-          "keyboard",
-          "programmatic"
-        ]
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.save",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.save",
-            "label": "Save receipts memory to PKM",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      }
-    },
-    {
       "action_id": "profile.gmail.disconnect",
       "surface_id": "gmail",
       "label": "Disconnect Gmail",
@@ -2071,10 +1861,10 @@
       "delegate_agent_id": null,
       "reachability": {
         "routes": [
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -2092,19 +1882,21 @@
       "execution_policy": "manual_only",
       "execution_target": {
         "status": "unwired",
-        "reason": "No global action dispatcher for Gmail disconnect yet.",
-        "intended_handler": "dispatchVoiceToolCall"
+        "reason": "Only local component handler exists (handleDisconnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleDisconnectGmail"
       },
-      "control_ids": [],
+      "control_ids": [
+        "disconnect_gmail"
+      ],
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
         "state_changes": [
-          "current route becomes /profile/gmail"
+          "current route becomes /one/gmail"
         ],
         "backend_effects": [
           {
@@ -2134,8 +1926,8 @@
             "label": "Disconnect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile/gmail",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -4694,7 +4486,8 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -756,7 +756,8 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -771,11 +772,10 @@
       ],
       "scope": {
         "routes": [
-          "/profile",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -787,8 +787,8 @@
       "execution_policy": "confirm_required",
       "execution_hint": {
         "status": "unwired",
-        "reason": "Only local component handler exists (handleConnectGmail in ProfilePage).",
-        "intended_handler": "router.push"
+        "reason": "Only local component handler exists (handleConnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleConnectGmail"
       },
       "goal": {
         "goal_id": "goal.profile.gmail.connect",
@@ -802,8 +802,8 @@
             "label": "Connect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -828,7 +828,7 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -843,12 +843,10 @@
       ],
       "scope": {
         "routes": [
-          "/one/gmail",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "gmail",
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -901,151 +899,7 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx",
-        "app/gmail/page.tsx"
-      ]
-    },
-    {
-      "id": "profile.receipts_memory.preview",
-      "label": "Build receipts memory preview",
-      "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "aliases": [
-        "preview receipts memory",
-        "generate receipts memory preview"
-      ],
-      "scope": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": []
-      },
-      "guard_ids": [],
-      "risk_level": "medium",
-      "execution_policy": "allow_direct",
-      "execution_hint": {
-        "status": "unwired",
-        "reason": "Implemented only in local receipts-page handlers; no shared voice/action adapter yet.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.preview",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.preview",
-            "label": "Build receipts memory preview",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      },
-      "map_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
-      ]
-    },
-    {
-      "id": "profile.receipts_memory.save",
-      "label": "Save receipts memory to PKM",
-      "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "aliases": [
-        "save receipts memory",
-        "save receipts to memory"
-      ],
-      "scope": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [
-          "receipt memory preview must exist before save"
-        ]
-      },
-      "guard_ids": [
-        "vault_unlocked",
-        "manual_user_execution"
-      ],
-      "risk_level": "medium",
-      "execution_policy": "manual_only",
-      "execution_hint": {
-        "status": "unwired",
-        "reason": "Save to PKM is currently implemented only inside the receipts page.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.save",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.save",
-            "label": "Save receipts memory to PKM",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      },
-      "map_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -1060,10 +914,10 @@
       ],
       "scope": {
         "routes": [
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -1076,8 +930,8 @@
       "execution_policy": "manual_only",
       "execution_hint": {
         "status": "unwired",
-        "reason": "No global action dispatcher for Gmail disconnect yet.",
-        "intended_handler": "dispatchVoiceToolCall"
+        "reason": "Only local component handler exists (handleDisconnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleDisconnectGmail"
       },
       "goal": {
         "goal_id": "goal.profile.gmail.disconnect",
@@ -1091,8 +945,8 @@
             "label": "Disconnect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile/gmail",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -1117,7 +971,7 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -2966,7 +2820,8 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {

--- a/docs/reference/kai/kai-action-gateway-vnext.md
+++ b/docs/reference/kai/kai-action-gateway-vnext.md
@@ -51,7 +51,7 @@ The action system is split into four deliberate layers.
 
 Each voice-capable or search-capable Kai surface owns a colocated `.voice-action-contract.json` file next to the feature surface.
 
-Current generated coverage includes 23 source contracts, 23 surfaces, and 90 actions. Source contracts:
+Current generated coverage includes 24 source contracts, 24 surfaces, and 95 actions. Source contracts:
 
 - [page.voice-action-contract.json](../../../hushh-webapp/app/one/kai/analysis/page.voice-action-contract.json)
 - [page.voice-action-contract.json](../../../hushh-webapp/app/one/page.voice-action-contract.json)

--- a/docs/reference/one/one-voice-action-coverage-audit.md
+++ b/docs/reference/one/one-voice-action-coverage-audit.md
@@ -137,8 +137,6 @@ Action inventory:
 | `route.profile_receipts` | wired route `/profile/receipts` | Can open receipts memory page. |
 | `profile.gmail.connect` | unwired | Local Gmail connect handler only; confirmation required. |
 | `profile.gmail.sync_now` | unwired | Local receipts/Profile handlers only; confirmation required. |
-| `profile.receipts_memory.preview` | unwired | Local receipts page handler only. |
-| `profile.receipts_memory.save` | unwired | Local receipts page save only; manual-only. |
 | `profile.gmail.disconnect` | unwired | No global voice/action adapter; manual-only. |
 | `route.ria_home` | wired route `/ria` plus workflow | Can ask to switch to RIA persona, then route to `/ria`. |
 | `route.ria_onboarding` | wired route `/ria/onboarding` | Can navigate to RIA setup. |

--- a/hushh-webapp/__tests__/app/profile/gmail/oauth/return/page.test.tsx
+++ b/hushh-webapp/__tests__/app/profile/gmail/oauth/return/page.test.tsx
@@ -87,7 +87,7 @@ describe("ProfileGmailOAuthReturnPage", () => {
     });
   });
 
-  it("redirects back to Gmail settings when the callback is replayed after a successful connection", async () => {
+  it("redirects back to Gmail receipts when the callback is replayed after a successful connection", async () => {
     mocks.gmailReceiptsService.completeConnect.mockRejectedValue(
       new Error("OAuth state expired")
     );
@@ -107,7 +107,7 @@ describe("ProfileGmailOAuthReturnPage", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.routerReplace).toHaveBeenCalledWith("/profile/gmail");
+      expect(mocks.routerReplace).toHaveBeenCalledWith("/one/gmail");
     });
 
     expect(screen.queryByText("Gmail connection needs attention")).toBeNull();

--- a/hushh-webapp/__tests__/app/profile/receipts/page.test.tsx
+++ b/hushh-webapp/__tests__/app/profile/receipts/page.test.tsx
@@ -11,10 +11,29 @@ const mocks = vi.hoisted(() => {
       success: vi.fn(),
       error: vi.fn(),
       message: vi.fn(),
+      info: vi.fn(),
+      promise: vi.fn((promise: Promise<unknown> | (() => Promise<unknown>)) => ({
+        unwrap: () => (typeof promise === "function" ? promise() : promise),
+      })),
     },
     gmailReceiptsService: {
       listReceipts: vi.fn(),
+      startConnect: vi.fn(),
       syncNow: vi.fn(),
+    },
+    assignWindowLocation: vi.fn(),
+    pkmDomainResourceService: {
+      prepareDomainWriteContext: vi.fn(),
+    },
+    pkmWriteCoordinator: {
+      savePreparedDomain: vi.fn(),
+    },
+    personalKnowledgeModelService: {
+      validatePreparedDomainStore: vi.fn(),
+    },
+    receiptMemoryPkm: {
+      buildShoppingReceiptMemoryPreparedDomain: vi.fn(),
+      hasMatchingReceiptMemoryProvenance: vi.fn(),
     },
     useVault: vi.fn(),
   };
@@ -56,15 +75,18 @@ vi.mock("@/components/app-ui/app-page-shell", () => ({
 
 vi.mock("@/components/app-ui/page-sections", () => ({
   PageHeader: ({
+    eyebrow,
     title,
     description,
     actions,
   }: {
+    eyebrow?: React.ReactNode;
     title?: React.ReactNode;
     description?: React.ReactNode;
     actions?: React.ReactNode;
   }) => (
     <div>
+      <div>{eyebrow}</div>
       <div>{title}</div>
       <div>{description}</div>
       <div>{actions}</div>
@@ -93,6 +115,55 @@ vi.mock("@/components/vault/vault-unlock-dialog", () => ({
   VaultUnlockDialog: () => null,
 }));
 
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    children,
+    open,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+  }) => (open ? <div>{children}</div> : null),
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogCancel: ({
+    children,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }) => (
+    <button type="button" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
 vi.mock("@/lib/morphy-ux/button", () => ({
   Button: ({
     children,
@@ -118,15 +189,21 @@ vi.mock("lucide-react", () => ({
   RotateCcw: () => <span />,
   Send: () => <span />,
   Sparkles: () => <span />,
+  Trash2: () => <span />,
 }));
 
 vi.mock("@/lib/navigation/routes", () => ({
   ROUTES: {
     PROFILE: "/profile",
     PROFILE_GMAIL: "/profile/gmail",
-    GMAIL: "/gmail",
+    GMAIL: "/one/gmail",
     PROFILE_RECEIPTS: "/profile/receipts",
+    PROFILE_GMAIL_OAUTH_RETURN: "/profile/gmail/oauth/return",
   },
+}));
+
+vi.mock("@/lib/utils/browser-navigation", () => ({
+  assignWindowLocation: mocks.assignWindowLocation,
 }));
 
 vi.mock("@/lib/vault/vault-context", () => ({
@@ -140,15 +217,11 @@ vi.mock("@/lib/services/vault-service", () => ({
 }));
 
 vi.mock("@/lib/pkm/pkm-domain-resource", () => ({
-  PkmDomainResourceService: {
-    refreshDomain: vi.fn(),
-  },
+  PkmDomainResourceService: mocks.pkmDomainResourceService,
 }));
 
 vi.mock("@/lib/services/pkm-write-coordinator", () => ({
-  PkmWriteCoordinator: {
-    writePreparedDomain: vi.fn(),
-  },
+  PkmWriteCoordinator: mocks.pkmWriteCoordinator,
 }));
 
 vi.mock("@/lib/services/gmail-receipt-memory-service", () => ({
@@ -265,14 +338,14 @@ vi.mock("@/lib/services/gmail-receipt-memory-service", () => ({
 }));
 
 vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
-  PersonalKnowledgeModelService: {
-    getPreparedDomain: vi.fn(),
-  },
+  PersonalKnowledgeModelService: mocks.personalKnowledgeModelService,
 }));
 
 vi.mock("@/lib/profile/gmail-receipt-memory-pkm", () => ({
-  buildShoppingReceiptMemoryPreparedDomain: vi.fn(),
-  hasMatchingReceiptMemoryProvenance: vi.fn().mockReturnValue(false),
+  buildShoppingReceiptMemoryPreparedDomain:
+    mocks.receiptMemoryPkm.buildShoppingReceiptMemoryPreparedDomain,
+  hasMatchingReceiptMemoryProvenance:
+    mocks.receiptMemoryPkm.hasMatchingReceiptMemoryProvenance,
 }));
 
 import ProfileReceiptsPage from "@/components/gmail/gmail-receipts-page";
@@ -282,6 +355,7 @@ import {
 } from "@/lib/profile/gmail-receipts-cache";
 import { GmailReceiptsService } from "@/lib/services/gmail-receipts-service";
 import { GmailReceiptMemoryService } from "@/lib/services/gmail-receipt-memory-service";
+import { assignWindowLocation } from "@/lib/utils/browser-navigation";
 
 function makeReceipt(id: number, merchant: string) {
   const timestamp = `2026-04-0${id}T00:00:00Z`;
@@ -364,6 +438,8 @@ describe("ProfileReceiptsPage", () => {
     mocks.useAuth.mockReturnValue({
       user: {
         uid: "user-123",
+        email: "akshat@example.com",
+        providerData: [{ providerId: "google.com" }],
         getIdToken: vi.fn().mockResolvedValue("token-abc"),
       },
       loading: false,
@@ -373,6 +449,22 @@ describe("ProfileReceiptsPage", () => {
       vaultOwnerToken: "vault-owner-token-123",
       isVaultUnlocked: true,
     });
+    mocks.pkmDomainResourceService.prepareDomainWriteContext.mockResolvedValue({
+      domainData: {},
+    });
+    mocks.pkmWriteCoordinator.savePreparedDomain.mockResolvedValue({
+      success: true,
+      conflict: false,
+      saveState: "saved",
+    });
+    mocks.personalKnowledgeModelService.validatePreparedDomainStore.mockResolvedValue(
+      {
+        success: true,
+      },
+    );
+    mocks.receiptMemoryPkm.hasMatchingReceiptMemoryProvenance.mockReturnValue(
+      false,
+    );
     gmailView = buildGmailView();
     mocks.useGmailConnectorStatus.mockReturnValue(gmailView);
 
@@ -382,6 +474,13 @@ describe("ProfileReceiptsPage", () => {
       per_page: 20,
       total: 0,
       has_more: false,
+    });
+    vi.mocked(GmailReceiptsService.startConnect).mockResolvedValue({
+      configured: true,
+      authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
+      state: "state-123",
+      redirect_uri: "http://localhost:3000/profile/gmail/oauth/return",
+      expires_at: "2026-04-01T00:00:00Z",
     });
   });
 
@@ -400,6 +499,80 @@ describe("ProfileReceiptsPage", () => {
     expect(mocks.toast.message).toHaveBeenCalledWith(
       "Syncing your receipts now.",
     );
+  });
+
+  it("removes the redundant Gmail eyebrow", () => {
+    render(<ProfileReceiptsPage />);
+
+    expect(screen.queryByText(/one \/ gmail/i)).toBeNull();
+  });
+
+  it("automatically saves the generated summary to private memory", async () => {
+    vi.mocked(GmailReceiptsService.listReceipts).mockResolvedValue({
+      items: [makeReceipt(1, "Summary Shop")],
+      page: 1,
+      per_page: 20,
+      total: 1,
+      has_more: false,
+    });
+
+    render(<ProfileReceiptsPage />);
+
+    expect(
+      await screen.findByText("Kai sees recent shopping activity."),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        mocks.pkmWriteCoordinator.savePreparedDomain,
+      ).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText("Saved to memory")).toBeTruthy();
+    expect(
+      screen.getByText("Your shopping summary is saved to your private memory."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /save insights/i })).toBeNull();
+  });
+
+  it("shows an existing matching summary as saved without another memory write", async () => {
+    vi.mocked(GmailReceiptsService.listReceipts).mockResolvedValue({
+      items: [makeReceipt(1, "Existing Summary Shop")],
+      page: 1,
+      per_page: 20,
+      total: 1,
+      has_more: false,
+    });
+    mocks.pkmDomainResourceService.prepareDomainWriteContext.mockResolvedValue({
+      domainData: { receipts_memory: { provenance: {} } },
+    });
+    mocks.receiptMemoryPkm.hasMatchingReceiptMemoryProvenance.mockReturnValue(
+      true,
+    );
+
+    render(<ProfileReceiptsPage />);
+
+    expect(await screen.findByText("Saved to memory")).toBeTruthy();
+    expect(mocks.pkmWriteCoordinator.savePreparedDomain).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the summary was saved when automatic persistence fails", async () => {
+    vi.mocked(GmailReceiptsService.listReceipts).mockResolvedValue({
+      items: [makeReceipt(1, "Failed Summary Shop")],
+      page: 1,
+      per_page: 20,
+      total: 1,
+      has_more: false,
+    });
+    mocks.pkmWriteCoordinator.savePreparedDomain.mockResolvedValue({
+      success: false,
+      conflict: false,
+      saveState: "failed",
+      message: "Private memory is temporarily unavailable.",
+    });
+
+    render(<ProfileReceiptsPage />);
+
+    expect(await screen.findByText("Save failed")).toBeTruthy();
+    expect(screen.queryByText("Saved to memory")).toBeNull();
   });
 
   it("holds sealed receipts behind vault unlock when the vault is locked", async () => {
@@ -679,11 +852,14 @@ describe("ProfileReceiptsPage", () => {
 
     expect(await screen.findByText("Stored Shop")).toBeTruthy();
     expect(
-      screen.getByText(/saved receipts are still available here/i),
-    ).toBeTruthy();
-    expect(
       screen.getByRole("heading", { name: /reconnect gmail/i }),
     ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /reconnect gmail/i }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/gmail is currently disconnected/i)).toBeNull();
+    expect(screen.queryByText(/shopping summary/i)).toBeNull();
+    expect(vi.mocked(GmailReceiptMemoryService.preview)).not.toHaveBeenCalled();
   });
 
   it("shows one clear Gmail connect action when Gmail is not connected", async () => {
@@ -724,6 +900,61 @@ describe("ProfileReceiptsPage", () => {
     ).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: /connect gmail/i }));
-    expect(mocks.routerPush).toHaveBeenCalledWith("/profile/gmail");
+    await waitFor(() => {
+      expect(GmailReceiptsService.startConnect).toHaveBeenCalledWith({
+        idToken: "token-abc",
+        userId: "user-123",
+        redirectUri: "http://localhost:3000/profile/gmail/oauth/return",
+        loginHint: "akshat@example.com",
+        includeGrantedScopes: true,
+      });
+    });
+    expect(assignWindowLocation).toHaveBeenCalledWith(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+  });
+
+  it("disconnects Gmail from the receipts page without clearing stored receipts", async () => {
+    vi.mocked(GmailReceiptsService.listReceipts).mockResolvedValue({
+      items: [makeReceipt(1, "Stored Shop")],
+      page: 1,
+      per_page: 20,
+      total: 1,
+      has_more: false,
+    });
+    gmailView.disconnectGmail.mockResolvedValue({
+      configured: true,
+      connected: false,
+      status: "disconnected",
+      scope_csv: "gmail.readonly",
+      last_sync_status: "completed",
+      auto_sync_enabled: false,
+      revoked: true,
+      latest_run: null,
+      google_email: "akshat@example.com",
+    });
+
+    render(<ProfileReceiptsPage />);
+
+    expect(await screen.findByText("Stored Shop")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /^disconnect$/i }));
+    expect(screen.getByText("Disconnect Gmail?")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /^disconnect gmail$/i }),
+    );
+
+    await waitFor(() => {
+      expect(gmailView.disconnectGmail).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.toast.promise).toHaveBeenCalledWith(
+      expect.any(Promise),
+      expect.objectContaining({
+        loading: "Disconnecting Gmail...",
+        success: "Gmail disconnected. Saved receipts stay available here.",
+      }),
+    );
+    expect(screen.getByText("Stored Shop")).toBeTruthy();
   });
 });

--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -55,6 +55,16 @@ describe("navigation routes", () => {
         detail: "support-compose:bug_report",
       }),
     ).toBe("/profile/support/compose?kind=bug_report");
+    expect(buildProfileRoute({ panel: "gmail" })).toBe("/one/gmail");
+    expect(
+      buildProfileRoute({
+        panel: "gmail",
+        detail: "gmail-actions",
+        searchParams: transient,
+      }),
+    ).toBe(
+      "/one/gmail?unlock_vault=1&return_to=%2Fone%2Flocation%2Finvite%2Ftoken_123",
+    );
     expect(
       buildProfileRoute({ panel: "security", searchParams: transient }),
     ).toBe(
@@ -79,6 +89,12 @@ describe("navigation routes", () => {
         "panel=support&detail=support-routing",
       ),
     ).toBe("/profile/support/routing");
+    expect(
+      buildCanonicalProfileRouteFromLegacyQuery(
+        "/profile",
+        "panel=gmail&detail=gmail-actions",
+      ),
+    ).toBe("/one/gmail");
   });
 
   it("preserves query parameter integrity for ria workspace tabs", () => {

--- a/hushh-webapp/__tests__/voice/investor-kai-action-registry.test.ts
+++ b/hushh-webapp/__tests__/voice/investor-kai-action-registry.test.ts
@@ -127,13 +127,10 @@ describe("investor-kai-action-registry", () => {
 
     expect(
       INVESTOR_KAI_ACTION_REGISTRY.find((action) => action.id === "profile.receipts_memory.preview")
-        ?.expectedEffects.backendEffects
-    ).toEqual([
-      {
-        api: "POST /api/kai/gmail/receipts-memory/preview (proxied)",
-        effect: "Builds or refreshes the receipts memory artifact preview.",
-      },
-    ]);
+    ).toBeUndefined();
+    expect(
+      INVESTOR_KAI_ACTION_REGISTRY.find((action) => action.id === "profile.receipts_memory.save")
+    ).toBeUndefined();
 
     expect(
       INVESTOR_KAI_ACTION_REGISTRY.find((action) => action.id === "profile.gmail.disconnect")
@@ -158,9 +155,9 @@ describe("investor-kai-action-registry", () => {
 
   it("lists surface-specific actions for Gmail and PKM routes", () => {
     const gmailActions = listInvestorKaiActionsForSurface({
-      screen: "profile_gmail_panel",
-      href: "/profile/gmail",
-      pathname: "/profile/gmail",
+      screen: "gmail",
+      href: "/one/gmail",
+      pathname: "/one/gmail",
     }).map((action) => action.id);
 
     expect(gmailActions).toEqual(

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -284,30 +284,30 @@ describe("buildStructuredScreenContext", () => {
       surfaceDefinition: {
         screenId: "profile_receipts",
         title: "Gmail receipts",
-        purpose: "This page manages Gmail receipt sync and receipt memory import.",
+        purpose: "This page syncs receipts and saves a private shopping summary automatically.",
         sections: [
           {
             id: "receipt_memory",
-            title: "Receipt memory",
-            purpose: "This section previews receipt memory before saving it to PKM.",
+            title: "Shopping summary",
+            purpose: "This section shows the summary saved automatically to PKM.",
           },
         ],
         actions: [
           {
-            id: "profile.receipts_memory.preview",
-            label: "Refresh receipt memory",
-            purpose: "Refreshes the current receipt memory preview.",
-            voiceAliases: ["refresh receipt memory"],
+            id: "profile.gmail.sync_now",
+            label: "Sync receipts",
+            purpose: "Syncs Gmail receipts and refreshes the shopping summary.",
+            voiceAliases: ["sync receipts"],
           },
         ],
         controls: [
           {
-            id: "save_receipts_memory",
-            label: "Save receipts memory to PKM",
-            purpose: "Saves the current receipt memory preview into PKM.",
-            actionId: "profile.receipts_memory.save",
+            id: "sync_gmail_receipts",
+            label: "Sync receipts",
+            purpose: "Syncs Gmail receipts.",
+            actionId: "profile.gmail.sync_now",
             role: "button",
-            voiceAliases: ["save receipts memory"],
+            voiceAliases: ["sync receipts"],
           },
         ],
         concepts: [
@@ -319,12 +319,12 @@ describe("buildStructuredScreenContext", () => {
           },
         ],
       },
-      activeSection: "Receipt memory preview",
-      visibleModules: ["Connector status", "Receipt memory preview"],
-      availableActions: ["Refresh receipt memory", "Save receipts memory to PKM"],
-      busyOperations: ["receipt_memory_preview"],
-      activeControlId: "save_receipts_memory",
-      lastInteractedControlId: "save_receipts_memory",
+      activeSection: "Shopping summary",
+      visibleModules: ["Connector status", "Shopping summary"],
+      availableActions: ["Sync receipts"],
+      busyOperations: [],
+      activeControlId: "sync_gmail_receipts",
+      lastInteractedControlId: "sync_gmail_receipts",
       screenMetadata: {
         connector_state: "connected",
         receipt_count: 12,
@@ -336,34 +336,32 @@ describe("buildStructuredScreenContext", () => {
       voiceContext: {},
     });
 
-    expect(context.ui.active_section).toBe("Receipt memory preview");
+    expect(context.ui.active_section).toBe("Shopping summary");
     expect(context.ui.visible_modules).toEqual(
-      expect.arrayContaining(["Connector status", "Receipt memory preview"])
+      expect.arrayContaining(["Connector status", "Shopping summary"])
     );
-    expect(context.ui.available_actions).toEqual(
-      expect.arrayContaining(["Refresh receipt memory", "Save receipts memory to PKM"])
-    );
-    expect(context.runtime.busy_operations).toContain("receipt_memory_preview");
+    expect(context.ui.available_actions).toEqual(["Sync receipts"]);
+    expect(context.runtime.busy_operations).toEqual([]);
     expect(context.surface.title).toBe("Gmail receipts");
-    expect(context.surface.purpose).toContain("receipt memory import");
+    expect(context.surface.purpose).toContain("saves a private shopping summary");
     expect(context.surface.sections).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: "receipt_memory",
-          title: "Receipt memory",
+          title: "Shopping summary",
         }),
       ])
     );
     expect(context.surface.controls).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "save_receipts_memory",
-          action_id: "profile.receipts_memory.save",
+          id: "sync_gmail_receipts",
+          action_id: "profile.gmail.sync_now",
         }),
       ])
     );
-    expect(context.surface.active_control_id).toBe("save_receipts_memory");
-    expect(context.surface.last_interacted_control_id).toBe("save_receipts_memory");
+    expect(context.surface.active_control_id).toBe("sync_gmail_receipts");
+    expect(context.surface.last_interacted_control_id).toBe("sync_gmail_receipts");
     expect(context.screen_metadata).toMatchObject({
       connector_state: "connected",
       receipt_count: 12,

--- a/hushh-webapp/app/one/gmail/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/gmail/page.voice-action-contract.json
@@ -2,15 +2,10 @@
   "schema_version": "kai.local_action_contract.v1",
   "surface_id": "gmail",
   "surface_title": "Gmail",
-  "docs_references": [
-    "docs/reference/kai/kai-action-gateway-vnext.md"
-  ],
+  "docs_references": ["docs/reference/kai/kai-action-gateway-vnext.md"],
   "defaults": {
     "reachability": {
-      "active_personas": [
-        "investor",
-        "ria"
-      ]
+      "active_personas": ["investor", "ria"]
     }
   },
   "actions": [
@@ -18,21 +13,11 @@
       "action_id": "route.profile_receipts",
       "label": "Open Receipts Page",
       "meaning": "Navigates directly to receipts page from any investor surface.",
-      "aliases": [
-        "open receipts",
-        "open gmail receipts"
-      ],
-      "search_keywords": [
-        "receipts",
-        "gmail receipts"
-      ],
+      "aliases": ["open receipts", "open gmail receipts"],
+      "search_keywords": ["receipts", "gmail receipts"],
       "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
+        "routes": ["/one/gmail"],
+        "screens": ["gmail"],
         "hidden_navigable": true,
         "navigation_prerequisites": [
           "navigate to Gmail surface if route is currently outside Gmail scope"
@@ -46,12 +31,11 @@
         "path": "route",
         "target": "/one/gmail"
       },
-      "control_ids": [
-        "top_agent_section_gmail"
-      ],
+      "control_ids": ["top_agent_section_gmail"],
       "state_exposure": [],
       "docs_references": [
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "expected_effects": {
         "backend_effects": [
@@ -71,42 +55,25 @@
       "action_id": "profile.gmail.connect",
       "label": "Connect Gmail",
       "meaning": "Starts OAuth flow for Gmail receipts connector.",
-      "aliases": [
-        "connect gmail",
-        "link gmail"
-      ],
-      "search_keywords": [
-        "gmail connect",
-        "gmail"
-      ],
+      "aliases": ["connect gmail", "link gmail"],
+      "search_keywords": ["gmail connect", "gmail"],
       "reachability": {
-        "routes": [
-          "/profile",
-          "/profile/gmail"
-        ],
-        "screens": [
-          "profile_gmail_panel"
-        ],
+        "routes": ["/one/gmail"],
+        "screens": ["gmail"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
-      "guard_ids": [
-        "gmail_configured"
-      ],
+      "guard_ids": ["gmail_configured"],
       "risk_level": "medium",
       "execution_policy": "confirm_required",
       "execution_target": {
         "status": "unwired",
-        "reason": "Only local component handler exists (handleConnectGmail in ProfilePage).",
-        "intended_handler": "router.push"
+        "reason": "Only local component handler exists (handleConnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleConnectGmail"
       },
-      "control_ids": [
-        "open_gmail_connector"
-      ],
+      "control_ids": ["open_gmail_connector"],
       "state_exposure": [],
-      "docs_references": [
-        "app/profile/profile-workspace-page.tsx"
-      ],
+      "docs_references": ["components/gmail/gmail-receipts-page.tsx"],
       "expected_effects": {
         "backend_effects": [
           {
@@ -121,29 +88,15 @@
       "action_id": "profile.gmail.sync_now",
       "label": "Sync Gmail Receipts Now",
       "meaning": "Queues and polls Gmail receipt sync run.",
-      "aliases": [
-        "sync gmail receipts",
-        "refresh gmail receipts"
-      ],
-      "search_keywords": [
-        "gmail sync",
-        "refresh receipts"
-      ],
+      "aliases": ["sync gmail receipts", "refresh gmail receipts"],
+      "search_keywords": ["gmail sync", "refresh receipts"],
       "reachability": {
-        "routes": [
-          "/one/gmail",
-          "/profile/gmail"
-        ],
-        "screens": [
-          "gmail",
-          "profile_gmail_panel"
-        ],
+        "routes": ["/one/gmail"],
+        "screens": ["gmail"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
-      "guard_ids": [
-        "gmail_connected"
-      ],
+      "guard_ids": ["gmail_connected"],
       "risk_level": "medium",
       "execution_policy": "confirm_required",
       "execution_target": {
@@ -151,14 +104,9 @@
         "reason": "Implemented only in local page handlers; no shared voice/action adapter yet.",
         "intended_handler": "dispatchVoiceToolCall"
       },
-      "control_ids": [
-        "sync_gmail_receipts"
-      ],
+      "control_ids": ["sync_gmail_receipts"],
       "state_exposure": [],
-      "docs_references": [
-        "app/profile/profile-workspace-page.tsx",
-        "app/gmail/page.tsx"
-      ],
+      "docs_references": ["components/gmail/gmail-receipts-page.tsx"],
       "expected_effects": {
         "backend_effects": [
           {
@@ -174,132 +122,28 @@
       "speaker_persona": "one"
     },
     {
-      "action_id": "profile.receipts_memory.preview",
-      "label": "Build receipts memory preview",
-      "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
-      "aliases": [
-        "preview receipts memory",
-        "generate receipts memory preview"
-      ],
-      "search_keywords": [
-        "receipts memory",
-        "preview receipts"
-      ],
-      "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": []
-      },
-      "guard_ids": [],
-      "risk_level": "medium",
-      "execution_policy": "allow_direct",
-      "execution_target": {
-        "status": "unwired",
-        "reason": "Implemented only in local receipts-page handlers; no shared voice/action adapter yet.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "control_ids": [
-        "edit_receipts_summary"
-      ],
-      "state_exposure": [],
-      "docs_references": [
-        "app/gmail/page.tsx"
-      ],
-      "expected_effects": {
-        "backend_effects": [
-          {
-            "api": "POST /api/kai/gmail/receipts-memory/preview (proxied)",
-            "effect": "Builds or refreshes the receipts memory artifact preview."
-          }
-        ]
-      },
-      "speaker_persona": "one"
-    },
-    {
-      "action_id": "profile.receipts_memory.save",
-      "label": "Save receipts memory to PKM",
-      "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
-      "aliases": [
-        "save receipts memory",
-        "save receipts to memory"
-      ],
-      "search_keywords": [
-        "save receipts memory"
-      ],
-      "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [
-          "receipt memory preview must exist before save"
-        ]
-      },
-      "guard_ids": [
-        "vault_unlocked",
-        "manual_user_execution"
-      ],
-      "risk_level": "medium",
-      "execution_policy": "manual_only",
-      "execution_target": {
-        "status": "unwired",
-        "reason": "Save to PKM is currently implemented only inside the receipts page.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "control_ids": [
-        "save_receipts_memory"
-      ],
-      "state_exposure": [],
-      "docs_references": [
-        "app/gmail/page.tsx"
-      ],
-      "speaker_persona": "one"
-    },
-    {
       "action_id": "profile.gmail.disconnect",
       "label": "Disconnect Gmail",
       "meaning": "Disconnects Gmail OAuth credentials for future syncs.",
-      "aliases": [
-        "disconnect gmail",
-        "unlink gmail"
-      ],
-      "search_keywords": [
-        "disconnect gmail"
-      ],
+      "aliases": ["disconnect gmail", "unlink gmail"],
+      "search_keywords": ["disconnect gmail"],
       "reachability": {
-        "routes": [
-          "/profile/gmail"
-        ],
-        "screens": [
-          "profile_gmail_panel"
-        ],
+        "routes": ["/one/gmail"],
+        "screens": ["gmail"],
         "hidden_navigable": false,
         "navigation_prerequisites": []
       },
-      "guard_ids": [
-        "gmail_connected",
-        "manual_user_execution"
-      ],
+      "guard_ids": ["gmail_connected", "manual_user_execution"],
       "risk_level": "high",
       "execution_policy": "manual_only",
       "execution_target": {
         "status": "unwired",
-        "reason": "No global action dispatcher for Gmail disconnect yet.",
-        "intended_handler": "dispatchVoiceToolCall"
+        "reason": "Only local component handler exists (handleDisconnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleDisconnectGmail"
       },
-      "control_ids": [],
+      "control_ids": ["disconnect_gmail"],
       "state_exposure": [],
-      "docs_references": [
-        "app/profile/profile-workspace-page.tsx"
-      ],
+      "docs_references": ["components/gmail/gmail-receipts-page.tsx"],
       "expected_effects": {
         "backend_effects": [
           {

--- a/hushh-webapp/app/profile/gmail/actions/page.tsx
+++ b/hushh-webapp/app/profile/gmail/actions/page.tsx
@@ -1,3 +1,7 @@
-import ProfileWorkspacePage from "../../profile-workspace-page";
+import { redirect } from "next/navigation";
 
-export default ProfileWorkspacePage;
+import { ROUTES } from "@/lib/navigation/routes";
+
+export default function ProfileGmailActionsRedirectPage() {
+  redirect(ROUTES.GMAIL);
+}

--- a/hushh-webapp/app/profile/gmail/connection/page.tsx
+++ b/hushh-webapp/app/profile/gmail/connection/page.tsx
@@ -1,3 +1,7 @@
-import ProfileWorkspacePage from "../../profile-workspace-page";
+import { redirect } from "next/navigation";
 
-export default ProfileWorkspacePage;
+import { ROUTES } from "@/lib/navigation/routes";
+
+export default function ProfileGmailConnectionRedirectPage() {
+  redirect(ROUTES.GMAIL);
+}

--- a/hushh-webapp/app/profile/gmail/oauth/return/page-client.tsx
+++ b/hushh-webapp/app/profile/gmail/oauth/return/page-client.tsx
@@ -66,7 +66,7 @@ export default function ProfileGmailOAuthReturnPageClient({
     const state = liveState || initialState;
     if (!code || !state) {
       setStage("error");
-      setError("Missing OAuth code or state. Start Connect Gmail again from Profile.");
+      setError("Missing OAuth code or state. Start Connect Gmail again from Gmail.");
       return;
     }
 
@@ -164,7 +164,7 @@ export default function ProfileGmailOAuthReturnPageClient({
           <HushhLoader
             label={
               stage === "redirecting"
-                ? "Returning to your profile..."
+                ? "Returning to Gmail..."
                 : "Completing your Gmail connector setup..."
             }
           />
@@ -193,7 +193,7 @@ export default function ProfileGmailOAuthReturnPageClient({
           <p className="mt-2 text-sm text-muted-foreground">{error}</p>
           <div className="mt-4 flex flex-col gap-2">
             <Button onClick={() => router.replace(buildProfileGmailReturnPath())} className="w-full">
-              Back to Profile
+              Back to Gmail
             </Button>
           </div>
         </div>

--- a/hushh-webapp/app/profile/gmail/page.tsx
+++ b/hushh-webapp/app/profile/gmail/page.tsx
@@ -1,3 +1,7 @@
-import ProfileWorkspacePage from "../profile-workspace-page";
+import { redirect } from "next/navigation";
 
-export default ProfileWorkspacePage;
+import { ROUTES } from "@/lib/navigation/routes";
+
+export default function ProfileGmailRedirectPage() {
+  redirect(ROUTES.GMAIL);
+}

--- a/hushh-webapp/app/profile/page.voice-action-contract.json
+++ b/hushh-webapp/app/profile/page.voice-action-contract.json
@@ -90,7 +90,8 @@
       "control_ids": [],
       "state_exposure": [],
       "docs_references": [
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "speaker_persona": "one"
     },

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -2111,7 +2111,7 @@ function ProfilePageContent() {
         id: "profile_gmail",
         label: "Gmail receipts",
         purpose: "opens Gmail receipt sync and receipt-memory management.",
-        actionId: "route.profile_gmail_panel",
+        actionId: "route.profile_receipts",
         role: "card",
         voiceAliases: ["gmail receipts", "receipts"],
       },
@@ -3708,7 +3708,7 @@ function ProfilePageContent() {
               ? "Reconnect Gmail"
               : "Connect Gmail"
           }
-          description="Authorize Gmail read-only access for receipt sync."
+          description="Authorize read-only receipt access. Shopping summaries are saved automatically to your private PKM."
           disabled={gmailActionsBusy || gmail.status?.configured === false}
           chevron
           onClick={() => void handleConnectGmail()}
@@ -4290,6 +4290,10 @@ function ProfilePageContent() {
       </AppPageContentRegion>
     </>
   );
+
+  if (legacyProfileRedirectHref) {
+    return null;
+  }
 
   return (
     <AppPageShell

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -11,18 +11,18 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 87,
-    "physical_page_count": 87,
-    "route_contract_count": 87,
-    "surface_map_count": 87,
+    "total_screens": 88,
+    "physical_page_count": 88,
+    "route_contract_count": 88,
+    "surface_map_count": 88,
     "class_counts": {
       "public/static": 3,
-      "realtime/SSE": 1,
-      "redirect/alias": 24,
-      "vault-backed": 36,
-      "hidden flow": 7,
+      "realtime/SSE": 2,
+      "hidden flow": 8,
+      "redirect/alias": 27,
       "auth/pre-vault": 6,
       "RIA/provider": 8,
+      "vault-backed": 32,
       "PKM-secure": 2
     },
     "pages_missing_route_contract": [],
@@ -132,6 +132,51 @@
       ]
     },
     {
+      "route": "/connect",
+      "page_file": "app/connect/page.tsx",
+      "route_contract_mode": "hidden",
+      "screen_class": "hidden flow",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/login?redirect=%2Fconnect",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
       "route": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_contract_mode": "redirect",
@@ -219,8 +264,8 @@
       "route": "/consents",
       "page_file": "app/consents/page.tsx",
       "route_contract_mode": "standard",
-      "screen_class": "vault-backed",
-      "cache_policy": "memory-only",
+      "screen_class": "realtime/SSE",
+      "cache_policy": "memory-only+sse-background",
       "cache_keys": [
         "CONSENT_CENTER_SUMMARY",
         "CONSENT_CENTER_LIST"
@@ -229,20 +274,22 @@
         "consent_list"
       ],
       "sensitivity_class": "app-metadata",
-      "ttl_class": "CACHE_TTL.MEDIUM",
+      "ttl_class": "CACHE_TTL.SHORT with active stream patching",
       "warm_source": "ConsentCenterService memory cache",
-      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "refresh_trigger": "SSE stream patch plus stale-aware background refresh",
       "mutation_invalidator": "CacheSyncService.onConsentMutated",
       "best_available_ux_path": [
         "fresh memory",
-        "cold loader"
+        "background refresh",
+        "cold loader when missing"
       ],
       "readiness_kpis": [
         "route_readiness_completed",
         "cache_resource_resolved",
-        "route_refresh_completed"
+        "route_refresh_completed",
+        "stream patch latency through route_refresh_completed"
       ],
-      "realtime_policy": "not realtime",
+      "realtime_policy": "cached shell/data renders first; stream patches active view state and cache through service-layer adapters only",
       "reviewer_fixture": "/login?redirect=%2Fconsents",
       "surface_map_present": true,
       "route_contract_present": true,
@@ -251,12 +298,12 @@
         "use_stale_resource": true,
         "device_cache": false,
         "secure_cache": false,
-        "cache_sync": false,
+        "cache_sync": true,
         "resource_wrapper": false,
         "direct_fetch": false,
         "api_service": false,
         "hushh_loader": false,
-        "sse_or_streaming": false,
+        "sse_or_streaming": true,
         "native_beacon": false
       },
       "findings": []
@@ -1958,12 +2005,13 @@
         "resource_wrapper": false,
         "direct_fetch": false,
         "api_service": false,
-        "hushh_loader": false,
+        "hushh_loader": true,
         "sse_or_streaming": false,
         "native_beacon": false
       },
       "findings": [
-        "no local cache primitive detected in page/contract source"
+        "no local cache primitive detected in page/contract source",
+        "loader detected; verify warm cache path avoids blocking loader"
       ]
     },
     {
@@ -2647,26 +2695,23 @@
     {
       "route": "/profile/gmail",
       "page_file": "app/profile/gmail/page.tsx",
-      "route_contract_mode": "standard",
-      "screen_class": "vault-backed",
-      "cache_policy": "memory-only",
+      "route_contract_mode": "redirect",
+      "screen_class": "redirect/alias",
+      "cache_policy": "none",
       "cache_keys": [],
       "resource_classes": [
         "unknown"
       ],
       "sensitivity_class": "app-metadata",
-      "ttl_class": "CACHE_TTL.MEDIUM",
-      "warm_source": "Route-local resource loader",
-      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
-      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "ttl_class": "none",
+      "warm_source": "none",
+      "refresh_trigger": "none",
+      "mutation_invalidator": "none",
       "best_available_ux_path": [
-        "fresh memory",
-        "cold loader"
+        "static render"
       ],
       "readiness_kpis": [
-        "route_readiness_completed",
-        "cache_resource_resolved",
-        "route_refresh_completed"
+        "route_readiness_completed"
       ],
       "realtime_policy": "not realtime",
       "reviewer_fixture": "/login?redirect=%2Fprofile%2Fgmail",
@@ -2677,7 +2722,7 @@
         "use_stale_resource": false,
         "device_cache": false,
         "secure_cache": false,
-        "cache_sync": true,
+        "cache_sync": false,
         "resource_wrapper": false,
         "direct_fetch": false,
         "api_service": false,
@@ -2685,33 +2730,28 @@
         "sse_or_streaming": false,
         "native_beacon": false
       },
-      "findings": [
-        "no local cache primitive detected in page/contract source"
-      ]
+      "findings": []
     },
     {
       "route": "/profile/gmail/actions",
       "page_file": "app/profile/gmail/actions/page.tsx",
-      "route_contract_mode": "standard",
-      "screen_class": "vault-backed",
-      "cache_policy": "memory-only",
+      "route_contract_mode": "redirect",
+      "screen_class": "redirect/alias",
+      "cache_policy": "none",
       "cache_keys": [],
       "resource_classes": [
         "unknown"
       ],
       "sensitivity_class": "app-metadata",
-      "ttl_class": "CACHE_TTL.MEDIUM",
-      "warm_source": "Route-local resource loader",
-      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
-      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "ttl_class": "none",
+      "warm_source": "none",
+      "refresh_trigger": "none",
+      "mutation_invalidator": "none",
       "best_available_ux_path": [
-        "fresh memory",
-        "cold loader"
+        "static render"
       ],
       "readiness_kpis": [
-        "route_readiness_completed",
-        "cache_resource_resolved",
-        "route_refresh_completed"
+        "route_readiness_completed"
       ],
       "realtime_policy": "not realtime",
       "reviewer_fixture": "/login?redirect=%2Fprofile%2Fgmail%2Factions",
@@ -2722,7 +2762,7 @@
         "use_stale_resource": false,
         "device_cache": false,
         "secure_cache": false,
-        "cache_sync": true,
+        "cache_sync": false,
         "resource_wrapper": false,
         "direct_fetch": false,
         "api_service": false,
@@ -2730,33 +2770,28 @@
         "sse_or_streaming": false,
         "native_beacon": false
       },
-      "findings": [
-        "no local cache primitive detected in page/contract source"
-      ]
+      "findings": []
     },
     {
       "route": "/profile/gmail/connection",
       "page_file": "app/profile/gmail/connection/page.tsx",
-      "route_contract_mode": "standard",
-      "screen_class": "vault-backed",
-      "cache_policy": "memory-only",
+      "route_contract_mode": "redirect",
+      "screen_class": "redirect/alias",
+      "cache_policy": "none",
       "cache_keys": [],
       "resource_classes": [
         "unknown"
       ],
       "sensitivity_class": "app-metadata",
-      "ttl_class": "CACHE_TTL.MEDIUM",
-      "warm_source": "Route-local resource loader",
-      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
-      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "ttl_class": "none",
+      "warm_source": "none",
+      "refresh_trigger": "none",
+      "mutation_invalidator": "none",
       "best_available_ux_path": [
-        "fresh memory",
-        "cold loader"
+        "static render"
       ],
       "readiness_kpis": [
-        "route_readiness_completed",
-        "cache_resource_resolved",
-        "route_refresh_completed"
+        "route_readiness_completed"
       ],
       "realtime_policy": "not realtime",
       "reviewer_fixture": "/login?redirect=%2Fprofile%2Fgmail%2Fconnection",
@@ -2767,7 +2802,7 @@
         "use_stale_resource": false,
         "device_cache": false,
         "secure_cache": false,
-        "cache_sync": true,
+        "cache_sync": false,
         "resource_wrapper": false,
         "direct_fetch": false,
         "api_service": false,
@@ -2775,9 +2810,7 @@
         "sse_or_streaming": false,
         "native_beacon": false
       },
-      "findings": [
-        "no local cache primitive detected in page/contract source"
-      ]
+      "findings": []
     },
     {
       "route": "/profile/gmail/oauth/return",

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Loader2, Lock, Mail, RefreshCw } from "lucide-react";
+import { Loader2, Lock, Mail, RefreshCw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -18,8 +17,19 @@ import GmailNudgesSection from "@/components/gmail/gmail-nudges-section";
 import { SurfaceInset, SurfaceStack } from "@/components/app-ui/surfaces";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { Button } from "@/lib/morphy-ux/button";
+import { morphyToast } from "@/lib/morphy-ux/morphy";
 import { useAuth } from "@/hooks/use-auth";
 import { ROUTES } from "@/lib/navigation/routes";
 import {
@@ -51,6 +61,7 @@ import {
 } from "@/lib/services/gmail-receipts-service";
 import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge-model-service";
 import { VaultService } from "@/lib/services/vault-service";
+import { assignWindowLocation } from "@/lib/utils/browser-navigation";
 import { useVault } from "@/lib/vault/vault-context";
 import {
   usePublishVoiceSurfaceMetadata,
@@ -100,42 +111,6 @@ function computeSyncProgressPercent(run: GmailSyncRun | null): number {
   return 100;
 }
 
-function buildEditableReceiptMemoryArtifact(
-  artifact: ReceiptMemoryArtifact,
-  summaryDraft: string,
-): ReceiptMemoryArtifact {
-  const nextSummary = summaryDraft.trim();
-  const currentSummary =
-    artifact.candidate_pkm_payload.receipts_memory.readable_summary.text.trim();
-
-  if (!nextSummary || nextSummary === currentSummary) {
-    return artifact;
-  }
-
-  return {
-    ...artifact,
-    enrichment: artifact.enrichment
-      ? {
-          ...artifact.enrichment,
-          readable_summary: {
-            ...artifact.enrichment.readable_summary,
-            text: nextSummary,
-          },
-        }
-      : null,
-    candidate_pkm_payload: {
-      ...artifact.candidate_pkm_payload,
-      receipts_memory: {
-        ...artifact.candidate_pkm_payload.receipts_memory,
-        readable_summary: {
-          ...artifact.candidate_pkm_payload.receipts_memory.readable_summary,
-          text: nextSummary,
-        },
-      },
-    },
-  };
-}
-
 const RECEIPT_MEMORY_DETERMINISTIC_CONFIG_VERSION = "receipt_memory_v1";
 const RECEIPT_MEMORY_INFERENCE_WINDOW_DAYS = 365;
 const RECEIPT_MEMORY_HIGHLIGHTS_WINDOW_DAYS = 90;
@@ -157,7 +132,9 @@ const receiptColumns: ColumnDef<ReceiptListItem>[] = [
     cell: ({ row }) => (
       <div className="min-w-0 space-y-1">
         <p className="truncate font-medium text-foreground">
-          {row.original.merchant_name || row.original.from_name || "Unknown merchant"}
+          {row.original.merchant_name ||
+            row.original.from_name ||
+            "Unknown merchant"}
         </p>
         <p className="truncate text-xs text-muted-foreground">
           {row.original.subject || "No subject"}
@@ -188,7 +165,9 @@ const receiptColumns: ColumnDef<ReceiptListItem>[] = [
     header: "Receipt date",
     cell: ({ row }) => (
       <span className="text-sm text-muted-foreground">
-        {formatDate(row.original.receipt_date || row.original.gmail_internal_date)}
+        {formatDate(
+          row.original.receipt_date || row.original.gmail_internal_date,
+        )}
       </span>
     ),
   },
@@ -301,7 +280,6 @@ function isReceiptMemoryWatermarkCurrent(
 }
 
 export default function ProfileReceiptsPage() {
-  const router = useRouter();
   const { user, loading } = useAuth();
   const { vaultKey, vaultOwnerToken, isVaultUnlocked } = useVault();
 
@@ -314,16 +292,22 @@ export default function ProfileReceiptsPage() {
   const [showVaultUnlock, setShowVaultUnlock] = useState(false);
   const [receiptMemoryArtifact, setReceiptMemoryArtifact] =
     useState<ReceiptMemoryArtifact | null>(null);
-  const [receiptSummaryDraft, setReceiptSummaryDraft] = useState("");
   const [receiptMemoryLoading, setReceiptMemoryLoading] = useState(false);
-  const [receiptMemorySaving, setReceiptMemorySaving] = useState(false);
+  const [receiptMemorySaveState, setReceiptMemorySaveState] = useState<
+    "idle" | "saving" | "saved" | "error"
+  >("idle");
   const [receiptMemoryMessage, setReceiptMemoryMessage] = useState<
     string | null
   >(null);
+  const [gmailActionBusy, setGmailActionBusy] = useState<
+    "connect" | "disconnect" | null
+  >(null);
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
   const receiptsRef = useRef<ReceiptListItem[]>([]);
   const pageRef = useRef(1);
   const pendingSyncFeedbackRef = useRef(false);
   const autoReceiptSummaryKeyRef = useRef<string | null>(null);
+  const autoReceiptSaveKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     receiptsRef.current = receipts;
@@ -481,12 +465,91 @@ export default function ProfileReceiptsPage() {
 
   const syncing = gmail.refreshingStatus || gmail.syncingRun;
   const isConnected = gmail.presentation.isConnected;
+  const hasKnownGmailAccount = Boolean(
+    gmail.status?.google_email ||
+      gmail.status?.connected ||
+      gmail.status?.connected_at,
+  );
   const loadingStatus = gmail.loadingStatus;
   const connectorState = gmail.presentation.state;
   const latestSyncText = gmail.presentation.latestSyncText;
   const latestSyncBadge = gmail.presentation.latestSyncBadge;
   const isPassiveBackfillState =
     connectorState === "connected_backfill_running";
+
+  const handleConnectGmail = useCallback(async () => {
+    if (!user?.uid) return;
+
+    try {
+      setGmailActionBusy("connect");
+      const idToken = await user.getIdToken();
+      const redirectUri =
+        typeof window !== "undefined"
+          ? `${window.location.origin}${ROUTES.PROFILE_GMAIL_OAUTH_RETURN}`
+          : ROUTES.PROFILE_GMAIL_OAUTH_RETURN;
+      const isGoogleProvider =
+        user.providerData?.some(
+          (provider) => provider.providerId === "google.com",
+        ) ?? false;
+
+      const payload = await GmailReceiptsService.startConnect({
+        idToken,
+        userId: user.uid,
+        redirectUri,
+        loginHint: isGoogleProvider ? user.email : null,
+        includeGrantedScopes: isGoogleProvider,
+      });
+
+      if (!payload.configured || !payload.authorize_url) {
+        throw new Error("Gmail OAuth is not configured for this environment.");
+      }
+
+      assignWindowLocation(payload.authorize_url);
+    } catch (error) {
+      const message = sanitizeGmailUserMessage(error, {
+        fallback:
+          "We couldn't start Gmail connection right now. Please try again in a moment.",
+      });
+      console.error("[ProfileReceiptsPage] Failed to start Gmail OAuth:", error);
+      toast.error(message);
+    } finally {
+      setGmailActionBusy(null);
+    }
+  }, [user]);
+
+  const handleDisconnectGmail = useCallback(async () => {
+    if (!user?.uid) return;
+
+    try {
+      setGmailActionBusy("disconnect");
+      await morphyToast
+        .promise(
+          (async () => {
+            const next = await gmail.disconnectGmail();
+            if (!next) {
+              throw new Error("Gmail could not be disconnected.");
+            }
+            return next;
+          })(),
+          {
+            loading: "Disconnecting Gmail...",
+            success: "Gmail disconnected. Saved receipts stay available here.",
+            error: (error) =>
+              sanitizeGmailUserMessage(error, {
+                fallback:
+                  "We couldn't disconnect Gmail right now. Please try again in a moment.",
+              }),
+            variant: "destructive",
+          },
+        )
+        .unwrap();
+      setShowDisconnectConfirm(false);
+    } catch (error) {
+      console.error("[ProfileReceiptsPage] Failed to disconnect Gmail:", error);
+    } finally {
+      setGmailActionBusy(null);
+    }
+  }, [gmail, user?.uid]);
 
   const handleSyncNow = useCallback(async () => {
     if (!user?.uid) return;
@@ -514,11 +577,6 @@ export default function ProfileReceiptsPage() {
     }
   }, [gmail, isConnected, syncing, user?.uid]);
 
-  const showDisconnectedNotice =
-    !gmail.loadingStatus &&
-    !gmail.statusError &&
-    !isConnected &&
-    hasStoredReceipts;
   const progressPercent = useMemo(
     () => computeSyncProgressPercent(gmail.syncRun),
     [gmail.syncRun],
@@ -543,7 +601,7 @@ export default function ProfileReceiptsPage() {
   } = useVoiceSurfaceControlTracking();
   const pageTitle = useMemo(
     () =>
-      gmail.status?.google_email
+      isConnected && gmail.status?.google_email
         ? `Connected to ${gmail.status.google_email}`
         : connectorState === "connected_initial_scan_running"
           ? "Connected to your Gmail"
@@ -552,7 +610,12 @@ export default function ProfileReceiptsPage() {
             : hasStoredReceipts
               ? "Saved receipts are still available here."
               : "Sync receipt emails into One.",
-    [connectorState, gmail.status?.google_email, hasStoredReceipts],
+    [
+      connectorState,
+      gmail.status?.google_email,
+      hasStoredReceipts,
+      isConnected,
+    ],
   );
   const isSyncingState =
     connectorState === "connected_initial_scan_running" ||
@@ -563,7 +626,6 @@ export default function ProfileReceiptsPage() {
     Boolean(user?.uid) &&
     hasSealedReceiptAccess &&
     (total > 0 || hasStoredReceipts);
-  const receiptSummaryDraftTrimmed = receiptSummaryDraft.trim();
   const autoReceiptSummaryKey = useMemo(() => {
     if (!user?.uid || !isConnected || !canBuildReceiptMemoryPreview) {
       return null;
@@ -587,6 +649,30 @@ export default function ProfileReceiptsPage() {
     total,
     user?.uid,
   ]);
+  const autoReceiptSaveKey = useMemo(() => {
+    if (
+      !user?.uid ||
+      !isConnected ||
+      !receiptMemoryArtifact ||
+      !vaultKey ||
+      !vaultOwnerToken ||
+      !isVaultUnlocked
+    ) {
+      return null;
+    }
+    return [
+      user.uid,
+      receiptMemoryArtifact.artifact_id,
+      receiptMemoryArtifact.candidate_pkm_payload_hash,
+    ].join(":");
+  }, [
+    isConnected,
+    isVaultUnlocked,
+    receiptMemoryArtifact,
+    user?.uid,
+    vaultKey,
+    vaultOwnerToken,
+  ]);
   const cachedReceipts = user?.uid ? getCachedGmailReceipts(user.uid) : null;
   const receiptMemoryWatermarkCurrent = useMemo(
     () =>
@@ -606,7 +692,7 @@ export default function ProfileReceiptsPage() {
     ? syncing
       ? "Syncing receipts…"
       : "Sync receipts"
-    : connectorState === "needs_reauthentication"
+    : connectorState === "needs_reauthentication" || gmail.status?.revoked
       ? "Reconnect Gmail"
       : "Connect Gmail";
   const statusToneClassName =
@@ -619,19 +705,12 @@ export default function ProfileReceiptsPage() {
           : "border-border/60 bg-background/68";
   const receiptsVoiceSurfaceMetadata = useMemo(() => {
     const visibleModules = ["Receipt status", "Receipts list"];
-    if (showDisconnectedNotice) {
-      visibleModules.push("Gmail reconnect notice");
-    }
-    if (receiptMemoryArtifact) {
+    if (isConnected && receiptMemoryArtifact) {
       visibleModules.push("Shopping summary");
-    }
-    if (canBuildReceiptMemoryPreview) {
-      visibleModules.push("Save insights");
     }
 
     const availableActions = [
-      ...(isConnected ? ["Sync receipts"] : ["Connect Gmail"]),
-      ...(receiptMemoryArtifact ? ["Save insights"] : []),
+      ...(isConnected ? ["Sync receipts"] : [primaryActionLabel]),
       ...(hasMore ? ["Load older receipts"] : []),
     ];
     const controls = [
@@ -645,28 +724,19 @@ export default function ProfileReceiptsPage() {
       },
       {
         id: "open_gmail_connector",
-        label: "Connect Gmail",
+        label: primaryActionLabel,
         purpose:
-          "opens the Gmail connector so you can connect or reconnect Gmail.",
-        actionId: "route.profile_gmail_panel",
+          "starts Gmail connection or reconnection from this receipts page.",
         role: "button",
         voiceAliases: ["connect gmail", "open gmail connector", "open gmail"],
       },
       {
-        id: "edit_receipts_summary",
-        label: "Shopping summary",
-        purpose: "edits the shopping summary before you save it.",
-        role: "textbox",
-        voiceAliases: ["edit summary", "shopping summary"],
-      },
-      {
-        id: "save_receipts_memory",
-        label: "Save insights",
+        id: "disconnect_gmail",
+        label: "Disconnect Gmail",
         purpose:
-          "saves the current shopping summary into your personal memory.",
-        actionId: "profile.receipts_memory.save",
+          "disconnects Gmail sync while keeping already saved receipts available.",
         role: "button",
-        voiceAliases: ["save insights", "save summary"],
+        voiceAliases: ["disconnect gmail", "turn off gmail sync"],
       },
       {
         id: "load_older_receipts",
@@ -680,7 +750,7 @@ export default function ProfileReceiptsPage() {
       screenId: "gmail",
       title: "Receipts",
       purpose:
-        "This page shows your Gmail receipts, lets you sync new ones, and helps you save a simple shopping summary.",
+        "This page shows your Gmail receipts, lets you sync new ones, and automatically saves a private shopping summary to memory.",
       sections: [
         {
           id: "receipt_status",
@@ -690,9 +760,9 @@ export default function ProfileReceiptsPage() {
         },
         {
           id: "receipt_insights",
-          title: "Save insights",
+          title: "Shopping summary",
           purpose:
-            "This section creates and saves a simple shopping summary from your receipts.",
+            "This section creates and automatically saves a private shopping summary from your receipts.",
         },
         {
           id: "stored_receipts",
@@ -716,10 +786,10 @@ export default function ProfileReceiptsPage() {
         },
         {
           id: "pkm",
-          label: "PKM",
+          label: "Private memory",
           explanation:
-            "PKM is your private personal memory, where Kai can save summaries for you to reuse later.",
-          aliases: ["pkm", "personal knowledge model"],
+            "Private memory is where One can save summaries for you to reuse later.",
+          aliases: ["private memory", "personal memory"],
         },
       ],
       activeControlId: activeVoiceControlId,
@@ -732,23 +802,27 @@ export default function ProfileReceiptsPage() {
 
     return {
       surfaceDefinition,
-      activeSection: receiptMemoryArtifact
-        ? "Save insights"
+      activeSection: isConnected && receiptMemoryArtifact
+        ? "Shopping summary"
         : isSyncingState
           ? "Receipt status"
           : "Stored receipts",
       visibleModules,
       focusedWidget:
         activeControl?.label ||
-        (receiptMemoryArtifact ? "Shopping summary" : "Receipts list"),
+        (isConnected && receiptMemoryArtifact
+          ? "Shopping summary"
+          : "Receipts list"),
       modalState: showVaultUnlock ? "vault_unlock" : null,
       availableActions,
       activeControlId: activeVoiceControlId,
       lastInteractedControlId: lastVoiceControlId,
       busyOperations: [
         ...(syncing ? ["gmail_sync"] : []),
+        ...(gmailActionBusy === "connect" ? ["gmail_connect"] : []),
+        ...(gmailActionBusy === "disconnect" ? ["gmail_disconnect"] : []),
         ...(receiptMemoryLoading ? ["receipt_memory_preview"] : []),
-        ...(receiptMemorySaving ? ["receipt_memory_save"] : []),
+        ...(receiptMemorySaveState === "saving" ? ["receipt_memory_save"] : []),
         ...(loadingReceipts ? ["receipts_list_refresh"] : []),
       ],
       screenMetadata: {
@@ -772,8 +846,9 @@ export default function ProfileReceiptsPage() {
                 },
               )
             : null,
-        preview_available: Boolean(receiptMemoryArtifact),
-        preview_summary_editable: Boolean(receiptMemoryArtifact),
+        preview_available: Boolean(isConnected && receiptMemoryArtifact),
+        preview_summary_editable: false,
+        summary_persistence_state: receiptMemorySaveState,
         preview_stale: receiptMemoryArtifact?.freshness.is_stale || false,
         preview_stale_after_days:
           receiptMemoryArtifact?.freshness.stale_after_days || null,
@@ -792,11 +867,11 @@ export default function ProfileReceiptsPage() {
       },
     };
   }, [
-    canBuildReceiptMemoryPreview,
     connectorState,
     gmail.presentation.badgeLabel,
     gmail.status?.last_sync_error,
     gmail.syncRun,
+    gmailActionBusy,
     hasMore,
     activeVoiceControlId,
     isConnected,
@@ -805,11 +880,11 @@ export default function ProfileReceiptsPage() {
     latestSyncBadge,
     latestSyncText,
     loadingReceipts,
+    primaryActionLabel,
     receiptMemoryArtifact,
     receiptMemoryLoading,
-    receiptMemorySaving,
+    receiptMemorySaveState,
     statusSummary.detail,
-    showDisconnectedNotice,
     showVaultUnlock,
     syncing,
     total,
@@ -821,7 +896,7 @@ export default function ProfileReceiptsPage() {
       return;
     }
     toast.info(
-      "Create and unlock your vault from Profile before saving receipt memory.",
+      "Create and unlock your vault from Profile before receipt summaries can be saved to memory.",
     );
   }, [hasVault]);
 
@@ -838,8 +913,9 @@ export default function ProfileReceiptsPage() {
           userId: user.uid,
           forceRefresh,
         });
+        setReceiptMemorySaveState("idle");
         setReceiptMemoryArtifact(artifact);
-        setReceiptMemoryMessage("Your shopping summary is ready to review.");
+        setReceiptMemoryMessage("Saving your shopping summary to memory...");
       } catch (error) {
         console.error(
           "[ProfileReceiptsPage] Failed to build receipt summary:",
@@ -859,17 +935,6 @@ export default function ProfileReceiptsPage() {
   );
 
   usePublishVoiceSurfaceMetadata(receiptsVoiceSurfaceMetadata);
-
-  useEffect(() => {
-    setReceiptSummaryDraft(
-      receiptMemoryArtifact?.candidate_pkm_payload.receipts_memory
-        .readable_summary.text || "",
-    );
-  }, [
-    receiptMemoryArtifact?.artifact_id,
-    receiptMemoryArtifact?.candidate_pkm_payload.receipts_memory
-      .readable_summary.text,
-  ]);
 
   useEffect(() => {
     if (
@@ -900,107 +965,106 @@ export default function ProfileReceiptsPage() {
     receiptMemoryLoading,
   ]);
 
-  const handleSaveReceiptMemory = useCallback(async () => {
-    if (!user?.uid || !receiptMemoryArtifact) return;
-    if (!vaultKey || !vaultOwnerToken || !isVaultUnlocked) {
-      requestVaultUnlock();
-      return;
-    }
+  const persistReceiptMemory = useCallback(
+    async (artifact: ReceiptMemoryArtifact) => {
+      if (!user?.uid) return;
+      if (!vaultKey || !vaultOwnerToken || !isVaultUnlocked) {
+        setReceiptMemorySaveState("error");
+        setReceiptMemoryMessage(
+          "Unlock your vault to save this summary to memory.",
+        );
+        return;
+      }
 
-    setReceiptMemorySaving(true);
-    setReceiptMemoryMessage(null);
-    try {
-      const artifactForSave = buildEditableReceiptMemoryArtifact(
-        receiptMemoryArtifact,
-        receiptSummaryDraft,
-      );
-      const existingContext =
-        await PkmDomainResourceService.prepareDomainWriteContext({
+      setReceiptMemorySaveState("saving");
+      setReceiptMemoryMessage("Saving your shopping summary to memory...");
+      try {
+        const existingContext =
+          await PkmDomainResourceService.prepareDomainWriteContext({
+            userId: user.uid,
+            domain: "shopping",
+            vaultKey,
+            vaultOwnerToken,
+          });
+        if (
+          existingContext.domainData &&
+          hasMatchingReceiptMemoryProvenance(
+            existingContext.domainData,
+            artifact,
+          )
+        ) {
+          setReceiptMemorySaveState("saved");
+          setReceiptMemoryMessage(
+            "Your shopping summary is saved to your private memory.",
+          );
+          return;
+        }
+
+        const result = await PkmWriteCoordinator.savePreparedDomain({
           userId: user.uid,
           domain: "shopping",
           vaultKey,
           vaultOwnerToken,
-        });
-      if (
-        existingContext.domainData &&
-        hasMatchingReceiptMemoryProvenance(
-          existingContext.domainData,
-          artifactForSave,
-        )
-      ) {
-        setReceiptMemoryMessage("Your saved insights are already up to date.");
-        toast.message("Your saved insights are already up to date.");
-        return;
-      }
-
-      const result = await PkmWriteCoordinator.savePreparedDomain({
-        userId: user.uid,
-        domain: "shopping",
-        vaultKey,
-        vaultOwnerToken,
-        build: async (context) => {
-          const prepared = buildShoppingReceiptMemoryPreparedDomain({
-            currentDomainData: context.currentDomainData,
-            currentManifest: context.currentManifest,
-            artifact: artifactForSave,
-          });
-          const validation =
-            await PersonalKnowledgeModelService.validatePreparedDomainStore({
-              userId: user.uid,
-              vaultKey,
-              vaultOwnerToken,
-              domain: "shopping",
-              domainData: prepared.domainData,
-              summary: prepared.summary,
-              manifest: prepared.manifest,
-              structureDecision: prepared.structureDecision,
-              baseFullBlob: context.baseFullBlob,
-              expectedDataVersion:
-                context.currentEncryptedDomain?.dataVersion ??
-                context.expectedDataVersion,
-              upgradeContext: context.upgradeContext,
+          build: async (context) => {
+            const prepared = buildShoppingReceiptMemoryPreparedDomain({
+              currentDomainData: context.currentDomainData,
+              currentManifest: context.currentManifest,
+              artifact,
             });
-          if (!validation.success) {
-            throw new Error(
-              validation.message ||
-                "Failed to validate receipt memory for PKM.",
-            );
-          }
-          return prepared;
-        },
-      });
+            const validation =
+              await PersonalKnowledgeModelService.validatePreparedDomainStore({
+                userId: user.uid,
+                vaultKey,
+                vaultOwnerToken,
+                domain: "shopping",
+                domainData: prepared.domainData,
+                summary: prepared.summary,
+                manifest: prepared.manifest,
+                structureDecision: prepared.structureDecision,
+                baseFullBlob: context.baseFullBlob,
+                expectedDataVersion:
+                  context.currentEncryptedDomain?.dataVersion ??
+                  context.expectedDataVersion,
+                upgradeContext: context.upgradeContext,
+              });
+            if (!validation.success) {
+              throw new Error("Failed to validate receipt memory.");
+            }
+            return prepared;
+          },
+        });
 
-      if (!result.success) {
-        throw new Error(
-          result.message || "Failed to save receipt memory to PKM.",
+        if (!result.success) {
+          throw new Error("Failed to save receipt memory.");
+        }
+        setReceiptMemorySaveState("saved");
+        setReceiptMemoryMessage(
+          "Your shopping summary is saved to your private memory.",
         );
+      } catch (error) {
+        console.error(
+          "[ProfileReceiptsPage] Failed to save receipt insights:",
+          error,
+        );
+        const message = sanitizeGmailUserMessage(error, {
+          fallback:
+            "We couldn't save your shopping summary to memory. Sync receipts again to retry.",
+        });
+        setReceiptMemorySaveState("error");
+        setReceiptMemoryMessage(message);
+        toast.error(message);
       }
-      setReceiptMemoryArtifact(artifactForSave);
-      setReceiptMemoryMessage("Your shopping summary is saved.");
-      toast.success("Insights saved");
-    } catch (error) {
-      console.error(
-        "[ProfileReceiptsPage] Failed to save receipt insights:",
-        error,
-      );
-      const message = sanitizeGmailUserMessage(error, {
-        fallback:
-          "We couldn't save your insights right now. Please try again in a moment.",
-      });
-      setReceiptMemoryMessage(message);
-      toast.error(message);
-    } finally {
-      setReceiptMemorySaving(false);
-    }
-  }, [
-    isVaultUnlocked,
-    receiptMemoryArtifact,
-    receiptSummaryDraft,
-    requestVaultUnlock,
-    user,
-    vaultKey,
-    vaultOwnerToken,
-  ]);
+    },
+    [isVaultUnlocked, user, vaultKey, vaultOwnerToken],
+  );
+
+  useEffect(() => {
+    if (!autoReceiptSaveKey || !receiptMemoryArtifact) return;
+    if (autoReceiptSaveKeyRef.current === autoReceiptSaveKey) return;
+
+    autoReceiptSaveKeyRef.current = autoReceiptSaveKey;
+    void persistReceiptMemory(receiptMemoryArtifact);
+  }, [autoReceiptSaveKey, persistReceiptMemory, receiptMemoryArtifact]);
 
   const handleLoadMore = useCallback(async () => {
     try {
@@ -1036,44 +1100,42 @@ export default function ProfileReceiptsPage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow="One / Gmail"
           title="Receipts"
           description={pageTitle}
           actions={
-            <Button
-              onClick={() =>
-                isConnected
-                  ? void handleSyncNow()
-                  : router.push(ROUTES.PROFILE_GMAIL)
-              }
-              disabled={
-                isConnected ? syncing : gmail.status?.configured === false
-              }
-              className="min-w-[140px]"
-              data-voice-control-id={
-                isConnected ? "sync_gmail_receipts" : "open_gmail_connector"
-              }
-              data-voice-action-id={
-                isConnected
-                  ? "profile.gmail.sync_now"
-                  : "route.profile_gmail_panel"
-              }
-              data-voice-label={primaryActionLabel}
-              data-voice-purpose={
-                isConnected
-                  ? "starts or refreshes Gmail receipt sync."
-                  : "opens the Gmail connector so you can connect Gmail."
-              }
-            >
-              {syncing || (!isConnected && loadingStatus) ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : isConnected ? (
-                <RefreshCw className="mr-2 h-4 w-4" />
-              ) : (
-                <Mail className="mr-2 h-4 w-4" />
-              )}
-              {primaryActionLabel}
-            </Button>
+            isConnected ? (
+              <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+                <Button
+                  onClick={() => void handleSyncNow()}
+                  disabled={syncing || gmailActionBusy !== null}
+                  className="min-w-[150px]"
+                  data-voice-control-id="sync_gmail_receipts"
+                  data-voice-action-id="profile.gmail.sync_now"
+                  data-voice-label={primaryActionLabel}
+                  data-voice-purpose="starts or refreshes Gmail receipt sync."
+                >
+                  {syncing ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                  )}
+                  {primaryActionLabel}
+                </Button>
+                <Button
+                  variant="destructive"
+                  effect="fade"
+                  onClick={() => setShowDisconnectConfirm(true)}
+                  disabled={syncing || gmailActionBusy !== null}
+                  className="min-w-[150px]"
+                  data-voice-control-id="disconnect_gmail"
+                  data-voice-label="Disconnect Gmail"
+                  data-voice-purpose="disconnects Gmail sync while keeping stored receipts available."
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Disconnect
+                </Button>
+              </div>
+            ) : null
           }
         />
       </AppPageHeaderRegion>
@@ -1119,22 +1181,64 @@ export default function ProfileReceiptsPage() {
                 behind for a bit.
               </p>
             ) : null}
+            {!isConnected && !loadingStatus ? (
+              <div className="flex flex-col items-center justify-center gap-2 pt-2 sm:flex-row">
+                <Button
+                  onClick={() => void handleConnectGmail()}
+                  disabled={gmailActionBusy !== null}
+                  className="h-12 w-full px-8 text-base shadow-lg sm:w-auto sm:min-w-[260px]"
+                  data-voice-control-id="open_gmail_connector"
+                  data-voice-label={primaryActionLabel}
+                  data-voice-purpose="starts Gmail connection or reconnection from this receipts page."
+                >
+                  {gmailActionBusy === "connect" ? (
+                    <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                  ) : (
+                    <Mail className="mr-2 h-5 w-5" />
+                  )}
+                  {primaryActionLabel}
+                </Button>
+                {hasKnownGmailAccount ? (
+                  <Button
+                    variant="none"
+                    effect="fade"
+                    onClick={() => setShowDisconnectConfirm(true)}
+                    disabled={gmailActionBusy !== null}
+                    className="h-12 w-full px-8 text-base sm:w-auto"
+                    data-voice-control-id="disconnect_gmail"
+                    data-voice-label="Disconnect Gmail"
+                    data-voice-purpose="disconnects Gmail sync while keeping stored receipts available."
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Disconnect
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
           </SurfaceInset>
 
-          {isConnected ? <GmailChatPanel vaultOwnerToken={vaultOwnerToken} /> : null}
+          {isConnected ? (
+            <GmailChatPanel vaultOwnerToken={vaultOwnerToken} />
+          ) : null}
 
-          <GmailNudgesSection
-            userId={user?.uid || null}
-            vaultOwnerToken={vaultOwnerToken}
-            isConnected={isConnected}
-            idTokenProvider={user?.getIdToken ? () => user.getIdToken() : null}
-          />
+          {isConnected ? (
+            <GmailNudgesSection
+              userId={user?.uid || null}
+              vaultOwnerToken={vaultOwnerToken}
+              isConnected
+              idTokenProvider={
+                user?.getIdToken ? () => user.getIdToken() : null
+              }
+            />
+          ) : null}
 
-          <SurfaceInset className="space-y-3 px-4 py-4 text-sm sm:px-5 sm:py-5">
+          {isConnected ? (
+            <SurfaceInset className="space-y-3 px-4 py-4 text-sm sm:px-5 sm:py-5">
             <div className="space-y-1">
-              <p className="font-medium text-foreground">Save insights</p>
+              <p className="font-medium text-foreground">Shopping summary</p>
               <p className="text-muted-foreground">
-                Review and edit your shopping summary before you save it.
+                Generated from your synced receipts and saved automatically to
+                your private memory.
               </p>
             </div>
 
@@ -1151,7 +1255,13 @@ export default function ProfileReceiptsPage() {
                   <Badge variant="secondary">
                     {receiptMemoryArtifact.freshness.is_stale
                       ? "Needs refresh"
-                      : "Ready to save"}
+                      : receiptMemorySaveState === "saving"
+                        ? "Saving memory"
+                        : receiptMemorySaveState === "saved"
+                          ? "Saved to memory"
+                          : receiptMemorySaveState === "error"
+                            ? "Save failed"
+                            : "Preparing"}
                   </Badge>
                   <Badge variant="outline">
                     {
@@ -1162,24 +1272,17 @@ export default function ProfileReceiptsPage() {
                   </Badge>
                 </div>
 
-                <label htmlFor="receipt-summary-draft" className="space-y-2">
-                  <span className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                <div className="space-y-2">
+                  <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
                     Shopping summary
-                  </span>
-                  <textarea
-                    id="receipt-summary-draft"
-                    value={receiptSummaryDraft}
-                    onChange={(event) =>
-                      setReceiptSummaryDraft(event.target.value)
+                  </p>
+                  <p className="min-h-[96px] whitespace-pre-wrap rounded-xl border border-border/70 bg-background px-3 py-3 text-sm leading-6 text-foreground">
+                    {
+                      receiptMemoryArtifact.candidate_pkm_payload
+                        .receipts_memory.readable_summary.text
                     }
-                    rows={5}
-                    className="min-h-[128px] w-full resize-y rounded-xl border border-border/70 bg-background px-3 py-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground/80 focus:border-foreground/20"
-                    placeholder="Your shopping summary will appear here."
-                    data-voice-control-id="edit_receipts_summary"
-                    data-voice-label="Shopping summary"
-                    data-voice-purpose="edits the shopping summary before you save it."
-                  />
-                </label>
+                  </p>
+                </div>
 
                 {receiptMemoryArtifact.candidate_pkm_payload.receipts_memory
                   .readable_summary.highlights.length > 0 ? (
@@ -1203,30 +1306,6 @@ export default function ProfileReceiptsPage() {
               </div>
             ) : null}
 
-            <div className="flex flex-wrap gap-2">
-              <Button
-                onClick={() => void handleSaveReceiptMemory()}
-                disabled={
-                  !receiptMemoryArtifact ||
-                  !receiptSummaryDraftTrimmed ||
-                  receiptMemorySaving
-                }
-                variant="none"
-                effect="fade"
-                data-voice-control-id="save_receipts_memory"
-                data-voice-action-id="profile.receipts_memory.save"
-                data-voice-label="Save insights"
-                data-voice-purpose="saves the current shopping summary into your personal memory."
-              >
-                {receiptMemorySaving ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : !vaultKey || !vaultOwnerToken || !isVaultUnlocked ? (
-                  <Lock className="mr-2 h-4 w-4" />
-                ) : null}
-                Save insights
-              </Button>
-            </div>
-
             {!canBuildReceiptMemoryPreview ? (
               <p className="text-xs text-muted-foreground">
                 Sync receipts first to create a shopping summary.
@@ -1239,7 +1318,7 @@ export default function ProfileReceiptsPage() {
             ) : null}
             {!vaultKey || !vaultOwnerToken || !isVaultUnlocked ? (
               <p className="text-xs text-muted-foreground">
-                Unlock your vault to save this summary.
+                Unlock your vault to create and save this summary to memory.
               </p>
             ) : null}
             {receiptMemoryMessage ? (
@@ -1247,12 +1326,6 @@ export default function ProfileReceiptsPage() {
                 {receiptMemoryMessage}
               </p>
             ) : null}
-          </SurfaceInset>
-
-          {loadingStatus ? (
-            <SurfaceInset className="flex items-center gap-2 px-4 py-4 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Loading Gmail connector status...
             </SurfaceInset>
           ) : null}
 
@@ -1293,19 +1366,6 @@ export default function ProfileReceiptsPage() {
             </SurfaceInset>
           ) : null}
 
-          {gmail.status?.configured === false && !loadingStatus ? (
-            <SurfaceInset className="px-4 py-4 text-sm text-muted-foreground">
-              Gmail receipts are not configured in this environment yet.
-            </SurfaceInset>
-          ) : null}
-
-          {showDisconnectedNotice ? (
-            <SurfaceInset className="px-4 py-4 text-sm text-muted-foreground">
-              Gmail is currently disconnected. Your previously synced receipts
-              stay available below, but Sync now is disabled until you
-              reconnect.
-            </SurfaceInset>
-          ) : null}
           {isConnected && !hasSealedReceiptAccess && !loadingStatus ? (
             <SurfaceInset className="flex flex-col items-start gap-3 px-4 py-4 text-sm text-muted-foreground">
               <div className="flex items-center gap-2 text-foreground">
@@ -1343,7 +1403,12 @@ export default function ProfileReceiptsPage() {
               columns={receiptColumns}
               data={receipts}
               searchKey="merchant_name"
-              globalSearchKeys={["merchant_name", "from_name", "subject", "order_id"]}
+              globalSearchKeys={[
+                "merchant_name",
+                "from_name",
+                "subject",
+                "order_id",
+              ]}
               searchPlaceholder="Search receipts"
               initialPageSize={8}
               pageSizeOptions={[8, 16, 24]}
@@ -1377,13 +1442,45 @@ export default function ProfileReceiptsPage() {
           open={showVaultUnlock}
           onOpenChange={setShowVaultUnlock}
           title="Unlock vault"
-          description="Unlock your vault before saving receipt memory into PKM."
+          description="Unlock your vault to create and save receipt summaries to memory."
           onSuccess={() => {
             setShowVaultUnlock(false);
             toast.success("Vault unlocked.");
           }}
         />
       ) : null}
+      <AlertDialog
+        open={showDisconnectConfirm}
+        onOpenChange={setShowDisconnectConfirm}
+      >
+        <AlertDialogContent className="w-[calc(100%-1rem)] sm:max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect Gmail?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This stops future Gmail receipt sync. Receipts already saved in
+              your account stay available on this page.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col-reverse gap-2 sm:flex-row">
+            <AlertDialogCancel disabled={gmailActionBusy === "disconnect"}>
+              Keep connected
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={gmailActionBusy === "disconnect"}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDisconnectGmail();
+              }}
+            >
+              {gmailActionBusy === "disconnect" ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Disconnect Gmail
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </AppPageShell>
   );
 }

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -1564,7 +1564,8 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
@@ -1645,11 +1646,10 @@
       "delegate_agent_id": null,
       "reachability": {
         "routes": [
-          "/profile",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -1666,8 +1666,8 @@
       "execution_policy": "confirm_required",
       "execution_target": {
         "status": "unwired",
-        "reason": "Only local component handler exists (handleConnectGmail in ProfilePage).",
-        "intended_handler": "router.push"
+        "reason": "Only local component handler exists (handleConnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleConnectGmail"
       },
       "control_ids": [
         "open_gmail_connector"
@@ -1675,12 +1675,12 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
         "state_changes": [
-          "current route becomes /profile"
+          "current route becomes /one/gmail"
         ],
         "backend_effects": [
           {
@@ -1710,8 +1710,8 @@
             "label": "Connect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -1752,12 +1752,10 @@
       "delegate_agent_id": null,
       "reachability": {
         "routes": [
-          "/one/gmail",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "gmail",
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -1783,8 +1781,7 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx",
-        "app/gmail/page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
@@ -1849,213 +1846,6 @@
       }
     },
     {
-      "action_id": "profile.receipts_memory.preview",
-      "surface_id": "gmail",
-      "label": "Build receipts memory preview",
-      "aliases": [
-        "preview receipts memory",
-        "generate receipts memory preview"
-      ],
-      "search_keywords": [
-        "receipts memory",
-        "preview receipts"
-      ],
-      "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [],
-        "active_personas": [
-          "investor",
-          "ria"
-        ],
-        "requires_persona_switch_confirmation": false
-      },
-      "guard_ids": [],
-      "risk_level": "medium",
-      "execution_policy": "allow_direct",
-      "execution_target": {
-        "status": "unwired",
-        "reason": "Implemented only in local receipts-page handlers; no shared voice/action adapter yet.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "control_ids": [
-        "edit_receipts_summary"
-      ],
-      "state_exposure": [],
-      "docs_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
-      ],
-      "workflow": null,
-      "expected_effects": {
-        "state_changes": [
-          "current route becomes /one/gmail"
-        ],
-        "backend_effects": [
-          {
-            "api": "POST /api/kai/gmail/receipts-memory/preview (proxied)",
-            "effect": "Builds or refreshes the receipts memory artifact preview."
-          }
-        ]
-      },
-      "trigger": {
-        "primary": "voice",
-        "supported": [
-          "voice",
-          "tap",
-          "keyboard",
-          "programmatic"
-        ]
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.preview",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.preview",
-            "label": "Build receipts memory preview",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      }
-    },
-    {
-      "action_id": "profile.receipts_memory.save",
-      "surface_id": "gmail",
-      "label": "Save receipts memory to PKM",
-      "aliases": [
-        "save receipts memory",
-        "save receipts to memory"
-      ],
-      "search_keywords": [
-        "save receipts memory"
-      ],
-      "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "reachability": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [
-          "receipt memory preview must exist before save"
-        ],
-        "active_personas": [
-          "investor",
-          "ria"
-        ],
-        "requires_persona_switch_confirmation": false
-      },
-      "guard_ids": [
-        "vault_unlocked",
-        "manual_user_execution"
-      ],
-      "risk_level": "medium",
-      "execution_policy": "manual_only",
-      "execution_target": {
-        "status": "unwired",
-        "reason": "Save to PKM is currently implemented only inside the receipts page.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "control_ids": [
-        "save_receipts_memory"
-      ],
-      "state_exposure": [],
-      "docs_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
-      ],
-      "workflow": null,
-      "expected_effects": {
-        "state_changes": [
-          "current route becomes /one/gmail"
-        ],
-        "backend_effects": []
-      },
-      "trigger": {
-        "primary": "voice",
-        "supported": [
-          "voice",
-          "tap",
-          "keyboard",
-          "programmatic"
-        ]
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.save",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.save",
-            "label": "Save receipts memory to PKM",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      }
-    },
-    {
       "action_id": "profile.gmail.disconnect",
       "surface_id": "gmail",
       "label": "Disconnect Gmail",
@@ -2071,10 +1861,10 @@
       "delegate_agent_id": null,
       "reachability": {
         "routes": [
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -2092,19 +1882,21 @@
       "execution_policy": "manual_only",
       "execution_target": {
         "status": "unwired",
-        "reason": "No global action dispatcher for Gmail disconnect yet.",
-        "intended_handler": "dispatchVoiceToolCall"
+        "reason": "Only local component handler exists (handleDisconnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleDisconnectGmail"
       },
-      "control_ids": [],
+      "control_ids": [
+        "disconnect_gmail"
+      ],
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {
         "state_changes": [
-          "current route becomes /profile/gmail"
+          "current route becomes /one/gmail"
         ],
         "backend_effects": [
           {
@@ -2134,8 +1926,8 @@
             "label": "Disconnect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile/gmail",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -4694,7 +4486,8 @@
       "state_exposure": [],
       "docs_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ],
       "workflow": null,
       "expected_effects": {

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -756,7 +756,8 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -771,11 +772,10 @@
       ],
       "scope": {
         "routes": [
-          "/profile",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -787,8 +787,8 @@
       "execution_policy": "confirm_required",
       "execution_hint": {
         "status": "unwired",
-        "reason": "Only local component handler exists (handleConnectGmail in ProfilePage).",
-        "intended_handler": "router.push"
+        "reason": "Only local component handler exists (handleConnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleConnectGmail"
       },
       "goal": {
         "goal_id": "goal.profile.gmail.connect",
@@ -802,8 +802,8 @@
             "label": "Connect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -828,7 +828,7 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -843,12 +843,10 @@
       ],
       "scope": {
         "routes": [
-          "/one/gmail",
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "gmail",
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -901,151 +899,7 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx",
-        "app/gmail/page.tsx"
-      ]
-    },
-    {
-      "id": "profile.receipts_memory.preview",
-      "label": "Build receipts memory preview",
-      "meaning": "Builds the receipts-to-PKM preview from stored Gmail receipts.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "aliases": [
-        "preview receipts memory",
-        "generate receipts memory preview"
-      ],
-      "scope": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": []
-      },
-      "guard_ids": [],
-      "risk_level": "medium",
-      "execution_policy": "allow_direct",
-      "execution_hint": {
-        "status": "unwired",
-        "reason": "Implemented only in local receipts-page handlers; no shared voice/action adapter yet.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.preview",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.preview",
-            "label": "Build receipts memory preview",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      },
-      "map_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
-      ]
-    },
-    {
-      "id": "profile.receipts_memory.save",
-      "label": "Save receipts memory to PKM",
-      "meaning": "Persists the current receipts-memory preview into shopping.receipts_memory.",
-      "speaker_persona": "one",
-      "delegate_agent_id": null,
-      "aliases": [
-        "save receipts memory",
-        "save receipts to memory"
-      ],
-      "scope": {
-        "routes": [
-          "/one/gmail"
-        ],
-        "screens": [
-          "gmail"
-        ],
-        "hidden_navigable": false,
-        "navigation_prerequisites": [
-          "receipt memory preview must exist before save"
-        ]
-      },
-      "guard_ids": [
-        "vault_unlocked",
-        "manual_user_execution"
-      ],
-      "risk_level": "medium",
-      "execution_policy": "manual_only",
-      "execution_hint": {
-        "status": "unwired",
-        "reason": "Save to PKM is currently implemented only inside the receipts page.",
-        "intended_handler": "dispatchVoiceToolCall"
-      },
-      "goal": {
-        "goal_id": "goal.profile.receipts_memory.save",
-        "required_inputs": [],
-        "input_resolvers": [],
-        "slot_schema": {},
-        "workflow_steps": [
-          {
-            "type": "action",
-            "action_id": "profile.receipts_memory.save",
-            "label": "Save receipts memory to PKM",
-            "failure_behavior": "stop",
-            "settlement_target": {
-              "route": "/one/gmail",
-              "screen": "gmail"
-            }
-          }
-        ],
-        "progress_contract": {
-          "mode": "none",
-          "milestone_events": []
-        },
-        "cancellation_contract": {
-          "cancellable": false,
-          "cancel_action_id": null
-        },
-        "result_contract": {
-          "summary_mode": "action_result"
-        },
-        "entrypoint_support": [
-          "voice",
-          "chat",
-          "typed_search",
-          "command_bar",
-          "ui"
-        ]
-      },
-      "map_references": [
-        "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -1060,10 +914,10 @@
       ],
       "scope": {
         "routes": [
-          "/profile/gmail"
+          "/one/gmail"
         ],
         "screens": [
-          "profile_gmail_panel"
+          "gmail"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -1076,8 +930,8 @@
       "execution_policy": "manual_only",
       "execution_hint": {
         "status": "unwired",
-        "reason": "No global action dispatcher for Gmail disconnect yet.",
-        "intended_handler": "dispatchVoiceToolCall"
+        "reason": "Only local component handler exists (handleDisconnectGmail in GmailReceiptsPage).",
+        "intended_handler": "handleDisconnectGmail"
       },
       "goal": {
         "goal_id": "goal.profile.gmail.disconnect",
@@ -1091,8 +945,8 @@
             "label": "Disconnect Gmail",
             "failure_behavior": "stop",
             "settlement_target": {
-              "route": "/profile/gmail",
-              "screen": "profile_gmail_panel"
+              "route": "/one/gmail",
+              "screen": "gmail"
             }
           }
         ],
@@ -1117,7 +971,7 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/profile/profile-workspace-page.tsx"
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {
@@ -2966,7 +2820,8 @@
       },
       "map_references": [
         "docs/reference/kai/kai-action-gateway-vnext.md",
-        "app/gmail/page.tsx"
+        "app/one/gmail/page.tsx",
+        "components/gmail/gmail-receipts-page.tsx"
       ]
     },
     {

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -358,7 +358,12 @@
       "route": "/connect",
       "page_file": "app/connect/page.tsx",
       "physical_page_exists": true,
-      "route_contract": null,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Standalone people-connection route intentionally bypasses the signed-in app shell while still exposing its own native test beacon.",
+        "shell_verification_file": null,
+        "shell_verification_includes": []
+      },
       "native": {
         "route": "/connect",
         "classification": "native-required-functional",
@@ -1501,8 +1506,6 @@
         "profile.gmail.connect",
         "profile.gmail.disconnect",
         "profile.gmail.sync_now",
-        "profile.receipts_memory.preview",
-        "profile.receipts_memory.save",
         "route.profile_receipts"
       ],
       "api_dependencies": [],
@@ -2671,16 +2674,10 @@
       "page_file": "app/profile/gmail/page.tsx",
       "physical_page_exists": true,
       "route_contract": {
-        "mode": "standard",
-        "exemption_reason": null,
-        "shell_verification_file": "app/profile/profile-workspace-page.tsx",
-        "shell_verification_includes": [
-          "AppPageShell",
-          "AppPageHeaderRegion",
-          "AppPageContentRegion",
-          "PageHeader",
-          "SurfaceStack"
-        ]
+        "mode": "redirect",
+        "exemption_reason": "Compatibility redirect route forwards to canonical /one/gmail.",
+        "shell_verification_file": null,
+        "shell_verification_includes": []
       },
       "native": {
         "route": "/profile/gmail",
@@ -2712,16 +2709,10 @@
       "page_file": "app/profile/gmail/actions/page.tsx",
       "physical_page_exists": true,
       "route_contract": {
-        "mode": "standard",
-        "exemption_reason": null,
-        "shell_verification_file": "app/profile/profile-workspace-page.tsx",
-        "shell_verification_includes": [
-          "AppPageShell",
-          "AppPageHeaderRegion",
-          "AppPageContentRegion",
-          "PageHeader",
-          "SurfaceStack"
-        ]
+        "mode": "redirect",
+        "exemption_reason": "Compatibility redirect route forwards to canonical /one/gmail.",
+        "shell_verification_file": null,
+        "shell_verification_includes": []
       },
       "native": {
         "route": "/profile/gmail/actions",
@@ -2753,16 +2744,10 @@
       "page_file": "app/profile/gmail/connection/page.tsx",
       "physical_page_exists": true,
       "route_contract": {
-        "mode": "standard",
-        "exemption_reason": null,
-        "shell_verification_file": "app/profile/profile-workspace-page.tsx",
-        "shell_verification_includes": [
-          "AppPageShell",
-          "AppPageHeaderRegion",
-          "AppPageContentRegion",
-          "PageHeader",
-          "SurfaceStack"
-        ]
+        "mode": "redirect",
+        "exemption_reason": "Compatibility redirect route forwards to canonical /one/gmail.",
+        "shell_verification_file": null,
+        "shell_verification_includes": []
       },
       "native": {
         "route": "/profile/gmail/connection",

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -133,6 +133,11 @@
     }
   },
   {
+    "route": "/connect",
+    "mode": "hidden",
+    "exemptionReason": "Standalone people-connection route intentionally bypasses the signed-in app shell while still exposing its own native test beacon."
+  },
+  {
     "route": "/register-phone",
     "mode": "hidden",
     "exemptionReason": "Mandatory post-login phone verification flow intentionally bypasses the signed-in app shell."
@@ -455,27 +460,18 @@
   },
   {
     "route": "/profile/gmail",
-    "mode": "standard",
-    "shellVerification": {
-      "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
-    }
+    "mode": "redirect",
+    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail."
   },
   {
     "route": "/profile/gmail/connection",
-    "mode": "standard",
-    "shellVerification": {
-      "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
-    }
+    "mode": "redirect",
+    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail."
   },
   {
     "route": "/profile/gmail/actions",
-    "mode": "standard",
-    "shellVerification": {
-      "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
-    }
+    "mode": "redirect",
+    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail."
   },
   {
     "route": "/profile/support",

--- a/hushh-webapp/lib/navigation/profile-routes.ts
+++ b/hushh-webapp/lib/navigation/profile-routes.ts
@@ -235,13 +235,7 @@ export function buildProfileRoute(params?: {
   }
 
   if (panel === "gmail") {
-    if (detail === "gmail-connection") {
-      return appendQuery(ROUTES.PROFILE_GMAIL_CONNECTION, {}, params?.searchParams);
-    }
-    if (detail === "gmail-actions") {
-      return appendQuery(ROUTES.PROFILE_GMAIL_ACTIONS, {}, params?.searchParams);
-    }
-    return appendQuery(ROUTES.PROFILE_GMAIL, {}, params?.searchParams);
+    return appendQuery(ROUTES.GMAIL, {}, params?.searchParams);
   }
 
   if (panel === "support") {

--- a/hushh-webapp/lib/profile/gmail-connector-store.ts
+++ b/hushh-webapp/lib/profile/gmail-connector-store.ts
@@ -390,7 +390,7 @@ function taskIdForRun(runId: string, kind: GmailConnectorTaskKind): string {
 
 function syncTaskRouteHref(routeHref?: string | null): string {
   if (routeHref && routeHref.trim()) return routeHref.trim();
-  return ROUTES.PROFILE_GMAIL;
+  return ROUTES.GMAIL;
 }
 
 function seedTaskFromRun(
@@ -932,7 +932,7 @@ export function useGmailConnectorStatus(
     () => getConnectorView(normalizedUserId),
   );
   const idTokenProvider = options.idTokenProvider || null;
-  const routeHref = options.routeHref || ROUTES.PROFILE_GMAIL;
+  const routeHref = options.routeHref || ROUTES.GMAIL;
   const enabled = options.enabled !== false && Boolean(normalizedUserId);
   const refreshKey = options.refreshKey || "";
 

--- a/hushh-webapp/lib/profile/mail-flow.ts
+++ b/hushh-webapp/lib/profile/mail-flow.ts
@@ -548,7 +548,7 @@ export function resolveGmailConnectionPresentation(options: {
 }
 
 export function buildProfileGmailReturnPath(): string {
-  return ROUTES.PROFILE_GMAIL;
+  return ROUTES.GMAIL;
 }
 
 export function stashProfileGmailReturnStatus(


### PR DESCRIPTION
## Summary
- Simplifies the Gmail receipt flow into the canonical /one/gmail screen.
- Redirects legacy /profile/gmail connection/action surfaces back to the Gmail receipts screen.
- Auto-saves receipt summaries to private memory and removes the old Save insights/PKM-facing copy.
- Keeps saved receipts available after Gmail disconnect and adds clearer disconnect feedback.
- Refreshes route, cache, surface, and voice contract artifacts after merging latest main.

## Verification
- cd hushh-webapp && npm test -- --run __tests__/app/profile/receipts/page.test.tsx __tests__/app/profile/gmail/oauth/return/page.test.tsx __tests__/navigation/routes.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:design-system
- cd hushh-webapp && npm run verify:service-boundary
- cd hushh-webapp && npm run audit:cache-coherence
- cd hushh-webapp && npm run verify:surface-map
- cd hushh-webapp && npm run verify:voice-gateway
- cd hushh-webapp && npm test -- --run __tests__/voice/investor-kai-action-registry.test.ts __tests__/voice/screen-context-builder.test.ts __tests__/voice/route-screen-derivation.test.ts
- git diff --check
- bash scripts/ci/check-dco-signoff.sh origin/main HEAD
- bash scripts/ci/secret-scan.sh
- ./scripts/ci/verify-main-branch-protection.sh
- curl -I --max-time 10 http://localhost:3000/one/gmail

## Known local limitation
- npm run verify:routes is blocked locally because REVIEWER_UID and REVIEWER_VAULT_PASSPHRASE are not present in this maintainer shell.
- The pre-push hook reported consent-upstream/main is ahead of the recorded sync point, but marked that subtree sync drift non-blocking for regular pushes; quick consent lint passed.