### PR TITLE
fix(location): show reconciled notification popups

### DIFF
--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -227,38 +227,33 @@ describe("global One Location notification provider", () => {
     expect(mocks.startTask).toHaveBeenCalledTimes(1);
   });
 
-  it("promotes a silent push-active reconciliation to one live popup without duplicating the bell", async () => {
+  it("presents a push-active reconciliation once and deduplicates a later live push", async () => {
     mocks.getState.mockResolvedValue({
       ...EMPTY_LOCATION_STATE,
-      receivedGrants: [
+      requests: [
         {
-          id: "grant-race-1",
-          ownerUserId: "owner-user",
-          recipientUserId: "recipient-user",
-          ownerDisplayName: "Alex",
-          recipientKeyId: "key-1",
-          status: "active",
-          consentScope: "one.location",
-          capabilityScopes: [],
-          durationHours: 1,
-          shareKind: "share",
+          id: "request-race-1",
+          ownerUserId: "recipient-user",
+          requesterUserId: "requester-user",
+          requesterDisplayName: "Alex",
+          status: "pending",
         },
       ],
     });
 
     renderProvider();
     await waitFor(() => expect(mocks.getState).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(mocks.startTask).toHaveBeenCalledTimes(1));
-    expect(mocks.toast).not.toHaveBeenCalled();
 
     act(() => {
       window.dispatchEvent(
         new CustomEvent("fcm-message", {
           detail: {
             data: {
-              type: "location_share_created",
-              grant_id: "grant-race-1",
-              owner_display_label: "Alex",
+              type: "location_access_request",
+              request_id: "request-race-1",
+              requester_display_label: "Alex",
             },
           },
         }),
@@ -267,6 +262,54 @@ describe("global One Location notification provider", () => {
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
     expect(mocks.startTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("presents a reconciliation once after a fetch finishes while the page is hidden", async () => {
+    const locationState = {
+      ...EMPTY_LOCATION_STATE,
+      requests: [
+        {
+          id: "request-visibility-race-1",
+          ownerUserId: "recipient-user",
+          requesterUserId: "requester-user",
+          requesterDisplayName: "Alex",
+          status: "pending",
+        },
+      ],
+    };
+    let resolveFirstState!: (state: typeof locationState) => void;
+    mocks.getState
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstState = resolve;
+          }),
+      )
+      .mockResolvedValue(locationState);
+    const visibilityState = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("visible");
+
+    renderProvider();
+    await waitFor(() => expect(mocks.getState).toHaveBeenCalledTimes(1));
+
+    visibilityState.mockReturnValue("hidden");
+    await act(async () => {
+      resolveFirstState(locationState);
+    });
+    await waitFor(() => expect(mocks.startTask).toHaveBeenCalledTimes(1));
+    expect(mocks.toast).not.toHaveBeenCalled();
+
+    visibilityState.mockReturnValue("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(mocks.getState).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
+    expect(mocks.startTask).toHaveBeenCalledTimes(1);
+
+    visibilityState.mockRestore();
   });
 
   it("keeps approval copy and the backend deep link without creating a second share entry", async () => {

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -679,12 +679,11 @@ export function ConsentNotificationProvider({
         silentlyReconciledOneLocationIdsRef.current.add(eventId);
         return;
       }
-      const canPresentReconciledEvent =
+      const canPresentSilentlyRecordedEvent =
         !created &&
         options.present !== false &&
-        options.source === "live" &&
         silentlyReconciledOneLocationIdsRef.current.delete(eventId);
-      if ((!created && !canPresentReconciledEvent) || options.present === false) return;
+      if ((!created && !canPresentSilentlyRecordedEvent) || options.present === false) return;
 
       const toastKey = `one-location-share:${grantId}`;
       const href = oneLocationPayloadRoute(
@@ -820,12 +819,11 @@ export function ConsentNotificationProvider({
         silentlyReconciledOneLocationIdsRef.current.add(eventId);
         return;
       }
-      const canPresentReconciledEvent =
+      const canPresentSilentlyRecordedEvent =
         !created &&
         options.present !== false &&
-        options.source === "live" &&
         silentlyReconciledOneLocationIdsRef.current.delete(eventId);
-      if ((!created && !canPresentReconciledEvent) || options.present === false) return;
+      if ((!created && !canPresentSilentlyRecordedEvent) || options.present === false) return;
 
       playOneLocationNotificationSound();
       const toastKey = `one-location-workflow:${msgType}:${id}`;
@@ -1341,8 +1339,10 @@ export function ConsentNotificationProvider({
       const vaultOwnerToken = getVaultOwnerToken();
       if (!vaultOwnerToken) return;
       const state = await OneLocationService.getState(vaultOwnerToken);
+      // Reconciliation is also the fallback for foreground pushes that never
+      // reach the page. The persistent event record keeps a later live push
+      // from presenting or creating a bell item twice.
       const shouldPresent =
-        deliveryMode !== "push_active" &&
         typeof document !== "undefined" &&
         document.visibilityState === "visible";
       const payloads = buildOneLocationNotificationPayloads(state, user.uid, {
@@ -1372,7 +1372,6 @@ export function ConsentNotificationProvider({
     oneLocationReconcilePromiseRef.current = request;
     return request;
   }, [
-    deliveryMode,
     fcmInitStatus,
     getVaultOwnerToken,
     isVaultUnlocked,


### PR DESCRIPTION
## Summary
- show newly reconciled One Location events as a popup whenever the app is visible, even when push delivery is marked active
- preserve exactly-once popup and bell behavior when the same event later arrives through foreground FCM
- promote events recorded during a visibility race when the user returns to the app

## Root cause
The global provider treated `push_active` as proof that foreground delivery would reach the page. Reconciliation therefore recorded the event in the notification bell with `present: false`; when FCM did not reach the page, the user never saw a popup.

## User impact
Location requests and other One Location workflow events discovered while the user is on Profile, Gmail, Settings, or another app page now surface visibly instead of remaining bell-only. Existing Open navigation continues to land on the relevant Location section.

## Impact map
- Routes touched: none; existing `/one/location` deep links are reused
- API/schema/type changes: none
- Runtime DB changes: none
- Cache keys: none
- Mobile parity: shared React provider behavior applies to web and Capacitor builds; no native bridge contract changed
- Trust boundary: no auth, vault, consent, PKM, or secret handling changes
- Rollback: revert this commit to restore the previous reconciliation presentation policy
- Docs: no contract changes; existing global notification architecture remains authoritative

## Verification
- `23/23` focused One Location notification tests passed
- TypeScript typecheck passed
- ESLint passed for changed files
- service-boundary and docs verification passed
- native static parity passed
- Capacitor production build passed
- full Next.js production build passed
- local Playwright: non-Location Profile page showed one popup for duplicate live events and Open routed to the approvals section
- DCO signoff passed
- gitleaks scanned the commit range with no leaks

## Local CI note
The canonical Windows local mirror reached governance and then stopped on an existing path-normalization assertion in `.codex/workflows/pr-governance-review/workflow.json`. This PR does not touch that file or governance configuration; GitHub Linux CI remains the authoritative validation surface.