### PR TITLE
feat(ria): add self-service profile manage actions

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -379,6 +379,22 @@ async def update_profile(
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
+@router.post("/profile/delete")
+async def delete_profile(firebase_uid: str = Depends(require_firebase_auth)):
+    """Self-service deletion of the caller's RIA sub-agent profile.
+
+    Auto-disconnects active clients (revokes consent), deletes the RIA profile and
+    its data, and drops the 'ria' persona (the investor/One account survives).
+    POST (not DELETE) to match the client authFetch GET/POST contract."""
+    service = RIAIAMService()
+    try:
+        return await service.delete_ria_self_profile(firebase_uid)
+    except IAMSchemaNotReadyError:
+        return _iam_schema_not_ready_response()
+    except RIAIAMPolicyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
 @router.get("/home")
 async def ria_home(firebase_uid: str = Depends(require_firebase_auth)):
     service = RIAIAMService()

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4653,6 +4653,196 @@ class RIAIAMService:
 
         return await self.get_ria_onboarding_status(user_id)
 
+    async def delete_ria_self_profile(self, user_id: str) -> dict[str, Any]:
+        """Self-service deletion of the caller's RIA sub-agent profile.
+
+        Removes ONLY the RIA persona/profile — the investor/One account survives.
+        Active client relationships are AUTO-DISCONNECTED first (their consent
+        scopes are revoked in consent_audit and the pick share-grant is revoked),
+        then the ria_profiles row is deleted (cascading its children) and the
+        'ria' persona is dropped from actor_profiles, falling back to investor.
+        Does NOT re-run or require live verification. Returns remaining personas.
+        """
+        conn = await self._conn()
+        try:
+            async with conn.transaction():
+                await self._ensure_iam_schema_ready(conn)
+                await self._ensure_vault_user_row(conn, user_id)
+                await self._ensure_actor_profile_row(conn, user_id)
+
+                profile_row = await conn.fetchrow(
+                    "SELECT id FROM ria_profiles WHERE user_id = $1", user_id
+                )
+                if profile_row is None:
+                    raise RIAIAMPolicyError("RIA profile not found.", status_code=404)
+                ria_profile_id = str(profile_row["id"])
+
+                # (1) Auto-disconnect active clients: revoke their consent scopes +
+                # the pick share-grant so investors lose access cleanly. The
+                # relationship rows themselves are removed by the cascade in (4).
+                active_relationships = await conn.fetch(
+                    """
+                    SELECT id, investor_user_id, last_request_id
+                    FROM advisor_investor_relationships
+                    WHERE ria_profile_id = $1::uuid
+                      AND status IN ('approved', 'request_pending')
+                    """,
+                    ria_profile_id,
+                )
+                agent_id = f"ria:{ria_profile_id}"
+                for rel in active_relationships:
+                    investor_user_id = rel["investor_user_id"]
+                    consent_rows = await conn.fetch(
+                        """
+                        SELECT scope, action, expires_at, issued_at
+                        FROM consent_audit
+                        WHERE user_id = $1
+                          AND agent_id = $2
+                          AND action IN ('CONSENT_GRANTED', 'REVOKED')
+                        ORDER BY issued_at DESC
+                        """,
+                        investor_user_id,
+                        agent_id,
+                    )
+                    latest_by_scope: dict[str, asyncpg.Record] = {}
+                    for row in consent_rows:
+                        scope_key = str(row["scope"] or "").strip()
+                        if not scope_key or scope_key in latest_by_scope:
+                            continue
+                        latest_by_scope[scope_key] = row
+                    active_scopes = [
+                        scope
+                        for scope, row in latest_by_scope.items()
+                        if row["action"] == "CONSENT_GRANTED"
+                        and (row["expires_at"] is None or int(row["expires_at"]) > self._now_ms())
+                    ]
+                    issued_at = self._now_ms()
+                    for scope in active_scopes:
+                        await conn.execute(
+                            """
+                            INSERT INTO consent_audit (
+                              token_id,
+                              user_id,
+                              agent_id,
+                              scope,
+                              action,
+                              request_id,
+                              scope_description,
+                              issued_at,
+                              metadata
+                            )
+                            VALUES ($1, $2, $3, $4, 'REVOKED', $5, $6, $7, $8::jsonb)
+                            """,
+                            f"evt_ria_delete_{issued_at}_{scope}",
+                            investor_user_id,
+                            agent_id,
+                            scope,
+                            rel["last_request_id"],
+                            get_scope_description(scope),
+                            issued_at,
+                            json.dumps(
+                                {
+                                    "disconnect_origin": "ria",
+                                    "ria_profile_delete": True,
+                                }
+                            ),
+                        )
+                    await self._revoke_relationship_share_grant(
+                        conn,
+                        relationship_id=str(rel["id"]),
+                        grant_key=_RELATIONSHIP_SHARE_ACTIVE_PICKS,
+                        status="revoked",
+                        reason="ria_profile_delete",
+                    )
+
+                opt_in = await conn.fetchval(
+                    "SELECT investor_marketplace_opt_in FROM actor_profiles WHERE user_id = $1",
+                    user_id,
+                )
+
+                # (2) Explicit cleanup of rows the ria_profiles cascade does NOT
+                # cover (keyed on user_id, or ON DELETE SET NULL). Guarded so a
+                # missing optional table never fails the delete.
+                for stmt, label in (
+                    (
+                        "DELETE FROM marketplace_investor_actions WHERE actor_user_id = $1",
+                        "marketplace_investor_actions",
+                    ),
+                    (
+                        "DELETE FROM ria_business_contacts WHERE user_id = $1",
+                        "ria_business_contacts",
+                    ),
+                    (
+                        "DELETE FROM ria_license_verifications WHERE user_id = $1",
+                        "ria_license_verifications",
+                    ),
+                    (
+                        "DELETE FROM actor_identity_cache WHERE user_id = $1",
+                        "actor_identity_cache",
+                    ),
+                ):
+                    try:
+                        await conn.execute(stmt, user_id)
+                    except asyncpg.exceptions.UndefinedTableError:
+                        logger.warning("%s unavailable during RIA delete; skipping", label)
+
+                # (3) Marketplace public projection: keep as an investor listing if
+                # the user opted in, else remove so the deleted RIA disappears from
+                # the (unauthenticated) public directory.
+                try:
+                    if opt_in:
+                        await conn.execute(
+                            """
+                            UPDATE marketplace_public_profiles
+                            SET profile_type = 'investor',
+                                verification_badge = NULL,
+                                strategy_summary = NULL,
+                                updated_at = NOW()
+                            WHERE user_id = $1
+                            """,
+                            user_id,
+                        )
+                    else:
+                        await conn.execute(
+                            "DELETE FROM marketplace_public_profiles WHERE user_id = $1",
+                            user_id,
+                        )
+                except asyncpg.exceptions.UndefinedTableError:
+                    logger.warning(
+                        "marketplace_public_profiles unavailable during RIA delete; skipping"
+                    )
+
+                # (4) Delete the RIA profile — cascades ria_firm_memberships,
+                # ria_verification_events, advisor_investor_relationships (→ share
+                # grants/events, pick share artifacts), ria_client_invites,
+                # ria_pick_uploads(→rows). The shared ria_firms row survives.
+                await conn.execute("DELETE FROM ria_profiles WHERE user_id = $1", user_id)
+
+                # (5) Drop the 'ria' persona and fall back to investor. Both fields
+                # must change together to satisfy actor_profiles_last_in_personas_check.
+                await conn.execute(
+                    """
+                    UPDATE actor_profiles
+                    SET personas = array_remove(personas, 'ria'),
+                        last_active_persona = 'investor',
+                        updated_at = NOW()
+                    WHERE user_id = $1
+                    """,
+                    user_id,
+                )
+
+                # (6) Reset the runtime persona pointer.
+                await self._set_runtime_last_persona(conn, user_id, "investor")
+        except asyncpg.exceptions.UndefinedTableError as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            await conn.close()
+
+        # (7) Bust the in-process persona cache so the next read reflects removal.
+        self._invalidate_cached_persona_state(user_id)
+
+        return {"deleted": True, "remaining_personas": ["investor"]}
+
     async def list_ria_firms(self, user_id: str) -> list[dict[str, Any]]:
         conn = await self._conn()
         try:

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -977,3 +977,44 @@ def test_ria_client_detail_route_exposes_relationship_share_fields(monkeypatch):
     assert payload["picks_feed_status"] == "ready"
     assert payload["has_active_pick_upload"] is True
     assert payload["relationship_shares"][0]["grant_key"] == "ria_active_picks_feed_v1"
+
+
+def test_ria_profile_delete_success(monkeypatch):
+    async def _mock_delete(self, user_id: str):
+        assert user_id == "user_test_123"
+        return {"deleted": True, "remaining_personas": ["investor"]}
+
+    monkeypatch.setattr(RIAIAMService, "delete_ria_self_profile", _mock_delete)
+
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/profile/delete")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["deleted"] is True
+    assert payload["remaining_personas"] == ["investor"]
+
+
+def test_ria_profile_delete_missing_profile_returns_404(monkeypatch):
+    async def _mock_delete(self, user_id: str):
+        raise RIAIAMPolicyError("RIA profile not found.", status_code=404)
+
+    monkeypatch.setattr(RIAIAMService, "delete_ria_self_profile", _mock_delete)
+
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/profile/delete")
+
+    assert response.status_code == 404
+
+
+def test_ria_profile_delete_schema_not_ready_returns_503(monkeypatch):
+    async def _mock_delete(self, user_id: str):
+        raise IAMSchemaNotReadyError("IAM schema is not ready")
+
+    monkeypatch.setattr(RIAIAMService, "delete_ria_self_profile", _mock_delete)
+
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/profile/delete")
+
+    assert response.status_code == 503
+    assert response.json()["code"] == "IAM_SCHEMA_NOT_READY"

--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -1070,6 +1070,34 @@ describe("RiaOnboardingPage", () => {
     expect(mocks.routerReplace).not.toHaveBeenCalled();
   });
 
+  it("keeps a switch advisor in the wizard at welcome via ?reinitiate=1", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("reinitiate=1"));
+    mocks.usePersonaState.mockReturnValue({
+      refresh: mocks.refreshPersonaState,
+      riaCapability: "switch",
+      loading: false,
+      refreshing: false,
+      riaOnboardingStatus: null,
+    });
+    mocks.riaService.getOnboardingStatus.mockResolvedValue({
+      exists: true,
+      advisory_status: "verified",
+      verification_status: "verified",
+      individual_crd: "7413463",
+      display_name: "Andrew Kirkland",
+      services_offered: ["Portfolio Management"],
+      fee_structure: ["Hourly"],
+    });
+
+    render(<RiaOnboardingPage />);
+
+    // Re-initiate bypasses the switch→profile guard and starts at step 1.
+    await waitFor(() => {
+      expect(screen.getByTestId("step-welcome")).toBeTruthy();
+    });
+    expect(mocks.routerReplace).not.toHaveBeenCalled();
+  });
+
   it("keeps the user on the services step when Continue is pressed with empty required fields", async () => {
     mocks.draftService.load.mockResolvedValue({
       currentStepId: "services",

--- a/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
@@ -1,0 +1,210 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  useAuth: vi.fn(),
+  usePersonaState: vi.fn(),
+  refresh: vi.fn(),
+  switchPersona: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  riaService: { deleteProfile: vi.fn(), updateProfile: vi.fn() },
+  openKaiCommandBar: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush, replace: mocks.routerReplace }),
+}));
+
+vi.mock("lucide-react", () => ({
+  ArrowRight: () => <span />,
+  Loader2: () => <span />,
+  RotateCcw: () => <span />,
+  Trash2: () => <span />,
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaPageShell: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="ria-page-shell">{children}</div>
+  ),
+  RiaCompatibilityState: () => <div data-testid="ria-compat" />,
+}));
+
+vi.mock("@/components/ria/onboarding/onboarding-step-review", () => ({
+  OnboardingStepReview: () => <div data-testid="step-review" />,
+}));
+
+vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
+  OnboardingStepServices: () => <div data-testid="step-services" />,
+}));
+
+vi.mock("@/components/app-ui/settings-ui", () => ({
+  SettingsDetailPanel: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="edit-panel">{children}</div> : null),
+  SettingsGroup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="manage-group">{children}</div>
+  ),
+  SettingsRow: ({
+    title,
+    onClick,
+    disabled,
+    testId,
+  }: {
+    title: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    testId?: string;
+  }) => (
+    <button data-testid={testId} onClick={onClick} disabled={disabled}>
+      {title}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="delete-dialog">{children}</div> : null),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
+    <button data-testid="delete-cancel">{children}</button>
+  ),
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: (e: { preventDefault: () => void }) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      data-testid="delete-confirm"
+      disabled={disabled}
+      onClick={(e) => onClick?.(e)}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: mocks.useAuth }));
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: mocks.usePersonaState,
+}));
+vi.mock("@/lib/services/ria-service", () => ({ RiaService: mocks.riaService }));
+vi.mock("@/lib/morphy-ux/morphy", () => ({ morphyToast: mocks.toast }));
+vi.mock("@/lib/navigation/routes", () => ({
+  ROUTES: { RIA_ONBOARDING: "/ria/onboarding", ONE_HOME: "/one" },
+}));
+vi.mock("@/lib/navigation/kai-command-bar-events", () => ({
+  openKaiCommandBar: mocks.openKaiCommandBar,
+}));
+
+import RiaProfilePage from "@/app/ria/profile/page";
+
+const VERIFIED_STATUS = {
+  exists: true,
+  advisory_status: "verified",
+  verification_status: "verified",
+  display_name: "Andrew Kirkland",
+  individual_crd: "7413463",
+  services_offered: ["Portfolio Management"],
+  fee_structure: ["Hourly"],
+};
+
+describe("RiaProfilePage manage actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({
+      user: { uid: "u1", getIdToken: vi.fn().mockResolvedValue("tok") },
+    });
+    mocks.usePersonaState.mockReturnValue({
+      riaOnboardingStatus: VERIFIED_STATUS,
+      riaCapability: "switch",
+      loading: false,
+      refreshing: false,
+      refresh: mocks.refresh,
+      switchPersona: mocks.switchPersona,
+    });
+    mocks.refresh.mockResolvedValue(undefined);
+    mocks.switchPersona.mockResolvedValue(null);
+    mocks.riaService.deleteProfile.mockResolvedValue({
+      deleted: true,
+      remaining_personas: ["investor"],
+    });
+  });
+
+  it("renders the Manage group with re-initiate and delete rows", async () => {
+    render(<RiaProfilePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("ria-profile-reinitiate")).toBeTruthy();
+      expect(screen.getByTestId("ria-profile-delete")).toBeTruthy();
+    });
+  });
+
+  it("re-initiate routes to the onboarding wizard with ?reinitiate=1", async () => {
+    render(<RiaProfilePage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("ria-profile-reinitiate")).toBeTruthy(),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ria-profile-reinitiate"));
+    });
+    expect(mocks.routerPush).toHaveBeenCalledWith(
+      "/ria/onboarding?reinitiate=1",
+    );
+  });
+
+  it("delete confirms, calls deleteProfile, switches persona, and routes to One", async () => {
+    render(<RiaProfilePage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("ria-profile-delete")).toBeTruthy(),
+    );
+    // Confirm dialog is not shown until the destructive row is tapped.
+    expect(screen.queryByTestId("delete-dialog")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ria-profile-delete"));
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("delete-dialog")).toBeTruthy(),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-confirm"));
+    });
+
+    await waitFor(() => {
+      expect(mocks.riaService.deleteProfile).toHaveBeenCalledWith("tok");
+      expect(mocks.switchPersona).toHaveBeenCalledWith("investor");
+      expect(mocks.routerReplace).toHaveBeenCalledWith("/one");
+    });
+    expect(mocks.toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/services/ria-service-delete-profile.test.ts
+++ b/hushh-webapp/__tests__/services/ria-service-delete-profile.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetchMock = vi.fn();
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  },
+}));
+
+vi.mock("@/lib/cache/request-audit-log", () => ({
+  logRequestAudit: vi.fn(),
+}));
+
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    read: vi.fn(),
+    write: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {},
+  PkmScopeExposureError: class PkmScopeExposureError extends Error {},
+}));
+
+vi.mock("@/lib/services/pkm-write-coordinator", () => ({
+  PkmWriteCoordinator: {},
+}));
+
+vi.mock("@/lib/observability/client", () => ({
+  trackEvent: vi.fn(),
+  toEventResult: vi.fn((value) => value),
+  toStatusBucket: vi.fn((value) => value),
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  resolveGrowthWorkspaceSource: vi.fn(() => "test"),
+  trackGrowthFunnelStepCompleted: vi.fn(),
+}));
+
+describe("RiaService.deleteProfile", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+  });
+
+  it("POSTs to the delete endpoint with the id token and returns the result", async () => {
+    apiFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({ deleted: true, remaining_personas: ["investor"] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    const result = await RiaService.deleteProfile("id-token");
+
+    expect(result.deleted).toBe(true);
+    expect(result.remaining_personas).toEqual(["investor"]);
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/ria/profile/delete",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer id-token",
+        }),
+      }),
+    );
+  });
+
+  it("throws when the backend returns an error status", async () => {
+    apiFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "RIA profile not found." }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    await expect(RiaService.deleteProfile("id-token")).rejects.toBeTruthy();
+  });
+});

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -32,6 +32,7 @@ import {
   buildRiaScrapePrefillPatch,
 } from "@/lib/ria/ria-onboarding-prefill";
 import { RiaOnboardingDraftLocalService } from "@/lib/services/ria-onboarding-draft-local-service";
+import { seedRiaDraftFromStatus } from "@/lib/ria/ria-profile-view-model";
 import {
   isIAMSchemaNotReadyError,
   RiaApiError,
@@ -150,17 +151,22 @@ export default function RiaOnboardingPage() {
     refreshing: personaRefreshing,
   } = usePersonaState();
 
-  // "Edit licence" from the RIA profile deep-links here with ?edit=license so an
-  // already-established advisor can re-run verification without being bounced to
-  // their profile by the guard below. A generic ?step= is also honoured.
+  // The RIA profile deep-links here for two intents, both of which must bypass
+  // the "established advisor → /ria/profile" guard below:
+  //   ?edit=license   → re-run licence verification (start at the licence step)
+  //   ?reinitiate=1   → re-run the whole 5-step wizard (start at welcome)
+  // A generic ?step= is also honoured.
   const editParam = searchParams?.get("edit") ?? null;
   const stepParam = searchParams?.get("step") ?? null;
+  const reinitiateIntent = (searchParams?.get("reinitiate") ?? null) === "1";
   const requestedStepId: RiaOnboardingStepId | null =
     editParam === "license"
       ? "license_number"
-      : isRiaOnboardingStepId(stepParam)
-        ? stepParam
-        : null;
+      : reinitiateIntent
+        ? "welcome"
+        : isRiaOnboardingStepId(stepParam)
+          ? stepParam
+          : null;
   const hasEditIntent = requestedStepId !== null;
 
   const [status, setStatus] = useState<RiaOnboardingStatus | null>(null);
@@ -193,6 +199,9 @@ export default function RiaOnboardingPage() {
   // Mirror the current edit-intent step for use inside the mount-only loader.
   const requestedStepIdRef = useRef<RiaOnboardingStepId | null>(requestedStepId);
   requestedStepIdRef.current = requestedStepId;
+  // Mirror the reinitiate intent for use inside the mount-only loader.
+  const reinitiateIntentRef = useRef(reinitiateIntent);
+  reinitiateIntentRef.current = reinitiateIntent;
 
   const advisoryVerificationStatus =
     status?.advisory_status || status?.verification_status || "draft";
@@ -289,8 +298,20 @@ export default function RiaOnboardingPage() {
           });
         }
 
-        // An explicit ?edit=license / ?step= deep-link wins over the persisted
-        // draft step so "Edit licence" from the profile lands on the right step.
+        // Re-initiate: seed the wizard from the FULL server profile (services,
+        // fees, bio, location, licence-found) so a redo starts prefilled rather
+        // than blank (the local draft was cleared on the prior submit). Keeps the
+        // contact overlay.
+        if (reinitiateIntentRef.current && nextStatus) {
+          resolvedDraft = normalizeRiaOnboardingDraft({
+            ...seedRiaDraftFromStatus(nextStatus),
+            contactEmail: seeded.contactEmail,
+            contactPhone: seeded.contactPhone,
+          });
+        }
+
+        // An explicit ?edit=license / ?step= / ?reinitiate deep-link wins over the
+        // persisted draft step so the profile CTAs land on the right step.
         const preferredStepId =
           requestedStepIdRef.current ?? localDraft?.currentStepId ?? null;
         const currentStepId = preferredStepId
@@ -661,7 +682,9 @@ export default function RiaOnboardingPage() {
   async function handleSubmit() {
     if (!user) return;
     if (submitInFlightRef.current) return;
-    if (advisoryAccessReady) {
+    // A verified advisor normally can't re-submit — but on a re-initiate they
+    // MUST, so the idempotent submitOnboarding re-runs and updates the profile.
+    if (advisoryAccessReady && !reinitiateIntent) {
       router.push(ROUTES.RIA_HOME);
       return;
     }

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowRight, Loader2 } from "lucide-react";
+import { ArrowRight, Loader2, RotateCcw, Trash2 } from "lucide-react";
 
 import {
   RiaCompatibilityState,
@@ -10,7 +10,21 @@ import {
 } from "@/components/ria/ria-page-shell";
 import { OnboardingStepReview } from "@/components/ria/onboarding/onboarding-step-review";
 import { OnboardingStepServices } from "@/components/ria/onboarding/onboarding-step-services";
-import { SettingsDetailPanel } from "@/components/app-ui/settings-ui";
+import {
+  SettingsDetailPanel,
+  SettingsGroup,
+  SettingsRow,
+} from "@/components/app-ui/settings-ui";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useAuth } from "@/hooks/use-auth";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { RiaService } from "@/lib/services/ria-service";
@@ -37,11 +51,14 @@ export default function RiaProfilePage() {
     loading: personaLoading,
     refreshing: personaRefreshing,
     refresh,
+    switchPersona,
   } = usePersonaState();
 
   const [editOpen, setEditOpen] = useState(false);
   const [draft, setDraft] = useState<RiaOnboardingDraft | null>(null);
   const [saving, setSaving] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // Setup advisors have no built profile yet — the profile is authored in the
   // wizard, so send them there. (Established "switch" advisors stay here.)
@@ -146,6 +163,36 @@ export default function RiaProfilePage() {
     }
   }, [draft, refresh, saving, user]);
 
+  const handleReinitiate = useCallback(() => {
+    // Re-run the whole wizard from step 1 (bypasses the switch→profile guard).
+    router.push(`${ROUTES.RIA_ONBOARDING}?reinitiate=1`);
+  }, [router]);
+
+  const handleDeleteProfile = useCallback(async () => {
+    if (!user || deleting) return;
+    setDeleting(true);
+    try {
+      const idToken = await user.getIdToken();
+      await RiaService.deleteProfile(idToken);
+      // Drop back to the investor persona (also busts the server persona cache),
+      // re-pull state, then leave the RIA sub-agent for One home.
+      await switchPersona("investor").catch(() => null);
+      await refresh({ force: true });
+      setShowDeleteConfirm(false);
+      toast.success("RIA profile deleted", {
+        description: "Your One account is unchanged.",
+      });
+      router.replace(ROUTES.ONE_HOME);
+    } catch (error) {
+      toast.error("Could not delete profile", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleting, refresh, router, switchPersona, user]);
+
   const isBooting =
     (personaLoading || personaRefreshing) && !riaOnboardingStatus;
   const dataState = isBooting
@@ -200,6 +247,32 @@ export default function RiaProfilePage() {
           onAskKaiUpdateAnything={handleAskKai}
         />
       )}
+
+      {!isBooting && riaCapability !== "disabled" ? (
+        <SettingsGroup
+          eyebrow="Manage"
+          title="RIA profile"
+          testId="ria-profile-manage"
+        >
+          <SettingsRow
+            icon={RotateCcw}
+            title="Re-initiate onboarding"
+            description="Run the 5-step setup wizard again. Your profile goes to pending until re-verified; clients stay connected."
+            onClick={handleReinitiate}
+            chevron
+            testId="ria-profile-reinitiate"
+          />
+          <SettingsRow
+            icon={Trash2}
+            tone="destructive"
+            title="Delete RIA profile"
+            description="Remove your RIA profile and disconnect any clients. Your One account stays."
+            onClick={() => setShowDeleteConfirm(true)}
+            disabled={deleting}
+            testId="ria-profile-delete"
+          />
+        </SettingsGroup>
+      ) : null}
 
       <SettingsDetailPanel
         open={editOpen}
@@ -261,6 +334,37 @@ export default function RiaProfilePage() {
           </div>
         ) : null}
       </SettingsDetailPanel>
+
+      <AlertDialog
+        open={showDeleteConfirm}
+        onOpenChange={(open) => {
+          if (!deleting) setShowDeleteConfirm(open);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete your RIA profile?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes your RIA advisor profile and automatically disconnects
+              any active clients (their consent is revoked). Your One account and
+              investor data are not affected. This can&apos;t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={deleting}
+              onClick={(event) => {
+                event.preventDefault();
+                if (!deleting) void handleDeleteProfile();
+              }}
+            >
+              {deleting ? "Deleting..." : "Delete profile"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </RiaPageShell>
   );
 }

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -1576,6 +1576,21 @@ export class RiaService {
     return toJsonOrThrow<RiaOnboardingStatus>(response);
   }
 
+  // Self-service deletion of the caller's RIA sub-agent profile. Auto-disconnects
+  // active clients (revokes consent), deletes the RIA profile + data, and drops
+  // the 'ria' persona — the investor/One account survives.
+  static async deleteProfile(
+    idToken: string,
+  ): Promise<{ deleted: boolean; remaining_personas: string[] }> {
+    const response = await authFetch("/api/ria/profile/delete", {
+      method: "POST",
+      idToken,
+    });
+    return toJsonOrThrow<{ deleted: boolean; remaining_personas: string[] }>(
+      response,
+    );
+  }
+
   static async getHome(
     idToken: string,
     options: CachedReadOptions & { userId: string },


### PR DESCRIPTION
## Summary
- Adds RIA profile Manage actions for re-initiating onboarding and deleting only the RIA sub-agent profile.
- Adds firebase-authed backend delete route that auto-disconnects active clients, revokes consent/share grants, cleans RIA projection rows, drops the ria persona, and preserves the One/investor account.
- Makes /ria/onboarding?reinitiate=1 bypass the verified-profile guard and re-submit through the existing idempotent onboarding flow.

## Verification
- cd consent-protocol && uv run pytest tests/test_ria_iam_routes.py -q
- cd consent-protocol && uv run ruff check api/routes/ria.py hushh_mcp/services/ria_iam_service.py tests/test_ria_iam_routes.py
- cd consent-protocol && uv run python -m py_compile api/routes/ria.py hushh_mcp/services/ria_iam_service.py
- cd hushh-webapp && npx vitest run __tests__/services/ria-service-delete-profile.test.ts __tests__/app/ria/profile-page.test.tsx __tests__/app/ria/onboarding-page.test.tsx
- cd hushh-webapp && npx eslint app/ria/profile/page.tsx app/ria/onboarding/page.tsx lib/services/ria-service.ts __tests__/services/ria-service-delete-profile.test.ts __tests__/app/ria/profile-page.test.tsx __tests__/app/ria/onboarding-page.test.tsx
- cd hushh-webapp && npm run typecheck