### PR TITLE
fix(ria): prevent deleted profile persona resurrection

### DIFF
--- a/consent-protocol/api/routes/iam.py
+++ b/consent-protocol/api/routes/iam.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -35,10 +35,16 @@ def _iam_schema_not_ready_response() -> JSONResponse:
 
 
 @router.get("/persona")
-async def get_persona(firebase_uid: str = Depends(require_firebase_auth)):
+async def get_persona(
+    firebase_uid: str = Depends(require_firebase_auth),
+    force: bool = Query(
+        default=False,
+        description="Bypass the server persona cache (used after a persona mutation).",
+    ),
+):
     service = RIAIAMService()
     try:
-        return await service.get_persona_state(firebase_uid)
+        return await service.get_persona_state(firebase_uid, force=force)
     except IAMSchemaNotReadyError:
         return {
             "user_id": firebase_uid,

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 86,
+  "expected_migration_version": 87,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/087_consent_audit_request_id_text.sql
+++ b/consent-protocol/db/migrations/087_consent_audit_request_id_text.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- consent_audit.request_id was VARCHAR(32) (legacy init schema), but
+-- advisor_investor_relationships.last_request_id is TEXT. The RIA sub-agent
+-- profile delete auto-disconnects active clients by writing consent_audit
+-- REVOKED rows using last_request_id; a value longer than 32 chars would raise
+-- StringDataRightTruncation and abort the ENTIRE delete transaction (HTTP 500),
+-- so a RIA with active clients could not delete. Widen to TEXT to match the
+-- source column. The partial index on request_id remains valid for TEXT.
+ALTER TABLE consent_audit
+  ALTER COLUMN request_id TYPE TEXT;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -64,7 +64,8 @@
     "083_one_location_recipient_key_encrypted_private.sql",
     "084_relay_ticket_nonces.sql",
     "085_developer_partner_apps.sql",
-    "086_connections.sql"
+    "086_connections.sql",
+    "087_consent_audit_request_id_text.sql"
   ],
   "groups": {
     "iam": [
@@ -101,7 +102,8 @@
       "069_drop_kai_location_plaintext.sql",
       "071_enterprise_crm_registry.sql",
       "072_crm_registry_mulesoft_pbkdf2_cbc.sql",
-      "073_crm_registry_mulesoft_simplify.sql"
+      "073_crm_registry_mulesoft_simplify.sql",
+      "087_consent_audit_request_id_text.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -2433,10 +2433,15 @@ class RIAIAMService:
             self._invalidate_cached_persona_state(user_id)
             await conn.close()
 
-    async def get_persona_state(self, user_id: str) -> dict[str, Any]:
-        cached = self._read_cached_persona_state(user_id)
-        if cached is not None:
-            return cached
+    async def get_persona_state(self, user_id: str, *, force: bool = False) -> dict[str, Any]:
+        # force=True skips the 30s in-process cache and recomputes from the DB.
+        # Required after a persona mutation (e.g. RIA delete): the client's forced
+        # refresh may be routed to a sibling gunicorn worker whose cache was not
+        # invalidated, so honouring force is the only cross-worker-safe read.
+        if not force:
+            cached = self._read_cached_persona_state(user_id)
+            if cached is not None:
+                return cached
         conn = await self._conn()
         try:
             async with conn.transaction():
@@ -8714,7 +8719,11 @@ class RIAIAMService:
         conn = await self._conn()
         try:
             await self._ensure_iam_schema_ready(conn)
-            await self._ensure_actor_profile_row(conn, user_id, include_ria_persona=True)
+            # READ endpoint: never provision the 'ria' persona here. This runs on a
+            # non-transactional pooled connection, so include_ria_persona=True would
+            # autocommit array_append('ria') before the 404 below and durably
+            # resurrect a deleted advisor's persona. Existing RIAs are unaffected.
+            await self._ensure_actor_profile_row(conn, user_id, include_ria_persona=False)
             ria = await self._get_ria_profile_by_user(conn, user_id)
             handled_keys = await self._marketplace_handled_investor_target_keys(
                 conn,
@@ -9140,7 +9149,10 @@ class RIAIAMService:
         conn = await self._conn()
         try:
             await self._ensure_iam_schema_ready(conn)
-            await self._ensure_actor_profile_row(conn, user_id, include_ria_persona=True)
+            # READ endpoint: never provision the 'ria' persona here (see the deck
+            # endpoint above) — a non-transactional include_ria_persona=True would
+            # durably resurrect a deleted advisor's persona.
+            await self._ensure_actor_profile_row(conn, user_id, include_ria_persona=False)
             ria = await self._get_ria_profile_by_user(conn, user_id)
             rows = await conn.fetch(
                 """

--- a/consent-protocol/tests/test_consent_audit_request_id_migration.py
+++ b/consent-protocol/tests/test_consent_audit_request_id_migration.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_NAME = "087_consent_audit_request_id_text.sql"
+
+
+def test_consent_audit_request_id_migration_is_registered_at_release_head():
+    migration = ROOT / "db" / "migrations" / MIGRATION_NAME
+    assert migration.exists()
+
+    sql = migration.read_text(encoding="utf-8")
+    assert "ALTER TABLE consent_audit" in sql
+    assert "ALTER COLUMN request_id TYPE TEXT" in sql
+
+    manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text())
+    assert manifest["ordered_migrations"][-1] == MIGRATION_NAME
+    assert MIGRATION_NAME in manifest["groups"]["iam"]
+
+    contract = json.loads((ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text())
+    assert contract["expected_migration_version"] == 87
+    assert contract["migration_version_policy"] == "exact"

--- a/consent-protocol/tests/test_partner_developer_apps.py
+++ b/consent-protocol/tests/test_partner_developer_apps.py
@@ -194,7 +194,7 @@ class TestPartnerMigrationContract:
         contract = json.loads(
             (ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text()
         )
-        assert contract["expected_migration_version"] == 86
+        assert contract["expected_migration_version"] >= 87
         cols = contract["required_tables"]["developer_apps"]
         assert "kind" in cols
         assert "crm_id" in cols

--- a/consent-protocol/tests/test_persona_state_cache.py
+++ b/consent-protocol/tests/test_persona_state_cache.py
@@ -347,7 +347,7 @@ class TestPersonaStateCacheHTTPReachability:
         }
         _PERSONA_STATE_CACHE.set(uid, stored)
 
-        async def _stubbed_get_persona_state(self, user_id: str):
+        async def _stubbed_get_persona_state(self, user_id: str, *, force: bool = False):
             cached = RIAIAMService._read_cached_persona_state(user_id)
             if cached is not None:
                 return cached
@@ -376,7 +376,7 @@ class TestPersonaStateCacheHTTPResponse:
         _PERSONA_STATE_CACHE.invalidate(uid)
         assert _PERSONA_STATE_CACHE.get(uid, _PERSONA_STATE_CACHE_TTL) is None
 
-        async def _stubbed_get_persona_state(self, user_id: str):
+        async def _stubbed_get_persona_state(self, user_id: str, *, force: bool = False):
             return {
                 "user_id": user_id,
                 "personas": ["investor"],

--- a/consent-protocol/tests/test_ria_iam_routes.py
+++ b/consent-protocol/tests/test_ria_iam_routes.py
@@ -27,7 +27,7 @@ def _build_app() -> FastAPI:
 
 
 def test_iam_persona_returns_actor_state(monkeypatch):
-    async def _mock_get_persona_state(self, user_id: str):
+    async def _mock_get_persona_state(self, user_id: str, *, force: bool = False):
         assert user_id == "user_test_123"
         return {
             "user_id": user_id,
@@ -48,7 +48,7 @@ def test_iam_persona_returns_actor_state(monkeypatch):
 
 
 def test_iam_persona_schema_not_ready_returns_compat_payload(monkeypatch):
-    async def _mock_get_persona_state(self, user_id: str):
+    async def _mock_get_persona_state(self, user_id: str, *, force: bool = False):
         assert user_id == "user_test_123"
         raise IAMSchemaNotReadyError("IAM schema is not ready")
 
@@ -1018,3 +1018,25 @@ def test_ria_profile_delete_schema_not_ready_returns_503(monkeypatch):
 
     assert response.status_code == 503
     assert response.json()["code"] == "IAM_SCHEMA_NOT_READY"
+
+
+def test_iam_persona_force_param_bypasses_cache(monkeypatch):
+    seen: dict[str, bool] = {}
+
+    async def _mock_get_persona_state(self, user_id: str, *, force: bool = False):
+        seen["force"] = force
+        return {
+            "user_id": user_id,
+            "personas": ["investor"],
+            "last_active_persona": "investor",
+            "investor_marketplace_opt_in": False,
+        }
+
+    monkeypatch.setattr(RIAIAMService, "get_persona_state", _mock_get_persona_state)
+    client = TestClient(_build_app())
+
+    assert client.get("/api/iam/persona?force=1").status_code == 200
+    assert seen["force"] is True
+
+    assert client.get("/api/iam/persona").status_code == 200
+    assert seen["force"] is False

--- a/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
@@ -12,6 +12,9 @@ const mocks = vi.hoisted(() => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
   riaService: { deleteProfile: vi.fn(), updateProfile: vi.fn() },
   openKaiCommandBar: vi.fn(),
+  draftClear: vi.fn(),
+  onPersonaStateChanged: vi.fn(),
+  invalidateResourcePrefix: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -118,6 +121,25 @@ vi.mock("@/lib/persona/persona-context", () => ({
   usePersonaState: mocks.usePersonaState,
 }));
 vi.mock("@/lib/services/ria-service", () => ({ RiaService: mocks.riaService }));
+vi.mock("@/lib/services/ria-onboarding-draft-local-service", () => ({
+  RiaOnboardingDraftLocalService: {
+    clear: (...a: unknown[]) => {
+      mocks.draftClear(...a);
+      return Promise.resolve();
+    },
+  },
+}));
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: { onPersonaStateChanged: mocks.onPersonaStateChanged },
+}));
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    invalidateResourcePrefix: (...a: unknown[]) => {
+      mocks.invalidateResourcePrefix(...a);
+      return Promise.resolve();
+    },
+  },
+}));
 vi.mock("@/lib/morphy-ux/morphy", () => ({ morphyToast: mocks.toast }));
 vi.mock("@/lib/navigation/routes", () => ({
   ROUTES: { RIA_ONBOARDING: "/ria/onboarding", ONE_HOME: "/one" },
@@ -206,5 +228,27 @@ describe("RiaProfilePage manage actions", () => {
       expect(mocks.routerReplace).toHaveBeenCalledWith("/one");
     });
     expect(mocks.toast.error).not.toHaveBeenCalled();
+    // Full teardown: local draft + in-memory + device caches cleared.
+    expect(mocks.draftClear).toHaveBeenCalledWith("u1");
+    expect(mocks.onPersonaStateChanged).toHaveBeenCalledWith("u1");
+    expect(mocks.invalidateResourcePrefix).toHaveBeenCalledWith("u1", "ria:");
+  });
+
+  it("redirects to onboarding when the profile no longer exists (split-brain guard)", async () => {
+    // Persona still reports 'ria' (stale/resurrected) but the profile row is gone.
+    mocks.usePersonaState.mockReturnValue({
+      riaOnboardingStatus: { exists: false },
+      riaCapability: "switch",
+      loading: false,
+      refreshing: false,
+      refresh: mocks.refresh,
+      switchPersona: mocks.switchPersona,
+    });
+
+    render(<RiaProfilePage />);
+
+    await waitFor(() =>
+      expect(mocks.routerReplace).toHaveBeenCalledWith("/ria/onboarding"),
+    );
   });
 });

--- a/hushh-webapp/__tests__/services/ria-service-delete-profile.test.ts
+++ b/hushh-webapp/__tests__/services/ria-service-delete-profile.test.ts
@@ -82,3 +82,48 @@ describe("RiaService.deleteProfile", () => {
     await expect(RiaService.deleteProfile("id-token")).rejects.toBeTruthy();
   });
 });
+
+describe("RiaService.getPersonaState force bypass", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+  });
+
+  it("forwards force to the persona route so the server bypasses its 30s cache", async () => {
+    apiFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          user_id: "u1",
+          personas: ["investor"],
+          last_active_persona: "investor",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { RiaService } = await import("@/lib/services/ria-service");
+    await RiaService.getPersonaState("tok", { userId: "u-force", force: true });
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/iam/persona?force=1",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("omits force on a normal read", async () => {
+    apiFetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          user_id: "u2",
+          personas: ["investor"],
+          last_active_persona: "investor",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { RiaService } = await import("@/lib/services/ria-service");
+    await RiaService.getPersonaState("tok", { userId: "u-normal" });
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/iam/persona",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -135,15 +135,25 @@ export default function RiaHomePage() {
   const { user } = useAuth();
   const {
     riaCapability,
+    riaOnboardingStatus,
     loading: personaLoading,
     refreshing: personaRefreshing,
   } = usePersonaState();
 
   useEffect(() => {
-    if (!personaLoading && !personaRefreshing && riaCapability === "setup") {
+    if (personaLoading || personaRefreshing) return;
+    // "setup" (never onboarded) OR a deleted profile whose persona is still/again
+    // 'ria' (exists:false) → send to onboarding for a clean new-user experience.
+    if (riaCapability === "setup" || riaOnboardingStatus?.exists === false) {
       router.replace(ROUTES.RIA_ONBOARDING);
     }
-  }, [personaLoading, personaRefreshing, riaCapability, router]);
+  }, [
+    personaLoading,
+    personaRefreshing,
+    riaCapability,
+    riaOnboardingStatus,
+    router,
+  ]);
 
   const homeResource = useStaleResource<RiaHomeResponse>({
     cacheKey: user?.uid ? `ria_home_${user.uid}` : "ria_home_guest",

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -28,6 +28,9 @@ import {
 import { useAuth } from "@/hooks/use-auth";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { RiaService } from "@/lib/services/ria-service";
+import { RiaOnboardingDraftLocalService } from "@/lib/services/ria-onboarding-draft-local-service";
+import { CacheSyncService } from "@/lib/cache/cache-sync-service";
+import { DeviceResourceCacheService } from "@/lib/services/device-resource-cache-service";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { ROUTES } from "@/lib/navigation/routes";
 import {
@@ -60,14 +63,24 @@ export default function RiaProfilePage() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  // Setup advisors have no built profile yet — the profile is authored in the
-  // wizard, so send them there. (Established "switch" advisors stay here.)
+  // No RIA profile to show → route to onboarding for a clean new-user experience.
+  // Covers both "setup" (never onboarded) AND the split-brain case where the
+  // persona still reports 'ria' but the profile row is gone (exists:false) — so a
+  // stale/resurrected persona can never render a zombie empty profile. Skipped
+  // while a delete is in flight (that navigates to One home itself).
   useEffect(() => {
-    if (personaLoading || personaRefreshing) return;
-    if (riaCapability === "setup") {
+    if (personaLoading || personaRefreshing || deleting) return;
+    if (riaCapability === "setup" || riaOnboardingStatus?.exists === false) {
       router.replace(ROUTES.RIA_ONBOARDING);
     }
-  }, [personaLoading, personaRefreshing, riaCapability, router]);
+  }, [
+    personaLoading,
+    personaRefreshing,
+    deleting,
+    riaCapability,
+    riaOnboardingStatus,
+    router,
+  ]);
 
   const reviewProps = useMemo(
     () => mapRiaStatusToReviewProps(riaOnboardingStatus),
@@ -174,7 +187,17 @@ export default function RiaProfilePage() {
     try {
       const idToken = await user.getIdToken();
       await RiaService.deleteProfile(idToken);
-      // Drop back to the investor persona (also busts the server persona cache),
+      // Full RIA client-state teardown so nothing stale survives the delete:
+      //  - local onboarding draft (else a re-onboard resumes prefilled with old data)
+      //  - in-memory RIA caches (persona, onboarding status, home, clients, ...)
+      //  - IndexedDB device caches under the `ria:` prefix (survive cold start)
+      await RiaOnboardingDraftLocalService.clear(user.uid).catch(() => {});
+      CacheSyncService.onPersonaStateChanged(user.uid);
+      await DeviceResourceCacheService.invalidateResourcePrefix(
+        user.uid,
+        "ria:",
+      ).catch(() => {});
+      // Drop back to the investor persona (server force-bypasses its 30s cache),
       // re-pull state, then leave the RIA sub-agent for One home.
       await switchPersona("investor").catch(() => null);
       await refresh({ force: true });

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -1153,10 +1153,16 @@ export class RiaService {
       inflightKey: cacheKey || "ria_persona_state",
       resourceLabel: "persona_state",
       loader: async () => {
-        const response = await authFetch("/api/iam/persona", {
-          method: "GET",
-          idToken,
-        });
+        // Forward force to the server so it bypasses its 30s in-process persona
+        // cache (cross-worker safe) — required after a persona mutation like RIA
+        // delete, otherwise a sibling worker can serve a stale 'ria' persona.
+        const response = await authFetch(
+          options?.force ? "/api/iam/persona?force=1" : "/api/iam/persona",
+          {
+            method: "GET",
+            idToken,
+          },
+        );
         return toJsonOrThrow<PersonaState>(response);
       },
     });


### PR DESCRIPTION
## Summary
- Bypass persona cache when the client requests a forced persona refresh after RIA delete.
- Stop marketplace read endpoints from re-provisioning the RIA persona after profile deletion.
- Redirect `/ria` and `/ria/profile` to onboarding when backend status says `exists:false`.
- Clear local RIA draft/device caches after delete.
- Add release migration `087` to widen `consent_audit.request_id` to TEXT and register it in the canonical release manifest/UAT contract.

## Verification
- `./bin/hushh protocol --help`
- `python3 scripts/ops/verify_release_migration_contract.py`
- `cd consent-protocol && uv run ruff check api/routes/iam.py hushh_mcp/services/ria_iam_service.py tests/test_persona_state_cache.py tests/test_ria_iam_routes.py tests/test_partner_developer_apps.py tests/test_consent_audit_request_id_migration.py`
- `cd consent-protocol && uv run pytest tests/test_consent_audit_request_id_migration.py tests/test_partner_developer_apps.py tests/test_persona_state_cache.py tests/test_ria_iam_routes.py -q`
- `cd hushh-webapp && npx vitest run __tests__/app/ria/profile-page.test.tsx __tests__/services/ria-service-delete-profile.test.ts`
- `cd hushh-webapp && npx eslint app/ria/page.tsx app/ria/profile/page.tsx lib/services/ria-service.ts __tests__/app/ria/profile-page.test.tsx __tests__/services/ria-service-delete-profile.test.ts`
- `cd hushh-webapp && npm run typecheck`
- `python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py`
