### PR TITLE
fix(location): remove phone suffixes from notifications

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -279,6 +279,21 @@ def _identity_display_label(row: dict[str, Any] | None, fallback: str = "A trust
     return " - ".join(item for item in (display_name, masked_phone) if item) or fallback
 
 
+def _identity_notification_label(
+    row: dict[str, Any] | None,
+    fallback: str = "A trusted person",
+) -> str:
+    """Return a lock-screen-safe identity label without phone-derived data."""
+    if not row:
+        return fallback
+    return str(row.get("display_name") or "").strip() or fallback
+
+
+def _notification_safe_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Exclude contact fields from notification transport metadata."""
+    return {key: value for key, value in data.items() if "phone" not in str(key).strip().lower()}
+
+
 def _fingerprint_public_key(public_key_jwk: dict[str, Any]) -> str:
     encoded = json.dumps(public_key_jwk, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
@@ -522,7 +537,8 @@ class OneLocationAgentService:
         data: dict[str, str | None],
     ) -> None:
         """Best-effort metadata-only FCM delivery for location workflow state."""
-        if not user_id or _contains_plaintext_location_key(data):
+        safe_data = _notification_safe_data(data)
+        if not user_id or _contains_plaintext_location_key(safe_data):
             return
         try:
             rows = (
@@ -548,7 +564,7 @@ class OneLocationAgentService:
                 "deep_link": "/one/location",
                 "notification_tag": notification_tag,
                 "notification_category": "ONE_LOCATION",
-                **{key: str(value) for key, value in data.items() if str(value or "").strip()},
+                **{key: str(value) for key, value in safe_data.items() if str(value or "").strip()},
             }
             if _contains_plaintext_location_key(message_data):
                 logger.warning(
@@ -2057,7 +2073,7 @@ class OneLocationAgentService:
             expires_at = _parse_datetime(row.get("expires_at"), field_name="expires_at")
             if expires_at <= retention_cutoff:
                 continue
-            owner_label = _identity_display_label(self._identity_row(owner_user_id))
+            owner_label = _identity_notification_label(self._identity_row(owner_user_id))
             self._insert_event(
                 owner_user_id=owner_user_id,
                 actor_user_id=None,
@@ -2686,7 +2702,7 @@ class OneLocationAgentService:
             require_phone_verified=require_recipient_phone_verified,
         )
         owner_identity = self._identity_row(owner_user_id)
-        owner_label = _identity_display_label(owner_identity)
+        owner_label = _identity_notification_label(owner_identity)
         key_id = str(recipient.get("key_id") or "")
         expires_at = _utcnow() + timedelta(hours=duration)
         capability = self._mint_grant_capability_token(
@@ -2801,9 +2817,6 @@ class OneLocationAgentService:
                     "grant_id": grant["id"],
                     "owner_user_id": owner_user_id,
                     "owner_display_label": owner_label,
-                    "owner_masked_phone": _mask_phone(owner_identity.get("phone_number"))
-                    if owner_identity
-                    else None,
                     "duration_hours": str(duration),
                     "expires_at": grant.get("expiresAt"),
                     "share_kind": share_kind,
@@ -3326,7 +3339,6 @@ class OneLocationAgentService:
                 "invite_id": invite["id"],
                 "request_id": request["id"] if request else None,
                 "visitor_display_label": display_name[:80],
-                "visitor_masked_phone": _mask_phone(phone_digits),
                 "matched_user_id": matched_user_id,
                 "status": status_value,
             },
@@ -3574,8 +3586,8 @@ class OneLocationAgentService:
             event_type="location_one_network_joined",
             metadata={"invite_id": invite_id, "connection_id": connection["id"]},
         )
-        claimant_label = _identity_display_label(claimant_identity, fallback="Someone")
-        owner_label = _identity_display_label(owner_identity)
+        claimant_label = _identity_notification_label(claimant_identity, fallback="Someone")
+        owner_label = _identity_notification_label(owner_identity)
         self._send_metadata_notification(
             user_id=owner_user_id,
             notification_type="location_one_network_joined",
@@ -3879,9 +3891,9 @@ class OneLocationAgentService:
             metadata={"reason": "owner_revoke" if actor_is_owner else "recipient_revoke"},
         )
         owner_identity = self._identity_row(str(row.get("owner_user_id") or owner_user_id))
-        owner_label = _identity_display_label(owner_identity)
+        owner_label = _identity_notification_label(owner_identity)
         recipient_identity = self._identity_row(recipient_user_id or "")
-        recipient_label = _identity_display_label(recipient_identity)
+        recipient_label = _identity_notification_label(recipient_identity)
         notification_user_id = (
             recipient_user_id if actor_is_owner else str(row.get("owner_user_id") or "")
         )
@@ -3902,9 +3914,6 @@ class OneLocationAgentService:
                 "grant_id": grant_id,
                 "owner_user_id": str(row.get("owner_user_id") or owner_user_id),
                 "owner_display_label": owner_label,
-                "owner_masked_phone": _mask_phone(owner_identity.get("phone_number"))
-                if owner_identity
-                else None,
                 "recipient_user_id": recipient_user_id,
                 "recipient_display_label": recipient_label,
             },
@@ -3997,7 +4006,7 @@ class OneLocationAgentService:
             metadata={"referred": bool(referred_by_user_id)},
         )
         requester_identity = self._identity_row(requester_user_id)
-        requester_label = _identity_display_label(requester_identity, fallback="Someone")
+        requester_label = _identity_notification_label(requester_identity, fallback="Someone")
         if notify_owner:
             self._send_metadata_notification(
                 user_id=owner_user_id,
@@ -4010,9 +4019,6 @@ class OneLocationAgentService:
                     "request_id": request["id"],
                     "requester_user_id": requester_user_id,
                     "requester_display_label": requester_label,
-                    "requester_masked_phone": _mask_phone(requester_identity.get("phone_number"))
-                    if requester_identity
-                    else None,
                     "referred_by_user_id": referred_by_user_id,
                 },
             )
@@ -4072,7 +4078,7 @@ class OneLocationAgentService:
             metadata={"duration_hours": normalize_duration_hours(duration_hours)},
         )
         owner_identity = self._identity_row(owner_user_id)
-        owner_label = _identity_display_label(owner_identity)
+        owner_label = _identity_notification_label(owner_identity)
         self._send_metadata_notification(
             user_id=requester_user_id,
             notification_type="location_access_approved",
@@ -4090,9 +4096,6 @@ class OneLocationAgentService:
                 "grant_id": grant["id"],
                 "owner_user_id": owner_user_id,
                 "owner_display_label": owner_label,
-                "owner_masked_phone": _mask_phone(owner_identity.get("phone_number"))
-                if owner_identity
-                else None,
             },
         )
         return {"request": self._request_payload(resolved), "grant": grant}
@@ -4124,7 +4127,7 @@ class OneLocationAgentService:
             metadata={},
         )
         owner_identity = self._identity_row(owner_user_id)
-        owner_label = _identity_display_label(owner_identity)
+        owner_label = _identity_notification_label(owner_identity)
         self._send_metadata_notification(
             user_id=str(row.get("requester_user_id") or ""),
             notification_type="location_access_denied",
@@ -4136,9 +4139,6 @@ class OneLocationAgentService:
                 "request_id": request_id,
                 "owner_user_id": owner_user_id,
                 "owner_display_label": owner_label,
-                "owner_masked_phone": _mask_phone(owner_identity.get("phone_number"))
-                if owner_identity
-                else None,
             },
         )
         return self._request_payload(row) or {}
@@ -4208,9 +4208,9 @@ class OneLocationAgentService:
             event_type="location_referral_invite",
             metadata={"creates_access": False},
         )
-        owner_label = _identity_display_label(self._identity_row(owner_user_id))
+        owner_label = _identity_notification_label(self._identity_row(owner_user_id))
         referring_identity = self._identity_row(referring_user_id)
-        referring_label = _identity_display_label(referring_identity)
+        referring_label = _identity_notification_label(referring_identity)
         if referral_payload:
             self._send_metadata_notification(
                 user_id=referred_user_id,
@@ -4231,9 +4231,6 @@ class OneLocationAgentService:
                     "owner_display_label": owner_label,
                     "referring_user_id": referring_user_id,
                     "referring_display_label": referring_label,
-                    "referring_masked_phone": _mask_phone(referring_identity.get("phone_number"))
-                    if referring_identity
-                    else None,
                 },
             )
         return {"referral": referral_payload, "request": request}

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -11,7 +11,9 @@ from hushh_mcp.services.one_location_agent_service import (
     OneLocationAgentError,
     OneLocationAgentService,
     _contains_plaintext_location_key,
+    _identity_notification_label,
     _json_param,
+    _notification_safe_data,
     _redact_location_metadata,
 )
 
@@ -49,6 +51,33 @@ def test_plaintext_coordinate_key_detection_is_recursive() -> None:
     assert _contains_plaintext_location_key({"metadata": {"lat": 1}}) is True
     assert _contains_plaintext_location_key({"metadata": [{"address": "home"}]}) is True
     assert _contains_plaintext_location_key({"payload": "coordinate_envelope"}) is False
+
+
+def test_notification_identity_label_never_falls_back_to_phone() -> None:
+    assert (
+        _identity_notification_label(
+            {"display_name": "hushh Social", "phone_number": "+91 99999 98014"}
+        )
+        == "hushh Social"
+    )
+    assert (
+        _identity_notification_label({"display_name": "", "phone_number": "+91 99999 98014"})
+        == "A trusted person"
+    )
+
+
+def test_notification_transport_data_excludes_phone_fields() -> None:
+    assert _notification_safe_data(
+        {
+            "grant_id": "grant-1",
+            "owner_display_label": "hushh Social",
+            "owner_masked_phone": "*******8014",
+            "phone_number": "+91 99999 98014",
+        }
+    ) == {
+        "grant_id": "grant-1",
+        "owner_display_label": "hushh Social",
+    }
 
 
 def test_duration_bounds_are_v1_limited() -> None:
@@ -257,6 +286,7 @@ class FourUserMemoryService(OneLocationAgentService):
 
     def _send_metadata_notification(self, **kwargs) -> None:
         assert _contains_plaintext_location_key(kwargs.get("data") or {}) is False
+        kwargs["data"] = _notification_safe_data(kwargs.get("data") or {})
         self.notifications.append(kwargs)
 
     def _active_key(self, user_id: str, key_id: str | None = None) -> dict | None:
@@ -1602,6 +1632,15 @@ def test_four_user_location_workflow_contract() -> None:
         recipient_key_id=f"key-{user_b}",
         duration_hours=1,
     )
+    share_notification = next(
+        item
+        for item in service.notifications
+        if item["notification_type"] == "location_share_created"
+        and (item.get("data") or {}).get("grant_id") == grant_b["id"]
+    )
+    assert share_notification["body"] == "User A shared location access with you."
+    assert "phone" not in json.dumps(share_notification).lower()
+    assert "0001" not in json.dumps(share_notification)
     service.store_encrypted_envelope(
         owner_user_id=user_a,
         grant_id=grant_b["id"],

--- a/consent-protocol/tests/test_fcm_messages.py
+++ b/consent-protocol/tests/test_fcm_messages.py
@@ -133,6 +133,53 @@ def test_build_push_message_for_web_keeps_webpush_notification():
     assert message.webpush.fcm_options.link == "https://uat.kai.hushh.ai/consents?tab=pending"
 
 
+def test_location_notification_name_only_body_reaches_every_platform() -> None:
+    body = "hushh Social shared location access with you."
+    android_target = "android-device-id"
+    web_target = "web-device-id"
+    ios_target = "ios-device-id"
+
+    android = build_push_message(
+        _MessagingStub,
+        token=android_target,
+        platform="android",
+        data={"type": "location_share_created"},
+        title="Location shared",
+        body=body,
+        request_url="/one/location",
+        notification_tag="one-location-share:test",
+        show_alert=True,
+    )
+    web = build_push_message(
+        _MessagingStub,
+        token=web_target,
+        platform="web",
+        data={"type": "location_share_created"},
+        title="Location shared",
+        body=body,
+        request_url="/one/location",
+        notification_tag="one-location-share:test",
+        show_alert=True,
+    )
+    ios = build_push_message(
+        _MessagingStub,
+        token=ios_target,
+        platform="ios",
+        data={"type": "location_share_created"},
+        title="Location shared",
+        body=body,
+        request_url="/one/location",
+        notification_tag="one-location-share:test",
+        show_alert=True,
+    )
+
+    assert android.notification.body == body
+    assert web.notification.body == body
+    assert web.webpush.notification.body == body
+    assert ios.notification.body == body
+    assert ios.apns.payload.aps.alert.body == body
+
+
 def test_build_push_message_without_alert_is_data_only():
     delivery_target = "web-device-id"
     message = build_push_message(

--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -120,6 +120,35 @@ beforeEach(() => {
 });
 
 describe("global One Location notification provider", () => {
+  it("removes a legacy masked phone suffix from the rendered popup", async () => {
+    renderProvider();
+    await waitFor(() => expect(mocks.initializeFCM).toHaveBeenCalledOnce());
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("fcm-message", {
+          detail: {
+            data: {
+              type: "location_share_created",
+              grant_id: "grant-legacy-phone-1",
+              owner_display_label: "hushh Social - ********8014",
+              notification_body:
+                "hushh Social - ********8014 shared location access with you.",
+            },
+          },
+        }),
+      );
+    });
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+    const popup = mocks.toast.mock.calls[0]?.[0] as ReactNode;
+    render(<>{popup}</>);
+    expect(
+      screen.getByText("hushh Social shared location access with you."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/8014/)).not.toBeInTheDocument();
+  });
+
   it("shows one popup and records one bell item for duplicate live pushes on a non-Location route", async () => {
     renderProvider();
     await waitFor(() => expect(mocks.initializeFCM).toHaveBeenCalledOnce());

--- a/hushh-webapp/__tests__/one-location-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-notifications.test.ts
@@ -40,6 +40,8 @@ import {
   oneLocationSectionForWorkflowNotificationType,
   recordOneLocationShareNotification,
   recordOneLocationWorkflowNotification,
+  privacySafeOneLocationNotificationBody,
+  privacySafeOneLocationNotificationLabel,
   resolveOneLocationNotificationHref,
 } from "@/lib/one-location/notifications";
 
@@ -54,6 +56,39 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe("One-Location notification privacy", () => {
+  it("uses the exact name-only copy for a plain location share", () => {
+    expect(locationShareNotificationCopy({ ownerLabel: "hushh Social" })).toEqual({
+      title: "Location shared",
+      description: "hushh Social shared location access with you.",
+    });
+  });
+
+  it("removes legacy masked-phone suffixes from labels and bodies", () => {
+    expect(
+      privacySafeOneLocationNotificationLabel("hushh Social - ********8014"),
+    ).toBe("hushh Social");
+    expect(
+      privacySafeOneLocationNotificationBody(
+        "hushh Social - ********8014 shared location access with you.",
+        "A trusted person shared location access with you.",
+      ),
+    ).toBe("hushh Social shared location access with you.");
+  });
+
+  it("uses a generic fallback when a legacy label is only a masked phone", () => {
+    expect(privacySafeOneLocationNotificationLabel("********8014")).toBe(
+      "A trusted person",
+    );
+    expect(
+      privacySafeOneLocationNotificationBody(
+        "********8014 shared location access with you.",
+        "A trusted person shared location access with you.",
+      ),
+    ).toBe("A trusted person shared location access with you.");
+  });
 });
 
 describe("One-Location persistent notification de-dup", () => {

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -77,6 +77,8 @@ import {
   markOneLocationGrantOpened,
   oneLocationSectionForWorkflowNotificationType,
   playOneLocationNotificationSound,
+  privacySafeOneLocationNotificationBody,
+  privacySafeOneLocationNotificationLabel,
   recordOneLocationShareNotification,
   recordOneLocationWorkflowNotification,
   type OneLocationWorkflowNotificationType,
@@ -383,45 +385,39 @@ function isOneLocationWorkflowNotificationType(
 }
 
 function oneLocationOwnerLabel(data: Record<string, string>): string {
-  return (
+  return privacySafeOneLocationNotificationLabel(
     String(data.owner_display_label || "").trim() ||
-    String(data.owner_label || "").trim() ||
-    String(data.owner_user_id || "").trim() ||
-    "A trusted person"
+    String(data.owner_label || "").trim(),
   );
 }
 
 function oneLocationRequesterLabel(data: Record<string, string>): string {
-  return (
+  return privacySafeOneLocationNotificationLabel(
     String(data.requester_display_label || "").trim() ||
-    String(data.requester_label || "").trim() ||
-    String(data.requester_user_id || "").trim() ||
-    "Someone"
+    String(data.requester_label || "").trim(),
+    "Someone",
   );
 }
 
 function oneLocationReferringLabel(data: Record<string, string>): string {
-  return (
-    String(data.referring_display_label || "").trim() ||
-    String(data.referring_user_id || "").trim() ||
-    "A trusted person"
+  return privacySafeOneLocationNotificationLabel(
+    String(data.referring_display_label || "").trim(),
   );
 }
 
 function oneLocationVisitorLabel(data: Record<string, string>): string {
-  return (
+  return privacySafeOneLocationNotificationLabel(
     String(data.visitor_display_label || "").trim() ||
-    String(data.visitor_label || "").trim() ||
-    "Someone"
+    String(data.visitor_label || "").trim(),
+    "Someone",
   );
 }
 
 function oneLocationNetworkLabel(data: Record<string, string>): string {
-  return (
+  return privacySafeOneLocationNotificationLabel(
     String(data.network_display_label || "").trim() ||
     String(data.invitee_display_label || "").trim() ||
-    String(data.inviter_display_label || "").trim() ||
-    "A trusted person"
+    String(data.inviter_display_label || "").trim(),
   );
 }
 
@@ -697,8 +693,10 @@ export function ConsentNotificationProvider({
       });
       const title =
         String(data.notification_title || "").trim() || generatedCopy.title;
-      const description =
-        String(data.notification_body || "").trim() || generatedCopy.description;
+      const description = privacySafeOneLocationNotificationBody(
+        data.notification_body,
+        generatedCopy.description,
+      );
       playOneLocationNotificationSound();
 
       toast(
@@ -776,9 +774,10 @@ export function ConsentNotificationProvider({
       const copy = {
         title:
           String(data.notification_title || "").trim() || generatedCopy.title,
-        description:
-          String(data.notification_body || "").trim() ||
+        description: privacySafeOneLocationNotificationBody(
+          data.notification_body,
           generatedCopy.description,
+        ),
       };
       const routeHref = oneLocationPayloadRoute(
         data,

--- a/hushh-webapp/lib/one-location/notification-reconciliation.ts
+++ b/hushh-webapp/lib/one-location/notification-reconciliation.ts
@@ -3,7 +3,10 @@ import type {
   OneLocationRecipient,
   OneLocationState,
 } from "@/lib/one-location/types";
-import type { OneLocationWorkflowNotificationType } from "@/lib/one-location/notifications";
+import {
+  privacySafeOneLocationNotificationLabel,
+  type OneLocationWorkflowNotificationType,
+} from "@/lib/one-location/notifications";
 
 export type OneLocationNotificationPayload = Record<string, string> & {
   type: OneLocationWorkflowNotificationType;
@@ -27,9 +30,9 @@ function recipientLabel(
   userId: string,
   fallback: string,
 ): string {
-  return (
-    recipients.find((recipient) => recipient.userId === userId)?.displayName?.trim() ||
-    fallback
+  return privacySafeOneLocationNotificationLabel(
+    recipients.find((recipient) => recipient.userId === userId)?.displayName,
+    fallback,
   );
 }
 
@@ -81,8 +84,10 @@ export function buildOneLocationNotificationPayloads(
     addValue(
       payload,
       "owner_display_label",
-      grant.ownerDisplayName ||
-        recipientLabel(recipients, grant.ownerUserId, "A trusted person"),
+      privacySafeOneLocationNotificationLabel(
+        grant.ownerDisplayName ||
+          recipientLabel(recipients, grant.ownerUserId, "A trusted person"),
+      ),
     );
     addValue(payload, "expires_at", grant.expiresAt);
     addValue(payload, "duration_hours", grant.durationHours);

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -410,9 +410,34 @@ export function oneLocationSectionForWorkflowNotificationType(
   }
 }
 
+const MASKED_PHONE_ONLY_PATTERN = /^\*{3,}\d{1,4}$/;
+const MASKED_PHONE_SUFFIX_PATTERN = /\s+-\s+\*{3,}\d{1,4}\s*$/;
+const MASKED_PHONE_BODY_PATTERN = /\s+-\s+\*{3,}\d{1,4}(?=\s|[.,!?]|$)/g;
+
+export function privacySafeOneLocationNotificationLabel(
+  value?: string | null,
+  fallback = "A trusted person",
+): string {
+  const normalized = String(value || "").trim();
+  if (!normalized || MASKED_PHONE_ONLY_PATTERN.test(normalized)) return fallback;
+  return normalized.replace(MASKED_PHONE_SUFFIX_PATTERN, "").trim() || fallback;
+}
+
+export function privacySafeOneLocationNotificationBody(
+  value: string | null | undefined,
+  fallback: string,
+): string {
+  const normalized = String(value || "").trim();
+  if (!normalized) return fallback;
+  if (MASKED_PHONE_ONLY_PATTERN.test(normalized.split(/\s+/, 1)[0] || "")) {
+    return fallback;
+  }
+  return normalized.replace(MASKED_PHONE_BODY_PATTERN, "").trim() || fallback;
+}
+
 export function locationShareNotificationDescription(ownerLabel?: string | null): string {
-  const label = String(ownerLabel || "").trim() || "A trusted person";
-  return `${label} shared location access with you. Open this notification to view it.`;
+  const label = privacySafeOneLocationNotificationLabel(ownerLabel);
+  return `${label} shared location access with you.`;
 }
 
 /** The share intents a recipient notification can represent. */
@@ -453,7 +478,7 @@ export function locationShareNotificationCopy(params: {
   shareKind?: string | null;
   shareMessage?: string | null;
 }): { title: string; description: string } {
-  const label = String(params.ownerLabel || "").trim() || "A trusted person";
+  const label = privacySafeOneLocationNotificationLabel(params.ownerLabel);
   const message = String(params.shareMessage || "").trim();
   const kind = normalizeOneLocationShareKind(params.shareKind);
   if (kind === "sos") {
@@ -492,11 +517,14 @@ export function locationWorkflowNotificationCopy(params: {
   networkLabel?: string | null;
 }): { title: string; description: string } {
   const copy = WORKFLOW_COPY[params.type];
-  const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
-  const requesterLabel = String(params.requesterLabel || "").trim() || "Someone";
-  const referringLabel = String(params.referringLabel || "").trim() || "A trusted person";
-  const visitorLabel = String(params.visitorLabel || "").trim() || "Someone";
-  const networkLabel = String(params.networkLabel || "").trim() || "A trusted person";
+  const ownerLabel = privacySafeOneLocationNotificationLabel(params.ownerLabel);
+  const requesterLabel = privacySafeOneLocationNotificationLabel(
+    params.requesterLabel,
+    "Someone",
+  );
+  const referringLabel = privacySafeOneLocationNotificationLabel(params.referringLabel);
+  const visitorLabel = privacySafeOneLocationNotificationLabel(params.visitorLabel, "Someone");
+  const networkLabel = privacySafeOneLocationNotificationLabel(params.networkLabel);
 
   switch (params.type) {
     case "location_share_created":


### PR DESCRIPTION
## Summary
- remove masked phone suffixes from One Location notification identities
- exclude phone-derived fields from notification transport metadata
- sanitize legacy notification labels and bodies in web foreground/reconciliation flows
- keep the exact plain-share copy: <name> shared location access with you.

## Cross-platform behavior
The backend remains the canonical notification source for Android FCM, WebPush, and iOS APNs. No native copy fork is introduced.

## Validation
- 43 backend tests passed
- 27 frontend notification/provider tests passed
- TypeScript typecheck passed
- ESLint and Ruff passed
- Capacitor static parity passed
- DCO sign-off present