### PR TITLE
feat(one-location): Pick Me Up redesign + reverse-geocoded pickup spot

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -100,6 +100,11 @@ class MapsPlaceDetailsRequest(_CamelModel):
     place_id: str = Field(alias="placeId", min_length=1, max_length=300)
 
 
+class MapsReverseGeocodeRequest(_CamelModel):
+    lat: float = Field(ge=-90, le=90)
+    lng: float = Field(ge=-180, le=180)
+
+
 class MapsRouteEtaRequest(_CamelModel):
     origin_lat: float = Field(alias="originLat", ge=-90, le=90)
     origin_lng: float = Field(alias="originLng", ge=-180, le=180)
@@ -380,6 +385,22 @@ async def maps_place_details(
     _user_id(token_data)
     try:
         place = await _maps_service().place_details(payload.place_id)
+        return {"place": place}
+    except GoogleMapsError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": "ONE_LOCATION_MAPS_FAILED", "message": str(exc)},
+        ) from exc
+
+
+@router.post("/location/maps/reverse-geocode")
+async def maps_reverse_geocode(
+    payload: MapsReverseGeocodeRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    _user_id(token_data)
+    try:
+        place = await _maps_service().reverse_geocode(lat=payload.lat, lng=payload.lng)
         return {"place": place}
     except GoogleMapsError as exc:
         raise HTTPException(

--- a/consent-protocol/hushh_mcp/services/google_maps_service.py
+++ b/consent-protocol/hushh_mcp/services/google_maps_service.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = httpx.Timeout(10.0, connect=5.0)
 _PLACES_BASE = "https://places.googleapis.com"
 _ROUTES_URL = "https://routes.googleapis.com/directions/v2:computeRoutes"
+_GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
 
 
 class GoogleMapsError(RuntimeError):
@@ -128,6 +129,33 @@ class GoogleMapsService:
             "latitude": float(location.get("latitude", 0.0)),
             "longitude": float(location.get("longitude", 0.0)),
         }
+
+    async def reverse_geocode(self, *, lat: float, lng: float) -> dict[str, Any]:
+        key = _require_key()
+        async with _async_client() as client:
+            try:
+                response = await client.get(
+                    _GEOCODE_URL,
+                    params={"latlng": f"{lat},{lng}", "key": key},
+                )
+            except httpx.HTTPError as exc:
+                raise GoogleMapsError(f"Reverse geocode failed: {exc}", status_code=502) from exc
+        if response.status_code >= 400:
+            logger.warning("maps.reverse_geocode upstream %s", response.status_code)
+            raise GoogleMapsError("Reverse geocode failed.", status_code=502)
+        results = response.json().get("results") or []
+        if not results:
+            return {"name": None, "formattedAddress": None}
+        formatted = results[0].get("formatted_address") or None
+        name: str | None = None
+        for result in results:
+            types = result.get("types") or []
+            if any(t in types for t in ("point_of_interest", "establishment", "premise")):
+                components = result.get("address_components") or []
+                if components:
+                    name = components[0].get("long_name") or None
+                break
+        return {"name": name, "formattedAddress": formatted}
 
     async def route_eta(
         self,

--- a/consent-protocol/tests/services/test_google_maps_service.py
+++ b/consent-protocol/tests/services/test_google_maps_service.py
@@ -130,3 +130,44 @@ async def test_upstream_error_maps_to_502(monkeypatch):
     with pytest.raises(gms.GoogleMapsError) as excinfo:
         await svc.route_eta(origin_lat=1, origin_lng=1, dest_lat=2, dest_lng=2)
     assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_parses_name_and_address(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "latlng=" in str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "formatted_address": "476 5th Ave, New York, NY 10018, USA",
+                        "types": ["point_of_interest", "establishment"],
+                        "address_components": [
+                            {"long_name": "Central Library", "types": ["point_of_interest"]}
+                        ],
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    svc = gms.GoogleMapsService()
+    out = await svc.reverse_geocode(lat=40.75, lng=-73.98)
+    assert out == {
+        "name": "Central Library",
+        "formattedAddress": "476 5th Ave, New York, NY 10018, USA",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_empty_results_returns_nulls(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"results": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    svc = gms.GoogleMapsService()
+    out = await svc.reverse_geocode(lat=1.0, lng=2.0)
+    assert out == {"name": None, "formattedAddress": None}

--- a/consent-protocol/tests/test_one_location_maps_routes.py
+++ b/consent-protocol/tests/test_one_location_maps_routes.py
@@ -52,6 +52,21 @@ def test_route_eta_route(client, monkeypatch):
     assert data["eta"]["trafficLevel"] == "light"
 
 
+def test_reverse_geocode_route(client, monkeypatch):
+    async def fake(self, *, lat, lng):
+        return {"name": "Central Library", "formattedAddress": "476 5th Ave"}
+
+    monkeypatch.setattr(gms.GoogleMapsService, "reverse_geocode", fake)
+    res = client.post(
+        "/api/one/location/maps/reverse-geocode",
+        json={"lat": 40.75, "lng": -73.98},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["place"]["name"] == "Central Library"
+    assert data["place"]["formattedAddress"] == "476 5th Ave"
+
+
 def test_maps_unconfigured_returns_503(client, monkeypatch):
     async def fake(self, input_text, *, session_token=None):
         raise gms.GoogleMapsError("no key", status_code=503)

--- a/docs/superpowers/plans/2026-07-12-pick-me-up-redesign.md
+++ b/docs/superpowers/plans/2026-07-12-pick-me-up-redesign.md
@@ -1,0 +1,920 @@
+# Pick Me Up Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the One Location "Pick Me Up" quick action to the Apple Blue v2 reference — a single-card map with a reverse-geocoded pickup spot, single-recipient selection, and a note — plus reverse geocoding, an adjustable fixed pickup spot, and gating Meeting + Safe Arrival as "coming soon".
+
+**Architecture:** New backend `reverse_geocode` (Google Geocoding API) surfaced via `OneLocationService.reverseGeocode`. `PickMeUpFlow` is rewritten to the reference layout with single-select recipients and distance shown only when a contact is sharing. A fixed "Adjust" spot is kept fixed by a `pickupSessionRef`/`pickupPointForGrant` in the owner watch loop (mirroring `driveSessionRef`). `onPickMeUp` gains an optional fixed pickup point.
+
+**Tech Stack:** Next.js (App Router) + React 18 + TypeScript, Tailwind, Vitest (frontend); FastAPI + Google Geocoding API, pytest (backend).
+
+## Visual Map
+
+```mermaid
+flowchart TD
+  PMU[PickMeUpFlow] --> MAP[LiveMap pickup marker]
+  PMU --> GEO[reverseGeocode → pickup label]
+  PMU --> ADJ[Adjust → Places search → fixed spot]
+  PMU --> WHO[single-select radio + distance when sharing]
+  PMU --> ASK[onPickMeUp: recipientIds, '4', note, pickupPoint?]
+  ASK --> PSR[pickupSessionRef → pickupPointForGrant keeps fixed spot]
+  GEO --> RG[backend reverse_geocode]
+```
+
+## Global Constraints
+
+- Backend Maps key `GOOGLE_MAPS_API_KEY` (server-side); never expose it / never touch browser `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`.
+- Reverse geocode degrades gracefully: on no results / failure, callers fall back to "Live location".
+- Pick Me Up is single-recipient (radio). `handlePickMeUp` still takes `recipientIds: string[]`; the flow passes `[selectedId]`.
+- Distance ("X km away") shows ONLY when the chosen contact is currently sharing their live location with the user; otherwise omitted (no fabricated data).
+- Drop urgency + duration pickers; share duration = `"4"` ("until picked up").
+- Adjusted fixed pickup spots must NOT drift to live GPS (kept fixed by `pickupPointForGrant`).
+- Meeting + Safe Arrival are "coming soon" (Safe Arrival flips from wired).
+- Commits: `git commit -s` (DCO). Do NOT add a `Co-Authored-By: Claude` trailer.
+- Tests: `npx vitest run <file>` (from `hushh-webapp/`); `.venv/bin/python -m pytest <file>` (from `consent-protocol/`). Typecheck `npx tsc --noEmit`.
+
+---
+
+### Task 1: Backend reverse geocode
+
+**Files:**
+- Modify: `consent-protocol/hushh_mcp/services/google_maps_service.py` (add `_GEOCODE_URL` near line 21; add `reverse_geocode` method after `place_details`)
+- Modify: `consent-protocol/api/routes/one/location.py` (add `MapsReverseGeocodeRequest` near line 99; add route after `maps_place_details`, line ~388)
+- Test: `consent-protocol/tests/services/test_google_maps_service.py`; `consent-protocol/tests/test_one_location_maps_routes.py`
+
+**Interfaces:**
+- Produces: `GoogleMapsService.reverse_geocode(*, lat: float, lng: float) -> {"name": str|None, "formattedAddress": str|None}`.
+- Produces: `POST /api/one/location/maps/reverse-geocode` body `{lat,lng}` → `{"place": {...}}`.
+
+- [ ] **Step 1: Write the failing service test**
+
+Add to `consent-protocol/tests/services/test_google_maps_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_reverse_geocode_parses_name_and_address(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "latlng=" in str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "formatted_address": "476 5th Ave, New York, NY 10018, USA",
+                        "types": ["point_of_interest", "establishment"],
+                        "address_components": [{"long_name": "Central Library", "types": ["point_of_interest"]}],
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    svc = gms.GoogleMapsService()
+    out = await svc.reverse_geocode(lat=40.75, lng=-73.98)
+    assert out == {
+        "name": "Central Library",
+        "formattedAddress": "476 5th Ave, New York, NY 10018, USA",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_empty_results_returns_nulls(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"results": []})
+
+    monkeypatch.setattr(gms, "GOOGLE_MAPS_API_KEY", "k")
+    monkeypatch.setattr(gms, "_async_client", lambda: _client_with(handler))
+    svc = gms.GoogleMapsService()
+    out = await svc.reverse_geocode(lat=1.0, lng=2.0)
+    assert out == {"name": None, "formattedAddress": None}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `.venv/bin/python -m pytest tests/services/test_google_maps_service.py::test_reverse_geocode_parses_name_and_address tests/services/test_google_maps_service.py::test_reverse_geocode_empty_results_returns_nulls -v`
+Expected: FAIL — `reverse_geocode` not defined.
+
+- [ ] **Step 3: Add `_GEOCODE_URL` + `reverse_geocode`**
+
+In `google_maps_service.py`, add after the `_ROUTES_URL` constant (line 21):
+
+```python
+_GEOCODE_URL = "https://maps.googleapis.com/maps/api/geocode/json"
+```
+
+Add this method immediately after `place_details` (after line 130):
+
+```python
+    async def reverse_geocode(self, *, lat: float, lng: float) -> dict[str, Any]:
+        key = _require_key()
+        async with _async_client() as client:
+            try:
+                response = await client.get(
+                    _GEOCODE_URL,
+                    params={"latlng": f"{lat},{lng}", "key": key},
+                )
+            except httpx.HTTPError as exc:
+                raise GoogleMapsError(
+                    f"Reverse geocode failed: {exc}", status_code=502
+                ) from exc
+        if response.status_code >= 400:
+            logger.warning("maps.reverse_geocode upstream %s", response.status_code)
+            raise GoogleMapsError("Reverse geocode failed.", status_code=502)
+        results = response.json().get("results") or []
+        if not results:
+            return {"name": None, "formattedAddress": None}
+        formatted = results[0].get("formatted_address") or None
+        name: str | None = None
+        for result in results:
+            types = result.get("types") or []
+            if any(t in types for t in ("point_of_interest", "establishment", "premise")):
+                components = result.get("address_components") or []
+                if components:
+                    name = components[0].get("long_name") or None
+                break
+        return {"name": name, "formattedAddress": formatted}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/python -m pytest tests/services/test_google_maps_service.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the route + request model**
+
+In `consent-protocol/api/routes/one/location.py`, add after `MapsPlaceDetailsRequest` (line ~99):
+
+```python
+class MapsReverseGeocodeRequest(_CamelModel):
+    lat: float = Field(ge=-90, le=90)
+    lng: float = Field(ge=-180, le=180)
+```
+
+Add this route after `maps_place_details` (after its closing, ~line 388):
+
+```python
+@router.post("/location/maps/reverse-geocode")
+async def maps_reverse_geocode(
+    payload: MapsReverseGeocodeRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    _user_id(token_data)
+    try:
+        place = await _maps_service().reverse_geocode(lat=payload.lat, lng=payload.lng)
+        return {"place": place}
+    except GoogleMapsError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": "ONE_LOCATION_MAPS_FAILED", "message": str(exc)},
+        ) from exc
+```
+
+- [ ] **Step 6: Add a passthrough route test**
+
+In `consent-protocol/tests/test_one_location_maps_routes.py`, mirror `test_route_eta_route`: monkeypatch `gms.GoogleMapsService.reverse_geocode` with an async fake returning `{"name": "Central Library", "formattedAddress": "476 5th Ave"}`, POST `/api/one/location/maps/reverse-geocode` with `{"lat": 40.75, "lng": -73.98}`, assert 200 and `data["place"]["name"] == "Central Library"`.
+
+- [ ] **Step 7: Run both suites + commit**
+
+Run: `.venv/bin/python -m pytest tests/services/test_google_maps_service.py tests/test_one_location_maps_routes.py -q`
+Expected: PASS.
+
+```bash
+git add consent-protocol/hushh_mcp/services/google_maps_service.py consent-protocol/api/routes/one/location.py consent-protocol/tests/services/test_google_maps_service.py consent-protocol/tests/test_one_location_maps_routes.py
+git commit -s -m "feat(one-location): reverse geocode for pickup-spot labels"
+```
+
+---
+
+### Task 2: Frontend reverseGeocode service
+
+**Files:**
+- Modify: `hushh-webapp/lib/one-location/service.ts` (add `reverseGeocode` after `placeDetails`, line ~442)
+
+(No new unit test — `reverseGeocode` is a thin `apiJson` wrapper covered by the backend tests and exercised in the PickMeUpFlow test in Task 4.)
+
+**Interfaces:**
+- Consumes: backend `POST /api/one/location/maps/reverse-geocode` (Task 1).
+- Produces: `OneLocationService.reverseGeocode({ vaultOwnerToken, lat, lng }): Promise<{ name: string | null; formattedAddress: string | null }>`.
+
+- [ ] **Step 1: Add the service method**
+
+In `hushh-webapp/lib/one-location/service.ts`, add after `placeDetails`:
+
+```typescript
+  static async reverseGeocode(params: {
+    vaultOwnerToken: string;
+    lat: number;
+    lng: number;
+  }): Promise<{ name: string | null; formattedAddress: string | null }> {
+    const response = await apiJson<{
+      place: { name: string | null; formattedAddress: string | null };
+    }>("/api/one/location/maps/reverse-geocode", {
+      method: "POST",
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({ lat: params.lat, lng: params.lng }),
+    });
+    return response.place;
+  }
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hushh-webapp/lib/one-location/service.ts
+git commit -s -m "feat(one-location): OneLocationService.reverseGeocode"
+```
+
+---
+
+### Task 3: View-model plumbing — live-point lookup, fixed pickup point, watch loop
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (`LocationHubViewModel` interface: add `recipientLivePoint`; extend `onPickMeUp` signature)
+- Modify: `hushh-webapp/app/one/location/page.tsx` (vm object: add `recipientLivePoint`, widen `onPickMeUp`; add `pickupSessionRef` + `pickupPointForGrant`; use it in the watch loop; extend `handlePickMeUp`)
+
+**Interfaces:**
+- Produces: `vm.recipientLivePoint(userId: string) => PlainLocationPoint | null`.
+- Produces: `vm.onPickMeUp(recipientIds: string[], durationHours: string, message?: string, pickupPoint?: { latitude: number; longitude: number; label?: string })`.
+
+- [ ] **Step 1: Extend the view-model interface**
+
+In `location-redesign-hub.tsx`, change the `onPickMeUp` type (line ~221) to:
+
+```typescript
+  onPickMeUp: (
+    recipientIds: string[],
+    durationHours: string,
+    message?: string,
+    pickupPoint?: { latitude: number; longitude: number; label?: string },
+  ) => void;
+```
+
+Add to the interface near `decryptedPoints` (after line 245):
+
+```typescript
+  /** Latest decrypted live point for a contact who is sharing with the user, else null. */
+  recipientLivePoint: (userId: string) => PlainLocationPoint | null;
+```
+
+- [ ] **Step 2: Add `pickupSessionRef` + `pickupPointForGrant` in page.tsx**
+
+After `driveSessionRef` (line ~1890) add:
+
+```typescript
+  const pickupSessionRef = useRef<{
+    grantIds: Set<string>;
+    point: PlainLocationPoint;
+  } | null>(null);
+```
+
+After `drivePointForGrant` (after line ~2760) add:
+
+```typescript
+  // Keep an adjusted (fixed) pickup spot fixed: the watch loop must not overwrite
+  // these grants with live GPS as the owner moves.
+  const pickupPointForGrant = useCallback(
+    (grant: OneLocationGrant, livePoint: PlainLocationPoint): PlainLocationPoint => {
+      const session = pickupSessionRef.current;
+      if (session && session.grantIds.has(grant.id)) return session.point;
+      return livePoint;
+    },
+    [],
+  );
+```
+
+In the watch republish loop (line ~3246, where `drivePointForGrant(grant, point)` is called), chain the pickup override:
+
+```typescript
+          const driven = await drivePointForGrant(grant, point);
+          const pointForGrant = pickupPointForGrant(grant, driven);
+```
+
+(Replace the existing `const pointForGrant = await drivePointForGrant(grant, point);` line.) Add `pickupPointForGrant` to that effect's dependency array.
+
+- [ ] **Step 3: Extend `handlePickMeUp` for a fixed pickup point**
+
+In `handlePickMeUp` (line ~4322), add `pickupPoint` as the 4th parameter and branch the location source. Replace the parameter list and the readiness/point block:
+
+```typescript
+  const handlePickMeUp = useCallback(
+    async (
+      recipientIds: string[],
+      durationHoursValue: string,
+      messageValue?: string,
+      pickupPoint?: { latitude: number; longitude: number; label?: string },
+    ) => {
+```
+
+Replace the `ensureForegroundLocationReady` + `const point = readiness.point;` block with:
+
+```typescript
+        let point: PlainLocationPoint;
+        if (pickupPoint) {
+          // Adjusted fixed spot: share exactly this point (kept fixed by the watch loop).
+          point = {
+            latitude: pickupPoint.latitude,
+            longitude: pickupPoint.longitude,
+            capturedAt: nowIso(),
+            sourcePlatform: "web",
+          };
+        } else {
+          const readiness = await ensureForegroundLocationReady({
+            capturePoint: true,
+            autoOpenSettings: true,
+          });
+          if (!readiness.ready || !readiness.point) {
+            toast.error("Couldn't get your location — pickup request not sent.");
+            return;
+          }
+          point = readiness.point;
+        }
+```
+
+After the `for (const recipient of selected)` grant-creation loop (after `successCount += 1;` and the loop close), record the fixed session when adjusted:
+
+```typescript
+        if (pickupPoint) {
+          pickupSessionRef.current = {
+            grantIds: new Set(grantCreatedIds),
+            point,
+          };
+        }
+```
+
+To collect `grantCreatedIds`, declare `const grantCreatedIds: string[] = [];` before the loop and `grantCreatedIds.push(grant.id);` inside it. If `nowIso()`/an ISO helper is not already imported in page.tsx, use `new Date().toISOString()` inline instead.
+
+- [ ] **Step 4: Add `recipientLivePoint` to the vm object**
+
+In the vm object literal (near `onPickMeUp` binding, line ~4929), update the binding to pass `pickupPoint` and add `recipientLivePoint`:
+
+```typescript
+    onPickMeUp: (recipientIds, durationHoursValue, messageValue, pickupPoint) =>
+      void handlePickMeUp(recipientIds, durationHoursValue, messageValue, pickupPoint),
+    recipientLivePoint: (userId: string) => {
+      const grant = (state?.receivedGrants ?? []).find(
+        (g) => String(g.ownerUserId || "").trim() === userId,
+      );
+      if (!grant) return null;
+      return decryptedPoints[grant.id] ?? null;
+    },
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors. (If `OneLocationGrant` isn't imported in page.tsx, it already is — used by `drivePointForGrant`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx hushh-webapp/app/one/location/page.tsx
+git commit -s -m "feat(one-location): fixed pickup spot + recipient live-point lookup for Pick Me Up"
+```
+
+---
+
+### Task 4: PickMeUpFlow rewrite (reference layout)
+
+**Files:**
+- Rewrite: `hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx`
+- Rewrite: `hushh-webapp/components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `vm.recipientLivePoint`, `vm.onPickMeUp(...,pickupPoint?)` (Task 3); `OneLocationService.reverseGeocode`, `placesAutocomplete`, `placeDetails` (Task 2 / existing); `LiveMap`; `haversineMeters` from `@/lib/one-location/marker-interpolation`.
+
+- [ ] **Step 1: Write the test first**
+
+Create `hushh-webapp/components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/one-location/use-google-maps", () => ({
+  useGoogleMaps: () => ({ status: "loading" }),
+}));
+
+import { PickMeUpFlow } from "@/components/one-location/redesign/pick-me-up-flow";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { LocationHubViewModel } from "@/components/one-location/redesign/location-redesign-hub";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+const point: PlainLocationPoint = {
+  latitude: 28.6562,
+  longitude: 77.241,
+  capturedAt: "2026-07-12T00:00:00Z",
+  sourcePlatform: "web",
+};
+
+function makeVm(overrides: Partial<LocationHubViewModel> = {}): LocationHubViewModel {
+  return {
+    vaultOwnerToken: "token",
+    onPickMeUp: vi.fn(),
+    sosRecipients: [
+      { userId: "a", displayName: "Ankit", keyId: "k1", publicKeyJwk: {} as JsonWebKey, canReceiveLocation: true },
+      { userId: "b", displayName: "Akshat", keyId: "k2", publicKeyJwk: {} as JsonWebKey, canReceiveLocation: true },
+    ],
+    isRecipientShareReady: () => true,
+    recipientLabel: (r) => r.displayName ?? r.userId,
+    recipientSubtitle: () => "Trusted",
+    recipientLivePoint: () => null,
+    myLocationPoint: point,
+    myLocationError: null,
+    onShowMyLocation: vi.fn(),
+    formatDateTime: () => "now",
+    busy: null,
+    ...overrides,
+  } as unknown as LocationHubViewModel;
+}
+
+describe("PickMeUpFlow", () => {
+  it("single-selects a recipient and labels the button with their name", async () => {
+    vi.spyOn(OneLocationService, "reverseGeocode").mockResolvedValue({
+      name: "Central Library",
+      formattedAddress: "476 5th Ave",
+    });
+    const vm = makeVm();
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Ankit/i }));
+    const ask = await screen.findByRole("button", { name: /ask ankit to pick me up/i });
+    await waitFor(() => expect(ask).not.toBeDisabled());
+    fireEvent.click(ask);
+    await waitFor(() =>
+      // No note typed → message is undefined; no fixed spot → pickupPoint undefined.
+      expect(vm.onPickMeUp).toHaveBeenCalledWith(["a"], "4", undefined, undefined),
+    );
+  });
+
+  it("switching selection replaces the prior one (radio, not multi)", async () => {
+    const vm = makeVm();
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: /Ankit/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Akshat/i }));
+    expect(
+      await screen.findByRole("button", { name: /ask akshat to pick me up/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows distance only for a contact that is sharing", async () => {
+    const vm = makeVm({
+      recipientLivePoint: (id) =>
+        id === "a"
+          ? { latitude: 28.60, longitude: 77.20, capturedAt: "x", sourcePlatform: "web" }
+          : null,
+    });
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+    expect(await screen.findByText(/km away/i)).toBeInTheDocument();
+  });
+
+  it("reverse-geocodes the pickup spot label", async () => {
+    vi.spyOn(OneLocationService, "reverseGeocode").mockResolvedValue({
+      name: "Central Library",
+      formattedAddress: "476 5th Ave",
+    });
+    const vm = makeVm();
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+    expect(await screen.findByText(/Central Library/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `npx vitest run components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx`
+Expected: FAIL (old multi-select UI / different labels).
+
+- [ ] **Step 3: Rewrite `pick-me-up-flow.tsx`**
+
+Replace the file with the reference layout below. It keeps the encrypted pipeline (calls `vm.onPickMeUp`), single-selects a recipient, reverse-geocodes the pickup label, supports Adjust, and shows distance only when a contact is sharing.
+
+```tsx
+"use client";
+
+/**
+ * One Location redesign — Pick Me Up flow (Quick Action).
+ *
+ * Ask ONE trusted person to come to your pickup spot. The spot defaults to your
+ * live location (reverse-geocoded for a human label) and can be Adjusted to a
+ * fixed searched place. Distance to a contact is shown only when they are
+ * currently sharing their live location with you. On confirm it hands the chosen
+ * recipient + note (+ optional fixed pickup point) to `vm.onPickMeUp`.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Check, Navigation } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { OneLocationService } from "@/lib/one-location/service";
+import { LiveMap } from "@/components/one-location/live-map";
+import { haversineMeters } from "@/lib/one-location/marker-interpolation";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+import { CARD_SURFACE } from "./tokens";
+import type { LocationHubViewModel } from "./location-redesign-hub";
+
+const PICKUP_DURATION_HOURS = "4"; // "until picked up"
+const NOTE_MAX = 160;
+
+function initialsOf(label: string): string {
+  const words = label.trim().split(/\s+/).filter(Boolean);
+  if (words.length >= 2) return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
+  return (words[0]?.slice(0, 1) || "?").toUpperCase();
+}
+
+function avatarTone(index: number): string {
+  const tones = [
+    "bg-red-500 text-white",
+    "bg-sky-500 text-white",
+    "bg-violet-500 text-white",
+    "bg-emerald-500 text-white",
+    "bg-amber-500 text-white",
+  ];
+  return tones[index % tones.length]!;
+}
+
+type FixedSpot = { latitude: number; longitude: number; label: string };
+
+export function PickMeUpFlow({
+  vm,
+  onClose,
+}: {
+  vm: LocationHubViewModel;
+  onClose: () => void;
+}) {
+  const contacts = vm.sosRecipients;
+  const busy = vm.busy === "share" || vm.busy === "selfLocation";
+  const livePoint = vm.myLocationPoint;
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [note, setNote] = useState("");
+  const [fixedSpot, setFixedSpot] = useState<FixedSpot | null>(null);
+  const [geoLabel, setGeoLabel] = useState<string | null>(null);
+
+  // Adjust search state
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<{ placeId: string; text: string }[]>([]);
+
+  // The point we actually share: fixed spot if adjusted, else the live location.
+  const pickupPoint: { latitude: number; longitude: number } | null = fixedSpot
+    ? { latitude: fixedSpot.latitude, longitude: fixedSpot.longitude }
+    : livePoint
+      ? { latitude: livePoint.latitude, longitude: livePoint.longitude }
+      : null;
+
+  // Reverse-geocode the LIVE location for the default label (skip when adjusted).
+  useEffect(() => {
+    const token = vm.vaultOwnerToken;
+    if (!token || fixedSpot || !livePoint) {
+      setGeoLabel(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken: token,
+          lat: livePoint.latitude,
+          lng: livePoint.longitude,
+        });
+        if (cancelled) return;
+        const label = place.name
+          ? place.formattedAddress
+            ? `${place.name} · ${place.formattedAddress}`
+            : place.name
+          : place.formattedAddress;
+        setGeoLabel(label ?? null);
+      } catch {
+        if (!cancelled) setGeoLabel(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [vm.vaultOwnerToken, livePoint, fixedSpot]);
+
+  // Debounced Places autocomplete for Adjust.
+  useEffect(() => {
+    const token = vm.vaultOwnerToken;
+    const q = query.trim();
+    if (!token || !adjustOpen || q.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      try {
+        const results = await OneLocationService.placesAutocomplete({
+          vaultOwnerToken: token,
+          input: q,
+        });
+        if (!cancelled) setSuggestions(results);
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, adjustOpen, vm.vaultOwnerToken]);
+
+  const selectPlace = async (placeId: string) => {
+    const token = vm.vaultOwnerToken;
+    if (!token) return;
+    try {
+      const place = await OneLocationService.placeDetails({ vaultOwnerToken: token, placeId });
+      setFixedSpot({ latitude: place.latitude, longitude: place.longitude, label: place.label });
+      setAdjustOpen(false);
+      setQuery("");
+      setSuggestions([]);
+    } catch {
+      /* leave adjust open; user can retry */
+    }
+  };
+
+  const pickupLabel = fixedSpot
+    ? fixedSpot.label
+    : geoLabel ?? "Live location";
+
+  const selectedContact = contacts.find((c) => c.userId === selectedId) ?? null;
+  const selectedName = selectedContact ? vm.recipientLabel(selectedContact) : null;
+  const canAsk = Boolean(pickupPoint) && Boolean(selectedContact) && !busy;
+
+  function distanceLabel(userId: string): string | null {
+    if (!pickupPoint) return null;
+    const p = vm.recipientLivePoint(userId);
+    if (!p) return null;
+    const meters = haversineMeters(
+      { lat: pickupPoint.latitude, lng: pickupPoint.longitude },
+      { lat: p.latitude, lng: p.longitude },
+    );
+    return `${(meters / 1000).toFixed(1)} km away`;
+  }
+
+  const mapPoint: PlainLocationPoint | null = fixedSpot
+    ? { latitude: fixedSpot.latitude, longitude: fixedSpot.longitude, capturedAt: new Date().toISOString(), sourcePlatform: "web" }
+    : livePoint;
+
+  return (
+    <div className="space-y-4">
+      {/* HEADER */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-[24px] font-semibold leading-tight tracking-[-0.3px] text-foreground">
+          Pick me up
+        </h2>
+        <button type="button" onClick={onClose} className="text-[15px] text-[#007aff]">
+          Cancel
+        </button>
+      </div>
+
+      {/* PICKUP CARD */}
+      <section className={cn(CARD_SURFACE, "overflow-hidden p-0")}>
+        <div className="relative h-[150px] bg-[#eceef2] dark:bg-white/5">
+          {mapPoint ? (
+            <LiveMap point={mapPoint} className="absolute inset-0" />
+          ) : (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
+              <p className="text-sm text-muted-foreground">
+                Turn on your live location so they know where to come.
+              </p>
+              <button
+                type="button"
+                onClick={vm.onShowMyLocation}
+                disabled={vm.busy === "selfLocation"}
+                className="inline-flex items-center gap-2 rounded-full bg-[#007aff] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                {vm.busy === "selfLocation" ? "Capturing…" : "Capture location"}
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-[15px] font-semibold text-foreground">Your pickup spot</div>
+            <div className="truncate text-sm text-muted-foreground">{pickupLabel}</div>
+          </div>
+          {fixedSpot ? (
+            <button
+              type="button"
+              onClick={() => setFixedSpot(null)}
+              className="shrink-0 text-[15px] text-[#007aff]"
+            >
+              Use live
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setAdjustOpen((v) => !v)}
+              className="shrink-0 text-[15px] text-[#007aff]"
+            >
+              Adjust
+            </button>
+          )}
+        </div>
+      </section>
+
+      {/* ADJUST SEARCH */}
+      {adjustOpen ? (
+        <section className={cn(CARD_SURFACE, "p-3")}>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search a pickup place…"
+            className="h-10 w-full rounded-[12px] border border-border/70 bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-[#007aff]/25"
+          />
+          {suggestions.length ? (
+            <div className="mt-2 space-y-1">
+              {suggestions.map((s) => (
+                <button
+                  key={s.placeId}
+                  type="button"
+                  onClick={() => void selectPlace(s.placeId)}
+                  className="flex w-full items-center gap-2 rounded-[11px] px-2 py-2 text-left hover:bg-[#007aff]/10"
+                >
+                  <Navigation className="h-4 w-4 shrink-0 rotate-90 text-[#007aff]" />
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">{s.text}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {/* WHO DO YOU ASK */}
+      <div>
+        <p className="mb-2 px-1 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Who do you ask
+        </p>
+        <section className={cn(CARD_SURFACE, "px-4")}>
+          {contacts.length ? (
+            contacts.map((recipient, index) => {
+              const ready = vm.isRecipientShareReady(recipient);
+              const selected = selectedId === recipient.userId;
+              const dist = distanceLabel(recipient.userId);
+              return (
+                <button
+                  key={recipient.userId}
+                  type="button"
+                  onClick={ready ? () => setSelectedId(recipient.userId) : undefined}
+                  disabled={!ready}
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex w-full items-center gap-[13px] py-3 text-left",
+                    index < contacts.length - 1 && "border-b border-black/[0.06] dark:border-white/10",
+                    !ready && "cursor-not-allowed opacity-60",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full text-sm font-semibold",
+                      avatarTone(index),
+                    )}
+                    aria-hidden
+                  >
+                    {initialsOf(vm.recipientLabel(recipient))}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[16px] font-semibold text-foreground">
+                      {vm.recipientLabel(recipient)}
+                    </span>
+                    {dist ? (
+                      <span className="block truncate text-sm text-muted-foreground">{dist}</span>
+                    ) : null}
+                  </span>
+                  <span
+                    className={cn(
+                      "flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+                      selected ? "border-[#007aff] bg-[#007aff] text-white" : "border-border",
+                    )}
+                  >
+                    {selected ? <Check className="h-3.5 w-3.5" strokeWidth={3} /> : null}
+                  </span>
+                </button>
+              );
+            })
+          ) : (
+            <p className="py-5 text-center text-sm text-muted-foreground">
+              No trusted contacts yet. Add people to your Circle first.
+            </p>
+          )}
+        </section>
+      </div>
+
+      {/* NOTE */}
+      <div>
+        <p className="mb-2 px-1 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Note
+        </p>
+        <section className={cn(CARD_SURFACE, "p-3")}>
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value.slice(0, NOTE_MAX))}
+            placeholder="Meet me at the main entrance."
+            className="w-full bg-transparent text-[15px] text-foreground outline-none placeholder:text-muted-foreground"
+          />
+        </section>
+      </div>
+
+      <p className="px-1 text-center text-sm text-muted-foreground">
+        {fixedSpot
+          ? "They see your pickup spot until you're picked up or cancel."
+          : "They see your live pickup spot until you're picked up or cancel."}
+      </p>
+
+      {/* ACTION */}
+      <div className="pt-1">
+        <button
+          type="button"
+          onClick={() =>
+            selectedContact &&
+            vm.onPickMeUp(
+              [selectedContact.userId],
+              PICKUP_DURATION_HOURS,
+              note.trim() || undefined,
+              fixedSpot ?? undefined,
+            )
+          }
+          disabled={!canAsk}
+          className="flex w-full items-center justify-center gap-2 rounded-full bg-[#007aff] py-4 text-[17px] font-medium text-white transition-opacity disabled:opacity-40"
+        >
+          <Navigation className="h-[18px] w-[18px]" fill="currentColor" strokeWidth={0} />
+          {busy ? "Asking…" : selectedName ? `Ask ${selectedName} to pick me up` : "Select who to ask"}
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests + tsc + eslint**
+
+Run: `npx vitest run components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx`
+Expected: PASS (4).
+Run: `npx tsc --noEmit` and `npx eslint components/one-location/redesign/pick-me-up-flow.tsx`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx hushh-webapp/components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx
+git commit -s -m "feat(one-location): Pick Me Up reference layout, single-select, reverse-geocoded spot, adjust"
+```
+
+---
+
+### Task 5: Meeting + Safe Arrival → coming soon
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (Safe Arrival card, line ~695-699)
+- Test: extend the hub/quick-actions test if one asserts card wiring; otherwise add a focused assertion.
+
+- [ ] **Step 1: Gate Safe Arrival**
+
+In the Safe Arrival `QuickActionCard` (line ~695), remove its `onClick={() => setFlow("safe-arrival")}` and add `comingSoon`, matching the Meeting card. Result:
+
+```tsx
+        <QuickActionCard
+          icon={/* unchanged */}
+          title="Safe Arrival"
+          subtitle="Get notified"
+          comingSoon
+        />
+```
+
+Update the nearby comment (line ~656) so the wired list no longer names Safe Arrival.
+
+- [ ] **Step 2: Typecheck (remove now-unused wiring if flagged)**
+
+Run: `npx tsc --noEmit` then `npx eslint components/one-location/redesign/location-redesign-hub.tsx`
+Expected: clean. If `onSafeArrival`/`safeArrivalBusy` become unused and eslint flags them, leave the vm fields (other code/tests reference the interface) — only remove a genuinely unused local. Do not delete `SafeArrivalFlow` or its flow branch.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+git commit -s -m "feat(one-location): gate Safe Arrival + Meeting as coming soon"
+```
+
+---
+
+### Task 6: End-to-end verification
+
+- [ ] **Step 1: Full suites**
+
+Run (from `hushh-webapp/`): `npx vitest run components/one-location lib/one-location && npx tsc --noEmit`
+Run (from `consent-protocol/`): `.venv/bin/python -m pytest tests/services/test_google_maps_service.py tests/test_one_location_maps_routes.py`
+Expected: all PASS.
+
+- [ ] **Step 2: Drive it on the iOS simulator**
+
+Rebuild against the local backend and launch (per the run-ios-sim skill; remember GOTCHA: never pipe `xcodebuild` to `tail`; a moving simulated location avoids the static-fix hang). Verify: pickup card shows the map + reverse-geocoded "Your pickup spot" label; single-select radio; distance appears only for a contact sharing with you; Adjust sets a fixed spot (label updates, "Use live" reverts); "Ask <name> to pick me up" creates the grant; Meeting + Safe Arrival render as coming soon.

--- a/docs/superpowers/specs/2026-07-12-pick-me-up-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-12-pick-me-up-redesign-design.md
@@ -1,0 +1,161 @@
+# Pick Me Up redesign + reverse-geocoded pickup spot — design
+
+**Date:** 2026-07-12
+**Branch:** `feat/pick-me-up-quick-action`
+**Status:** Approved
+
+## Visual Map
+
+```mermaid
+flowchart TD
+  subgraph Frontend
+    PMU[PickMeUpFlow] --> MAP[LiveMap single pickup marker]
+    PMU --> GEO[OneLocationService.reverseGeocode]
+    PMU --> ADJ[Adjust → Places search → fixed spot]
+    PMU --> WHO[Who do you ask — single-select radio]
+    WHO --> DIST[distance only when contact is sharing]
+    PMU --> ASK[Ask name to pick me up → onPickMeUp]
+  end
+  subgraph Backend
+    GEO --> RG[reverse_geocode lat,lng → name + formattedAddress]
+  end
+  subgraph OwnerWatchLoop
+    ASK --> PSR[pickupSessionRef]
+    PSR --> PPFG[pickupPointForGrant keeps fixed spot from drifting to live GPS]
+  end
+```
+
+## Goal
+
+Redesign the One Location **Pick Me Up** quick action to match the Apple Blue v2
+reference: a clean single-card map with the pickup spot, a reverse-geocoded
+address, single-recipient selection, and a note. Add the ability to show a
+human-readable place name/address for the current location (reverse geocoding)
+and to Adjust the pickup spot to a fixed searched place. Gate the last two quick
+actions (Meeting, Safe Arrival) as "coming soon".
+
+## Scope
+
+In scope:
+- Backend reverse geocoding (`reverse_geocode`) + route + frontend service.
+- `PickMeUpFlow` rewrite to the reference layout.
+- Single-recipient (radio) selection.
+- Distance ("X km away") shown only when the contact is currently sharing their
+  live location with the user.
+- Adjust → fixed pickup spot (Places search), shared instead of live GPS, kept
+  fixed by a `pickupSessionRef` in the owner watch loop.
+- Meeting + Safe Arrival → "coming soon" in the quick-actions grid.
+
+Out of scope:
+- Reworking Drive-To's "Starting from" to use reverse geocoding (future reuse).
+- "usually fastest" heuristic labels (we cannot back them with data).
+- Changing the encryption/consent pipeline.
+
+## Components
+
+### 1. Backend — reverse geocode
+
+Files: `consent-protocol/hushh_mcp/services/google_maps_service.py`,
+`consent-protocol/api/routes/one/location.py`, tests.
+
+- `reverse_geocode(*, lat, lng) -> {"name": str | None, "formattedAddress": str | None}`.
+  Calls Google Geocoding API `https://maps.googleapis.com/maps/api/geocode/json?latlng=<lat>,<lng>&key=…`.
+  - `formattedAddress` = `results[0].formatted_address`.
+  - `name` = the most specific named component when present (e.g. a
+    `point_of_interest`/`establishment`/`premise` in `results`), else `null`.
+  - Returns both `null` when there are no results (caller falls back).
+  - Reuses `_require_key()` and the existing async client + error mapping.
+- Route: `POST /api/one/location/maps/reverse-geocode` (auth: `require_vault_owner_token`),
+  body `{ lat, lng }`, returns `{ "place": <dict> }`. Mirrors `maps_place_details`.
+
+Frontend: `OneLocationService.reverseGeocode({ vaultOwnerToken, lat, lng })`
+returns `{ name: string | null; formattedAddress: string | null }`.
+
+### 2. `PickMeUpFlow` rewrite
+
+File: `hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx` + test.
+
+Layout (top → bottom):
+- Header: "Pick me up" title + blue "Cancel" (matches Drive-to header pattern).
+- **Pickup card** (`CARD_SURFACE`, `overflow-hidden`):
+  - Map area (`h-[150px]`): `LiveMap` for the pickup point when we have one; a
+    "Capture location" prompt when no fix.
+  - Row: "Your pickup spot" + reverse-geocoded label
+    (`name ? "<name> · <formattedAddress>" : formattedAddress ?? "Live location"`)
+    + a blue **Adjust** button on the right.
+- **WHO DO YOU ASK** — single-select radio list. Each row: avatar + name +
+  optional "X km away" subtitle (only when a live point for that contact exists)
+  + a radio circle (filled blue when selected). Selecting sets `selectedId`
+  (replaces any prior selection).
+- **NOTE** — free-text card (`maxLength` 160), placeholder "Meet me at the main entrance."
+- Footer helper text: "They see your live pickup spot until you're picked up or cancel."
+  (When a fixed spot is set: "They see your pickup spot until you're picked up or cancel.")
+- Action button: "Ask <name> to pick me up" (name of the selected recipient);
+  disabled until a recipient is selected and a pickup point exists.
+
+Adjust behavior:
+- Tapping "Adjust" reveals a Places search (reuse the debounced
+  `placesAutocomplete` + `placeDetails` pattern from Drive-To). Selecting a place
+  sets a fixed pickup spot `{ latitude, longitude, label }`. The map + address
+  row reflect the fixed spot. A "Use live location" affordance clears it back to
+  live.
+
+Distance:
+- `vm.recipientLivePoint(userId)` (new vm helper) returns the contact's latest
+  decrypted live point if they are currently sharing with the user, else `null`.
+  When present, show `"<km> km away"` computed from the pickup point via the
+  existing `locationDistanceMeters`/haversine helper.
+
+### 3. Owner watch loop — keep a fixed pickup spot fixed
+
+File: `hushh-webapp/app/one/location/page.tsx`.
+
+- `onPickMeUp` view-model binding + `handlePickMeUp` gain an optional
+  `pickupPoint?: { latitude: number; longitude: number; label?: string }`.
+  - When provided: skip live capture; build the shared `PlainLocationPoint` from
+    the fixed spot; record `pickupSessionRef = { grantIds, point }`.
+  - When absent: unchanged (live capture + live watch).
+- Add `pickupSessionRef` (mirrors `driveSessionRef`) and
+  `pickupPointForGrant(grant, livePoint)` returning the fixed point for grants in
+  `pickupSessionRef.grantIds`, else `livePoint`. Call it in the watch republish
+  loop alongside `drivePointForGrant` so a fixed pickup does not drift to live GPS.
+- Selection is single-recipient: `handlePickMeUp` still accepts `recipientIds`
+  (an array with one id) — no signature break; the flow passes `[selectedId]`.
+
+### 4. Quick actions — Meeting + Safe Arrival coming soon
+
+File: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx`.
+
+- The Safe Arrival `QuickActionCard` gains `comingSoon` and drops its
+  `onClick={() => setFlow("safe-arrival")}` (Meeting is already `comingSoon`).
+- The `safe-arrival` flow branch may remain in the switch (unreachable) or be
+  left as-is; the card no longer opens it.
+
+## Data flow
+
+1. User opens Pick Me Up → live location captured (existing) → `reverseGeocode`
+   fills the pickup-spot label.
+2. Optional: Adjust → Places search → fixed pickup spot (label + lat/lng).
+3. User picks ONE contact (radio); distance shown if that contact is sharing.
+4. User adds an optional note.
+5. "Ask <name> to pick me up" → `onPickMeUp([selectedId], "4", note, pickupPoint?)`.
+6. `handlePickMeUp` creates the grant + publishes the pickup point; fixed spots
+   are kept fixed by `pickupPointForGrant` in the watch loop.
+
+## Error handling / fallbacks
+
+- No location fix → "Capture location" prompt in the map area; button disabled.
+- `reverseGeocode` failure/unavailable → label falls back to "Live location".
+- Maps JS unavailable → `LiveMap` iframe fallback (existing).
+- `handlePickMeUp` keeps its existing toast on every failure branch.
+
+## Testing
+
+- Backend: `reverse_geocode` parses `name`/`formattedAddress`; returns nulls on
+  empty results; field/URL shape asserted; passthrough route test.
+- `pick-me-up-flow.test.tsx`: single-select (selecting B deselects A); button
+  label "Ask <name> to pick me up"; distance shown only when a live point is
+  provided; Adjust sets a fixed spot; `onPickMeUp` called with `[selectedId]`,
+  `"4"`, note, and the fixed point when adjusted.
+- Hub test / assertion: Safe Arrival renders as coming-soon (no `safe-arrival`
+  flow opens on click).

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1889,10 +1889,11 @@ function OneLocationAgentPageContent() {
     lastEtaPoint: PlainLocationPoint | null;
     lastEtaAt: number;
   } | null>(null);
-  const pickupSessionRef = useRef<{
-    grantIds: Set<string>;
-    point: PlainLocationPoint;
-  } | null>(null);
+  // Maps each fixed-pickup grantId to the PlainLocationPoint anchored at request
+  // time. Using a Map (rather than a single shared object) means a second "Pick
+  // Me Up" request no longer overwrites the first grant's fixed spot, which
+  // would otherwise cause it to drift back to live GPS.
+  const pickupSessionRef = useRef<Map<string, PlainLocationPoint>>(new Map());
   const [recentDestinations, setRecentDestinations] = useState<DriveDestination[]>([]);
 
 
@@ -2750,11 +2751,8 @@ function OneLocationAgentPageContent() {
   // Keep an adjusted (fixed) pickup spot fixed: the watch loop must not overwrite
   // these grants with live GPS as the owner moves.
   const pickupPointForGrant = useCallback(
-    (grant: OneLocationGrant, livePoint: PlainLocationPoint): PlainLocationPoint => {
-      const session = pickupSessionRef.current;
-      if (session && session.grantIds.has(grant.id)) return session.point;
-      return livePoint;
-    },
+    (grant: OneLocationGrant, livePoint: PlainLocationPoint): PlainLocationPoint =>
+      pickupSessionRef.current.get(grant.id) ?? livePoint,
     [],
   );
 
@@ -4381,7 +4379,6 @@ function OneLocationAgentPageContent() {
           point = readiness.point;
         }
         const durationHoursNum = Number(durationHoursValue) || 1;
-        const grantCreatedIds: string[] = [];
         for (const recipient of selected) {
           const grant = await OneLocationService.createGrant({
             vaultOwnerToken,
@@ -4393,15 +4390,11 @@ function OneLocationAgentPageContent() {
           // Anchor the grant to the fixed-pickup session BEFORE publishing so a
           // mid-publish failure can't leave a created grant drifting to live GPS
           // when the user chose a fixed spot.
-          grantCreatedIds.push(grant.id);
+          if (pickupPoint) {
+            pickupSessionRef.current.set(grant.id, point);
+          }
           await publishEnvelopeWithRetry(grant, recipient, "manual", point);
           successCount += 1;
-        }
-        if (pickupPoint) {
-          pickupSessionRef.current = {
-            grantIds: new Set(grantCreatedIds),
-            point,
-          };
         }
         trackEvent("one_location_share_confirmed", {
           route_id: "one_location",

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4390,8 +4390,11 @@ function OneLocationAgentPageContent() {
             durationHours: durationHoursNum,
             reason: pickupMessage,
           });
-          await publishEnvelopeWithRetry(grant, recipient, "manual", point);
+          // Anchor the grant to the fixed-pickup session BEFORE publishing so a
+          // mid-publish failure can't leave a created grant drifting to live GPS
+          // when the user chose a fixed spot.
           grantCreatedIds.push(grant.id);
+          await publishEnvelopeWithRetry(grant, recipient, "manual", point);
           successCount += 1;
         }
         if (pickupPoint) {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1889,6 +1889,10 @@ function OneLocationAgentPageContent() {
     lastEtaPoint: PlainLocationPoint | null;
     lastEtaAt: number;
   } | null>(null);
+  const pickupSessionRef = useRef<{
+    grantIds: Set<string>;
+    point: PlainLocationPoint;
+  } | null>(null);
   const [recentDestinations, setRecentDestinations] = useState<DriveDestination[]>([]);
 
 
@@ -2743,6 +2747,17 @@ function OneLocationAgentPageContent() {
     [vaultOwnerToken],
   );
 
+  // Keep an adjusted (fixed) pickup spot fixed: the watch loop must not overwrite
+  // these grants with live GPS as the owner moves.
+  const pickupPointForGrant = useCallback(
+    (grant: OneLocationGrant, livePoint: PlainLocationPoint): PlainLocationPoint => {
+      const session = pickupSessionRef.current;
+      if (session && session.grantIds.has(grant.id)) return session.point;
+      return livePoint;
+    },
+    [],
+  );
+
   const resetShareComposer = useCallback(() => {
     suppressAutoRecipientSelectionRef.current = true;
     setSelectedRecipientId("");
@@ -3243,7 +3258,8 @@ function OneLocationAgentPageContent() {
         for (const grant of activeOwnerGrants) {
           const recipient = recipientForGrant(grant);
           if (!recipient?.keyId || !recipient.publicKeyJwk) continue;
-          const pointForGrant = await drivePointForGrant(grant, point);
+          const driven = await drivePointForGrant(grant, point);
+          const pointForGrant = pickupPointForGrant(grant, driven);
           await publishEnvelopeWithRetry(
             grant,
             recipient,
@@ -3295,6 +3311,7 @@ function OneLocationAgentPageContent() {
     publishEnvelopeWithRetry,
     recipientForGrant,
     drivePointForGrant,
+    pickupPointForGrant,
     vaultOwnerToken,
   ]);
 
@@ -4324,6 +4341,7 @@ function OneLocationAgentPageContent() {
       recipientIds: string[],
       durationHoursValue: string,
       messageValue?: string,
+      pickupPoint?: { latitude: number; longitude: number; label?: string },
     ) => {
       if (!vaultOwnerToken || locationPermissionBlocksSharing(permission)) {
         toast.error("Location permission is required to request a pickup.");
@@ -4342,16 +4360,28 @@ function OneLocationAgentPageContent() {
       setBusy("share");
       let successCount = 0;
       try {
-        const readiness = await ensureForegroundLocationReady({
-          capturePoint: true,
-          autoOpenSettings: true,
-        });
-        if (!readiness.ready || !readiness.point) {
-          toast.error("Couldn't get your location — pickup request not sent.");
-          return;
+        let point: PlainLocationPoint;
+        if (pickupPoint) {
+          // Adjusted fixed spot: share exactly this point (kept fixed by the watch loop).
+          point = {
+            latitude: pickupPoint.latitude,
+            longitude: pickupPoint.longitude,
+            capturedAt: new Date().toISOString(),
+            sourcePlatform: "web",
+          };
+        } else {
+          const readiness = await ensureForegroundLocationReady({
+            capturePoint: true,
+            autoOpenSettings: true,
+          });
+          if (!readiness.ready || !readiness.point) {
+            toast.error("Couldn't get your location — pickup request not sent.");
+            return;
+          }
+          point = readiness.point;
         }
-        const point = readiness.point;
         const durationHoursNum = Number(durationHoursValue) || 1;
+        const grantCreatedIds: string[] = [];
         for (const recipient of selected) {
           const grant = await OneLocationService.createGrant({
             vaultOwnerToken,
@@ -4361,7 +4391,14 @@ function OneLocationAgentPageContent() {
             reason: pickupMessage,
           });
           await publishEnvelopeWithRetry(grant, recipient, "manual", point);
+          grantCreatedIds.push(grant.id);
           successCount += 1;
+        }
+        if (pickupPoint) {
+          pickupSessionRef.current = {
+            grantIds: new Set(grantCreatedIds),
+            point,
+          };
         }
         trackEvent("one_location_share_confirmed", {
           route_id: "one_location",
@@ -4926,8 +4963,15 @@ function OneLocationAgentPageContent() {
     recentDestinations,
     onDriveTo: (destination, recipientIds, durationHoursValue) =>
       void handleDriveTo(destination, recipientIds, durationHoursValue),
-    onPickMeUp: (recipientIds, durationHoursValue, messageValue) =>
-      void handlePickMeUp(recipientIds, durationHoursValue, messageValue),
+    onPickMeUp: (recipientIds, durationHoursValue, messageValue, pickupPoint) =>
+      void handlePickMeUp(recipientIds, durationHoursValue, messageValue, pickupPoint),
+    recipientLivePoint: (userId: string) => {
+      const grant = (state?.receivedGrants ?? []).find(
+        (g) => String(g.ownerUserId || "").trim() === userId,
+      );
+      if (!grant) return null;
+      return decryptedPoints[grant.id] ?? null;
+    },
     safeArrivalBusy: busy === "safeArrival",
     onSafeArrival: (destination, recipientIds, durationHoursValue, messageValue) =>
       void handleSafeArrival(

--- a/hushh-webapp/components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/pick-me-up-flow.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/one-location/use-google-maps", () => ({
+  useGoogleMaps: () => ({ status: "loading" }),
+}));
+
+import { PickMeUpFlow } from "@/components/one-location/redesign/pick-me-up-flow";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { LocationHubViewModel } from "@/components/one-location/redesign/location-redesign-hub";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+const point: PlainLocationPoint = {
+  latitude: 28.6562,
+  longitude: 77.241,
+  capturedAt: "2026-07-12T00:00:00Z",
+  sourcePlatform: "web",
+};
+
+function makeVm(overrides: Partial<LocationHubViewModel> = {}): LocationHubViewModel {
+  return {
+    vaultOwnerToken: "token",
+    onPickMeUp: vi.fn(),
+    sosRecipients: [
+      { userId: "a", displayName: "Ankit", keyId: "k1", publicKeyJwk: {} as JsonWebKey, canReceiveLocation: true },
+      { userId: "b", displayName: "Akshat", keyId: "k2", publicKeyJwk: {} as JsonWebKey, canReceiveLocation: true },
+    ],
+    isRecipientShareReady: () => true,
+    recipientLabel: (r) => r.displayName ?? r.userId,
+    recipientSubtitle: () => "Trusted",
+    recipientLivePoint: () => null,
+    myLocationPoint: point,
+    myLocationError: null,
+    onShowMyLocation: vi.fn(),
+    formatDateTime: () => "now",
+    busy: null,
+    ...overrides,
+  } as unknown as LocationHubViewModel;
+}
+
+describe("PickMeUpFlow", () => {
+  it("single-selects a recipient and labels the button with their name", async () => {
+    vi.spyOn(OneLocationService, "reverseGeocode").mockResolvedValue({
+      name: "Central Library",
+      formattedAddress: "476 5th Ave",
+    });
+    const vm = makeVm();
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Ankit/i }));
+    const ask = await screen.findByRole("button", { name: /ask ankit to pick me up/i });
+    await waitFor(() => expect(ask).not.toBeDisabled());
+    fireEvent.click(ask);
+    await waitFor(() =>
+      // No note typed → message is undefined; no fixed spot → pickupPoint undefined.
+      expect(vm.onPickMeUp).toHaveBeenCalledWith(["a"], "4", undefined, undefined),
+    );
+  });
+
+  it("switching selection replaces the prior one (radio, not multi)", async () => {
+    const vm = makeVm();
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+    fireEvent.click(await screen.findByRole("button", { name: /Ankit/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /Akshat/i }));
+    expect(
+      await screen.findByRole("button", { name: /ask akshat to pick me up/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows distance only for a contact that is sharing", async () => {
+    const vm = makeVm({
+      recipientLivePoint: (id) =>
+        id === "a"
+          ? { latitude: 28.60, longitude: 77.20, capturedAt: "x", sourcePlatform: "web" }
+          : null,
+    });
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+    expect(await screen.findByText(/km away/i)).toBeInTheDocument();
+  });
+
+  it("reverse-geocodes the pickup spot label", async () => {
+    vi.spyOn(OneLocationService, "reverseGeocode").mockResolvedValue({
+      name: "Central Library",
+      formattedAddress: "476 5th Ave",
+    });
+    const vm = makeVm();
+    render(<PickMeUpFlow vm={vm} onClose={vi.fn()} />);
+    expect(await screen.findByText(/Central Library/)).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -209,6 +209,7 @@ export type LocationHubViewModel = {
     recipientIds: string[],
     durationHours: string,
     message?: string,
+    pickupPoint?: { latitude: number; longitude: number; label?: string },
   ) => void;
 
   /* Safe Arrival (quick action) — outbound: share your live journey + ETA to a
@@ -243,6 +244,8 @@ export type LocationHubViewModel = {
   ) => ReactNode;
   mapLocationHref: (point: PlainLocationPoint) => string;
   decryptedPoints: Record<string, PlainLocationPoint>;
+  /** Latest decrypted live point for a contact who is sharing with the user, else null. */
+  recipientLivePoint: (userId: string) => PlainLocationPoint | null;
 };
 
 type FlowKind =

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -542,7 +542,7 @@ function NowHub({
   onCheckIn,
   onDriveTo,
   onPickMeUp,
-  onSafeArrival,
+  onSafeArrival: _onSafeArrival,
   onSos,
   onOpenPrivacy,
 }: {
@@ -655,9 +655,9 @@ function NowHub({
         </Button>
       </div>
 
-      {/* Quick actions — six location shortcuts on a 3-col grid. Five are live
-          (Check-In, Alert, Drive To, Pick Me Up, Safe Arrival); only "Meeting"
-          remains coming soon. "Alert" opens the SOS/notify-circle panel. */}
+      {/* Quick actions — six location shortcuts on a 3-col grid. Four are live
+          (Check-In, Alert, Drive To, Pick Me Up); "Meeting" and "Safe Arrival"
+          are coming soon. "Alert" opens the SOS/notify-circle panel. */}
       <QuickActionsSection title="Quick actions">
 
         <QuickActionCard
@@ -700,7 +700,7 @@ function NowHub({
           icon={<ShieldCheck className="h-5 w-5" />}
           title="Safe Arrival"
           subtitle="Get notified"
-          onClick={onSafeArrival}
+          comingSoon
         />
 
       </QuickActionsSection>

--- a/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
@@ -3,86 +3,31 @@
 /**
  * One Location redesign — Pick Me Up flow (Quick Action).
  *
- * "Ask a trusted person to come get you." The inbound counterpart to Drive To:
- * instead of telling people where you're going, you ask someone to come to
- * exactly where you are right now (stranded, no ride, unsafe late night, a
- * child/elder who needs a lift, car trouble, airport/station pickup).
- *
- * PRESENTATION + LOCAL SELECTION STATE ONLY.
- * - The list of people ("Who can come get you?") is the SAME trusted circle used
- *   by SOS / Check-In (`vm.sosRecipients`), so help comes from people you already
- *   trust with your live location.
- * - On confirm it hands the chosen recipient ids + duration + a pickup message to
- *   `vm.onPickMeUp`, which runs the exact same createGrant + encrypt + publish
- *   path as a normal share (no new crypto, no new consent surface). Recipients
- *   receive your LIVE location, so they can navigate straight to you and watch
- *   you until they arrive.
+ * Ask ONE trusted person to come to your pickup spot. The spot defaults to your
+ * live location (reverse-geocoded for a human label) and can be Adjusted to a
+ * fixed searched place. Distance to a contact is shown only when they are
+ * currently sharing their live location with you. On confirm it hands the chosen
+ * recipient + note (+ optional fixed pickup point) to `vm.onPickMeUp`.
  */
 
-import { useMemo, useState } from "react";
-import { Check, Clock, Hand, MapPin, Navigation, RefreshCw, ShieldCheck } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Check, Navigation } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { OneLocationService } from "@/lib/one-location/service";
+import { LiveMap } from "@/components/one-location/live-map";
+import { haversineMeters } from "@/lib/one-location/marker-interpolation";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
 
-import { TaskFlowHeader } from "./primitives";
-import { PersonSearchInput } from "./selectors";
-import { CARD_SURFACE, MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
+import { CARD_SURFACE } from "./tokens";
 import type { LocationHubViewModel } from "./location-redesign-hub";
 
-/** How long to keep sharing your live location while you wait for the pickup. */
-const PICK_ME_UP_DURATIONS: { value: string; label: string }[] = [
-  { value: "0.5", label: "30 min" },
-  { value: "1", label: "1 hour" },
-  { value: "2", label: "2 hours" },
-];
-/** "Until I'm picked up" maps to the longest supported live-share window. */
-const UNTIL_PICKED_UP_VALUE = "4";
-
-/**
- * Urgency shapes the message the recipient sees in their notification, so a
- * casual "whenever you can" pickup reads differently from an "I need a ride
- * now" one. The user can still add their own detail on top.
- */
-type UrgencyValue = "flexible" | "soon" | "urgent";
-const URGENCY_OPTIONS: {
-  value: UrgencyValue;
-  label: string;
-  lead: string;
-  tone: string;
-}[] = [
-  {
-    value: "flexible",
-    label: "Whenever you can",
-    lead: "Could you pick me up when you get a chance?",
-    tone: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-  },
-  {
-    value: "soon",
-    label: "Soon",
-    lead: "Could you come pick me up soon?",
-    tone: "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-  },
-  {
-    value: "urgent",
-    label: "Urgent",
-    lead: "I need a ride now — please pick me up ASAP.",
-    tone: "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
-  },
-];
-
-const PICK_ME_UP_NOTE_MAX_LENGTH = 120;
-
-// Contact list cap: trusted circles can be long, so show ~4 rows then scroll.
-const CONTACT_LIST_SCROLL_CLASS =
-  "max-h-[300px] space-y-2.5 overflow-y-auto overscroll-contain pr-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/20";
+const PICKUP_DURATION_HOURS = "4"; // "until picked up"
+const NOTE_MAX = 160;
 
 function initialsOf(label: string): string {
   const words = label.trim().split(/\s+/).filter(Boolean);
-  if (words.length >= 2) {
-    return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
-  }
+  if (words.length >= 2) return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
   return (words[0]?.slice(0, 1) || "?").toUpperCase();
 }
 
@@ -97,88 +42,7 @@ function avatarTone(index: number): string {
   return tones[index % tones.length]!;
 }
 
-function accuracyLine(point: PlainLocationPoint | null): string | null {
-  if (!point) return null;
-  const accuracyM = point.accuracyM;
-  if (typeof accuracyM !== "number" || !Number.isFinite(accuracyM) || accuracyM <= 0) {
-    return null;
-  }
-  return `Accurate to about ${Math.round(accuracyM)} meters`;
-}
-
-/**
- * Compose the message the recipient reads. The urgency lead is always present so
- * the intent is unmistakable; the optional detail is appended verbatim.
- */
-export function composePickMeUpMessage(urgency: UrgencyValue, note: string): string {
-  const lead =
-    URGENCY_OPTIONS.find((option) => option.value === urgency)?.lead ??
-    URGENCY_OPTIONS[0]!.lead;
-  const detail = note.trim();
-  const composed = detail ? `${lead} ${detail}` : lead;
-  return composed.slice(0, 160);
-}
-
-function ContactRow({
-  index,
-  checked,
-  ready,
-  label,
-  subtitle,
-  onToggle,
-}: {
-  index: number;
-  checked: boolean;
-  ready: boolean;
-  label: string;
-  subtitle: string;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={ready ? onToggle : undefined}
-      disabled={!ready}
-      aria-pressed={checked}
-      className={cn(
-        SUBCARD_SURFACE,
-        "flex w-full items-center gap-3 p-3 text-left transition-all duration-150",
-        ready
-          ? "hover:border-[#007aff]/40 active:scale-[0.99]"
-          : "cursor-not-allowed opacity-60",
-        checked && "border-[#007aff]/60 ring-1 ring-[#007aff]/30",
-      )}
-    >
-      <span
-        className={cn(
-          "flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold",
-          avatarTone(index),
-        )}
-        aria-hidden
-      >
-        {initialsOf(label)}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-semibold text-foreground">
-          {label}
-        </span>
-        <span className={cn(MUTED_TEXT, "block truncate")}>
-          {ready ? subtitle : "Not ready to receive location"}
-        </span>
-      </span>
-      <span
-        className={cn(
-          "flex h-6 w-6 shrink-0 items-center justify-center rounded-[7px] border-2 transition-colors",
-          checked
-            ? "border-[#007aff] bg-[#007aff] text-white"
-            : "border-border bg-background",
-        )}
-      >
-        {checked ? <Check className="h-4 w-4" strokeWidth={3} /> : null}
-      </span>
-    </button>
-  );
-}
+type FixedSpot = { latitude: number; longitude: number; label: string };
 
 export function PickMeUpFlow({
   vm,
@@ -189,293 +53,306 @@ export function PickMeUpFlow({
 }) {
   const contacts = vm.sosRecipients;
   const busy = vm.busy === "share" || vm.busy === "selfLocation";
+  const livePoint = vm.myLocationPoint;
 
-  const [search, setSearch] = useState("");
-  const [checkedIds, setCheckedIds] = useState<string[]>([]);
-  const [durationValue, setDurationValue] = useState("1");
-  const [untilPickedUp, setUntilPickedUp] = useState(true);
-  const [urgency, setUrgency] = useState<UrgencyValue>("soon");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [note, setNote] = useState("");
+  const [fixedSpot, setFixedSpot] = useState<FixedSpot | null>(null);
+  const [geoLabel, setGeoLabel] = useState<string | null>(null);
 
-  // No default selection: the user explicitly chooses who can come get them.
+  // Adjust search state
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<{ placeId: string; text: string }[]>([]);
 
-  const filtered = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return contacts;
-    return contacts.filter((r) =>
-      vm.recipientLabel(r).toLowerCase().includes(q),
+  // The point we actually share: fixed spot if adjusted, else the live location.
+  const pickupPoint: { latitude: number; longitude: number } | null = fixedSpot
+    ? { latitude: fixedSpot.latitude, longitude: fixedSpot.longitude }
+    : livePoint
+      ? { latitude: livePoint.latitude, longitude: livePoint.longitude }
+      : null;
+
+  // Reverse-geocode the LIVE location for the default label (skip when adjusted).
+  useEffect(() => {
+    const token = vm.vaultOwnerToken;
+    if (!token || fixedSpot || !livePoint) {
+      setGeoLabel(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken: token,
+          lat: livePoint.latitude,
+          lng: livePoint.longitude,
+        });
+        if (cancelled) return;
+        const label = place.name
+          ? place.formattedAddress
+            ? `${place.name} · ${place.formattedAddress}`
+            : place.name
+          : place.formattedAddress;
+        setGeoLabel(label ?? null);
+      } catch {
+        if (!cancelled) setGeoLabel(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [vm.vaultOwnerToken, livePoint, fixedSpot]);
+
+  // Debounced Places autocomplete for Adjust.
+  useEffect(() => {
+    const token = vm.vaultOwnerToken;
+    const q = query.trim();
+    if (!token || !adjustOpen || q.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      try {
+        const results = await OneLocationService.placesAutocomplete({
+          vaultOwnerToken: token,
+          input: q,
+        });
+        if (!cancelled) setSuggestions(results);
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, adjustOpen, vm.vaultOwnerToken]);
+
+  const selectPlace = async (placeId: string) => {
+    const token = vm.vaultOwnerToken;
+    if (!token) return;
+    try {
+      const place = await OneLocationService.placeDetails({ vaultOwnerToken: token, placeId });
+      setFixedSpot({ latitude: place.latitude, longitude: place.longitude, label: place.label });
+      setAdjustOpen(false);
+      setQuery("");
+      setSuggestions([]);
+    } catch {
+      /* leave adjust open; user can retry */
+    }
+  };
+
+  const pickupLabel = fixedSpot
+    ? fixedSpot.label
+    : geoLabel ?? "Live location";
+
+  const selectedContact = contacts.find((c) => c.userId === selectedId) ?? null;
+  const selectedName = selectedContact ? vm.recipientLabel(selectedContact) : null;
+  const canAsk = Boolean(pickupPoint) && Boolean(selectedContact) && !busy;
+
+  function distanceLabel(userId: string): string | null {
+    if (!pickupPoint) return null;
+    const p = vm.recipientLivePoint(userId);
+    if (!p) return null;
+    const meters = haversineMeters(
+      { lat: pickupPoint.latitude, lng: pickupPoint.longitude },
+      { lat: p.latitude, lng: p.longitude },
     );
-  }, [contacts, search, vm]);
+    return `${(meters / 1000).toFixed(1)} km away`;
+  }
 
-  const selectedReadyCount = useMemo(
-    () =>
-      contacts.filter(
-        (r) => checkedIds.includes(r.userId) && vm.isRecipientShareReady(r),
-      ).length,
-    [contacts, checkedIds, vm],
-  );
-
-  const toggle = (id: string) =>
-    setCheckedIds((current) =>
-      current.includes(id)
-        ? current.filter((value) => value !== id)
-        : [...current, id],
-    );
-
-  const effectiveDuration = untilPickedUp ? UNTIL_PICKED_UP_VALUE : durationValue;
-  const point = vm.myLocationPoint;
-  const accuracy = accuracyLine(point);
-  const previewMessage = composePickMeUpMessage(urgency, note);
+  const mapPoint: PlainLocationPoint | null = fixedSpot
+    ? { latitude: fixedSpot.latitude, longitude: fixedSpot.longitude, capturedAt: new Date().toISOString(), sourcePlatform: "web" }
+    : livePoint;
 
   return (
-    <div className="space-y-5">
-      <TaskFlowHeader
-        eyebrow="Pick Me Up"
-        title="Ask someone to come get you"
-        description="Share your live location so a trusted person can drive straight to you."
-        onBack={onClose}
-      />
+    <div className="space-y-4">
+      {/* HEADER */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-[24px] font-semibold leading-tight tracking-[-0.3px] text-foreground">
+          Pick me up
+        </h2>
+        <button type="button" onClick={onClose} className="text-[15px] text-[#007aff]">
+          Cancel
+        </button>
+      </div>
 
-      {/* YOUR LOCATION — the exact point the helper will drive to. */}
-      <section className={cn(CARD_SURFACE, "p-4")}>
-        <div className="flex items-start gap-3">
-          <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#007aff]/12 text-[#007aff]">
-            <MapPin className="h-5 w-5" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              Where to pick you up
-            </p>
-            {point ? (
-              <>
-                <p className="mt-0.5 text-[15px] font-semibold text-foreground">
-                  Live location ready
-                </p>
-                <p className={cn(MUTED_TEXT, "mt-0.5")}>
-                  {accuracy ?? "Location captured"} ·{" "}
-                  {vm.formatDateTime(point.capturedAt)}
-                </p>
-              </>
-            ) : (
-              <>
-                <p className="mt-0.5 text-[15px] font-semibold text-foreground">
-                  Location not captured yet
-                </p>
-                <p className={cn(MUTED_TEXT, "mt-0.5")}>
-                  Capture your current location so they know where to come.
-                </p>
-              </>
-            )}
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={vm.onShowMyLocation}
-            isLoading={vm.busy === "selfLocation"}
-            className="h-9 shrink-0 rounded-full px-3 text-xs"
-          >
-            <RefreshCw className="mr-1 h-3.5 w-3.5" />
-            {point ? "Refresh" : "Capture"}
-          </Button>
-        </div>
-        {vm.myLocationError ? (
-          <p className="mt-2 text-xs font-medium text-red-600 dark:text-red-300">
-            {vm.myLocationError}
-          </p>
-        ) : null}
-        {point ? (
-          <div className="mt-3">{vm.renderMapPreview(point, false)}</div>
-        ) : null}
-      </section>
-
-      {/* WHO CAN COME GET YOU? */}
-      <section className={cn(CARD_SURFACE, "p-4")}>
-        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Who can come get you?
-        </p>
-        <PersonSearchInput
-          value={search}
-          onChange={setSearch}
-          placeholder="Search contacts..."
-        />
-        <div
-          className={cn(
-            "mt-3",
-            filtered.length ? CONTACT_LIST_SCROLL_CLASS : "space-y-2.5",
-          )}
-        >
-          {filtered.length ? (
-            filtered.map((recipient, index) => (
-              <ContactRow
-                key={recipient.userId}
-                index={index}
-                checked={checkedIds.includes(recipient.userId)}
-                ready={vm.isRecipientShareReady(recipient)}
-                label={vm.recipientLabel(recipient)}
-                subtitle={vm.recipientSubtitle(recipient)}
-                onToggle={() => toggle(recipient.userId)}
-              />
-            ))
+      {/* PICKUP CARD */}
+      <section className={cn(CARD_SURFACE, "overflow-hidden p-0")}>
+        <div className="relative h-[150px] bg-[#eceef2] dark:bg-white/5">
+          {mapPoint ? (
+            <LiveMap point={mapPoint} className="absolute inset-0" />
           ) : (
-            <div
-              className={cn(
-                SUBCARD_SURFACE,
-                "p-5 text-center text-sm text-muted-foreground",
-              )}
-            >
-              {contacts.length === 0
-                ? "No trusted contacts yet. Add people to your Circle first."
-                : "No matching contacts."}
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center">
+              <p className="text-sm text-muted-foreground">
+                Turn on your live location so they know where to come.
+              </p>
+              <button
+                type="button"
+                onClick={vm.onShowMyLocation}
+                disabled={vm.busy === "selfLocation"}
+                className="inline-flex items-center gap-2 rounded-full bg-[#007aff] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                {vm.busy === "selfLocation" ? "Capturing…" : "Capture location"}
+              </button>
             </div>
           )}
         </div>
-      </section>
-
-      {/* URGENCY — sets the tone of the request in the recipient's alert. */}
-      <section className={cn(CARD_SURFACE, "p-4")}>
-        <p className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-          How soon do you need it?
-        </p>
-        <div className="grid grid-cols-3 gap-2">
-          {URGENCY_OPTIONS.map((option) => {
-            const active = urgency === option.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => setUrgency(option.value)}
-                className={cn(
-                  "flex h-10 items-center justify-center rounded-full border px-2 text-[13px] font-semibold transition-colors",
-                  active
-                    ? option.tone
-                    : "border-border/70 bg-background text-muted-foreground hover:border-[#007aff]/40",
-                )}
-              >
-                {option.label}
-              </button>
-            );
-          })}
+        <div className="flex items-center gap-3 px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-[15px] font-semibold text-foreground">Your pickup spot</div>
+            <div className="truncate text-sm text-muted-foreground">{pickupLabel}</div>
+          </div>
+          {fixedSpot ? (
+            <button
+              type="button"
+              onClick={() => setFixedSpot(null)}
+              className="shrink-0 text-[15px] text-[#007aff]"
+            >
+              Use live
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setAdjustOpen((v) => !v)}
+              className="shrink-0 text-[15px] text-[#007aff]"
+            >
+              Adjust
+            </button>
+          )}
         </div>
       </section>
 
-      {/* DURATION */}
-      <section
-        className={cn(
-          "rounded-[var(--app-card-radius-standard)] border border-amber-500/20 bg-amber-500/[0.06] p-4 dark:bg-amber-400/[0.08]",
-        )}
-      >
-        <p className="mb-3 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
-          <Clock className="h-3.5 w-3.5" />
-          Keep sharing for
+      {/* ADJUST SEARCH */}
+      {adjustOpen ? (
+        <section className={cn(CARD_SURFACE, "p-3")}>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search a pickup place…"
+            className="h-10 w-full rounded-[12px] border border-border/70 bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-[#007aff]/25"
+          />
+          {suggestions.length ? (
+            <div className="mt-2 space-y-1">
+              {suggestions.map((s) => (
+                <button
+                  key={s.placeId}
+                  type="button"
+                  onClick={() => void selectPlace(s.placeId)}
+                  className="flex w-full items-center gap-2 rounded-[11px] px-2 py-2 text-left hover:bg-[#007aff]/10"
+                >
+                  <Navigation className="h-4 w-4 shrink-0 rotate-90 text-[#007aff]" />
+                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">{s.text}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {/* WHO DO YOU ASK */}
+      <div>
+        <p className="mb-2 px-1 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Who do you ask
         </p>
-        <div className="flex flex-wrap gap-2">
-          {PICK_ME_UP_DURATIONS.map((option) => {
-            const active = !untilPickedUp && option.value === durationValue;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                onClick={() => {
-                  setUntilPickedUp(false);
-                  setDurationValue(option.value);
-                }}
-                className={cn(
-                  "h-9 rounded-full border px-4 text-sm font-medium transition-colors",
-                  active
-                    ? "border-[#007aff] bg-[#007aff] text-white"
-                    : "border-border/70 bg-background text-foreground hover:border-[#007aff]/40",
-                )}
-              >
-                {option.label}
-              </button>
-            );
-          })}
-        </div>
+        <section className={cn(CARD_SURFACE, "px-4")}>
+          {contacts.length ? (
+            contacts.map((recipient, index) => {
+              const ready = vm.isRecipientShareReady(recipient);
+              const selected = selectedId === recipient.userId;
+              const dist = distanceLabel(recipient.userId);
+              return (
+                <button
+                  key={recipient.userId}
+                  type="button"
+                  onClick={ready ? () => setSelectedId(recipient.userId) : undefined}
+                  disabled={!ready}
+                  aria-pressed={selected}
+                  className={cn(
+                    "flex w-full items-center gap-[13px] py-3 text-left",
+                    index < contacts.length - 1 && "border-b border-black/[0.06] dark:border-white/10",
+                    !ready && "cursor-not-allowed opacity-60",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full text-sm font-semibold",
+                      avatarTone(index),
+                    )}
+                    aria-hidden
+                  >
+                    {initialsOf(vm.recipientLabel(recipient))}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[16px] font-semibold text-foreground">
+                      {vm.recipientLabel(recipient)}
+                    </span>
+                    {dist ? (
+                      <span className="block truncate text-sm text-muted-foreground">{dist}</span>
+                    ) : null}
+                  </span>
+                  <span
+                    className={cn(
+                      "flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+                      selected ? "border-[#007aff] bg-[#007aff] text-white" : "border-border",
+                    )}
+                  >
+                    {selected ? <Check className="h-3.5 w-3.5" strokeWidth={3} /> : null}
+                  </span>
+                </button>
+              );
+            })
+          ) : (
+            <p className="py-5 text-center text-sm text-muted-foreground">
+              No trusted contacts yet. Add people to your Circle first.
+            </p>
+          )}
+        </section>
+      </div>
+
+      {/* NOTE */}
+      <div>
+        <p className="mb-2 px-1 text-[13px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Note
+        </p>
+        <section className={cn(CARD_SURFACE, "p-3")}>
+          <input
+            type="text"
+            value={note}
+            onChange={(e) => setNote(e.target.value.slice(0, NOTE_MAX))}
+            placeholder="Meet me at the main entrance."
+            className="w-full bg-transparent text-[15px] text-foreground outline-none placeholder:text-muted-foreground"
+          />
+        </section>
+      </div>
+
+      <p className="px-1 text-center text-sm text-muted-foreground">
+        {fixedSpot
+          ? "They see your pickup spot until you're picked up or cancel."
+          : "They see your live pickup spot until you're picked up or cancel."}
+      </p>
+
+      {/* ACTION */}
+      <div className="pt-1">
         <button
           type="button"
-          onClick={() => setUntilPickedUp((value) => !value)}
-          className={cn(
-            "mt-3 flex w-full items-center gap-2 rounded-[12px] border px-3 py-2.5 text-left text-sm font-medium transition-colors",
-            untilPickedUp
-              ? "border-[#007aff]/50 bg-[#007aff]/10 text-foreground"
-              : "border-border/70 bg-background text-foreground hover:border-[#007aff]/40",
-          )}
-        >
-          <span
-            className={cn(
-              "flex h-5 w-5 items-center justify-center rounded-full border-2",
-              untilPickedUp ? "border-[#007aff] bg-[#007aff]" : "border-border",
-            )}
-          >
-            {untilPickedUp ? (
-              <span className="h-2 w-2 rounded-full bg-white" />
-            ) : null}
-          </span>
-          Until I&apos;m picked up
-        </button>
-        <p className="mt-3 flex items-center gap-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
-          <ShieldCheck className="h-3.5 w-3.5" />
-          Sharing stops automatically · no manual revoke needed
-        </p>
-      </section>
-
-      {/* DETAIL — optional context appended to the pickup message. */}
-      <section className={cn(CARD_SURFACE, "p-4")}>
-        <div className="mb-2 flex items-center justify-between">
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-            Add detail (optional)
-          </p>
-          <span className="text-[11px] font-medium text-muted-foreground">
-            {note.length}/{PICK_ME_UP_NOTE_MAX_LENGTH}
-          </span>
-        </div>
-        <textarea
-          value={note}
-          onChange={(event) =>
-            setNote(event.target.value.slice(0, PICK_ME_UP_NOTE_MAX_LENGTH))
-          }
-          rows={2}
-          placeholder="I'm at the north gate near the coffee cart"
-          className="w-full rounded-[14px] border border-border/70 bg-background p-3 text-sm text-foreground outline-none transition-shadow focus:ring-2 focus:ring-[#007aff]/25"
-        />
-        <div className={cn(SUBCARD_SURFACE, "mt-3 flex items-start gap-2 p-3")}>
-          <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-[#007aff]" />
-          <p className="min-w-0 text-xs leading-snug text-muted-foreground">
-            They&apos;ll see:{" "}
-            <span className="font-medium text-foreground">
-              &ldquo;{previewMessage}&rdquo;
-            </span>{" "}
-            with your live location and one-tap directions to you.
-          </p>
-        </div>
-      </section>
-
-      {/* ACTION BAR */}
-      <div className="space-y-2 pt-1">
-        <Button
           onClick={() =>
-            vm.onPickMeUp(checkedIds, effectiveDuration, previewMessage)
+            selectedContact &&
+            vm.onPickMeUp(
+              [selectedContact.userId],
+              PICKUP_DURATION_HOURS,
+              note.trim() || undefined,
+              fixedSpot ?? undefined,
+            )
           }
-          disabled={!point || selectedReadyCount === 0}
-          isLoading={busy}
-          className="h-12 w-full rounded-2xl bg-amber-600 text-base font-semibold text-white hover:bg-amber-600/90 disabled:opacity-50"
+          disabled={!canAsk}
+          className="flex w-full items-center justify-center gap-2 rounded-full bg-[#007aff] py-4 text-[17px] font-medium text-white transition-opacity disabled:opacity-40"
         >
-          <Hand className="mr-1.5 h-5 w-5" />
-          {point
-            ? selectedReadyCount > 0
-              ? `Ask ${selectedReadyCount} ${
-                  selectedReadyCount === 1 ? "person" : "people"
-                } to pick you up`
-              : "Select who can come get you"
-            : "Capture your location first"}
-        </Button>
-        <Button
-          variant="ghost"
-          onClick={onClose}
-          className="h-10 w-full rounded-2xl text-sm text-muted-foreground"
-        >
-          Cancel
-        </Button>
+          <Navigation className="h-[18px] w-[18px]" fill="currentColor" strokeWidth={0} />
+          {busy ? "Asking…" : selectedName ? `Ask ${selectedName} to pick me up` : "Select who to ask"}
+        </button>
       </div>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
@@ -10,7 +10,7 @@
  * recipient + note (+ optional fixed pickup point) to `vm.onPickMeUp`.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, Navigation } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -60,6 +60,11 @@ export function PickMeUpFlow({
   const [fixedSpot, setFixedSpot] = useState<FixedSpot | null>(null);
   const [geoLabel, setGeoLabel] = useState<string | null>(null);
 
+  // Track the last coordinates we actually reverse-geocoded so we can skip the
+  // call when the live GPS hasn't moved meaningfully (avoids billable requests
+  // every ~5s during the self-preview stream).
+  const lastGeocodedLatLng = useRef<{ lat: number; lng: number } | null>(null);
+
   // Adjust search state
   const [adjustOpen, setAdjustOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -73,10 +78,20 @@ export function PickMeUpFlow({
       : null;
 
   // Reverse-geocode the LIVE location for the default label (skip when adjusted).
+  // Guard: only re-request when the location has moved at least 50 m since the
+  // last geocode, so the live-preview stream (which updates ~every 5 s) and GPS
+  // jitter don't trigger a billable Google Geocoding request on every tick.
   useEffect(() => {
     const token = vm.vaultOwnerToken;
     if (!token || fixedSpot || !livePoint) {
       setGeoLabel(null);
+      lastGeocodedLatLng.current = null;
+      return;
+    }
+    const current = { lat: livePoint.latitude, lng: livePoint.longitude };
+    const last = lastGeocodedLatLng.current;
+    if (last && haversineMeters(last, current) < 50) {
+      // Location hasn't moved enough — keep the existing label.
       return;
     }
     let cancelled = false;
@@ -88,6 +103,7 @@ export function PickMeUpFlow({
           lng: livePoint.longitude,
         });
         if (cancelled) return;
+        lastGeocodedLatLng.current = current;
         const label = place.name
           ? place.formattedAddress
             ? `${place.name} · ${place.formattedAddress}`
@@ -162,9 +178,18 @@ export function PickMeUpFlow({
     return `${(meters / 1000).toFixed(1)} km away`;
   }
 
-  const mapPoint: PlainLocationPoint | null = fixedSpot
-    ? { latitude: fixedSpot.latitude, longitude: fixedSpot.longitude, capturedAt: new Date().toISOString(), sourcePlatform: "web" }
-    : livePoint;
+  const mapPoint: PlainLocationPoint | null = useMemo(
+    () =>
+      fixedSpot
+        ? {
+            latitude: fixedSpot.latitude,
+            longitude: fixedSpot.longitude,
+            capturedAt: new Date().toISOString(),
+            sourcePlatform: "web" as const,
+          }
+        : livePoint,
+    [fixedSpot, livePoint],
+  );
 
   return (
     <div className="space-y-4">

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -441,6 +441,21 @@ export class OneLocationService {
     return response.place;
   }
 
+  static async reverseGeocode(params: {
+    vaultOwnerToken: string;
+    lat: number;
+    lng: number;
+  }): Promise<{ name: string | null; formattedAddress: string | null }> {
+    const response = await apiJson<{
+      place: { name: string | null; formattedAddress: string | null };
+    }>("/api/one/location/maps/reverse-geocode", {
+      method: "POST",
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({ lat: params.lat, lng: params.lng }),
+    });
+    return response.place;
+  }
+
   static async routeEta(params: {
     vaultOwnerToken: string;
     originLat: number;


### PR DESCRIPTION
## Summary
Redesigns the One Location **Pick Me Up** quick action to the Apple Blue v2 reference and adds reverse geocoding.

- **Layout** — single-card map with the pickup spot, "Your pickup spot · <reverse-geocoded address>", and **Adjust** (Places search → fixed spot; "Use live" reverts). **Single-select** (radio) recipients — "Ask <name> to pick me up". Optional **Note**. Urgency + duration pickers dropped (shares "until picked up").
- **Reverse geocode** (new) — backend `reverse_geocode` (Google Geocoding API) + `POST /api/one/location/maps/reverse-geocode` + `OneLocationService.reverseGeocode`; graceful fallback to "Live location"; throttled to refetch only after ~50 m of movement.
- **Distance** — "X km away" shown only when that contact is currently sharing their live location with you (via `recipientLivePoint`); never fabricated.
- **Fixed pickup spot** — an adjusted spot is shared instead of live GPS and kept fixed by a per-grant `pickupSessionRef` (`Map<grantId, point>`) + `pickupPointForGrant` in the owner watch loop, so it never drifts to live GPS.
- **Quick actions** — Meeting + Safe Arrival gated as "coming soon".

## Testing
- Backend: `pytest` maps service + routes (reverse-geocode parse/nulls + passthrough).
- Frontend: `vitest` — PickMeUpFlow (single-select, distance-when-sharing, reverse-geocode, adjust); `tsc` + `eslint` clean; 145 One Location tests pass.
- Verified end-to-end on the iOS simulator against a local backend.

## Notes
- `DriveSharePayload` / encryption + consent pipeline unchanged; backend `GOOGLE_MAPS_API_KEY` only (browser key untouched).
- Docs: design spec + implementation plan under `docs/superpowers/`.