### PR TITLE
feat(one): add route-aware Morphy AX onboarding

### DIFF
--- a/.codex/evals/cases/morphy-ax.json
+++ b/.codex/evals/cases/morphy-ax.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "morphy-ax",
+  "trigger": {
+    "positive": [
+      {
+        "prompt": "add a shared Morphy AX snapshot for voice chat onboarding and ambient agent presentation",
+        "top_k": 3
+      },
+      {
+        "prompt": "benchmark agent experience assessment accuracy without adding another runtime store",
+        "top_k": 3
+      },
+      {
+        "prompt": "preserve the One Voice wire contract while migrating shared agent presentation state",
+        "top_k": 3
+      }
+    ],
+    "negative": [
+      {
+        "prompt": "change the generated voice action gateway and author a new action contract",
+        "owner": "kai-voice-governance"
+      },
+      {
+        "prompt": "create a reusable visual card primitive in the design system",
+        "owner": "frontend-design-system"
+      }
+    ]
+  }
+}

--- a/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
+++ b/.codex/skills/codex-skill-authoring/scripts/skill_lint.py
@@ -65,6 +65,7 @@ EXPECTED_WORKFLOW_IDS = [
     "new-feature-tri-flow",
     "frontend-native-surface-map",
     "frontend-cache-coherence",
+    "morphy-ax-governance",
     "api-contract-change",
     "pr-governance-review",
     "analytics-observability-review",

--- a/.codex/skills/frontend/skill.json
+++ b/.codex/skills/frontend/skill.json
@@ -21,7 +21,8 @@
     "bug-triage",
     "docs-sync",
     "frontend-native-surface-map",
-    "frontend-cache-coherence"
+    "frontend-cache-coherence",
+    "morphy-ax-governance"
   ],
   "required_reads": [
     "docs/reference/quality/frontend-ui-architecture-map.md",
@@ -55,6 +56,7 @@
     "frontend-architecture",
     "frontend-surface-placement",
     "frontend-cache-coherence",
+    "morphy-ax",
     "mobile-native",
     "repo-context"
   ],
@@ -63,6 +65,7 @@
     "frontend-architecture",
     "frontend-surface-placement",
     "frontend-cache-coherence",
+    "morphy-ax",
     "mobile-native",
     "backend-api-contracts",
     "quality-contracts"

--- a/.codex/skills/morphy-ax/SKILL.md
+++ b/.codex/skills/morphy-ax/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: morphy-ax
+description: Use when changing Morphy AX shared agent-experience state, semantic assessment presentation, performance budgets, or cross-modal compatibility.
+---
+
+# Morphy AX
+
+## Purpose and Trigger
+
+- Primary scope: `morphy-agent-experience`
+- Trigger on Morphy AX snapshots, presentation derivation, semantic-assessment validation, compatibility projections, or AX performance budgets.
+- Avoid overlap with `frontend-design-system`, `kai-voice-governance`, and `backend-agents-operons`.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `frontend`
+
+Owned repo surfaces:
+
+1. `hushh-webapp/lib/morphy-ax`
+2. `docs/reference/quality/morphy-agent-experience.md`
+
+Non-owned surfaces:
+
+1. `hushh-webapp/lib/voice`
+2. `consent-protocol/hushh_mcp/agents`
+3. `hushh-webapp/lib/morphy-ux`
+
+## Do Use
+
+1. Shared, redacted agent-experience snapshot and presentation contracts.
+2. Intelligence-assessment validation and compatibility/non-regression budgets.
+3. Cross-modal AX behavior that reuses the existing runtime owner and action gateway.
+
+## Do Not Use
+
+1. Voice action authoring, generated gateway changes, or ADK orchestration ownership.
+2. Visual primitive work owned by Morphy UX.
+3. A second React provider, store, router, action registry, or model-facing route tool.
+
+## Read First
+
+1. `docs/reference/quality/morphy-agent-experience.md`
+2. `docs/reference/one/one-voice-runtime-architecture.md`
+3. `docs/reference/quality/frontend-ui-architecture-map.md`
+4. `docs/reference/kai/kai-action-gateway-vnext.md`
+
+## Workflow
+
+1. Verify the existing runtime, voice FSM, route playbook, and generated action authority before changing AX.
+2. Keep Morphy AX pure, redacted, memoizable, and hosted by `AgentRuntimeStateProvider`.
+3. Let intelligence assess meaning; deterministic code may validate, reject, normalize, and enforce authority only.
+4. Preserve `OneVoiceContextSnapshot` through an explicit compatibility projection while migration is active.
+5. Benchmark the same fixtures flag-off and flag-on; block wrong actions, unsafe fallbacks, or budget regressions.
+6. Route voice, backend-agent, design-system, docs, or quality changes to their owning skills.
+
+## Handoff Rules
+
+1. Broad frontend work routes to `frontend`.
+2. Voice/action contracts route to `kai-voice-governance`.
+3. ADK or product-agent changes route to `backend-agents-operons`.
+4. Visual primitives route to `frontend-design-system`; verification policy routes to `quality-contracts`.
+
+## Required Checks
+
+```bash
+cd hushh-webapp && npm run verify:morphy-ax
+cd hushh-webapp && npm run typecheck
+cd hushh-webapp && npm run verify:voice-gateway
+cd hushh-webapp && npm run verify:design-system
+cd consent-protocol && python3 -m pytest tests/test_onboarding_goal_agent.py tests/test_one_adk_agent_tree.py -q
+./bin/hushh docs verify
+```

--- a/.codex/skills/morphy-ax/skill.json
+++ b/.codex/skills/morphy-ax/skill.json
@@ -1,0 +1,62 @@
+{
+  "id": "morphy-ax",
+  "role": "spoke",
+  "owner_family": "frontend",
+  "primary_scope": "morphy-agent-experience",
+  "description": "Use when changing Morphy AX shared agent-experience state, semantic assessment presentation, performance budgets, or cross-modal compatibility.",
+  "owned_paths": [
+    "hushh-webapp/lib/morphy-ax",
+    "docs/reference/quality/morphy-agent-experience.md"
+  ],
+  "non_owned_paths": [
+    "hushh-webapp/lib/voice",
+    "consent-protocol/hushh_mcp/agents",
+    "hushh-webapp/lib/morphy-ux"
+  ],
+  "task_types": ["morphy-ax-governance"],
+  "required_reads": [
+    "docs/reference/quality/morphy-agent-experience.md",
+    "docs/reference/one/one-voice-runtime-architecture.md",
+    "docs/reference/quality/frontend-ui-architecture-map.md",
+    "docs/reference/kai/kai-action-gateway-vnext.md"
+  ],
+  "required_commands": [
+    "cd hushh-webapp && npm run verify:morphy-ax",
+    "cd hushh-webapp && npm run typecheck",
+    "cd hushh-webapp && npm run verify:voice-gateway",
+    "cd hushh-webapp && npm run verify:design-system",
+    "cd consent-protocol && python3 -m pytest tests/test_onboarding_goal_agent.py tests/test_one_adk_agent_tree.py -q",
+    "./bin/hushh docs verify"
+  ],
+  "verification_bundles": [
+    {
+      "id": "morphy-ax-governance",
+      "commands": [
+        "cd hushh-webapp && npm run verify:morphy-ax",
+        "cd hushh-webapp && npm run typecheck",
+        "cd hushh-webapp && npm run verify:voice-gateway",
+        "cd consent-protocol && python3 -m pytest tests/test_onboarding_goal_agent.py tests/test_one_adk_agent_tree.py -q",
+        "./bin/hushh docs verify"
+      ],
+      "tests": [
+        "hushh-webapp/__tests__/morphy-ax/morphy-ax-contract.test.ts",
+        "consent-protocol/tests/test_onboarding_goal_agent.py"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "frontend",
+    "kai-voice-governance",
+    "backend-agents-operons",
+    "frontend-design-system",
+    "quality-contracts",
+    "docs-governance"
+  ],
+  "adjacent_skills": [
+    "frontend-design-system",
+    "kai-voice-governance",
+    "backend-agents-operons",
+    "quality-contracts"
+  ],
+  "risk_tags": ["voice", "onboarding", "generated-contract", "performance", "privacy"]
+}

--- a/.codex/skills/repo-context/references/ownership-map.md
+++ b/.codex/skills/repo-context/references/ownership-map.md
@@ -34,6 +34,7 @@ Use this reference after the initial scan to choose the correct owner skill firs
 3. `frontend-surface-placement`
 4. `frontend-native-surface-mapper`
 5. `frontend-cache-coherence`
+6. `morphy-ax`
 
 ### `mobile-native`
 
@@ -84,17 +85,18 @@ Use this reference after the initial scan to choose the correct owner skill firs
 18. `hushh-consent-mcp-ops`
 19. `kai-voice-governance`
 20. `mcp-surface-change`
-21. `mobile-parity-check`
-22. `new-feature-tri-flow`
-23. `oss-license-governance`
-24. `pr-governance-review`
-25. `pre-pr-readiness`
-26. `release-readiness`
-27. `report-artifact-generation`
-28. `repo-orientation`
-29. `ria-api-reference`
-30. `security-consent-audit`
-31. `security-posture-maintenance`
-32. `skill-authoring`
-33. `subtree-upstream-governance`
-34. `uat-scoped-deploy`
+21. `morphy-ax-governance`
+22. `mobile-parity-check`
+23. `new-feature-tri-flow`
+24. `oss-license-governance`
+25. `pr-governance-review`
+26. `pre-pr-readiness`
+27. `release-readiness`
+28. `report-artifact-generation`
+29. `repo-orientation`
+30. `ria-api-reference`
+31. `security-consent-audit`
+32. `security-posture-maintenance`
+33. `skill-authoring`
+34. `subtree-upstream-governance`
+35. `uat-scoped-deploy`

--- a/.codex/skills/repo-context/scripts/repo_scan.py
+++ b/.codex/skills/repo-context/scripts/repo_scan.py
@@ -94,6 +94,7 @@ REQUIRED_WORKFLOWS = [
     "subtree-upstream-governance",
     "hushh-consent-mcp-ops",
     "mcp-surface-change",
+    "morphy-ax-governance",
     "security-posture-maintenance",
 ]
 PATH_PREFIXES = (

--- a/.codex/workflows/morphy-ax-governance/PLAYBOOK.md
+++ b/.codex/workflows/morphy-ax-governance/PLAYBOOK.md
@@ -1,0 +1,27 @@
+# Morphy AX Governance
+
+Use this workflow for shared agent-experience state, presentation, assessment, and performance work.
+
+## Goal
+
+Improve One's cross-modal experience while retaining one runtime owner, one semantic head, one generated action authority, and the existing consent/vault boundaries.
+
+## Steps
+
+1. Route through `frontend` with `morphy-ax` as the narrow spoke.
+2. Inventory the current provider, voice FSM, route playbook, generated actions, redaction, and settlement path.
+3. Keep AX logic pure and memoizable inside the existing `AgentRuntimeStateProvider`.
+4. Require typed intelligence assessment before deterministic validation; never infer meaning with lexical rules.
+5. Preserve the current wire shape through the compatibility projection and keep flag-off behavior intact.
+6. Benchmark production derivation functions with the same fixtures before and after the change.
+7. Prove critical action accuracy, wrong-screen rejection, clarification, redaction, and success-after-settlement.
+8. Run the workflow verification bundle and record remaining browser/UAT risks explicitly.
+
+## Common Drift Risks
+
+1. turning AX into a second router or state system
+2. making presentation state mutate the canonical voice FSM
+3. passing prose, transcripts, credentials, or sensitive values into the AX snapshot
+4. accepting an intelligence proposal without route/action validation
+5. adding an inference hop to clear visible actions
+6. shipping benchmark improvements that remove compatibility behavior

--- a/.codex/workflows/morphy-ax-governance/workflow.json
+++ b/.codex/workflows/morphy-ax-governance/workflow.json
@@ -1,0 +1,74 @@
+{
+  "id": "morphy-ax-governance",
+  "title": "Morphy AX Governance",
+  "goal": "Evolve shared agent experience without duplicating runtime authority, weakening privacy, changing generated action authority, or regressing accuracy and latency.",
+  "owner_skill": "frontend",
+  "default_spoke": "morphy-ax",
+  "task_type": "morphy-ax-governance",
+  "affected_surfaces": [
+    "hushh-webapp/lib/morphy-ax",
+    "hushh-webapp/lib/agent/agent-runtime-context.tsx",
+    "hushh-webapp/lib/voice",
+    "consent-protocol/hushh_mcp/agents/onboarding",
+    "docs/reference/quality/morphy-agent-experience.md"
+  ],
+  "required_reads": [
+    "docs/reference/quality/morphy-agent-experience.md",
+    "docs/reference/one/one-voice-runtime-architecture.md",
+    "docs/reference/quality/frontend-ui-architecture-map.md",
+    "docs/reference/kai/kai-action-gateway-vnext.md"
+  ],
+  "required_commands": [
+    "cd hushh-webapp && npm run verify:morphy-ax",
+    "cd hushh-webapp && npm run typecheck",
+    "cd hushh-webapp && npm run verify:voice-gateway",
+    "cd hushh-webapp && npm run verify:design-system",
+    "cd consent-protocol && python3 -m pytest tests/test_onboarding_goal_agent.py tests/test_one_adk_agent_tree.py -q",
+    "./bin/hushh docs verify"
+  ],
+  "verification_bundle": {
+    "id": "morphy-ax-governance",
+    "commands": [
+      "cd hushh-webapp && npm run verify:morphy-ax",
+      "cd hushh-webapp && npm run typecheck",
+      "cd hushh-webapp && npm run verify:voice-gateway",
+      "cd consent-protocol && python3 -m pytest tests/test_onboarding_goal_agent.py tests/test_one_adk_agent_tree.py -q",
+      "./bin/hushh docs verify"
+    ],
+    "tests": [
+      "hushh-webapp/__tests__/morphy-ax/morphy-ax-contract.test.ts",
+      "consent-protocol/tests/test_onboarding_goal_agent.py"
+    ]
+  },
+  "deliverables": [
+    "pure Morphy AX contract and compatibility projection",
+    "typed intelligence assessment with deterministic validation",
+    "accuracy and latency benchmark evidence",
+    "updated runtime, skill, workflow, and canonical docs"
+  ],
+  "impact_fields": [
+    "Runtime authority preserved",
+    "Wire and generated-contract compatibility",
+    "Privacy/redaction impact",
+    "Accuracy corpus result",
+    "Performance benchmark result",
+    "Rollback flag",
+    "Verification commands executed"
+  ],
+  "handoff_chain": [
+    "morphy-ax",
+    "kai-voice-governance",
+    "backend-agents-operons",
+    "frontend-design-system",
+    "quality-contracts",
+    "docs-governance"
+  ],
+  "common_failures": [
+    "adding a second provider, store, router, action registry, or voice FSM",
+    "using deterministic keyword rules as semantic intelligence",
+    "letting route playbooks or Morphy AX grant action authority",
+    "breaking the One Voice wire contract during incremental rollout",
+    "benchmarking mocks that do not exercise production derivation functions",
+    "claiming universal model accuracy instead of safe clarification outside the release corpus"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ These are the durable architecture principles for every Hussh product agent (One
 6. Product agents and engineering agents are separate namespaces. `.codex/agents` contains read-only engineering evidence lanes; `consent-protocol/hushh_mcp/agents` contains runtime product agents. Never make one impersonate or generate the other.
 7. `AgentManifestV2` YAML is the sole authored product-agent source. Generated registries, cards, action identifiers, surface metadata, and hierarchy projections must be reproducible from it; parallel Python manifests and prompt copies are prohibited.
 8. Use ADK `chat`, `task`, and `single_turn` modes inside one runtime, official A2A Tasks across process or deployment boundaries, and MCP for consented tools and encrypted resources. Invocation authority, information authority, and action authority remain separate at every hop.
+9. Intelligence owns semantic assessment. Deterministic policy may validate, normalize, reject, and enforce authority, but it must not replace agent meaning with keyword or regex classification.
 
 ## Project-Wide Premise Verification Gate
 

--- a/consent-protocol/api/routes/one/adk_live.py
+++ b/consent-protocol/api/routes/one/adk_live.py
@@ -37,6 +37,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import secrets
 import uuid
 from typing import Any, Optional
@@ -71,6 +72,7 @@ from hushh_mcp.one_adk.agent_tree import (
     get_one_runner,
 )
 from hushh_mcp.services.route_orchestration_index import resolve_route_orchestration_entry
+from hushh_mcp.services.voice_action_manifest import get_voice_manifest_action
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +86,7 @@ router = APIRouter(prefix="/api/one/adk", tags=["One ADK"])
 _ONBOARDING_SCREENS = frozenset(
     {
         "getting_started",
+        "one_intro",
         "login",
         "register_phone",
         "one_setup",
@@ -115,6 +118,43 @@ _ONBOARDING_CAPABILITIES = frozenset(
 _ACTION_SETTLEMENT_STATUSES = frozenset(
     {"succeeded", "started", "blocked", "invalid", "failed", "noop"}
 )
+_INITIAL_GREETING_IDLE_SECONDS = 1.5
+_ROUTE_PLAYBOOK_TEXT_CAP = 480
+
+
+class _InitialGreetingGate:
+    """Own one initial cue without allowing it to overtake visitor speech.
+
+    The browser sends ``voice_activity_start`` only after local speech activity
+    crosses its bounded threshold. That explicit, transcript-free signal lets
+    the relay cancel an idle cue without guessing from continuous microphone
+    frames (which include silence). The epoch makes a delayed task harmless if
+    cancellation races with its timer.
+    """
+
+    def __init__(self) -> None:
+        self._epoch = 0
+        self._visitor_activity_seen = False
+        self._greeting_sent = False
+
+    def schedule(self) -> int | None:
+        if self._visitor_activity_seen or self._greeting_sent:
+            return None
+        self._epoch += 1
+        return self._epoch
+
+    def cancel_for_visitor_activity(self) -> None:
+        self._visitor_activity_seen = True
+        self._epoch += 1
+
+    def may_send(self, epoch: int) -> bool:
+        return not self._visitor_activity_seen and not self._greeting_sent and epoch == self._epoch
+
+    def mark_sent(self, epoch: int) -> bool:
+        if not self.may_send(epoch):
+            return False
+        self._greeting_sent = True
+        return True
 
 
 class OneAdkRelaySessionResponse(BaseModel):
@@ -188,14 +228,78 @@ def _bounded_text_list(value: Any, limit: int) -> list[str]:
     return result
 
 
+def _sanitize_route_playbook(route_entry: Any) -> dict[str, Any] | None:
+    """Read only checked-in generated guidance; never trust browser prose."""
+    if (os.getenv("HUSHH_ROUTE_PLAYBOOKS_DISABLED") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }:
+        return None
+    if not isinstance(route_entry, dict):
+        return None
+    value = route_entry.get("voice_playbook")
+    if not isinstance(value, dict):
+        return None
+    proactivity = _bounded_text(value.get("proactivity"), 16)
+    return {
+        "playbook_id": _bounded_text(value.get("playbook_id"), 96),
+        "purpose": _bounded_text(value.get("purpose"), _ROUTE_PLAYBOOK_TEXT_CAP),
+        "screen": _bounded_text(value.get("screen"), 64),
+        "entry_cue": _bounded_text(value.get("entry_cue"), 240),
+        "proactivity": proactivity if proactivity in {"on_entry", "ambient"} else "ambient",
+        "primary_action_id": _bounded_text(value.get("primary_action_id"), 128) or None,
+        "completion_boundary": _bounded_text(
+            value.get("completion_boundary"), _ROUTE_PLAYBOOK_TEXT_CAP
+        ),
+        "next_route": _bounded_text(value.get("next_route"), 128) or None,
+        "return_policy": _bounded_text(value.get("return_policy"), 32),
+        "out_of_scope_behavior": _bounded_text(
+            value.get("out_of_scope_behavior"), _ROUTE_PLAYBOOK_TEXT_CAP
+        ),
+    }
+
+
+def _compose_route_context_note(context: dict[str, Any]) -> str | None:
+    """Build one bounded model note from server-resolved route intelligence."""
+    playbook = context.get("route_playbook")
+    if not isinstance(playbook, dict):
+        return None
+    if context.get("route_context_policy") == "suppress":
+        return None
+    purpose = str(playbook.get("purpose") or "Use the verified current screen.")
+    cue = str(playbook.get("entry_cue") or "")
+    primary = str(playbook.get("primary_action_id") or "")
+    proactive = playbook.get("proactivity") == "on_entry"
+    return (
+        "[App route context - not user speech] The verified current route is "
+        f"'{context.get('route_pattern') or context.get('route_family') or '/'}' "
+        f"and its purpose is: {purpose} "
+        "Generated actions and their guards remain the only execution authority. "
+        "For an explicit request matching a visible action, call list_app_actions "
+        "and run the exact returned id before any identity or greeting response. "
+        f"The preferred action reference is '{primary or 'none'}'. "
+        + (
+            f"After route settlement, orient once with this intent: {cue} "
+            if proactive and cue
+            else "Use this context silently until the person speaks. "
+        )
+        + "Never claim completion before correlated browser settlement."
+    )
+
+
 def _sanitize_live_context(payload: dict[str, Any]) -> dict[str, Any]:
     """Keep only bounded, redacted UI state for tool availability decisions."""
     cache_freshness = _bounded_text(payload.get("cache_freshness"), 32)
     route_family = _bounded_text(payload.get("route_family"))
     route_entry = resolve_route_orchestration_entry(route_family)
-    submitted_action_ids = _bounded_text_list(
-        payload.get("available_action_ids"), _LIVE_CONTEXT_ARRAY_CAP
-    )
+    submitted_action_ids = [
+        action_id
+        for action_id in _bounded_text_list(
+            payload.get("available_action_ids"), _LIVE_CONTEXT_ARRAY_CAP
+        )
+        if get_voice_manifest_action(action_id) is not None
+    ]
     return {
         # The generated index is the server-side source of route policy.  A
         # client may describe its current UI, but cannot invent a route
@@ -211,10 +315,15 @@ def _sanitize_live_context(payload: dict[str, Any]) -> dict[str, Any]:
         "route_context_policy": route_entry.get("context_policy")
         if isinstance(route_entry, dict)
         else "suppress",
+        "route_playbook": _sanitize_route_playbook(route_entry),
         "persona": _bounded_text(payload.get("persona")),
         "voice_state": _bounded_text(payload.get("voice_state"), 32),
         "available_action_ids": submitted_action_ids,
         "visible_modules": _bounded_text_list(payload.get("visible_modules"), _LIVE_MODULE_CAP),
+        "visible_control_ids": _bounded_text_list(
+            payload.get("visible_control_ids"), _LIVE_MODULE_CAP
+        ),
+        "pending_settlement": payload.get("pending_settlement") is True,
         "cache_freshness": cache_freshness
         if cache_freshness in {"fresh_or_stale_safe", "locked", "missing"}
         else "missing",
@@ -333,19 +442,17 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
     # not-yet-authenticated visitor who is (or is about to be) in onboarding.
     is_fresh_visitor = not uid
 
-    # Proactive greeting: the session should never open in silence, but the
-    # greeting must be SCREEN-AWARE (a fresh visitor on the onboarding root
-    # should be welcomed in and guided into setup, never greeted as if they
-    # were "back again"). The browser sends the current screen in its first
-    # app_context frame right after setupComplete, so the greeting is DEFERRED
-    # until that frame arrives and then composed with the screen. A short
-    # fallback timer still greets if no app_context ever lands, so the session
-    # never opens silently. This kickoff is app-composed (not user speech) and
-    # rides the same single ordered event stream, so a user who starts talking
-    # immediately simply barges in over it.
-    greeting_sent = False
+    # The initial cue is screen-aware and idle-only. It is deliberately not
+    # enqueued synchronously with the first app_context because the browser's
+    # microphone follows that frame; doing so placed a visitor command behind
+    # One's greeting in LiveRequestQueue. A redacted transport activity frame
+    # now cancels the cue before it reaches the model.
+    greeting_gate = _InitialGreetingGate()
+    greeting_task: Optional[asyncio.Task[None]] = None
 
-    def _compose_greeting_prompt(screen: str) -> str:
+    def _compose_greeting_prompt(screen: str, playbook: dict[str, Any] | None) -> str:
+        entry_cue = _bounded_text(playbook.get("entry_cue"), 240) if playbook else ""
+        proactive = bool(playbook and playbook.get("proactivity") == "on_entry" and entry_cue)
         onboarding = (screen in _ONBOARDING_SCREENS) or is_fresh_visitor
         if onboarding:
             return (
@@ -362,7 +469,13 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 "breath. Do not list capabilities and do not ask more than one "
                 "light question. If their next reply is a short challenge or "
                 "follow-up such as 'so what?' or 'why?', answer the value "
-                "question directly before mentioning setup."
+                "question directly before mentioning setup. "
+                + (
+                    f"The checked-in route cue is: {entry_cue} Use that active-screen "
+                    "guidance instead of an identity-only greeting."
+                    if proactive
+                    else ""
+                )
             )
         return (
             "[Session start - not user speech] Greet the user right now in one "
@@ -371,40 +484,57 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
             "and do not ask more than one light question."
         )
 
-    def _send_greeting(screen: str) -> None:
-        nonlocal greeting_sent
-        if greeting_sent:
+    def _send_greeting(screen: str, playbook: dict[str, Any] | None, epoch: int) -> None:
+        if not greeting_gate.mark_sent(epoch):
             return
-        greeting_sent = True
         queue.send_content(
             genai_types.Content(
                 role="user",
-                parts=[genai_types.Part(text=_compose_greeting_prompt(screen))],
+                parts=[genai_types.Part(text=_compose_greeting_prompt(screen, playbook))],
             )
         )
 
-    async def _greet_if_no_context() -> None:
-        # Fallback: the browser always sends an app_context frame, but if one
-        # never arrives the session must still open with a spoken greeting.
-        await asyncio.sleep(1.5)
-        _send_greeting("")
+    def _cancel_pending_greeting() -> None:
+        nonlocal greeting_task
+        if greeting_task is not None and not greeting_task.done():
+            greeting_task.cancel()
 
-    greeting_fallback_task = asyncio.create_task(_greet_if_no_context())
+    def _schedule_idle_greeting(screen: str, playbook: dict[str, Any] | None = None) -> None:
+        nonlocal greeting_task
+        _cancel_pending_greeting()
+        epoch = greeting_gate.schedule()
+        if epoch is None:
+            return
+
+        async def _send_after_idle() -> None:
+            try:
+                await asyncio.sleep(_INITIAL_GREETING_IDLE_SECONDS)
+            except asyncio.CancelledError:
+                return
+            _send_greeting(screen, playbook, epoch)
+
+        greeting_task = asyncio.create_task(_send_after_idle())
+
+    # If the browser never publishes context and the visitor remains idle, a
+    # short generic cue is still available. The first context replaces it with
+    # a screen-aware cue rather than sending two turns.
+    _schedule_idle_greeting("")
 
     # Last screen injected as model-visible context. Screen changes arrive as
     # app_context frames; sending content mid-generation PREEMPTS the model's
     # current turn on the Live API, so screen text is injected only when the
     # screen truly changed (never for the first frame; session state already
     # carries it for tools).
-    last_injected_screen: Optional[str] = None
+    last_injected_route_key: Optional[str] = None
     first_app_context_seen = False
     # Action outcomes are accepted only when they match a directive forwarded
     # on this same authenticated WebSocket. This keeps arbitrary browser
     # frames from becoming model-visible completion claims.
     issued_action_directives: dict[str, str] = {}
+    initial_context_ready = asyncio.Event()
 
     async def pump_browser_to_queue() -> None:
-        nonlocal last_injected_screen, first_app_context_seen
+        nonlocal last_injected_route_key, first_app_context_seen
         while True:
             raw = await websocket.receive_text()
             try:
@@ -439,7 +569,8 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 # Full UI snapshots never reach the model prompt. Action tools
                 # read this bounded redacted state when deciding what can be
                 # proposed or executed on the current screen.
-                state_delta[STATE_VOICE_CONTEXT] = _sanitize_live_context(context_payload)
+                sanitized_context = _sanitize_live_context(context_payload)
+                state_delta[STATE_VOICE_CONTEXT] = sanitized_context
                 if state_delta:
                     await runner.session_service.append_event(
                         session,
@@ -449,44 +580,46 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                             actions=EventActions(state_delta=state_delta),
                         ),
                     )
+                initial_context_ready.set()
                 screen = context_payload.get("screen")
                 clean_screen = screen.strip()[:64] if isinstance(screen, str) else ""
                 is_first = not first_app_context_seen
-                if is_first and not greeting_sent:
-                    # First context frame carries the entry screen: cancel the
-                    # silent-open fallback and greet with the screen in hand so
-                    # a fresh visitor is welcomed in and guided into setup.
-                    greeting_fallback_task.cancel()
-                    _send_greeting(clean_screen)
+                if is_first:
+                    # The first context establishes the entry screen. Keep the
+                    # cue idle-only so visitor speech always owns the first
+                    # actionable turn.
+                    _schedule_idle_greeting(
+                        clean_screen,
+                        sanitized_context.get("route_playbook"),
+                    )
                 if clean_screen:
-                    changed = clean_screen != last_injected_screen
-                    last_injected_screen = clean_screen
+                    route_key = ":".join(
+                        [
+                            str(sanitized_context.get("route_pattern") or ""),
+                            clean_screen,
+                            str(sanitized_context.get("route_instruction_id") or ""),
+                        ]
+                    )
+                    changed = route_key != last_injected_route_key
+                    last_injected_route_key = route_key
                     if changed and not is_first:
-                        if clean_screen in _ONBOARDING_SCREENS:
-                            note_text = (
-                                "[App state update - not user speech] The user is "
-                                f"now on the '{clean_screen}' screen while finishing "
-                                "account setup. Only offer what is actually "
-                                "available ON THIS screen: call list_app_actions "
-                                "for the current screen first, then briefly name "
-                                "the one next thing they can do here. If that step "
-                                "needs an answer from them, ask for it directly in "
-                                "the same breath. Do not bring up steps that belong "
-                                "to other screens."
+                        note_text = _compose_route_context_note(sanitized_context)
+                        if note_text:
+                            queue.send_content(
+                                genai_types.Content(
+                                    role="user",
+                                    parts=[genai_types.Part(text=note_text)],
+                                )
                             )
-                        else:
-                            note_text = (
-                                "[App state update - not user speech] The user is "
-                                f"now on the '{clean_screen}' screen. Use this "
-                                "silently."
-                            )
-                        queue.send_content(
-                            genai_types.Content(
-                                role="user",
-                                parts=[genai_types.Part(text=note_text)],
-                            )
-                        )
                 first_app_context_seen = True
+                continue
+            if message.get("type") == "voice_activity_start":
+                # The browser emits this once after local speech activity, not
+                # on raw microphone frames. It is transport control only: no
+                # transcript, page information, or intent is trusted here.
+                greeting_gate.cancel_for_visitor_activity()
+                _cancel_pending_greeting()
+                queue.send_activity_start()
                 continue
             if message.get("type") == "action_settled":
                 settlement = _sanitize_action_settlement(
@@ -549,6 +682,8 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
                 # message, NOT app-composed speech.
                 text = message.get("text")
                 if isinstance(text, str) and text.strip():
+                    greeting_gate.cancel_for_visitor_activity()
+                    _cancel_pending_greeting()
                     queue.send_content(
                         genai_types.Content(
                             role="user",
@@ -569,6 +704,15 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
             queue.send_realtime(genai_types.Blob(data=base64.b64decode(data), mime_type=mime))
 
     async def pump_events_to_browser() -> None:
+        # ADK evaluates a callable system instruction when run_live opens.
+        # Wait briefly for the browser's first bounded app_context so the
+        # active server-resolved playbook is present for the first real turn.
+        # Legacy clients still start after the compatibility timeout; queued
+        # audio is retained by LiveRequestQueue during this bounded wait.
+        try:
+            await asyncio.wait_for(initial_context_ready.wait(), timeout=1.0)
+        except TimeoutError:
+            pass
         async for event in runner.run_live(
             user_id=session_user,
             session_id=session_id,
@@ -626,8 +770,10 @@ async def one_adk_live_relay(websocket: WebSocket) -> None:
     except WebSocketDisconnect:
         pass
     finally:
-        for task in (up, down, greeting_fallback_task):
-            task.cancel()
+        up.cancel()
+        down.cancel()
+        if greeting_task is not None:
+            greeting_task.cancel()
         queue.close()
         try:
             await websocket.close()

--- a/consent-protocol/docs/monorepo-integration.md
+++ b/consent-protocol/docs/monorepo-integration.md
@@ -21,7 +21,7 @@ This allows branch merges that already contain newer subtree sync commits to pas
 - `ops/monorepo/protocol.mk` - Make targets for sync/check/push/setup
 - `ops/monorepo/setup.sh` - installs hooks + upstream remote + initial bookmark
 - `ops/monorepo/pre-commit.sh` - lint gate + upstream push reminder
-- `ops/monorepo/pre-push.sh` - subtree drift guard + lint gate
+- `ops/monorepo/pre-push.sh` - branch freshness + lint gate, with opt-in subtree verification
 
 ## Host monorepo setup
 
@@ -56,11 +56,15 @@ exec sh consent-protocol/ops/monorepo/pre-push.sh "$@"
 ./bin/hushh protocol push      # push subtree changes back to upstream
 ```
 
+Normal pushes intentionally skip the expensive subtree projection. Verify it
+explicitly with `./bin/hushh protocol check-sync`, or enable it for one push
+with `CONSENT_PRE_PUSH_SYNC_CHECK=1 git push`.
+
 ## Branch behavior notes
 
-If branch A syncs subtree and branch B does not, merging A into B can still leave B's local bookmark stale. The pre-push guard now reconciles bookmark + subtree commit metadata and auto-heals bookmark when content is already in sync.
+If branch A syncs subtree and branch B does not, merging A into B can still leave B's local bookmark stale. The explicit sync check reconciles bookmark + subtree commit metadata and auto-heals the bookmark when content is already in sync.
 
-If upstream is truly ahead, push is blocked and you must run:
+If the explicit check reports that upstream is truly ahead, run:
 
 ```bash
 ./bin/hushh protocol sync

--- a/consent-protocol/hushh_mcp/agents/onboarding/agent.py
+++ b/consent-protocol/hushh_mcp/agents/onboarding/agent.py
@@ -30,16 +30,24 @@ _CAPABILITIES = {
     "connected-systems",
 }
 _PHASE_ACTIONS = {
-    "anonymous_auth": {"auth.sign_in_google", "auth.sign_in_apple"},
-    "phone_required": {"phone_mandate.submit_number"},
+    "anonymous_auth": {
+        "onboarding.claim_one",
+        "auth.sign_in_google",
+        "auth.sign_in_apple",
+    },
+    "phone_required": {
+        "phone_mandate.submit_number",
+        "phone_mandate.submit_code",
+    },
     "setup_hub": {
         "setup.hub_master_ack",
         "setup.open_finance",
         "setup.open_gmail",
         "setup.open_email",
         "setup.open_location",
-        "setup.open_personal_data",
+        "setup.open_pkm",
         "setup.open_consent",
+        "setup.open_marketplace",
         "setup.open_connected_systems",
     },
     "capability_setup": {
@@ -52,6 +60,30 @@ _PHASE_ACTIONS = {
     "external_connector": set(),
     "root_completion": set(),
 }
+
+
+class OnboardingAssessmentV1(BaseModel):
+    """Semantic interpretation authored by One or the bounded adjudicator."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1] = 1
+    source: Literal["one", "agent_onboarding"] = "one"
+    intent: Literal[
+        "execute_visible_action",
+        "confirm_visible_action",
+        "answer_current_page",
+        "answer_conversationally",
+        "ask_clarifying_question",
+        "provide_input",
+        "recover",
+        "next_step",
+    ] = "next_step"
+    candidate_action_id: str | None = Field(default=None, max_length=128)
+    provider: Literal["google", "apple"] | None = None
+    missing_input: str | None = Field(default=None, max_length=64)
+    ambiguous: bool = False
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class OnboardingJourneyContext(BaseModel):
@@ -78,7 +110,7 @@ class OnboardingJourneyContext(BaseModel):
     available_action_ids: list[str] = Field(default_factory=list, max_length=18)
     setup_capability_ids: list[str] = Field(default_factory=list, max_length=10)
     screen: str = Field(default="unknown", max_length=64)
-    requested_provider: Literal["google", "apple"] | None = None
+    assessment: OnboardingAssessmentV1 = Field(default_factory=OnboardingAssessmentV1)
 
 
 class OnboardingGoal(BaseModel):
@@ -91,10 +123,16 @@ class OnboardingGoal(BaseModel):
     permitted_action_ids: list[str]
     selected_action_id: str | None = None
     missing_input: str | None = None
-    expected_settlement: Literal["route", "external_redirect", "callback", "local_action", "none"]
+    expected_settlement: Literal[
+        "route", "auth_session", "external_redirect", "callback", "local_action", "none"
+    ]
     return_to_hub: bool
     resolves_root: bool
     recovery: Literal["retry", "choose_provider", "verify_phone", "unlock", "return_to_hub", "none"]
+    assessment_status: Literal[
+        "admitted", "guidance_only", "needs_input", "rejected", "not_applicable"
+    ] = "guidance_only"
+    reason_code: str | None = Field(default=None, max_length=64)
 
 
 def build_onboarding_specialist():
@@ -120,53 +158,116 @@ def resolve_onboarding_goal(context: OnboardingJourneyContext) -> OnboardingGoal
 
     allowed = _PHASE_ACTIONS[phase]
     permitted = [action_id for action_id in context.available_action_ids if action_id in allowed]
+    assessment = context.assessment
+    candidate = assessment.candidate_action_id
+    provider_candidate = (
+        f"auth.sign_in_{assessment.provider}" if assessment.provider is not None else None
+    )
+    proposal_conflict = bool(candidate and provider_candidate and candidate != provider_candidate)
+    if candidate is None:
+        candidate = provider_candidate
+    action_intent = assessment.intent in {
+        "execute_visible_action",
+        "confirm_visible_action",
+        "provide_input",
+    }
+    selected = (
+        candidate
+        if action_intent
+        and candidate in permitted
+        and not assessment.ambiguous
+        and not proposal_conflict
+        else None
+    )
+    assessment_missing = assessment.missing_input if assessment.ambiguous else None
+    if assessment.intent in {"answer_current_page", "answer_conversationally"}:
+        assessment_status = "not_applicable"
+        reason_code = None
+    elif assessment.ambiguous or assessment.intent == "ask_clarifying_question":
+        assessment_status = "needs_input"
+        reason_code = assessment_missing or "ambiguous_intent"
+    elif proposal_conflict:
+        assessment_status = "rejected"
+        reason_code = "provider_action_mismatch"
+    elif candidate and candidate not in permitted:
+        assessment_status = "rejected"
+        reason_code = "action_not_available_on_screen"
+    elif selected:
+        assessment_status = "admitted"
+        reason_code = None
+    else:
+        assessment_status = "guidance_only"
+        reason_code = None
 
     if phase == "anonymous_auth":
-        provider_action = (
-            f"auth.sign_in_{context.requested_provider}" if context.requested_provider else None
-        )
-        selected = provider_action if provider_action in permitted else None
+        if context.screen == "one_intro" and selected == "onboarding.claim_one":
+            return OnboardingGoal(
+                phase=phase,
+                next_route="/login",
+                permitted_action_ids=permitted,
+                selected_action_id="onboarding.claim_one",
+                missing_input=None,
+                expected_settlement="route",
+                return_to_hub=False,
+                resolves_root=False,
+                recovery="none",
+                assessment_status=assessment_status,
+                reason_code=reason_code,
+            )
         return OnboardingGoal(
             phase=phase,
             next_route="/login",
             permitted_action_ids=permitted,
             selected_action_id=selected,
-            missing_input="provider" if selected is None else None,
-            expected_settlement="external_redirect",
+            missing_input=assessment_missing or ("provider" if selected is None else None),
+            expected_settlement="auth_session",
             return_to_hub=False,
             resolves_root=False,
             recovery="choose_provider",
+            assessment_status=assessment_status,
+            reason_code=reason_code,
         )
     if phase == "phone_required":
         return OnboardingGoal(
             phase=phase,
             next_route="/register-phone",
             permitted_action_ids=permitted,
-            missing_input="verified_phone",
+            selected_action_id=selected,
+            missing_input=assessment_missing or ("verified_phone" if selected is None else None),
             expected_settlement="callback",
             return_to_hub=False,
             resolves_root=False,
             recovery="verify_phone",
+            assessment_status=assessment_status,
+            reason_code=reason_code,
         )
     if phase == "capability_setup":
         return OnboardingGoal(
             phase=phase,
             next_route="/one/setup",
             permitted_action_ids=permitted,
+            selected_action_id=selected,
+            missing_input=assessment_missing,
             expected_settlement="local_action",
             return_to_hub=True,
             resolves_root=False,
             recovery="return_to_hub",
+            assessment_status=assessment_status,
+            reason_code=reason_code,
         )
     if phase == "setup_hub":
         return OnboardingGoal(
             phase=phase,
             next_route="/one/setup",
             permitted_action_ids=permitted,
+            selected_action_id=selected,
+            missing_input=assessment_missing,
             expected_settlement="route",
             return_to_hub=True,
             resolves_root=False,
             recovery="none",
+            assessment_status=assessment_status,
+            reason_code=reason_code,
         )
     if phase == "external_connector":
         callback_failed = context.callback_state in {"cancelled", "failed"}
@@ -179,6 +280,8 @@ def resolve_onboarding_goal(context: OnboardingJourneyContext) -> OnboardingGoal
             return_to_hub=True,
             resolves_root=False,
             recovery="retry" if callback_failed else "return_to_hub",
+            assessment_status=assessment_status,
+            reason_code=reason_code,
         )
     return OnboardingGoal(
         phase=phase,
@@ -191,4 +294,6 @@ def resolve_onboarding_goal(context: OnboardingJourneyContext) -> OnboardingGoal
         # needs to resolve it again.
         resolves_root=False,
         recovery="none",
+        assessment_status=assessment_status,
+        reason_code=reason_code,
     )

--- a/consent-protocol/hushh_mcp/agents/onboarding/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/onboarding/agent.yaml
@@ -2,7 +2,7 @@ manifest_version: 2
 id: agent_onboarding
 name: Onboarding Specialist
 version: 1.0.0
-description: Deterministic setup-goal specialist beneath One; it never accesses private content or executes actions.
+description: Semantic onboarding adjudicator and deterministic journey-policy specialist beneath One.
 status: active
 owner: backend
 parent: agent_one
@@ -12,9 +12,9 @@ credential_policy:
   allowed:
     - hushh_managed_vertex
 system_instruction: |
-  You are the deterministic onboarding specialist beneath One. Resolve only
-  redacted journey state into the next allowed setup goal. Never speak to the
-  person directly, call a connector, request credentials, or widen authority.
+  You are the bounded onboarding policy adjudicator beneath One. Validate
+  One's typed semantic assessment against redacted route and journey state.
+  Never speak directly, execute an action, request credentials, or widen authority.
 runtime:
   kind: deterministic
   factory: hushh_mcp.agents.onboarding.agent.build_onboarding_specialist
@@ -29,6 +29,9 @@ authorities:
   data: []
   actions: []
 inputs:
+  - name: turn_assessment
+    type: object
+    description: Typed semantic proposal produced by One's current ADK turn.
   - name: journey_context
     type: object
     description: Bounded redacted onboarding state.
@@ -51,10 +54,17 @@ surfaces:
 privacy:
   context_allowlist:
     - phase
+    - authenticated
+    - phone_verified
+    - vault_state
     - active_capability
     - root_resolved
     - return_route
     - available_action_ids
+    - callback_state
+    - setup_capability_ids
+    - screen
+    - assessment
   plaintext_telemetry: false
 telemetry_namespace: agent.onboarding
 performance:

--- a/consent-protocol/hushh_mcp/one_adk/action_tools.py
+++ b/consent-protocol/hushh_mcp/one_adk/action_tools.py
@@ -211,8 +211,10 @@ async def run_app_action(
         # One offers a next step after every governed action it runs, not
         # only after an onboarding screen change.
         "next_step": (
-            f"After {label} completes, briefly confirm what happened and, if "
-            "there's an obvious next step, offer it before waiting to be asked."
+            "Wait for the correlated browser action settlement before saying "
+            f"{label} completed. Then acknowledge only the reported outcome "
+            "and, if there is an obvious next step, offer it before waiting to "
+            "be asked."
         ),
     }
 

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional
+import time
+from typing import Any, Literal, Optional
 
 from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
@@ -32,6 +33,7 @@ from google.adk.tools.tool_context import ToolContext
 from hushh_mcp.adk_bridge.contract import A2ATask
 from hushh_mcp.adk_bridge.dispatch import dispatch, is_wired_specialist
 from hushh_mcp.agents.onboarding.agent import (
+    OnboardingAssessmentV1,
     OnboardingJourneyContext,
 )
 from hushh_mcp.agents.onboarding.agent import (
@@ -131,6 +133,16 @@ ONE_IDENTITY_INSTRUCTION = (
     'simply: "I\'m One." Never call yourself Kai, Gemini, or any other name. '
     "You hold the relationship layer: speak warmly, concisely, and in plain "
     "English.\n\n"
+    "Visible controls take priority over introductions. When the person clearly "
+    "asks for a currently available, low-risk visible control, call "
+    "list_app_actions for their words, then call run_app_action with the exact "
+    "returned action id immediately. Do this before greeting, explaining who "
+    "you are, or narrating onboarding. Do not infer controls from page text, "
+    "offer actions from another screen, or ask for confirmation when the "
+    "generated action policy is allow_direct. After dispatch, do not claim it "
+    "worked or describe it as complete until the correlated app action "
+    "settlement reports the outcome. If no current action matches, answer as "
+    "normal conversation instead of forcing a workflow.\n\n"
     "Conversation comes before workflow. Treat short follow-ups such as 'so what?', "
     "'why?', 'how?', 'tell me more', or 'what do you mean?' as replies to "
     "your immediately preceding statement. Answer their underlying question "
@@ -150,7 +162,7 @@ ONE_IDENTITY_INSTRUCTION = (
     "- Consent Center (Nav): what the user has shared and with whom, approvals, "
     "and revocations. Its Connections subagent handles the trusted-people "
     "graph itself; both surface in the Consent Center.\n"
-    "- Information Marketplace: governed data-slice requests and delivery.\n"
+    "- Information Marketplace: governed information-slice requests and delivery.\n"
     "- Connected Systems: CRM and external system workflows.\n\n"
     "Delegate naturally: when a request belongs to a specialist's domain, call "
     "that specialist's tool with the user's request. When the user asks to go "
@@ -166,7 +178,7 @@ ONE_IDENTITY_INSTRUCTION = (
     "tool; run_app_action will redirect you if needed. Use google_search when "
     "the user needs fresh public information from the web. Answer general "
     "questions yourself. Never invent tool results; if a specialist reports "
-    "it cannot act (missing consent, locked vault, no data), relay that "
+    "it cannot act (missing consent, locked vault, no information), relay that "
     "honestly and tell the user what would unlock it. You never execute "
     "sensitive actions directly: specialists validate consent and the app "
     "confirms every state change.\n\n"
@@ -174,9 +186,15 @@ ONE_IDENTITY_INSTRUCTION = (
     "other app action is: setup steps (welcome, sign-in, phone verification, "
     "the setup hub, and the Finance preferences wizard) are reachable through "
     "run_app_action. These steps live on DIFFERENT screens and are not all "
-    "available at once. Call resolve_onboarding_goal before guiding a new "
-    "user or advancing setup; it returns the bounded next step and never "
-    "takes over the conversation. Only ever offer what is reachable on the user's "
+    "available at once. For an explicit request matching a current visible "
+    "low-risk setup action, execute the generated action first; the resolver "
+    "must never delay or replace that command with identity narration. Call "
+    "resolve_onboarding_goal when the person asks what to do next, when input "
+    "is missing, or when recovering a setup goal; it returns the bounded next "
+    "step and never takes over semantic routing. Pass your typed assessment "
+    "fields (intent, candidate action, provider, missing input, ambiguity, and "
+    "confidence); never pass or lexically reclassify the raw transcript. Only "
+    "ever offer what is reachable on the user's "
     "CURRENT screen. If resolve_onboarding_goal returns selected_action_id, call "
     "run_app_action with that exact id immediately; never turn an explicit Apple "
     "or Google request back into a generic provider question. Call "
@@ -193,13 +211,64 @@ ONE_IDENTITY_INSTRUCTION = (
 )
 
 
-async def resolve_onboarding_goal(request: str, tool_context: ToolContext) -> dict[str, Any]:
-    """Resolve the next redacted onboarding goal without invoking a specialist.
+def _one_runtime_instruction(context: Any) -> str:
+    """Append only the active server-sanitized route playbook at Live start."""
+    state = getattr(context, "state", None)
+    state_getter = getattr(state, "get", None)
+    voice_context = state_getter(STATE_VOICE_CONTEXT) if callable(state_getter) else None
+    playbook = voice_context.get("route_playbook") if isinstance(voice_context, dict) else None
+    if not isinstance(playbook, dict):
+        return ONE_IDENTITY_INSTRUCTION
+
+    def bounded(field: str, limit: int) -> str:
+        value = playbook.get(field)
+        return str(value).strip()[:limit] if isinstance(value, str) else ""
+
+    purpose = bounded("purpose", 480)
+    entry_cue = bounded("entry_cue", 240)
+    primary_action = bounded("primary_action_id", 128)
+    completion = bounded("completion_boundary", 480)
+    out_of_scope = bounded("out_of_scope_behavior", 480)
+    return (
+        ONE_IDENTITY_INSTRUCTION
+        + "\n\nACTIVE ROUTE PLAYBOOK (guidance only; never authority):\n"
+        + f"Purpose: {purpose or 'Use the verified current screen.'}\n"
+        + f"Entry cue: {entry_cue or 'Remain ambient until the person speaks.'}\n"
+        + f"Primary generated action reference: {primary_action or 'none'}\n"
+        + f"Completion boundary: {completion or 'Wait for browser settlement.'}\n"
+        + f"Out-of-scope behavior: {out_of_scope or 'Answer naturally without inventing controls.'}\n"
+        + "The generated action gateway, current available actions, and runtime guards "
+        + "remain the only execution authority."
+    )
+
+
+async def resolve_onboarding_goal(
+    tool_context: ToolContext,
+    intent: Literal[
+        "execute_visible_action",
+        "confirm_visible_action",
+        "answer_current_page",
+        "answer_conversationally",
+        "ask_clarifying_question",
+        "provide_input",
+        "recover",
+        "next_step",
+    ] = "next_step",
+    candidate_action_id: str = "",
+    provider: Literal["google", "apple", "none"] = "none",
+    missing_input: str = "",
+    ambiguous: bool = False,
+    confidence: float = 1.0,
+    assessment_source: Literal["one", "agent_onboarding"] = "one",
+) -> dict[str, Any]:
+    """Validate One's typed semantic assessment against redacted journey state.
 
     Anonymous sign-in guidance must not pass through consent-gated A2A. This
-    pure deterministic tool reads only the bounded live context and returns a
-    goal that One can explain; browser and gateway guards still execute it.
+    policy tool receives meaning from One's current ADK turn, reads only the
+    bounded live context, and returns a goal that browser/gateway guards still
+    independently validate and execute.
     """
+    assessment_started_at = time.perf_counter()
     voice_context = tool_context.state.get(STATE_VOICE_CONTEXT)
     if not isinstance(voice_context, dict):
         voice_context = {}
@@ -214,14 +283,25 @@ async def resolve_onboarding_goal(request: str, tool_context: ToolContext) -> di
         }
     consent_token = str(tool_context.state.get(STATE_CONSENT_TOKEN) or "").strip()
     phase = str(onboarding.get("phase") or "anonymous_auth")
-    request_lower = str(request or "").lower()
-    requested_provider = (
-        "apple"
-        if "apple" in request_lower and "google" not in request_lower
-        else "google"
-        if "google" in request_lower and "apple" not in request_lower
-        else None
-    )
+    # One's current ADK turn supplies semantic fields. The deterministic layer
+    # validates them but never reclassifies the request with keywords.
+    try:
+        assessment = OnboardingAssessmentV1.model_validate(
+            {
+                "source": assessment_source,
+                "intent": intent,
+                "candidate_action_id": candidate_action_id or None,
+                "provider": None if provider == "none" else provider,
+                "missing_input": missing_input or None,
+                "ambiguous": ambiguous,
+                "confidence": confidence,
+            }
+        )
+    except ValueError:
+        return {
+            "status": "invalid_assessment",
+            "message": "I need to clarify the next onboarding step before acting.",
+        }
     context_payload = {
         "phase": phase,
         "authenticated": bool(user_id),
@@ -234,7 +314,7 @@ async def resolve_onboarding_goal(request: str, tool_context: ToolContext) -> di
         "available_action_ids": voice_context.get("available_action_ids") or [],
         "setup_capability_ids": onboarding.get("setup_capability_ids") or [],
         "screen": str(tool_context.state.get(STATE_SCREEN) or "unknown"),
-        "requested_provider": requested_provider,
+        "assessment": assessment.model_dump(),
     }
     try:
         context = OnboardingJourneyContext.model_validate(context_payload)
@@ -244,6 +324,22 @@ async def resolve_onboarding_goal(request: str, tool_context: ToolContext) -> di
             "message": "The app has not supplied a usable onboarding state yet.",
         }
     goal = _resolve_onboarding_goal(context)
+    logger.info(
+        "one_onboarding_assessment",
+        extra={
+            "assessment_source": assessment.source,
+            "assessment_intent": assessment.intent,
+            "assessment_status": goal.assessment_status,
+            "assessment_reason": goal.reason_code or "none",
+            "assessment_action_id": goal.selected_action_id or "none",
+            "assessment_screen": context.screen,
+            "assessment_phase": goal.phase,
+            "assessment_latency_ms": round(
+                (time.perf_counter() - assessment_started_at) * 1000,
+                3,
+            ),
+        },
+    )
     return {"status": "ok", "goal": goal.model_dump()}
 
 
@@ -532,7 +628,7 @@ def build_one_root_agent() -> LlmAgent:
         name="one",
         model=_build_one_live_model(),
         description="One, the Hussh head private agent and orchestrator.",
-        instruction=ONE_IDENTITY_INSTRUCTION,
+        instruction=_one_runtime_instruction,
         tools=_one_roster_tools(),
     )
 

--- a/consent-protocol/ops/monorepo/pre-push.sh
+++ b/consent-protocol/ops/monorepo/pre-push.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 # consent-protocol/ops/monorepo/pre-push.sh
-# Subtree sync guard + lint gate for consent-protocol subtree changes.
+# Fast push freshness/lint gate. Upstream subtree sync is explicit or opt-in.
 
 CHECK_ONLY=0
 if [ "${1:-}" = "--check-only" ]; then
   CHECK_ONLY=1
   shift
 fi
+
+# A normal push must not rebuild the full subtree projection. Maintainers can
+# opt in for one push, while --check-only and CI remain authoritative explicit
+# verification surfaces.
+PRE_PUSH_SYNC_CHECK="${CONSENT_PRE_PUSH_SYNC_CHECK:-0}"
 
 REMOTE="${1:-}"
 URL="${2:-}"
@@ -222,7 +227,9 @@ else
 
         CHANGED=$(git diff --name-only "$RANGE" 2>/dev/null | grep "^${SUBTREE_PREFIX}/" || true)
         if [ -n "$CHANGED" ]; then
-          should_check_subtree=1
+          if [ "$PRE_PUSH_SYNC_CHECK" = "1" ]; then
+            should_check_subtree=1
+          fi
           CP_FILES="$CP_FILES
 $CHANGED"
         fi

--- a/consent-protocol/tests/performance/test_onboarding_policy_benchmark.py
+++ b/consent-protocol/tests/performance/test_onboarding_policy_benchmark.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import time
+
+from hushh_mcp.agents.onboarding.agent import (
+    OnboardingAssessmentV1,
+    OnboardingJourneyContext,
+    resolve_onboarding_goal,
+)
+
+
+def _percentile(samples: list[float], percentile: float) -> float:
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, max(0, int(len(ordered) * percentile)))
+    return ordered[index]
+
+
+def test_onboarding_policy_meets_morphy_ax_budget_over_10k_runs() -> None:
+    context = OnboardingJourneyContext(
+        phase="setup_hub",
+        authenticated=True,
+        phone_verified=True,
+        vault_state="locked",
+        screen="one_setup",
+        available_action_ids=[
+            "setup.open_finance",
+            "setup.open_gmail",
+            "setup.open_pkm",
+            "setup.open_marketplace",
+        ],
+        assessment=OnboardingAssessmentV1(
+            intent="execute_visible_action",
+            candidate_action_id="setup.open_pkm",
+            confidence=0.99,
+        ),
+    )
+
+    for _ in range(100):
+        resolve_onboarding_goal(context)
+
+    samples_ms: list[float] = []
+    for _ in range(10_000):
+        started_at = time.perf_counter()
+        goal = resolve_onboarding_goal(context)
+        samples_ms.append((time.perf_counter() - started_at) * 1000)
+        assert goal.selected_action_id == "setup.open_pkm"
+
+    assert _percentile(samples_ms, 0.95) <= 5
+    assert _percentile(samples_ms, 0.99) <= 10

--- a/consent-protocol/tests/test_onboarding_goal_agent.py
+++ b/consent-protocol/tests/test_onboarding_goal_agent.py
@@ -1,4 +1,5 @@
 from hushh_mcp.agents.onboarding.agent import (
+    OnboardingAssessmentV1,
     OnboardingJourneyContext,
     resolve_onboarding_goal,
 )
@@ -17,7 +18,7 @@ def test_login_only_permits_explicit_provider_actions_and_requests_choice() -> N
     )
 
     assert goal.next_route == "/login"
-    assert goal.expected_settlement == "external_redirect"
+    assert goal.expected_settlement == "auth_session"
     assert goal.permitted_action_ids == [
         "auth.sign_in_google",
         "auth.sign_in_apple",
@@ -30,7 +31,11 @@ def test_explicit_apple_request_selects_the_apple_action() -> None:
     goal = resolve_onboarding_goal(
         OnboardingJourneyContext(
             phase="anonymous_auth",
-            requested_provider="apple",
+            assessment=OnboardingAssessmentV1(
+                intent="execute_visible_action",
+                provider="apple",
+                candidate_action_id="auth.sign_in_apple",
+            ),
             available_action_ids=["auth.sign_in_google", "auth.sign_in_apple"],
         )
     )
@@ -39,11 +44,33 @@ def test_explicit_apple_request_selects_the_apple_action() -> None:
     assert goal.missing_input is None
 
 
+def test_root_claim_is_selected_before_provider_choice() -> None:
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="anonymous_auth",
+            screen="one_intro",
+            assessment=OnboardingAssessmentV1(
+                intent="execute_visible_action",
+                candidate_action_id="onboarding.claim_one",
+            ),
+            available_action_ids=["onboarding.claim_one"],
+        )
+    )
+
+    assert goal.selected_action_id == "onboarding.claim_one"
+    assert goal.expected_settlement == "route"
+    assert goal.missing_input is None
+
+
 def test_unavailable_explicit_provider_keeps_safe_provider_recovery() -> None:
     goal = resolve_onboarding_goal(
         OnboardingJourneyContext(
             phase="anonymous_auth",
-            requested_provider="apple",
+            assessment=OnboardingAssessmentV1(
+                intent="execute_visible_action",
+                provider="apple",
+                candidate_action_id="auth.sign_in_apple",
+            ),
             available_action_ids=["auth.sign_in_google"],
         )
     )
@@ -112,3 +139,111 @@ def test_stale_capability_does_not_override_the_setup_hub_phase() -> None:
 
     assert goal.phase == "setup_hub"
     assert goal.permitted_action_ids == ["setup.open_finance"]
+
+
+def test_setup_hub_admits_every_catalog_action() -> None:
+    actions = [
+        "setup.open_finance",
+        "setup.open_gmail",
+        "setup.open_email",
+        "setup.open_location",
+        "setup.open_pkm",
+        "setup.open_consent",
+        "setup.open_marketplace",
+        "setup.open_connected_systems",
+    ]
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="setup_hub",
+            authenticated=True,
+            available_action_ids=actions,
+        )
+    )
+
+    assert goal.permitted_action_ids == actions
+
+
+def test_intelligence_assessment_admits_only_current_visible_action() -> None:
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="setup_hub",
+            authenticated=True,
+            available_action_ids=["setup.open_pkm"],
+            assessment=OnboardingAssessmentV1(
+                intent="execute_visible_action",
+                candidate_action_id="setup.open_pkm",
+                confidence=0.97,
+            ),
+        )
+    )
+
+    assert goal.selected_action_id == "setup.open_pkm"
+    assert goal.assessment_status == "admitted"
+
+
+def test_wrong_screen_intelligence_assessment_fails_closed() -> None:
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="setup_hub",
+            authenticated=True,
+            available_action_ids=["setup.open_pkm"],
+            assessment=OnboardingAssessmentV1(
+                intent="execute_visible_action",
+                candidate_action_id="auth.sign_in_apple",
+            ),
+        )
+    )
+
+    assert goal.selected_action_id is None
+    assert goal.assessment_status == "rejected"
+    assert goal.reason_code == "action_not_available_on_screen"
+
+
+def test_conversational_assessment_does_not_force_onboarding() -> None:
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="anonymous_auth",
+            screen="one_intro",
+            available_action_ids=["onboarding.claim_one"],
+            assessment=OnboardingAssessmentV1(intent="answer_conversationally"),
+        )
+    )
+
+    assert goal.selected_action_id is None
+    assert goal.assessment_status == "not_applicable"
+
+
+def test_ambiguous_assessment_retains_goal_and_requests_input() -> None:
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="anonymous_auth",
+            available_action_ids=["auth.sign_in_google", "auth.sign_in_apple"],
+            assessment=OnboardingAssessmentV1(
+                intent="ask_clarifying_question",
+                ambiguous=True,
+                missing_input="provider",
+            ),
+        )
+    )
+
+    assert goal.selected_action_id is None
+    assert goal.assessment_status == "needs_input"
+    assert goal.missing_input == "provider"
+
+
+def test_provider_and_candidate_mismatch_is_rejected() -> None:
+    goal = resolve_onboarding_goal(
+        OnboardingJourneyContext(
+            phase="anonymous_auth",
+            available_action_ids=["auth.sign_in_google", "auth.sign_in_apple"],
+            assessment=OnboardingAssessmentV1(
+                intent="execute_visible_action",
+                provider="apple",
+                candidate_action_id="auth.sign_in_google",
+            ),
+        )
+    )
+
+    assert goal.selected_action_id is None
+    assert goal.assessment_status == "rejected"
+    assert goal.reason_code == "provider_action_mismatch"

--- a/consent-protocol/tests/test_one_adk_agent_tree.py
+++ b/consent-protocol/tests/test_one_adk_agent_tree.py
@@ -14,6 +14,7 @@ Contract under test:
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -33,6 +34,8 @@ from hushh_mcp.one_adk.agent_tree import (
     STATE_CONSENT_TOKEN,
     STATE_PENDING_DIRECTIVE,
     STATE_USER_ID,
+    STATE_VOICE_CONTEXT,
+    _one_runtime_instruction,
     _specialist_turn,
     build_one_root_agent,
     get_one_runner,
@@ -73,8 +76,44 @@ class TestAgentTreeShape:
     def test_identity_instruction_answers_name_question(self):
         assert "I'm One" in ONE_IDENTITY_INSTRUCTION
         assert "Never call yourself Kai" in ONE_IDENTITY_INSTRUCTION
+        assert "Visible controls take priority over introductions" in ONE_IDENTITY_INSTRUCTION
+        assert "list_app_actions" in ONE_IDENTITY_INSTRUCTION
+        assert "correlated app action settlement" in ONE_IDENTITY_INSTRUCTION
         assert "Conversation comes before workflow" in ONE_IDENTITY_INSTRUCTION
         assert "so what?" in ONE_IDENTITY_INSTRUCTION
+
+    def test_runtime_instruction_injects_only_the_active_route_playbook(self):
+        instruction = _one_runtime_instruction(
+            SimpleNamespace(
+                state={
+                    STATE_VOICE_CONTEXT: {
+                        "route_playbook": {
+                            "purpose": "Welcome the person on the current root screen.",
+                            "entry_cue": "Say Claim your One.",
+                            "primary_action_id": "onboarding.claim_one",
+                            "completion_boundary": "Wait for browser settlement.",
+                            "out_of_scope_behavior": "Answer naturally.",
+                        }
+                    }
+                }
+            )
+        )
+
+        assert ONE_IDENTITY_INSTRUCTION in instruction
+        assert "onboarding.claim_one" in instruction
+        assert "ACTIVE ROUTE PLAYBOOK" in instruction
+
+    def test_onboarding_tool_accepts_typed_assessment_not_raw_request(self):
+        signature = inspect.signature(_tree.resolve_onboarding_goal)
+        assert "request" not in signature.parameters
+        assert {
+            "intent",
+            "candidate_action_id",
+            "provider",
+            "missing_input",
+            "ambiguous",
+            "confidence",
+        } <= set(signature.parameters)
 
     def test_runner_is_singleton(self):
         assert get_one_runner() is get_one_runner()
@@ -284,6 +323,28 @@ class TestRunAppAction:
         }
         result = await run_app_action("analysis.start", {"symbol": "NVDA"}, _tool_context(state))
         assert result["status"] == "action_unavailable"
+        assert _STATE_PENDING_DIRECTIVE not in state
+
+    @pytest.mark.asyncio
+    async def test_root_claim_is_available_only_on_the_public_intro_screen(self):
+        state = {
+            _STATE_SCREEN: "one_intro",
+            "hussh:voice_context": {
+                "available_action_ids": ["onboarding.claim_one"],
+            },
+        }
+        result = await run_app_action("onboarding.claim_one", {}, _tool_context(state))
+        assert result["status"] == "ok"
+        assert state[_STATE_PENDING_DIRECTIVE]["payload"]["actionId"] == "onboarding.claim_one"
+
+        state = {
+            _STATE_SCREEN: "login",
+            "hussh:voice_context": {
+                "available_action_ids": ["onboarding.claim_one"],
+            },
+        }
+        result = await run_app_action("onboarding.claim_one", {}, _tool_context(state))
+        assert result["status"] == "wrong_screen"
         assert _STATE_PENDING_DIRECTIVE not in state
 
     @pytest.mark.asyncio

--- a/consent-protocol/tests/test_one_adk_live_protocol.py
+++ b/consent-protocol/tests/test_one_adk_live_protocol.py
@@ -1,6 +1,32 @@
 """Unit coverage for One ADK Live browser-frame trust boundaries."""
 
-from api.routes.one.adk_live import _sanitize_action_settlement, _sanitize_live_context
+from api.routes.one.adk_live import (
+    _compose_route_context_note,
+    _InitialGreetingGate,
+    _sanitize_action_settlement,
+    _sanitize_live_context,
+)
+
+
+def test_initial_greeting_gate_allows_one_idle_cue_only():
+    gate = _InitialGreetingGate()
+    epoch = gate.schedule()
+
+    assert epoch is not None
+    assert gate.may_send(epoch) is True
+    assert gate.mark_sent(epoch) is True
+    assert gate.schedule() is None
+
+
+def test_initial_greeting_gate_invalidates_a_pending_cue_after_visitor_activity():
+    gate = _InitialGreetingGate()
+    epoch = gate.schedule()
+
+    assert epoch is not None
+    gate.cancel_for_visitor_activity()
+    assert gate.may_send(epoch) is False
+    assert gate.mark_sent(epoch) is False
+    assert gate.schedule() is None
 
 
 def test_live_context_keeps_only_bounded_redacted_ui_fields():
@@ -9,7 +35,7 @@ def test_live_context_keeps_only_bounded_redacted_ui_fields():
             "route_family": "/one/kai",
             "persona": "investor",
             "voice_state": "listening",
-            "available_action_ids": ["analysis.start", "analysis.start", 7],
+            "available_action_ids": ["analysis.start", "analysis.start", "not.generated", 7],
             "visible_modules": ["Portfolio"],
             "cache_freshness": "fresh_or_stale_safe",
             "vault_ready": True,
@@ -25,10 +51,13 @@ def test_live_context_keeps_only_bounded_redacted_ui_fields():
         "route_pattern": "/one/kai",
         "route_instruction_id": "route.one.kai",
         "route_context_policy": "publish",
+        "route_playbook": context["route_playbook"],
         "persona": "investor",
         "voice_state": "listening",
         "available_action_ids": ["analysis.start"],
         "visible_modules": ["Portfolio"],
+        "visible_control_ids": [],
+        "pending_settlement": False,
         "cache_freshness": "fresh_or_stale_safe",
         "vault_ready": True,
         "portfolio_ready": True,
@@ -55,8 +84,21 @@ def test_live_context_derives_dynamic_route_policy_and_rejects_client_policy_fie
     )
 
     assert context["route_pattern"] == "/one/setup/[capability]"
-    assert context["route_instruction_id"] == "route.one.setup.capability."
-    assert context["route_context_policy"] == "minimal"
+    assert context["route_instruction_id"] == "route.one.setup.capability"
+    assert context["route_context_policy"] == "publish"
+    assert context["route_playbook"]["primary_action_id"] == "setup.capability_continue"
+
+
+def test_route_note_prioritizes_visible_actions_without_granting_authority():
+    context = _sanitize_live_context(
+        {"route_family": "/", "available_action_ids": ["onboarding.claim_one"]}
+    )
+    note = _compose_route_context_note(context)
+
+    assert note is not None
+    assert "onboarding.claim_one" in note
+    assert "before any identity or greeting response" in note
+    assert "only execution authority" in note
 
 
 def test_action_settlement_requires_matching_issued_directive_and_can_retry_after_invalid():

--- a/consent-protocol/tests/test_route_orchestration_index.py
+++ b/consent-protocol/tests/test_route_orchestration_index.py
@@ -9,7 +9,9 @@ def test_resolves_parameterized_next_route_pattern_for_concrete_paths() -> None:
 
     assert entry is not None
     assert entry["route_pattern"] == "/one/setup/[capability]"
-    assert entry["instruction_id"] == "route.one.setup.capability."
+    assert entry["instruction_id"] == "route.one.setup.capability"
+    assert entry["voice_playbook"]["primary_action_id"] == "setup.capability_continue"
+    assert "setup.capability_continue" in entry["action_ids"]
     assert is_one_delegate_admitted("/one/setup/finance", "agent_kai") is False
 
 

--- a/contracts/agents/product-agent-registry.v2.json
+++ b/contracts/agents/product-agent-registry.v2.json
@@ -1322,7 +1322,7 @@
         ],
         "default": "hushh_managed_vertex"
       },
-      "description": "Deterministic setup-goal specialist beneath One; it never accesses private content or executes actions.",
+      "description": "Semantic onboarding adjudicator and deterministic journey-policy specialist beneath One.",
       "evaluations": [],
       "failure_states": [
         "invalid_context",
@@ -1334,6 +1334,11 @@
       "icon": null,
       "id": "agent_onboarding",
       "inputs": [
+        {
+          "description": "Typed semantic proposal produced by One's current ADK turn.",
+          "name": "turn_assessment",
+          "type": "object"
+        },
         {
           "description": "Bounded redacted onboarding state.",
           "name": "journey_context",
@@ -1367,10 +1372,17 @@
       "privacy": {
         "context_allowlist": [
           "phase",
+          "authenticated",
+          "phone_verified",
+          "vault_state",
           "active_capability",
           "root_resolved",
           "return_route",
-          "available_action_ids"
+          "available_action_ids",
+          "callback_state",
+          "setup_capability_ids",
+          "screen",
+          "assessment"
         ],
         "plaintext_telemetry": false
       },
@@ -1403,7 +1415,7 @@
         "voice": true,
         "web": true
       },
-      "system_instruction_sha256": "356b5c399d0a116dd57f684725f77279d139ed965d3811934f31d3d8f29bcf81",
+      "system_instruction_sha256": "a8519c516cad52790683b90511cd8519e72c360549d44e6cb72d405af3323914",
       "telemetry_namespace": "agent.onboarding",
       "tools": [],
       "ui_type": "chat",

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -12,6 +12,7 @@
     "hushh-webapp/app/one/page.voice-action-contract.json",
     "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
     "hushh-webapp/app/one/setup/kai/page.voice-action-contract.json",
+    "hushh-webapp/app/page.voice-action-contract.json",
     "hushh-webapp/app/profile/page.voice-action-contract.json",
     "hushh-webapp/app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
     "hushh-webapp/app/register-phone/page.voice-action-contract.json",
@@ -227,8 +228,8 @@
         }
       },
       "orchestration": {
-        "instruction_id": "route.one.home",
-        "context_policy": "publish",
+        "instruction_id": null,
+        "context_policy": null,
         "trust_boundary": "consent",
         "delegation_policy": "one_action_gate"
       }
@@ -286,6 +287,31 @@
         "context_policy": null,
         "trust_boundary": null,
         "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_intro",
+      "surface_title": "Claim your One",
+      "docs_references": [
+        "docs/reference/one/one-voice-runtime-architecture.md",
+        "docs/reference/one/one-voice-onboarding-journey.md"
+      ],
+      "contract_file": "hushh-webapp/app/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one"
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": "none",
+        "delegation_policy": "no_delegation"
       }
     },
     {
@@ -1202,7 +1228,7 @@
         "login",
         "authenticate"
       ],
-      "meaning": "Starts Google sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Google provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -1310,7 +1336,7 @@
         "login",
         "authenticate"
       ],
-      "meaning": "Starts Apple sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Apple provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -4241,6 +4267,7 @@
           "/one/setup/location",
           "/one/setup/pkm",
           "/one/setup/consent",
+          "/one/setup/marketplace",
           "/one/setup/connected-systems"
         ],
         "screens": [
@@ -4250,6 +4277,7 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
+          "one_setup_marketplace",
           "one_setup_connected-systems",
           "one_setup"
         ],
@@ -4700,19 +4728,20 @@
     {
       "action_id": "kai.setup.launch_dashboard",
       "surface_id": "kai_setup_wizard",
-      "label": "Launch Kai Dashboard",
+      "label": "Save Finance Preferences",
       "aliases": [
-        "launch my dashboard",
+        "save finance preferences",
         "looks good, continue",
-        "finish kai setup"
+        "finish finance setup"
       ],
       "search_keywords": [
-        "launch",
-        "dashboard",
+        "save",
+        "finance",
+        "preferences",
         "finish",
         "persona"
       ],
-      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "meaning": "Saves Finance preferences, marks only Finance ready, and returns to the One setup hub without resolving root onboarding.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "reachability": {
@@ -4779,11 +4808,118 @@
           {
             "type": "action",
             "action_id": "kai.setup.launch_dashboard",
-            "label": "Launch Kai Dashboard",
+            "label": "Save Finance Preferences",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/kai",
               "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "onboarding.claim_one",
+      "surface_id": "one_intro",
+      "label": "Claim your One",
+      "aliases": [
+        "claim your one",
+        "claim my one",
+        "claim one",
+        "get started",
+        "start with one",
+        "begin with one"
+      ],
+      "search_keywords": [
+        "claim",
+        "one",
+        "start",
+        "welcome",
+        "sign in"
+      ],
+      "meaning": "Continues from One's public welcome screen to sign in and begin setup.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/"
+        ],
+        "screens": [
+          "one_intro"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "onboarding.claim_one"
+      },
+      "control_ids": [
+        "onboarding_claim_one"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/one/one-voice-runtime-architecture.md",
+        "docs/reference/one/one-voice-onboarding-journey.md"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.onboarding.claim_one",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "onboarding.claim_one",
+            "label": "Claim your One",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/",
+              "screen": "one_intro"
             }
           }
         ],
@@ -6169,7 +6305,7 @@
         "verify",
         "confirm"
       ],
-      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "meaning": "Confirms the six-digit SMS code after an explicit inline confirmation and completes phone verification. The code is sensitive and must never be repeated or retained.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -6192,14 +6328,14 @@
       },
       "guard_ids": [
         "auth_signed_in",
-        "manual_user_execution"
+        "explicit_user_confirmation"
       ],
       "risk_level": "high",
-      "execution_policy": "manual_only",
+      "execution_policy": "confirm_required",
       "execution_target": {
-        "status": "unwired",
-        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
-        "intended_handler": "local_handler"
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_code"
       },
       "control_ids": [
         "phone-flow-code"
@@ -6231,7 +6367,14 @@
       },
       "goal": {
         "goal_id": "goal.phone_mandate.submit_code",
-        "required_inputs": [],
+        "required_inputs": [
+          {
+            "name": "verification_code",
+            "prompt": "Say or type the six-digit code. Spoken codes are processed by the voice service.",
+            "required": true,
+            "slot": "code"
+          }
+        ],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
@@ -10774,7 +10917,8 @@
           "/one/kai/import"
         ],
         "screens": [
-          "kai_portfolio_dashboard"
+          "kai_portfolio_dashboard",
+          "import"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11579,7 +11723,7 @@
       }
     },
     {
-      "action_id": "setup.open_personal_data",
+      "action_id": "setup.open_pkm",
       "surface_id": "one_setup_hub",
       "label": "Set Up Memory",
       "aliases": [
@@ -11648,18 +11792,124 @@
         ]
       },
       "goal": {
-        "goal_id": "goal.setup.open_personal_data",
+        "goal_id": "goal.setup.open_pkm",
         "required_inputs": [],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
           {
             "type": "action",
-            "action_id": "setup.open_personal_data",
+            "action_id": "setup.open_pkm",
             "label": "Set Up Memory",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_marketplace",
+      "surface_id": "one_setup_hub",
+      "label": "Explore Information Marketplace",
+      "aliases": [
+        "explore information marketplace",
+        "open marketplace setup",
+        "set up marketplace"
+      ],
+      "search_keywords": [
+        "information marketplace",
+        "marketplace",
+        "setup",
+        "explore"
+      ],
+      "meaning": "Opens the Information Marketplace explore step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub",
+          "one_setup"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/marketplace"
+      },
+      "control_ids": [
+        "one_setup_tile_marketplace"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/marketplace"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_marketplace",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_marketplace",
+            "label": "Explore Information Marketplace",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/marketplace",
               "screen": "one_setup_hub"
             }
           }

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "one.route_orchestration_index.v1",
+  "schema_version": "one.route_orchestration_index.v2",
   "purpose": "Generated, redacted route discovery and One delegation-admission index.",
   "sources": [
     "hushh-webapp/frontend-native-surface-map.generated.json",
@@ -10,12 +10,38 @@
       "route_pattern": "/",
       "page_file": "app/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
-      "instruction_id": "route.root",
-      "context_policy": "suppress",
-      "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "orchestration_class": "interactive",
+      "instruction_id": "route.one.intro",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.intro",
+        "purpose": "Welcome a new person and help them claim their private agent.",
+        "screen": "one_intro",
+        "entry_cue": "Say ‘Claim your One’ whenever you are ready.",
+        "proactivity": "on_entry",
+        "primary_action_id": "onboarding.claim_one",
+        "happy_path_action_ids": [
+          "onboarding.claim_one"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "The welcome step completes only after the browser settles navigation to Login.",
+        "next_route": "/login",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "voice_contract_file": "app/page.voice-action-contract.json",
+      "action_ids": [
+        "onboarding.claim_one"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -30,6 +56,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.agent",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.agent",
+        "purpose": "Help the person understand and use the agent screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -43,10 +91,32 @@
     {
       "route_pattern": "/blog",
       "page_file": "app/blog/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
       "instruction_id": "route.blog",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.blog",
+        "purpose": "Help the person understand and use the blog screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -60,10 +130,32 @@
     {
       "route_pattern": "/blog/[slug]",
       "page_file": "app/blog/[slug]/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
-      "instruction_id": "route.blog.slug.",
-      "context_policy": "minimal",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.blog.slug",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.blog.slug",
+        "purpose": "Help the person understand and use the blog screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -81,6 +173,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.connect",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.connect",
+        "purpose": "Help the person understand and use the connect screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -95,9 +209,33 @@
       "route_pattern": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.connected.systems",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.connected.systems",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "connected_systems",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [
+          "utterance"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "connected_systems.chat.turn"
@@ -116,9 +254,31 @@
       "route_pattern": "/connected-systems/[systemId]",
       "page_file": "app/connected-systems/[systemId]/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
-      "instruction_id": "route.connected.systems.systemId.",
-      "context_policy": "minimal",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.connected.systems.systemid",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.connected.systems.systemid",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -136,6 +296,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.consents",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.consents",
+        "purpose": "Help the person understand and use the consents screen through its generated controls.",
+        "screen": "consents",
+        "entry_cue": "You can say “Open RIA Requests” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_requests_compat",
+        "happy_path_action_ids": [
+          "route.ria_requests_compat"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/requests",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "connections.chat.turn",
@@ -161,6 +345,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.developers",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.developers",
+        "purpose": "Help the person understand and use the developers screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -175,30 +381,75 @@
       "route_pattern": "/getting-started",
       "page_file": "app/getting-started/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
+      "orchestration_class": "interactive",
       "instruction_id": "route.getting.started",
-      "context_policy": "suppress",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.getting.started",
+        "purpose": "Help the person understand and use the getting started screen through its generated controls.",
+        "screen": "getting_started",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/getting-started",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/getting-started/page.voice-action-contract.json",
       "action_ids": [
         "auth.sign_in_open",
         "onboarding.continue",
-        "route.getting_started"
+        "route.getting_started",
+        "vault.setup_open"
       ],
       "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
       },
-      "trust_boundary": "none",
+      "trust_boundary": "auth",
       "native_surface_id": "native-route-getting-started"
     },
     {
       "route_pattern": "/gmail",
       "page_file": "app/gmail/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.gmail",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.gmail",
+        "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+        "screen": "gmail",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -213,9 +464,31 @@
       "route_pattern": "/kai",
       "page_file": "app/kai/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai",
+        "purpose": "Help the person understand and use the kai screen through its generated controls.",
+        "screen": "kai_market",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -233,6 +506,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.kai.alpaca.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.alpaca.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -247,9 +542,31 @@
       "route_pattern": "/kai/analysis",
       "page_file": "app/kai/analysis/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.analysis",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.analysis",
+        "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+        "screen": "kai_analysis",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -264,9 +581,31 @@
       "route_pattern": "/kai/dashboard",
       "page_file": "app/kai/dashboard/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.dashboard",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.dashboard",
+        "purpose": "Help the person understand and use the dashboard screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -281,9 +620,31 @@
       "route_pattern": "/kai/dashboard/analysis",
       "page_file": "app/kai/dashboard/analysis/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.dashboard.analysis",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.dashboard.analysis",
+        "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -298,9 +659,31 @@
       "route_pattern": "/kai/funding-trade",
       "page_file": "app/kai/funding-trade/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.funding.trade",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.funding.trade",
+        "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+        "screen": "kai_funding_trade",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -315,9 +698,31 @@
       "route_pattern": "/kai/import",
       "page_file": "app/kai/import/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.import",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.import",
+        "purpose": "Help the person understand and use the import screen through its generated controls.",
+        "screen": "import",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -332,9 +737,31 @@
       "route_pattern": "/kai/investments",
       "page_file": "app/kai/investments/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.investments",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.investments",
+        "purpose": "Help the person understand and use the investments screen through its generated controls.",
+        "screen": "kai_investments",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -349,9 +776,31 @@
       "route_pattern": "/kai/onboarding",
       "page_file": "app/kai/onboarding/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.onboarding",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.onboarding",
+        "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -366,9 +815,31 @@
       "route_pattern": "/kai/optimize",
       "page_file": "app/kai/optimize/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.optimize",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.optimize",
+        "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+        "screen": "kai_optimize",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -386,6 +857,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.kai.plaid.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.plaid.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -400,9 +893,31 @@
       "route_pattern": "/kai/portfolio",
       "page_file": "app/kai/portfolio/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.portfolio",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.portfolio",
+        "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -417,9 +932,33 @@
       "route_pattern": "/login",
       "page_file": "app/login/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
+      "orchestration_class": "interactive",
       "instruction_id": "route.login",
-      "context_policy": "suppress",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.login",
+        "purpose": "Let the person choose Google or Apple and begin the matching sign-in flow.",
+        "screen": "login",
+        "entry_cue": "Say ‘Continue with Google’ or ‘Continue with Apple’.",
+        "proactivity": "on_entry",
+        "primary_action_id": "auth.sign_in_google",
+        "happy_path_action_ids": [
+          "auth.sign_in_google"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Authentication completes only after the provider popup returns a verified Firebase user session.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/login/page.voice-action-contract.json",
       "action_ids": [
         "auth.sign_in_apple",
@@ -440,6 +979,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.logout",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.logout",
+        "purpose": "Help the person understand and use the logout screen through its generated controls.",
+        "screen": "logout",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -457,6 +1018,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.marketplace",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace",
+        "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+        "screen": "marketplace",
+        "entry_cue": "You can say “Continue Browsing Marketplace” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.marketplace_browse_from_ria_profile",
+        "happy_path_action_ids": [
+          "route.marketplace_browse_from_ria_profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/marketplace",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.marketplace_browse_from_ria_profile",
@@ -474,9 +1059,33 @@
       "route_pattern": "/marketplace/connections",
       "page_file": "app/marketplace/connections/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.marketplace.connections",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace.connections",
+        "purpose": "Help the person understand and use the connections screen through its generated controls.",
+        "screen": "marketplace",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [
+          "utterance"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "connections.chat.turn"
@@ -495,9 +1104,31 @@
       "route_pattern": "/marketplace/connections/portfolio",
       "page_file": "app/marketplace/connections/portfolio/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.marketplace.connections.portfolio",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace.connections.portfolio",
+        "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+        "screen": "marketplace",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -515,6 +1146,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.marketplace.ria",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace.ria",
+        "purpose": "Help the person understand and use the ria screen through its generated controls.",
+        "screen": "marketplace_ria_profile",
+        "entry_cue": "You can say “Open Marketplace RIA Profile” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.marketplace_ria_profile",
+        "happy_path_action_ids": [
+          "route.marketplace_ria_profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/marketplace/ria",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/marketplace/ria/page-client.voice-action-contract.json",
       "action_ids": [
         "marketplace.ria.manage_profile",
@@ -536,6 +1191,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.home",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.home",
+        "purpose": "Help the person understand and use the one screen through its generated controls.",
+        "screen": "one_agents",
+        "entry_cue": "You can say “Open Agents” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_agents",
+        "happy_path_action_ids": [
+          "route.one_agents"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/page.voice-action-contract.json",
       "action_ids": [
         "connected_systems.chat.turn",
@@ -546,7 +1225,9 @@
         "location.chat.turn",
         "marketplace.information.chat.turn",
         "marketplace.information.requests.turn",
-        "route.one_agents"
+        "route.one_agents",
+        "route.one_location",
+        "route.one_pkm"
       ],
       "action_coverage": "inherited",
       "delegation_policy": {
@@ -571,6 +1252,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.connected.systems",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.connected.systems",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "connected_systems",
+        "entry_cue": "You can say “Open Connected Systems Panel” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_connected_systems",
+        "happy_path_action_ids": [
+          "route.profile_connected_systems"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/connected-systems",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.profile_connected_systems"
@@ -588,8 +1293,30 @@
       "page_file": "app/one/connected-systems/[systemId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "context_only",
-      "instruction_id": "route.one.connected.systems.systemId.",
+      "instruction_id": "route.one.connected.systems.systemid",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.one.connected.systems.systemid",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -607,6 +1334,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.gmail",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.gmail",
+        "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+        "screen": "gmail",
+        "entry_cue": "You can say “Open Receipts Page” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_receipts",
+        "happy_path_action_ids": [
+          "route.profile_receipts"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/gmail",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/gmail/page.voice-action-contract.json",
       "action_ids": [
         "email.chat.turn",
@@ -632,6 +1383,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai",
+        "purpose": "Help the person understand and use the kai screen through its generated controls.",
+        "screen": "kai_market",
+        "entry_cue": "You can say “Open Market Home” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_home",
+        "happy_path_action_ids": [
+          "route.kai_home"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.back",
@@ -652,6 +1427,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.one.kai.alpaca.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.alpaca.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -669,6 +1466,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.analysis",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.analysis",
+        "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+        "screen": "kai_analysis",
+        "entry_cue": "You can say “Open Analysis Surface” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_analysis",
+        "happy_path_action_ids": [
+          "route.kai_analysis"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kai/analysis",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/kai/analysis/page.voice-action-contract.json",
       "action_ids": [
         "analysis.cancel_active",
@@ -693,6 +1514,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.one.kai.funding.trade",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.funding.trade",
+        "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+        "screen": "kai_funding_trade",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -710,6 +1553,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.import",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.import",
+        "purpose": "Help the person understand and use the import screen through its generated controls.",
+        "screen": "import",
+        "entry_cue": "You can say “Open Portfolio Import” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_import",
+        "happy_path_action_ids": [
+          "route.kai_import"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_import"
@@ -729,6 +1596,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.investments",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.investments",
+        "purpose": "Help the person understand and use the investments screen through its generated controls.",
+        "screen": "kai_investments",
+        "entry_cue": "You can say “Open Investments Surface” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_investments",
+        "happy_path_action_ids": [
+          "route.kai_investments"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kai/investments",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_investments"
@@ -745,9 +1636,31 @@
       "route_pattern": "/one/kai/onboarding",
       "page_file": "app/one/kai/onboarding/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.one.kai.onboarding",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.onboarding",
+        "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -765,6 +1678,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.optimize",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.optimize",
+        "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+        "screen": "kai_optimize",
+        "entry_cue": "You can say “Open Optimize Surface” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_optimize",
+        "happy_path_action_ids": [
+          "route.kai_optimize"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kai/optimize",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_optimize"
@@ -784,6 +1721,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.one.kai.plaid.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.plaid.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -801,6 +1760,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.portfolio",
+        "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "You can say “Open Portfolio Dashboard” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_dashboard",
+        "happy_path_action_ids": [
+          "route.kai_dashboard"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_dashboard"
@@ -820,6 +1803,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kyc",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kyc",
+        "purpose": "Help the person understand and use the kyc screen through its generated controls.",
+        "screen": "one_kyc",
+        "entry_cue": "You can say “Open Email” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_kyc",
+        "happy_path_action_ids": [
+          "route.one_kyc"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kyc",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/kyc/page.voice-action-contract.json",
       "action_ids": [
         "route.one_kyc"
@@ -839,8 +1846,32 @@
       "page_file": "app/one/location/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.one.home",
+      "instruction_id": "route.one.location",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.location",
+        "purpose": "Help the person understand and use the location screen through its generated controls.",
+        "screen": "one_location",
+        "entry_cue": "You can say “Open Location” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_location",
+        "happy_path_action_ids": [
+          "route.one_location"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/location",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "location.chat.turn",
@@ -861,8 +1892,30 @@
       "page_file": "app/one/location/invite/[token]/page.tsx",
       "route_mode": "hidden",
       "orchestration_class": "transitional",
-      "instruction_id": "route.one.location.invite.token.",
+      "instruction_id": "route.one.location.invite.token",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.location.invite.token",
+        "purpose": "Help the person understand and use the invite screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -878,8 +1931,30 @@
       "page_file": "app/one/location/request/[token]/page.tsx",
       "route_mode": "hidden",
       "orchestration_class": "transitional",
-      "instruction_id": "route.one.location.request.token.",
+      "instruction_id": "route.one.location.request.token",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.location.request.token",
+        "purpose": "Help the person understand and use the request screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -897,6 +1972,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.marketplace",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.marketplace",
+        "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+        "screen": "one_marketplace",
+        "entry_cue": "You can say “Open Information Marketplace” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_marketplace",
+        "happy_path_action_ids": [
+          "route.one_marketplace"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/marketplace",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/marketplace/page.voice-action-contract.json",
       "action_ids": [
         "marketplace.information.chat.turn",
@@ -918,8 +2017,32 @@
       "page_file": "app/one/pkm/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.one.home",
+      "instruction_id": "route.one.pkm",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.pkm",
+        "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+        "screen": "pkm",
+        "entry_cue": "You can say “Open Memory” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_pkm",
+        "happy_path_action_ids": [
+          "route.one_pkm"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/pkm",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.one_pkm",
@@ -940,6 +2063,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.setup",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.setup",
+        "purpose": "Help the person choose, resume, skip, or finish one setup capability.",
+        "screen": "one_setup",
+        "entry_cue": "Choose something to set up, or say ‘finish setup’ when you are ready.",
+        "proactivity": "on_entry",
+        "primary_action_id": "setup.open_finance",
+        "happy_path_action_ids": [
+          "setup.open_finance"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Only the hub finish or skip action resolves root onboarding.",
+        "next_route": "/one",
+        "return_policy": "resolve_root",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "setup.hub_master_ack",
@@ -949,7 +2096,8 @@
         "setup.open_finance",
         "setup.open_gmail",
         "setup.open_location",
-        "setup.open_personal_data",
+        "setup.open_marketplace",
+        "setup.open_pkm",
         "vault.setup_open"
       ],
       "action_coverage": "inherited",
@@ -964,17 +2112,43 @@
       "route_pattern": "/one/setup/[capability]",
       "page_file": "app/one/setup/[capability]/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
-      "instruction_id": "route.one.setup.capability.",
-      "context_policy": "minimal",
-      "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "orchestration_class": "interactive",
+      "instruction_id": "route.one.setup.capability",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.setup.capability",
+        "purpose": "Explain the active setup capability and advance only its visible next step.",
+        "screen": "one_setup",
+        "entry_cue": "Say ‘Continue’ when you are ready for the next step.",
+        "proactivity": "on_entry",
+        "primary_action_id": "setup.capability_continue",
+        "happy_path_action_ids": [
+          "setup.capability_continue"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "The step settles after its local handler opens the capability destination.",
+        "next_route": "/one/setup",
+        "return_policy": "return_to_hub",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "voice_contract_file": "app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+      "action_ids": [
+        "setup.capability_continue"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
       },
-      "trust_boundary": "none",
+      "trust_boundary": "auth",
       "native_surface_id": null
     },
     {
@@ -984,6 +2158,32 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.setup.kai",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.setup.kai",
+        "purpose": "Collect Finance preferences and return to the setup hub without resolving root onboarding.",
+        "screen": "one_setup",
+        "entry_cue": "Answer the visible Finance question to continue.",
+        "proactivity": "on_entry",
+        "primary_action_id": "kai.setup.answer_horizon",
+        "happy_path_action_ids": [
+          "kai.setup.answer_horizon"
+        ],
+        "required_inputs": [
+          "investment_horizon"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Finance setup completes only after preferences are saved and the hub route settles.",
+        "next_route": "/one/setup",
+        "return_policy": "return_to_hub",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/setup/kai/page.voice-action-contract.json",
       "action_ids": [
         "kai.setup.answer_drawdown",
@@ -1003,9 +2203,31 @@
       "route_pattern": "/pkm",
       "page_file": "app/pkm/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.pkm",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.pkm",
+        "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+        "screen": "pkm",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1023,6 +2245,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.portfolio.shared",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.portfolio.shared",
+        "purpose": "Help the person understand and use the shared screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1040,10 +2284,39 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile",
+        "purpose": "Help the person understand and use the profile screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "You can say “Open Profile” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile",
+        "happy_path_action_ids": [
+          "route.profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/profile/page.voice-action-contract.json",
       "action_ids": [
         "route.back",
         "route.profile",
+        "route.profile_connected_systems",
+        "route.profile_gmail_panel",
+        "route.profile_pkm_agent_lab",
+        "route.profile_security_panel",
+        "route.profile_support_panel",
         "route.ria_settings_compat"
       ],
       "action_coverage": "inherited",
@@ -1061,6 +2334,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.access",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.access",
+        "purpose": "Help the person understand and use the access screen through its generated controls.",
+        "screen": "profile_privacy",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1078,6 +2373,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.access.connection",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.access.connection",
+        "purpose": "Help the person understand and use the connection screen through its generated controls.",
+        "screen": "profile_privacy",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1095,6 +2412,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.account",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.account",
+        "purpose": "Help the person understand and use the account screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1112,6 +2451,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.account.phone",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.account.phone",
+        "purpose": "Help the person understand and use the phone screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1129,6 +2490,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.connected.systems",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.connected.systems",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "connected_systems",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1143,9 +2526,31 @@
       "route_pattern": "/profile/gmail",
       "page_file": "app/profile/gmail/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail",
+        "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+        "screen": "profile_gmail_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1160,9 +2565,31 @@
       "route_pattern": "/profile/gmail/actions",
       "page_file": "app/profile/gmail/actions/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail.actions",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail.actions",
+        "purpose": "Help the person understand and use the actions screen through its generated controls.",
+        "screen": "profile_gmail_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1177,9 +2604,31 @@
       "route_pattern": "/profile/gmail/connection",
       "page_file": "app/profile/gmail/connection/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail.connection",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail.connection",
+        "purpose": "Help the person understand and use the connection screen through its generated controls.",
+        "screen": "profile_gmail_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1197,6 +2646,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1214,6 +2685,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.my.data",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.my.data",
+        "purpose": "Help the person understand and use the personal information screen through its generated controls.",
+        "screen": "profile_my_data",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1231,6 +2724,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.my.data.domain",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.my.data.domain",
+        "purpose": "Help the person understand and use the domain screen through its generated controls.",
+        "screen": "profile_my_data",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1245,9 +2760,31 @@
       "route_pattern": "/profile/pkm",
       "page_file": "app/profile/pkm/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.pkm",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.pkm",
+        "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+        "screen": "pkm",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1265,6 +2802,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile.pkm.agent.lab",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile.pkm.agent.lab",
+        "purpose": "Help the person understand and use the pkm agent lab screen through its generated controls.",
+        "screen": "profile_pkm_agent_lab",
+        "entry_cue": "You can say “Generate PKM capture preview” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "profile.pkm.preview_capture",
+        "happy_path_action_ids": [
+          "profile.pkm.preview_capture"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
       "action_ids": [
         "profile.pkm.preview_capture"
@@ -1284,6 +2845,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.preferences",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences",
+        "purpose": "Help the person understand and use the preferences screen through its generated controls.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1301,6 +2884,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.preferences.device",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.device",
+        "purpose": "Help the person understand and use the device screen through its generated controls.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1318,6 +2923,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.preferences.kai",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.kai",
+        "purpose": "Help the person understand and use the kai screen through its generated controls.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1332,9 +2959,31 @@
       "route_pattern": "/profile/receipts",
       "page_file": "app/profile/receipts/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.receipts",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.receipts",
+        "purpose": "Help the person understand and use the receipts screen through its generated controls.",
+        "screen": "gmail",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1352,6 +3001,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile.security",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security",
+        "purpose": "Help the person understand and use the security screen through its generated controls.",
+        "screen": "profile_security_panel",
+        "entry_cue": "You can say “Open Vault Security Panel” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_security_panel",
+        "happy_path_action_ids": [
+          "route.profile_security_panel"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/profile/security",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.profile_security_panel"
@@ -1371,6 +3044,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.security.session",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.session",
+        "purpose": "Help the person understand and use the session screen through its generated controls.",
+        "screen": "profile_security_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1388,6 +3083,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.security.vault",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.vault",
+        "purpose": "Help the person understand and use the vault screen through its generated controls.",
+        "screen": "profile_security_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1405,6 +3122,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile.support",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile.support",
+        "purpose": "Help the person understand and use the support screen through its generated controls.",
+        "screen": "profile_support_panel",
+        "entry_cue": "You can say “Open Support Panel” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_support_panel",
+        "happy_path_action_ids": [
+          "route.profile_support_panel"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/profile/support",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.profile_support_panel"
@@ -1424,6 +3165,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.support.compose",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.support.compose",
+        "purpose": "Help the person understand and use the compose screen through its generated controls.",
+        "screen": "profile_support_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1441,6 +3204,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.support.routing",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.support.routing",
+        "purpose": "Help the person understand and use the routing screen through its generated controls.",
+        "screen": "profile_support_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1455,11 +3240,38 @@
       "route_pattern": "/register-phone",
       "page_file": "app/register-phone/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
+      "orchestration_class": "interactive",
       "instruction_id": "route.register.phone",
-      "context_policy": "suppress",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.register.phone",
+        "purpose": "Verify the signed-in person’s phone before setup continues.",
+        "screen": "register_phone",
+        "entry_cue": "Say your phone number including country code, or type it below.",
+        "proactivity": "on_entry",
+        "primary_action_id": "phone_mandate.submit_number",
+        "happy_path_action_ids": [
+          "phone_mandate.submit_number"
+        ],
+        "required_inputs": [
+          "phone_number"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Phone verification completes only after the submitted code is accepted.",
+        "next_route": "/one/setup",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/register-phone/page.voice-action-contract.json",
       "action_ids": [
+        "phone_mandate.submit_code",
         "phone_mandate.submit_number"
       ],
       "action_coverage": "inherited",
@@ -1473,10 +3285,32 @@
     {
       "route_pattern": "/research",
       "page_file": "app/research/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
       "instruction_id": "route.research",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.research",
+        "purpose": "Help the person understand and use the research screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1490,10 +3324,32 @@
     {
       "route_pattern": "/research/protocol",
       "page_file": "app/research/protocol/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
       "instruction_id": "route.research.protocol",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.research.protocol",
+        "purpose": "Help the person understand and use the protocol screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1511,6 +3367,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria",
+        "purpose": "Help the person understand and use the ria screen through its generated controls.",
+        "screen": "ria_home",
+        "entry_cue": "You can say “Open RIA Home” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_home",
+        "happy_path_action_ids": [
+          "route.ria_home"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_home"
@@ -1530,9 +3410,34 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.clients",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients",
+        "purpose": "Help the person understand and use the clients screen through its generated controls.",
+        "screen": "ria_clients",
+        "entry_cue": "You can say “Open RIA Clients” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_clients",
+        "happy_path_action_ids": [
+          "route.ria_clients"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/clients/page.voice-action-contract.json",
       "action_ids": [
-        "route.ria_clients"
+        "route.ria_clients",
+        "route.ria_marketplace_connect"
       ],
       "action_coverage": "inherited",
       "delegation_policy": {
@@ -1547,8 +3452,32 @@
       "page_file": "app/ria/clients/[userId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.ria.clients.userId.",
+      "instruction_id": "route.ria.clients.userid",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients.userid",
+        "purpose": "Help the person understand and use the clients screen through its generated controls.",
+        "screen": "ria_client_workspace",
+        "entry_cue": "You can say “Open RIA Client Workspace” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_client_workspace",
+        "happy_path_action_ids": [
+          "route.ria_client_workspace"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients/[userId]",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "ria.client_workspace.open_overview_tab",
@@ -1567,8 +3496,32 @@
       "page_file": "app/ria/clients/[userId]/accounts/[accountId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.ria.clients.userId.accounts.accountId.",
+      "instruction_id": "route.ria.clients.userid.accounts.accountid",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients.userid.accounts.accountid",
+        "purpose": "Help the person understand and use the accounts screen through its generated controls.",
+        "screen": "ria_client_account_detail",
+        "entry_cue": "You can say “Return To Client Information Explorer” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "ria.client_account.open_workspace_fallback",
+        "happy_path_action_ids": [
+          "ria.client_account.open_workspace_fallback"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients/[userId]?tab=explorer",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "ria.client_account.open_workspace_fallback"
@@ -1586,8 +3539,32 @@
       "page_file": "app/ria/clients/[userId]/requests/[requestId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.ria.clients.userId.requests.requestId.",
+      "instruction_id": "route.ria.clients.userid.requests.requestid",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients.userid.requests.requestid",
+        "purpose": "Help the person understand and use the requests screen through its generated controls.",
+        "screen": "ria_client_request_detail",
+        "entry_cue": "You can say “Return To Client Access” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "ria.client_request.open_access_fallback",
+        "happy_path_action_ids": [
+          "ria.client_request.open_access_fallback"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients/[userId]?tab=access",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "ria.client_request.open_access_fallback"
@@ -1607,6 +3584,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.onboarding",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.onboarding",
+        "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+        "screen": "ria_onboarding",
+        "entry_cue": "You can say “Open RIA Onboarding” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_onboarding",
+        "happy_path_action_ids": [
+          "route.ria_onboarding"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/onboarding",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/onboarding/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_onboarding"
@@ -1626,8 +3627,38 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.picks",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.picks",
+        "purpose": "Help the person understand and use the picks screen through its generated controls.",
+        "screen": "ria_picks",
+        "entry_cue": "You can say “Open RIA Picks” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_picks",
+        "happy_path_action_ids": [
+          "route.ria_picks"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/picks",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/picks/page.voice-action-contract.json",
       "action_ids": [
+        "ria.picks.download_template",
+        "ria.picks.open_category_avoid",
+        "ria.picks.open_category_screening",
+        "ria.picks.open_category_top_picks",
+        "ria.picks.open_source_kai",
+        "ria.picks.open_source_my",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",
@@ -1641,10 +3672,34 @@
     {
       "route_pattern": "/ria/profile",
       "page_file": "app/ria/profile/page.tsx",
-      "route_mode": "unclassified",
+      "route_mode": "flow",
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.profile",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.profile",
+        "purpose": "Help the person understand and use the profile screen through its generated controls.",
+        "screen": "ria_profile",
+        "entry_cue": "You can say “Open RIA Profile” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_profile",
+        "happy_path_action_ids": [
+          "route.ria_profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/profile",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/profile/page.voice-action-contract.json",
       "action_ids": [
         "ria.profile.edit_services",
@@ -1662,9 +3717,31 @@
       "route_pattern": "/ria/requests",
       "page_file": "app/ria/requests/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.ria.requests",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.ria.requests",
+        "purpose": "Help the person understand and use the requests screen through its generated controls.",
+        "screen": "ria_requests",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/requests",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/requests/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_requests_compat"
@@ -1681,9 +3758,31 @@
       "route_pattern": "/ria/settings",
       "page_file": "app/ria/settings/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.ria.settings",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.ria.settings",
+        "purpose": "Help the person understand and use the settings screen through its generated controls.",
+        "screen": "ria_settings",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/settings",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/settings/page.voice-action-contract.json",
       "action_ids": [
         "marketplace.ria.manage_profile",
@@ -1701,9 +3800,31 @@
       "route_pattern": "/ria/workspace",
       "page_file": "app/ria/workspace/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.ria.workspace",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.ria.workspace",
+        "purpose": "Help the person understand and use the workspace screen through its generated controls.",
+        "screen": "ria_workspace",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/workspace",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/workspace/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_workspace_compat"

--- a/contracts/kai/voice-action-manifest.v1.json
+++ b/contracts/kai/voice-action-manifest.v1.json
@@ -312,7 +312,7 @@
     {
       "id": "auth.sign_in_google",
       "label": "Continue with Google",
-      "meaning": "Starts Google sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Google provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "aliases": [
@@ -388,7 +388,7 @@
     {
       "id": "auth.sign_in_apple",
       "label": "Continue with Apple",
-      "meaning": "Starts Apple sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Apple provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "aliases": [
@@ -2456,6 +2456,7 @@
           "/one/setup/location",
           "/one/setup/pkm",
           "/one/setup/consent",
+          "/one/setup/marketplace",
           "/one/setup/connected-systems"
         ],
         "screens": [
@@ -2465,6 +2466,7 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
+          "one_setup_marketplace",
           "one_setup_connected-systems",
           "one_setup"
         ],
@@ -2791,14 +2793,14 @@
     },
     {
       "id": "kai.setup.launch_dashboard",
-      "label": "Launch Kai Dashboard",
-      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "label": "Save Finance Preferences",
+      "meaning": "Saves Finance preferences, marks only Finance ready, and returns to the One setup hub without resolving root onboarding.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "aliases": [
-        "launch my dashboard",
+        "save finance preferences",
         "looks good, continue",
-        "finish kai setup"
+        "finish finance setup"
       ],
       "scope": {
         "routes": [
@@ -2833,7 +2835,7 @@
           {
             "type": "action",
             "action_id": "kai.setup.launch_dashboard",
-            "label": "Launch Kai Dashboard",
+            "label": "Save Finance Preferences",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/kai",
@@ -2864,6 +2866,80 @@
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "docs/reference/quality/one-onboarding-architecture.md",
         "hushh-webapp/app/one/setup/kai/page.tsx"
+      ]
+    },
+    {
+      "id": "onboarding.claim_one",
+      "label": "Claim your One",
+      "meaning": "Continues from One's public welcome screen to sign in and begin setup.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "claim your one",
+        "claim my one",
+        "claim one",
+        "get started",
+        "start with one",
+        "begin with one"
+      ],
+      "scope": {
+        "routes": [
+          "/"
+        ],
+        "screens": [
+          "one_intro"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "onboarding.claim_one"
+      },
+      "external_callback": null,
+      "goal": {
+        "goal_id": "goal.onboarding.claim_one",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "onboarding.claim_one",
+            "label": "Claim your One",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/",
+              "screen": "one_intro"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/one/one-voice-runtime-architecture.md",
+        "docs/reference/one/one-voice-onboarding-journey.md"
       ]
     },
     {
@@ -3832,7 +3908,7 @@
     {
       "id": "phone_mandate.submit_code",
       "label": "Submit Verification Code",
-      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "meaning": "Confirms the six-digit SMS code after an explicit inline confirmation and completes phone verification. The code is sensitive and must never be repeated or retained.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "aliases": [
@@ -3856,19 +3932,26 @@
       },
       "guard_ids": [
         "auth_signed_in",
-        "manual_user_execution"
+        "explicit_user_confirmation"
       ],
       "risk_level": "high",
-      "execution_policy": "manual_only",
+      "execution_policy": "confirm_required",
       "execution_hint": {
-        "status": "unwired",
-        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
-        "intended_handler": "local_handler"
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_code"
       },
       "external_callback": null,
       "goal": {
         "goal_id": "goal.phone_mandate.submit_code",
-        "required_inputs": [],
+        "required_inputs": [
+          {
+            "name": "verification_code",
+            "prompt": "Say or type the six-digit code. Spoken codes are processed by the voice service.",
+            "required": true,
+            "slot": "code"
+          }
+        ],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
@@ -7073,7 +7156,8 @@
           "/one/kai/import"
         ],
         "screens": [
-          "kai_portfolio_dashboard"
+          "kai_portfolio_dashboard",
+          "import"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7642,7 +7726,7 @@
       ]
     },
     {
-      "id": "setup.open_personal_data",
+      "id": "setup.open_pkm",
       "label": "Set Up Memory",
       "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
       "speaker_persona": "one",
@@ -7675,18 +7759,92 @@
       },
       "external_callback": null,
       "goal": {
-        "goal_id": "goal.setup.open_personal_data",
+        "goal_id": "goal.setup.open_pkm",
         "required_inputs": [],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
           {
             "type": "action",
-            "action_id": "setup.open_personal_data",
+            "action_id": "setup.open_pkm",
             "label": "Set Up Memory",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_marketplace",
+      "label": "Explore Information Marketplace",
+      "meaning": "Opens the Information Marketplace explore step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "explore information marketplace",
+        "open marketplace setup",
+        "set up marketplace"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub",
+          "one_setup"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/marketplace"
+      },
+      "external_callback": null,
+      "goal": {
+        "goal_id": "goal.setup.open_marketplace",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_marketplace",
+            "label": "Explore Information Marketplace",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/marketplace",
               "screen": "one_setup_hub"
             }
           }

--- a/docs/reference/architecture/route-contracts.md
+++ b/docs/reference/architecture/route-contracts.md
@@ -35,6 +35,11 @@ state. The browser publishes the canonical redacted route state derived by
 BFF validate and execute the permitted action. See
 [One Voice Onboarding Journey](../one/one-voice-onboarding-journey.md).
 
+Every physical page also has one required `voicePlaybook` in
+`app-route-layout.contract.json`. The surface-map and route-index generators reject
+missing, duplicate, structurally ambiguous, or action-incompatible entries. Playbooks
+are prompt posture only; generated actions and their guards remain execution authority.
+
 ## Files
 
 - Canonical app route source: `hushh-webapp/lib/navigation/routes.ts`
@@ -143,6 +148,20 @@ Auth-only routes can still be mandatory even when they intentionally bypass the 
 - `/login`
 - `/register-phone`
 - `/logout`
+
+## Public SEO and answer-engine projection
+
+Route playbooks and public search semantics share stable route and playbook identifiers,
+not prose. `hushh-webapp/lib/seo/site.ts` owns the public index allowlist and editorial
+title/description/schema projection; a parity test requires each entry to resolve to its
+typed route playbook. Sitemap and public `WebPage`/`CollectionPage` JSON-LD are generated
+from that allowlist.
+
+Never copy runtime recovery guidance, action aliases, trust-boundary details, journey
+state, or private-route playbooks into crawler metadata. Authenticated routes and Login
+remain non-indexable. This keeps SEO/AEO aligned with the same route ontology without
+turning orchestration prompts into public content or making search markup an execution
+authority.
 
 ## When To Update Route Governance
 

--- a/docs/reference/kai/kai-action-gateway-vnext.md
+++ b/docs/reference/kai/kai-action-gateway-vnext.md
@@ -51,9 +51,9 @@ The action system is split into four deliberate layers.
 
 Each voice-capable or search-capable Kai surface owns a colocated `.voice-action-contract.json` file next to the feature surface.
 
-Current generated coverage includes 30 source contracts, 30 surfaces, and 114 actions. Source contracts:
+Current generated coverage includes 31 source contracts, 31 surfaces, and 116 actions. Source contracts:
 
-- [page.voice-action-contract.json](../../../hushh-webapp/app/login/page.voice-action-contract.json) — Login-local Google and Apple redirect actions. Generic sign-in remains a provider-choice interaction.
+- [page.voice-action-contract.json](../../../hushh-webapp/app/login/page.voice-action-contract.json) — Login-local Google and Apple popup actions shared with the visible provider buttons. Generic sign-in remains a provider-choice interaction.
 
 - [page.voice-action-contract.json](../../../hushh-webapp/app/one/kai/analysis/page.voice-action-contract.json)
 - [page.voice-action-contract.json](../../../hushh-webapp/app/one/page.voice-action-contract.json)
@@ -92,9 +92,9 @@ The gateway is the shared semantic authority.
 The manifest is a generated compatibility artifact for consumers that still read the neutral manifest shape.
 
 The companion [route orchestration index](../../../contracts/kai/one-route-orchestration-index.v1.json)
-joins this gateway to every physical app route. Interactive contracts can add a
-bounded `orchestration` block (`instruction_id`, context policy, trust boundary,
-and delegation policy); its output is discovery/admission metadata only and
+joins this gateway to every physical app route. The route-layout contract owns one
+bounded `voicePlaybook` per route; local action contracts continue to own actions,
+trust boundaries, and delegation policy. The joined output is guidance/discovery metadata only and
 does not grant consent or alter TrustLink signatures.
 
 ### 3. Runtime adapter layer

--- a/docs/reference/one/one-agent-hierarchy.md
+++ b/docs/reference/one/one-agent-hierarchy.md
@@ -57,7 +57,7 @@ This page is current-state implementation truth. It does not rename runtime iden
 | Layer | Runtime id | Current role | Authority |
 | --- | --- | --- | --- |
 | Head agent | `agent_one` | Relationship layer, intent framing, specialist routing | `cap.one.invoke` for external task invocation only |
-| Onboarding resolver | `agent_onboarding` | Deterministic redacted next-goal resolution beneath One; never a second conversational router | No tools, scopes, vault access, or standing authority |
+| Onboarding policy adjudicator | `agent_onboarding` | Validates One's typed semantic assessment against redacted journey and current-screen action state; never a second semantic router | No tools, scopes, vault access, speaking authority, or standing authority |
 | Legacy alias | `agent_orchestrator` | Compatibility package and manifest alias for One | Must resolve to One semantics |
 | Finance specialist | `agent_kai` | Finance, portfolio, markets; RIA (advisor workspace) and Investor (personal investing) are its subagents | `agent.kai.analyze` plus finance PKM gates |
 | Consent Center parent | `agent_nav` | Consent, scope review, vault friction, deletion, revocation; parent of Connections | `agent.nav.review` |

--- a/docs/reference/one/one-voice-onboarding-journey.md
+++ b/docs/reference/one/one-voice-onboarding-journey.md
@@ -16,50 +16,63 @@ flowchart LR
 
 ## Ownership and boundaries
 
-One remains the only conversational head. `agent_onboarding` is a manifest-authored,
-deterministic resolver beneath One: it receives a redacted journey context and returns
-the next permitted goal. It has no LLM, tools, tokens, vault access, transcript, or
-authority to execute an action. The generated action gateway and browser-local handler
+One remains the only conversational and semantic head. Its current ADK turn supplies a
+typed onboarding assessment; `agent_onboarding` deterministically adjudicates that
+proposal against redacted journey and current-screen action state. It never classifies
+meaning with keywords and has no tools, tokens, vault access, transcript, speaking
+authority, or action authority. The generated action gateway and browser-local handler
 remain the execution authority.
 
 ## Journey state
 
 Authenticated progress is a versioned, pre-vault row: phase, active capability,
 callback outcome, timestamp, and the fixed `/one/setup` resume route. Anonymous state
-is browser-ephemeral until Firebase has settled the redirect callback. The record never
+is browser-ephemeral until Firebase has settled the provider flow. The record never
 stores raw voice turns, private page content, OAuth material, or vault material. It is a
 resumption hint; route guards and the generated contracts are still authoritative.
 
 | Phase | Permitted work | Success exit | Safe recovery |
 | --- | --- | --- | --- |
-| Anonymous auth | choose Google or Apple | Firebase callback | choose a provider / retry |
+| Anonymous auth | choose Google or Apple | verified Firebase session | choose a provider / retry |
 | Phone required | phone verification only | setup hub | verify phone |
 | Setup hub | choose a capability, skip, or finish | capability route / One home | return to hub |
-| Capability setup | scoped local action or approved connector | `/one/setup` | retain goal and return hub |
+| Capability setup | scoped local action or approved connector | terminal callback or explicit breadcrumb return to `/one/setup` | retain goal and return hub |
 | External connector | callback settlement only | `/one/setup` | retry/cancel without root completion |
 | Root completion | explicit hub finish or skip only | `/one` | none |
 
-Every individual capability, including Finance, returns to `/one/setup`. Only the
-hub's explicit Finish/Skip calls the setup-exit service and synchronizes root completion
-to the pre-vault record and, when unlocked, the vault-backed compatibility state.
+Finance and external connector completion return directly to `/one/setup`. Capability
+workspaces without an authoritative terminal event preserve a setup-origin breadcrumb
+and active goal so the person can explicitly return to the hub; they must not fabricate
+completion from navigation alone. Only the hub's explicit Finish/Skip calls the
+setup-exit service and synchronizes root completion to the pre-vault record and, when
+unlocked, the vault-backed compatibility state.
 
 ## Voice and provider authentication
 
-On Login, `auth.sign_in_google` and `auth.sign_in_apple` are generated Login-local
-actions. A button uses Firebase popup OAuth because its trusted click permits a popup.
-An explicit hands-free provider command uses web redirect OAuth in the existing tab:
-an asynchronous voice directive has no browser user activation and therefore cannot
-reliably open that popup. Native retains its native provider path. Generic “sign in”
-must ask which provider; it does not claim completion or silently select one.
+The public root route is the distinct `one_intro` voice screen. Its single
+visible primary action, **Claim your One**, is the generated
+`onboarding.claim_one` local action. Voice and tap call the same mounted
+handler, so the same post-sign-in destination remains intact. Research, Blog, and
+Developers remain descriptive public navigation until each has a visible,
+wired generated action; One does not invent action identifiers for them.
 
-Before a voice redirect, the browser persists a versioned ephemeral intent containing
-only provider, generated action id, directive correlation, original Login path, resume
-target, and timestamp—never tokens or provider material. The launch settles as
-`external_redirect_started`, which is terminal for the old WebSocket, not a success.
-On return, Login makes the redirect callback the sole post-auth routing authority;
-it settles from `getRedirectResult` or a Firebase-restored user, then resolves the
-post-auth route. Cancellation, callback error, timeout, and route mismatch retain the
-same goal and report the next safe instruction.
+At session start, One may offer a short idle cue, but it never wins over a
+visitor command. A redacted speech-activity signal cancels the pending cue
+before the relay queues it. When a visitor clearly names an available,
+low-risk visible control, One uses the generated action search and exact
+action runner immediately, without reintroducing itself or asking for a
+redundant confirmation. It reports only the browser-observed settlement.
+
+On Login, voice and tap first call the same Firebase popup functions. If the browser
+rejects a voice-triggered popup because the directive lacks transient user activation,
+voice alone falls back to the correlated Firebase redirect/resume path. Native retains
+its native provider path. Generic “sign in” asks which provider; it does not claim
+completion or silently select one. Cancellation, popup/redirect failure, missing user,
+timeout, and route mismatch retain the goal and report the next safe instruction.
+
+The phone code action is confirmation-required. A spoken code is processed by the
+configured voice provider, held only in transient client memory, hidden from the
+confirmation card, omitted from telemetry and journey state, and never repeated aloud.
 
 Next middleware is intentionally not an intelligence layer: it cannot reliably observe
 Firebase identity or client-local state. `deriveVoiceRouteScreen`, the generated gateway,
@@ -76,14 +89,15 @@ and callback posture) and waits for browser-observed settlement before speaking 
 The deterministic resolver is in-process and targets a sub-50 ms computation. “Learning”
 means this minimal consented progress record plus de-identified operational outcomes;
 individual onboarding turns are not model-training input by default. Rollout is guarded
-by `HUSHH_ONBOARDING_GOALS_DISABLED`; the pre-existing route flow remains rollback while
+by `HUSHH_ONBOARDING_GOALS_DISABLED`; route guidance has the independent
+`HUSHH_ROUTE_PLAYBOOKS_DISABLED` kill switch. The pre-existing route flow remains rollback while
 the browser journey suite is expanded.
 
 ## Verification matrix
 
-- explicit Google/Apple from Login starts the matching redirect; generic sign-in requests a provider
-- cancelled, failed, or duplicate callbacks retain the existing goal and post-auth route
-- Login → phone → hub → capability → hub reaches One home only through explicit hub completion
+- explicit Google/Apple from Login tries the visible button's popup path and uses correlated redirect recovery only when browser activation blocks it; generic sign-in requests a provider
+- cancelled or failed provider flows retain the existing goal and post-auth route
+- Login → phone → hub → capability → terminal/explicit hub return reaches One home only through explicit hub completion
 - Finance completion returns to the hub and cannot resolve root setup
 - redacted relay context and directive settlement are correlated; One cannot state success before settlement
 - generated contract output, Next.js BFF header forwarding, and browser hands-free journeys remain parity gates

--- a/docs/reference/one/one-voice-runtime-architecture.md
+++ b/docs/reference/one/one-voice-runtime-architecture.md
@@ -45,18 +45,47 @@ flowchart TD
 
 `contracts/kai/one-route-orchestration-index.v1.json` is generated from the
 complete frontend/native surface map and the generated action gateway. Every
-physical route has exactly one bounded descriptor: route class, stable
-instruction identifier, context publication policy, action coverage, and
-specialist-admission policy. Interactive pages may author an `orchestration`
-block next to their local voice-action contract; routes without an action
-contract receive a generated minimal descriptor.
+physical route has exactly one bounded, authored `voicePlaybook` in the route-layout
+contract: purpose, canonical screen, entry cue, primary generated action reference,
+happy-path references, recovery posture, completion boundary, and return policy. The
+generated index joins that guidance to action coverage and specialist admission.
+Only the server-resolved active playbook reaches a live session; the browser cannot
+submit prompt text or widen its action set.
+
+Morphy AX consumes this verified state as a pure redacted presentation and
+assessment-policy layer. It does not choose actions, create a second voice state
+machine, or change `one_voice_context.v1` during rollout. See
+[Morphy Agent Experience](../quality/morphy-agent-experience.md).
 
 The index is not a second router, prompt bundle, consent grant, or TrustLink
-input. `deriveVoiceRouteScreen` remains the browser's canonical screen mapper,
+input. Playbooks guide conversation but never execute. `deriveVoiceRouteScreen` remains the browser's canonical screen mapper,
 and the action gateway remains the only executable-action authority. Before
 One dispatches an internal A2A specialist, the backend checks the redacted
 current route against this index; scoped consent remains the authority gate,
 and TrustLink validation remains separate for delegation paths that use it.
+
+### Public welcome and first-turn priority
+
+`/` is the public `one_intro` screen; it is not the authenticated `one_agents`
+screen at `/one`. Its visible **Claim your One** button publishes
+`onboarding.claim_one` through a local action contract and a browser-local
+handler. The handler shares the exact redirect-preserving navigation path used
+by the button, while the generated gateway remains the only way One can issue
+that action.
+
+The initial welcome cue is idle-only. The browser sends one bounded,
+transcript-free `voice_activity_start` frame after sustained local speech
+activity. The relay cancels its pending cue before it enters the ADK queue;
+the client interrupts any already-playing cue through its normal barge-in
+fence. One gives a clear, current-screen, low-risk visible-control request
+priority over an introduction or onboarding narration, then waits for the
+correlated browser settlement before claiming completion. No DOM inference,
+client-side intent router, or public MCP route tool participates in this path.
+
+Interactive route entry cues are debounced by the verified route/playbook key. A
+visitor speech-activity frame cancels any pending cue before retained audio reaches
+ADK. Confirmation-required voice directives use an inline ambient card; slots remain
+transient and hidden, and confirm/cancel both report a correlated settlement.
 
 One's voice runtime is Google ADK's `Runner.run_live` over Vertex AI. The
 browser is an audio pump and directive executor; every decision (conversation

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -95,6 +95,8 @@ Use `.codex/skills/github-contribution-governance/` as the repo-operations spoke
 Use `.codex/skills/uat-scoped-deploy/` as the repo-operations spoke for frontend-only/backend-only UAT deploys, Cloud Build timing proof, and Cloud Run region/provenance evidence.
 Use `.codex/skills/frontend-native-surface-mapper/` before route/API/native/plugin/voice mapping work so the generated frontend/native surface map stays authoritative.
 Use `.codex/skills/frontend-cache-coherence/` when a screen needs warm-cache UX, TTL, stale background refresh, or reviewer-backed cache behavior proof.
+
+Use `.codex/skills/morphy-ax/` and workflow `morphy-ax-governance` for shared agent-experience snapshots, presentation posture, typed semantic-assessment validation, compatibility, and AX performance budgets.
 Workflow packs under `.codex/workflows/` are the canonical recurring task surface for routing and onboarding.
 Use `ci-watch-and-heal` plus `./bin/hushh codex ci-status` when the task depends on live PR checks or GitHub Actions state.
 Use `data-model-audit` plus `./bin/hushh codex data-model-audit` when migrations, table ownership, data classes, retention, or legacy memory write drift are in scope.

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -222,6 +222,7 @@ Operational note:
 - `Upstream Sync` and `Main Freshness Gate` are different surfaces.
 - `Upstream Sync` must summarize the actual `consent-protocol/` subtree state from `scripts/ci/subtree-sync-check.sh`.
 - `Main Freshness Gate` only describes branch currency relative to `main`.
+- Local pre-push keeps upstream sync opt-in for shipping speed. Use `./bin/hushh protocol check-sync` or `CONSENT_PRE_PUSH_SYNC_CHECK=1 git push`; CI remains the shared advisory evidence lane.
 
 ## Live GitHub Enforcement
 

--- a/docs/reference/operations/coding-agent-mcp.md
+++ b/docs/reference/operations/coding-agent-mcp.md
@@ -291,6 +291,7 @@ Operator precedence:
 12. Use `.codex/skills/uat-scoped-deploy/` for scoped UAT deploys and Cloud Run region/provenance proof.
 13. Use `.codex/skills/frontend-native-surface-mapper/` before route/API/native/plugin/voice mapping work.
 14. Use `.codex/skills/frontend-cache-coherence/` for warm-cache UX, TTL, stale background refresh, and reviewer-backed screen cache proof.
+15. Use `.codex/skills/morphy-ax/` for shared Agent Experience state, typed semantic-assessment validation, compatibility projection, and performance budgets.
 15. Use `.codex/skills/codex-skill-authoring/` when creating or retrofitting repo-local Codex skills, adding skill tooling, or tightening the local taxonomy and coverage rules.
 16. Use `.codex/skills/future-planner/` for future-state roadmap concepts, R&D architecture notes, and planning-only assessments that must stay separate from north-star vision and active implementation docs.
 17. Use `.codex/skills/planning-board/` for `Hussh Engineering Core` board work and `.codex/skills/comms-community/` for public/community explanation workflows.

--- a/docs/reference/operations/subtree-maintainers.md
+++ b/docs/reference/operations/subtree-maintainers.md
@@ -33,4 +33,22 @@ When subtree coordination is required:
 - keep the commands small and explicit
 - avoid turning upstream sync into repo-wide onboarding complexity
 
+Normal `git push` does not run the expensive upstream subtree projection. It
+still checks branch freshness and runs the fast protocol lint gate when
+protocol files changed. Maintainers choose either explicit verification:
+
+```bash
+./bin/hushh protocol check-sync
+```
+
+or opt in for a single push:
+
+```bash
+CONSENT_PRE_PUSH_SYNC_CHECK=1 git push
+```
+
+CI keeps the advisory upstream-sync check as the shared evidence lane. Actual
+`sync` and `push` operations remain explicit maintainer commands and are never
+performed by the pre-push hook.
+
 The older, more detailed subtree notes may still exist temporarily during cleanup, but this page is the canonical ownership boundary.

--- a/docs/reference/quality/README.md
+++ b/docs/reference/quality/README.md
@@ -24,6 +24,8 @@ flowchart TD
   root --> n9
   n7["Profile Settings Design System"]
   root --> n7
+  n10["Morphy Agent Experience"]
+  root --> n10
 ```
 
 This is the north-star entrypoint for design-system rules plus verification contracts that decide whether UI and analytics behavior are trustworthy.
@@ -38,5 +40,6 @@ This is the north-star entrypoint for design-system rules plus verification cont
 - [app-surface-audit-matrix.md](./app-surface-audit-matrix.md): current rollout matrix across routes.
 - [pr-impact-checklist.md](./pr-impact-checklist.md): change-impact review checklist.
 - [definition-of-done.md](./definition-of-done.md): the standing repo-wide completion bar — acceptance criteria answer "did we build it", this answers "is it ready".
+- [morphy-agent-experience.md](./morphy-agent-experience.md): internal AX snapshot, intelligence-validation boundary, presentation posture, and performance contract.
 - [pr-contributor-readiness.md](./pr-contributor-readiness.md): contributor-facing merge readiness, common blockers, maintainer patch/harvest handling, and attribution rules.
 - [analytics-verification-contract.md](./analytics-verification-contract.md): proof ladder for GA4, Firebase, BigQuery, and growth dashboard trust.

--- a/docs/reference/quality/design-system.md
+++ b/docs/reference/quality/design-system.md
@@ -127,8 +127,11 @@ Project-local UI skills live in `.codex/skills/`:
 3. `frontend-architecture`
 4. `frontend-surface-placement`
 5. `frontend-native-surface-mapper`
+6. `morphy-ax`
 
 These skills must stay aligned with this document, `frontend-ui-architecture-map.md`, and the runtime verification commands.
+
+Morphy UX owns reusable visual primitives. The narrower `morphy-ax` spoke owns pure redacted agent-state derivation and compatibility; see [Morphy Agent Experience](./morphy-agent-experience.md).
 
 ## Settings Surfaces
 The Profile page is the canonical settings implementation for the app.

--- a/docs/reference/quality/frontend-ui-architecture-map.md
+++ b/docs/reference/quality/frontend-ui-architecture-map.md
@@ -76,5 +76,6 @@ Project skills live under `.codex/skills/`:
 4. `frontend-surface-placement`
 5. `frontend-native-surface-mapper`
 6. `frontend-cache-coherence`
+7. `morphy-ax`
 
 These skills must stay aligned with the docs and verification commands in this quality section.

--- a/docs/reference/quality/morphy-agent-experience.md
+++ b/docs/reference/quality/morphy-agent-experience.md
@@ -1,0 +1,91 @@
+# Morphy Agent Experience
+
+Status: current internal architecture contract.
+
+## Visual Context
+
+Canonical visual owner: [Quality and Design System Index](README.md). Morphy UX owns reusable visual and interaction primitives; Morphy AX owns the pure, redacted derivation that makes agent behavior consistent across voice, chat, onboarding, and ambient surfaces.
+
+```mermaid
+flowchart LR
+  sources["Verified runtime state"] --> ax["Morphy AX snapshot"]
+  one["One semantic assessment"] --> policy["Deterministic validation"]
+  ax --> policy
+  policy --> gateway["Generated action gateway"]
+  gateway --> settle["Browser settlement"]
+  settle --> present["Shared AX presentation"]
+```
+
+## Ownership
+
+Morphy AX is the internal Agent Experience system. It is a peer to Morphy UX, not a replacement:
+
+- Morphy UX owns tokens, motion, reusable surfaces, and interaction primitives.
+- Morphy AX owns the shared redacted snapshot, assessment-validation boundary, and presentation posture.
+- `AgentRuntimeStateProvider` remains the single frontend runtime owner.
+- The One Voice state machine remains the lifecycle authority.
+- One remains the sole conversational and semantic head.
+- Generated action contracts and the gateway remain the only action authority.
+
+Morphy AX must never introduce another provider, store, router, voice state machine, action registry, route-awareness MCP tool, or consent path.
+
+## Snapshot contract
+
+`MorphyAxSnapshotV1` is organized around four AX dimensions:
+
+| Dimension | Bounded content |
+| --- | --- |
+| Access | signed-in posture, vault readiness, active persona |
+| Context | canonical screen, route family, active playbook, visible modules and controls, onboarding posture |
+| Tools | currently available generated action identifiers |
+| Orchestration | pending settlement, voice lifecycle posture, bounded busy operations |
+
+Privacy is explicit: the snapshot is redacted and excludes raw voice turns, OTP values, credentials, OAuth material, vault material, private page content, and action slots. The snapshot is derived synchronously and performs no network or model call.
+
+During rollout, `toOneVoiceContextSnapshot` preserves the existing `one_voice_context.v1` wire shape. Disabling `NEXT_PUBLIC_MORPHY_AX_ENABLED` keeps the pre-existing compatibility path authoritative.
+
+## Intelligence and deterministic policy
+
+Semantic meaning must come from intelligence. One's current ADK turn produces a typed assessment describing the conversational disposition, candidate generated action, missing input, ambiguity, and expected outcome. Deterministic code may then:
+
+- verify that the proposed action is currently visible and generated
+- enforce route, onboarding phase, consent, vault, confirmation, and settlement boundaries
+- normalize bounded fields
+- reject stale, conflicting, unavailable, or unsafe proposals
+- retain the current goal and request clarification
+
+Deterministic code must not classify meaning from keyword or regex rules, substitute a different action, create a capability, or claim completion. `agent_onboarding` is the bounded policy adjudicator beneath One; it receives One's typed assessment plus redacted journey facts and has no information, action, credential, or speaking authority.
+
+With Morphy AX enabled, Agent Bar validates One's typed action directive against the active snapshot before entering the existing generated gateway. A confirmation-required assessment remains a distinct decision and can only enter the inline confirmation path; it is never collapsed into direct execution.
+
+## Presentation contract
+
+Morphy AX projects the existing voice lifecycle into a shared presentation vocabulary:
+
+`idle → orienting → listening → understanding → confirming → acting → settling → responding`, with `recovering` as the safe failure posture.
+
+The projection controls cadence and appearance only. It cannot dispatch voice transitions or actions. Agent Bar, ambient edge glow, Agent Chat streaming, and onboarding confirmation/recovery consume this shared posture progressively.
+
+## Accuracy and performance
+
+Release gates are measurable:
+
+- 100% route, screen, playbook, visible-control, generated-action, and registered-handler parity
+- 100% compatibility projection parity for behavior that has not migrated
+- 100% correct or safe-clarification outcome across the fixed critical onboarding corpus
+- zero wrong-screen, unauthorized, sensitive-value, or success-before-settlement outcomes
+- snapshot and policy p95 at or below 5 ms and p99 at or below 10 ms over 10,000 warmed evaluations
+- presentation projection p95 at or below 2 ms
+- no additional network call, model call, or live-session recreation for a clear visible action
+
+Open-ended language outside the release corpus is not described as universally perfect. When meaning is unresolved, One asks one natural clarification and preserves the active goal.
+
+CI uses deterministic production-function benchmarks. Live-model and provider timing belongs in UAT because network and provider variance would make local CI misleading. Telemetry may record stage timing, assessment disposition, action identifier, outcome bucket, and route/playbook identifiers; it must not retain raw voice turns, OTPs, email addresses, user identifiers, query strings, slots, or private page information.
+
+## SEO and AEO boundary
+
+SEO and answer-engine content remains server-authored through canonical Next.js metadata, structured content, and public route contracts. A route may share a stable purpose identifier with its voice playbook, but prompt instructions and private AX context are never rendered or indexed. Morphy AX is runtime orchestration, not a second publishing or indexing source.
+
+## Verification
+
+Use the `morphy-ax-governance` workflow. At minimum, run the Morphy AX contract/benchmark tests, shared runtime-context tests, frontend typecheck, generated voice verification, backend onboarding-policy tests, design-system verification, and documentation verification. Browser proof is required for route continuity, inline confirmation, responsive presentation, and provider callback recovery.

--- a/hushh-webapp/__tests__/app/one/one-onboarding-capability-client.test.tsx
+++ b/hushh-webapp/__tests__/app/one/one-onboarding-capability-client.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   setOnboardingCompleted: vi.fn(),
   markSeen: vi.fn(),
   syncSetupCapabilities: vi.fn(),
+  syncOnboardingJourney: vi.fn(),
   markExplored: vi.fn(),
   loadExploredIds: vi.fn(),
 }));
@@ -55,6 +56,7 @@ vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
   PreVaultUserStateService: {
     syncKaiSetupState: mocks.syncKaiSetupState,
     syncSetupCapabilities: mocks.syncSetupCapabilities,
+    syncOnboardingJourney: mocks.syncOnboardingJourney,
   },
 }));
 
@@ -94,6 +96,7 @@ describe("OneOnboardingCapabilityClient — Continue forwarding", () => {
     mocks.loadExploredIds.mockResolvedValue([]);
     mocks.markExplored.mockResolvedValue(undefined);
     mocks.syncSetupCapabilities.mockResolvedValue(undefined);
+    mocks.syncOnboardingJourney.mockResolvedValue(undefined);
   });
 
   it("forwards into a hard-gated surface with ?from=/one/setup and does NOT resolve the master gate (location)", async () => {

--- a/hushh-webapp/__tests__/app/profile/gmail/oauth/return/page.test.tsx
+++ b/hushh-webapp/__tests__/app/profile/gmail/oauth/return/page.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
     completeConnect: vi.fn(),
     getStatus: vi.fn(),
   },
+  syncOnboardingJourney: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -25,6 +26,12 @@ vi.mock("@/hooks/use-auth", () => ({
 
 vi.mock("@/lib/services/gmail-receipts-service", () => ({
   GmailReceiptsService: mocks.gmailReceiptsService,
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    syncOnboardingJourney: mocks.syncOnboardingJourney,
+  },
 }));
 
 vi.mock("@/lib/profile/gmail-connector-store", () => ({
@@ -85,6 +92,8 @@ describe("ProfileGmailOAuthReturnPage", () => {
       auto_sync_enabled: true,
       revoked: false,
     });
+    mocks.syncOnboardingJourney.mockResolvedValue(undefined);
+    window.sessionStorage.clear();
   });
 
   it("redirects back to Gmail receipts when the callback is replayed after a successful connection", async () => {
@@ -131,5 +140,63 @@ describe("ProfileGmailOAuthReturnPage", () => {
         redirectUri: "http://localhost:3000/profile/gmail/oauth/return",
       });
     });
+  });
+
+  it("settles a setup-originated Gmail callback back to the setup hub", async () => {
+    window.sessionStorage.setItem(
+      "one_onboarding_connector_intent_v1",
+      JSON.stringify({
+        version: 1,
+        capability: "gmail",
+        returnTo: "/one/setup",
+        correlationId: "connector-test",
+        startedAt: Date.now(),
+      })
+    );
+    mocks.searchParamsGet.mockImplementation((key: string) => {
+      if (key === "code") return "code-setup";
+      if (key === "state") return "state-setup";
+      return null;
+    });
+
+    render(<ProfileGmailOAuthReturnPage />);
+
+    await waitFor(() => {
+      expect(mocks.syncOnboardingJourney).toHaveBeenCalledWith({
+        userId: "user-123",
+        phase: "setup_hub",
+        activeCapability: null,
+        callbackState: "succeeded",
+      });
+      expect(mocks.routerReplace).toHaveBeenCalledWith("/one/setup");
+    });
+    expect(window.sessionStorage.getItem("one_onboarding_connector_intent_v1")).toBeNull();
+  });
+
+  it("keeps connector success authoritative when the journey echo fails", async () => {
+    window.sessionStorage.setItem(
+      "one_onboarding_connector_intent_v1",
+      JSON.stringify({
+        version: 1,
+        capability: "gmail",
+        returnTo: "/one/setup",
+        correlationId: "connector-test",
+        startedAt: Date.now(),
+      }),
+    );
+    mocks.searchParamsGet.mockImplementation((key: string) => {
+      if (key === "code") return "code-setup";
+      if (key === "state") return "state-setup";
+      return null;
+    });
+    mocks.syncOnboardingJourney.mockRejectedValue(new Error("journey unavailable"));
+
+    render(<ProfileGmailOAuthReturnPage />);
+
+    await waitFor(() => {
+      expect(mocks.routerReplace).toHaveBeenCalledWith("/one/setup");
+    });
+    expect(screen.queryByText("Gmail connection needs attention")).toBeNull();
+    expect(window.sessionStorage.getItem("one_onboarding_connector_intent_v1")).toBeNull();
   });
 });

--- a/hushh-webapp/__tests__/components/capability-setup-tile.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-setup-tile.test.tsx
@@ -19,6 +19,7 @@ describe("CapabilitySetupTile", () => {
         title="Gmail"
         description="Bring in receipts."
         href="/one/setup/gmail"
+        voiceControlId="one_setup_tile_gmail"
         icon={Mail}
         tone="gmail"
         status={{
@@ -34,6 +35,7 @@ describe("CapabilitySetupTile", () => {
     const row = screen.getByRole("button", { name: "Gmail: Set up" });
 
     expect(row).toHaveAttribute("data-href", "/one/setup/gmail");
+    expect(row).toHaveAttribute("data-voice-control-id", "one_setup_tile_gmail");
     fireEvent.click(row);
 
     expect(mocks.push).toHaveBeenCalledWith("/one/setup/gmail", {

--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IntroStep } from "@/components/onboarding/IntroStep";
+import {
+  resolveLocalOnboardingHandler,
+} from "@/lib/agent/local-onboarding-actions";
+import { getVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+
+vi.mock("@/components/app-ui/hushh-wordmark", () => ({
+  HushhWordmark: () => <span>hussh</span>,
+}));
+
+vi.mock("@/components/onboarding/OnboardingHeroBackground", () => ({
+  OnboardingHeroBackground: () => null,
+}));
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("IntroStep voice contract", () => {
+  it("publishes and executes the same Claim your One control used by tapping", async () => {
+    const onLogin = vi.fn();
+    render(<IntroStep onLogin={onLogin} />);
+
+    await waitFor(() => {
+      expect(getVoiceSurfaceMetadata()).toMatchObject({
+        screenId: "one_intro",
+        actions: [expect.objectContaining({ actionId: "onboarding.claim_one" })],
+        controls: [expect.objectContaining({ id: "onboarding_claim_one" })],
+      });
+      expect(resolveLocalOnboardingHandler("onboarding.claim_one")).not.toBeNull();
+    });
+
+    const button = screen.getByRole("button", { name: /claim your one/i });
+    expect(button).toHaveAttribute("data-voice-control-id", "onboarding_claim_one");
+    fireEvent.click(button);
+    expect(onLogin).toHaveBeenCalledTimes(1);
+
+    const handler = resolveLocalOnboardingHandler("onboarding.claim_one");
+    const result = await handler?.({});
+    expect(onLogin).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ status: "started", summary: "Opening sign-in." });
+  });
+});

--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -2,10 +2,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { PhoneVerificationFlow } from "@/components/auth/phone-verification-flow";
+import { resolveLocalOnboardingHandler } from "@/lib/agent/local-onboarding-actions";
 
-function renderPhoneVerificationFlow() {
-  const startVerification = vi.fn().mockResolvedValue({ autoVerified: false });
-  const confirmVerification = vi.fn();
+function renderPhoneVerificationFlow(options?: { startRejects?: boolean }) {
+  const startVerification = options?.startRejects
+    ? vi.fn().mockRejectedValue(new Error("provider unavailable"))
+    : vi.fn().mockResolvedValue({ autoVerified: false });
+  const confirmVerification = vi.fn().mockResolvedValue({ uid: "user_1" });
   const onCompleted = vi.fn();
 
   render(
@@ -19,6 +22,8 @@ function renderPhoneVerificationFlow() {
 
   return {
     startVerification,
+    confirmVerification,
+    onCompleted,
   };
 }
 
@@ -65,5 +70,40 @@ describe("PhoneVerificationFlow country selector", () => {
         resendCode: false,
       });
     });
+  });
+
+  it("reports a failed voice settlement when the SMS provider rejects", async () => {
+    renderPhoneVerificationFlow({ startRejects: true });
+    await waitFor(() => {
+      expect(resolveLocalOnboardingHandler("phone_mandate.submit_number")).not.toBeNull();
+    });
+
+    const result = await resolveLocalOnboardingHandler("phone_mandate.submit_number")?.({
+      phoneNumber: "+16505550101",
+    });
+
+    expect(result).toMatchObject({ status: "failed" });
+  });
+
+  it("keeps the spoken code transient and settles only after confirmation succeeds", async () => {
+    const { confirmVerification, onCompleted } = renderPhoneVerificationFlow();
+    await waitFor(() => {
+      expect(resolveLocalOnboardingHandler("phone_mandate.submit_number")).not.toBeNull();
+    });
+    await resolveLocalOnboardingHandler("phone_mandate.submit_number")?.({
+      phoneNumber: "+16505550101",
+    });
+    await waitFor(() => {
+      expect(resolveLocalOnboardingHandler("phone_mandate.submit_code")).not.toBeNull();
+    });
+
+    const result = await resolveLocalOnboardingHandler("phone_mandate.submit_code")?.({
+      code: "123456",
+    });
+
+    expect(confirmVerification).toHaveBeenCalledWith("123456");
+    expect(onCompleted).toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "succeeded" });
+    expect(result?.summary).not.toContain("123456");
   });
 });

--- a/hushh-webapp/__tests__/lib/agent-runtime-context.test.tsx
+++ b/hushh-webapp/__tests__/lib/agent-runtime-context.test.tsx
@@ -9,6 +9,10 @@ import {
 } from "@/lib/agent/agent-runtime-context";
 
 let mockPathname = "/profile";
+const cacheMocks = vi.hoisted(() => ({
+  values: new Map<string, unknown>(),
+  listeners: new Set<(event: { type: "set"; key: string }) => void>(),
+}));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
@@ -50,11 +54,15 @@ vi.mock("@/lib/services/cache-service", () => ({
   CACHE_KEYS: {
     PORTFOLIO_DATA: (uid: string) => `portfolio:${uid}`,
     DOMAIN_DATA: (uid: string, domain: string) => `domain:${uid}:${domain}`,
+    PRE_VAULT_BOOTSTRAP: (uid: string) => `pre-vault:${uid}`,
   },
   CacheService: {
     getInstance: () => ({
-      get: () => null,
-      subscribe: () => () => undefined,
+      get: (key: string) => cacheMocks.values.get(key) ?? null,
+      subscribe: (listener: (event: { type: "set"; key: string }) => void) => {
+        cacheMocks.listeners.add(listener);
+        return () => cacheMocks.listeners.delete(listener);
+      },
     }),
   },
 }));
@@ -75,6 +83,8 @@ describe("AgentRuntimeStateProvider", () => {
   beforeEach(() => {
     mockPathname = "/profile";
     window.history.replaceState({}, "", "/profile");
+    cacheMocks.values.clear();
+    cacheMocks.listeners.clear();
   });
 
   it("updates shared runtime context for query-only route changes", async () => {
@@ -100,6 +110,45 @@ describe("AgentRuntimeStateProvider", () => {
         "/profile?panel=gmail&tab=account"
       );
       expect(latest?.oneVoiceContextSnapshot.revisions.route).toBeTruthy();
+      expect(latest?.morphyAxSnapshot.context.screen).toBe("profile_gmail_panel");
+      expect(latest?.morphyAxPresentation).toBe("idle");
+    });
+  });
+
+  it("publishes onboarding journey cache writes without remounting the provider", async () => {
+    mockPathname = "/one/setup";
+    const seen: AgentRuntimeState[] = [];
+    render(
+      <AgentRuntimeStateProvider>
+        <Probe onValue={(value) => seen.push(value)} />
+      </AgentRuntimeStateProvider>
+    );
+
+    await waitFor(() => expect(seen.at(-1)?.oneVoiceContextSnapshot.onboarding.phase).toBe("setup_hub"));
+
+    cacheMocks.values.set("pre-vault:user_1", {
+      userId: "user_1",
+      phoneVerified: true,
+      setupCompleted: false,
+      setupCapabilityIds: ["gmail"],
+      onboardingPhase: "external_connector",
+      onboardingActiveCapability: "gmail",
+      onboardingCallbackState: "pending",
+    });
+    act(() => {
+      for (const listener of cacheMocks.listeners) {
+        listener({ type: "set", key: "pre-vault:user_1" });
+      }
+    });
+
+    await waitFor(() => {
+      const onboarding = seen.at(-1)?.oneVoiceContextSnapshot.onboarding;
+      // The verified current setup-hub route remains phase authority, while
+      // durable connector/capability progress refreshes immediately.
+      expect(onboarding?.phase).toBe("setup_hub");
+      expect(onboarding?.active_capability).toBe("gmail");
+      expect(onboarding?.callback_state).toBe("pending");
+      expect(onboarding?.setup_capability_ids).toEqual(["gmail"]);
     });
   });
 });

--- a/hushh-webapp/__tests__/lib/seo.test.ts
+++ b/hushh-webapp/__tests__/lib/seo.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import robots from "@/app/robots";
 import sitemap from "@/app/sitemap";
+import { BLOG_POSTS } from "@/lib/research/blog";
 import {
   absoluteUrl,
   DISALLOWED_PREFIXES,
@@ -10,10 +11,13 @@ import {
 } from "@/lib/seo/site";
 
 describe("seo: sitemap", () => {
-  it("covers exactly the public allow-list routes", () => {
+  it("covers exactly the public allow-list routes and published posts", () => {
     const entries = sitemap();
     const urls = entries.map((e) => e.url).sort();
-    const expected = PUBLIC_ROUTES.map((r) => absoluteUrl(r)).sort();
+    const expected = [
+      ...PUBLIC_ROUTES.map((route) => absoluteUrl(route)),
+      ...BLOG_POSTS.map((post) => absoluteUrl(`/blog/${post.slug}`)),
+    ].sort();
     expect(urls).toEqual(expected);
   });
 

--- a/hushh-webapp/__tests__/morphy-ax/morphy-ax-contract.test.ts
+++ b/hushh-webapp/__tests__/morphy-ax/morphy-ax-contract.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMorphyAxSnapshot,
+  resolveMorphyAxPresentation,
+  toOneVoiceContextSnapshot,
+  validateMorphyAxAssessment,
+  type MorphyAxAssessmentV1,
+} from "@/lib/morphy-ax";
+import type { OneVoiceContextSnapshot } from "@/lib/voice/screen-context-builder";
+
+function voiceFixture(): OneVoiceContextSnapshot {
+  return {
+    schema_version: "one_voice_context.v1",
+    snapshot_id: "ctx_fixture",
+    revisions: { route: "r1", ui: "u1", cache: "c1", persona: "p1", voice: 2 },
+    route: {
+      screen: "one_intro",
+      playbook_id: "route.one.intro",
+      route_family: "/",
+      nav_stack: [],
+    },
+    ui: {
+      visible_modules: ["One intro"],
+      visible_control_ids: ["claim-your-one"],
+      selected_entity_present: false,
+    },
+    available_action_ids: ["onboarding.claim_one"],
+    pending_settlement: false,
+    cache: {
+      vault_ready: false,
+      portfolio_ready: false,
+      busy_operations: [],
+      freshness: "locked",
+    },
+    persona: {
+      active: "investor",
+      primary_nav: "investor",
+      available: ["investor"],
+    },
+    onboarding: {
+      phase: "anonymous_auth",
+      active_capability: null,
+      root_resolved: false,
+      return_route: "/one/setup",
+      phone_verified: null,
+      callback_state: "none",
+      setup_capability_ids: [],
+    },
+    voice: {
+      state: "listening",
+      transition_seq: 2,
+      session_id: null,
+      source_id: null,
+      last_transition: null,
+    },
+    world_model: { summary_available: false, mode: "redacted_summary_only" },
+    privacy: {
+      redacted: true,
+      excludes: ["raw_transcript", "credentials", "vault_material"],
+    },
+  };
+}
+
+function assessment(
+  overrides: Partial<MorphyAxAssessmentV1> = {},
+): MorphyAxAssessmentV1 {
+  return {
+    schema_version: "morphy_ax_assessment.v1",
+    source: "one",
+    disposition: "execute_visible_action",
+    candidate_action_id: "onboarding.claim_one",
+    missing_input: null,
+    ambiguous: false,
+    confidence: 1,
+    expected_outcome: "action",
+    ...overrides,
+  };
+}
+
+describe("Morphy AX contract", () => {
+  it("projects back to the unchanged One Voice wire shape", () => {
+    const baseline = voiceFixture();
+    const ax = buildMorphyAxSnapshot(baseline);
+    const projected = toOneVoiceContextSnapshot(ax, baseline);
+
+    expect(projected).toEqual(baseline);
+    expect(ax.privacy.redacted).toBe(true);
+    expect(ax.tools.available_action_ids).toEqual(["onboarding.claim_one"]);
+  });
+
+  it("admits only intelligence-selected actions visible on the current screen", () => {
+    const snapshot = buildMorphyAxSnapshot(voiceFixture());
+    expect(validateMorphyAxAssessment(assessment(), snapshot)).toEqual({
+      status: "permitted",
+      action_id: "onboarding.claim_one",
+    });
+    expect(
+      validateMorphyAxAssessment(
+        assessment({ candidate_action_id: "auth.sign_in_apple" }),
+        snapshot,
+      ),
+    ).toEqual({ status: "rejected", reason: "action_not_available_on_screen" });
+  });
+
+  it("preserves confirmation as a distinct policy decision", () => {
+    const snapshot = buildMorphyAxSnapshot(voiceFixture());
+    expect(
+      validateMorphyAxAssessment(
+        assessment({
+          disposition: "confirm_visible_action",
+          expected_outcome: "confirmation",
+        }),
+        snapshot,
+      ),
+    ).toEqual({
+      status: "confirmation_required",
+      action_id: "onboarding.claim_one",
+    });
+  });
+
+  it("clarifies ambiguity and never converts conversation into an action", () => {
+    const snapshot = buildMorphyAxSnapshot(voiceFixture());
+    expect(
+      validateMorphyAxAssessment(
+        assessment({ ambiguous: true, missing_input: "provider" }),
+        snapshot,
+      ),
+    ).toEqual({ status: "clarify", reason: "provider" });
+    expect(
+      validateMorphyAxAssessment(
+        assessment({
+          disposition: "answer_conversationally",
+          candidate_action_id: null,
+          expected_outcome: "conversation",
+        }),
+        snapshot,
+      ),
+    ).toEqual({
+      status: "conversation",
+      disposition: "answer_conversationally",
+    });
+  });
+
+  it("maps the existing voice FSM without creating another transition authority", () => {
+    expect(resolveMorphyAxPresentation("listening")).toBe("listening");
+    expect(resolveMorphyAxPresentation("needs_consent")).toBe("confirming");
+    expect(resolveMorphyAxPresentation("navigation_settling")).toBe("settling");
+    expect(resolveMorphyAxPresentation("error_recovery")).toBe("recovering");
+  });
+
+  it("meets the pure snapshot, policy, and presentation budgets over 10,000 runs", () => {
+    const baseline = voiceFixture();
+    const assessmentFixture = assessment();
+    const snapshotSamples: number[] = [];
+    const policySamples: number[] = [];
+    const presentationSamples: number[] = [];
+
+    for (let index = 0; index < 100; index += 1) {
+      const warm = buildMorphyAxSnapshot(baseline);
+      validateMorphyAxAssessment(assessmentFixture, warm);
+      resolveMorphyAxPresentation("listening");
+    }
+    for (let index = 0; index < 10_000; index += 1) {
+      let started = performance.now();
+      const snapshot = buildMorphyAxSnapshot(baseline);
+      snapshotSamples.push(performance.now() - started);
+      started = performance.now();
+      validateMorphyAxAssessment(assessmentFixture, snapshot);
+      policySamples.push(performance.now() - started);
+      started = performance.now();
+      resolveMorphyAxPresentation("listening");
+      presentationSamples.push(performance.now() - started);
+    }
+
+    const percentile = (values: number[], value: number) => {
+      const sorted = [...values].sort((left, right) => left - right);
+      return (
+        sorted[
+          Math.min(sorted.length - 1, Math.ceil(sorted.length * value) - 1)
+        ] ?? Infinity
+      );
+    };
+    expect(percentile(snapshotSamples, 0.95)).toBeLessThanOrEqual(5);
+    expect(percentile(snapshotSamples, 0.99)).toBeLessThanOrEqual(10);
+    expect(percentile(policySamples, 0.95)).toBeLessThanOrEqual(5);
+    expect(percentile(policySamples, 0.99)).toBeLessThanOrEqual(10);
+    expect(percentile(presentationSamples, 0.95)).toBeLessThanOrEqual(2);
+  });
+});

--- a/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
+++ b/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
@@ -153,4 +153,39 @@ describe("executeAgentGatewayAction", () => {
       unregisterLocalOnboardingHandler("auth.sign_in_google", handler);
     }
   });
+
+  it("settles the root claim action through its local handler", async () => {
+    const router = { push: vi.fn() };
+    const handler = vi.fn().mockResolvedValue({
+      status: "started",
+      summary: "Opening sign-in.",
+    });
+    registerLocalOnboardingHandler("onboarding.claim_one", handler);
+
+    try {
+      const result = await executeAgentGatewayAction({
+        actionId: "onboarding.claim_one",
+        slots: {},
+        userId: "",
+        router,
+        appRuntimeState: runtimeState({
+          auth: { signed_in: false, user_id: null },
+          vault: { unlocked: false, token_available: false, token_valid: false },
+          route: { pathname: "/", screen: "one_intro", subview: null },
+        }),
+        hasPortfolioData: false,
+        busyOperations: {},
+        setAnalysisParams: vi.fn(),
+      });
+
+      expect(handler).toHaveBeenCalledWith({}, undefined);
+      expect(result).toMatchObject({
+        status: "started",
+        actionId: "onboarding.claim_one",
+        resultSummary: "Opening sign-in.",
+      });
+    } finally {
+      unregisterLocalOnboardingHandler("onboarding.claim_one", handler);
+    }
+  });
 });

--- a/hushh-webapp/__tests__/voice/onboarding-journey-phase.test.ts
+++ b/hushh-webapp/__tests__/voice/onboarding-journey-phase.test.ts
@@ -1,0 +1,9 @@
+import { resolvePostPhoneOnboardingPhase } from "@/lib/onboarding/onboarding-journey-phase";
+import { describe, expect, it } from "vitest";
+
+describe("post-phone onboarding phase", () => {
+  it("returns to the setup hub unless the durable root gate is already resolved", () => {
+    expect(resolvePostPhoneOnboardingPhase(false)).toBe("setup_hub");
+    expect(resolvePostPhoneOnboardingPhase(true)).toBe("root_completion");
+  });
+});

--- a/hushh-webapp/__tests__/voice/onboarding-login-contract.test.ts
+++ b/hushh-webapp/__tests__/voice/onboarding-login-contract.test.ts
@@ -4,9 +4,10 @@ import { describe, expect, it } from "vitest";
 
 const contractPath = resolve(process.cwd(), "app/login/page.voice-action-contract.json");
 const welcomeContractPath = resolve(process.cwd(), "app/getting-started/page.voice-action-contract.json");
+const introContractPath = resolve(process.cwd(), "app/page.voice-action-contract.json");
 
 describe("One Voice Login onboarding contracts", () => {
-  it("exposes provider-specific redirect actions only on Login", () => {
+  it("exposes provider-specific popup actions only on Login", () => {
     const contract = JSON.parse(readFileSync(contractPath, "utf8"));
     const actions = new Map(contract.actions.map((action: { action_id: string }) => [action.action_id, action]));
 
@@ -14,24 +15,10 @@ describe("One Voice Login onboarding contracts", () => {
     expect(actions.get("auth.sign_in_google")).toMatchObject({
       execution_target: { path: "local_handler", target: "auth.sign_in_google" },
       reachability: { screens: ["login"] },
-      external_callback: {
-        provider: "google",
-        starts: "external_redirect_started",
-        settlement: "firebase_redirect_callback",
-        failure_behavior: "retain_goal_and_retry",
-        return_to: "/one/setup",
-      },
     });
     expect(actions.get("auth.sign_in_apple")).toMatchObject({
       execution_target: { path: "local_handler", target: "auth.sign_in_apple" },
       reachability: { screens: ["login"] },
-      external_callback: {
-        provider: "apple",
-        starts: "external_redirect_started",
-        settlement: "firebase_redirect_callback",
-        failure_behavior: "retain_goal_and_retry",
-        return_to: "/one/setup",
-      },
     });
   });
 
@@ -42,5 +29,20 @@ describe("One Voice Login onboarding contracts", () => {
     );
 
     expect(generic.reachability.screens).not.toContain("login");
+  });
+
+  it("exposes the visible root claim control as a root-only local action", () => {
+    const contract = JSON.parse(readFileSync(introContractPath, "utf8"));
+    const claim = contract.actions.find(
+      (action: { action_id: string }) => action.action_id === "onboarding.claim_one"
+    );
+
+    expect(claim).toMatchObject({
+      label: "Claim your One",
+      aliases: expect.arrayContaining(["claim your one", "claim my one", "get started"]),
+      reachability: { routes: ["/"], screens: ["one_intro"] },
+      execution_target: { path: "local_handler", target: "onboarding.claim_one" },
+      control_ids: ["onboarding_claim_one"],
+    });
   });
 });

--- a/hushh-webapp/__tests__/voice/one-voice-transport.test.ts
+++ b/hushh-webapp/__tests__/voice/one-voice-transport.test.ts
@@ -134,6 +134,50 @@ describe("One Voice realtime transports", () => {
     });
   });
 
+  it("emits one transcript-free visitor activity frame after sustained speech", () => {
+    const transport = new GeminiLiveTransport();
+    const send = vi.fn();
+    const testTransport = transport as unknown as {
+      ws: { readyState: number; send: (message: string) => void };
+      setupComplete: boolean;
+      sendVisitorActivityStart: (level: number, pcm: Uint8Array) => boolean;
+    };
+    testTransport.ws = { readyState: WebSocket.OPEN, send };
+    testTransport.setupComplete = true;
+
+    for (let index = 0; index < 7; index += 1) {
+      expect(testTransport.sendVisitorActivityStart(0.09, new Uint8Array([index]))).toBe(false);
+    }
+    expect(send).not.toHaveBeenCalled();
+
+    expect(testTransport.sendVisitorActivityStart(0.09, new Uint8Array([7]))).toBe(false);
+    expect(testTransport.sendVisitorActivityStart(0.5, new Uint8Array([8]))).toBe(true);
+
+    expect(send).toHaveBeenCalledTimes(9);
+    expect(JSON.parse(send.mock.calls[0][0])).toEqual({ type: "voice_activity_start" });
+    expect(JSON.parse(send.mock.calls[1][0])).toMatchObject({
+      realtimeInput: { audio: { data: expect.any(String) } },
+    });
+  });
+
+  it("does not treat low microphone energy as visitor activity", () => {
+    const transport = new GeminiLiveTransport();
+    const send = vi.fn();
+    const testTransport = transport as unknown as {
+      ws: { readyState: number; send: (message: string) => void };
+      setupComplete: boolean;
+      sendVisitorActivityStart: (level: number, pcm: Uint8Array) => boolean;
+    };
+    testTransport.ws = { readyState: WebSocket.OPEN, send };
+    testTransport.setupComplete = true;
+
+    for (let index = 0; index < 20; index += 1) {
+      testTransport.sendVisitorActivityStart(0.01, new Uint8Array([index]));
+    }
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("keeps OpenAI Realtime behind the same interface until enabled", async () => {
     const onEvent = vi.fn();
     const transport = new OpenAIRealtimeTransport({ onEvent });

--- a/hushh-webapp/__tests__/voice/route-orchestration-index.test.ts
+++ b/hushh-webapp/__tests__/voice/route-orchestration-index.test.ts
@@ -1,17 +1,71 @@
 import index from "@/contracts/kai/one-route-orchestration-index.v1.json";
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
+import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
 import { describe, expect, it } from "vitest";
 
 describe("One route orchestration index", () => {
   it("covers each physical route exactly once with bounded metadata", () => {
-    expect(index.schema_version).toBe("one.route_orchestration_index.v1");
+    expect(index.schema_version).toBe("one.route_orchestration_index.v2");
     expect(index.routes.length).toBeGreaterThan(0);
     expect(new Set(index.routes.map((entry) => entry.route_pattern)).size).toBe(index.routes.length);
     expect(index.routes.every((entry) => entry.instruction_id && entry.context_policy)).toBe(true);
+    expect(index.routes.every((entry) => entry.voice_playbook?.playbook_id)).toBe(true);
   });
 
   it("keeps generic sign-in off Login while retaining explicit provider actions", () => {
     const login = index.routes.find((entry) => entry.route_pattern === "/login");
     expect(login?.action_ids).toEqual(["auth.sign_in_apple", "auth.sign_in_google"]);
+  });
+
+  it("keeps every generated executable route action aligned with a canonical screen", () => {
+    const mismatches: string[] = [];
+    for (const route of index.routes) {
+      const canonicalScreen = deriveVoiceRouteScreen(route.route_pattern).screen;
+      for (const actionId of route.action_ids) {
+        const action = getKaiActionById(actionId);
+        const routeIsTheActionSurface =
+          action?.reachability.routes.length === 1 &&
+          action.reachability.routes[0] === route.route_pattern;
+        if (!routeIsTheActionSurface) continue;
+        if (!action) {
+          mismatches.push(`${route.route_pattern}: missing ${actionId}`);
+          continue;
+        }
+        if (!action.reachability.screens.includes(canonicalScreen)) {
+          mismatches.push(
+            `${route.route_pattern}: ${actionId} lacks canonical screen ${canonicalScreen}`
+          );
+        }
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it("indexes the root welcome as a published, generated action surface", () => {
+    const root = index.routes.find((entry) => entry.route_pattern === "/");
+    expect(root).toMatchObject({
+      instruction_id: "route.one.intro",
+      context_policy: "publish",
+      action_ids: ["onboarding.claim_one"],
+      delegation_policy: { mode: "no_delegation" },
+    });
+    expect(root?.voice_playbook).toMatchObject({
+      screen: "one_intro",
+      primary_action_id: "onboarding.claim_one",
+      proactivity: "on_entry",
+    });
+  });
+
+  it("joins the shared dynamic setup route to its concrete action contract", () => {
+    const capability = index.routes.find(
+      (entry) => entry.route_pattern === "/one/setup/[capability]"
+    );
+    expect(capability?.orchestration_class).toBe("interactive");
+    expect(capability?.action_ids).toEqual(["setup.capability_continue"]);
+    expect(capability?.voice_playbook.primary_action_id).toBe("setup.capability_continue");
+    expect(capability?.voice_contract_file).toContain(
+      "one-onboarding-capability-step.voice-action-contract.json"
+    );
   });
 
   it("admits Location delegation only from its declared route", () => {

--- a/hushh-webapp/__tests__/voice/route-playbook-contract.test.ts
+++ b/hushh-webapp/__tests__/voice/route-playbook-contract.test.ts
@@ -1,0 +1,47 @@
+import surfaceMap from "@/frontend-native-surface-map.generated.json";
+import { APP_ROUTE_LAYOUT_CONTRACT, resolveAppRouteLayout } from "@/lib/navigation/app-route-layout";
+import { PUBLIC_ROUTES, PUBLIC_ROUTE_SEMANTICS } from "@/lib/seo/site";
+import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
+import { describe, expect, it } from "vitest";
+
+describe("One route voice playbooks", () => {
+  it("authors exactly one bounded playbook for every physical route", () => {
+    const physicalRoutes = surfaceMap.routes
+      .filter((entry) => entry.physical_page_exists)
+      .map((entry) => entry.route)
+      .sort();
+    const authoredRoutes = APP_ROUTE_LAYOUT_CONTRACT.map((entry) => entry.route).sort();
+
+    expect(authoredRoutes).toEqual(physicalRoutes);
+    expect(new Set(authoredRoutes).size).toBe(authoredRoutes.length);
+    for (const entry of APP_ROUTE_LAYOUT_CONTRACT) {
+      expect(entry.voicePlaybook.playbookId).toMatch(/^route\./);
+      expect(entry.voicePlaybook.purpose.length).toBeGreaterThan(0);
+      expect(entry.voicePlaybook.screen).toBe(deriveVoiceRouteScreen(entry.route).screen);
+      expect(entry.voicePlaybook.completionBoundary.length).toBeGreaterThan(0);
+      if (entry.voicePlaybook.proactivity === "on_entry") {
+        expect(entry.voicePlaybook.entryCue.length).toBeGreaterThan(0);
+        expect(entry.voicePlaybook.primaryActionId).toBeTruthy();
+      }
+    }
+  });
+
+  it("prefers exact setup routes before the dynamic capability pattern", () => {
+    expect(resolveAppRouteLayout("/one/setup/kai").route).toBe("/one/setup/kai");
+    expect(resolveAppRouteLayout("/one/setup/finance").route).toBe(
+      "/one/setup/[capability]"
+    );
+  });
+
+  it("aligns public SEO/AEO semantics by route identity without publishing runtime prompts", () => {
+    for (const route of PUBLIC_ROUTES) {
+      const layout = resolveAppRouteLayout(route);
+      expect(PUBLIC_ROUTE_SEMANTICS[route].voicePlaybookId).toBe(
+        layout.voicePlaybook.playbookId,
+      );
+      expect(PUBLIC_ROUTE_SEMANTICS[route].description).not.toContain(
+        layout.voicePlaybook.recoveries.failed,
+      );
+    }
+  });
+});

--- a/hushh-webapp/__tests__/voice/route-screen-derivation.test.ts
+++ b/hushh-webapp/__tests__/voice/route-screen-derivation.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vitest";
 import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
 
 describe("deriveVoiceRouteScreen", () => {
+  it("keeps the public One introduction distinct from authenticated One", () => {
+    expect(deriveVoiceRouteScreen("/")).toEqual({
+      screen: "one_intro",
+      subview: null,
+    });
+    expect(deriveVoiceRouteScreen("/one")).toEqual({
+      screen: "one_agents",
+      subview: null,
+    });
+  });
+
   it("maps the One Agents dashboard to an explicit voice screen", () => {
     expect(deriveVoiceRouteScreen("/one")).toEqual({
       screen: "one_agents",
@@ -136,6 +147,14 @@ describe("deriveVoiceRouteScreen", () => {
   });
 
   it("maps RIA roster, workspace, and detail routes to specific voice screens", () => {
+    expect(deriveVoiceRouteScreen("/ria/onboarding")).toEqual({
+      screen: "ria_onboarding",
+      subview: null,
+    });
+    expect(deriveVoiceRouteScreen("/ria/profile", "tab=services")).toEqual({
+      screen: "ria_profile",
+      subview: "services",
+    });
     expect(deriveVoiceRouteScreen("/ria/clients")).toEqual({
       screen: "ria_clients",
       subview: null,

--- a/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
+++ b/hushh-webapp/__tests__/voice/screen-context-builder.test.ts
@@ -192,6 +192,38 @@ describe("buildStructuredScreenContext", () => {
     expect(analysisContext.ui.active_section).toBe("history");
   });
 
+  it("publishes the root claim control as the generated action available on one_intro", () => {
+    window.history.pushState({}, "", "/");
+    publishVoiceSurfaceMetadata("test_surface", {
+      screenId: "one_intro",
+      title: "Claim your One",
+      purpose: "Continue to sign in and begin setting up One.",
+      actions: [
+        {
+          id: "onboarding_claim_one",
+          actionId: "onboarding.claim_one",
+          label: "Claim your One",
+        },
+      ],
+      controls: [
+        {
+          id: "onboarding_claim_one",
+          actionId: "onboarding.claim_one",
+          label: "Claim your One",
+          type: "button",
+        },
+      ],
+    });
+
+    const snapshot = buildOneVoiceContextSnapshot({
+      appRuntimeState: makeRuntimeState("/", "one_intro"),
+    });
+
+    expect(snapshot.route.screen).toBe("one_intro");
+    expect(snapshot.available_action_ids).toContain("onboarding.claim_one");
+    expect(snapshot.available_action_ids).not.toContain("onboarding_claim_one");
+  });
+
   it("collects visible modules from DOM attributes", () => {
     window.history.pushState({}, "", "/profile?tab=account");
     document.body.innerHTML = `

--- a/hushh-webapp/__tests__/voice/setup-catalog-action-parity.test.ts
+++ b/hushh-webapp/__tests__/voice/setup-catalog-action-parity.test.ts
@@ -1,0 +1,22 @@
+import gateway from "@/contracts/kai/kai-action-gateway.vnext.json";
+import { ONE_CAPABILITIES } from "@/lib/onboarding/one-capabilities";
+import { buildOneSetupCapabilityRoute } from "@/lib/navigation/routes";
+import { describe, expect, it } from "vitest";
+
+describe("setup catalog voice parity", () => {
+  it("keeps every visible capability mapped to one wired route action", () => {
+    const actions = new Map(gateway.actions.map((action) => [action.action_id, action]));
+
+    expect(ONE_CAPABILITIES).toHaveLength(8);
+    for (const capability of ONE_CAPABILITIES) {
+      const action = actions.get(capability.setupActionId);
+      expect(action, capability.id).toBeDefined();
+      expect(action?.execution_target).toMatchObject({
+        status: "wired",
+        path: "route",
+        target: buildOneSetupCapabilityRoute(capability.id),
+      });
+      expect(action?.control_ids).toContain(capability.setupControlId);
+    }
+  });
+});

--- a/hushh-webapp/__tests__/voice/voice-feature-flags.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-feature-flags.test.ts
@@ -12,6 +12,7 @@ const ORIGINAL_ENV = {
     process.env.NEXT_PUBLIC_VOICE_V2_GROUNDED_ACTION_EXECUTION_ENABLED,
   NEXT_PUBLIC_VOICE_V2_CLIENT_VAD_FALLBACK_ENABLED:
     process.env.NEXT_PUBLIC_VOICE_V2_CLIENT_VAD_FALLBACK_ENABLED,
+  NEXT_PUBLIC_MORPHY_AX_ENABLED: process.env.NEXT_PUBLIC_MORPHY_AX_ENABLED,
 };
 
 function restoreEnv() {
@@ -55,5 +56,12 @@ describe("voice-feature-flags", () => {
     expect(flags.groundedActionResolutionEnabled).toBe(true);
     expect(flags.groundedActionPolicyEnforcementEnabled).toBe(true);
     expect(flags.groundedActionExecutionEnabled).toBe(false);
+  });
+
+  it("keeps Morphy AX off by default and independently reversible", () => {
+    delete process.env.NEXT_PUBLIC_MORPHY_AX_ENABLED;
+    expect(getVoiceV2Flags().morphyAxEnabled).toBe(false);
+    process.env.NEXT_PUBLIC_MORPHY_AX_ENABLED = "1";
+    expect(getVoiceV2Flags().morphyAxEnabled).toBe(true);
   });
 });

--- a/hushh-webapp/__tests__/voice/voice-sensitive-redaction.test.ts
+++ b/hushh-webapp/__tests__/voice/voice-sensitive-redaction.test.ts
@@ -1,0 +1,19 @@
+import { redactSensitiveVoiceTranscript } from "@/lib/voice/voice-sensitive-redaction";
+import { describe, expect, it } from "vitest";
+
+describe("voice sensitive transcript redaction", () => {
+  it("redacts spoken phone and OTP digits from the phone-screen mirror", () => {
+    expect(redactSensitiveVoiceTranscript("My code is 123 456", "register_phone")).toBe(
+      "My code is [sensitive number redacted]"
+    );
+    expect(redactSensitiveVoiceTranscript("+1 650 555 0101", "phone_mandate")).toBe(
+      "+[sensitive number redacted]"
+    );
+  });
+
+  it("does not alter ordinary conversation on other screens", () => {
+    expect(redactSensitiveVoiceTranscript("Analyze 2026 results", "one_agents")).toBe(
+      "Analyze 2026 results"
+    );
+  });
+});

--- a/hushh-webapp/app/blog/page.tsx
+++ b/hushh-webapp/app/blog/page.tsx
@@ -4,7 +4,7 @@ import { BlogIndex } from "@/components/research/blog-index";
 export const metadata: Metadata = {
   title: "Blog · Hushh Research",
   description:
-    "Writing on consent-first data sharing, the Personal Consent Handshake Protocol, and working backwards from the human — by Manish Sainani and the 🤫 Research & Intelligence Team.",
+    "Writing on consent-first information sharing, the Personal Consent Handshake Protocol, and working backwards from the human — by Manish Sainani and the 🤫 Research & Intelligence Team.",
 };
 
 export default function BlogPage() {

--- a/hushh-webapp/app/developers/page.tsx
+++ b/hushh-webapp/app/developers/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import { DeveloperDocsHub } from "@/components/developers/developer-docs-hub";
+
+export const metadata: Metadata = {
+  title: "Developers · Hussh",
+  description:
+    "Build consent-first agent experiences with Hussh protocols and developer tools.",
+};
 
 export default function DevelopersPage() {
   return <DeveloperDocsHub />;

--- a/hushh-webapp/app/layout.tsx
+++ b/hushh-webapp/app/layout.tsx
@@ -19,8 +19,8 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://hushh.ai"),
   title: "Hussh One | Your Private Agent",
   description:
-    "Personal AI agents with consent at the core. Your information, your control.",
-  keywords: ["AI agents", "personal AI", "Hussh One", "consent-first", "privacy"],
+    "Private AI agents with consent at the core. Your information, your control.",
+  keywords: ["AI agents", "private AI", "Hussh One", "consent-first", "privacy"],
   authors: [{ name: "Hussh Labs" }],
   icons: {
     icon: [
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
   manifest: "/manifest.webmanifest",
   openGraph: {
     title: "Hussh One | Your Private Agent",
-    description: "Personal AI agents with consent at the core.",
+    description: "Private AI agents with consent at the core.",
     siteName: "Hussh",
     url: "https://hushh.ai",
     type: "website",
@@ -55,7 +55,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Hussh One | Your Private Agent",
-    description: "Personal AI agents with consent at the core.",
+    description: "Private AI agents with consent at the core.",
     images: ["/quiet-emoji-icon.png"],
   },
 };

--- a/hushh-webapp/app/login/layout.tsx
+++ b/hushh-webapp/app/login/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/hushh-webapp/app/login/page.voice-action-contract.json
+++ b/hushh-webapp/app/login/page.voice-action-contract.json
@@ -15,7 +15,7 @@
     {
       "action_id": "auth.sign_in_google",
       "label": "Continue with Google",
-      "meaning": "Starts Google sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Google provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "aliases": ["sign in with google", "continue with google", "google sign in"],
       "search_keywords": ["google", "sign in", "login", "authenticate"],
       "reachability": {
@@ -46,7 +46,7 @@
     {
       "action_id": "auth.sign_in_apple",
       "label": "Continue with Apple",
-      "meaning": "Starts Apple sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Apple provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "aliases": ["sign in with apple", "continue with apple", "apple sign in"],
       "search_keywords": ["apple", "sign in", "login", "authenticate"],
       "reachability": {

--- a/hushh-webapp/app/one/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/page.voice-action-contract.json
@@ -3,8 +3,6 @@
   "surface_id": "one_agents",
   "surface_title": "Agents",
   "orchestration": {
-    "instruction_id": "route.one.home",
-    "context_policy": "publish",
     "trust_boundary": "consent",
     "delegation_policy": "one_action_gate"
   },

--- a/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx
+++ b/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-client.tsx
@@ -104,7 +104,7 @@ export function OneOnboardingCapabilityClient({
     // just forward so the user is never stranded on this screen.
     if (!userId) {
       router.replace(target);
-      return;
+      return { status: "started" as const, summary: "Opening the capability." };
     }
 
     setBusy(true);
@@ -118,7 +118,7 @@ export function OneOnboardingCapabilityClient({
         userId,
         phase: "capability_setup",
         activeCapability: capabilityId,
-      }).catch(() => undefined);
+      });
 
       if (capability?.isExploreOnly === true) {
         await CapabilityTourService.markExplored(userId, capabilityId).catch(
@@ -136,14 +136,22 @@ export function OneOnboardingCapabilityClient({
       // allows through) — see the component doc comment. Marking
       // `setupCompleted = true` on capability entry was the cause of the
       // dashboard "Finish setup" bar clearing prematurely.
+      router.replace(target);
+      return {
+        status: "started" as const,
+        summary: `Opening ${capability?.title || capabilityId}.`,
+      };
     } catch (resolveError) {
       console.warn(
         "[OneOnboardingCapabilityClient] Failed to record capability signal:",
         resolveError,
       );
-      // Fail-open: still forward so the user is never stranded.
+      return {
+        status: "failed" as const,
+        summary: "This setup step could not save its progress. Please try again.",
+      };
     } finally {
-      router.replace(target);
+      setBusy(false);
     }
   };
 
@@ -158,8 +166,7 @@ export function OneOnboardingCapabilityClient({
     if (busy) {
       return { status: "blocked", summary: "Already continuing, one moment." };
     }
-    await runPrimary();
-    return { status: "succeeded", summary: `Continuing from ${capability.title} setup.` };
+    return runPrimary();
   });
 
   if (!capability) {

--- a/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json
+++ b/hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json
@@ -21,7 +21,7 @@
       "aliases": ["continue", "unlock and continue", "got it", "next"],
       "search_keywords": ["continue", "next", "got it", "unlock"],
       "reachability": {
-        "routes": ["/one/setup/finance", "/one/setup/gmail", "/one/setup/email", "/one/setup/location", "/one/setup/pkm", "/one/setup/consent", "/one/setup/connected-systems"],
+        "routes": ["/one/setup/finance", "/one/setup/gmail", "/one/setup/email", "/one/setup/location", "/one/setup/pkm", "/one/setup/consent", "/one/setup/marketplace", "/one/setup/connected-systems"],
         "screens": [
           "one_setup_finance",
           "one_setup_gmail",
@@ -29,6 +29,7 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
+          "one_setup_marketplace",
           "one_setup_connected-systems",
           "one_setup"
         ],

--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -297,7 +297,9 @@ function KaiOnboardingPageContent() {
   }, [source, stage]);
 
   const handleLaunchDashboard = async () => {
-    if (saving || !user) return;
+    if (saving || !user) {
+      return { status: "blocked" as const, summary: "Finance setup is not ready to finish yet." };
+    }
 
     try {
       setSaving(true);
@@ -306,15 +308,11 @@ function KaiOnboardingPageContent() {
       // person can continue through the rest of One's onboarding deliberately.
       await CapabilityTourService.markExplored(user.uid, "finance");
       const explored = await CapabilityTourService.loadExploredIds(user.uid);
-      await PreVaultUserStateService.syncSetupCapabilities(user.uid, explored).catch(
-        (syncError) => {
-          console.warn("[OneOnboardingPage] Failed finance capability sync:", syncError);
-        }
-      );
+      await PreVaultUserStateService.syncSetupCapabilities(user.uid, explored);
       await PreVaultUserStateService.syncOnboardingJourney({
         userId: user.uid,
         phase: "setup_hub",
-      }).catch(() => undefined);
+      });
       toast.success("Finance preferences saved. Back to your setup checklist.");
       setOnboardingRequiredCookie(true);
       setOnboardingFlowActiveCookie(false);
@@ -323,6 +321,10 @@ function KaiOnboardingPageContent() {
         result: "success",
       });
       router.replace(buildOneSetupRoute({ from: onboardingFromHref }));
+      return {
+        status: "succeeded" as const,
+        summary: "Finance preferences saved. Returning to setup.",
+      };
     } catch (error) {
       console.error("[OneOnboardingPage] Failed to finalize onboarding:", error);
       trackEvent("onboarding_completed", {
@@ -330,6 +332,10 @@ function KaiOnboardingPageContent() {
         result: "error",
       });
       toast.error("Couldn't complete onboarding. Please retry.");
+      return {
+        status: "failed" as const,
+        summary: "Finance preferences could not be finalized. Please try again.",
+      };
     } finally {
       setSaving(false);
     }
@@ -346,8 +352,7 @@ function KaiOnboardingPageContent() {
     if (stage !== "persona") {
       return { status: "blocked", summary: "Answer all three questions first." };
     }
-    await handleLaunchDashboard();
-    return { status: "succeeded", summary: "Finance preferences saved. Returning to setup." };
+    return handleLaunchDashboard();
   });
 
   // Publish the screen id the generated action contract expects

--- a/hushh-webapp/app/one/setup/kai/page.voice-action-contract.json
+++ b/hushh-webapp/app/one/setup/kai/page.voice-action-contract.json
@@ -121,10 +121,10 @@
     },
     {
       "action_id": "kai.setup.launch_dashboard",
-      "label": "Launch Kai Dashboard",
-      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
-      "aliases": ["launch my dashboard", "looks good, continue", "finish kai setup"],
-      "search_keywords": ["launch", "dashboard", "finish", "persona"],
+      "label": "Save Finance Preferences",
+      "meaning": "Saves Finance preferences, marks only Finance ready, and returns to the One setup hub without resolving root onboarding.",
+      "aliases": ["save finance preferences", "looks good, continue", "finish finance setup"],
+      "search_keywords": ["save", "finance", "preferences", "finish", "persona"],
       "reachability": {
         "routes": ["/one/setup/kai"],
         "screens": ["kai_setup_wizard", "one_setup"],

--- a/hushh-webapp/app/page.voice-action-contract.json
+++ b/hushh-webapp/app/page.voice-action-contract.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "kai.local_action_contract.v1",
+  "surface_id": "one_intro",
+  "surface_title": "Claim your One",
+  "docs_references": [
+    "docs/reference/one/one-voice-runtime-architecture.md",
+    "docs/reference/one/one-voice-onboarding-journey.md"
+  ],
+  "orchestration": {
+    "trust_boundary": "none",
+    "delegation_policy": "no_delegation"
+  },
+  "defaults": {
+    "reachability": {
+      "active_personas": ["investor", "ria"]
+    },
+    "speaker_persona": "one"
+  },
+  "actions": [
+    {
+      "action_id": "onboarding.claim_one",
+      "label": "Claim your One",
+      "meaning": "Continues from One's public welcome screen to sign in and begin setup.",
+      "aliases": [
+        "claim your one",
+        "claim my one",
+        "claim one",
+        "get started",
+        "start with one",
+        "begin with one"
+      ],
+      "search_keywords": ["claim", "one", "start", "welcome", "sign in"],
+      "reachability": {
+        "routes": ["/"],
+        "screens": ["one_intro"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "onboarding.claim_one"
+      },
+      "control_ids": ["onboarding_claim_one"],
+      "state_exposure": [],
+      "docs_references": []
+    }
+  ]
+}

--- a/hushh-webapp/app/profile/gmail/oauth/return/page-client.tsx
+++ b/hushh-webapp/app/profile/gmail/oauth/return/page-client.tsx
@@ -18,6 +18,11 @@ import {
 } from "@/lib/profile/mail-flow";
 import { primeConnectorStatus } from "@/lib/profile/gmail-connector-store";
 import { GmailReceiptsService } from "@/lib/services/gmail-receipts-service";
+import {
+  clearOnboardingConnectorIntent,
+  readOnboardingConnectorIntent,
+} from "@/lib/onboarding/onboarding-connector-intent";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 
 type CompleteStage = "loading" | "completing" | "redirecting" | "error";
 
@@ -45,6 +50,7 @@ export default function ProfileGmailOAuthReturnPageClient({
   const { user, loading } = useAuth();
   const [stage, setStage] = useState<CompleteStage>("loading");
   const [error, setError] = useState<string | null>(null);
+  const [returnToSetup] = useState(() => Boolean(readOnboardingConnectorIntent()));
 
   useEffect(() => {
     if (loading || startedRef.current) return;
@@ -55,10 +61,22 @@ export default function ProfileGmailOAuthReturnPageClient({
     const liveState = String(searchParams.get("state") || "").trim();
 
     const oauthError = liveError || initialError;
+    const onboardingIntent = readOnboardingConnectorIntent();
     if (oauthError) {
       const oauthErrorDescription = liveErrorDescription || initialErrorDescription;
       setStage("error");
       setError(oauthErrorDescription || oauthError || "Google OAuth authorization was denied.");
+      if (user?.uid && onboardingIntent) {
+        void PreVaultUserStateService.syncOnboardingJourney({
+          userId: user.uid,
+          phase: "external_connector",
+          activeCapability: "gmail",
+          callbackState: "cancelled",
+        }).catch((error) => {
+          console.warn("[GmailOAuthReturn] Failed to persist cancellation:", error);
+        });
+        clearOnboardingConnectorIntent();
+      }
       return;
     }
 
@@ -67,6 +85,17 @@ export default function ProfileGmailOAuthReturnPageClient({
     if (!code || !state) {
       setStage("error");
       setError("Missing OAuth code or state. Start Connect Gmail again from Gmail.");
+      if (user?.uid && onboardingIntent) {
+        void PreVaultUserStateService.syncOnboardingJourney({
+          userId: user.uid,
+          phase: "external_connector",
+          activeCapability: "gmail",
+          callbackState: "cancelled",
+        }).catch((error) => {
+          console.warn("[GmailOAuthReturn] Failed to persist invalid callback:", error);
+        });
+        clearOnboardingConnectorIntent();
+      }
       return;
     }
 
@@ -105,7 +134,23 @@ export default function ProfileGmailOAuthReturnPageClient({
         stashProfileGmailReturnStatus(status);
 
         setStage("redirecting");
-        router.replace(buildProfileGmailReturnPath());
+        if (onboardingIntent) {
+          await PreVaultUserStateService.syncOnboardingJourney({
+            userId: user.uid,
+            phase: "setup_hub",
+            activeCapability: null,
+            callbackState: "succeeded",
+          }).catch((error) => {
+            // Connector success is authoritative even if the resumable journey
+            // echo is temporarily unavailable. Do not relabel a connected
+            // account as a failed OAuth callback.
+            console.warn("[GmailOAuthReturn] Failed to persist setup return:", error);
+          });
+          clearOnboardingConnectorIntent();
+          router.replace(ROUTES.ONE_SETUP);
+        } else {
+          router.replace(buildProfileGmailReturnPath());
+        }
       } catch (completeError) {
         if (isRecoverableGmailOAuthReplayError(completeError)) {
           try {
@@ -123,7 +168,20 @@ export default function ProfileGmailOAuthReturnPageClient({
               });
               stashProfileGmailReturnStatus(status);
               setStage("redirecting");
-              router.replace(buildProfileGmailReturnPath());
+              if (onboardingIntent) {
+                await PreVaultUserStateService.syncOnboardingJourney({
+                  userId: user.uid,
+                  phase: "setup_hub",
+                  activeCapability: null,
+                  callbackState: "succeeded",
+                }).catch((error) => {
+                  console.warn("[GmailOAuthReturn] Failed to persist replay return:", error);
+                });
+                clearOnboardingConnectorIntent();
+                router.replace(ROUTES.ONE_SETUP);
+              } else {
+                router.replace(buildProfileGmailReturnPath());
+              }
               return;
             }
           } catch {
@@ -132,6 +190,15 @@ export default function ProfileGmailOAuthReturnPageClient({
         }
         setStage("error");
         setError(resolveErrorMessage(completeError));
+        if (onboardingIntent) {
+          await PreVaultUserStateService.syncOnboardingJourney({
+            userId: user.uid,
+            phase: "external_connector",
+            activeCapability: "gmail",
+            callbackState: "failed",
+          }).catch(() => undefined);
+          clearOnboardingConnectorIntent();
+        }
       }
     })();
   }, [
@@ -192,8 +259,11 @@ export default function ProfileGmailOAuthReturnPageClient({
           <h1 className="text-lg font-semibold text-foreground">Gmail connection needs attention</h1>
           <p className="mt-2 text-sm text-muted-foreground">{error}</p>
           <div className="mt-4 flex flex-col gap-2">
-            <Button onClick={() => router.replace(buildProfileGmailReturnPath())} className="w-full">
-              Back to Gmail
+            <Button
+              onClick={() => router.replace(returnToSetup ? ROUTES.ONE_SETUP : buildProfileGmailReturnPath())}
+              className="w-full"
+            >
+              {returnToSetup ? "Back to setup" : "Back to Gmail"}
             </Button>
           </div>
         </div>

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -24,8 +24,10 @@ import {
   setOnboardingRequiredCookie,
 } from "@/lib/services/onboarding-route-cookie";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-mandate-service";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+import { resolvePostPhoneOnboardingPhase } from "@/lib/onboarding/onboarding-journey-phase";
 
 function requiresVaultUnlockForRedirect(path?: string | null): boolean {
   const normalizedPath = String(path ?? "").trim();
@@ -87,6 +89,24 @@ function PhoneMandatePageContent() {
         phoneNumber: activeUser.phoneNumber,
         phoneVerified: AccountIdentityService.hasVerifiedPhone(identity),
         hostname: window.location.hostname,
+      });
+      const setupResolved = await PreVaultUserStateService.bootstrapState(activeUser.uid, {
+        force: true,
+      })
+        .then((state) => PreVaultUserStateService.isSetupResolved(state))
+        .catch((error) => {
+          console.warn("[RegisterPhonePage] Failed to refresh setup state:", error);
+          return false;
+        });
+      await PreVaultUserStateService.syncOnboardingJourney({
+        userId: activeUser.uid,
+        // A destination is never proof that root onboarding resolved. Only the
+        // hub's durable Finish/Skip write can move the journey to completion.
+        phase: resolvePostPhoneOnboardingPhase(setupResolved),
+        activeCapability: null,
+        callbackState: "none",
+      }).catch((error) => {
+        console.warn("[RegisterPhonePage] Failed to persist phone journey settlement:", error);
       });
       router.replace(nextPath);
     },

--- a/hushh-webapp/app/register-phone/page.voice-action-contract.json
+++ b/hushh-webapp/app/register-phone/page.voice-action-contract.json
@@ -56,7 +56,7 @@
     {
       "action_id": "phone_mandate.submit_code",
       "label": "Submit Verification Code",
-      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "meaning": "Confirms the six-digit SMS code after an explicit inline confirmation and completes phone verification. The code is sensitive and must never be repeated or retained.",
       "aliases": [
         "the code is",
         "verify my code",
@@ -70,17 +70,27 @@
         "hidden_navigable": false,
         "navigation_prerequisites": ["A verification code must already be sent."]
       },
-      "guard_ids": ["auth_signed_in", "manual_user_execution"],
+      "guard_ids": ["auth_signed_in", "explicit_user_confirmation"],
       "risk_level": "high",
-      "execution_policy": "manual_only",
+      "execution_policy": "confirm_required",
       "execution_target": {
-        "status": "unwired",
-        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
-        "intended_handler": "local_handler"
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_code"
       },
       "control_ids": ["phone-flow-code"],
       "state_exposure": ["verification step"],
-      "docs_references": ["hushh-webapp/components/auth/phone-verification-flow.tsx"]
+      "docs_references": ["hushh-webapp/components/auth/phone-verification-flow.tsx"],
+      "goal": {
+        "required_inputs": [
+          {
+            "name": "verification_code",
+            "prompt": "Say or type the six-digit code. Spoken codes are processed by the voice service.",
+            "required": true,
+            "slot": "code"
+          }
+        ]
+      }
     }
   ]
 }

--- a/hushh-webapp/app/sitemap.ts
+++ b/hushh-webapp/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 
 import { absoluteUrl, PUBLIC_ROUTES } from "@/lib/seo/site";
+import { BLOG_POSTS } from "@/lib/research/blog";
 
 /**
  * sitemap.xml
@@ -11,10 +12,18 @@ import { absoluteUrl, PUBLIC_ROUTES } from "@/lib/seo/site";
 export default function sitemap(): MetadataRoute.Sitemap {
   const lastModified = new Date();
 
-  return PUBLIC_ROUTES.map((route) => ({
+  return [
+    ...PUBLIC_ROUTES.map((route) => ({
     url: absoluteUrl(route),
     lastModified,
     changeFrequency: route === "/" ? "daily" : "weekly",
     priority: route === "/" ? 1 : 0.7,
-  }));
+    } as const)),
+    ...BLOG_POSTS.map((post) => ({
+      url: absoluteUrl(`/blog/${post.slug}`),
+      lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    })),
+  ];
 }

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -35,26 +35,43 @@ import {
   useAgentVoiceState,
 } from "@/lib/agent/agent-voice-state";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
+import { validateMorphyAxAssessment } from "@/lib/morphy-ax";
 import { useKaiBottomChromeVisibility } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
-import { ROUTES, isFoundationPublicRoute, isOneSetupRoute } from "@/lib/navigation/routes";
+import {
+  ROUTES,
+  isFoundationPublicRoute,
+  isOneSetupRoute,
+} from "@/lib/navigation/routes";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import { getVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+import { getKaiActionById } from "@/lib/voice/kai-action-gateway";
 import { createRealtimeVoiceTransport } from "@/lib/voice/one-voice-transport-factory";
 import type {
   OneVoiceSessionEvent,
   RealtimeVoiceTransport,
 } from "@/lib/voice/one-voice-transport";
-import type { AgentVoiceEventOptions, AgentVoiceStatus } from "@/lib/agent/agent-voice-state";
+import type {
+  AgentVoiceEventOptions,
+  AgentVoiceStatus,
+} from "@/lib/agent/agent-voice-state";
+import { redactSensitiveVoiceTranscript } from "@/lib/voice/voice-sensitive-redaction";
 
 type PrewarmedGeminiRelay = {
   relayUrl: string;
   expiresAtMs: number;
   snapshotId: string;
   accessTier: string;
+};
+
+type PendingVoiceConfirmation = {
+  directiveId: string;
+  actionId: string;
+  slots?: Record<string, unknown>;
+  route: string | null;
 };
 
 // Precaution: if a live voice session sits idle (no user speech, no agent
@@ -109,8 +126,12 @@ export function AgentBar() {
   const { switchPersona } = usePersonaState();
   const busyOperations = useKaiSession((state) => state.busyOperations);
   const setAnalysisParams = useKaiSession((state) => state.setAnalysisParams);
-  const appendMirrorEvent = useOneConversationSession((state) => state.appendMirrorEvent);
-  const createHandoff = useOneConversationSession((state) => state.createHandoff);
+  const appendMirrorEvent = useOneConversationSession(
+    (state) => state.appendMirrorEvent,
+  );
+  const createHandoff = useOneConversationSession(
+    (state) => state.createHandoff,
+  );
   const mirrorSessionId = useOneConversationSession((state) => state.sessionId);
 
   // In-bar conversation (Gemini Live full-duplex) state. This lives entirely in
@@ -118,6 +139,9 @@ export function AgentBar() {
   // the bar highlights and an ambient waveform animates in place, reacting to
   // the user's voice (listening) and the agent's reply (speaking).
   const [conversationActive, setConversationActive] = useState(false);
+  const [pendingConfirmation, setPendingConfirmation] =
+    useState<PendingVoiceConfirmation | null>(null);
+  const pendingConfirmationRef = useRef<PendingVoiceConfirmation | null>(null);
   const voiceStatus = useAgentVoiceState((s) => s.status);
   const voiceMessage = useAgentVoiceState((s) => s.message);
   const voiceLevel = useAgentVoiceState((s) => s.level);
@@ -167,278 +191,443 @@ export function AgentBar() {
     }, AGENT_BAR_VOICE_IDLE_TIMEOUT_MS);
   }, [clearVoiceIdleTimer]);
 
-  const handleTransportEvent = useCallback((event: OneVoiceSessionEvent) => {
-    if (
-      event.type === "state" ||
-      event.type === "transcript_final" ||
-      event.type === "assistant_text" ||
-      event.type === "client_directive" ||
-      event.type === "handoff"
-    ) {
-      scheduleVoiceIdleTimer();
-    }
-    const eventOptions: AgentVoiceEventOptions = {
-      sessionId: "sessionId" in event ? event.sessionId ?? null : null,
-      sourceId: "sourceId" in event ? event.sourceId ?? null : event.provider,
-      sourceSeq: "sourceSeq" in event ? event.sourceSeq ?? null : null,
-    };
-    if (event.type === "state") {
-      const status: AgentVoiceStatus =
-        event.state === "opening"
-          ? "connecting"
-          : event.state === "listening"
-            ? "listening"
-            : event.state === "understanding" ||
-                event.state === "intent_preview" ||
-                event.state === "needs_consent" ||
-                event.state === "acting" ||
-                event.state === "navigation_settling"
-              ? "thinking"
-              : event.state === "result" || event.state === "follow_up"
-                ? "speaking"
-                : event.state === "error_recovery"
-                  ? "error"
-                  : "idle";
-      if (status !== "idle") {
-        setVoiceStatus(status, event.message ?? null, eventOptions);
-      }
-      return;
-    }
-    if (event.type === "input_level") {
-      const current = useAgentVoiceState.getState().status;
-      if (current === "listening" || current === "connecting") {
-        setVoiceLevel(event.level);
-      }
-      return;
-    }
-    if (event.type === "output_level") {
-      if (useAgentVoiceState.getState().status === "speaking") {
-        setVoiceLevel(event.level);
-      }
-      return;
-    }
-    if (event.type === "error") {
-      erroredRef.current = true;
-      setVoiceStatus("error", event.message, eventOptions);
-      return;
-    }
-    if (event.type === "assistant_text") {
-      appendMirrorEvent({
-        role: "assistant",
-        text: event.text,
-        source: "gemini_live",
-        turnId: event.turnId ?? null,
+  const abandonPendingConfirmation = useCallback(
+    (reason: string, summary: string, clearUi = true) => {
+      const pending = pendingConfirmationRef.current;
+      if (!pending) return;
+      pendingConfirmationRef.current = null;
+      if (clearUi) setPendingConfirmation(null);
+      liveClientRef.current?.reportActionSettlement?.({
+        directiveId: pending.directiveId,
+        actionId: pending.actionId,
+        status: "blocked",
+        summary,
+        reason,
       });
-      return;
-    }
-    if (event.type === "transcript_final") {
-      // Mirror the user's transcript into the conversation session. One's
-      // agent tree decides everything server-side; there is no client-side
-      // planner to feed here.
-      const transcript = event.text.trim();
-      const previous = lastTranscriptRef.current;
+    },
+    [],
+  );
+
+  const handleTransportEvent = useCallback(
+    (event: OneVoiceSessionEvent) => {
       if (
-        previous &&
-        previous.text === transcript &&
-        Date.now() - previous.atMs < 1500
+        event.type === "state" ||
+        event.type === "transcript_final" ||
+        event.type === "assistant_text" ||
+        event.type === "client_directive" ||
+        event.type === "handoff"
       ) {
-        return;
+        scheduleVoiceIdleTimer();
       }
-      lastTranscriptRef.current = { text: transcript, atMs: Date.now() };
-      appendMirrorEvent({
-        role: "user",
-        text: transcript,
-        source: "gemini_live",
-        turnId: event.turnId ?? null,
-      });
-      setVoiceStatus("thinking", "Understanding", eventOptions);
-      return;
-    }
-    if (event.type === "client_directive") {
-      // One's tools decided this (single decision-maker); the client only
-      // executes through the same governed gateway the app uses.
-      if (event.directive.kind === "navigate") {
-        const route =
-          typeof event.directive.payload?.route === "string"
-            ? event.directive.payload.route
-            : null;
-        if (route && route.startsWith("/")) {
-          router.push(route);
+      const eventOptions: AgentVoiceEventOptions = {
+        sessionId: "sessionId" in event ? (event.sessionId ?? null) : null,
+        sourceId:
+          "sourceId" in event ? (event.sourceId ?? null) : event.provider,
+        sourceSeq: "sourceSeq" in event ? (event.sourceSeq ?? null) : null,
+      };
+      if (event.type === "state") {
+        const status: AgentVoiceStatus =
+          event.state === "opening"
+            ? "connecting"
+            : event.state === "listening"
+              ? "listening"
+              : event.state === "understanding" ||
+                  event.state === "intent_preview" ||
+                  event.state === "needs_consent" ||
+                  event.state === "acting" ||
+                  event.state === "navigation_settling"
+                ? "thinking"
+                : event.state === "result" || event.state === "follow_up"
+                  ? "speaking"
+                  : event.state === "error_recovery"
+                    ? "error"
+                    : "idle";
+        if (status !== "idle") {
+          setVoiceStatus(status, event.message ?? null, eventOptions);
         }
         return;
       }
-      if (event.directive.kind === "action") {
-        const actionId =
-          typeof event.directive.payload?.actionId === "string"
-            ? event.directive.payload.actionId
-            : null;
-        if (actionId) {
-          const directiveId =
-            typeof event.directive.payload?.directiveId === "string"
-              ? event.directive.payload.directiveId
+      if (event.type === "input_level") {
+        const current = useAgentVoiceState.getState().status;
+        if (current === "listening" || current === "connecting") {
+          setVoiceLevel(event.level);
+        }
+        return;
+      }
+      if (event.type === "output_level") {
+        if (useAgentVoiceState.getState().status === "speaking") {
+          setVoiceLevel(event.level);
+        }
+        return;
+      }
+      if (event.type === "error") {
+        abandonPendingConfirmation(
+          "transport_error",
+          "The confirmation was cancelled because the voice session hit an error.",
+        );
+        erroredRef.current = true;
+        setVoiceStatus("error", event.message, eventOptions);
+        return;
+      }
+      if (event.type === "assistant_text") {
+        appendMirrorEvent({
+          role: "assistant",
+          text: event.text,
+          source: "gemini_live",
+          turnId: event.turnId ?? null,
+        });
+        return;
+      }
+      if (event.type === "transcript_final") {
+        // Mirror the user's transcript into the conversation session. One's
+        // agent tree decides everything server-side; there is no client-side
+        // planner to feed here.
+        const transcript = event.text.trim();
+        const previous = lastTranscriptRef.current;
+        if (
+          previous &&
+          previous.text === transcript &&
+          Date.now() - previous.atMs < 1500
+        ) {
+          return;
+        }
+        lastTranscriptRef.current = { text: transcript, atMs: Date.now() };
+        appendMirrorEvent({
+          role: "user",
+          text: redactSensitiveVoiceTranscript(transcript, runtime?.screen),
+          source: "gemini_live",
+          turnId: event.turnId ?? null,
+        });
+        setVoiceStatus("thinking", "Understanding", eventOptions);
+        return;
+      }
+      if (event.type === "client_directive") {
+        // One's tools decided this (single decision-maker); the client only
+        // executes through the same governed gateway the app uses.
+        if (event.directive.kind === "navigate") {
+          const route =
+            typeof event.directive.payload?.route === "string"
+              ? event.directive.payload.route
               : null;
-          const slots =
-            event.directive.payload?.slots &&
-            typeof event.directive.payload.slots === "object"
-              ? (event.directive.payload.slots as Record<string, unknown>)
-              : undefined;
-          if (event.directive.payload?.needsConfirmation === true) {
-            // Sensitive actions confirm in the audited chat surface, never
-            // silently from voice.
-            const handoff = createHandoff({
-              reason: "action_requires_chat",
-              transcript: null,
-              assistantText: `Confirm before running: ${actionId}`,
-              actionId,
-            });
-            liveClientRef.current?.interrupt?.();
-            agentPopover?.openAgent({ handoff });
-            return;
+          if (route && route.startsWith("/")) {
+            router.push(route);
           }
-          const runtimeState = runtime?.appRuntimeState;
-          if (!runtimeState) {
-            if (directiveId) {
-              liveClientRef.current?.reportActionSettlement?.({
-                directiveId,
-                actionId,
-                status: "failed",
-                summary: "The app was not ready to run that action.",
-                reason: "missing_runtime_state",
-              });
-            }
-            return;
-          }
-          void (async () => {
-            try {
-              const result = await executeAgentGatewayAction({
-                actionId,
-                slots,
-                userId: user?.uid ?? "",
-                router,
-                appRuntimeState: runtimeState,
-                surfaceMetadata: getVoiceSurfaceMetadata(),
-                hasPortfolioData:
-                  runtimeState.portfolio.has_portfolio_data ||
-                  runtime?.oneVoiceContextSnapshot.cache.portfolio_ready === true,
-                busyOperations,
-                setAnalysisParams,
-                switchPersona,
-                executionContext: { directiveId },
-              });
-              if (directiveId) {
-                liveClientRef.current?.reportActionSettlement?.({
-                  directiveId,
-                  actionId,
-                  status: result.status,
-                  summary: result.resultSummary,
-                  reason: result.reason,
-                  routeAfter: result.routeAfter,
-                  screenAfter: result.screenAfter,
-                });
+          return;
+        }
+        if (event.directive.kind === "action") {
+          const actionId =
+            typeof event.directive.payload?.actionId === "string"
+              ? event.directive.payload.actionId
+              : null;
+          if (actionId) {
+            const directiveId =
+              typeof event.directive.payload?.directiveId === "string"
+                ? event.directive.payload.directiveId
+                : null;
+            const slots =
+              event.directive.payload?.slots &&
+              typeof event.directive.payload.slots === "object"
+                ? (event.directive.payload.slots as Record<string, unknown>)
+                : undefined;
+            const needsConfirmation =
+              event.directive.payload?.needsConfirmation === true;
+            if (runtime?.morphyAxEnabled) {
+              const decision = validateMorphyAxAssessment(
+                {
+                  schema_version: "morphy_ax_assessment.v1",
+                  source: "one",
+                  disposition: needsConfirmation
+                    ? "confirm_visible_action"
+                    : "execute_visible_action",
+                  candidate_action_id: actionId,
+                  missing_input: null,
+                  ambiguous: false,
+                  confidence: 1,
+                  expected_outcome: needsConfirmation
+                    ? "confirmation"
+                    : "action",
+                },
+                runtime.morphyAxSnapshot,
+              );
+              const admitted = needsConfirmation
+                ? decision.status === "confirmation_required"
+                : decision.status === "permitted";
+              if (!admitted) {
+                if (directiveId) {
+                  liveClientRef.current?.reportActionSettlement?.({
+                    directiveId,
+                    actionId,
+                    status: "blocked",
+                    summary:
+                      "The requested action is not available on this screen.",
+                    reason: `morphy_ax_${decision.status}`,
+                  });
+                }
+                return;
               }
-            } catch {
+            }
+            if (needsConfirmation) {
+              if (!directiveId) return;
+              // Keep sensitive arguments transient in component memory. The
+              // confirmation card never renders slots (including OTP values).
+              abandonPendingConfirmation(
+                "confirmation_superseded",
+                "A newer confirmation replaced the pending action.",
+              );
+              const pending = { directiveId, actionId, slots, route: pathname };
+              pendingConfirmationRef.current = pending;
+              setPendingConfirmation(pending);
+              liveClientRef.current?.interrupt?.();
+              setVoiceStatus("thinking", "Confirmation needed", eventOptions);
+              return;
+            }
+            const runtimeState = runtime?.appRuntimeState;
+            if (!runtimeState) {
               if (directiveId) {
                 liveClientRef.current?.reportActionSettlement?.({
                   directiveId,
                   actionId,
                   status: "failed",
-                  summary: "The app could not complete that action.",
-                  reason: "client_execution_failed",
+                  summary: "The app was not ready to run that action.",
+                  reason: "missing_runtime_state",
                 });
               }
+              return;
             }
-          })();
+            void (async () => {
+              try {
+                const result = await executeAgentGatewayAction({
+                  actionId,
+                  slots,
+                  userId: user?.uid ?? "",
+                  router,
+                  appRuntimeState: runtimeState,
+                  surfaceMetadata: getVoiceSurfaceMetadata(),
+                  hasPortfolioData:
+                    runtimeState.portfolio.has_portfolio_data ||
+                    runtime?.oneVoiceContextSnapshot.cache.portfolio_ready ===
+                      true,
+                  busyOperations,
+                  setAnalysisParams,
+                  switchPersona,
+                  executionContext: { directiveId },
+                });
+                if (directiveId) {
+                  liveClientRef.current?.reportActionSettlement?.({
+                    directiveId,
+                    actionId,
+                    status: result.status,
+                    summary: result.resultSummary,
+                    reason: result.reason,
+                    routeAfter: result.routeAfter,
+                    screenAfter: result.screenAfter,
+                  });
+                }
+              } catch {
+                if (directiveId) {
+                  liveClientRef.current?.reportActionSettlement?.({
+                    directiveId,
+                    actionId,
+                    status: "failed",
+                    summary: "The app could not complete that action.",
+                    reason: "client_execution_failed",
+                  });
+                }
+              }
+            })();
+            return;
+          }
+          // Specialist directive (location share/check-in/SOS, device
+          // permission re-ask, connected-systems update, etc.) rather than a
+          // run_app_action directive: these need vault-owner crypto/native
+          // calls that only exist in the chat surface's directive runtime.
+          // Without this branch the directive silently dropped (no actionId),
+          // which is why asking One over voice to re-ask location permission
+          // did nothing even though the specialist correctly proposed it.
+          const delegateAgentId =
+            typeof event.directive.payload?.delegateAgentId === "string"
+              ? event.directive.payload.delegateAgentId
+              : null;
+          const directiveType =
+            typeof event.directive.payload?.type === "string"
+              ? event.directive.payload.type
+              : "this";
+          const handoff = createHandoff({
+            reason: "action_requires_chat",
+            transcript: null,
+            assistantText: `One line this up for you: ${directiveType}. Confirm here to continue.`,
+            specialistDirective: delegateAgentId
+              ? {
+                  delegateAgentId,
+                  directive: {
+                    kind: "action",
+                    payload: event.directive.payload ?? {},
+                  },
+                  message: "",
+                  stateChanged: false,
+                }
+              : null,
+          });
+          liveClientRef.current?.interrupt?.();
+          agentPopover?.openAgent({ handoff });
           return;
         }
-        // Specialist directive (location share/check-in/SOS, device
-        // permission re-ask, connected-systems update, etc.) rather than a
-        // run_app_action directive: these need vault-owner crypto/native
-        // calls that only exist in the chat surface's directive runtime.
-        // Without this branch the directive silently dropped (no actionId),
-        // which is why asking One over voice to re-ask location permission
-        // did nothing even though the specialist correctly proposed it.
-        const delegateAgentId =
-          typeof event.directive.payload?.delegateAgentId === "string"
-            ? event.directive.payload.delegateAgentId
+        return;
+      }
+      if (event.type === "handoff") {
+        const transcript =
+          typeof event.payload?.transcript === "string"
+            ? event.payload.transcript
             : null;
-        const directiveType =
-          typeof event.directive.payload?.type === "string"
-            ? event.directive.payload.type
-            : "this";
+        const assistantText =
+          typeof event.payload?.assistantText === "string"
+            ? event.payload.assistantText
+            : null;
+        const actionId =
+          typeof event.payload?.actionId === "string"
+            ? event.payload.actionId
+            : null;
         const handoff = createHandoff({
           reason: "action_requires_chat",
-          transcript: null,
-          assistantText: `One line this up for you: ${directiveType}. Confirm here to continue.`,
-          specialistDirective: delegateAgentId
-            ? {
-                delegateAgentId,
-                directive: {
-                  kind: "action",
-                  payload: event.directive.payload ?? {},
-                },
-                message: "",
-                stateChanged: false,
-              }
-            : null,
+          transcript,
+          assistantText: assistantText || event.reason,
+          actionId,
         });
         liveClientRef.current?.interrupt?.();
         agentPopover?.openAgent({ handoff });
         return;
       }
-      return;
-    }
-    if (event.type === "handoff") {
-      const transcript =
-        typeof event.payload?.transcript === "string" ? event.payload.transcript : null;
-      const assistantText =
-        typeof event.payload?.assistantText === "string" ? event.payload.assistantText : null;
-      const actionId =
-        typeof event.payload?.actionId === "string" ? event.payload.actionId : null;
-      const handoff = createHandoff({
-        reason: "action_requires_chat",
-        transcript,
-        assistantText: assistantText || event.reason,
-        actionId,
-      });
-      liveClientRef.current?.interrupt?.();
-      agentPopover?.openAgent({ handoff });
-      return;
-    }
-    if (event.type === "closed") {
-      clearVoiceIdleTimer();
-      liveClientRef.current = null;
-      if (erroredRef.current) return;
-      setConversationActive(false);
-    }
-  }, [
-    agentPopover,
-    appendMirrorEvent,
-    busyOperations,
-    clearVoiceIdleTimer,
-    createHandoff,
-    router,
-    runtime,
-    scheduleVoiceIdleTimer,
-    setAnalysisParams,
-    setVoiceLevel,
-    setVoiceStatus,
-    switchPersona,
-    user?.uid,
-  ]);
+      if (event.type === "closed") {
+        clearVoiceIdleTimer();
+        abandonPendingConfirmation(
+          "session_closed",
+          "The confirmation was cancelled when the voice session closed.",
+        );
+        liveClientRef.current = null;
+        if (erroredRef.current) return;
+        setConversationActive(false);
+      }
+    },
+    [
+      agentPopover,
+      abandonPendingConfirmation,
+      appendMirrorEvent,
+      busyOperations,
+      clearVoiceIdleTimer,
+      createHandoff,
+      pathname,
+      router,
+      runtime,
+      scheduleVoiceIdleTimer,
+      setAnalysisParams,
+      setVoiceLevel,
+      setVoiceStatus,
+      switchPersona,
+      user?.uid,
+    ],
+  );
 
   const stopConversation = useCallback(() => {
     clearVoiceIdleTimer();
     erroredRef.current = false;
+    abandonPendingConfirmation(
+      "session_cancelled",
+      "The confirmation was cancelled when the voice session ended.",
+    );
     liveClientRef.current?.stop();
     liveClientRef.current = null;
     prewarmedRelayRef.current = null;
     setConversationActive(false);
     resetVoice();
-  }, [clearVoiceIdleTimer, resetVoice]);
+  }, [abandonPendingConfirmation, clearVoiceIdleTimer, resetVoice]);
+
+  const settlePendingConfirmation = useCallback(
+    async (confirmed: boolean) => {
+      const pending = pendingConfirmationRef.current;
+      if (!pending) return;
+      pendingConfirmationRef.current = null;
+      setPendingConfirmation(null);
+      if (!confirmed) {
+        liveClientRef.current?.reportActionSettlement?.({
+          directiveId: pending.directiveId,
+          actionId: pending.actionId,
+          status: "blocked",
+          summary: "The person cancelled the confirmation.",
+          reason: "user_cancelled",
+        });
+        setVoiceStatus("listening", "Listening");
+        return;
+      }
+      const runtimeState = runtime?.appRuntimeState;
+      if (!runtimeState) {
+        liveClientRef.current?.reportActionSettlement?.({
+          directiveId: pending.directiveId,
+          actionId: pending.actionId,
+          status: "failed",
+          summary: "The app was not ready to confirm that action.",
+          reason: "missing_runtime_state",
+        });
+        return;
+      }
+      setVoiceStatus("thinking", "Confirming");
+      try {
+        const result = await executeAgentGatewayAction({
+          actionId: pending.actionId,
+          slots: pending.slots,
+          userId: user?.uid ?? "",
+          router,
+          appRuntimeState: runtimeState,
+          surfaceMetadata: getVoiceSurfaceMetadata(),
+          hasPortfolioData:
+            runtimeState.portfolio.has_portfolio_data ||
+            runtime?.oneVoiceContextSnapshot.cache.portfolio_ready === true,
+          busyOperations,
+          setAnalysisParams,
+          switchPersona,
+          executionContext: { directiveId: pending.directiveId },
+        });
+        liveClientRef.current?.reportActionSettlement?.({
+          directiveId: pending.directiveId,
+          actionId: pending.actionId,
+          status: result.status,
+          summary: result.resultSummary,
+          reason: result.reason,
+          routeAfter: result.routeAfter,
+          screenAfter: result.screenAfter,
+        });
+      } catch {
+        liveClientRef.current?.reportActionSettlement?.({
+          directiveId: pending.directiveId,
+          actionId: pending.actionId,
+          status: "failed",
+          summary: "The app could not complete the confirmed action.",
+          reason: "client_execution_failed",
+        });
+      }
+    },
+    [
+      busyOperations,
+      router,
+      runtime,
+      setAnalysisParams,
+      setVoiceStatus,
+      switchPersona,
+      user?.uid,
+    ],
+  );
 
   useEffect(() => {
     stopConversationRef.current = stopConversation;
   }, [stopConversation]);
+
+  useEffect(() => {
+    const pending = pendingConfirmationRef.current;
+    if (!pending || pending.route === pathname) return;
+    abandonPendingConfirmation(
+      "route_changed",
+      "The confirmation was cancelled because the screen changed.",
+    );
+  }, [abandonPendingConfirmation, pathname]);
 
   const openAgentChat = useCallback(() => {
     if (conversationActive) return;
@@ -543,7 +732,10 @@ export function AgentBar() {
     if (!context || !accessTier || conversationActive || erroredRef.current) {
       return;
     }
-    if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState !== "visible"
+    ) {
       return;
     }
     if (
@@ -578,11 +770,7 @@ export function AgentBar() {
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [
-    conversationActive,
-    runtime?.oneVoiceContextSnapshot,
-    runtime?.tier,
-  ]);
+  }, [conversationActive, runtime?.oneVoiceContextSnapshot, runtime?.tier]);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -608,12 +796,17 @@ export function AgentBar() {
         clearTimeout(idleTimeoutRef.current);
         idleTimeoutRef.current = null;
       }
+      abandonPendingConfirmation(
+        "component_unmounted",
+        "The confirmation was cancelled when the voice surface closed.",
+        false,
+      );
       liveClientRef.current?.stop();
       liveClientRef.current = null;
       prewarmedRelayRef.current = null;
       resetVoice();
     };
-  }, [resetVoice]);
+  }, [abandonPendingConfirmation, resetVoice]);
 
   const chromeState = useMemo(() => getKaiChromeState(pathname), [pathname]);
   // The root intro screen ("/") has no bottom nav, exactly like the onboarding
@@ -658,14 +851,15 @@ export function AgentBar() {
   // The agent bar rides most surfaces, degrading gracefully by auth/vault level
   // (locked-vault users get an in-place unlock prompt; unlocked users get the
   // full agent). We also unmount where an agent launcher genuinely must not
-  // exist (legacy dedicated agent route, phone mandate, appearance lab,
-  // developers) or on transient auth transitions (login, logout) where the
+  // exist (legacy dedicated agent route or appearance lab) or on transient
+  // auth transitions where the
   // app shell is not the host.
   const path = pathname ?? "";
   // The waveform action circle is white only on the 2c dark dashboard (where a
   // white circle pops); on every other surface (welcome, profile, kai, …) it is
   // the indigo accent, per design.md §5.5.
-  const onDashboard = path === ROUTES.ONE_HOME || path === `${ROUTES.ONE_HOME}/`;
+  const onDashboard =
+    path === ROUTES.ONE_HOME || path === `${ROUTES.ONE_HOME}/`;
   // The logged-out welcome ("/") and the sign-in screen ("/login") both host
   // the dogfooding onboarding voice greeter instead of unmounting the bar
   // outright: it doubles as the pre-auth conversation starter and stays
@@ -674,7 +868,11 @@ export function AgentBar() {
   const onboardingGreeterMode =
     (isHomeRoute && runtime?.tier === "anon_onboarding") ||
     (isLoginRoute && !user);
-  const ambientVoiceOnly = isFoundationPublic && !isHomeRoute;
+  const focusedOnboardingVoiceOnly =
+    isOneSetupRoute(pathname ?? "") ||
+    (pathname ?? "").startsWith(ROUTES.PHONE_MANDATE);
+  const ambientVoiceOnly =
+    (isFoundationPublic && !isHomeRoute) || focusedOnboardingVoiceOnly;
 
   // Signed-out dogfooding: greet the person the moment the onboarding welcome
   // ("/") loads, instead of waiting for a tap. This reuses the exact same
@@ -692,7 +890,8 @@ export function AgentBar() {
       return;
     }
     if (autoGreetedRef.current) return;
-    if (conversationActive || liveClientRef.current || erroredRef.current) return;
+    if (conversationActive || liveClientRef.current || erroredRef.current)
+      return;
     autoGreetedRef.current = true;
     startConversation();
     // Intentionally excludes startConversation/conversationActive from deps:
@@ -703,15 +902,8 @@ export function AgentBar() {
 
   const unmountBar =
     !agentPopover ||
-    // The One setup surface is a focused onboarding flow (like Apple's "Finish
-    // Setting Up" in Settings): a centered translucent agent launcher reads
-    // over the wide grouped-list rows on scroll (they show through it / beside
-    // it), so it is unmounted across the whole setup surface. isOneSetupRoute
-    // (not an exact match) is required because the Capacitor build uses
-    // trailingSlash, so the runtime pathname is "/one/setup/".
-    isOneSetupRoute(path) ||
-    path.startsWith(ROUTES.PHONE_MANDATE) ||
-    path === ROUTES.DEVELOPERS ||
+    // Focused onboarding routes retain voice but use the voice-only rendering
+    // branch above, so Agent Chat never appears over setup or phone entry.
     path === ROUTES.AGENT ||
     // "/login" keeps the bar (signed-out onboarding greeter, parity with "/");
     // only the logout transition unmounts it.
@@ -760,7 +952,10 @@ export function AgentBar() {
       title="Tap to end conversation"
       className="relative flex min-w-0 flex-1 items-center gap-3 overflow-hidden rounded-full pl-1 pr-2 text-left"
     >
-      <span aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+      >
         <MaterialRipple variant="gradient" effect="fill" />
       </span>
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-accent-strong">
@@ -814,7 +1009,10 @@ export function AgentBar() {
         <span className="min-w-0 flex-1 truncate text-[14px] font-semibold text-[#17130C]/80 dark:text-white/85">
           Talk to One
         </span>
-        <span aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+        >
           <MaterialRipple variant="gradient" effect="fill" />
         </span>
       </button>
@@ -822,7 +1020,11 @@ export function AgentBar() {
       <button
         type="button"
         onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-        aria-label={resolvedTheme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+        aria-label={
+          resolvedTheme === "dark"
+            ? "Switch to light mode"
+            : "Switch to dark mode"
+        }
         title="Toggle theme"
         className="relative grid h-9 w-9 shrink-0 place-items-center overflow-hidden rounded-full text-accent-strong transition-colors duration-200 hover:bg-black/[0.05] dark:hover:bg-white/[0.08]"
       >
@@ -831,7 +1033,10 @@ export function AgentBar() {
         ) : (
           <Moon className="h-[17px] w-[17px]" />
         )}
-        <span aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+        >
           <MaterialRipple variant="gradient" effect="fill" />
         </span>
       </button>
@@ -870,7 +1075,10 @@ export function AgentBar() {
         >
           {hint}
         </span>
-        <span aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+        >
           <MaterialRipple variant="gradient" effect="fill" />
         </span>
       </button>
@@ -885,7 +1093,10 @@ export function AgentBar() {
         className="relative grid h-9 w-9 shrink-0 place-items-center overflow-hidden rounded-full text-accent-strong transition-colors duration-200 hover:bg-black/[0.05] dark:hover:bg-white/[0.08]"
       >
         <MessageCircle className="h-[17px] w-[17px]" />
-        <span aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden rounded-full">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-full"
+        >
           <MaterialRipple variant="gradient" effect="fill" />
         </span>
       </button>
@@ -894,7 +1105,7 @@ export function AgentBar() {
 
   return (
     <div
-      className="pointer-events-none fixed inset-x-0 z-[118] flex justify-center px-4 transform-gpu"
+      className="pointer-events-none fixed inset-x-0 z-[118] flex flex-col items-center gap-3 px-4 transform-gpu"
       style={
         {
           // Sit just above the visible bottom nav and ride the same scroll-hide
@@ -927,9 +1138,44 @@ export function AgentBar() {
       }
       aria-hidden={barHidden}
     >
+      {pendingConfirmation ? (
+        <div
+          role="dialog"
+          aria-label="Confirm voice action"
+          className="pointer-events-auto w-full max-w-[min(calc(100vw-3rem),392px)] rounded-3xl border border-black/10 bg-white/95 p-4 text-[#1d1d1f] shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-[#1c1c1e]/95 dark:text-[#f5f5f7]"
+        >
+          <p className="text-[13px] font-medium text-muted-foreground">
+            One is ready to
+          </p>
+          <p className="mt-1 text-[16px] font-semibold">
+            {getKaiActionById(pendingConfirmation.actionId)?.label ||
+              "Continue this action"}
+          </p>
+          <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
+            Sensitive values are hidden. Nothing runs until you confirm.
+          </p>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => void settlePendingConfirmation(false)}
+              className="h-10 rounded-full bg-black/[0.05] text-[14px] font-semibold dark:bg-white/[0.08]"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void settlePendingConfirmation(true)}
+              className="h-10 rounded-full bg-primary text-[14px] font-semibold text-primary-foreground"
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      ) : null}
       <div
         data-testid="one-voice-agent-bar"
         data-voice-mode={nativeVoiceMode}
+        data-morphy-ax-presentation={runtime?.morphyAxPresentation ?? "idle"}
         className={cn(
           // z-0 (not just `relative`) is required so this pill forms its own
           // local stacking context: the `.one-bar-aurora -z-10` glow span
@@ -967,7 +1213,9 @@ export function AgentBar() {
             aria-hidden
             className={cn(
               "one-bar-aurora -z-10 transition-opacity duration-500",
-              useOnboardingChrome ? "one-bar-aurora--onboarding" : "one-bar-aurora--active",
+              useOnboardingChrome
+                ? "one-bar-aurora--onboarding"
+                : "one-bar-aurora--active",
             )}
           />
         ) : null}

--- a/hushh-webapp/components/agent/agent-voice-edge-glow.tsx
+++ b/hushh-webapp/components/agent/agent-voice-edge-glow.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
 import { useAgentVoiceState } from "@/lib/agent/agent-voice-state";
+import { useAgentRuntimeStateOptional } from "@/lib/agent/agent-runtime-context";
 import { cn } from "@/lib/utils";
 
 // Per-status color mixes. Each mix is a FULL spectrum walked once around the
@@ -106,6 +107,7 @@ const ANIM_NAME: Record<PoolDef["anim"], string> = {
 };
 
 export function AgentVoiceEdgeGlow() {
+  const runtime = useAgentRuntimeStateOptional();
   const active = useAgentVoiceState((s) => s.active);
   const status = useAgentVoiceState((s) => s.status);
   const level = useAgentVoiceState((s) => s.level);
@@ -170,6 +172,7 @@ export function AgentVoiceEdgeGlow() {
     <div
       aria-hidden
       data-voice-status={status}
+      data-morphy-ax-presentation={runtime?.morphyAxPresentation ?? "idle"}
       data-testid="one-voice-edge-glow"
       className={cn(
         "pointer-events-none fixed inset-0 z-[117] overflow-hidden",

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -68,6 +68,12 @@ type PhoneVerificationFlowProps = {
 };
 
 type VerificationStep = "phone" | "code" | "linked";
+type StartVerificationOutcome =
+  | "code_sent"
+  | "auto_verified"
+  | "already_linked"
+  | "invalid"
+  | "failed";
 
 function getCountryOptionLabel(option: {
   label: string;
@@ -252,11 +258,11 @@ export function PhoneVerificationFlow({
   }, []);
 
   const handleStartVerification = useCallback(
-    async (resendCode = false, phoneNumberOverride?: string) => {
+    async (resendCode = false, phoneNumberOverride?: string): Promise<StartVerificationOutcome> => {
       const normalizedPhone = (phoneNumberOverride ?? normalizedPhoneInput).trim();
       if (!E164_PHONE_PATTERN.test(normalizedPhone)) {
         morphyToast.error("Enter a valid country code and phone number.");
-        return;
+        return "invalid";
       }
 
       if (currentPhoneNumber && normalizedPhone === currentPhoneNumber) {
@@ -266,7 +272,7 @@ export function PhoneVerificationFlow({
         });
         morphyToast.success("This phone number is already linked to your account.");
         await onCompleted();
-        return;
+        return "already_linked";
       }
 
       setBusy(true);
@@ -285,7 +291,7 @@ export function PhoneVerificationFlow({
             mode === "replace" ? "Phone number updated." : "Phone number verified."
           );
           await onCompleted(result.user ?? undefined);
-          return;
+          return "auto_verified";
         }
 
         setSubmittedPhoneNumber(normalizedPhone);
@@ -293,6 +299,7 @@ export function PhoneVerificationFlow({
         morphyToast.success(
           resendCode ? "A new verification code has been sent." : "Verification code sent."
         );
+        return "code_sent";
       } catch (error) {
         console.error("[PhoneVerificationFlow] Failed to start verification:", error);
         trackEvent("phone_verification_started", {
@@ -302,6 +309,7 @@ export function PhoneVerificationFlow({
         morphyToast.error(
           error instanceof Error ? error.message : "Failed to send verification code."
         );
+        return "failed";
       } finally {
         setBusy(false);
       }
@@ -314,10 +322,10 @@ export function PhoneVerificationFlow({
   // tapping the Send code button. The phone number is passed directly to
   // `handleStartVerification` (not read back from `normalizedPhoneInput`)
   // because the field-state updates below are async and would not be visible
-  // yet on this same tick. The confirmation-code step
-  // (`phone_mandate.submit_code`) stays `manual_only`/unwired by contract
-  // (see `app/register-phone/page.voice-action-contract.json`), so no
-  // handler is registered for it here.
+  // yet on this same tick. The confirmation-code action uses the same
+  // verification operation as the typed form, but only after the voice
+  // surface receives an explicit inline confirmation. Its sensitive slot is
+  // kept transient and is never rendered or repeated in the settlement.
   useLocalOnboardingActionHandler("phone_mandate.submit_number", async (slots) => {
     const rawPhoneNumber = String(slots.phoneNumber ?? "").trim();
     if (!rawPhoneNumber) {
@@ -333,8 +341,17 @@ export function PhoneVerificationFlow({
     const fields = derivePhoneFields(candidate);
     setSelectedCountry(fields.countryValue);
     setLocalPhoneNumber(fields.localPhoneNumber);
-    await handleStartVerification(false, candidate);
-    return { status: "succeeded", summary: "Verification code sent." };
+    const outcome = await handleStartVerification(false, candidate);
+    if (outcome === "failed") {
+      return { status: "failed", summary: "The verification code could not be sent." };
+    }
+    if (outcome === "invalid") {
+      return { status: "blocked", summary: "That phone number could not be verified." };
+    }
+    return {
+      status: "succeeded",
+      summary: outcome === "code_sent" ? "Verification code sent." : "Phone verified.",
+    };
   });
 
   const handleConfirmVerification = useCallback(async () => {
@@ -366,6 +383,30 @@ export function PhoneVerificationFlow({
       setBusy(false);
     }
   }, [confirmVerification, mode, onCompleted, verificationCode]);
+
+  useLocalOnboardingActionHandler("phone_mandate.submit_code", async (slots) => {
+    const code = String(slots.code ?? slots.verificationCode ?? "").replace(/\D/g, "").slice(0, 6);
+    if (step !== "code") {
+      return { status: "blocked", summary: "Send a verification code first." };
+    }
+    if (code.length !== 6) {
+      return { status: "blocked", summary: "Please provide the six-digit verification code." };
+    }
+    setVerificationCode(code);
+    setBusy(true);
+    try {
+      const verifiedUser = await confirmVerification(code);
+      trackEvent("phone_verification_completed", { action: mode, result: "success" });
+      await onCompleted(verifiedUser);
+      return { status: "succeeded", summary: "Phone verified. Continuing setup." };
+    } catch (error) {
+      console.error("[PhoneVerificationFlow] Voice code verification failed:", error);
+      trackEvent("phone_verification_completed", { action: mode, result: "error" });
+      return { status: "failed", summary: "That code could not be verified." };
+    } finally {
+      setBusy(false);
+    }
+  });
 
   if (step === "linked") {
     return (
@@ -462,6 +503,7 @@ export function PhoneVerificationFlow({
               <InputGroup className={FLOW_CONTROL_SHELL_CLASS_NAME}>
                 <InputGroupInput
                   id="phone-flow-number"
+                  data-voice-control-id="phone-flow-number"
                   type="tel"
                   inputMode="tel"
                   autoComplete="tel-national"
@@ -519,6 +561,9 @@ export function PhoneVerificationFlow({
                 <span className="font-semibold text-foreground">{submittedPhoneNumber}</span>.
                 Enter it to continue.
               </p>
+              <p className="mt-1 text-[12px] leading-[1.35] text-black/45 dark:text-white/50">
+                You can type the code or say it to One. Spoken codes are processed by the voice service and are not retained by Hussh.
+              </p>
             </div>
           </div>
 
@@ -550,6 +595,7 @@ export function PhoneVerificationFlow({
               </div>
               <input
                 id="phone-flow-code"
+                data-voice-control-id="phone-flow-code"
                 type="text"
                 inputMode="numeric"
                 autoComplete="one-time-code"

--- a/hushh-webapp/components/gmail/gmail-receipts-page.tsx
+++ b/hushh-webapp/components/gmail/gmail-receipts-page.tsx
@@ -62,6 +62,11 @@ import {
 import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge-model-service";
 import { VaultService } from "@/lib/services/vault-service";
 import { assignWindowLocation } from "@/lib/utils/browser-navigation";
+import {
+  beginOnboardingConnectorIntent,
+  clearOnboardingConnectorIntent,
+} from "@/lib/onboarding/onboarding-connector-intent";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import { useVault } from "@/lib/vault/vault-context";
 import {
   usePublishVoiceSurfaceMetadata,
@@ -479,6 +484,9 @@ export default function ProfileReceiptsPage() {
 
   const handleConnectGmail = useCallback(async () => {
     if (!user?.uid) return;
+    const fromSetup =
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("from") === ROUTES.ONE_SETUP;
 
     try {
       setGmailActionBusy("connect");
@@ -504,8 +512,24 @@ export default function ProfileReceiptsPage() {
         throw new Error("Gmail OAuth is not configured for this environment.");
       }
 
+      if (fromSetup) {
+        await PreVaultUserStateService.syncOnboardingJourney({
+          userId: user.uid,
+          phase: "external_connector",
+          activeCapability: "gmail",
+          callbackState: "pending",
+        });
+        // Write the browser correlation marker only after the durable journey
+        // accepted the pending transition. A failed write must not cause an
+        // unrelated callback to be mistaken for onboarding later.
+        beginOnboardingConnectorIntent("gmail");
+      }
+
       assignWindowLocation(payload.authorize_url);
     } catch (error) {
+      if (fromSetup) {
+        clearOnboardingConnectorIntent();
+      }
       const message = sanitizeGmailUserMessage(error, {
         fallback:
           "We couldn't start Gmail connection right now. Please try again in a moment.",

--- a/hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json
+++ b/hushh-webapp/components/kai/views/dashboard-master-view.voice-action-contract.json
@@ -69,7 +69,8 @@
           "/one/kai/import"
         ],
         "screens": [
-          "kai_portfolio_dashboard"
+          "kai_portfolio_dashboard",
+          "import"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []

--- a/hushh-webapp/components/onboarding/AuthProviderButton.tsx
+++ b/hushh-webapp/components/onboarding/AuthProviderButton.tsx
@@ -11,6 +11,7 @@ type AuthProviderButtonProps = {
   disabled?: boolean;
   onClick?: () => void | Promise<void>;
   className?: string;
+  voiceControlId?: string;
 };
 
 export function AuthProviderButton({
@@ -19,6 +20,7 @@ export function AuthProviderButton({
   disabled = false,
   onClick,
   className,
+  voiceControlId,
 }: AuthProviderButtonProps) {
   return (
     <Button
@@ -30,6 +32,7 @@ export function AuthProviderButton({
       showRipple={!disabled}
       disabled={disabled}
       onClick={onClick}
+      data-voice-control-id={voiceControlId}
       className={cn(
         "type-headline min-h-[52px] rounded-full border-0 bg-black/[0.05] text-[#1d1d1f] shadow-none [backdrop-filter:none] transition-[background] hover:bg-black/[0.08] dark:bg-white/[0.07] dark:text-[#f5f5f7] dark:hover:bg-white/[0.10]",
         className

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -18,7 +18,6 @@ import { morphyToast } from "@/lib/morphy-ux/morphy";
 import { AuthProviderButton } from "@/components/onboarding/AuthProviderButton";
 import {
   useLocalOnboardingActionHandler,
-  type LocalOnboardingActionContext,
 } from "@/lib/agent/local-onboarding-actions";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
@@ -66,6 +65,15 @@ function isAuthCancel(error: unknown): boolean {
       ? String((error as { code?: unknown }).code ?? "")
       : "";
   return AUTH_CANCEL_CODES.has(code);
+}
+
+function isAuthPopupBlocked(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      String((error as { code?: unknown }).code ?? "") === "auth/popup-blocked",
+  );
 }
 
 function authErrorMessage(error: unknown): string {
@@ -511,8 +519,10 @@ export function AuthStep({
     user,
   ]);
 
-  const handleGoogleLogin = async () => {
-    if (pendingProvider) return;
+  const handleGoogleLogin = async (voiceDirectiveId?: string | null) => {
+    if (pendingProvider) {
+      return { status: "blocked" as const, summary: "A sign-in window is already open." };
+    }
     setPendingProvider("google");
     trackEvent("auth_started", {
       action: "google",
@@ -544,6 +554,7 @@ export function AuthStep({
           await authenticatedUser.getIdToken(),
           authenticatedUser.phoneNumber
         );
+        return { status: "succeeded" as const, summary: "Google sign-in completed." };
       } else {
         debugError("[AuthStep] No user returned from signInWithGoogle");
         trackEvent("auth_failed", {
@@ -554,8 +565,21 @@ export function AuthStep({
         morphyToast.error("Sign-in completed but no user session was returned.", {
           description: "Please try again.",
         });
+        return { status: "failed" as const, summary: "Google did not return a user session." };
       }
     } catch (err: any) {
+      if (voiceDirectiveId !== undefined && isAuthPopupBlocked(err)) {
+        trackEvent("auth_started", { action: "google" });
+        await AuthService.startGoogleSignInForVoice({
+          directiveId: voiceDirectiveId,
+          returnTo: ROUTES.LOGIN,
+          resumeTarget: redirectPath || ROUTES.ONE_SETUP,
+        });
+        return {
+          status: "started" as const,
+          summary: "Google sign-in opened in this browser.",
+        };
+      }
       debugError("[AuthStep] Google login failed", err);
       trackEvent("auth_failed", {
         action: "google",
@@ -567,13 +591,19 @@ export function AuthStep({
           description: authErrorMessage(err),
         });
       }
+      return {
+        status: isAuthCancel(err) ? "blocked" as const : "failed" as const,
+        summary: isAuthCancel(err) ? "Google sign-in was cancelled." : authErrorMessage(err),
+      };
     } finally {
       setPendingProvider(null);
     }
   };
 
-  const handleAppleLogin = async () => {
-    if (pendingProvider) return;
+  const handleAppleLogin = async (voiceDirectiveId?: string | null) => {
+    if (pendingProvider) {
+      return { status: "blocked" as const, summary: "A sign-in window is already open." };
+    }
     setPendingProvider("apple");
     trackEvent("auth_started", {
       action: "apple",
@@ -605,6 +635,7 @@ export function AuthStep({
           await authenticatedUser.getIdToken(),
           authenticatedUser.phoneNumber
         );
+        return { status: "succeeded" as const, summary: "Apple sign-in completed." };
       } else {
         debugError("[AuthStep] No user returned from signInWithApple");
         trackEvent("auth_failed", {
@@ -615,8 +646,21 @@ export function AuthStep({
         morphyToast.error("Sign-in completed but no user session was returned.", {
           description: "Please try again.",
         });
+        return { status: "failed" as const, summary: "Apple did not return a user session." };
       }
     } catch (err: any) {
+      if (voiceDirectiveId !== undefined && isAuthPopupBlocked(err)) {
+        trackEvent("auth_started", { action: "apple" });
+        await AuthService.startAppleSignInForVoice({
+          directiveId: voiceDirectiveId,
+          returnTo: ROUTES.LOGIN,
+          resumeTarget: redirectPath || ROUTES.ONE_SETUP,
+        });
+        return {
+          status: "started" as const,
+          summary: "Apple sign-in opened in this browser.",
+        };
+      }
       debugError("[AuthStep] Apple login failed", err);
       trackEvent("auth_failed", {
         action: "apple",
@@ -628,76 +672,24 @@ export function AuthStep({
           description: authErrorMessage(err),
         });
       }
-    } finally {
-      setPendingProvider(null);
-    }
-  };
-
-  const startVoiceProviderLogin = async (
-    provider: "google" | "apple",
-    context?: LocalOnboardingActionContext
-  ) => {
-    if (pendingProvider) {
-      return { status: "blocked" as const, summary: "A sign-in window is already open." };
-    }
-    setPendingProvider(provider);
-    trackEvent("auth_started", { action: provider });
-    try {
-      const authResult =
-        provider === "google"
-          ? await AuthService.startGoogleSignInForVoice({
-              directiveId: context?.directiveId || null,
-              returnTo: `${window.location.pathname}${window.location.search}`,
-              resumeTarget: redirectPath,
-            })
-          : await AuthService.startAppleSignInForVoice({
-              directiveId: context?.directiveId || null,
-              returnTo: `${window.location.pathname}${window.location.search}`,
-              resumeTarget: redirectPath,
-            });
-
-      // Browser redirect starts navigation and settles through getRedirectResult
-      // on return. Native sign-in completes in-process and can use the same
-      // post-auth route resolution as the visible provider buttons.
-      if (!authResult?.user) {
-        return {
-          status: "started" as const,
-          summary: `Opening ${provider === "google" ? "Google" : "Apple"} sign-in.`,
-        };
-      }
-      setNativeUser(authResult.user);
-      await resolveAndNavigate(
-        authResult.user.uid,
-        authResult.idToken || (await authResult.user.getIdToken()),
-        authResult.user.phoneNumber
-      );
       return {
-        status: "succeeded" as const,
-        summary: "Sign-in completed. Continuing your setup.",
-      };
-    } catch (error) {
-      trackEvent("auth_failed", {
-        action: provider,
-        result: "error",
-        error_class: "auth_failed",
-      });
-      return {
-        status: "failed" as const,
-        summary:
-          error instanceof Error && error.message
-            ? error.message
-            : `Could not start ${provider === "google" ? "Google" : "Apple"} sign-in.`,
+        status: isAuthCancel(err) ? "blocked" as const : "failed" as const,
+        summary: isAuthCancel(err) ? "Apple sign-in was cancelled." : authErrorMessage(err),
       };
     } finally {
       setPendingProvider(null);
     }
   };
 
+  // Voice first uses the exact same popup path as tap. Browsers may reject a
+  // WebSocket-delivered directive because it has no transient user activation;
+  // only that explicit failure falls back to the correlated redirect/resume
+  // path handled by the callback effect above.
   useLocalOnboardingActionHandler("auth.sign_in_google", async (_slots, context) =>
-    startVoiceProviderLogin("google", context)
+    handleGoogleLogin(context?.directiveId ?? null),
   );
   useLocalOnboardingActionHandler("auth.sign_in_apple", async (_slots, context) =>
-    startVoiceProviderLogin("apple", context)
+    handleAppleLogin(context?.directiveId ?? null),
   );
 
   if (authLoading || user) {
@@ -710,13 +702,13 @@ export function AuthStep({
           id: "google",
           label: "Continue with Google",
           icon: <GoogleIcon />,
-          onClick: handleGoogleLogin,
+          onClick: () => handleGoogleLogin(),
         },
         {
           id: "apple",
           label: "Continue with Apple",
           icon: <AppleIcon />,
-          onClick: handleAppleLogin,
+          onClick: () => handleAppleLogin(),
         },
       ]
     : [
@@ -724,13 +716,13 @@ export function AuthStep({
           id: "apple",
           label: "Continue with Apple",
           icon: <AppleIcon />,
-          onClick: handleAppleLogin,
+          onClick: () => handleAppleLogin(),
         },
         {
           id: "google",
           label: "Continue with Google",
           icon: <GoogleIcon />,
-          onClick: handleGoogleLogin,
+          onClick: () => handleGoogleLogin(),
         },
       ];
 
@@ -819,8 +811,11 @@ export function AuthStep({
                 key={option.id}
                 label={option.label}
                 icon={option.icon}
-                onClick={option.onClick}
+                onClick={() => {
+                  void option.onClick();
+                }}
                 disabled={pendingProvider !== null}
+                voiceControlId={`auth_${option.id}`}
                 className={option.id === "apple" ? APPLE_BTN_CLASS : GOOGLE_BTN_CLASS}
               />
             ))}

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { useCallback } from "react";
 import { HushhWordmark } from "@/components/app-ui/hushh-wordmark";
 import { OnboardingHeroBackground } from "@/components/onboarding/OnboardingHeroBackground";
+import { useLocalOnboardingActionHandler } from "@/lib/agent/local-onboarding-actions";
 import { Button } from "@/lib/morphy-ux/button";
 import { ROUTES } from "@/lib/navigation/routes";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
 /* ────────────────────────────────────────────────────────────
  * Welcome ("/"). A restrained, Foundation-warm canvas carries one centered
@@ -22,6 +25,49 @@ export function IntroStep({
 }: {
   onLogin?: () => void;
 }) {
+  const claimOne = useCallback(() => {
+    if (!onLogin) {
+      return {
+        status: "blocked" as const,
+        summary: "Sign-in is not available yet. Please wait a moment and try again.",
+      };
+    }
+    // Voice and tap intentionally share this one navigation path so a valid
+    // post-sign-in redirect is preserved instead of rebuilt by the voice layer.
+    onLogin();
+    return {
+      status: "started" as const,
+      summary: "Opening sign-in.",
+    };
+  }, [onLogin]);
+
+  useLocalOnboardingActionHandler("onboarding.claim_one", claimOne);
+  usePublishVoiceSurfaceMetadata({
+    screenId: "one_intro",
+    title: "Claim your One",
+    purpose:
+      "This is One's public welcome screen. The person can claim their private agent and continue to sign in.",
+    actions: [
+      {
+        id: "onboarding_claim_one",
+        actionId: "onboarding.claim_one",
+        label: "Claim your One",
+        purpose: "Continue to sign in and begin setting up One.",
+        voiceAliases: ["claim your one", "claim one", "get started", "start with one"],
+      },
+    ],
+    controls: [
+      {
+        id: "onboarding_claim_one",
+        actionId: "onboarding.claim_one",
+        label: "Claim your One",
+        type: "button",
+        purpose: "Continue to sign in and begin setting up One.",
+        voiceAliases: ["claim your one", "claim one", "get started", "start with one"],
+      },
+    ],
+  });
+
   return (
     <main className="relative flex min-h-[100dvh] w-full flex-col overflow-hidden">
       <OnboardingHeroBackground />
@@ -109,7 +155,10 @@ export function IntroStep({
             size="lg"
             fullWidth
             showRipple
-            onClick={onLogin}
+            onClick={() => {
+              void claimOne();
+            }}
+            data-voice-control-id="onboarding_claim_one"
             // Theme-matching surface (same contract as the login provider
             // buttons): light button in light mode, dark button in dark
             // mode, definition from a hairline border + soft shadow instead

--- a/hushh-webapp/components/onboarding/setup/capability-setup-tile.tsx
+++ b/hushh-webapp/components/onboarding/setup/capability-setup-tile.tsx
@@ -40,6 +40,7 @@ export interface CapabilitySetupTileProps {
   /** Plain, One-voice description of what this step sets up. */
   description: string;
   href: string;
+  voiceControlId: string;
   icon: LucideIcon;
   tone: OneCapabilityTone;
   status: CapabilityStatus;
@@ -54,6 +55,7 @@ export function CapabilitySetupTile({
   title,
   description,
   href,
+  voiceControlId,
   icon: Icon,
   status,
   isExploreOnly = false,
@@ -102,6 +104,7 @@ export function CapabilitySetupTile({
         aria-label={`${title}: ${display.label}`}
         aria-current={isCurrent ? "step" : undefined}
         data-href={href}
+        data-voice-control-id={voiceControlId}
         className={cn(
           "[&]:focus-visible:ring-2 [&]:focus-visible:ring-ring [&]:focus-visible:ring-inset",
           className,

--- a/hushh-webapp/components/onboarding/setup/onboarding-capability-step.tsx
+++ b/hushh-webapp/components/onboarding/setup/onboarding-capability-step.tsx
@@ -196,6 +196,7 @@ export function OnboardingCapabilityStep({
             onClick={handlePrimary}
             disabled={busy || acted}
             data-testid="one-setup-capability-primary"
+            data-voice-control-id="one_setup_capability_primary"
           >
             {ctaLabel}
           </Button>

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -96,7 +96,7 @@ export function OneSetupHub() {
     actions: [
       ...CAPABILITY_SETUP_COPY.map((cap) => ({
         id: cap.id,
-        actionId: `setup.open_${cap.id.replace(/-/g, "_")}`,
+        actionId: getOneCapability(cap.id)?.setupActionId,
         label: cap.title,
         purpose: cap.setupBlurb,
       })),
@@ -120,10 +120,12 @@ export function OneSetupHub() {
   // so the gate is consistent on the very next route resolve. Failures stay
   // fail-open (we still navigate home).
   const handleMasterAck = async () => {
-    if (dismissing) return;
+    if (dismissing) {
+      return { status: "blocked" as const, summary: "Setup is already being finished." };
+    }
     if (!user?.uid) {
       router.push(completionTarget);
-      return;
+      return { status: "started" as const, summary: "Opening home." };
     }
     setDismissing(true);
     try {
@@ -134,22 +136,26 @@ export function OneSetupHub() {
         vaultKey,
         vaultOwnerToken,
       });
+      router.push(completionTarget);
+      return {
+        status: "succeeded" as const,
+        summary: masterSkipped ? "Skipped setup for now." : "Setup acknowledged. Opening home.",
+      };
     } catch (error) {
       console.warn("[OneSetupHub] Failed to resolve master setup gate:", error);
+      return {
+        status: "failed" as const,
+        summary: "Setup could not be finished yet. You are still on the setup hub.",
+      };
     } finally {
       setDismissing(false);
-      router.push(completionTarget);
     }
   };
 
   // Voice parity: "skip setup" / "continue to home" drive the same master
   // acknowledgement as tapping the hub's Skip/Continue button.
   useLocalOnboardingActionHandler("setup.hub_master_ack", async () => {
-    await handleMasterAck();
-    return {
-      status: "succeeded",
-      summary: masterSkipped ? "Skipped setup for now." : "Setup acknowledged. Opening home.",
-    };
+    return handleMasterAck();
   });
 
   const summary = isLoading
@@ -184,6 +190,7 @@ export function OneSetupHub() {
               disabled={dismissing}
               onClick={() => void handleMasterAck()}
               data-testid="one-setup-master-ack"
+              data-voice-control-id="one-setup-master-ack"
               className={cn(
                 "rounded-full type-subhead font-medium",
                 "transition-[background-color,transform] duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
@@ -222,6 +229,7 @@ export function OneSetupHub() {
                 title={item.copy.setupTitle}
                 description={item.copy.setupBlurb}
                 href={item.copy.href}
+                voiceControlId={item.voiceControlId}
                 icon={item.icon}
                 tone={item.tone}
                 status={item.status}
@@ -242,6 +250,7 @@ interface SetupItem {
   status: CapabilityStatus;
   icon: LucideIcon;
   tone: OneCapabilityTone;
+  voiceControlId: string;
   isActionable: boolean;
   isExploreOnly: boolean;
   isCurrent: boolean;
@@ -270,6 +279,7 @@ function buildSetupItems(
         status,
         icon: capability.icon,
         tone: capability.tone,
+        voiceControlId: capability.setupControlId,
         isActionable: isCapabilitySetupActionable(status),
         isExploreOnly: capability.isExploreOnly === true,
       },

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.voice-action-contract.json
@@ -95,7 +95,7 @@
       "docs_references": []
     },
     {
-      "action_id": "setup.open_personal_data",
+      "action_id": "setup.open_pkm",
       "label": "Set Up Memory",
       "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
       "aliases": ["set up memory", "open memory setup", "set up personal information"],
@@ -111,6 +111,26 @@
       "execution_policy": "allow_direct",
       "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/pkm" },
       "control_ids": ["one_setup_tile_pkm"],
+      "state_exposure": [],
+      "docs_references": []
+    },
+    {
+      "action_id": "setup.open_marketplace",
+      "label": "Explore Information Marketplace",
+      "meaning": "Opens the Information Marketplace explore step from the setup hub.",
+      "aliases": ["explore information marketplace", "open marketplace setup", "set up marketplace"],
+      "search_keywords": ["information marketplace", "marketplace", "setup", "explore"],
+      "reachability": {
+        "routes": ["/one/setup"],
+        "screens": ["one_setup_hub", "one_setup"],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": ["auth_signed_in"],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": { "status": "wired", "path": "route", "target": "/one/setup/marketplace" },
+      "control_ids": ["one_setup_tile_marketplace"],
       "state_exposure": [],
       "docs_references": []
     },

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -12,6 +12,7 @@
     "hushh-webapp/app/one/page.voice-action-contract.json",
     "hushh-webapp/app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
     "hushh-webapp/app/one/setup/kai/page.voice-action-contract.json",
+    "hushh-webapp/app/page.voice-action-contract.json",
     "hushh-webapp/app/profile/page.voice-action-contract.json",
     "hushh-webapp/app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
     "hushh-webapp/app/register-phone/page.voice-action-contract.json",
@@ -227,8 +228,8 @@
         }
       },
       "orchestration": {
-        "instruction_id": "route.one.home",
-        "context_policy": "publish",
+        "instruction_id": null,
+        "context_policy": null,
         "trust_boundary": "consent",
         "delegation_policy": "one_action_gate"
       }
@@ -286,6 +287,31 @@
         "context_policy": null,
         "trust_boundary": null,
         "delegation_policy": null
+      }
+    },
+    {
+      "schema_version": "kai.local_action_contract.v1",
+      "surface_id": "one_intro",
+      "surface_title": "Claim your One",
+      "docs_references": [
+        "docs/reference/one/one-voice-runtime-architecture.md",
+        "docs/reference/one/one-voice-onboarding-journey.md"
+      ],
+      "contract_file": "hushh-webapp/app/page.voice-action-contract.json",
+      "defaults": {
+        "reachability": {
+          "active_personas": [
+            "investor",
+            "ria"
+          ]
+        },
+        "speaker_persona": "one"
+      },
+      "orchestration": {
+        "instruction_id": null,
+        "context_policy": null,
+        "trust_boundary": "none",
+        "delegation_policy": "no_delegation"
       }
     },
     {
@@ -1202,7 +1228,7 @@
         "login",
         "authenticate"
       ],
-      "meaning": "Starts Google sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Google provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -1310,7 +1336,7 @@
         "login",
         "authenticate"
       ],
-      "meaning": "Starts Apple sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Apple provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -4241,6 +4267,7 @@
           "/one/setup/location",
           "/one/setup/pkm",
           "/one/setup/consent",
+          "/one/setup/marketplace",
           "/one/setup/connected-systems"
         ],
         "screens": [
@@ -4250,6 +4277,7 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
+          "one_setup_marketplace",
           "one_setup_connected-systems",
           "one_setup"
         ],
@@ -4700,19 +4728,20 @@
     {
       "action_id": "kai.setup.launch_dashboard",
       "surface_id": "kai_setup_wizard",
-      "label": "Launch Kai Dashboard",
+      "label": "Save Finance Preferences",
       "aliases": [
-        "launch my dashboard",
+        "save finance preferences",
         "looks good, continue",
-        "finish kai setup"
+        "finish finance setup"
       ],
       "search_keywords": [
-        "launch",
-        "dashboard",
+        "save",
+        "finance",
+        "preferences",
         "finish",
         "persona"
       ],
-      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "meaning": "Saves Finance preferences, marks only Finance ready, and returns to the One setup hub without resolving root onboarding.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "reachability": {
@@ -4779,11 +4808,118 @@
           {
             "type": "action",
             "action_id": "kai.setup.launch_dashboard",
-            "label": "Launch Kai Dashboard",
+            "label": "Save Finance Preferences",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/kai",
               "screen": "kai_setup_wizard"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "onboarding.claim_one",
+      "surface_id": "one_intro",
+      "label": "Claim your One",
+      "aliases": [
+        "claim your one",
+        "claim my one",
+        "claim one",
+        "get started",
+        "start with one",
+        "begin with one"
+      ],
+      "search_keywords": [
+        "claim",
+        "one",
+        "start",
+        "welcome",
+        "sign in"
+      ],
+      "meaning": "Continues from One's public welcome screen to sign in and begin setup.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/"
+        ],
+        "screens": [
+          "one_intro"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "onboarding.claim_one"
+      },
+      "control_ids": [
+        "onboarding_claim_one"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/one/one-voice-runtime-architecture.md",
+        "docs/reference/one/one-voice-onboarding-journey.md"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.onboarding.claim_one",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "onboarding.claim_one",
+            "label": "Claim your One",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/",
+              "screen": "one_intro"
             }
           }
         ],
@@ -6169,7 +6305,7 @@
         "verify",
         "confirm"
       ],
-      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "meaning": "Confirms the six-digit SMS code after an explicit inline confirmation and completes phone verification. The code is sensitive and must never be repeated or retained.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "reachability": {
@@ -6192,14 +6328,14 @@
       },
       "guard_ids": [
         "auth_signed_in",
-        "manual_user_execution"
+        "explicit_user_confirmation"
       ],
       "risk_level": "high",
-      "execution_policy": "manual_only",
+      "execution_policy": "confirm_required",
       "execution_target": {
-        "status": "unwired",
-        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
-        "intended_handler": "local_handler"
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_code"
       },
       "control_ids": [
         "phone-flow-code"
@@ -6231,7 +6367,14 @@
       },
       "goal": {
         "goal_id": "goal.phone_mandate.submit_code",
-        "required_inputs": [],
+        "required_inputs": [
+          {
+            "name": "verification_code",
+            "prompt": "Say or type the six-digit code. Spoken codes are processed by the voice service.",
+            "required": true,
+            "slot": "code"
+          }
+        ],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
@@ -10774,7 +10917,8 @@
           "/one/kai/import"
         ],
         "screens": [
-          "kai_portfolio_dashboard"
+          "kai_portfolio_dashboard",
+          "import"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": [],
@@ -11579,7 +11723,7 @@
       }
     },
     {
-      "action_id": "setup.open_personal_data",
+      "action_id": "setup.open_pkm",
       "surface_id": "one_setup_hub",
       "label": "Set Up Memory",
       "aliases": [
@@ -11648,18 +11792,124 @@
         ]
       },
       "goal": {
-        "goal_id": "goal.setup.open_personal_data",
+        "goal_id": "goal.setup.open_pkm",
         "required_inputs": [],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
           {
             "type": "action",
-            "action_id": "setup.open_personal_data",
+            "action_id": "setup.open_pkm",
             "label": "Set Up Memory",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
+      "action_id": "setup.open_marketplace",
+      "surface_id": "one_setup_hub",
+      "label": "Explore Information Marketplace",
+      "aliases": [
+        "explore information marketplace",
+        "open marketplace setup",
+        "set up marketplace"
+      ],
+      "search_keywords": [
+        "information marketplace",
+        "marketplace",
+        "setup",
+        "explore"
+      ],
+      "meaning": "Opens the Information Marketplace explore step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub",
+          "one_setup"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "investor",
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/marketplace"
+      },
+      "control_ids": [
+        "one_setup_tile_marketplace"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /one/setup/marketplace"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.setup.open_marketplace",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_marketplace",
+            "label": "Explore Information Marketplace",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/marketplace",
               "screen": "one_setup_hub"
             }
           }

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "one.route_orchestration_index.v1",
+  "schema_version": "one.route_orchestration_index.v2",
   "purpose": "Generated, redacted route discovery and One delegation-admission index.",
   "sources": [
     "hushh-webapp/frontend-native-surface-map.generated.json",
@@ -10,12 +10,38 @@
       "route_pattern": "/",
       "page_file": "app/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
-      "instruction_id": "route.root",
-      "context_policy": "suppress",
-      "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "orchestration_class": "interactive",
+      "instruction_id": "route.one.intro",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.intro",
+        "purpose": "Welcome a new person and help them claim their private agent.",
+        "screen": "one_intro",
+        "entry_cue": "Say ‘Claim your One’ whenever you are ready.",
+        "proactivity": "on_entry",
+        "primary_action_id": "onboarding.claim_one",
+        "happy_path_action_ids": [
+          "onboarding.claim_one"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "The welcome step completes only after the browser settles navigation to Login.",
+        "next_route": "/login",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "voice_contract_file": "app/page.voice-action-contract.json",
+      "action_ids": [
+        "onboarding.claim_one"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
@@ -30,6 +56,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.agent",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.agent",
+        "purpose": "Help the person understand and use the agent screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -43,10 +91,32 @@
     {
       "route_pattern": "/blog",
       "page_file": "app/blog/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
       "instruction_id": "route.blog",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.blog",
+        "purpose": "Help the person understand and use the blog screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -60,10 +130,32 @@
     {
       "route_pattern": "/blog/[slug]",
       "page_file": "app/blog/[slug]/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
-      "instruction_id": "route.blog.slug.",
-      "context_policy": "minimal",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.blog.slug",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.blog.slug",
+        "purpose": "Help the person understand and use the blog screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -81,6 +173,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.connect",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.connect",
+        "purpose": "Help the person understand and use the connect screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -95,9 +209,33 @@
       "route_pattern": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.connected.systems",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.connected.systems",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "connected_systems",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [
+          "utterance"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "connected_systems.chat.turn"
@@ -116,9 +254,31 @@
       "route_pattern": "/connected-systems/[systemId]",
       "page_file": "app/connected-systems/[systemId]/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
-      "instruction_id": "route.connected.systems.systemId.",
-      "context_policy": "minimal",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.connected.systems.systemid",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.connected.systems.systemid",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -136,6 +296,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.consents",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.consents",
+        "purpose": "Help the person understand and use the consents screen through its generated controls.",
+        "screen": "consents",
+        "entry_cue": "You can say “Open RIA Requests” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_requests_compat",
+        "happy_path_action_ids": [
+          "route.ria_requests_compat"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/requests",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "connections.chat.turn",
@@ -161,6 +345,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.developers",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.developers",
+        "purpose": "Help the person understand and use the developers screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -175,30 +381,75 @@
       "route_pattern": "/getting-started",
       "page_file": "app/getting-started/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
+      "orchestration_class": "interactive",
       "instruction_id": "route.getting.started",
-      "context_policy": "suppress",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.getting.started",
+        "purpose": "Help the person understand and use the getting started screen through its generated controls.",
+        "screen": "getting_started",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/getting-started",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/getting-started/page.voice-action-contract.json",
       "action_ids": [
         "auth.sign_in_open",
         "onboarding.continue",
-        "route.getting_started"
+        "route.getting_started",
+        "vault.setup_open"
       ],
       "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
       },
-      "trust_boundary": "none",
+      "trust_boundary": "auth",
       "native_surface_id": "native-route-getting-started"
     },
     {
       "route_pattern": "/gmail",
       "page_file": "app/gmail/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.gmail",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.gmail",
+        "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+        "screen": "gmail",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -213,9 +464,31 @@
       "route_pattern": "/kai",
       "page_file": "app/kai/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai",
+        "purpose": "Help the person understand and use the kai screen through its generated controls.",
+        "screen": "kai_market",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -233,6 +506,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.kai.alpaca.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.alpaca.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -247,9 +542,31 @@
       "route_pattern": "/kai/analysis",
       "page_file": "app/kai/analysis/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.analysis",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.analysis",
+        "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+        "screen": "kai_analysis",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -264,9 +581,31 @@
       "route_pattern": "/kai/dashboard",
       "page_file": "app/kai/dashboard/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.dashboard",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.dashboard",
+        "purpose": "Help the person understand and use the dashboard screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -281,9 +620,31 @@
       "route_pattern": "/kai/dashboard/analysis",
       "page_file": "app/kai/dashboard/analysis/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.dashboard.analysis",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.dashboard.analysis",
+        "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -298,9 +659,31 @@
       "route_pattern": "/kai/funding-trade",
       "page_file": "app/kai/funding-trade/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.funding.trade",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.funding.trade",
+        "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+        "screen": "kai_funding_trade",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -315,9 +698,31 @@
       "route_pattern": "/kai/import",
       "page_file": "app/kai/import/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.import",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.import",
+        "purpose": "Help the person understand and use the import screen through its generated controls.",
+        "screen": "import",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -332,9 +737,31 @@
       "route_pattern": "/kai/investments",
       "page_file": "app/kai/investments/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.investments",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.investments",
+        "purpose": "Help the person understand and use the investments screen through its generated controls.",
+        "screen": "kai_investments",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -349,9 +776,31 @@
       "route_pattern": "/kai/onboarding",
       "page_file": "app/kai/onboarding/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.onboarding",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.onboarding",
+        "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -366,9 +815,31 @@
       "route_pattern": "/kai/optimize",
       "page_file": "app/kai/optimize/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.optimize",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.optimize",
+        "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+        "screen": "kai_optimize",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -386,6 +857,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.kai.plaid.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.plaid.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -400,9 +893,31 @@
       "route_pattern": "/kai/portfolio",
       "page_file": "app/kai/portfolio/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.kai.portfolio",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.kai.portfolio",
+        "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -417,9 +932,33 @@
       "route_pattern": "/login",
       "page_file": "app/login/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
+      "orchestration_class": "interactive",
       "instruction_id": "route.login",
-      "context_policy": "suppress",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.login",
+        "purpose": "Let the person choose Google or Apple and begin the matching sign-in flow.",
+        "screen": "login",
+        "entry_cue": "Say ‘Continue with Google’ or ‘Continue with Apple’.",
+        "proactivity": "on_entry",
+        "primary_action_id": "auth.sign_in_google",
+        "happy_path_action_ids": [
+          "auth.sign_in_google"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Authentication completes only after the provider popup returns a verified Firebase user session.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/login/page.voice-action-contract.json",
       "action_ids": [
         "auth.sign_in_apple",
@@ -440,6 +979,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.logout",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.logout",
+        "purpose": "Help the person understand and use the logout screen through its generated controls.",
+        "screen": "logout",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -457,6 +1018,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.marketplace",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace",
+        "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+        "screen": "marketplace",
+        "entry_cue": "You can say “Continue Browsing Marketplace” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.marketplace_browse_from_ria_profile",
+        "happy_path_action_ids": [
+          "route.marketplace_browse_from_ria_profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/marketplace",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.marketplace_browse_from_ria_profile",
@@ -474,9 +1059,33 @@
       "route_pattern": "/marketplace/connections",
       "page_file": "app/marketplace/connections/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.marketplace.connections",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace.connections",
+        "purpose": "Help the person understand and use the connections screen through its generated controls.",
+        "screen": "marketplace",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [
+          "utterance"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "connections.chat.turn"
@@ -495,9 +1104,31 @@
       "route_pattern": "/marketplace/connections/portfolio",
       "page_file": "app/marketplace/connections/portfolio/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.marketplace.connections.portfolio",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace.connections.portfolio",
+        "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+        "screen": "marketplace",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -515,6 +1146,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.marketplace.ria",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.marketplace.ria",
+        "purpose": "Help the person understand and use the ria screen through its generated controls.",
+        "screen": "marketplace_ria_profile",
+        "entry_cue": "You can say “Open Marketplace RIA Profile” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.marketplace_ria_profile",
+        "happy_path_action_ids": [
+          "route.marketplace_ria_profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/marketplace/ria",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/marketplace/ria/page-client.voice-action-contract.json",
       "action_ids": [
         "marketplace.ria.manage_profile",
@@ -536,6 +1191,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.home",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.home",
+        "purpose": "Help the person understand and use the one screen through its generated controls.",
+        "screen": "one_agents",
+        "entry_cue": "You can say “Open Agents” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_agents",
+        "happy_path_action_ids": [
+          "route.one_agents"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/page.voice-action-contract.json",
       "action_ids": [
         "connected_systems.chat.turn",
@@ -546,7 +1225,9 @@
         "location.chat.turn",
         "marketplace.information.chat.turn",
         "marketplace.information.requests.turn",
-        "route.one_agents"
+        "route.one_agents",
+        "route.one_location",
+        "route.one_pkm"
       ],
       "action_coverage": "inherited",
       "delegation_policy": {
@@ -571,6 +1252,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.connected.systems",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.connected.systems",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "connected_systems",
+        "entry_cue": "You can say “Open Connected Systems Panel” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_connected_systems",
+        "happy_path_action_ids": [
+          "route.profile_connected_systems"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/connected-systems",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.profile_connected_systems"
@@ -588,8 +1293,30 @@
       "page_file": "app/one/connected-systems/[systemId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "context_only",
-      "instruction_id": "route.one.connected.systems.systemId.",
+      "instruction_id": "route.one.connected.systems.systemid",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.one.connected.systems.systemid",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -607,6 +1334,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.gmail",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.gmail",
+        "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+        "screen": "gmail",
+        "entry_cue": "You can say “Open Receipts Page” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_receipts",
+        "happy_path_action_ids": [
+          "route.profile_receipts"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/gmail",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/gmail/page.voice-action-contract.json",
       "action_ids": [
         "email.chat.turn",
@@ -632,6 +1383,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai",
+        "purpose": "Help the person understand and use the kai screen through its generated controls.",
+        "screen": "kai_market",
+        "entry_cue": "You can say “Open Market Home” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_home",
+        "happy_path_action_ids": [
+          "route.kai_home"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.back",
@@ -652,6 +1427,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.one.kai.alpaca.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.alpaca.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -669,6 +1466,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.analysis",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.analysis",
+        "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+        "screen": "kai_analysis",
+        "entry_cue": "You can say “Open Analysis Surface” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_analysis",
+        "happy_path_action_ids": [
+          "route.kai_analysis"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kai/analysis",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/kai/analysis/page.voice-action-contract.json",
       "action_ids": [
         "analysis.cancel_active",
@@ -693,6 +1514,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.one.kai.funding.trade",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.funding.trade",
+        "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+        "screen": "kai_funding_trade",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -710,6 +1553,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.import",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.import",
+        "purpose": "Help the person understand and use the import screen through its generated controls.",
+        "screen": "import",
+        "entry_cue": "You can say “Open Portfolio Import” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_import",
+        "happy_path_action_ids": [
+          "route.kai_import"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_import"
@@ -729,6 +1596,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.investments",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.investments",
+        "purpose": "Help the person understand and use the investments screen through its generated controls.",
+        "screen": "kai_investments",
+        "entry_cue": "You can say “Open Investments Surface” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_investments",
+        "happy_path_action_ids": [
+          "route.kai_investments"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kai/investments",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_investments"
@@ -745,9 +1636,31 @@
       "route_pattern": "/one/kai/onboarding",
       "page_file": "app/one/kai/onboarding/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.one.kai.onboarding",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.onboarding",
+        "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -765,6 +1678,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.optimize",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.optimize",
+        "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+        "screen": "kai_optimize",
+        "entry_cue": "You can say “Open Optimize Surface” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_optimize",
+        "happy_path_action_ids": [
+          "route.kai_optimize"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kai/optimize",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_optimize"
@@ -784,6 +1721,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.one.kai.plaid.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.plaid.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "kai",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -801,6 +1760,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kai.portfolio",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kai.portfolio",
+        "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+        "screen": "kai_portfolio_dashboard",
+        "entry_cue": "You can say “Open Portfolio Dashboard” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.kai_dashboard",
+        "happy_path_action_ids": [
+          "route.kai_dashboard"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.kai_dashboard"
@@ -820,6 +1803,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.kyc",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.kyc",
+        "purpose": "Help the person understand and use the kyc screen through its generated controls.",
+        "screen": "one_kyc",
+        "entry_cue": "You can say “Open Email” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_kyc",
+        "happy_path_action_ids": [
+          "route.one_kyc"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/kyc",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/kyc/page.voice-action-contract.json",
       "action_ids": [
         "route.one_kyc"
@@ -839,8 +1846,32 @@
       "page_file": "app/one/location/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.one.home",
+      "instruction_id": "route.one.location",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.location",
+        "purpose": "Help the person understand and use the location screen through its generated controls.",
+        "screen": "one_location",
+        "entry_cue": "You can say “Open Location” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_location",
+        "happy_path_action_ids": [
+          "route.one_location"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/location",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "location.chat.turn",
@@ -861,8 +1892,30 @@
       "page_file": "app/one/location/invite/[token]/page.tsx",
       "route_mode": "hidden",
       "orchestration_class": "transitional",
-      "instruction_id": "route.one.location.invite.token.",
+      "instruction_id": "route.one.location.invite.token",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.location.invite.token",
+        "purpose": "Help the person understand and use the invite screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -878,8 +1931,30 @@
       "page_file": "app/one/location/request/[token]/page.tsx",
       "route_mode": "hidden",
       "orchestration_class": "transitional",
-      "instruction_id": "route.one.location.request.token.",
+      "instruction_id": "route.one.location.request.token",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.one.location.request.token",
+        "purpose": "Help the person understand and use the request screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -897,6 +1972,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.marketplace",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.marketplace",
+        "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+        "screen": "one_marketplace",
+        "entry_cue": "You can say “Open Information Marketplace” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_marketplace",
+        "happy_path_action_ids": [
+          "route.one_marketplace"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/marketplace",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/marketplace/page.voice-action-contract.json",
       "action_ids": [
         "marketplace.information.chat.turn",
@@ -918,8 +2017,32 @@
       "page_file": "app/one/pkm/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.one.home",
+      "instruction_id": "route.one.pkm",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.pkm",
+        "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+        "screen": "pkm",
+        "entry_cue": "You can say “Open Memory” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.one_pkm",
+        "happy_path_action_ids": [
+          "route.one_pkm"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/one/pkm",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.one_pkm",
@@ -940,6 +2063,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.setup",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.setup",
+        "purpose": "Help the person choose, resume, skip, or finish one setup capability.",
+        "screen": "one_setup",
+        "entry_cue": "Choose something to set up, or say ‘finish setup’ when you are ready.",
+        "proactivity": "on_entry",
+        "primary_action_id": "setup.open_finance",
+        "happy_path_action_ids": [
+          "setup.open_finance"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Only the hub finish or skip action resolves root onboarding.",
+        "next_route": "/one",
+        "return_policy": "resolve_root",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "setup.hub_master_ack",
@@ -949,7 +2096,8 @@
         "setup.open_finance",
         "setup.open_gmail",
         "setup.open_location",
-        "setup.open_personal_data",
+        "setup.open_marketplace",
+        "setup.open_pkm",
         "vault.setup_open"
       ],
       "action_coverage": "inherited",
@@ -964,17 +2112,43 @@
       "route_pattern": "/one/setup/[capability]",
       "page_file": "app/one/setup/[capability]/page.tsx",
       "route_mode": "standard",
-      "orchestration_class": "context_only",
-      "instruction_id": "route.one.setup.capability.",
-      "context_policy": "minimal",
-      "voice_contract_file": null,
-      "action_ids": [],
-      "action_coverage": "none",
+      "orchestration_class": "interactive",
+      "instruction_id": "route.one.setup.capability",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.setup.capability",
+        "purpose": "Explain the active setup capability and advance only its visible next step.",
+        "screen": "one_setup",
+        "entry_cue": "Say ‘Continue’ when you are ready for the next step.",
+        "proactivity": "on_entry",
+        "primary_action_id": "setup.capability_continue",
+        "happy_path_action_ids": [
+          "setup.capability_continue"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "The step settles after its local handler opens the capability destination.",
+        "next_route": "/one/setup",
+        "return_policy": "return_to_hub",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "voice_contract_file": "app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+      "action_ids": [
+        "setup.capability_continue"
+      ],
+      "action_coverage": "inherited",
       "delegation_policy": {
         "mode": "no_delegation",
         "allowed_delegate_agent_ids": []
       },
-      "trust_boundary": "none",
+      "trust_boundary": "auth",
       "native_surface_id": null
     },
     {
@@ -984,6 +2158,32 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.one.setup.kai",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.one.setup.kai",
+        "purpose": "Collect Finance preferences and return to the setup hub without resolving root onboarding.",
+        "screen": "one_setup",
+        "entry_cue": "Answer the visible Finance question to continue.",
+        "proactivity": "on_entry",
+        "primary_action_id": "kai.setup.answer_horizon",
+        "happy_path_action_ids": [
+          "kai.setup.answer_horizon"
+        ],
+        "required_inputs": [
+          "investment_horizon"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Finance setup completes only after preferences are saved and the hub route settles.",
+        "next_route": "/one/setup",
+        "return_policy": "return_to_hub",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/one/setup/kai/page.voice-action-contract.json",
       "action_ids": [
         "kai.setup.answer_drawdown",
@@ -1003,9 +2203,31 @@
       "route_pattern": "/pkm",
       "page_file": "app/pkm/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.pkm",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.pkm",
+        "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+        "screen": "pkm",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1023,6 +2245,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.portfolio.shared",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.portfolio.shared",
+        "purpose": "Help the person understand and use the shared screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1040,10 +2284,39 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile",
+        "purpose": "Help the person understand and use the profile screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "You can say “Open Profile” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile",
+        "happy_path_action_ids": [
+          "route.profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/profile/page.voice-action-contract.json",
       "action_ids": [
         "route.back",
         "route.profile",
+        "route.profile_connected_systems",
+        "route.profile_gmail_panel",
+        "route.profile_pkm_agent_lab",
+        "route.profile_security_panel",
+        "route.profile_support_panel",
         "route.ria_settings_compat"
       ],
       "action_coverage": "inherited",
@@ -1061,6 +2334,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.access",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.access",
+        "purpose": "Help the person understand and use the access screen through its generated controls.",
+        "screen": "profile_privacy",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1078,6 +2373,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.access.connection",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.access.connection",
+        "purpose": "Help the person understand and use the connection screen through its generated controls.",
+        "screen": "profile_privacy",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1095,6 +2412,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.account",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.account",
+        "purpose": "Help the person understand and use the account screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1112,6 +2451,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.account.phone",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.account.phone",
+        "purpose": "Help the person understand and use the phone screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1129,6 +2490,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.connected.systems",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.connected.systems",
+        "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+        "screen": "connected_systems",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1143,9 +2526,31 @@
       "route_pattern": "/profile/gmail",
       "page_file": "app/profile/gmail/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail",
+        "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+        "screen": "profile_gmail_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1160,9 +2565,31 @@
       "route_pattern": "/profile/gmail/actions",
       "page_file": "app/profile/gmail/actions/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail.actions",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail.actions",
+        "purpose": "Help the person understand and use the actions screen through its generated controls.",
+        "screen": "profile_gmail_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1177,9 +2604,31 @@
       "route_pattern": "/profile/gmail/connection",
       "page_file": "app/profile/gmail/connection/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail.connection",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail.connection",
+        "purpose": "Help the person understand and use the connection screen through its generated controls.",
+        "screen": "profile_gmail_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1197,6 +2646,28 @@
       "orchestration_class": "transitional",
       "instruction_id": "route.profile.gmail.oauth.return",
       "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.gmail.oauth.return",
+        "purpose": "Help the person understand and use the return screen through its generated controls.",
+        "screen": "profile_account",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1214,6 +2685,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.my.data",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.my.data",
+        "purpose": "Help the person understand and use the personal information screen through its generated controls.",
+        "screen": "profile_my_data",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1231,6 +2724,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.my.data.domain",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.my.data.domain",
+        "purpose": "Help the person understand and use the domain screen through its generated controls.",
+        "screen": "profile_my_data",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1245,9 +2760,31 @@
       "route_pattern": "/profile/pkm",
       "page_file": "app/profile/pkm/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.pkm",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.pkm",
+        "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+        "screen": "pkm",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1265,6 +2802,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile.pkm.agent.lab",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile.pkm.agent.lab",
+        "purpose": "Help the person understand and use the pkm agent lab screen through its generated controls.",
+        "screen": "profile_pkm_agent_lab",
+        "entry_cue": "You can say “Generate PKM capture preview” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "profile.pkm.preview_capture",
+        "happy_path_action_ids": [
+          "profile.pkm.preview_capture"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/profile/pkm-agent-lab/page-client.voice-action-contract.json",
       "action_ids": [
         "profile.pkm.preview_capture"
@@ -1284,6 +2845,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.preferences",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences",
+        "purpose": "Help the person understand and use the preferences screen through its generated controls.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1301,6 +2884,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.preferences.device",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.device",
+        "purpose": "Help the person understand and use the device screen through its generated controls.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1318,6 +2923,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.preferences.kai",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.preferences.kai",
+        "purpose": "Help the person understand and use the kai screen through its generated controls.",
+        "screen": "profile_preferences",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1332,9 +2959,31 @@
       "route_pattern": "/profile/receipts",
       "page_file": "app/profile/receipts/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "context_only",
+      "orchestration_class": "transitional",
       "instruction_id": "route.profile.receipts",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.receipts",
+        "purpose": "Help the person understand and use the receipts screen through its generated controls.",
+        "screen": "gmail",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1352,6 +3001,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile.security",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security",
+        "purpose": "Help the person understand and use the security screen through its generated controls.",
+        "screen": "profile_security_panel",
+        "entry_cue": "You can say “Open Vault Security Panel” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_security_panel",
+        "happy_path_action_ids": [
+          "route.profile_security_panel"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/profile/security",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.profile_security_panel"
@@ -1371,6 +3044,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.security.session",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.session",
+        "purpose": "Help the person understand and use the session screen through its generated controls.",
+        "screen": "profile_security_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1388,6 +3083,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.security.vault",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.vault",
+        "purpose": "Help the person understand and use the vault screen through its generated controls.",
+        "screen": "profile_security_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1405,6 +3122,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.profile.support",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.profile.support",
+        "purpose": "Help the person understand and use the support screen through its generated controls.",
+        "screen": "profile_support_panel",
+        "entry_cue": "You can say “Open Support Panel” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.profile_support_panel",
+        "happy_path_action_ids": [
+          "route.profile_support_panel"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/profile/support",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "route.profile_support_panel"
@@ -1424,6 +3165,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.support.compose",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.support.compose",
+        "purpose": "Help the person understand and use the compose screen through its generated controls.",
+        "screen": "profile_support_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1441,6 +3204,28 @@
       "orchestration_class": "context_only",
       "instruction_id": "route.profile.support.routing",
       "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.support.routing",
+        "purpose": "Help the person understand and use the routing screen through its generated controls.",
+        "screen": "profile_support_panel",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1455,11 +3240,38 @@
       "route_pattern": "/register-phone",
       "page_file": "app/register-phone/page.tsx",
       "route_mode": "hidden",
-      "orchestration_class": "transitional",
+      "orchestration_class": "interactive",
       "instruction_id": "route.register.phone",
-      "context_policy": "suppress",
+      "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.register.phone",
+        "purpose": "Verify the signed-in person’s phone before setup continues.",
+        "screen": "register_phone",
+        "entry_cue": "Say your phone number including country code, or type it below.",
+        "proactivity": "on_entry",
+        "primary_action_id": "phone_mandate.submit_number",
+        "happy_path_action_ids": [
+          "phone_mandate.submit_number"
+        ],
+        "required_inputs": [
+          "phone_number"
+        ],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Phone verification completes only after the submitted code is accepted.",
+        "next_route": "/one/setup",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/register-phone/page.voice-action-contract.json",
       "action_ids": [
+        "phone_mandate.submit_code",
         "phone_mandate.submit_number"
       ],
       "action_coverage": "inherited",
@@ -1473,10 +3285,32 @@
     {
       "route_pattern": "/research",
       "page_file": "app/research/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
       "instruction_id": "route.research",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.research",
+        "purpose": "Help the person understand and use the research screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1490,10 +3324,32 @@
     {
       "route_pattern": "/research/protocol",
       "page_file": "app/research/protocol/page.tsx",
-      "route_mode": "unclassified",
-      "orchestration_class": "context_only",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
       "instruction_id": "route.research.protocol",
-      "context_policy": "minimal",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.research.protocol",
+        "purpose": "Help the person understand and use the protocol screen through its generated controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [],
       "action_coverage": "none",
@@ -1511,6 +3367,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria",
+        "purpose": "Help the person understand and use the ria screen through its generated controls.",
+        "screen": "ria_home",
+        "entry_cue": "You can say “Open RIA Home” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_home",
+        "happy_path_action_ids": [
+          "route.ria_home"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_home"
@@ -1530,9 +3410,34 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.clients",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients",
+        "purpose": "Help the person understand and use the clients screen through its generated controls.",
+        "screen": "ria_clients",
+        "entry_cue": "You can say “Open RIA Clients” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_clients",
+        "happy_path_action_ids": [
+          "route.ria_clients"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/clients/page.voice-action-contract.json",
       "action_ids": [
-        "route.ria_clients"
+        "route.ria_clients",
+        "route.ria_marketplace_connect"
       ],
       "action_coverage": "inherited",
       "delegation_policy": {
@@ -1547,8 +3452,32 @@
       "page_file": "app/ria/clients/[userId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.ria.clients.userId.",
+      "instruction_id": "route.ria.clients.userid",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients.userid",
+        "purpose": "Help the person understand and use the clients screen through its generated controls.",
+        "screen": "ria_client_workspace",
+        "entry_cue": "You can say “Open RIA Client Workspace” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_client_workspace",
+        "happy_path_action_ids": [
+          "route.ria_client_workspace"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients/[userId]",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "ria.client_workspace.open_overview_tab",
@@ -1567,8 +3496,32 @@
       "page_file": "app/ria/clients/[userId]/accounts/[accountId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.ria.clients.userId.accounts.accountId.",
+      "instruction_id": "route.ria.clients.userid.accounts.accountid",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients.userid.accounts.accountid",
+        "purpose": "Help the person understand and use the accounts screen through its generated controls.",
+        "screen": "ria_client_account_detail",
+        "entry_cue": "You can say “Return To Client Information Explorer” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "ria.client_account.open_workspace_fallback",
+        "happy_path_action_ids": [
+          "ria.client_account.open_workspace_fallback"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients/[userId]?tab=explorer",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "ria.client_account.open_workspace_fallback"
@@ -1586,8 +3539,32 @@
       "page_file": "app/ria/clients/[userId]/requests/[requestId]/page.tsx",
       "route_mode": "standard",
       "orchestration_class": "interactive",
-      "instruction_id": "route.ria.clients.userId.requests.requestId.",
+      "instruction_id": "route.ria.clients.userid.requests.requestid",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.clients.userid.requests.requestid",
+        "purpose": "Help the person understand and use the requests screen through its generated controls.",
+        "screen": "ria_client_request_detail",
+        "entry_cue": "You can say “Return To Client Access” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "ria.client_request.open_access_fallback",
+        "happy_path_action_ids": [
+          "ria.client_request.open_access_fallback"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/clients/[userId]?tab=access",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": null,
       "action_ids": [
         "ria.client_request.open_access_fallback"
@@ -1607,6 +3584,30 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.onboarding",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.onboarding",
+        "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+        "screen": "ria_onboarding",
+        "entry_cue": "You can say “Open RIA Onboarding” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_onboarding",
+        "happy_path_action_ids": [
+          "route.ria_onboarding"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/onboarding",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/onboarding/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_onboarding"
@@ -1626,8 +3627,38 @@
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.picks",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.picks",
+        "purpose": "Help the person understand and use the picks screen through its generated controls.",
+        "screen": "ria_picks",
+        "entry_cue": "You can say “Open RIA Picks” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_picks",
+        "happy_path_action_ids": [
+          "route.ria_picks"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/picks",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/picks/page.voice-action-contract.json",
       "action_ids": [
+        "ria.picks.download_template",
+        "ria.picks.open_category_avoid",
+        "ria.picks.open_category_screening",
+        "ria.picks.open_category_top_picks",
+        "ria.picks.open_source_kai",
+        "ria.picks.open_source_my",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",
@@ -1641,10 +3672,34 @@
     {
       "route_pattern": "/ria/profile",
       "page_file": "app/ria/profile/page.tsx",
-      "route_mode": "unclassified",
+      "route_mode": "flow",
       "orchestration_class": "interactive",
       "instruction_id": "route.ria.profile",
       "context_policy": "publish",
+      "voice_playbook": {
+        "playbook_id": "route.ria.profile",
+        "purpose": "Help the person understand and use the profile screen through its generated controls.",
+        "screen": "ria_profile",
+        "entry_cue": "You can say “Open RIA Profile” to use the primary control on this screen.",
+        "proactivity": "on_entry",
+        "primary_action_id": "route.ria_profile",
+        "happy_path_action_ids": [
+          "route.ria_profile"
+        ],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/profile",
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/profile/page.voice-action-contract.json",
       "action_ids": [
         "ria.profile.edit_services",
@@ -1662,9 +3717,31 @@
       "route_pattern": "/ria/requests",
       "page_file": "app/ria/requests/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.ria.requests",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.ria.requests",
+        "purpose": "Help the person understand and use the requests screen through its generated controls.",
+        "screen": "ria_requests",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/requests",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/requests/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_requests_compat"
@@ -1681,9 +3758,31 @@
       "route_pattern": "/ria/settings",
       "page_file": "app/ria/settings/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.ria.settings",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.ria.settings",
+        "purpose": "Help the person understand and use the settings screen through its generated controls.",
+        "screen": "ria_settings",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/settings",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/settings/page.voice-action-contract.json",
       "action_ids": [
         "marketplace.ria.manage_profile",
@@ -1701,9 +3800,31 @@
       "route_pattern": "/ria/workspace",
       "page_file": "app/ria/workspace/page.tsx",
       "route_mode": "redirect",
-      "orchestration_class": "interactive",
+      "orchestration_class": "transitional",
       "instruction_id": "route.ria.workspace",
-      "context_policy": "publish",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.ria.workspace",
+        "purpose": "Help the person understand and use the workspace screen through its generated controls.",
+        "screen": "ria_workspace",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": "/ria/workspace",
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
       "voice_contract_file": "app/ria/workspace/page.voice-action-contract.json",
       "action_ids": [
         "route.ria_workspace_compat"

--- a/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
+++ b/hushh-webapp/contracts/kai/voice-action-manifest.v1.json
@@ -312,7 +312,7 @@
     {
       "id": "auth.sign_in_google",
       "label": "Continue with Google",
-      "meaning": "Starts Google sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Google provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "aliases": [
@@ -388,7 +388,7 @@
     {
       "id": "auth.sign_in_apple",
       "label": "Continue with Apple",
-      "meaning": "Starts Apple sign-in for the person already on the One sign-in screen.",
+      "meaning": "Uses the visible Apple provider flow, with correlated redirect recovery only when the browser blocks a voice-triggered popup, and settles only after Firebase returns a user session.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "aliases": [
@@ -2456,6 +2456,7 @@
           "/one/setup/location",
           "/one/setup/pkm",
           "/one/setup/consent",
+          "/one/setup/marketplace",
           "/one/setup/connected-systems"
         ],
         "screens": [
@@ -2465,6 +2466,7 @@
           "one_setup_location",
           "one_setup_pkm",
           "one_setup_consent",
+          "one_setup_marketplace",
           "one_setup_connected-systems",
           "one_setup"
         ],
@@ -2791,14 +2793,14 @@
     },
     {
       "id": "kai.setup.launch_dashboard",
-      "label": "Launch Kai Dashboard",
-      "meaning": "Confirms the computed investor persona and completes Kai setup, opening portfolio import.",
+      "label": "Save Finance Preferences",
+      "meaning": "Saves Finance preferences, marks only Finance ready, and returns to the One setup hub without resolving root onboarding.",
       "speaker_persona": "kai",
       "delegate_agent_id": null,
       "aliases": [
-        "launch my dashboard",
+        "save finance preferences",
         "looks good, continue",
-        "finish kai setup"
+        "finish finance setup"
       ],
       "scope": {
         "routes": [
@@ -2833,7 +2835,7 @@
           {
             "type": "action",
             "action_id": "kai.setup.launch_dashboard",
-            "label": "Launch Kai Dashboard",
+            "label": "Save Finance Preferences",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/kai",
@@ -2864,6 +2866,80 @@
         "docs/reference/kai/kai-action-gateway-vnext.md",
         "docs/reference/quality/one-onboarding-architecture.md",
         "hushh-webapp/app/one/setup/kai/page.tsx"
+      ]
+    },
+    {
+      "id": "onboarding.claim_one",
+      "label": "Claim your One",
+      "meaning": "Continues from One's public welcome screen to sign in and begin setup.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "claim your one",
+        "claim my one",
+        "claim one",
+        "get started",
+        "start with one",
+        "begin with one"
+      ],
+      "scope": {
+        "routes": [
+          "/"
+        ],
+        "screens": [
+          "one_intro"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "local_handler",
+        "target": "onboarding.claim_one"
+      },
+      "external_callback": null,
+      "goal": {
+        "goal_id": "goal.onboarding.claim_one",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "onboarding.claim_one",
+            "label": "Claim your One",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/",
+              "screen": "one_intro"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/one/one-voice-runtime-architecture.md",
+        "docs/reference/one/one-voice-onboarding-journey.md"
       ]
     },
     {
@@ -3832,7 +3908,7 @@
     {
       "id": "phone_mandate.submit_code",
       "label": "Submit Verification Code",
-      "meaning": "Confirms the verification code sent by SMS and completes phone verification. Stays user-triggered because it settles account security state.",
+      "meaning": "Confirms the six-digit SMS code after an explicit inline confirmation and completes phone verification. The code is sensitive and must never be repeated or retained.",
       "speaker_persona": "one",
       "delegate_agent_id": null,
       "aliases": [
@@ -3856,19 +3932,26 @@
       },
       "guard_ids": [
         "auth_signed_in",
-        "manual_user_execution"
+        "explicit_user_confirmation"
       ],
       "risk_level": "high",
-      "execution_policy": "manual_only",
+      "execution_policy": "confirm_required",
       "execution_hint": {
-        "status": "unwired",
-        "reason": "Completing phone verification changes account security state and must stay user-triggered from the visible code field.",
-        "intended_handler": "local_handler"
+        "status": "wired",
+        "path": "local_handler",
+        "target": "phone_mandate.submit_code"
       },
       "external_callback": null,
       "goal": {
         "goal_id": "goal.phone_mandate.submit_code",
-        "required_inputs": [],
+        "required_inputs": [
+          {
+            "name": "verification_code",
+            "prompt": "Say or type the six-digit code. Spoken codes are processed by the voice service.",
+            "required": true,
+            "slot": "code"
+          }
+        ],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
@@ -7073,7 +7156,8 @@
           "/one/kai/import"
         ],
         "screens": [
-          "kai_portfolio_dashboard"
+          "kai_portfolio_dashboard",
+          "import"
         ],
         "hidden_navigable": false,
         "navigation_prerequisites": []
@@ -7642,7 +7726,7 @@
       ]
     },
     {
-      "id": "setup.open_personal_data",
+      "id": "setup.open_pkm",
       "label": "Set Up Memory",
       "meaning": "Opens the Memory (PKM) capability setup step from the setup hub.",
       "speaker_persona": "one",
@@ -7675,18 +7759,92 @@
       },
       "external_callback": null,
       "goal": {
-        "goal_id": "goal.setup.open_personal_data",
+        "goal_id": "goal.setup.open_pkm",
         "required_inputs": [],
         "input_resolvers": [],
         "slot_schema": {},
         "workflow_steps": [
           {
             "type": "action",
-            "action_id": "setup.open_personal_data",
+            "action_id": "setup.open_pkm",
             "label": "Set Up Memory",
             "failure_behavior": "stop",
             "settlement_target": {
               "route": "/one/setup/pkm",
+              "screen": "one_setup_hub"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      },
+      "map_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "docs/reference/quality/one-onboarding-architecture.md"
+      ]
+    },
+    {
+      "id": "setup.open_marketplace",
+      "label": "Explore Information Marketplace",
+      "meaning": "Opens the Information Marketplace explore step from the setup hub.",
+      "speaker_persona": "one",
+      "delegate_agent_id": null,
+      "aliases": [
+        "explore information marketplace",
+        "open marketplace setup",
+        "set up marketplace"
+      ],
+      "scope": {
+        "routes": [
+          "/one/setup"
+        ],
+        "screens": [
+          "one_setup_hub",
+          "one_setup"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": []
+      },
+      "guard_ids": [
+        "auth_signed_in"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_hint": {
+        "status": "wired",
+        "path": "route",
+        "target": "/one/setup/marketplace"
+      },
+      "external_callback": null,
+      "goal": {
+        "goal_id": "goal.setup.open_marketplace",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "setup.open_marketplace",
+            "label": "Explore Information Marketplace",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/one/setup/marketplace",
               "screen": "one_setup_hub"
             }
           }

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -286,7 +286,31 @@
         "mode": "hidden",
         "exemption_reason": "Anonymous auth-split entry route redirects signed-in users to /one and intentionally does not own the signed-in dashboard shell.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.one.intro",
+          "purpose": "Welcome a new person and help them claim their private agent.",
+          "screen": "one_intro",
+          "entry_cue": "Say ‘Claim your One’ whenever you are ready.",
+          "proactivity": "on_entry",
+          "primary_action_id": "onboarding.claim_one",
+          "happy_path_action_ids": [
+            "onboarding.claim_one"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "The welcome step completes only after the browser settles navigation to Login.",
+          "next_route": "/login",
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/",
@@ -307,8 +331,10 @@
         "shared_loader": true,
         "back_button_pattern": "shared-shell"
       },
-      "voice_action_contract_file": null,
-      "voice_action_contract_ids": [],
+      "voice_action_contract_file": "app/page.voice-action-contract.json",
+      "voice_action_contract_ids": [
+        "onboarding.claim_one"
+      ],
       "api_dependencies": [],
       "native_plugin_dependencies": [],
       "thread_and_consent_contract": null
@@ -325,7 +351,29 @@
           "AppPageShell",
           "AppPageContentRegion",
           "AgentChatWorkspace"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.agent",
+          "purpose": "Help the person understand and use the agent screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/agent",
@@ -358,7 +406,34 @@
       "route": "/blog",
       "page_file": "app/blog/page.tsx",
       "physical_page_exists": true,
-      "route_contract": null,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.blog",
+          "purpose": "Help the person understand and use the blog screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
       "native": {
         "route": "/blog",
         "classification": "excluded-web-only"
@@ -380,7 +455,34 @@
       "route": "/blog/[slug]",
       "page_file": "app/blog/[slug]/page.tsx",
       "physical_page_exists": true,
-      "route_contract": null,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.blog.slug",
+          "purpose": "Help the person understand and use the blog screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
       "native": {
         "route": "/blog/[slug]",
         "classification": "excluded-web-only"
@@ -406,7 +508,29 @@
         "mode": "hidden",
         "exemption_reason": "Standalone people-connection route intentionally bypasses the signed-in app shell while still exposing its own native test beacon.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.connect",
+          "purpose": "Help the person understand and use the connect screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/connect",
@@ -443,7 +567,31 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/connected-systems surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.connected.systems",
+          "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+          "screen": "connected_systems",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [
+            "utterance"
+          ],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/connected-systems",
@@ -503,7 +651,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/connected-systems/[systemId] surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.connected.systems.systemid",
+          "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -532,7 +702,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.consents",
+          "purpose": "Help the person understand and use the consents screen through its generated controls.",
+          "screen": "consents",
+          "entry_cue": "You can say “Open RIA Requests” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_requests_compat",
+          "happy_path_action_ids": [
+            "route.ria_requests_compat"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/requests",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/consents",
@@ -571,7 +765,29 @@
           "AppPageShell",
           "AppPageHeaderRegion",
           "AppPageContentRegion"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.developers",
+          "purpose": "Help the person understand and use the developers screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/developers",
@@ -598,7 +814,29 @@
         "mode": "hidden",
         "exemption_reason": "Anonymous pre-auth intro route intentionally bypasses the signed-in app shell, matching the root and login entry routes.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.getting.started",
+          "purpose": "Help the person understand and use the getting started screen through its generated controls.",
+          "screen": "getting_started",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/getting-started",
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/getting-started",
@@ -638,7 +876,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/gmail surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.gmail",
+          "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+          "screen": "gmail",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/gmail",
@@ -705,7 +965,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai market surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai",
+          "purpose": "Help the person understand and use the kai screen through its generated controls.",
+          "screen": "kai_market",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai",
@@ -741,7 +1023,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/alpaca/oauth/return surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.alpaca.oauth.return",
+          "purpose": "Help the person understand and use the return screen through its generated controls.",
+          "screen": "kai",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/alpaca/oauth/return",
@@ -778,7 +1082,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/analysis surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.analysis",
+          "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+          "screen": "kai_analysis",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/analysis",
@@ -814,7 +1140,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical portfolio/dashboard entry.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.dashboard",
+          "purpose": "Help the person understand and use the dashboard screen through its generated controls.",
+          "screen": "kai_portfolio_dashboard",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/dashboard",
@@ -852,7 +1200,29 @@
         "shell_verification_file": "app/kai/dashboard/analysis/page.tsx",
         "shell_verification_includes": [
           "AppPageShell"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.kai.dashboard.analysis",
+          "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+          "screen": "kai_portfolio_dashboard",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/dashboard/analysis",
@@ -888,7 +1258,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/funding-trade surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.funding.trade",
+          "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+          "screen": "kai_funding_trade",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/funding-trade",
@@ -925,7 +1317,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/import flow.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.import",
+          "purpose": "Help the person understand and use the import screen through its generated controls.",
+          "screen": "import",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/import",
@@ -961,7 +1375,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/investments surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.investments",
+          "purpose": "Help the person understand and use the investments screen through its generated controls.",
+          "screen": "kai_investments",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/investments",
@@ -997,7 +1433,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/setup/kai flow.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.onboarding",
+          "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+          "screen": "kai",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/onboarding",
@@ -1033,7 +1491,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/optimize surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.optimize",
+          "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+          "screen": "kai_optimize",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/optimize",
@@ -1071,7 +1551,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/plaid/oauth/return surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.plaid.oauth.return",
+          "purpose": "Help the person understand and use the return screen through its generated controls.",
+          "screen": "kai",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/plaid/oauth/return",
@@ -1108,7 +1610,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/kai/portfolio surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.kai.portfolio",
+          "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+          "screen": "kai_portfolio_dashboard",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/kai/portfolio",
@@ -1144,7 +1668,31 @@
         "mode": "hidden",
         "exemption_reason": "Auth-only route intentionally bypasses the signed-in app shell.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.login",
+          "purpose": "Let the person choose Google or Apple and begin the matching sign-in flow.",
+          "screen": "login",
+          "entry_cue": "Say ‘Continue with Google’ or ‘Continue with Apple’.",
+          "proactivity": "on_entry",
+          "primary_action_id": "auth.sign_in_google",
+          "happy_path_action_ids": [
+            "auth.sign_in_google"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Authentication completes only after the provider popup returns a verified Firebase user session.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/login",
@@ -1182,7 +1730,29 @@
         "mode": "hidden",
         "exemption_reason": "Logout route is a transitional auth screen, not a standard content page.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.logout",
+          "purpose": "Help the person understand and use the logout screen through its generated controls.",
+          "screen": "logout",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/logout",
@@ -1222,7 +1792,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.marketplace",
+          "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+          "screen": "marketplace",
+          "entry_cue": "You can say “Continue Browsing Marketplace” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.marketplace_browse_from_ria_profile",
+          "happy_path_action_ids": [
+            "route.marketplace_browse_from_ria_profile"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/marketplace",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/marketplace",
@@ -1259,7 +1853,31 @@
         "mode": "redirect",
         "exemption_reason": "Legacy connection route now deep-links into the canonical /consents access manager.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.marketplace.connections",
+          "purpose": "Help the person understand and use the connections screen through its generated controls.",
+          "screen": "marketplace",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [
+            "utterance"
+          ],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/marketplace/connections",
@@ -1295,7 +1913,29 @@
         "mode": "redirect",
         "exemption_reason": "Legacy portfolio explorer route now deep-links into the dedicated /ria/clients/[userId] workspace.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.marketplace.connections.portfolio",
+          "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+          "screen": "marketplace",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/marketplace/connections/portfolio",
@@ -1338,7 +1978,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.marketplace.ria",
+          "purpose": "Help the person understand and use the ria screen through its generated controls.",
+          "screen": "marketplace_ria_profile",
+          "entry_cue": "You can say “Open Marketplace RIA Profile” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.marketplace_ria_profile",
+          "happy_path_action_ids": [
+            "route.marketplace_ria_profile"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/marketplace/ria",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/marketplace/ria",
@@ -1386,7 +2050,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.home",
+          "purpose": "Help the person understand and use the one screen through its generated controls.",
+          "screen": "one_agents",
+          "entry_cue": "You can say “Open Agents” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.one_agents",
+          "happy_path_action_ids": [
+            "route.one_agents"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one",
@@ -1431,7 +2119,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "ConnectedSystemsPanel"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.connected.systems",
+          "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+          "screen": "connected_systems",
+          "entry_cue": "You can say “Open Connected Systems Panel” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.profile_connected_systems",
+          "happy_path_action_ids": [
+            "route.profile_connected_systems"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/connected-systems",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/connected-systems",
@@ -1474,7 +2186,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "ConnectedSystemsPanel"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.connected.systems.systemid",
+          "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -1504,7 +2238,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.gmail",
+          "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+          "screen": "gmail",
+          "entry_cue": "You can say “Open Receipts Page” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.profile_receipts",
+          "happy_path_action_ids": [
+            "route.profile_receipts"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/gmail",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/gmail",
@@ -1551,7 +2309,31 @@
           "AppPageContentRegion",
           "SurfaceStack",
           "SectionHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai",
+          "purpose": "Help the person understand and use the kai screen through its generated controls.",
+          "screen": "kai_market",
+          "entry_cue": "You can say “Open Market Home” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.kai_home",
+          "happy_path_action_ids": [
+            "route.kai_home"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai",
@@ -1589,7 +2371,29 @@
         "shell_verification_includes": [
           "AppPageShell",
           "AppPageContentRegion"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.alpaca.oauth.return",
+          "purpose": "Help the person understand and use the return screen through its generated controls.",
+          "screen": "kai",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/alpaca/oauth/return",
@@ -1630,7 +2434,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.analysis",
+          "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+          "screen": "kai_analysis",
+          "entry_cue": "You can say “Open Analysis Surface” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.kai_analysis",
+          "happy_path_action_ids": [
+            "route.kai_analysis"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/kai/analysis",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/analysis",
@@ -1677,7 +2505,29 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.funding.trade",
+          "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+          "screen": "kai_funding_trade",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/funding-trade",
@@ -1716,7 +2566,31 @@
         "shell_verification_includes": [
           "FullscreenFlowShell",
           "KaiFlow"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.import",
+          "purpose": "Help the person understand and use the import screen through its generated controls.",
+          "screen": "import",
+          "entry_cue": "You can say “Open Portfolio Import” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.kai_import",
+          "happy_path_action_ids": [
+            "route.kai_import"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/import",
@@ -1756,7 +2630,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.investments",
+          "purpose": "Help the person understand and use the investments screen through its generated controls.",
+          "screen": "kai_investments",
+          "entry_cue": "You can say “Open Investments Surface” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.kai_investments",
+          "happy_path_action_ids": [
+            "route.kai_investments"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/kai/investments",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/investments",
@@ -1791,7 +2689,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/setup/kai flow.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.onboarding",
+          "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+          "screen": "kai",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/onboarding",
@@ -1833,7 +2753,31 @@
           "AppPageContentRegion",
           "SurfaceStack",
           "PageHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.optimize",
+          "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+          "screen": "kai_optimize",
+          "entry_cue": "You can say “Open Optimize Surface” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.kai_optimize",
+          "happy_path_action_ids": [
+            "route.kai_optimize"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/kai/optimize",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/optimize",
@@ -1873,7 +2817,29 @@
         "shell_verification_includes": [
           "AppPageShell",
           "AppPageContentRegion"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.plaid.oauth.return",
+          "purpose": "Help the person understand and use the return screen through its generated controls.",
+          "screen": "kai",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/plaid/oauth/return",
@@ -1912,7 +2878,31 @@
         "shell_verification_includes": [
           "AppPageShell",
           "AppPageContentRegion"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kai.portfolio",
+          "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+          "screen": "kai_portfolio_dashboard",
+          "entry_cue": "You can say “Open Portfolio Dashboard” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.kai_dashboard",
+          "happy_path_action_ids": [
+            "route.kai_dashboard"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kai/portfolio",
@@ -1952,7 +2942,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "PageHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.kyc",
+          "purpose": "Help the person understand and use the kyc screen through its generated controls.",
+          "screen": "one_kyc",
+          "entry_cue": "You can say “Open Email” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.one_kyc",
+          "happy_path_action_ids": [
+            "route.one_kyc"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/kyc",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/kyc",
@@ -2056,7 +3070,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "PageHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.location",
+          "purpose": "Help the person understand and use the location screen through its generated controls.",
+          "screen": "one_location",
+          "entry_cue": "You can say “Open Location” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.one_location",
+          "happy_path_action_ids": [
+            "route.one_location"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/location",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/location",
@@ -2093,7 +3131,29 @@
         "mode": "hidden",
         "exemption_reason": "Public one-location circle invite route is a standalone external-acceptance form outside the signed-in app shell.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.one.location.invite.token",
+          "purpose": "Help the person understand and use the invite screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -2117,7 +3177,29 @@
         "mode": "hidden",
         "exemption_reason": "Public one-location invite route is a standalone external-request form outside the signed-in app shell.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.one.location.request.token",
+          "purpose": "Help the person understand and use the request screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -2147,7 +3229,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.marketplace",
+          "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+          "screen": "one_marketplace",
+          "entry_cue": "You can say “Open Information Marketplace” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.one_marketplace",
+          "happy_path_action_ids": [
+            "route.one_marketplace"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/marketplace",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/marketplace",
@@ -2192,7 +3298,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.pkm",
+          "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+          "screen": "pkm",
+          "entry_cue": "You can say “Open Memory” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.one_pkm",
+          "happy_path_action_ids": [
+            "route.one_pkm"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/one/pkm",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/pkm",
@@ -2234,7 +3364,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "PageHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.setup",
+          "purpose": "Help the person choose, resume, skip, or finish one setup capability.",
+          "screen": "one_setup",
+          "entry_cue": "Choose something to set up, or say ‘finish setup’ when you are ready.",
+          "proactivity": "on_entry",
+          "primary_action_id": "setup.open_finance",
+          "happy_path_action_ids": [
+            "setup.open_finance"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Only the hub finish or skip action resolves root onboarding.",
+          "next_route": "/one",
+          "return_policy": "resolve_root",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/setup",
@@ -2274,7 +3428,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "PageHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.one.setup.capability",
+          "purpose": "Explain the active setup capability and advance only its visible next step.",
+          "screen": "one_setup",
+          "entry_cue": "Say ‘Continue’ when you are ready for the next step.",
+          "proactivity": "on_entry",
+          "primary_action_id": "setup.capability_continue",
+          "happy_path_action_ids": [
+            "setup.capability_continue"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "The step settles after its local handler opens the capability destination.",
+          "next_route": "/one/setup",
+          "return_policy": "return_to_hub",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -2284,8 +3462,10 @@
         "shared_loader": false,
         "back_button_pattern": "shared-shell"
       },
-      "voice_action_contract_file": null,
-      "voice_action_contract_ids": [],
+      "voice_action_contract_file": "app/one/setup/[capability]/one-onboarding-capability-step.voice-action-contract.json",
+      "voice_action_contract_ids": [
+        "setup.capability_continue"
+      ],
       "api_dependencies": [],
       "native_plugin_dependencies": [],
       "thread_and_consent_contract": null
@@ -2298,7 +3478,33 @@
         "mode": "flow",
         "exemption_reason": "Fullscreen setup wizard owns its own shell and safe-area spacing.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.one.setup.kai",
+          "purpose": "Collect Finance preferences and return to the setup hub without resolving root onboarding.",
+          "screen": "one_setup",
+          "entry_cue": "Answer the visible Finance question to continue.",
+          "proactivity": "on_entry",
+          "primary_action_id": "kai.setup.answer_horizon",
+          "happy_path_action_ids": [
+            "kai.setup.answer_horizon"
+          ],
+          "required_inputs": [
+            "investment_horizon"
+          ],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Finance setup completes only after preferences are saved and the hub route settles.",
+          "next_route": "/one/setup",
+          "return_policy": "return_to_hub",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/one/setup/kai",
@@ -2338,7 +3544,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route only launches the canonical /one/pkm surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.pkm",
+          "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+          "screen": "pkm",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/pkm",
@@ -2409,7 +3637,29 @@
         "mode": "hidden",
         "exemption_reason": "Public shared portfolio view uses chrome-free layout for external recipients.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.portfolio.shared",
+          "purpose": "Help the person understand and use the shared screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/portfolio/shared",
@@ -2452,7 +3702,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile",
+          "purpose": "Help the person understand and use the profile screen through its generated controls.",
+          "screen": "profile_account",
+          "entry_cue": "You can say “Open Profile” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.profile",
+          "happy_path_action_ids": [
+            "route.profile"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile",
@@ -2504,7 +3778,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.access",
+          "purpose": "Help the person understand and use the access screen through its generated controls.",
+          "screen": "profile_privacy",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/access",
@@ -2545,7 +3841,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.access.connection",
+          "purpose": "Help the person understand and use the connection screen through its generated controls.",
+          "screen": "profile_privacy",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/access/connection",
@@ -2586,7 +3904,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.account",
+          "purpose": "Help the person understand and use the account screen through its generated controls.",
+          "screen": "profile_account",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/account",
@@ -2627,7 +3967,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.account.phone",
+          "purpose": "Help the person understand and use the phone screen through its generated controls.",
+          "screen": "profile_account",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/account/phone",
@@ -2668,7 +4030,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.connected.systems",
+          "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+          "screen": "connected_systems",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/connected-systems",
@@ -2703,7 +4087,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route forwards to canonical /one/gmail.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.profile.gmail",
+          "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+          "screen": "profile_gmail_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/gmail",
@@ -2738,7 +4144,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route forwards to canonical /one/gmail.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.profile.gmail.actions",
+          "purpose": "Help the person understand and use the actions screen through its generated controls.",
+          "screen": "profile_gmail_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/gmail/actions",
@@ -2773,7 +4201,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route forwards to canonical /one/gmail.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.profile.gmail.connection",
+          "purpose": "Help the person understand and use the connection screen through its generated controls.",
+          "screen": "profile_gmail_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/gmail/connection",
@@ -2812,7 +4262,29 @@
           "AppPageShell",
           "AppPageContentRegion",
           "HushhLoader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.gmail.oauth.return",
+          "purpose": "Help the person understand and use the return screen through its generated controls.",
+          "screen": "profile_account",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/gmail/oauth/return",
@@ -2854,7 +4326,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.my.data",
+          "purpose": "Help the person understand and use the personal information screen through its generated controls.",
+          "screen": "profile_my_data",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/my-data",
@@ -2895,7 +4389,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.my.data.domain",
+          "purpose": "Help the person understand and use the domain screen through its generated controls.",
+          "screen": "profile_my_data",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/my-data/domain",
@@ -2930,7 +4446,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route forwards to canonical /pkm.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.profile.pkm",
+          "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+          "screen": "pkm",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/pkm",
@@ -2972,7 +4510,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.pkm.agent.lab",
+          "purpose": "Help the person understand and use the pkm agent lab screen through its generated controls.",
+          "screen": "profile_pkm_agent_lab",
+          "entry_cue": "You can say “Generate PKM capture preview” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "profile.pkm.preview_capture",
+          "happy_path_action_ids": [
+            "profile.pkm.preview_capture"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/pkm-agent-lab",
@@ -3008,7 +4570,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.preferences",
+          "purpose": "Help the person understand and use the preferences screen through its generated controls.",
+          "screen": "profile_preferences",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/preferences",
@@ -3049,7 +4633,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.preferences.device",
+          "purpose": "Help the person understand and use the device screen through its generated controls.",
+          "screen": "profile_preferences",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/preferences/device",
@@ -3090,7 +4696,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.preferences.kai",
+          "purpose": "Help the person understand and use the kai screen through its generated controls.",
+          "screen": "profile_preferences",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/preferences/kai",
@@ -3125,7 +4753,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility redirect route forwards to canonical /gmail.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.profile.receipts",
+          "purpose": "Help the person understand and use the receipts screen through its generated controls.",
+          "screen": "gmail",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/receipts",
@@ -3169,7 +4819,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.security",
+          "purpose": "Help the person understand and use the security screen through its generated controls.",
+          "screen": "profile_security_panel",
+          "entry_cue": "You can say “Open Vault Security Panel” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.profile_security_panel",
+          "happy_path_action_ids": [
+            "route.profile_security_panel"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/profile/security",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/security",
@@ -3210,7 +4884,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.security.session",
+          "purpose": "Help the person understand and use the session screen through its generated controls.",
+          "screen": "profile_security_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/security/session",
@@ -3251,7 +4947,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.security.vault",
+          "purpose": "Help the person understand and use the vault screen through its generated controls.",
+          "screen": "profile_security_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/security/vault",
@@ -3292,7 +5010,31 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.support",
+          "purpose": "Help the person understand and use the support screen through its generated controls.",
+          "screen": "profile_support_panel",
+          "entry_cue": "You can say “Open Support Panel” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.profile_support_panel",
+          "happy_path_action_ids": [
+            "route.profile_support_panel"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/profile/support",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/support",
@@ -3333,7 +5075,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.support.compose",
+          "purpose": "Help the person understand and use the compose screen through its generated controls.",
+          "screen": "profile_support_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/support/compose",
@@ -3374,7 +5138,29 @@
           "AppPageContentRegion",
           "PageHeader",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.profile.support.routing",
+          "purpose": "Help the person understand and use the routing screen through its generated controls.",
+          "screen": "profile_support_panel",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/profile/support/routing",
@@ -3409,7 +5195,33 @@
         "mode": "hidden",
         "exemption_reason": "Mandatory post-login phone verification flow intentionally bypasses the signed-in app shell.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.register.phone",
+          "purpose": "Verify the signed-in person’s phone before setup continues.",
+          "screen": "register_phone",
+          "entry_cue": "Say your phone number including country code, or type it below.",
+          "proactivity": "on_entry",
+          "primary_action_id": "phone_mandate.submit_number",
+          "happy_path_action_ids": [
+            "phone_mandate.submit_number"
+          ],
+          "required_inputs": [
+            "phone_number"
+          ],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Phone verification completes only after the submitted code is accepted.",
+          "next_route": "/one/setup",
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/register-phone",
@@ -3443,7 +5255,34 @@
       "route": "/research",
       "page_file": "app/research/page.tsx",
       "physical_page_exists": true,
-      "route_contract": null,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.research",
+          "purpose": "Help the person understand and use the research screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
       "native": {
         "route": "/research",
         "classification": "excluded-web-only"
@@ -3465,7 +5304,34 @@
       "route": "/research/protocol",
       "page_file": "app/research/protocol/page.tsx",
       "physical_page_exists": true,
-      "route_contract": null,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.research.protocol",
+          "purpose": "Help the person understand and use the protocol screen through its generated controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
       "native": {
         "route": "/research/protocol",
         "classification": "excluded-web-only"
@@ -3496,7 +5362,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria",
+          "purpose": "Help the person understand and use the ria screen through its generated controls.",
+          "screen": "ria_home",
+          "entry_cue": "You can say “Open RIA Home” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_home",
+          "happy_path_action_ids": [
+            "route.ria_home"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria",
@@ -3540,7 +5430,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "PageHeader"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria.clients",
+          "purpose": "Help the person understand and use the clients screen through its generated controls.",
+          "screen": "ria_clients",
+          "entry_cue": "You can say “Open RIA Clients” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_clients",
+          "happy_path_action_ids": [
+            "route.ria_clients"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/clients",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria/clients",
@@ -3586,7 +5500,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria.clients.userid",
+          "purpose": "Help the person understand and use the clients screen through its generated controls.",
+          "screen": "ria_client_workspace",
+          "entry_cue": "You can say “Open RIA Client Workspace” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_client_workspace",
+          "happy_path_action_ids": [
+            "route.ria_client_workspace"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/clients/[userId]",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -3615,7 +5553,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria.clients.userid.accounts.accountid",
+          "purpose": "Help the person understand and use the accounts screen through its generated controls.",
+          "screen": "ria_client_account_detail",
+          "entry_cue": "You can say “Return To Client Information Explorer” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "ria.client_account.open_workspace_fallback",
+          "happy_path_action_ids": [
+            "ria.client_account.open_workspace_fallback"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/clients/[userId]?tab=explorer",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -3644,7 +5606,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria.clients.userid.requests.requestid",
+          "purpose": "Help the person understand and use the requests screen through its generated controls.",
+          "screen": "ria_client_request_detail",
+          "entry_cue": "You can say “Return To Client Access” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "ria.client_request.open_access_fallback",
+          "happy_path_action_ids": [
+            "ria.client_request.open_access_fallback"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/clients/[userId]?tab=access",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": null,
       "shell": {
@@ -3671,7 +5657,31 @@
         "shell_verification_includes": [
           "FullscreenFlowShell",
           "OnboardingShell"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria.onboarding",
+          "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+          "screen": "ria_onboarding",
+          "entry_cue": "You can say “Open RIA Onboarding” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_onboarding",
+          "happy_path_action_ids": [
+            "route.ria_onboarding"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/onboarding",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria/onboarding",
@@ -3717,7 +5727,31 @@
           "AppPageHeaderRegion",
           "AppPageContentRegion",
           "SurfaceStack"
-        ]
+        ],
+        "voice_playbook": {
+          "playbook_id": "route.ria.picks",
+          "purpose": "Help the person understand and use the picks screen through its generated controls.",
+          "screen": "ria_picks",
+          "entry_cue": "You can say “Open RIA Picks” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_picks",
+          "happy_path_action_ids": [
+            "route.ria_picks"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/picks",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria/picks",
@@ -3763,7 +5797,36 @@
       "route": "/ria/profile",
       "page_file": "app/ria/profile/page.tsx",
       "physical_page_exists": true,
-      "route_contract": null,
+      "route_contract": {
+        "mode": "flow",
+        "exemption_reason": "RIA profile uses its existing focused settings surface outside the standard app-page shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.ria.profile",
+          "purpose": "Help the person understand and use the profile screen through its generated controls.",
+          "screen": "ria_profile",
+          "entry_cue": "You can say “Open RIA Profile” to use the primary control on this screen.",
+          "proactivity": "on_entry",
+          "primary_action_id": "route.ria_profile",
+          "happy_path_action_ids": [
+            "route.ria_profile"
+          ],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/profile",
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
       "native": {
         "route": "/ria/profile",
         "classification": "native-required-functional",
@@ -3801,7 +5864,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility alias routes into the shared consent workspace.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.ria.requests",
+          "purpose": "Help the person understand and use the requests screen through its generated controls.",
+          "screen": "ria_requests",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/requests",
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria/requests",
@@ -3838,7 +5923,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility alias routes into the canonical profile/settings surface.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.ria.settings",
+          "purpose": "Help the person understand and use the settings screen through its generated controls.",
+          "screen": "ria_settings",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/settings",
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria/settings",
@@ -3875,7 +5982,29 @@
         "mode": "redirect",
         "exemption_reason": "Compatibility alias now redirects into the dedicated /ria/clients/[userId] client workspace.",
         "shell_verification_file": null,
-        "shell_verification_includes": []
+        "shell_verification_includes": [],
+        "voice_playbook": {
+          "playbook_id": "route.ria.workspace",
+          "purpose": "Help the person understand and use the workspace screen through its generated controls.",
+          "screen": "ria_workspace",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": "/ria/workspace",
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
       },
       "native": {
         "route": "/ria/workspace",

--- a/hushh-webapp/lib/agent/agent-runtime-context.tsx
+++ b/hushh-webapp/lib/agent/agent-runtime-context.tsx
@@ -43,6 +43,14 @@ import {
   buildOneVoiceContextSnapshot,
   type OneVoiceContextSnapshot,
 } from "@/lib/voice/screen-context-builder";
+import {
+  buildMorphyAxSnapshot,
+  resolveMorphyAxPresentation,
+  toOneVoiceContextSnapshot,
+  type MorphyAxPresentationState,
+  type MorphyAxSnapshotV1,
+} from "@/lib/morphy-ax";
+import { getVoiceV2Flags } from "@/lib/voice/voice-feature-flags";
 
 // The access tier the agent should operate at. This is what drives how the
 // bar presents itself and which persona the backend should compose.
@@ -81,6 +89,12 @@ export type AgentRuntimeState = {
   screen: string;
   /** Redacted One Voice snapshot safe for realtime prompt shaping. */
   oneVoiceContextSnapshot: OneVoiceContextSnapshot;
+  /** Pure, redacted Agent Experience snapshot; never an action authority. */
+  morphyAxSnapshot: MorphyAxSnapshotV1;
+  /** Shared presentation posture derived from the existing voice FSM. */
+  morphyAxPresentation: MorphyAxPresentationState;
+  /** False keeps the compatibility path authoritative during rollout. */
+  morphyAxEnabled: boolean;
 };
 
 const AgentRuntimeStateContext = createContext<AgentRuntimeState | null>(null);
@@ -240,6 +254,12 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
       return;
     }
     let active = true;
+    const cache = CacheService.getInstance();
+    const cacheKey = CACHE_KEYS.PRE_VAULT_BOOTSTRAP(uid);
+    const refreshFromCache = () => {
+      const cached = cache.get<PreVaultUserState>(cacheKey);
+      if (active && cached) setPreVaultState(cached);
+    };
     void PreVaultUserStateService.bootstrapState(uid)
       .then((state) => {
         if (active) setPreVaultState(state);
@@ -247,8 +267,26 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
       .catch(() => {
         if (active) setPreVaultState(null);
       });
+    const unsubscribe = cache.subscribe((event) => {
+      if (event.type === "set" && event.key === cacheKey) {
+        refreshFromCache();
+        return;
+      }
+      if (
+        event.type === "clear" ||
+        (event.type === "invalidate" && event.keys.includes(cacheKey)) ||
+        (event.type === "invalidate_user" && event.userId === uid)
+      ) {
+        void PreVaultUserStateService.bootstrapState(uid)
+          .then((state) => {
+            if (active) setPreVaultState(state);
+          })
+          .catch(() => undefined);
+      }
+    });
     return () => {
       active = false;
+      unsubscribe();
     };
   }, [uid]);
 
@@ -370,7 +408,7 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
 
   const value = useMemo<AgentRuntimeState>(
     () => {
-      const oneVoiceContextSnapshot = buildOneVoiceContextSnapshot({
+      const compatibilitySnapshot = buildOneVoiceContextSnapshot({
         appRuntimeState,
         state: oneVoiceState,
         lastTransition: lastVoiceTransition,
@@ -396,6 +434,13 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
           setupCapabilityIds: preVaultState?.setupCapabilityIds || [],
         },
       });
+      const morphyAxSnapshot = buildMorphyAxSnapshot(compatibilitySnapshot, {
+        signedIn,
+      });
+      const morphyAxEnabled = getVoiceV2Flags().morphyAxEnabled;
+      const oneVoiceContextSnapshot = morphyAxEnabled
+        ? toOneVoiceContextSnapshot(morphyAxSnapshot, compatibilitySnapshot)
+        : compatibilitySnapshot;
       return {
         appRuntimeState,
         tier,
@@ -405,6 +450,9 @@ export function AgentRuntimeStateProvider({ children }: { children: ReactNode })
         activePersona,
         screen: routeInfo.screen,
         oneVoiceContextSnapshot,
+        morphyAxSnapshot,
+        morphyAxPresentation: resolveMorphyAxPresentation(oneVoiceState),
+        morphyAxEnabled,
       };
     },
     [

--- a/hushh-webapp/lib/morphy-ax/assessment.ts
+++ b/hushh-webapp/lib/morphy-ax/assessment.ts
@@ -1,0 +1,49 @@
+import type {
+  MorphyAxAssessmentDecision,
+  MorphyAxAssessmentV1,
+  MorphyAxSnapshotV1,
+} from "./types";
+
+/**
+ * Apply repeatable policy to an intelligence-produced assessment.
+ * This validator never infers meaning or substitutes a different action.
+ */
+export function validateMorphyAxAssessment(
+  assessment: MorphyAxAssessmentV1,
+  snapshot: MorphyAxSnapshotV1,
+): MorphyAxAssessmentDecision {
+  if (
+    !Number.isFinite(assessment.confidence) ||
+    assessment.confidence < 0 ||
+    assessment.confidence > 1
+  ) {
+    return { status: "rejected", reason: "invalid_confidence" };
+  }
+  if (
+    assessment.ambiguous ||
+    assessment.disposition === "ask_clarifying_question"
+  ) {
+    return {
+      status: "clarify",
+      reason: assessment.missing_input || "ambiguous_intent",
+    };
+  }
+  if (
+    assessment.disposition !== "execute_visible_action" &&
+    assessment.disposition !== "confirm_visible_action"
+  ) {
+    return { status: "conversation", disposition: assessment.disposition };
+  }
+  const actionId = assessment.candidate_action_id?.trim();
+  if (!actionId) return { status: "clarify", reason: "missing_action" };
+  if (snapshot.orchestration.pending_settlement) {
+    return { status: "rejected", reason: "settlement_pending" };
+  }
+  if (!snapshot.tools.available_action_ids.includes(actionId)) {
+    return { status: "rejected", reason: "action_not_available_on_screen" };
+  }
+  if (assessment.disposition === "confirm_visible_action") {
+    return { status: "confirmation_required", action_id: actionId };
+  }
+  return { status: "permitted", action_id: actionId };
+}

--- a/hushh-webapp/lib/morphy-ax/index.ts
+++ b/hushh-webapp/lib/morphy-ax/index.ts
@@ -1,0 +1,4 @@
+export * from "./assessment";
+export * from "./presentation";
+export * from "./snapshot";
+export * from "./types";

--- a/hushh-webapp/lib/morphy-ax/presentation.ts
+++ b/hushh-webapp/lib/morphy-ax/presentation.ts
@@ -1,0 +1,30 @@
+import type { OneVoiceUiState } from "@/lib/voice/voice-ui-state-machine";
+
+import type { MorphyAxPresentationState } from "./types";
+
+export function resolveMorphyAxPresentation(
+  state: OneVoiceUiState,
+): MorphyAxPresentationState {
+  switch (state) {
+    case "opening":
+      return "orienting";
+    case "listening":
+      return "listening";
+    case "understanding":
+    case "intent_preview":
+      return "understanding";
+    case "needs_consent":
+      return "confirming";
+    case "acting":
+      return "acting";
+    case "navigation_settling":
+      return "settling";
+    case "result":
+    case "follow_up":
+      return "responding";
+    case "error_recovery":
+      return "recovering";
+    default:
+      return "idle";
+  }
+}

--- a/hushh-webapp/lib/morphy-ax/snapshot.ts
+++ b/hushh-webapp/lib/morphy-ax/snapshot.ts
@@ -1,0 +1,92 @@
+import type { OneVoiceContextSnapshot } from "@/lib/voice/screen-context-builder";
+
+import type { MorphyAxSnapshotV1 } from "./types";
+
+export function buildMorphyAxSnapshot(
+  voice: OneVoiceContextSnapshot,
+  access?: { signedIn?: boolean },
+): MorphyAxSnapshotV1 {
+  return {
+    schema_version: "morphy_ax_snapshot.v1",
+    snapshot_id: `ax_${voice.snapshot_id}`,
+    revisions: { ...voice.revisions },
+    access: {
+      signed_in:
+        access?.signedIn ?? voice.onboarding.phase !== "anonymous_auth",
+      vault_ready: voice.cache.vault_ready,
+      persona: voice.persona.active,
+    },
+    context: {
+      screen: voice.route.screen,
+      route_family: voice.route.route_family,
+      playbook_id: voice.route.playbook_id,
+      visible_modules: [...voice.ui.visible_modules],
+      visible_control_ids: [...voice.ui.visible_control_ids],
+      onboarding: {
+        ...voice.onboarding,
+        setup_capability_ids: [...voice.onboarding.setup_capability_ids],
+      },
+    },
+    tools: {
+      available_action_ids: [...voice.available_action_ids],
+    },
+    orchestration: {
+      pending_settlement: voice.pending_settlement,
+      voice: {
+        ...voice.voice,
+        last_transition: voice.voice.last_transition
+          ? { ...voice.voice.last_transition }
+          : null,
+      },
+      busy_operations: [...voice.cache.busy_operations],
+    },
+    privacy: {
+      redacted: true,
+      excludes: [...voice.privacy.excludes],
+    },
+  };
+}
+
+/** Compatibility projection: the existing backend wire contract remains unchanged. */
+export function toOneVoiceContextSnapshot(
+  ax: MorphyAxSnapshotV1,
+  baseline: OneVoiceContextSnapshot,
+): OneVoiceContextSnapshot {
+  return {
+    ...baseline,
+    revisions: { ...ax.revisions },
+    route: {
+      ...baseline.route,
+      screen: ax.context.screen,
+      route_family: ax.context.route_family,
+      playbook_id: ax.context.playbook_id,
+    },
+    ui: {
+      ...baseline.ui,
+      visible_modules: [...ax.context.visible_modules],
+      visible_control_ids: [...ax.context.visible_control_ids],
+    },
+    available_action_ids: [...ax.tools.available_action_ids],
+    pending_settlement: ax.orchestration.pending_settlement,
+    cache: {
+      ...baseline.cache,
+      vault_ready: ax.access.vault_ready,
+      busy_operations: [...ax.orchestration.busy_operations],
+    },
+    persona: { ...baseline.persona, active: ax.access.persona },
+    onboarding: {
+      ...ax.context.onboarding,
+      setup_capability_ids: [...ax.context.onboarding.setup_capability_ids],
+    },
+    voice: {
+      ...ax.orchestration.voice,
+      last_transition: ax.orchestration.voice.last_transition
+        ? { ...ax.orchestration.voice.last_transition }
+        : null,
+    },
+    privacy: {
+      redacted: true,
+      excludes: [...ax.privacy.excludes],
+    },
+  };
+}

--- a/hushh-webapp/lib/morphy-ax/types.ts
+++ b/hushh-webapp/lib/morphy-ax/types.ts
@@ -1,0 +1,74 @@
+import type { OneVoiceContextSnapshot } from "@/lib/voice/screen-context-builder";
+
+export type MorphyAxDisposition =
+  | "execute_visible_action"
+  | "confirm_visible_action"
+  | "answer_current_page"
+  | "answer_conversationally"
+  | "ask_clarifying_question"
+  | "provide_input"
+  | "recover";
+
+export type MorphyAxAssessmentSource = "one" | "agent_onboarding";
+
+/** A semantic assessment produced by intelligence, never by lexical matching. */
+export type MorphyAxAssessmentV1 = {
+  schema_version: "morphy_ax_assessment.v1";
+  source: MorphyAxAssessmentSource;
+  disposition: MorphyAxDisposition;
+  candidate_action_id: string | null;
+  missing_input: string | null;
+  ambiguous: boolean;
+  confidence: number;
+  expected_outcome:
+    "action" | "confirmation" | "conversation" | "clarification";
+};
+
+export type MorphyAxSnapshotV1 = {
+  schema_version: "morphy_ax_snapshot.v1";
+  snapshot_id: string;
+  revisions: OneVoiceContextSnapshot["revisions"];
+  access: {
+    signed_in: boolean;
+    vault_ready: boolean;
+    persona: string;
+  };
+  context: {
+    screen: string;
+    route_family: string;
+    playbook_id: string;
+    visible_modules: string[];
+    visible_control_ids: string[];
+    onboarding: OneVoiceContextSnapshot["onboarding"];
+  };
+  tools: {
+    available_action_ids: string[];
+  };
+  orchestration: {
+    pending_settlement: boolean;
+    voice: OneVoiceContextSnapshot["voice"];
+    busy_operations: string[];
+  };
+  privacy: {
+    redacted: true;
+    excludes: string[];
+  };
+};
+
+export type MorphyAxPresentationState =
+  | "idle"
+  | "orienting"
+  | "listening"
+  | "understanding"
+  | "confirming"
+  | "acting"
+  | "settling"
+  | "responding"
+  | "recovering";
+
+export type MorphyAxAssessmentDecision =
+  | { status: "permitted"; action_id: string }
+  | { status: "confirmation_required"; action_id: string }
+  | { status: "conversation"; disposition: MorphyAxDisposition }
+  | { status: "clarify"; reason: string }
+  | { status: "rejected"; reason: string };

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -2,14 +2,68 @@
   {
     "route": "/",
     "mode": "hidden",
-    "exemptionReason": "Anonymous auth-split entry route redirects signed-in users to /one and intentionally does not own the signed-in dashboard shell."
+    "exemptionReason": "Anonymous auth-split entry route redirects signed-in users to /one and intentionally does not own the signed-in dashboard shell.",
+    "voicePlaybook": {
+      "playbookId": "route.one.intro",
+      "purpose": "Welcome a new person and help them claim their private agent.",
+      "screen": "one_intro",
+      "entryCue": "Say ‘Claim your One’ whenever you are ready.",
+      "proactivity": "on_entry",
+      "primaryActionId": "onboarding.claim_one",
+      "happyPathActionIds": [
+        "onboarding.claim_one"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "The welcome step completes only after the browser settles navigation to Login.",
+      "nextRoute": "/login",
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one",
     "mode": "standard",
     "shellVerification": {
       "file": "components/dashboard/one-dashboard-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.home",
+      "purpose": "Help the person understand and use the one screen through its generated controls.",
+      "screen": "one_agents",
+      "entryCue": "You can say “Open Agents” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.one_agents",
+      "happyPathActionIds": [
+        "route.one_agents"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -17,7 +71,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/onboarding/setup/one-setup-hub.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.setup",
+      "purpose": "Help the person choose, resume, skip, or finish one setup capability.",
+      "screen": "one_setup",
+      "entryCue": "Choose something to set up, or say ‘finish setup’ when you are ready.",
+      "proactivity": "on_entry",
+      "primaryActionId": "setup.open_finance",
+      "happyPathActionIds": [
+        "setup.open_finance"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Only the hub finish or skip action resolves root onboarding.",
+      "nextRoute": "/one",
+      "returnPolicy": "resolve_root",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -25,7 +108,33 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/developers/developer-docs-hub.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.developers",
+      "purpose": "Help the person understand and use the developers screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -33,25 +142,126 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/agent/agent-screen.tsx",
-      "includes": ["AppPageShell", "AppPageContentRegion", "AgentChatWorkspace"]
+      "includes": [
+        "AppPageShell",
+        "AppPageContentRegion",
+        "AgentChatWorkspace"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.agent",
+      "purpose": "Help the person understand and use the agent screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/login",
     "mode": "hidden",
-    "exemptionReason": "Auth-only route intentionally bypasses the signed-in app shell."
+    "exemptionReason": "Auth-only route intentionally bypasses the signed-in app shell.",
+    "voicePlaybook": {
+      "playbookId": "route.login",
+      "purpose": "Let the person choose Google or Apple and begin the matching sign-in flow.",
+      "screen": "login",
+      "entryCue": "Say ‘Continue with Google’ or ‘Continue with Apple’.",
+      "proactivity": "on_entry",
+      "primaryActionId": "auth.sign_in_google",
+      "happyPathActionIds": [
+        "auth.sign_in_google"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Authentication completes only after the provider popup returns a verified Firebase user session.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/getting-started",
     "mode": "hidden",
-    "exemptionReason": "Anonymous pre-auth intro route intentionally bypasses the signed-in app shell, matching the root and login entry routes."
+    "exemptionReason": "Anonymous pre-auth intro route intentionally bypasses the signed-in app shell, matching the root and login entry routes.",
+    "voicePlaybook": {
+      "playbookId": "route.getting.started",
+      "purpose": "Help the person understand and use the getting started screen through its generated controls.",
+      "screen": "getting_started",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/getting-started",
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kyc",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/kyc/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kyc",
+      "purpose": "Help the person understand and use the kyc screen through its generated controls.",
+      "screen": "one_kyc",
+      "entryCue": "You can say “Open Email” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.one_kyc",
+      "happyPathActionIds": [
+        "route.one_kyc"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/kyc",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -59,43 +269,220 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/location/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.location",
+      "purpose": "Help the person understand and use the location screen through its generated controls.",
+      "screen": "one_location",
+      "entryCue": "You can say “Open Location” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.one_location",
+      "happyPathActionIds": [
+        "route.one_location"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/location",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/one/location/request/[token]",
     "mode": "hidden",
-    "exemptionReason": "Public one-location invite route is a standalone external-request form outside the signed-in app shell."
+    "exemptionReason": "Public one-location invite route is a standalone external-request form outside the signed-in app shell.",
+    "voicePlaybook": {
+      "playbookId": "route.one.location.request.token",
+      "purpose": "Help the person understand and use the request screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/location/invite/[token]",
     "mode": "hidden",
-    "exemptionReason": "Public one-location circle invite route is a standalone external-acceptance form outside the signed-in app shell."
+    "exemptionReason": "Public one-location circle invite route is a standalone external-acceptance form outside the signed-in app shell.",
+    "voicePlaybook": {
+      "playbookId": "route.one.location.invite.token",
+      "purpose": "Help the person understand and use the invite screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/gmail",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/gmail surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/gmail surface.",
+    "voicePlaybook": {
+      "playbookId": "route.gmail",
+      "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+      "screen": "gmail",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/gmail",
     "mode": "standard",
     "shellVerification": {
       "file": "components/gmail/gmail-receipts-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.gmail",
+      "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+      "screen": "gmail",
+      "entryCue": "You can say “Open Receipts Page” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.profile_receipts",
+      "happyPathActionIds": [
+        "route.profile_receipts"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/gmail",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/pkm",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/pkm surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/pkm surface.",
+    "voicePlaybook": {
+      "playbookId": "route.pkm",
+      "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+      "screen": "pkm",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/pkm",
     "mode": "standard",
     "shellVerification": {
       "file": "components/profile/pkm-settings-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.pkm",
+      "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+      "screen": "pkm",
+      "entryCue": "You can say “Open Memory” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.one_pkm",
+      "happyPathActionIds": [
+        "route.one_pkm"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/pkm",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -103,25 +490,131 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/profile/pkm-settings-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.marketplace",
+      "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+      "screen": "one_marketplace",
+      "entryCue": "You can say “Open Information Marketplace” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.one_marketplace",
+      "happyPathActionIds": [
+        "route.one_marketplace"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/marketplace",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/connected-systems",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/connected-systems surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/connected-systems surface.",
+    "voicePlaybook": {
+      "playbookId": "route.connected.systems",
+      "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+      "screen": "connected_systems",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [
+        "utterance"
+      ],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/connected-systems/[systemId]",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/connected-systems/[systemId] surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/connected-systems/[systemId] surface.",
+    "voicePlaybook": {
+      "playbookId": "route.connected.systems.systemid",
+      "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/connected-systems",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/connected-systems/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "ConnectedSystemsPanel"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "ConnectedSystemsPanel"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.connected.systems",
+      "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+      "screen": "connected_systems",
+      "entryCue": "You can say “Open Connected Systems Panel” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.profile_connected_systems",
+      "happyPathActionIds": [
+        "route.profile_connected_systems"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/connected-systems",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -129,62 +622,313 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/connected-systems/[systemId]/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "ConnectedSystemsPanel"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "ConnectedSystemsPanel"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.connected.systems.systemid",
+      "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/connect",
     "mode": "hidden",
-    "exemptionReason": "Standalone people-connection route intentionally bypasses the signed-in app shell while still exposing its own native test beacon."
+    "exemptionReason": "Standalone people-connection route intentionally bypasses the signed-in app shell while still exposing its own native test beacon.",
+    "voicePlaybook": {
+      "playbookId": "route.connect",
+      "purpose": "Help the person understand and use the connect screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/register-phone",
     "mode": "hidden",
-    "exemptionReason": "Mandatory post-login phone verification flow intentionally bypasses the signed-in app shell."
+    "exemptionReason": "Mandatory post-login phone verification flow intentionally bypasses the signed-in app shell.",
+    "voicePlaybook": {
+      "playbookId": "route.register.phone",
+      "purpose": "Verify the signed-in person’s phone before setup continues.",
+      "screen": "register_phone",
+      "entryCue": "Say your phone number including country code, or type it below.",
+      "proactivity": "on_entry",
+      "primaryActionId": "phone_mandate.submit_number",
+      "happyPathActionIds": [
+        "phone_mandate.submit_number"
+      ],
+      "requiredInputs": [
+        "phone_number"
+      ],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Phone verification completes only after the submitted code is accepted.",
+      "nextRoute": "/one/setup",
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/logout",
     "mode": "hidden",
-    "exemptionReason": "Logout route is a transitional auth screen, not a standard content page."
+    "exemptionReason": "Logout route is a transitional auth screen, not a standard content page.",
+    "voicePlaybook": {
+      "playbookId": "route.logout",
+      "purpose": "Help the person understand and use the logout screen through its generated controls.",
+      "screen": "logout",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/consents",
     "mode": "standard",
     "shellVerification": {
       "file": "components/consent/consent-center-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.consents",
+      "purpose": "Help the person understand and use the consents screen through its generated controls.",
+      "screen": "consents",
+      "entryCue": "You can say “Open RIA Requests” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_requests_compat",
+      "happyPathActionIds": [
+        "route.ria_requests_compat"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/requests",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai market surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai market surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai",
+      "purpose": "Help the person understand and use the kai screen through its generated controls.",
+      "screen": "kai_market",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai",
     "mode": "standard",
     "shellVerification": {
       "file": "components/kai/views/kai-market-preview-view.tsx",
-      "includes": ["AppPageShell", "AppPageContentRegion", "SurfaceStack", "SectionHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageContentRegion",
+        "SurfaceStack",
+        "SectionHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai",
+      "purpose": "Help the person understand and use the kai screen through its generated controls.",
+      "screen": "kai_market",
+      "entryCue": "You can say “Open Market Home” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.kai_home",
+      "happyPathActionIds": [
+        "route.kai_home"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/analysis",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/analysis surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/analysis surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.analysis",
+      "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+      "screen": "kai_analysis",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/analysis",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/kai/analysis/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.analysis",
+      "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+      "screen": "kai_analysis",
+      "entryCue": "You can say “Open Analysis Surface” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.kai_analysis",
+      "happyPathActionIds": [
+        "route.kai_analysis"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/kai/analysis",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/dashboard",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical portfolio/dashboard entry."
+    "exemptionReason": "Compatibility redirect route only launches the canonical portfolio/dashboard entry.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.dashboard",
+      "purpose": "Help the person understand and use the dashboard screen through its generated controls.",
+      "screen": "kai_portfolio_dashboard",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/kai/dashboard/analysis",
@@ -192,13 +936,59 @@
     "exemptionReason": "Compatibility redirect route only launches the canonical analysis entry.",
     "shellVerification": {
       "file": "app/kai/dashboard/analysis/page.tsx",
-      "includes": ["AppPageShell"]
+      "includes": [
+        "AppPageShell"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.kai.dashboard.analysis",
+      "purpose": "Help the person understand and use the analysis screen through its generated controls.",
+      "screen": "kai_portfolio_dashboard",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/import",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/import flow."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/import flow.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.import",
+      "purpose": "Help the person understand and use the import screen through its generated controls.",
+      "screen": "import",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/import",
@@ -206,108 +996,529 @@
     "exemptionReason": "Fullscreen import flow uses FullscreenFlowShell instead of standard AppPageShell.",
     "shellVerification": {
       "file": "app/one/kai/import/page.tsx",
-      "includes": ["FullscreenFlowShell", "KaiFlow"]
+      "includes": [
+        "FullscreenFlowShell",
+        "KaiFlow"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.import",
+      "purpose": "Help the person understand and use the import screen through its generated controls.",
+      "screen": "import",
+      "entryCue": "You can say “Open Portfolio Import” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.kai_import",
+      "happyPathActionIds": [
+        "route.kai_import"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/investments",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/investments surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/investments surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.investments",
+      "purpose": "Help the person understand and use the investments screen through its generated controls.",
+      "screen": "kai_investments",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/investments",
     "mode": "standard",
     "shellVerification": {
       "file": "components/kai/views/investments-master-view.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.investments",
+      "purpose": "Help the person understand and use the investments screen through its generated controls.",
+      "screen": "kai_investments",
+      "entryCue": "You can say “Open Investments Surface” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.kai_investments",
+      "happyPathActionIds": [
+        "route.kai_investments"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/kai/investments",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/funding-trade",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/funding-trade surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/funding-trade surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.funding.trade",
+      "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+      "screen": "kai_funding_trade",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/funding-trade",
     "mode": "standard",
     "shellVerification": {
       "file": "components/kai/views/funding-trade-view.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.funding.trade",
+      "purpose": "Help the person understand and use the funding trade screen through its generated controls.",
+      "screen": "kai_funding_trade",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/onboarding",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/setup/kai flow."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/setup/kai flow.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.onboarding",
+      "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+      "screen": "kai",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/onboarding",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/setup/kai flow."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/setup/kai flow.",
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.onboarding",
+      "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+      "screen": "kai",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/setup/kai",
     "mode": "flow",
-    "exemptionReason": "Fullscreen setup wizard owns its own shell and safe-area spacing."
+    "exemptionReason": "Fullscreen setup wizard owns its own shell and safe-area spacing.",
+    "voicePlaybook": {
+      "playbookId": "route.one.setup.kai",
+      "purpose": "Collect Finance preferences and return to the setup hub without resolving root onboarding.",
+      "screen": "one_setup",
+      "entryCue": "Answer the visible Finance question to continue.",
+      "proactivity": "on_entry",
+      "primaryActionId": "kai.setup.answer_horizon",
+      "happyPathActionIds": [
+        "kai.setup.answer_horizon"
+      ],
+      "requiredInputs": [
+        "investment_horizon"
+      ],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Finance setup completes only after preferences are saved and the hub route settles.",
+      "nextRoute": "/one/setup",
+      "returnPolicy": "return_to_hub",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/setup/[capability]",
     "mode": "standard",
     "shellVerification": {
       "file": "components/onboarding/setup/onboarding-capability-step.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.setup.capability",
+      "purpose": "Explain the active setup capability and advance only its visible next step.",
+      "screen": "one_setup",
+      "entryCue": "Say ‘Continue’ when you are ready for the next step.",
+      "proactivity": "on_entry",
+      "primaryActionId": "setup.capability_continue",
+      "happyPathActionIds": [
+        "setup.capability_continue"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "The step settles after its local handler opens the capability destination.",
+      "nextRoute": "/one/setup",
+      "returnPolicy": "return_to_hub",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/optimize",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/optimize surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/optimize surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.optimize",
+      "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+      "screen": "kai_optimize",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/optimize",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/kai/optimize/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack", "PageHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.optimize",
+      "purpose": "Help the person understand and use the optimize screen through its generated controls.",
+      "screen": "kai_optimize",
+      "entryCue": "You can say “Open Optimize Surface” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.kai_optimize",
+      "happyPathActionIds": [
+        "route.kai_optimize"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/one/kai/optimize",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/plaid/oauth/return",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/plaid/oauth/return surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/plaid/oauth/return surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.plaid.oauth.return",
+      "purpose": "Help the person understand and use the return screen through its generated controls.",
+      "screen": "kai",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/plaid/oauth/return",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/kai/plaid/oauth/return/page.tsx",
-      "includes": ["AppPageShell", "AppPageContentRegion"]
+      "includes": [
+        "AppPageShell",
+        "AppPageContentRegion"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.plaid.oauth.return",
+      "purpose": "Help the person understand and use the return screen through its generated controls.",
+      "screen": "kai",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/alpaca/oauth/return",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/alpaca/oauth/return surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/alpaca/oauth/return surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.alpaca.oauth.return",
+      "purpose": "Help the person understand and use the return screen through its generated controls.",
+      "screen": "kai",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/alpaca/oauth/return",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/kai/alpaca/oauth/return/page.tsx",
-      "includes": ["AppPageShell", "AppPageContentRegion"]
+      "includes": [
+        "AppPageShell",
+        "AppPageContentRegion"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.alpaca.oauth.return",
+      "purpose": "Help the person understand and use the return screen through its generated controls.",
+      "screen": "kai",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/kai/portfolio",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/portfolio surface."
+    "exemptionReason": "Compatibility redirect route only launches the canonical /one/kai/portfolio surface.",
+    "voicePlaybook": {
+      "playbookId": "route.kai.portfolio",
+      "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+      "screen": "kai_portfolio_dashboard",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/one/kai/portfolio",
     "mode": "standard",
     "shellVerification": {
       "file": "app/one/kai/portfolio/page.tsx",
-      "includes": ["AppPageShell", "AppPageContentRegion"]
+      "includes": [
+        "AppPageShell",
+        "AppPageContentRegion"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.kai.portfolio",
+      "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+      "screen": "kai_portfolio_dashboard",
+      "entryCue": "You can say “Open Portfolio Dashboard” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.kai_dashboard",
+      "happyPathActionIds": [
+        "route.kai_dashboard"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -315,7 +1526,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-page-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.marketplace",
+      "purpose": "Help the person understand and use the marketplace screen through its generated controls.",
+      "screen": "marketplace",
+      "entryCue": "You can say “Continue Browsing Marketplace” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.marketplace_browse_from_ria_profile",
+      "happyPathActionIds": [
+        "route.marketplace_browse_from_ria_profile"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/marketplace",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -323,30 +1563,157 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-page-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.marketplace.ria",
+      "purpose": "Help the person understand and use the ria screen through its generated controls.",
+      "screen": "marketplace_ria_profile",
+      "entryCue": "You can say “Open Marketplace RIA Profile” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.marketplace_ria_profile",
+      "happyPathActionIds": [
+        "route.marketplace_ria_profile"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/marketplace/ria",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/marketplace/connections",
     "mode": "redirect",
-    "exemptionReason": "Legacy connection route now deep-links into the canonical /consents access manager."
+    "exemptionReason": "Legacy connection route now deep-links into the canonical /consents access manager.",
+    "voicePlaybook": {
+      "playbookId": "route.marketplace.connections",
+      "purpose": "Help the person understand and use the connections screen through its generated controls.",
+      "screen": "marketplace",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [
+        "utterance"
+      ],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/marketplace/connections/portfolio",
     "mode": "redirect",
-    "exemptionReason": "Legacy portfolio explorer route now deep-links into the dedicated /ria/clients/[userId] workspace."
+    "exemptionReason": "Legacy portfolio explorer route now deep-links into the dedicated /ria/clients/[userId] workspace.",
+    "voicePlaybook": {
+      "playbookId": "route.marketplace.connections.portfolio",
+      "purpose": "Help the person understand and use the portfolio screen through its generated controls.",
+      "screen": "marketplace",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/portfolio/shared",
     "mode": "hidden",
-    "exemptionReason": "Public shared portfolio view uses chrome-free layout for external recipients."
+    "exemptionReason": "Public shared portfolio view uses chrome-free layout for external recipients.",
+    "voicePlaybook": {
+      "playbookId": "route.portfolio.shared",
+      "purpose": "Help the person understand and use the shared screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/profile",
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile",
+      "purpose": "Help the person understand and use the profile screen through its generated controls.",
+      "screen": "profile_account",
+      "entryCue": "You can say “Open Profile” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.profile",
+      "happyPathActionIds": [
+        "route.profile"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -354,7 +1721,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.account",
+      "purpose": "Help the person understand and use the account screen through its generated controls.",
+      "screen": "profile_account",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -362,7 +1757,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.account.phone",
+      "purpose": "Help the person understand and use the phone screen through its generated controls.",
+      "screen": "profile_account",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -370,7 +1793,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.preferences",
+      "purpose": "Help the person understand and use the preferences screen through its generated controls.",
+      "screen": "profile_preferences",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -378,7 +1829,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.preferences.kai",
+      "purpose": "Help the person understand and use the kai screen through its generated controls.",
+      "screen": "profile_preferences",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -386,7 +1865,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.preferences.device",
+      "purpose": "Help the person understand and use the device screen through its generated controls.",
+      "screen": "profile_preferences",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -394,7 +1901,37 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.security",
+      "purpose": "Help the person understand and use the security screen through its generated controls.",
+      "screen": "profile_security_panel",
+      "entryCue": "You can say “Open Vault Security Panel” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.profile_security_panel",
+      "happyPathActionIds": [
+        "route.profile_security_panel"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/profile/security",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -402,7 +1939,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.security.vault",
+      "purpose": "Help the person understand and use the vault screen through its generated controls.",
+      "screen": "profile_security_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -410,7 +1975,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.security.session",
+      "purpose": "Help the person understand and use the session screen through its generated controls.",
+      "screen": "profile_security_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -418,7 +2011,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.my.data",
+      "purpose": "Help the person understand and use the personal information screen through its generated controls.",
+      "screen": "profile_my_data",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -426,7 +2047,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.my.data.domain",
+      "purpose": "Help the person understand and use the domain screen through its generated controls.",
+      "screen": "profile_my_data",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -434,7 +2083,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.access",
+      "purpose": "Help the person understand and use the access screen through its generated controls.",
+      "screen": "profile_privacy",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -442,7 +2119,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.access.connection",
+      "purpose": "Help the person understand and use the connection screen through its generated controls.",
+      "screen": "profile_privacy",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -450,30 +2155,154 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.connected.systems",
+      "purpose": "Help the person understand and use the connected systems screen through its generated controls.",
+      "screen": "connected_systems",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/profile/gmail",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail."
+    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail.",
+    "voicePlaybook": {
+      "playbookId": "route.profile.gmail",
+      "purpose": "Help the person understand and use the gmail screen through its generated controls.",
+      "screen": "profile_gmail_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/profile/gmail/connection",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail."
+    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail.",
+    "voicePlaybook": {
+      "playbookId": "route.profile.gmail.connection",
+      "purpose": "Help the person understand and use the connection screen through its generated controls.",
+      "screen": "profile_gmail_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/profile/gmail/actions",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail."
+    "exemptionReason": "Compatibility redirect route forwards to canonical /one/gmail.",
+    "voicePlaybook": {
+      "playbookId": "route.profile.gmail.actions",
+      "purpose": "Help the person understand and use the actions screen through its generated controls.",
+      "screen": "profile_gmail_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/profile/support",
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.support",
+      "purpose": "Help the person understand and use the support screen through its generated controls.",
+      "screen": "profile_support_panel",
+      "entryCue": "You can say “Open Support Panel” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.profile_support_panel",
+      "happyPathActionIds": [
+        "route.profile_support_panel"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/profile/support",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -481,7 +2310,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.support.routing",
+      "purpose": "Help the person understand and use the routing screen through its generated controls.",
+      "screen": "profile_support_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -489,7 +2346,35 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/profile-workspace-page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.support.compose",
+      "purpose": "Help the person understand and use the compose screen through its generated controls.",
+      "screen": "profile_support_panel",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -497,25 +2382,125 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/profile/gmail/oauth/return/page-client.tsx",
-      "includes": ["AppPageShell", "AppPageContentRegion", "HushhLoader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageContentRegion",
+        "HushhLoader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.gmail.oauth.return",
+      "purpose": "Help the person understand and use the return screen through its generated controls.",
+      "screen": "profile_account",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/profile/receipts",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route forwards to canonical /gmail."
+    "exemptionReason": "Compatibility redirect route forwards to canonical /gmail.",
+    "voicePlaybook": {
+      "playbookId": "route.profile.receipts",
+      "purpose": "Help the person understand and use the receipts screen through its generated controls.",
+      "screen": "gmail",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/profile/pkm",
     "mode": "redirect",
-    "exemptionReason": "Compatibility redirect route forwards to canonical /pkm."
+    "exemptionReason": "Compatibility redirect route forwards to canonical /pkm.",
+    "voicePlaybook": {
+      "playbookId": "route.profile.pkm",
+      "purpose": "Help the person understand and use the pkm screen through its generated controls.",
+      "screen": "pkm",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/profile/pkm-agent-lab",
     "mode": "standard",
     "shellVerification": {
       "file": "components/profile/pkm-settings-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.pkm.agent.lab",
+      "purpose": "Help the person understand and use the pkm agent lab screen through its generated controls.",
+      "screen": "profile_pkm_agent_lab",
+      "entryCue": "You can say “Generate PKM capture preview” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "profile.pkm.preview_capture",
+      "happyPathActionIds": [
+        "profile.pkm.preview_capture"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -523,7 +2508,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-page-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria",
+      "purpose": "Help the person understand and use the ria screen through its generated controls.",
+      "screen": "ria_home",
+      "entryCue": "You can say “Open RIA Home” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_home",
+      "happyPathActionIds": [
+        "route.ria_home"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -531,7 +2545,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "app/ria/clients/page.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "PageHeader"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria.clients",
+      "purpose": "Help the person understand and use the clients screen through its generated controls.",
+      "screen": "ria_clients",
+      "entryCue": "You can say “Open RIA Clients” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_clients",
+      "happyPathActionIds": [
+        "route.ria_clients"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/clients",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -539,7 +2582,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-client-workspace.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria.clients.userid",
+      "purpose": "Help the person understand and use the clients screen through its generated controls.",
+      "screen": "ria_client_workspace",
+      "entryCue": "You can say “Open RIA Client Workspace” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_client_workspace",
+      "happyPathActionIds": [
+        "route.ria_client_workspace"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/clients/[userId]",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -547,7 +2619,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-client-account-detail.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria.clients.userid.accounts.accountid",
+      "purpose": "Help the person understand and use the accounts screen through its generated controls.",
+      "screen": "ria_client_account_detail",
+      "entryCue": "You can say “Return To Client Information Explorer” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "ria.client_account.open_workspace_fallback",
+      "happyPathActionIds": [
+        "ria.client_account.open_workspace_fallback"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/clients/[userId]?tab=explorer",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -555,7 +2656,36 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-client-request-detail.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria.clients.userid.requests.requestid",
+      "purpose": "Help the person understand and use the requests screen through its generated controls.",
+      "screen": "ria_client_request_detail",
+      "entryCue": "You can say “Return To Client Access” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "ria.client_request.open_access_fallback",
+      "happyPathActionIds": [
+        "ria.client_request.open_access_fallback"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/clients/[userId]?tab=access",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -564,7 +2694,34 @@
     "exemptionReason": "RIA onboarding is a five-step fullscreen setup flow that owns its own compact content rhythm.",
     "shellVerification": {
       "file": "app/ria/onboarding/page.tsx",
-      "includes": ["FullscreenFlowShell", "OnboardingShell"]
+      "includes": [
+        "FullscreenFlowShell",
+        "OnboardingShell"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria.onboarding",
+      "purpose": "Help the person understand and use the onboarding screen through its generated controls.",
+      "screen": "ria_onboarding",
+      "entryCue": "You can say “Open RIA Onboarding” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_onboarding",
+      "happyPathActionIds": [
+        "route.ria_onboarding"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/onboarding",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
@@ -572,22 +2729,254 @@
     "mode": "standard",
     "shellVerification": {
       "file": "components/ria/ria-page-shell.tsx",
-      "includes": ["AppPageShell", "AppPageHeaderRegion", "AppPageContentRegion", "SurfaceStack"]
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.ria.picks",
+      "purpose": "Help the person understand and use the picks screen through its generated controls.",
+      "screen": "ria_picks",
+      "entryCue": "You can say “Open RIA Picks” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_picks",
+      "happyPathActionIds": [
+        "route.ria_picks"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/picks",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
     }
   },
   {
     "route": "/ria/requests",
     "mode": "redirect",
-    "exemptionReason": "Compatibility alias routes into the shared consent workspace."
+    "exemptionReason": "Compatibility alias routes into the shared consent workspace.",
+    "voicePlaybook": {
+      "playbookId": "route.ria.requests",
+      "purpose": "Help the person understand and use the requests screen through its generated controls.",
+      "screen": "ria_requests",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/requests",
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/ria/settings",
     "mode": "redirect",
-    "exemptionReason": "Compatibility alias routes into the canonical profile/settings surface."
+    "exemptionReason": "Compatibility alias routes into the canonical profile/settings surface.",
+    "voicePlaybook": {
+      "playbookId": "route.ria.settings",
+      "purpose": "Help the person understand and use the settings screen through its generated controls.",
+      "screen": "ria_settings",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/settings",
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   },
   {
     "route": "/ria/workspace",
     "mode": "redirect",
-    "exemptionReason": "Compatibility alias now redirects into the dedicated /ria/clients/[userId] client workspace."
+    "exemptionReason": "Compatibility alias now redirects into the dedicated /ria/clients/[userId] client workspace.",
+    "voicePlaybook": {
+      "playbookId": "route.ria.workspace",
+      "purpose": "Help the person understand and use the workspace screen through its generated controls.",
+      "screen": "ria_workspace",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/workspace",
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
+    "route": "/blog",
+    "mode": "hidden",
+    "exemptionReason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+    "voicePlaybook": {
+      "playbookId": "route.blog",
+      "purpose": "Help the person understand and use the blog screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
+    "route": "/blog/[slug]",
+    "mode": "hidden",
+    "exemptionReason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+    "voicePlaybook": {
+      "playbookId": "route.blog.slug",
+      "purpose": "Help the person understand and use the blog screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
+    "route": "/research",
+    "mode": "hidden",
+    "exemptionReason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+    "voicePlaybook": {
+      "playbookId": "route.research",
+      "purpose": "Help the person understand and use the research screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
+    "route": "/research/protocol",
+    "mode": "hidden",
+    "exemptionReason": "Foundation public route intentionally uses the shared ambient public canvas outside the signed-in shell.",
+    "voicePlaybook": {
+      "playbookId": "route.research.protocol",
+      "purpose": "Help the person understand and use the protocol screen through its generated controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
+    "route": "/ria/profile",
+    "mode": "flow",
+    "exemptionReason": "RIA profile uses its existing focused settings surface outside the standard app-page shell.",
+    "voicePlaybook": {
+      "playbookId": "route.ria.profile",
+      "purpose": "Help the person understand and use the profile screen through its generated controls.",
+      "screen": "ria_profile",
+      "entryCue": "You can say “Open RIA Profile” to use the primary control on this screen.",
+      "proactivity": "on_entry",
+      "primaryActionId": "route.ria_profile",
+      "happyPathActionIds": [
+        "route.ria_profile"
+      ],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": "/ria/profile",
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
   }
 ]

--- a/hushh-webapp/lib/navigation/app-route-layout.ts
+++ b/hushh-webapp/lib/navigation/app-route-layout.ts
@@ -7,9 +7,41 @@ export interface AppRouteShellVerification {
   includes: readonly string[];
 }
 
+export type AppRouteVoiceProactivity = "on_entry" | "ambient";
+export type AppRouteVoiceReturnPolicy =
+  | "stay"
+  | "navigate"
+  | "external_callback"
+  | "return_to_hub"
+  | "resolve_root";
+
+export interface AppRouteVoicePlaybook {
+  playbookId: string;
+  purpose: string;
+  screen: string;
+  entryCue: string;
+  proactivity: AppRouteVoiceProactivity;
+  primaryActionId: string | null;
+  happyPathActionIds: readonly string[];
+  requiredInputs: readonly string[];
+  recoveries: {
+    blocked: string;
+    cancelled: string;
+    failed: string;
+    timeout: string;
+    callbackError: string;
+    routeMismatch: string;
+  };
+  completionBoundary: string;
+  nextRoute: string | null;
+  returnPolicy: AppRouteVoiceReturnPolicy;
+  outOfScopeBehavior: string;
+}
+
 export interface AppRouteLayoutContractEntry {
   route: string;
   mode: AppRouteLayoutMode;
+  voicePlaybook: AppRouteVoicePlaybook;
   shellVerification?: AppRouteShellVerification;
   exemptionReason?: string;
   pageTopLocalOffset?: string;
@@ -21,6 +53,28 @@ export const APP_ROUTE_LAYOUT_CONTRACT =
 const DEFAULT_ROUTE_LAYOUT: AppRouteLayoutContractEntry = {
   route: "*",
   mode: "standard",
+  voicePlaybook: {
+    playbookId: "route.unknown",
+    purpose: "Remain conversational without proposing unavailable controls.",
+    screen: "unknown",
+    entryCue: "",
+    proactivity: "ambient",
+    primaryActionId: null,
+    happyPathActionIds: [],
+    requiredInputs: [],
+    recoveries: {
+      blocked: "Explain that the current control is unavailable.",
+      cancelled: "Respect the cancellation and remain on the current screen.",
+      failed: "Acknowledge the failure without claiming completion.",
+      timeout: "Retain the goal and offer a safe retry.",
+      callbackError: "Retain the goal and explain the callback failed.",
+      routeMismatch: "Use the verified current route before offering an action.",
+    },
+    completionBoundary: "No action completes without browser settlement.",
+    nextRoute: null,
+    returnPolicy: "stay",
+    outOfScopeBehavior: "Answer normally and do not invent a control.",
+  },
 };
 
 function normalizePathname(pathname: string): string {
@@ -52,10 +106,10 @@ function matchRoutePattern(pathname: string, routePattern: string): boolean {
 }
 
 export function resolveAppRouteLayout(pathname: string): AppRouteLayoutContractEntry {
-  return (
-    APP_ROUTE_LAYOUT_CONTRACT.find((entry) => matchRoutePattern(pathname, entry.route)) ??
-    DEFAULT_ROUTE_LAYOUT
-  );
+  const normalized = normalizePathname(pathname);
+  return APP_ROUTE_LAYOUT_CONTRACT.find((entry) => entry.route === normalized) ??
+    APP_ROUTE_LAYOUT_CONTRACT.find((entry) => matchRoutePattern(normalized, entry.route)) ??
+    DEFAULT_ROUTE_LAYOUT;
 }
 
 export function resolveAppRouteLayoutMode(pathname: string): AppRouteLayoutMode {

--- a/hushh-webapp/lib/onboarding/onboarding-connector-intent.ts
+++ b/hushh-webapp/lib/onboarding/onboarding-connector-intent.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { ROUTES } from "@/lib/navigation/routes";
+
+const STORAGE_KEY = "one_onboarding_connector_intent_v1";
+const MAX_AGE_MS = 15 * 60 * 1000;
+
+export type OnboardingConnectorIntent = {
+  version: 1;
+  capability: "gmail";
+  returnTo: typeof ROUTES.ONE_SETUP;
+  correlationId: string;
+  startedAt: number;
+};
+
+function storage(): Storage | null {
+  return typeof window === "undefined" ? null : window.sessionStorage;
+}
+
+export function beginOnboardingConnectorIntent(
+  capability: "gmail"
+): OnboardingConnectorIntent {
+  const intent: OnboardingConnectorIntent = {
+    version: 1,
+    capability,
+    returnTo: ROUTES.ONE_SETUP,
+    correlationId:
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `connector_${Date.now().toString(36)}`,
+    startedAt: Date.now(),
+  };
+  storage()?.setItem(STORAGE_KEY, JSON.stringify(intent));
+  return intent;
+}
+
+export function readOnboardingConnectorIntent(): OnboardingConnectorIntent | null {
+  const store = storage();
+  const raw = store?.getItem(STORAGE_KEY);
+  if (!store || !raw) return null;
+  try {
+    const value = JSON.parse(raw) as Partial<OnboardingConnectorIntent>;
+    const valid =
+      value.version === 1 &&
+      value.capability === "gmail" &&
+      value.returnTo === ROUTES.ONE_SETUP &&
+      typeof value.correlationId === "string" &&
+      typeof value.startedAt === "number" &&
+      Date.now() - value.startedAt <= MAX_AGE_MS;
+    if (valid) return value as OnboardingConnectorIntent;
+  } catch {
+    // Invalid browser state is discarded below.
+  }
+  store.removeItem(STORAGE_KEY);
+  return null;
+}
+
+export function clearOnboardingConnectorIntent(): void {
+  storage()?.removeItem(STORAGE_KEY);
+}

--- a/hushh-webapp/lib/onboarding/onboarding-journey-phase.ts
+++ b/hushh-webapp/lib/onboarding/onboarding-journey-phase.ts
@@ -1,0 +1,8 @@
+import type { PreVaultUserState } from "@/lib/services/pre-vault-user-state-service";
+
+/** A destination is not authority to resolve onboarding after phone verification. */
+export function resolvePostPhoneOnboardingPhase(
+  setupResolved: boolean,
+): NonNullable<PreVaultUserState["onboardingPhase"]> {
+  return setupResolved ? "root_completion" : "setup_hub";
+}

--- a/hushh-webapp/lib/onboarding/one-capabilities.ts
+++ b/hushh-webapp/lib/onboarding/one-capabilities.ts
@@ -42,6 +42,10 @@ export type OneCapabilityGroup = "workflow" | "memory" | "access";
 
 export interface OneCapability {
   id: string;
+  /** Stable generated action identity for opening this setup tile. */
+  setupActionId: `setup.open_${string}`;
+  /** Stable DOM/action-contract correlation id for the setup tile. */
+  setupControlId: `one_setup_tile_${string}`;
   /**
    * Backend agent lane this tile is bound to, or null when the tile is a
    * pure access/preview surface with no agent behind it (consent center,
@@ -91,6 +95,8 @@ export interface OneCapability {
 export const ONE_CAPABILITIES: readonly OneCapability[] = [
   {
     id: "finance",
+    setupActionId: "setup.open_finance",
+    setupControlId: "one_setup_tile_finance",
     agentId: "agent_kai",
     // Public agent name is "Finance" (renamed back from a brief "Investor"
     // pass). Kai remains the internal finance runtime naming: id, routes,
@@ -106,6 +112,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "gmail",
+    setupActionId: "setup.open_gmail",
+    setupControlId: "one_setup_tile_gmail",
     agentId: "agent_gmail",
     title: "Gmail",
     description: "Receipt sync and purchase-memory review.",
@@ -118,6 +126,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "email",
+    setupActionId: "setup.open_email",
+    setupControlId: "one_setup_tile_email",
     agentId: "agent_email",
     title: "Email",
     description: "Approval drafts and client request workflows.",
@@ -129,6 +139,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "location",
+    setupActionId: "setup.open_location",
+    setupControlId: "one_setup_tile_location",
     agentId: "agent_location",
     title: "Onepoint",
     description: "Live location & Alerts",
@@ -141,6 +153,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "pkm",
+    setupActionId: "setup.open_pkm",
+    setupControlId: "one_setup_tile_pkm",
     agentId: "agent_personal_information",
     title: "Memory",
     description: "Saved knowledge and context you can review.",
@@ -152,6 +166,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "consent",
+    setupActionId: "setup.open_consent",
+    setupControlId: "one_setup_tile_consent",
     // Nav owns the consent center: approvals, revocations, and the
     // Connections tab (trusted connections are Nav's domain too).
     agentId: "agent_nav",
@@ -165,6 +181,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "marketplace",
+    setupActionId: "setup.open_marketplace",
+    setupControlId: "one_setup_tile_marketplace",
     // Preview surface only today; no roster agent behind it.
     agentId: null,
     title: "Information Marketplace",
@@ -178,6 +196,8 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
   },
   {
     id: "connected-systems",
+    setupActionId: "setup.open_connected_systems",
+    setupControlId: "one_setup_tile_connected-systems",
     agentId: "agent_connected_systems",
     title: "Connected Systems",
     description: "Approved CRM reads and writes.",

--- a/hushh-webapp/lib/seo/site.ts
+++ b/hushh-webapp/lib/seo/site.ts
@@ -24,12 +24,71 @@ export const SITE_URL = (
 export const PUBLIC_ROUTES = [
   "/",
   "/getting-started",
-  "/login",
   "/marketplace",
   "/developers",
+  "/research",
+  "/research/protocol",
+  "/blog",
 ] as const;
 
 export type PublicRoute = (typeof PUBLIC_ROUTES)[number];
+
+export type PublicRouteSemantic = {
+  title: string;
+  description: string;
+  schemaType: "WebPage" | "CollectionPage";
+  voicePlaybookId: string;
+};
+
+/**
+ * Public search/answer semantics. Voice playbooks share the stable route and
+ * playbook identity, but their runtime instructions are never copied into
+ * crawler markup. A parity test keeps this editorial projection aligned.
+ */
+export const PUBLIC_ROUTE_SEMANTICS: Record<PublicRoute, PublicRouteSemantic> = {
+  "/": {
+    title: "Hussh One | Your Private Agent",
+    description: "Private AI agents with consent at the core. Your information, your control.",
+    schemaType: "WebPage",
+    voicePlaybookId: "route.one.intro",
+  },
+  "/getting-started": {
+    title: "Get started with Hussh One",
+    description: "Understand how to claim and set up your private agent with consent-first controls.",
+    schemaType: "WebPage",
+    voicePlaybookId: "route.getting.started",
+  },
+  "/marketplace": {
+    title: "Hussh Information Marketplace",
+    description: "Explore consent-first exchanges governed by scoped access and owner control.",
+    schemaType: "WebPage",
+    voicePlaybookId: "route.marketplace",
+  },
+  "/developers": {
+    title: "Hussh Developers",
+    description: "Build consent-first agent experiences with Hussh protocols and developer tools.",
+    schemaType: "WebPage",
+    voicePlaybookId: "route.developers",
+  },
+  "/research": {
+    title: "Research & Papers | Hussh",
+    description: "Open consent protocols and research from Hussh, including PCHP.",
+    schemaType: "CollectionPage",
+    voicePlaybookId: "route.research",
+  },
+  "/research/protocol": {
+    title: "Personal Consent Handshake Protocol | Hussh Research",
+    description: "Read the open protocol for explicit, scoped, auditable consent between people and agents.",
+    schemaType: "WebPage",
+    voicePlaybookId: "route.research.protocol",
+  },
+  "/blog": {
+    title: "Hussh Research Blog",
+    description: "Writing on consent-first information sharing, private agents, and human-centered systems.",
+    schemaType: "CollectionPage",
+    voicePlaybookId: "route.blog",
+  },
+};
 
 /**
  * Path prefixes that must never be indexed. Used by robots to disallow
@@ -37,6 +96,7 @@ export type PublicRoute = (typeof PUBLIC_ROUTES)[number];
  */
 export const DISALLOWED_PREFIXES = [
   "/api/",
+  "/login",
   "/agent",
   "/one",
   "/kai",

--- a/hushh-webapp/lib/seo/structured-data.ts
+++ b/hushh-webapp/lib/seo/structured-data.ts
@@ -6,7 +6,12 @@
  * (Hussh -> One -> {Kai, Nav, KYC}); see docs/vision/agent-ontology.md.
  */
 
-import { absoluteUrl, SITE_URL } from "@/lib/seo/site";
+import {
+  absoluteUrl,
+  PUBLIC_ROUTES,
+  PUBLIC_ROUTE_SEMANTICS,
+  SITE_URL,
+} from "@/lib/seo/site";
 
 const ORG_ID = `${SITE_URL}/#organization`;
 const SITE_ID = `${SITE_URL}/#website`;
@@ -32,7 +37,17 @@ export function buildOrganizationGraph(): Record<string, unknown> {
         url: SITE_URL,
         name: "Hussh",
         publisher: { "@id": ORG_ID },
+        hasPart: PUBLIC_ROUTES.map((route) => ({ "@id": `${absoluteUrl(route)}#page` })),
       },
+      ...PUBLIC_ROUTES.map((route) => ({
+        "@type": PUBLIC_ROUTE_SEMANTICS[route].schemaType,
+        "@id": `${absoluteUrl(route)}#page`,
+        url: absoluteUrl(route),
+        name: PUBLIC_ROUTE_SEMANTICS[route].title,
+        description: PUBLIC_ROUTE_SEMANTICS[route].description,
+        isPartOf: { "@id": SITE_ID },
+        publisher: { "@id": ORG_ID },
+      })),
       {
         "@type": "SoftwareApplication",
         "@id": APP_ID,
@@ -54,7 +69,7 @@ export function buildOrganizationGraph(): Record<string, unknown> {
           "Nav: privacy, consent, and vault guardian",
           "KYC: identity workflow specialist",
           "Consent-first scoped access with BYOK",
-          "Zero-knowledge vault and encrypted PKM",
+          "Zero-knowledge vault and encrypted personal information memory",
         ],
       },
     ],

--- a/hushh-webapp/lib/services/gemini-live-client.ts
+++ b/hushh-webapp/lib/services/gemini-live-client.ts
@@ -29,6 +29,11 @@ import { mapAgentVoiceStatusToOneVoiceState } from "@/lib/voice/voice-ui-state-m
 
 const INPUT_SAMPLE_RATE = 16000;
 const OUTPUT_SAMPLE_RATE = 24000;
+// This is intentionally a coarse barge-in signal, not speech recognition.
+// It needs sustained energy to avoid treating microphone silence/noise as a
+// visitor turn and cancelling the idle welcome cue on every connection.
+const VISITOR_ACTIVITY_LEVEL = 0.08;
+const VISITOR_ACTIVITY_FRAMES = 8;
 
 export type GeminiLiveVoiceState =
   | "idle"
@@ -199,6 +204,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
   private startContext: OneVoiceContextSnapshot | null = null;
   /** Consent token for One's specialist tools; rides only in app_context frames. */
   private consentToken: string | null = null;
+  private visitorActivitySent = false;
+  private consecutiveSpeechFrames = 0;
+  private bufferedVisitorSpeechFrames: Uint8Array[] = [];
   /**
    * True while the model's turn is open (audio received since the last
    * turnComplete/interrupted). The Live API closes a model turn with
@@ -257,6 +265,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     if (this.ws) return;
     this.sessionId = createGeminiLiveSessionId();
     this.sourceSeq = 0;
+    this.visitorActivitySent = false;
+    this.consecutiveSpeechFrames = 0;
+    this.bufferedVisitorSpeechFrames = [];
     this.setState("connecting");
 
     const context = options?.context ?? null;
@@ -343,17 +354,54 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       }
       const sourceRate = this.inputContext?.sampleRate ?? INPUT_SAMPLE_RATE;
       const pcm = floatToPcm16(downsample(frame, sourceRate));
-      this.ws.send(
-        JSON.stringify({
-          realtimeInput: {
-            audio: {
-              mimeType: `audio/pcm;rate=${INPUT_SAMPLE_RATE}`,
-              data: base64FromBytes(pcm),
-            },
-          },
-        })
-      );
+      if (!this.sendVisitorActivityStart(level, pcm)) return;
+      this.sendRealtimeAudio(pcm);
     };
+  }
+
+  private sendRealtimeAudio(pcm: Uint8Array): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.setupComplete) return;
+    this.ws.send(
+      JSON.stringify({
+        realtimeInput: {
+          audio: {
+            mimeType: `audio/pcm;rate=${INPUT_SAMPLE_RATE}`,
+            data: base64FromBytes(pcm),
+          },
+        },
+      })
+    );
+  }
+
+  /**
+   * Returns false while an initial speech onset is buffered. That makes the
+   * transcript-free activity signal precede every first-turn audio frame on
+   * the same socket, instead of relying on raw silence frames as a proxy for
+   * visitor intent.
+   */
+  private sendVisitorActivityStart(level: number, pcm: Uint8Array): boolean {
+    if (this.visitorActivitySent) return true;
+    if (level >= VISITOR_ACTIVITY_LEVEL) {
+      this.consecutiveSpeechFrames += 1;
+      this.bufferedVisitorSpeechFrames.push(pcm);
+    } else {
+      this.consecutiveSpeechFrames = 0;
+      this.bufferedVisitorSpeechFrames = [];
+    }
+    if (this.consecutiveSpeechFrames < VISITOR_ACTIVITY_FRAMES) return false;
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN || !this.setupComplete) return false;
+    this.visitorActivitySent = true;
+    this.ws.send(JSON.stringify({ type: "voice_activity_start" }));
+    for (const bufferedFrame of this.bufferedVisitorSpeechFrames) {
+      this.sendRealtimeAudio(bufferedFrame);
+    }
+    this.bufferedVisitorSpeechFrames = [];
+    // A visitor who starts speaking should be able to barge in over an
+    // already-playing idle cue. The interruption fence drops stale audio.
+    if (this.modelTurnOpen || this.state === "speaking") {
+      this.interrupt();
+    }
+    return false;
   }
 
   private connectSocket(relayUrl: string): void {
@@ -410,7 +458,9 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
       if (this.startContext) {
         this.updateContext(this.startContext);
         this.startContext = null;
-      } else if (this.consentToken) {
+      } else {
+        // Even a context-free/legacy start publishes one bounded frame so the
+        // relay can settle its initial-context gate without guessing.
         this.sendAppContext({});
       }
       this.setState("listening");
@@ -652,10 +702,13 @@ export class GeminiLiveClient implements RealtimeVoiceTransport {
     return this.sendAppContext({
       screen: context.route.screen,
       route_family: context.route.route_family,
+      route_playbook_id: context.route.playbook_id,
       persona: context.persona.active,
       voice_state: context.voice.state,
       available_action_ids: context.available_action_ids,
       visible_modules: context.ui.visible_modules,
+      visible_control_ids: context.ui.visible_control_ids,
+      pending_settlement: context.pending_settlement,
       cache_freshness: context.cache.freshness,
       vault_ready: context.cache.vault_ready,
       portfolio_ready: context.cache.portfolio_ready,

--- a/hushh-webapp/lib/voice/route-screen-derivation.ts
+++ b/hushh-webapp/lib/voice/route-screen-derivation.ts
@@ -26,7 +26,10 @@ export function deriveVoiceRouteScreen(
   if (!normalizedPath) {
     return { screen: "unknown", subview: null };
   }
-  if (normalizedPath === ROUTES.HOME || normalizedPath === ROUTES.ONE_HOME) {
+  if (normalizedPath === ROUTES.HOME) {
+    return { screen: "one_intro", subview: null };
+  }
+  if (normalizedPath === ROUTES.ONE_HOME) {
     return { screen: "one_agents", subview: null };
   }
   if (normalizedPath === ROUTES.GETTING_STARTED) {
@@ -104,6 +107,12 @@ export function deriveVoiceRouteScreen(
   }
   if (normalizedPath === ROUTES.RIA_HOME) {
     return { screen: "ria_home", subview: query.get("tab") || null };
+  }
+  if (normalizedPath === ROUTES.RIA_ONBOARDING) {
+    return { screen: "ria_onboarding", subview: query.get("step") || null };
+  }
+  if (normalizedPath === ROUTES.RIA_PROFILE) {
+    return { screen: "ria_profile", subview: query.get("tab") || null };
   }
   if (normalizedPath === ROUTES.RIA_CLIENTS) {
     return { screen: "ria_clients", subview: query.get("tab") || null };

--- a/hushh-webapp/lib/voice/screen-context-builder.ts
+++ b/hushh-webapp/lib/voice/screen-context-builder.ts
@@ -10,6 +10,7 @@ import type {
 import { getKaiActionById, getKaiActionsForControlId } from "@/lib/voice/kai-action-gateway";
 import { listInvestorKaiActionsForSurface } from "@/lib/voice/investor-kai-action-registry";
 import { getVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+import { resolveAppRouteLayout } from "@/lib/navigation/app-route-layout";
 import type {
   OneVoiceTransition,
   OneVoiceUiState,
@@ -178,12 +179,14 @@ export type OneVoiceContextSnapshot = {
   };
   route: {
     screen: string;
+    playbook_id: string;
     subview?: string | null;
     route_family: string;
     nav_stack: string[];
   };
   ui: {
     visible_modules: string[];
+    visible_control_ids: string[];
     active_section?: string | null;
     active_tab?: string | null;
     selected_entity_present: boolean;
@@ -191,6 +194,7 @@ export type OneVoiceContextSnapshot = {
     focused_widget?: string | null;
   };
   available_action_ids: string[];
+  pending_settlement: boolean;
   cache: {
     vault_ready: boolean;
     portfolio_ready: boolean;
@@ -556,7 +560,7 @@ export function buildStructuredScreenContext(args: {
         .map((control) => control.actionId || null)
         .filter((actionId): actionId is string => Boolean(actionId))),
       ...((publishedSurface?.actions || [])
-        .flatMap((action) => [action.actionId || null, action.id])
+        .map((action) => action.actionId || action.id)
         .filter((actionId): actionId is string => Boolean(actionId))),
     ],
     screen
@@ -669,6 +673,10 @@ export function buildOneVoiceContextSnapshot(args: {
       : "missing"
     : "locked";
   const routeFamily = sanitizeRouteFamily(structured.route.pathname);
+  const routePlaybook = resolveAppRouteLayout(routeFamily).voicePlaybook;
+  const visibleControlIds = uniqueStrings(
+    structured.surface.controls.map((control) => control.id || "")
+  );
   const navStack = uniqueStrings(structured.route.nav_stack.map(sanitizeRouteFamily));
   const transitionSeq = args.lastTransition?.transitionSeq ?? 0;
   const routeRevision = stableRevision([
@@ -676,6 +684,7 @@ export function buildOneVoiceContextSnapshot(args: {
     structured.route.screen,
     structured.route.subview ?? null,
     navStack,
+    routePlaybook.playbookId,
   ]);
   const uiRevision = stableRevision([
     structured.ui.visible_modules,
@@ -685,6 +694,7 @@ export function buildOneVoiceContextSnapshot(args: {
     structured.ui.modal_state ?? null,
     structured.ui.focused_widget ?? null,
     availableActionIds,
+    visibleControlIds,
   ]);
   const cacheRevision = stableRevision([
     vaultReady,
@@ -727,12 +737,14 @@ export function buildOneVoiceContextSnapshot(args: {
     },
     route: {
       screen: structured.route.screen,
+      playbook_id: routePlaybook.playbookId,
       subview: structured.route.subview ?? null,
       route_family: routeFamily,
       nav_stack: navStack,
     },
     ui: {
       visible_modules: structured.ui.visible_modules,
+      visible_control_ids: visibleControlIds,
       active_section: structured.ui.active_section ?? null,
       active_tab: structured.ui.active_tab ?? null,
       selected_entity_present: Boolean(structured.ui.selected_entity),
@@ -740,6 +752,8 @@ export function buildOneVoiceContextSnapshot(args: {
       focused_widget: structured.ui.focused_widget ?? null,
     },
     available_action_ids: availableActionIds,
+    pending_settlement:
+      args.state === "acting" || args.state === "navigation_settling",
     cache: {
       vault_ready: vaultReady,
       portfolio_ready: portfolioReady,

--- a/hushh-webapp/lib/voice/voice-feature-flags.ts
+++ b/hushh-webapp/lib/voice/voice-feature-flags.ts
@@ -31,6 +31,7 @@ export type VoiceV2Flags = {
   groundedActionResolutionEnabled: boolean;
   groundedActionPolicyEnforcementEnabled: boolean;
   groundedActionExecutionEnabled: boolean;
+  morphyAxEnabled: boolean;
 };
 
 export function getVoiceV2Flags(): VoiceV2Flags {
@@ -63,6 +64,10 @@ export function getVoiceV2Flags(): VoiceV2Flags {
     groundedActionExecutionEnabled: resolveFlag(
       process.env.NEXT_PUBLIC_VOICE_V2_GROUNDED_ACTION_EXECUTION_ENABLED,
       groundedActionResolutionEnabled,
+    ),
+    morphyAxEnabled: resolveFlag(
+      process.env.NEXT_PUBLIC_MORPHY_AX_ENABLED,
+      false,
     ),
   };
 }

--- a/hushh-webapp/lib/voice/voice-sensitive-redaction.ts
+++ b/hushh-webapp/lib/voice/voice-sensitive-redaction.ts
@@ -1,0 +1,8 @@
+const DIGIT_SEQUENCE = /(?:\d[\s.-]*){4,}/g;
+
+/** Keep phone numbers and OTP values out of the local conversation mirror. */
+export function redactSensitiveVoiceTranscript(text: string, screen?: string | null): string {
+  const normalized = text.trim();
+  if (screen !== "register_phone" && screen !== "phone_mandate") return normalized;
+  return normalized.replace(DIGIT_SEQUENCE, "[sensitive number redacted]");
+}

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -21,6 +21,7 @@
     "build:one-gateway": "npm run build:voice-gateway",
     "verify:one-gateway": "npm run verify:voice-gateway",
     "verify:one-voice": "vitest run __tests__/voice/kai-action-gateway.test.ts __tests__/voice/voice-action-manifest.test.ts __tests__/voice/screen-context-builder.test.ts __tests__/voice/voice-grounding.test.ts __tests__/voice/one-voice-live-action-bridge.test.ts __tests__/voice/one-intelligence-eval.test.ts __tests__/one-goal/one-goal-planner.test.ts __tests__/one-goal/one-goal-runner.test.ts",
+    "verify:morphy-ax": "vitest run __tests__/morphy-ax/morphy-ax-contract.test.ts __tests__/lib/agent-runtime-context.test.tsx __tests__/voice/voice-feature-flags.test.ts",
     "verify:analytics": "vitest run __tests__/services/observability-schema.test.ts __tests__/services/observability-route-map.test.ts __tests__/services/observability-growth.test.ts __tests__/services/observability-native-firebase.test.ts __tests__/services/observability-web-transport.test.ts",
     "verify:analytics:governed": "npm run verify:analytics && npm run audit:analytics-sandbox && npm run smoke:analytics:uat && cd .. && python3 .codex/skills/analytics-observability-governance/scripts/inspect_analytics_surface.py health && ./bin/hushh docs verify",
     "verify:service-boundary": "node ./scripts/architecture/verify-service-layer-boundary.mjs",

--- a/hushh-webapp/scripts/architecture/generate-surface-map.mjs
+++ b/hushh-webapp/scripts/architecture/generate-surface-map.mjs
@@ -58,6 +58,9 @@ function routeToVoiceContractFile(route) {
   const candidates = [
     `${base}/page.voice-action-contract.json`,
     `${base}/page-client.voice-action-contract.json`,
+    ...(route === "/one/setup/[capability]"
+      ? [`${base}/one-onboarding-capability-step.voice-action-contract.json`]
+      : []),
   ].filter((candidate) => fs.existsSync(path.join(appRoot, candidate)));
   if (candidates.length > 1) {
     throw new Error(`Ambiguous voice action contracts for ${route}: ${candidates.join(", ")}`);
@@ -261,9 +264,56 @@ const routeOverrides = {
   },
 };
 
+function validateVoicePlaybook(route, value) {
+  const requiredStrings = [
+    "playbookId",
+    "purpose",
+    "screen",
+    "completionBoundary",
+    "outOfScopeBehavior",
+  ];
+  for (const field of requiredStrings) {
+    if (typeof value?.[field] !== "string" || !value[field].trim()) {
+      throw new Error(`Route ${route} voicePlaybook.${field} is required`);
+    }
+  }
+  if (!/^[a-z0-9._-]{3,96}$/.test(value.playbookId)) {
+    throw new Error(`Route ${route} has an invalid voicePlaybook.playbookId`);
+  }
+  if (!["on_entry", "ambient"].includes(value.proactivity)) {
+    throw new Error(`Route ${route} has invalid voicePlaybook.proactivity`);
+  }
+  if (!["stay", "navigate", "external_callback", "return_to_hub", "resolve_root"].includes(value.returnPolicy)) {
+    throw new Error(`Route ${route} has invalid voicePlaybook.returnPolicy`);
+  }
+  if (!Array.isArray(value.happyPathActionIds) || !Array.isArray(value.requiredInputs)) {
+    throw new Error(`Route ${route} playbook action/input collections must be arrays`);
+  }
+  for (const recovery of ["blocked", "cancelled", "failed", "timeout", "callbackError", "routeMismatch"]) {
+    if (typeof value.recoveries?.[recovery] !== "string" || !value.recoveries[recovery].trim()) {
+      throw new Error(`Route ${route} voicePlaybook.recoveries.${recovery} is required`);
+    }
+  }
+  if (value.proactivity === "on_entry" && !String(value.entryCue || "").trim()) {
+    throw new Error(`Route ${route} proactive playbook requires an entryCue`);
+  }
+  return value;
+}
+
 function buildSurfaceMap() {
   const routeContract = readJson(path.join(appRoot, "lib/navigation/app-route-layout.contract.json"));
   const contractByRoute = new Map((routeContract || []).map((entry) => [entry.route, entry]));
+  if (contractByRoute.size !== (routeContract || []).length) {
+    throw new Error("app-route-layout.contract.json contains duplicate routes");
+  }
+  const structuralPatterns = new Set();
+  for (const entry of routeContract || []) {
+    const structural = String(entry.route).replace(/\[[^\]]+\]/g, "[]");
+    if (structuralPatterns.has(structural)) {
+      throw new Error(`Ambiguous dynamic route layout pattern: ${structural}`);
+    }
+    structuralPatterns.add(structural);
+  }
   const routes = [
     ...new Set([
       ...routeValuesFromRoutesTs(read(path.join(appRoot, "lib/navigation/routes.ts"))),
@@ -301,6 +351,14 @@ function buildSurfaceMap() {
       const pageFile = routeToPageFile(route);
       const voiceContractFile = routeToVoiceContractFile(route);
       const routeContractEntry = contractByRoute.get(route) || null;
+      if (!routeContractEntry) {
+        throw new Error(`Route ${route} is missing from app-route-layout.contract.json`);
+      }
+      const voicePlaybook = routeContractEntry.voicePlaybook;
+      if (!voicePlaybook || typeof voicePlaybook !== "object") {
+        throw new Error(`Route ${route} is missing its required voicePlaybook`);
+      }
+      validateVoicePlaybook(route, voicePlaybook);
       return {
         route,
         page_file: pageFile,
@@ -311,6 +369,28 @@ function buildSurfaceMap() {
               exemption_reason: routeContractEntry.exemptionReason || null,
               shell_verification_file: routeContractEntry.shellVerification?.file || null,
               shell_verification_includes: routeContractEntry.shellVerification?.includes || [],
+              voice_playbook: {
+                playbook_id: voicePlaybook.playbookId,
+                purpose: voicePlaybook.purpose,
+                screen: voicePlaybook.screen,
+                entry_cue: voicePlaybook.entryCue,
+                proactivity: voicePlaybook.proactivity,
+                primary_action_id: voicePlaybook.primaryActionId || null,
+                happy_path_action_ids: voicePlaybook.happyPathActionIds || [],
+                required_inputs: voicePlaybook.requiredInputs || [],
+                recoveries: {
+                  blocked: voicePlaybook.recoveries?.blocked || "",
+                  cancelled: voicePlaybook.recoveries?.cancelled || "",
+                  failed: voicePlaybook.recoveries?.failed || "",
+                  timeout: voicePlaybook.recoveries?.timeout || "",
+                  callback_error: voicePlaybook.recoveries?.callbackError || "",
+                  route_mismatch: voicePlaybook.recoveries?.routeMismatch || "",
+                },
+                completion_boundary: voicePlaybook.completionBoundary,
+                next_route: voicePlaybook.nextRoute || null,
+                return_policy: voicePlaybook.returnPolicy,
+                out_of_scope_behavior: voicePlaybook.outOfScopeBehavior,
+              },
             }
           : null,
         native: inventoryByRoute.get(route) || null,

--- a/hushh-webapp/scripts/voice/generate-route-orchestration-index.mjs
+++ b/hushh-webapp/scripts/voice/generate-route-orchestration-index.mjs
@@ -24,6 +24,15 @@ function trustBoundary(actionIds, byId) {
   if (guards.some((guard) => /auth|signed_in/i.test(guard))) return "auth";
   return "none";
 }
+function routeMatchesPattern(route, pattern) {
+  if (route === pattern) return true;
+  const routeSegments = String(route).split("/").filter(Boolean);
+  const patternSegments = String(pattern).split("/").filter(Boolean);
+  if (routeSegments.length !== patternSegments.length) return false;
+  return patternSegments.every((segment, index) =>
+    /^\[[^\]]+\]$/.test(segment) || segment === routeSegments[index]
+  );
+}
 
 const surfaceMap = JSON.parse(fs.readFileSync(surfaceMapPath, "utf8"));
 const gateway = JSON.parse(fs.readFileSync(gatewayPath, "utf8"));
@@ -32,8 +41,15 @@ const byId = new Map(actions.map((action) => [action.action_id, action]));
 const surfaces = new Map((gateway.surfaces || []).map((surface) => [surface.surface_id, surface]));
 const routes = (surfaceMap.routes || []).map((entry) => {
   const route = entry.route;
+  const localActionIds = new Set(entry.voice_action_contract_ids || []);
   const routeActions = actions.filter((action) =>
-    Array.isArray(action.reachability?.routes) && action.reachability.routes.includes(route)
+    localActionIds.has(action.action_id) ||
+    (Array.isArray(action.reachability?.routes) &&
+      action.reachability.routes.some((actionRoute) =>
+        // Reachability patterns may admit a concrete physical route, but a
+        // concrete action must never leak into a dynamic physical-route entry.
+        routeMatchesPattern(route, actionRoute)
+      ))
   );
   const actionIds = routeActions
     .filter((action) => action.execution_target?.status === "wired")
@@ -43,17 +59,31 @@ const routes = (surfaceMap.routes || []).map((entry) => {
     .map((action) => action.delegate_agent_id)
     .filter((agentId) => typeof agentId === "string" && agentId.trim()))].sort();
   const mode = entry.route_contract?.mode || "unclassified";
-  const transitional = mode === "hidden" || /oauth\/return|callback|logout/.test(route);
+  const transitional =
+    mode === "redirect" ||
+    /oauth\/return|callback|logout/.test(route) ||
+    (mode === "hidden" && actionIds.length === 0);
   const authored = routeActions
     .map((action) => surfaces.get(action.surface_id)?.orchestration)
     .find((value) => value && Object.values(value).some(Boolean)) || {};
+  const playbook = entry.route_contract?.voice_playbook;
+  if (!playbook) throw new Error(`Route ${route} has no generated voice playbook`);
+  if (playbook.primary_action_id && !actionIds.includes(playbook.primary_action_id)) {
+    throw new Error(`Route ${route} primary action ${playbook.primary_action_id} is not reachable`);
+  }
+  for (const actionId of playbook.happy_path_action_ids || []) {
+    if (!actionIds.includes(actionId)) {
+      throw new Error(`Route ${route} happy-path action ${actionId} is not reachable`);
+    }
+  }
   return {
     route_pattern: route,
     page_file: entry.page_file,
     route_mode: mode,
     orchestration_class: transitional ? "transitional" : actionIds.length ? "interactive" : "context_only",
-    instruction_id: authored.instruction_id || idFor(route),
-    context_policy: authored.context_policy || (transitional ? "suppress" : actionIds.length ? "publish" : "minimal"),
+    instruction_id: playbook.playbook_id || authored.instruction_id || idFor(route),
+    context_policy: transitional ? "suppress" : playbook.proactivity === "on_entry" ? "publish" : "minimal",
+    voice_playbook: playbook,
     voice_contract_file: entry.voice_action_contract_file,
     action_ids: actionIds,
     action_coverage: actionIds.length ? "inherited" : entry.voice_action_contract_file ? "local" : "none",
@@ -67,7 +97,7 @@ const routes = (surfaceMap.routes || []).map((entry) => {
 }).sort((left, right) => left.route_pattern.localeCompare(right.route_pattern));
 
 const payload = {
-  schema_version: "one.route_orchestration_index.v1",
+  schema_version: "one.route_orchestration_index.v2",
   purpose: "Generated, redacted route discovery and One delegation-admission index.",
   sources: ["hushh-webapp/frontend-native-surface-map.generated.json", "contracts/kai/kai-action-gateway.vnext.json"],
   routes,


### PR DESCRIPTION
## Summary
- add route-aware Morphy AX snapshots, typed assessments, onboarding policy, and generated-contract coverage
- make One Voice prioritize visible route-local actions with settlement-safe recovery
- make protocol subtree verification opt-in for normal pre-push while preserving explicit and CI evidence lanes

## Verification
- `./bin/hushh ci`
- explicit subtree sync check, docs verification, Apache surface verification
- browser and focused voice/onboarding checks completed locally

Admin release path: merge queue required by live GitHub rules; deploy UAT only after exact landed SHA post-merge smoke.

---
Closes #4477
(retroactive board-linkage backfill, 2026-07-14)