### PR TITLE
Security quick-wins from the pre-certification audit (non-breaking subset)

### DIFF
--- a/consent-protocol/Dockerfile
+++ b/consent-protocol/Dockerfile
@@ -43,6 +43,12 @@ ENV PATH=/usr/local/bin:$PATH
 COPY . .
 RUN python -m compileall -q .
 
+# Run as a non-root, least-privilege user (FedRAMP CM-6 / SC-2). The app writes
+# no bytecode at runtime (PYTHONDONTWRITEBYTECODE=1) and reads world-readable
+# code, so a non-root UID needs no extra grants.
+RUN useradd --system --uid 10001 --home-dir /app appuser
+USER 10001
+
 # Expose port (Cloud Run will override this)
 EXPOSE 8080
 

--- a/consent-protocol/api/utils/firebase_auth.py
+++ b/consent-protocol/api/utils/firebase_auth.py
@@ -36,7 +36,13 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
 
     try:
         firebase_app = get_firebase_auth_app()
-        decoded = firebase_auth.verify_id_token(id_token, app=firebase_app)
+        # check_revoked=True rejects tokens from disabled accounts or sessions
+        # that were force-revoked (e.g. remote sign-out / device loss), instead of
+        # honoring them until natural ~1h expiry. The revoked/disabled cases are
+        # already handled in the except block below.
+        decoded = firebase_auth.verify_id_token(
+            id_token, app=firebase_app, check_revoked=True
+        )
         uid = decoded.get("uid")
         if not isinstance(uid, str) or not uid:
             raise HTTPException(status_code=401, detail="Invalid Firebase ID token")

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -7706,7 +7706,12 @@ class RIAIAMService:
                         ),
                     )
             if updated.endswith("0"):
-                logger.warning("RIA invite accept race detected for token=%s", invite_token)
+                # Never log the raw invite bearer token (log-read = invite replay);
+                # correlate on the request id instead. (FedRAMP IA-5 / SI-11.)
+                logger.warning(
+                    "RIA invite accept race detected for request_id=%s",
+                    request["request_id"],
+                )
             return {
                 "invite_token": invite_token,
                 "request_id": request["request_id"],

--- a/consent-protocol/scripts/ci/backend-check.sh
+++ b/consent-protocol/scripts/ci/backend-check.sh
@@ -14,7 +14,7 @@ bash scripts/sync_runtime_requirements.sh --check
 
 uv run ruff check .
 uv run mypy --config-file pyproject.toml --ignore-missing-imports
-uv run bandit -r hushh_mcp/ api/ -c pyproject.toml -ll
+uv run bandit -r hushh_mcp/ api/ server.py mcp_server.py mcp_remote.py server_a2a.py -c pyproject.toml -ll
 
 if [ -f scripts/run-test-ci.sh ]; then
   bash scripts/run-test-ci.sh

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -73,7 +73,15 @@ def _is_app_review_mode_enabled() -> bool:
 
 def _parse_cors_allowed_origins() -> list[str]:
     explicit = str(os.getenv("CORS_ALLOWED_ORIGINS", "")).strip()
-    origins = [item.strip() for item in explicit.split(",") if item.strip()]
+    # Defensively drop any wildcard: the middleware sends
+    # Access-Control-Allow-Credentials: true, and a reflected "*" origin with
+    # credentials would enable cross-origin credential theft. Origins must be
+    # explicit. (FedRAMP CM-6 / AC-4.)
+    origins = [
+        item.strip()
+        for item in explicit.split(",")
+        if item.strip() and item.strip() != "*"
+    ]
 
     frontend_url = _APP_RUNTIME_SETTINGS.app_frontend_origin
     if frontend_url and frontend_url not in origins:
@@ -742,4 +750,4 @@ async def startup_consent_revocation_worker() -> None:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000, access_log=False)  # noqa: S104
+    uvicorn.run(app, host="0.0.0.0", port=8000, access_log=False)  # noqa: S104  # nosec B104 - dev-only __main__ run; prod serves via gunicorn in a Cloud Run container

--- a/consent-protocol/server_a2a.py
+++ b/consent-protocol/server_a2a.py
@@ -74,4 +74,4 @@ app = WSGIMiddleware(flask_app) if isinstance(flask_app, Flask) else flask_app
 
 if __name__ == "__main__":
     logger.info("Starting Kai A2A Server on Port 8001 (WSGI/ASGI)...")
-    uvicorn.run(app, host="0.0.0.0", port=8001)  # noqa: S104
+    uvicorn.run(app, host="0.0.0.0", port=8001)  # noqa: S104  # nosec B104 - dev-only __main__ run; prod serves via gunicorn in a Cloud Run container


### PR DESCRIPTION
## What

The low-risk, non-behavior-breaking fixes from the FedRAMP High / SOC 2 readiness audit. **No consent/crypto changes and no route-contract changes** — deliberately the subset that cannot lock users out, so it can land ahead of the larger architecture workstreams.

| Fix | File | Control | POA&M |
|-----|------|---------|-------|
| Reject disabled/force-revoked Firebase sessions immediately (`check_revoked=True`) instead of honoring them until ~1h expiry | `api/utils/firebase_auth.py` | AC-12, IA-2 | PA-L1 |
| Run the container as a non-root least-privilege user (`USER 10001`) | `Dockerfile` | CM-6, SC-2 | PA-H4 |
| Defensively drop `*` from `CORS_ALLOWED_ORIGINS` (Allow-Credentials is on, so a reflected wildcard = credential-theft risk if misconfigured) | `server.py` | CM-6, AC-4 | PA-L4 |
| Stop logging the raw RIA invite bearer token (log-read enabled invite replay); correlate on `request_id` | `hushh_mcp/services/ria_iam_service.py` | IA-5, SI-11 | PA-M3 |
| Extend bandit SAST to the network-facing entrypoints (`server.py`, `mcp_server.py`, `mcp_remote.py`, `server_a2a.py`); annotate the two legitimate dev-only `0.0.0.0` binds with `# nosec B104` | `scripts/ci/backend-check.sh` (+ the two binds) | SA-11 | PA-L6 |

## Verification

Run locally before push: **ruff clean**, **`bandit -ll` clean** (Medium/High severity: 0 across the newly-covered entrypoints), **`py_compile` OK**. The revoked-session and disabled-account exceptions were already handled in `firebase_auth.py`'s except block, so `check_revoked=True` only tightens behavior.

## Deliberately NOT in this PR (need dedicated review)

The larger items from the audit — FIPS-validated crypto module, immutable audit log, US-sovereign egress boundary, MFA, DB-layer RLS, the token base64-malleability revocation fix, the connector-credential AEAD, wiring the PII log formatter at startup, and adding auth to `/api/agents/kai/chat` — are tracked in the POA&M and warrant their own reviewed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4491
(retroactive board-linkage backfill, 2026-07-14)