### PR TITLE
fix(one-location): minor location UI polish + Command place search

### DIFF
--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2462,12 +2462,12 @@ md-ripple.morphy-md-ripple {
 }
 
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
-  color: var(--foundation-gold-deep) !important;
+  color: #007aff !important;
   font-weight: 600;
 }
 
 .dark .kai-bottom-nav-pill [role="radio"][aria-checked="true"] {
-  color: var(--foundation-gold-deep) !important;
+  color: #4a9eff !important;
 }
 
 .kai-bottom-nav-pill [role="radio"] svg {
@@ -2483,7 +2483,7 @@ md-ripple.morphy-md-ripple {
 .kai-bottom-nav-pill [role="radio"][aria-checked="true"] svg {
   opacity: 1;
   stroke-width: 1.95;
-  filter: drop-shadow(0 3px 8px color-mix(in srgb, var(--foundation-gold-deep) 28%, transparent));
+  filter: drop-shadow(0 3px 8px color-mix(in srgb, #007aff 28%, transparent));
   transform: translateY(-0.5px);
 }
 

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -465,10 +465,9 @@ export const Navbar = () => {
             className={cn(
               "kai-bottom-nav-pill relative z-10 w-full chrome-bottom-foreground",
               // Shared bottom chrome surface: flat translucent track, no
-              // route-local glass or ink override. Active state is Foundation
-              // accent foreground so the nav matches the rest of the app
-              // identity without turning the background yellow.
-              "[&_[aria-checked=true]]:text-accent-strong [&_[aria-checked=true]]:font-semibold",
+              // route-local glass or ink override. Active state uses iOS system
+              // blue (#007aff) so the selected tab reads blue on every screen.
+              "[&_[aria-checked=true]]:text-[#007aff] [&_[aria-checked=true]]:font-semibold",
               "[&_[data-segment-indicator]]:bg-black/[0.06] [&_[data-segment-indicator]]:shadow-none [&_[data-segment-indicator]]:backdrop-blur-none dark:[&_[data-segment-indicator]]:bg-white/[0.1]",
             )}
           />
@@ -489,7 +488,7 @@ export const Navbar = () => {
             "transition-[color,transform,background-color] duration-200 ease-[cubic-bezier(0.25,1,0.5,1)]",
             // Hover styles behind (hover:hover) so iOS taps never latch a
             // sticky hover background on the first touch.
-            "[@media(hover:hover)]:hover:bg-black/[0.08] [@media(hover:hover)]:hover:text-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background [@media(hover:hover)]:dark:hover:bg-white/[0.1] active:scale-90 chrome-bottom-foreground",
+            "[@media(hover:hover)]:hover:bg-black/[0.08] [@media(hover:hover)]:hover:text-[#007aff] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#007aff]/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background [@media(hover:hover)]:dark:hover:bg-white/[0.1] active:scale-90 chrome-bottom-foreground",
           )}
           onClick={() => {
             if (busyOperations["portfolio_save"]) {

--- a/hushh-webapp/components/one-location/redesign/__tests__/drive-to-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/drive-to-flow.test.tsx
@@ -6,10 +6,37 @@ vi.mock("@/lib/one-location/use-google-maps", () => ({
   useGoogleMaps: () => ({ status: "loading" }),
 }));
 
+// The destination search is exercised in place-search-dialog.test.tsx; here we
+// stub it to a one-click selector so the flow tests stay focused.
+vi.mock("@/components/one-location/redesign/place-search-dialog", () => ({
+  PlaceSearchDialog: ({
+    open,
+    onSelect,
+  }: {
+    open: boolean;
+    onSelect: (d: { placeId: string; label: string; latitude: number; longitude: number }) => void;
+  }) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() =>
+          onSelect({
+            placeId: "p1",
+            label: "Starbucks, Market St",
+            latitude: 37.79,
+            longitude: -122.4,
+          })
+        }
+      >
+        stub-pick-place
+      </button>
+    ) : null,
+}));
+
 import { DriveToFlow } from "@/components/one-location/redesign/drive-to-flow";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { LocationHubViewModel } from "@/components/one-location/redesign/location-redesign-hub";
-import type { DriveDestination, PlainLocationPoint } from "@/lib/one-location/types";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
 
 const point: PlainLocationPoint = {
   latitude: 37.7,
@@ -47,19 +74,9 @@ function makeVm(overrides: Partial<LocationHubViewModel> = {}): LocationHubViewM
 }
 
 async function pickDestination() {
-  vi.spyOn(OneLocationService, "placesAutocomplete").mockResolvedValue([
-    { placeId: "p1", text: "Starbucks, Market St" },
-  ]);
-  vi.spyOn(OneLocationService, "placeDetails").mockResolvedValue({
-    placeId: "p1",
-    label: "Starbucks, Market St",
-    latitude: 37.79,
-    longitude: -122.4,
-  } as DriveDestination);
-  fireEvent.change(screen.getByPlaceholderText(/where are you headed/i), {
-    target: { value: "Starbucks" },
-  });
-  fireEvent.click(await screen.findByText("Starbucks, Market St"));
+  // Open the (stubbed) place-search dialog, then pick the stub result.
+  fireEvent.click(screen.getByRole("button", { name: /where are you headed/i }));
+  fireEvent.click(await screen.findByText("stub-pick-place"));
 }
 
 describe("DriveToFlow", () => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/place-search-dialog.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/place-search-dialog.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { PlaceSearchDialog } from "@/components/one-location/redesign/place-search-dialog";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { DriveDestination } from "@/lib/one-location/types";
+
+// jsdom shims for Radix Dialog + cmdk.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  // @ts-expect-error jsdom lacks pointer capture
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  // @ts-expect-error jsdom lacks pointer capture
+  Element.prototype.setPointerCapture = vi.fn();
+  // @ts-expect-error jsdom lacks pointer capture
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.matchMedia) {
+    // @ts-expect-error jsdom lacks matchMedia
+    window.matchMedia = () => ({
+      matches: false,
+      media: "",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+  }
+  // @ts-expect-error jsdom lacks ResizeObserver
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("PlaceSearchDialog", () => {
+  it("searches, returns the selected place, and closes", async () => {
+    vi.spyOn(OneLocationService, "placesAutocomplete").mockResolvedValue([
+      { placeId: "p1", text: "Indira Gandhi Intl Airport T3" },
+    ]);
+    vi.spyOn(OneLocationService, "placeDetails").mockResolvedValue({
+      placeId: "p1",
+      label: "Indira Gandhi Intl Airport T3",
+      latitude: 28.55,
+      longitude: 77.1,
+    } as DriveDestination);
+    const onSelect = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <PlaceSearchDialog
+        open
+        onOpenChange={onOpenChange}
+        vaultOwnerToken="t"
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/search a place/i), {
+      target: { value: "IGI" },
+    });
+
+    const result = await screen.findByRole("option", { name: /Indira Gandhi/i });
+    fireEvent.click(result);
+
+    await waitFor(() =>
+      expect(onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({ placeId: "p1", latitude: 28.55 }),
+      ),
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("shows a Recent group when the query is empty", () => {
+    const recents: DriveDestination[] = [
+      { placeId: "r1", label: "Home", latitude: 1, longitude: 1 },
+    ];
+    render(
+      <PlaceSearchDialog
+        open
+        onOpenChange={vi.fn()}
+        vaultOwnerToken="t"
+        recents={recents}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Recent")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Home/i })).toBeInTheDocument();
+  });
+
+  it("prompts to type when empty with no recents", () => {
+    render(
+      <PlaceSearchDialog
+        open
+        onOpenChange={vi.fn()}
+        vaultOwnerToken="t"
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/type to search a place/i)).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/drive-to-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/drive-to-flow.tsx
@@ -11,8 +11,9 @@
  * The map reuses the same live-location map component as the home screen: when a
  * live fix is available it renders the interactive map (with the route once a
  * destination is chosen); otherwise it prompts the user to capture their
- * location. Destination + ETA travel inside the encrypted envelope — this
- * component only collects intent and calls `vm.onDriveTo`.
+ * location. Destination search uses the shared Command-based PlaceSearchDialog.
+ * Destination + ETA travel inside the encrypted envelope — this component only
+ * collects intent and calls `vm.onDriveTo`.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -25,6 +26,7 @@ import type { DriveDestination, RouteEta } from "@/lib/one-location/types";
 
 import { CARD_SURFACE } from "./tokens";
 import { DriveRouteMap } from "./drive-route-map";
+import { PlaceSearchDialog } from "./place-search-dialog";
 import type { LocationHubViewModel } from "./location-redesign-hub";
 
 // Drive-to shares default to a 2-hour window (no per-flow duration picker).
@@ -59,77 +61,12 @@ export function DriveToFlow({
   const contacts = vm.sosRecipients;
   const busy = vm.driveBusy || vm.busy === "selfLocation";
 
-  const [query, setQuery] = useState("");
-  const [suggestions, setSuggestions] = useState<{ placeId: string; text: string }[]>([]);
-  const [searching, setSearching] = useState(false);
   const [destination, setDestination] = useState<DriveDestination | null>(null);
   const [checkedIds, setCheckedIds] = useState<string[]>([]);
   const [eta, setEta] = useState<RouteEta | null>(null);
-  const [searchError, setSearchError] = useState<string | null>(null);
+  const [searchOpen, setSearchOpen] = useState(false);
 
   const point = vm.myLocationPoint;
-
-  // Debounced Places autocomplete via the backend proxy.
-  useEffect(() => {
-    const token = vm.vaultOwnerToken;
-    const q = query.trim();
-    if (!token || q.length < 2 || destination?.label === q) {
-      setSuggestions([]);
-      return;
-    }
-    let cancelled = false;
-    setSearching(true);
-    setSearchError(null);
-    const handle = setTimeout(async () => {
-      try {
-        const results = await OneLocationService.placesAutocomplete({
-          vaultOwnerToken: token,
-          input: q,
-        });
-        if (!cancelled) setSuggestions(results);
-      } catch {
-        if (!cancelled) {
-          setSuggestions([]);
-          setSearchError("Couldn't search places. Check your connection.");
-        }
-      } finally {
-        if (!cancelled) setSearching(false);
-      }
-    }, 300);
-    return () => {
-      cancelled = true;
-      clearTimeout(handle);
-    };
-  }, [query, vm.vaultOwnerToken, destination?.label]);
-
-  const selectSuggestion = async (placeId: string, text: string) => {
-    const token = vm.vaultOwnerToken;
-    if (!token) return;
-    setQuery(text);
-    setSuggestions([]);
-    try {
-      const details = await OneLocationService.placeDetails({
-        vaultOwnerToken: token,
-        placeId,
-      });
-      setDestination(details);
-    } catch {
-      setSearchError("Couldn't load that place. Try another.");
-    }
-  };
-
-  const selectRecent = (recent: DriveDestination) => {
-    setDestination(recent);
-    setQuery(recent.label);
-    setSuggestions([]);
-  };
-
-  const clearDestination = () => {
-    setDestination(null);
-    setQuery("");
-    setSuggestions([]);
-    setEta(null);
-  };
 
   // Fetch a live ETA whenever both origin and destination are known.
   useEffect(() => {
@@ -177,14 +114,6 @@ export function DriveToFlow({
 
   const canStart =
     Boolean(destination) && Boolean(point) && selectedReadyCount > 0 && !busy;
-
-  const recentDestinations = vm.recentDestinations;
-  const showSuggestions =
-    !destination &&
-    (suggestions.length > 0 ||
-      searching ||
-      Boolean(searchError) ||
-      (!query.trim() && recentDestinations.length > 0));
 
   return (
     <div className="space-y-4">
@@ -254,78 +183,37 @@ export function DriveToFlow({
             </div>
           </div>
 
-          {/* Heading to */}
+          {/* Heading to — opens the Command place-search dialog */}
           <div className="flex items-center gap-3 py-[11px]">
             <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-[#1d1d1f] dark:bg-white" />
-            <div className="min-w-0 flex-1">
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              className="min-w-0 flex-1 text-left"
+            >
               <div className="text-xs text-muted-foreground">Heading to</div>
               {destination ? (
-                <button
-                  type="button"
-                  onClick={clearDestination}
-                  className="block w-full truncate text-left text-[15px] font-semibold text-foreground"
-                >
+                <div className="text-[15px] font-semibold text-foreground">
                   {destination.label}
-                </button>
+                </div>
               ) : (
-                <input
-                  type="text"
-                  value={query}
-                  onChange={(event) => {
-                    setQuery(event.target.value);
-                    setDestination(null);
-                  }}
-                  placeholder="Where are you headed?"
-                  className="w-full bg-transparent text-[15px] font-semibold text-foreground outline-none placeholder:font-normal placeholder:text-muted-foreground"
-                />
+                <div className="text-[15px] font-semibold text-muted-foreground">
+                  Where are you headed?
+                </div>
               )}
-            </div>
+            </button>
+            {destination ? (
+              <button
+                type="button"
+                onClick={() => setSearchOpen(true)}
+                className="shrink-0 text-[13px] font-medium text-[#007aff]"
+              >
+                Change
+              </button>
+            ) : null}
           </div>
         </div>
       </section>
-
-      {/* DESTINATION SUGGESTIONS / RECENTS (only while choosing) */}
-      {showSuggestions ? (
-        <section className={cn(CARD_SURFACE, "p-2")}>
-          {searchError ? (
-            <p className="px-2 py-1.5 text-xs font-medium text-red-600 dark:text-red-300">
-              {searchError}
-            </p>
-          ) : null}
-          {searching && suggestions.length === 0 ? (
-            <p className="px-2 py-1.5 text-xs text-muted-foreground">Searching…</p>
-          ) : null}
-          {suggestions.length > 0
-            ? suggestions.map((suggestion) => (
-                <button
-                  key={suggestion.placeId}
-                  type="button"
-                  onClick={() => void selectSuggestion(suggestion.placeId, suggestion.text)}
-                  className="flex w-full items-center gap-3 rounded-[11px] px-2 py-2.5 text-left hover:bg-[#007aff]/10"
-                >
-                  <Navigation className="h-4 w-4 shrink-0 rotate-90 text-[#007aff]" />
-                  <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                    {suggestion.text}
-                  </span>
-                </button>
-              ))
-            : !query.trim()
-              ? recentDestinations.map((recent) => (
-                  <button
-                    key={recent.placeId ?? recent.label}
-                    type="button"
-                    onClick={() => selectRecent(recent)}
-                    className="flex w-full items-center gap-3 rounded-[11px] px-2 py-2.5 text-left hover:bg-[#007aff]/10"
-                  >
-                    <Navigation className="h-4 w-4 shrink-0 rotate-90 text-muted-foreground" />
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                      {recent.label}
-                    </span>
-                  </button>
-                ))
-              : null}
-        </section>
-      ) : null}
 
       {/* WHO SEES YOUR DRIVE */}
       <div>
@@ -398,6 +286,16 @@ export function DriveToFlow({
           {busy ? "Starting…" : "Start sharing drive"}
         </button>
       </div>
+
+      <PlaceSearchDialog
+        open={searchOpen}
+        onOpenChange={setSearchOpen}
+        vaultOwnerToken={vm.vaultOwnerToken}
+        recents={vm.recentDestinations}
+        onSelect={(dest) => setDestination(dest)}
+        title="Where are you headed?"
+        placeholder="Search a destination…"
+      />
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -438,7 +438,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   /* ----------------------------------------------------------------- */
   const headerSubtitle =
     tab === "now"
-      ? "Private by default"
+      ? ""
       : tab === "people"
         ? "Circle, contacts and invites"
         : tab === "links"

--- a/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/pick-me-up-flow.tsx
@@ -20,6 +20,7 @@ import { haversineMeters } from "@/lib/one-location/marker-interpolation";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
 
 import { CARD_SURFACE } from "./tokens";
+import { PlaceSearchDialog } from "./place-search-dialog";
 import type { LocationHubViewModel } from "./location-redesign-hub";
 
 const PICKUP_DURATION_HOURS = "4"; // "until picked up"
@@ -65,10 +66,8 @@ export function PickMeUpFlow({
   // every ~5s during the self-preview stream).
   const lastGeocodedLatLng = useRef<{ lat: number; lng: number } | null>(null);
 
-  // Adjust search state
+  // Adjust opens the shared Command place-search dialog.
   const [adjustOpen, setAdjustOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [suggestions, setSuggestions] = useState<{ placeId: string; text: string }[]>([]);
 
   // The point we actually share: fixed spot if adjusted, else the live location.
   const pickupPoint: { latitude: number; longitude: number } | null = fixedSpot
@@ -118,46 +117,6 @@ export function PickMeUpFlow({
       cancelled = true;
     };
   }, [vm.vaultOwnerToken, livePoint, fixedSpot]);
-
-  // Debounced Places autocomplete for Adjust.
-  useEffect(() => {
-    const token = vm.vaultOwnerToken;
-    const q = query.trim();
-    if (!token || !adjustOpen || q.length < 2) {
-      setSuggestions([]);
-      return;
-    }
-    let cancelled = false;
-    const handle = setTimeout(async () => {
-      try {
-        const results = await OneLocationService.placesAutocomplete({
-          vaultOwnerToken: token,
-          input: q,
-        });
-        if (!cancelled) setSuggestions(results);
-      } catch {
-        if (!cancelled) setSuggestions([]);
-      }
-    }, 300);
-    return () => {
-      cancelled = true;
-      clearTimeout(handle);
-    };
-  }, [query, adjustOpen, vm.vaultOwnerToken]);
-
-  const selectPlace = async (placeId: string) => {
-    const token = vm.vaultOwnerToken;
-    if (!token) return;
-    try {
-      const place = await OneLocationService.placeDetails({ vaultOwnerToken: token, placeId });
-      setFixedSpot({ latitude: place.latitude, longitude: place.longitude, label: place.label });
-      setAdjustOpen(false);
-      setQuery("");
-      setSuggestions([]);
-    } catch {
-      /* leave adjust open; user can retry */
-    }
-  };
 
   const pickupLabel = fixedSpot
     ? fixedSpot.label
@@ -240,7 +199,7 @@ export function PickMeUpFlow({
           ) : (
             <button
               type="button"
-              onClick={() => setAdjustOpen((v) => !v)}
+              onClick={() => setAdjustOpen(true)}
               className="shrink-0 text-[15px] text-[#007aff]"
             >
               Adjust
@@ -248,34 +207,6 @@ export function PickMeUpFlow({
           )}
         </div>
       </section>
-
-      {/* ADJUST SEARCH */}
-      {adjustOpen ? (
-        <section className={cn(CARD_SURFACE, "p-3")}>
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search a pickup place…"
-            className="h-10 w-full rounded-[12px] border border-border/70 bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-[#007aff]/25"
-          />
-          {suggestions.length ? (
-            <div className="mt-2 space-y-1">
-              {suggestions.map((s) => (
-                <button
-                  key={s.placeId}
-                  type="button"
-                  onClick={() => void selectPlace(s.placeId)}
-                  className="flex w-full items-center gap-2 rounded-[11px] px-2 py-2 text-left hover:bg-[#007aff]/10"
-                >
-                  <Navigation className="h-4 w-4 shrink-0 rotate-90 text-[#007aff]" />
-                  <span className="min-w-0 flex-1 truncate text-sm text-foreground">{s.text}</span>
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </section>
-      ) : null}
 
       {/* WHO DO YOU ASK */}
       <div>
@@ -379,6 +310,22 @@ export function PickMeUpFlow({
           {busy ? "Asking…" : selectedName ? `Ask ${selectedName} to pick me up` : "Select who to ask"}
         </button>
       </div>
+
+      <PlaceSearchDialog
+        open={adjustOpen}
+        onOpenChange={setAdjustOpen}
+        vaultOwnerToken={vm.vaultOwnerToken}
+        recents={vm.recentDestinations}
+        onSelect={(place) =>
+          setFixedSpot({
+            latitude: place.latitude,
+            longitude: place.longitude,
+            label: place.label,
+          })
+        }
+        title="Search a pickup place"
+        placeholder="Search a pickup place…"
+      />
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/place-search-dialog.tsx
+++ b/hushh-webapp/components/one-location/redesign/place-search-dialog.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+/**
+ * One Location redesign — reusable place search dialog.
+ *
+ * A shadcn Command (cmdk) full-screen combobox for picking a place: debounced
+ * Google Places autocomplete (server-side, so cmdk filtering is disabled), a
+ * loading state, an empty state, an optional "Recent" group, and full-width
+ * result rows (no truncation) with keyboard navigation. Selecting a result
+ * resolves place details and hands back a `DriveDestination`.
+ *
+ * Used by Drive To (destination) and Pick Me Up (Adjust pickup spot).
+ */
+
+import { useEffect, useState } from "react";
+import { Loader2, MapPin, Navigation } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { DriveDestination } from "@/lib/one-location/types";
+
+export interface PlaceSearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vaultOwnerToken: string | null;
+  recents?: DriveDestination[];
+  onSelect: (destination: DriveDestination) => void;
+  title?: string;
+  placeholder?: string;
+}
+
+export function PlaceSearchDialog({
+  open,
+  onOpenChange,
+  vaultOwnerToken,
+  recents = [],
+  onSelect,
+  title = "Search a place",
+  placeholder = "Search a place…",
+}: PlaceSearchDialogProps) {
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<{ placeId: string; text: string }[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [resolving, setResolving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state whenever the dialog closes.
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setSuggestions([]);
+      setSearching(false);
+      setResolving(false);
+      setError(null);
+    }
+  }, [open]);
+
+  // Debounced Places autocomplete via the backend proxy.
+  useEffect(() => {
+    const token = vaultOwnerToken;
+    const q = query.trim();
+    if (!token || q.length < 2) {
+      setSuggestions([]);
+      setSearching(false);
+      return;
+    }
+    let cancelled = false;
+    setSearching(true);
+    setError(null);
+    const handle = setTimeout(async () => {
+      try {
+        const results = await OneLocationService.placesAutocomplete({
+          vaultOwnerToken: token,
+          input: q,
+        });
+        if (!cancelled) setSuggestions(results);
+      } catch {
+        if (!cancelled) {
+          setSuggestions([]);
+          setError("Couldn't search places. Check your connection.");
+        }
+      } finally {
+        if (!cancelled) setSearching(false);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+    };
+  }, [query, vaultOwnerToken]);
+
+  const choose = async (placeId: string) => {
+    const token = vaultOwnerToken;
+    if (!token) return;
+    setResolving(true);
+    try {
+      const details = await OneLocationService.placeDetails({
+        vaultOwnerToken: token,
+        placeId,
+      });
+      onSelect(details);
+      onOpenChange(false);
+    } catch {
+      setError("Couldn't load that place. Try another.");
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  const chooseRecent = (recent: DriveDestination) => {
+    onSelect(recent);
+    onOpenChange(false);
+  };
+
+  const q = query.trim();
+  const showRecents = q.length < 2 && recents.length > 0;
+  const showEmptyPrompt = q.length < 2 && recents.length === 0 && !searching;
+  const showNoResults =
+    q.length >= 2 && !searching && !error && suggestions.length === 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0" showCloseButton>
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>Search for a place</DialogDescription>
+        </DialogHeader>
+        <Command
+          shouldFilter={false}
+          className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3"
+        >
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={placeholder}
+          />
+          <CommandList>
+            {error ? (
+              <div className="px-3 py-3 text-sm font-medium text-red-600 dark:text-red-300">
+                {error}
+              </div>
+            ) : null}
+            {searching ? (
+              <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Searching…
+              </div>
+            ) : null}
+            {showEmptyPrompt ? (
+              <CommandEmpty>Type to search a place.</CommandEmpty>
+            ) : null}
+            {showNoResults ? <CommandEmpty>No places found.</CommandEmpty> : null}
+
+            {showRecents ? (
+              <CommandGroup heading="Recent">
+                {recents.map((recent) => (
+                  <CommandItem
+                    key={recent.placeId ?? recent.label}
+                    value={`recent:${recent.placeId ?? recent.label}`}
+                    onSelect={() => chooseRecent(recent)}
+                  >
+                    <MapPin className="text-[#007aff]" />
+                    <span className="min-w-0 flex-1">{recent.label}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+
+            {suggestions.length > 0 ? (
+              <CommandGroup heading="Results">
+                {suggestions.map((suggestion) => (
+                  <CommandItem
+                    key={suggestion.placeId}
+                    value={suggestion.placeId}
+                    disabled={resolving}
+                    onSelect={() => void choose(suggestion.placeId)}
+                  >
+                    <Navigation className="rotate-90 text-[#007aff]" />
+                    <span className="min-w-0 flex-1">{suggestion.text}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/place-search-dialog.tsx
+++ b/hushh-webapp/components/one-location/redesign/place-search-dialog.tsx
@@ -31,6 +31,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { OneLocationService } from "@/lib/one-location/service";
+import { cn } from "@/lib/utils";
 import type { DriveDestination } from "@/lib/one-location/types";
 
 export interface PlaceSearchDialogProps {
@@ -141,7 +142,12 @@ export function PlaceSearchDialog({
         </DialogHeader>
         <Command
           shouldFilter={false}
-          className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3"
+          className={cn(
+            "[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3",
+            // Blue active/highlighted row (scoped to this dialog; overrides the
+            // shared CommandItem's neutral `bg-accent`).
+            "[&_[data-slot=command-item][data-selected=true]]:bg-[#007aff]/12 [&_[data-slot=command-item][data-selected=true]]:text-[#007aff]",
+          )}
         >
           <CommandInput
             value={query}


### PR DESCRIPTION
## Summary
Minor One Location UI fixes plus a shadcn Command-based place search.

- **Onepoint header:** remove the "Private by default" subtitle (Now tab).
- **Bottom nav:** the selected tab is now iOS blue (light `#007aff`, dark `#4a9eff`) instead of gold — fixed at the shared `.kai-bottom-nav-pill` CSS (the gold was `!important`), so it persists on every screen; active-icon glow + search hover/focus updated too.
- **Place search (shadcn Command / cmdk):** a reusable full-screen `PlaceSearchDialog` for destination/pickup search — debounced Places autocomplete (loading + empty states), a "Recent" group, keyboard nav, full-width rows (no more truncated "…"), and a blue highlighted row. Wired into **Drive To** ("Heading to") and **Pick Me Up** ("Adjust"), replacing the ad-hoc inline lists.

## Testing
- `vitest` — new `place-search-dialog.test.tsx` (search→select→close, recents, empty); updated Drive To flow test; 148 One Location tests pass.
- `tsc --noEmit` + `eslint` clean.
- Verified on the iOS simulator against a local backend.

## Notes
- The blue selected-row override is scoped to `PlaceSearchDialog` (shared `CommandItem` unchanged). No design tokens changed globally.