### PR TITLE
fix(release): restore One UAT origin and fail-closed verification

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -685,6 +685,7 @@ jobs:
           semantic_report = load_json("/tmp/dev-release-verify-attempt-2.json") or load_json(
               "/tmp/dev-release-verify-attempt-1.json"
           )
+          semantic_report_present = bool(semantic_report)
 
           parity_success = os.environ.get("PARITY_ATTEMPT_1") == "success" or os.environ.get("PARITY_ATTEMPT_2") == "success"
           backend_provenance_success = (
@@ -755,6 +756,8 @@ jobs:
               item for item in semantic_failures if not item.startswith("signed_in_routes:")
           }
           if not semantic_success:
+              if not semantic_report_present:
+                  append_unique(blocking, ["semantic_verifier_failed"])
               if blocking_semantic_failures:
                   append_unique(blocking, ["runtime_behavior_failed"])
               if "smoke_auth" in blocking_semantic_failures:
@@ -798,6 +801,7 @@ jobs:
                   "attempt_1": os.environ.get("SEMANTIC_ATTEMPT_1", ""),
                   "attempt_2": os.environ.get("SEMANTIC_ATTEMPT_2", ""),
                   "success": semantic_success,
+                  "report_present": semantic_report_present,
                   "failures": sorted(semantic_failures),
                   "blocking_failures": sorted(blocking_semantic_failures),
                   "advisory_failures": advisory_semantic_failures,

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,7 +36,7 @@ env:
   GCP_REGION: us-central1
   BACKEND_SERVICE: consent-protocol
   FRONTEND_SERVICE: hushh-webapp
-  APP_FRONTEND_ORIGIN: https://dev.kai.hushh.ai
+  APP_FRONTEND_ORIGIN: https://dev.one.hushh.ai
   DEV_CLOUDSQL_INSTANCE: hushh-pda-dev:us-central1:hushh-dev-pg
   DEV_DB_UNIX_SOCKET: /cloudsql/hushh-pda-dev:us-central1:hushh-dev-pg
   # One Email KYC runs in dev via topic fanout: dev consumes the SAME UAT
@@ -245,7 +245,7 @@ jobs:
             "${EXTRA_ARGS[@]}" \
             --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
             --obs-data-stale-ratio-threshold "0.25" \
-            --passkey-allowed-rp-ids "localhost,127.0.0.1,kai.hushh.ai,dev.kai.hushh.ai" \
+            --passkey-allowed-rp-ids "localhost,127.0.0.1,one.hushh.ai,dev.one.hushh.ai" \
             --plaid-env "production" \
             --plaid-client-name "Hushh Kai" \
             --plaid-country-codes "US" \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,7 +42,7 @@ env:
   GCP_REGION: us-central1
   BACKEND_SERVICE: consent-protocol
   FRONTEND_SERVICE: hushh-webapp
-  APP_FRONTEND_ORIGIN: https://kai.hushh.ai
+  APP_FRONTEND_ORIGIN: https://one.hushh.ai
   CLOUD_RUN_REVISION_RETENTION: "10"
   BACKUP_BUCKET: hushh-pda-prod-db-backups
   BACKUP_PREFIX: prod/supabase-logical
@@ -176,7 +176,7 @@ jobs:
             --crm-registry-db-enabled "true" \
             --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
             --obs-data-stale-ratio-threshold "0.25" \
-            --passkey-allowed-rp-ids "localhost,127.0.0.1,kai.hushh.ai" \
+            --passkey-allowed-rp-ids "localhost,127.0.0.1,one.hushh.ai" \
             --plaid-env "production" \
             --plaid-client-name "Hushh Kai" \
             --plaid-country-codes "US" \

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -27,7 +27,7 @@ env:
   GCP_REGION: us-central1
   BACKEND_SERVICE: consent-protocol
   FRONTEND_SERVICE: hushh-webapp
-  APP_FRONTEND_ORIGIN: https://uat.kai.hushh.ai
+  APP_FRONTEND_ORIGIN: https://uat.one.hushh.ai
   UAT_CLOUDSQL_INSTANCE: hushh-pda-uat:us-central1:hushh-uat-pg
   UAT_DB_UNIX_SOCKET: /cloudsql/hushh-pda-uat:us-central1:hushh-uat-pg
   CLOUD_RUN_REVISION_RETENTION: "10"
@@ -202,7 +202,7 @@ jobs:
             --crm-registry-db-enabled "true" \
             --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
             --obs-data-stale-ratio-threshold "0.25" \
-            --passkey-allowed-rp-ids "localhost,127.0.0.1,kai.hushh.ai,uat.kai.hushh.ai" \
+            --passkey-allowed-rp-ids "localhost,127.0.0.1,one.hushh.ai,uat.one.hushh.ai" \
             --plaid-env "production" \
             --plaid-client-name "Hushh Kai" \
             --plaid-country-codes "US" \

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -603,6 +603,7 @@ jobs:
           semantic_report = load_json("/tmp/uat-release-verify-attempt-2.json") or load_json(
               "/tmp/uat-release-verify-attempt-1.json"
           )
+          semantic_report_present = bool(semantic_report)
 
           parity_success = os.environ.get("PARITY_ATTEMPT_1") == "success" or os.environ.get("PARITY_ATTEMPT_2") == "success"
           backend_provenance_success = (
@@ -673,6 +674,8 @@ jobs:
               item for item in semantic_failures if not item.startswith("signed_in_routes:")
           }
           if not semantic_success:
+              if not semantic_report_present:
+                  append_unique(blocking, ["semantic_verifier_failed"])
               if blocking_semantic_failures:
                   append_unique(blocking, ["runtime_behavior_failed"])
               if "smoke_auth" in blocking_semantic_failures:
@@ -716,6 +719,7 @@ jobs:
                   "attempt_1": os.environ.get("SEMANTIC_ATTEMPT_1", ""),
                   "attempt_2": os.environ.get("SEMANTIC_ATTEMPT_2", ""),
                   "success": semantic_success,
+                  "report_present": semantic_report_present,
                   "failures": sorted(semantic_failures),
                   "blocking_failures": sorted(blocking_semantic_failures),
                   "advisory_failures": advisory_semantic_failures,

--- a/consent-protocol/docs/reference/env-vars.md
+++ b/consent-protocol/docs/reference/env-vars.md
@@ -103,7 +103,8 @@ What is in `.env` / GCP Secret Manager must match exactly what the code reads --
 | `ALPACA_DEFAULT_ACCOUNT_ID` | `hushh_mcp/integrations/alpaca/config.py` | Recommended | Default Alpaca account ID for funding when user-specific mapping is absent. |
 | `ALPACA_CONNECT_CLIENT_ID` | `hushh_mcp/services/broker_funding_service.py` | If Alpaca OAuth connect enabled | Alpaca OAuth app client ID for user login flow. |
 | `ALPACA_CONNECT_CLIENT_SECRET` | `hushh_mcp/services/broker_funding_service.py` | If Alpaca OAuth connect enabled | Alpaca OAuth app client secret. |
-| `ALPACA_CONNECT_REDIRECT_URI` / `ALPACA_OAUTH_REDIRECT_URI` | `hushh_mcp/services/broker_funding_service.py` | If Alpaca OAuth connect enabled | HTTPS callback URI for Alpaca OAuth code exchange. |
+| `ALPACA_CONNECT_REDIRECT_URI` / `ALPACA_OAUTH_REDIRECT_URI` | `hushh_mcp/services/broker_funding_service.py` | Optional override | Full allowlisted HTTPS callback URI. Use only when overriding `APP_FRONTEND_ORIGIN + ALPACA_CONNECT_REDIRECT_PATH`. |
+| `ALPACA_CONNECT_REDIRECT_PATH` | `hushh_mcp/services/broker_funding_service.py` | No | Relative callback path used with `APP_FRONTEND_ORIGIN` (same pattern as `PLAID_REDIRECT_PATH`). Default: `/kai/alpaca/oauth/return`. |
 | `ALPACA_CONNECT_AUTHORIZE_URL` | `hushh_mcp/services/broker_funding_service.py` | No | Override OAuth authorize endpoint. Default `https://app.alpaca.markets/oauth/authorize`. |
 | `ALPACA_CONNECT_TOKEN_URL` | `hushh_mcp/services/broker_funding_service.py` | No | Override OAuth token endpoint. Default `https://api.alpaca.markets/oauth/token`. |
 | `ALPACA_CONNECT_ACCOUNT_URL` | `hushh_mcp/services/broker_funding_service.py` | No | OAuth Bearer account profile endpoint. Default `https://api.alpaca.markets/v2/account`. |

--- a/consent-protocol/hushh_mcp/services/broker_funding_service.py
+++ b/consent-protocol/hushh_mcp/services/broker_funding_service.py
@@ -27,7 +27,10 @@ from hushh_mcp.integrations.alpaca import (
     AlpacaBrokerRuntimeConfig,
 )
 from hushh_mcp.integrations.plaid import PlaidHttpClient, PlaidRuntimeConfig
-from hushh_mcp.runtime_settings import get_optional_plaid_access_token_key
+from hushh_mcp.runtime_settings import (
+    get_app_runtime_settings,
+    get_optional_plaid_access_token_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -604,7 +607,7 @@ class BrokerFundingService:
             )
             if not redirect_path.startswith("/"):
                 redirect_path = f"/{redirect_path}"
-            frontend_origin = _clean_text(os.getenv("APP_FRONTEND_ORIGIN"))
+            frontend_origin = get_app_runtime_settings().app_frontend_origin
             if frontend_origin:
                 redirect_uri = _normalize_https_url(f"{frontend_origin.rstrip('/')}{redirect_path}")
         authorize_url = _normalize_https_url(

--- a/consent-protocol/hushh_mcp/services/broker_funding_service.py
+++ b/consent-protocol/hushh_mcp/services/broker_funding_service.py
@@ -54,6 +54,12 @@ _ALPACA_CONNECT_DEFAULT_TOKEN_URL = "https://api.alpaca.markets/oauth/token"  # 
 _ALPACA_CONNECT_DEFAULT_ACCOUNT_URL = "https://api.alpaca.markets/v2/account"
 _ALPACA_CONNECT_DEFAULT_SCOPES = "account:write trading"
 _ALPACA_CONNECT_SESSION_TTL_SECONDS_DEFAULT = 15 * 60
+# Relative callback path used with APP_FRONTEND_ORIGIN when no absolute
+# ALPACA_CONNECT_REDIRECT_URI is explicitly configured. Mirrors how Plaid's
+# redirect URI is derived (see hushh_mcp/integrations/plaid/config.py) so a
+# domain migration only requires updating APP_FRONTEND_ORIGIN, not every
+# individual OAuth redirect secret.
+_ALPACA_CONNECT_DEFAULT_REDIRECT_PATH = "/kai/alpaca/oauth/return"
 
 _TRADE_INTENT_TERMINAL_STATUSES = {
     "order_filled",
@@ -586,6 +592,21 @@ class BrokerFundingService:
         redirect_uri = _normalize_https_url(
             os.getenv("ALPACA_CONNECT_REDIRECT_URI") or os.getenv("ALPACA_OAUTH_REDIRECT_URI")
         )
+        if redirect_uri is None:
+            # No explicit absolute override configured: derive from the
+            # backend-owned APP_FRONTEND_ORIGIN + a relative path, same
+            # pattern Plaid uses. This means a domain migration only needs
+            # APP_FRONTEND_ORIGIN updated once, instead of every OAuth
+            # redirect secret being hand-maintained per environment.
+            redirect_path = _clean_text(
+                os.getenv("ALPACA_CONNECT_REDIRECT_PATH"),
+                default=_ALPACA_CONNECT_DEFAULT_REDIRECT_PATH,
+            )
+            if not redirect_path.startswith("/"):
+                redirect_path = f"/{redirect_path}"
+            frontend_origin = _clean_text(os.getenv("APP_FRONTEND_ORIGIN"))
+            if frontend_origin:
+                redirect_uri = _normalize_https_url(f"{frontend_origin.rstrip('/')}{redirect_path}")
         authorize_url = _normalize_https_url(
             os.getenv("ALPACA_CONNECT_AUTHORIZE_URL") or _ALPACA_CONNECT_DEFAULT_AUTHORIZE_URL
         )

--- a/consent-protocol/tests/test_kai_funding_orchestration_contract.py
+++ b/consent-protocol/tests/test_kai_funding_orchestration_contract.py
@@ -30,6 +30,33 @@ def test_decimal_to_currency_text_formats_positive_values():
     assert _decimal_to_currency_text("12.345") == "12.35"
 
 
+def test_alpaca_connect_redirect_uri_derives_from_app_frontend_origin(monkeypatch):
+    """Domain migrations should only require updating APP_FRONTEND_ORIGIN.
+
+    Regression guard for the kai.hushh.ai -> one.hushh.ai migration: the
+    Alpaca redirect URI must derive from APP_FRONTEND_ORIGIN + a relative
+    path (same as Plaid) whenever no absolute ALPACA_CONNECT_REDIRECT_URI
+    override is explicitly configured.
+    """
+    monkeypatch.delenv("ALPACA_CONNECT_REDIRECT_URI", raising=False)
+    monkeypatch.delenv("ALPACA_OAUTH_REDIRECT_URI", raising=False)
+    monkeypatch.delenv("ALPACA_CONNECT_REDIRECT_PATH", raising=False)
+    monkeypatch.setenv("APP_FRONTEND_ORIGIN", "https://one.hushh.ai")
+
+    service = BrokerFundingService()
+    config = service._alpaca_connect_config()
+    assert config["redirect_uri"] == "https://one.hushh.ai/kai/alpaca/oauth/return"
+
+
+def test_alpaca_connect_redirect_uri_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv("APP_FRONTEND_ORIGIN", "https://one.hushh.ai")
+    monkeypatch.setenv("ALPACA_CONNECT_REDIRECT_URI", "https://custom.example.com/alpaca/return")
+
+    service = BrokerFundingService()
+    config = service._alpaca_connect_config()
+    assert config["redirect_uri"] == "https://custom.example.com/alpaca/return"
+
+
 def test_decimal_to_currency_text_rejects_invalid_values():
     with pytest.raises(FundingOrchestrationError) as bad_text:
         _decimal_to_currency_text("bad")

--- a/consent-protocol/tests/test_verify_uat_release.py
+++ b/consent-protocol/tests/test_verify_uat_release.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import requests
+
+
+def _load_verifier() -> ModuleType:
+    path = Path(__file__).resolve().parents[2] / "scripts" / "ops" / "verify_uat_release.py"
+    spec = importlib.util.spec_from_file_location("verify_uat_release", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_http_probe_returns_structured_failure_on_transport_error(monkeypatch) -> None:
+    verifier = _load_verifier()
+
+    def raise_tls_error(*_args, **_kwargs):
+        raise requests.exceptions.SSLError("TLS handshake failed")
+
+    monkeypatch.setattr(verifier.requests, "get", raise_tls_error)
+
+    result = verifier._http_probe("https://uat.one.hushh.ai/login")
+
+    assert result == {
+        "url": "https://uat.one.hushh.ai/login",
+        "status_code": None,
+        "ok": False,
+        "error": "TLS handshake failed",
+    }

--- a/scripts/ops/verify_uat_release.py
+++ b/scripts/ops/verify_uat_release.py
@@ -37,7 +37,15 @@ RIA_STAGE1_SMOKE_CRD = "5838118"
 
 
 def _http_probe(url: str) -> dict[str, Any]:
-    response = requests.get(url, timeout=30)
+    try:
+        response = requests.get(url, timeout=30)
+    except requests.RequestException as exc:
+        return {
+            "url": url,
+            "status_code": None,
+            "ok": False,
+            "error": str(exc),
+        }
     return {
         "url": url,
         "status_code": response.status_code,


### PR DESCRIPTION
# Description

Correct the canonical One host across deploy workflows and derive Alpaca's callback from the governed frontend-origin setting. Harden semantic release verification so transport failures become structured failures and a crashed verifier can never classify a release as healthy.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB information-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None; native provider behavior is unchanged.
- Docs updated (exact files):
  - [x] `consent-protocol/docs/reference/env-vars.md`
- Top-level / devex / config / generated / ignore files touched:
  - [x] `.github/workflows/deploy-dev.yml`, `.github/workflows/deploy-uat.yml`, and `.github/workflows/deploy-production.yml` retain the existing deploy workflow and use the canonical One origins.
- Trust boundary touched:
  - [x] Deploy/public ingress and finance OAuth callback configuration.
- Caller / proxy / backend pairing:
  - [x] Alpaca callback construction consumes `get_app_runtime_settings().app_frontend_origin`; explicit absolute callback overrides continue to win.
- Rollback or safe-failure behavior:
  - [x] HTTP/TLS exceptions produce a structured failed check; missing semantic reports produce `semantic_verifier_failed` and block release classification.
- UI browser or Playwright proof:
  - [x] Not applicable to this corrective configuration-only follow-up; Cloud Run service URLs and canonical mapping were probed directly.
- Verification commands executed:
  - [x] `./bin/hushh codex pre-pr`
  - [x] `cd consent-protocol && uv run pytest -q tests/test_kai_funding_orchestration_contract.py tests/test_verify_uat_release.py`
  - [x] `python3 scripts/ci/verify-runtime-config-contract.py`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this extends the existing deploy and runtime-settings paths.
- [x] Current reachable deploy/runtime surfaces are corrected.
- [x] New tests import and exercise production code.
- [x] Production attach points are the existing deploy workflows and `BrokerFundingService`.
- [x] Required local checks are current, commits are signed off, and the branch contains current `main`.
- [x] Maintainer edits are enabled.
- [x] This is a corrective follow-up to #4439 after its semantic probe exposed the retired UAT hostname.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: existing web/Cloud Run deploy path corrected.
- [x] **iOS**: not applicable; native auth/provider behavior is unchanged.
- [x] **Android**: not applicable; native auth/provider behavior is unchanged.

## 🧪 Testing

- [x] Tested on Web through the full local CI mirror and direct Cloud Run probes.
- [x] Commits are signed off (`git commit -s`).
- [x] No generated artifacts changed.

## 📸 Screenshots / Video

Not applicable: this follow-up changes deployment origin configuration, OAuth callback derivation, and semantic release failure handling.

## 🛡️ Privacy & Consent

- [x] This change does not access owner information.
- [x] Sensitive surface: deploy, public ingress, finance OAuth callback.
- [x] Safe failure is proved by the TLS transport regression test and fail-closed classifier.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changes.

Signed-off-by: kushaltrivedi5 <40542375+kushaltrivedi5@users.noreply.github.com>


---
Closes #4488
(retroactive board-linkage backfill, 2026-07-14)