### PR TITLE
ci(deploy-prod): add post-deploy runtime health gate + auto-rollback

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -152,6 +152,34 @@ jobs:
           echo "deploy_backend=$DEPLOY_BACKEND" >> "$GITHUB_OUTPUT"
           echo "deploy_frontend=$DEPLOY_FRONTEND" >> "$GITHUB_OUTPUT"
 
+      - name: Capture predeploy Cloud Run state
+        id: predeploy-state
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+          echo "Predeploy backend ready revision: ${backend_revision:-none}"
+          echo "Predeploy frontend ready revision: ${frontend_revision:-none}"
+
       - name: Set up Python + uv runtime
         uses: ./consent-protocol/.github/actions/setup-python-uv
         with:
@@ -279,7 +307,7 @@ jobs:
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/backend.cloudbuild.yaml \
-            "--substitutions=_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID,_PLAID_SECRET_SECRET=PLAID_SECRET,_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY,_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY,_PMP_API_KEY_SECRET=PMP_API_KEY,_NEWSAPI_KEY_SECRET=NEWSAPI_KEY,_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID,_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET,_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI,_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY,_OPENAI_API_KEY_SECRET=OPENAI_API_KEY,_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY,_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON,_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+            "--substitutions=_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID,_PLAID_SECRET_SECRET=PLAID_SECRET,_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY,_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY,_PMP_API_KEY_SECRET=PMP_API_KEY,_NEWSAPI_KEY_SECRET=NEWSAPI_KEY,_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID,_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET,_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI,_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY,_OPENAI_API_KEY_SECRET=OPENAI_API_KEY,_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY,_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON,_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
 
       - name: Get backend URL
         if: steps.scope.outputs.deploy_backend == 'true'
@@ -303,7 +331,7 @@ jobs:
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/frontend.cloudbuild.yaml \
-            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_APP_ENV=production,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_APP_ENV=production,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
 
       - name: Get frontend URL
         if: steps.scope.outputs.deploy_frontend == 'true'
@@ -321,8 +349,80 @@ jobs:
         continue-on-error: true
         run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
 
+      - name: Resolve deployed candidate revisions
+        id: candidate-state
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_revision=""
+          frontend_revision=""
+          if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
+            backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --format='value(status.latestCreatedRevisionName)')"
+          fi
+          if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
+            frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --format='value(status.latestCreatedRevisionName)')"
+          fi
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "Backend candidate revision: ${backend_revision:-n/a}"
+          echo "Frontend candidate revision: ${frontend_revision:-n/a}"
+
+      # New revisions are deployed with --no-traffic (see _CLOUD_RUN_NO_TRAFFIC=true
+      # above), so promotion is an explicit, reversible step: shift 100% to the
+      # freshly built revision, then health-gate it, then auto-roll-back on failure.
+      - name: Promote deployed revisions to production traffic
+        id: promote-traffic
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
+            gcloud run services update-traffic "${{ env.BACKEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --to-revisions="${{ steps.candidate-state.outputs.backend_revision }}=100"
+          fi
+          if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
+            gcloud run services update-traffic "${{ env.FRONTEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --to-revisions="${{ steps.candidate-state.outputs.frontend_revision }}=100"
+          fi
+
+      - name: Post-deploy backend runtime health gate
+        id: health-backend
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Require 5 consecutive 200s from /health. A crash-looping revision
+          # (passes TCP startup probe, then dies serving requests, flapping
+          # 200<->503) can never reach a stable streak, so this fails and the
+          # rollback step below reverts traffic to the predeploy revision.
+          bash scripts/ci/cloudrun-http-health.sh \
+            "${{ steps.backend-url.outputs.url }}" "/health" 5 30 5 200
+
+      - name: Post-deploy frontend runtime health gate
+        id: health-frontend
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/cloudrun-http-health.sh \
+            "${{ steps.frontend-url.outputs.url }}" "/" 3 30 5 200
+
       - name: Verify production runtime env parity
+        id: verify-parity
         if: steps.scope.outputs.deploy_backend == 'true' || steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
         run: |
           python3 scripts/ops/verify-env-secrets-parity.py \
             --project "${{ env.GCP_PROJECT_ID }}" \
@@ -335,22 +435,150 @@ jobs:
             --require-voice \
             --assert-runtime-env-contract
 
+      - name: Classify production release outcome
+        id: classify
+        if: always()
+        shell: bash
+        env:
+          DEPLOY_BACKEND: ${{ steps.scope.outputs.deploy_backend }}
+          DEPLOY_FRONTEND: ${{ steps.scope.outputs.deploy_frontend }}
+          HEALTH_BACKEND: ${{ steps.health-backend.outcome }}
+          HEALTH_FRONTEND: ${{ steps.health-frontend.outcome }}
+          PARITY_OUTCOME: ${{ steps.verify-parity.outcome }}
+          PROMOTE_OUTCOME: ${{ steps.promote-traffic.outcome }}
+        run: |
+          set -euo pipefail
+          backend_failure=false
+          frontend_failure=false
+          parity_failed=false
+          promote_failed=false
+
+          # Runtime health is the rollback trigger: only revert traffic when the
+          # newly promoted revision is not actually serving. A parity gap (e.g. a
+          # benign missing optional secret) fails the workflow for visibility but
+          # does NOT auto-revert a revision that is serving traffic healthily.
+          if [ "$DEPLOY_BACKEND" = "true" ] && [ "$HEALTH_BACKEND" = "failure" ]; then
+            backend_failure=true
+          fi
+          if [ "$DEPLOY_FRONTEND" = "true" ] && [ "$HEALTH_FRONTEND" = "failure" ]; then
+            frontend_failure=true
+          fi
+          if [ "$PARITY_OUTCOME" = "failure" ]; then
+            parity_failed=true
+          fi
+          if [ "$PROMOTE_OUTCOME" = "failure" ]; then
+            promote_failed=true
+          fi
+
+          release_failed=false
+          if [ "$backend_failure" = "true" ] || [ "$frontend_failure" = "true" ] \
+             || [ "$parity_failed" = "true" ] || [ "$promote_failed" = "true" ]; then
+            release_failed=true
+          fi
+
+          {
+            echo "backend_failure=$backend_failure"
+            echo "frontend_failure=$frontend_failure"
+            echo "parity_failed=$parity_failed"
+            echo "promote_failed=$promote_failed"
+            echo "release_failed=$release_failed"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Release classification: release_failed=$release_failed backend_failure=$backend_failure frontend_failure=$frontend_failure parity_failed=$parity_failed promote_failed=$promote_failed"
+
+      - name: Roll back backend revision
+        id: rollback-backend
+        if: always() && steps.classify.outputs.backend_failure == 'true' && steps.scope.outputs.deploy_backend == 'true' && steps.predeploy-state.outputs.backend_revision != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Backend runtime health gate failed; reverting traffic to predeploy revision ${{ steps.predeploy-state.outputs.backend_revision }}"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.backend_revision }}"
+
+      - name: Roll back frontend revision
+        id: rollback-frontend
+        if: always() && steps.classify.outputs.frontend_failure == 'true' && steps.scope.outputs.deploy_frontend == 'true' && steps.predeploy-state.outputs.frontend_revision != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Frontend runtime health gate failed; reverting traffic to predeploy revision ${{ steps.predeploy-state.outputs.frontend_revision }}"
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.frontend_revision }}"
+
+      - name: Resolve final Cloud Run state
+        id: final-state
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_serving="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+          frontend_serving="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+          echo "backend_serving=${backend_serving}" >> "$GITHUB_OUTPUT"
+          echo "frontend_serving=${frontend_serving}" >> "$GITHUB_OUTPUT"
+
       - name: Deployment Summary
         if: always()
         shell: bash
         run: |
-          echo "✅ Production Deployment Complete"
-          echo "Commit SHA: ${{ github.event.inputs.sha }}"
-          echo "Scope: ${{ steps.scope.outputs.scope }}"
-          if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
-            echo "Backend: ${{ steps.backend-url.outputs.url }}"
-            echo "Latest backup object: ${{ steps.backup-gate.outputs.backup_object_uri }}"
-            echo "Latest backup completed at: ${{ steps.backup-gate.outputs.backup_completed_at }}"
-          else
-            echo "Backend: skipped"
+          {
+            echo "## Production Release"
+            echo ""
+            echo "- Commit SHA: \`${{ github.event.inputs.sha }}\`"
+            echo "- Scope: \`${{ steps.scope.outputs.scope }}\`"
+            if [ "${{ steps.classify.outputs.release_failed }}" = "true" ]; then
+              echo "- Status: \`FAILED\`"
+            else
+              echo "- Status: \`healthy\`"
+            fi
+            echo ""
+            if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
+              echo "- Backend URL: \`${{ steps.backend-url.outputs.url }}\`"
+              echo "- Backend predeploy revision: \`${{ steps.predeploy-state.outputs.backend_revision || 'unknown' }}\`"
+              echo "- Backend candidate revision: \`${{ steps.candidate-state.outputs.backend_revision || 'n/a' }}\`"
+              echo "- Backend serving revision (final): \`${{ steps.final-state.outputs.backend_serving || 'unknown' }}\`"
+              echo "- Backend health gate: \`${{ steps.health-backend.outcome }}\`"
+              echo "- Backend rollback: \`${{ steps.rollback-backend.outcome }}\`"
+              echo "- Latest backup object: \`${{ steps.backup-gate.outputs.backup_object_uri }}\`"
+              echo "- Latest backup completed at: \`${{ steps.backup-gate.outputs.backup_completed_at }}\`"
+            else
+              echo "- Backend: skipped"
+            fi
+            if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
+              echo "- Frontend URL: \`${{ steps.frontend-url.outputs.url }}\`"
+              echo "- Frontend predeploy revision: \`${{ steps.predeploy-state.outputs.frontend_revision || 'unknown' }}\`"
+              echo "- Frontend candidate revision: \`${{ steps.candidate-state.outputs.frontend_revision || 'n/a' }}\`"
+              echo "- Frontend serving revision (final): \`${{ steps.final-state.outputs.frontend_serving || 'unknown' }}\`"
+              echo "- Frontend health gate: \`${{ steps.health-frontend.outcome }}\`"
+              echo "- Frontend rollback: \`${{ steps.rollback-frontend.outcome }}\`"
+            else
+              echo "- Frontend: skipped"
+            fi
+            echo ""
+            echo "- Traffic promotion: \`${{ steps.promote-traffic.outcome }}\`"
+            echo "- Env parity: \`${{ steps.verify-parity.outcome }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail workflow when production release did not end healthy
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.classify.outputs.release_failed }}" = "true" ]; then
+            echo "Production release did not end healthy."
+            echo "backend_failure=${{ steps.classify.outputs.backend_failure }}"
+            echo "frontend_failure=${{ steps.classify.outputs.frontend_failure }}"
+            echo "parity_failed=${{ steps.classify.outputs.parity_failed }}"
+            echo "promote_failed=${{ steps.classify.outputs.promote_failed }}"
+            echo "backend_rollback=${{ steps.rollback-backend.outcome }}"
+            echo "frontend_rollback=${{ steps.rollback-frontend.outcome }}"
+            if [ "${{ steps.rollback-backend.outcome }}" = "success" ] || [ "${{ steps.rollback-frontend.outcome }}" = "success" ]; then
+              echo "Traffic was auto-reverted to the predeploy revision(s). Investigate before redeploying."
+            fi
+            exit 1
           fi
-          if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
-            echo "Frontend: ${{ steps.frontend-url.outputs.url }}"
-          else
-            echo "Frontend: skipped"
-          fi
+          echo "✅ Production release healthy; new revisions serving traffic."

--- a/scripts/ci/cloudrun-http-health.sh
+++ b/scripts/ci/cloudrun-http-health.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Poll an HTTP endpoint until it is *stably* healthy or the time budget is spent.
+#
+# A crash-looping Cloud Run revision passes its TCP startup probe (so the
+# control plane reports it "healthy") yet fails when it actually serves
+# requests, flapping between 200 and 503. Requiring several *consecutive*
+# successes distinguishes a genuinely healthy revision from a flapping one,
+# while the attempt budget tolerates a normal cold-start warmup.
+#
+# Usage:
+#   cloudrun-http-health.sh <base_url> [path] [need_consecutive] [max_attempts] [sleep_seconds] [expected_status]
+#
+# Defaults: path=/health need_consecutive=5 max_attempts=30 sleep_seconds=5 expected_status=200
+# Exit 0 when <need_consecutive> consecutive <expected_status> responses are observed; exit 1 otherwise.
+set -euo pipefail
+
+BASE_URL="${1:-}"
+PATH_SUFFIX="${2:-/health}"
+NEED_CONSECUTIVE="${3:-5}"
+MAX_ATTEMPTS="${4:-30}"
+SLEEP_SECONDS="${5:-5}"
+EXPECTED_STATUS="${6:-200}"
+
+if [[ "$BASE_URL" == "-h" || "$BASE_URL" == "--help" ]]; then
+  echo "Usage: $0 <base_url> [path] [need_consecutive] [max_attempts] [sleep_seconds] [expected_status]" >&2
+  exit 0
+fi
+
+if [[ -z "$BASE_URL" ]]; then
+  echo "Usage: $0 <base_url> [path] [need_consecutive] [max_attempts] [sleep_seconds] [expected_status]" >&2
+  exit 1
+fi
+
+url="${BASE_URL%/}${PATH_SUFFIX}"
+consecutive=0
+attempt=0
+last_code="none"
+
+echo "Probing ${url}: need ${NEED_CONSECUTIVE} consecutive ${EXPECTED_STATUS} within ${MAX_ATTEMPTS} attempts (${SLEEP_SECONDS}s apart)"
+
+while [ "$attempt" -lt "$MAX_ATTEMPTS" ]; do
+  attempt=$((attempt + 1))
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$url" 2>/dev/null || echo 000)"
+  last_code="$code"
+  if [ "$code" = "$EXPECTED_STATUS" ]; then
+    consecutive=$((consecutive + 1))
+    echo "  attempt ${attempt}/${MAX_ATTEMPTS}: ${code} (consecutive ${consecutive}/${NEED_CONSECUTIVE})"
+    if [ "$consecutive" -ge "$NEED_CONSECUTIVE" ]; then
+      echo "HEALTHY: ${url} returned ${EXPECTED_STATUS} ${NEED_CONSECUTIVE} times in a row"
+      exit 0
+    fi
+  else
+    if [ "$consecutive" -gt 0 ]; then
+      echo "  attempt ${attempt}/${MAX_ATTEMPTS}: ${code} (streak reset from ${consecutive})"
+    else
+      echo "  attempt ${attempt}/${MAX_ATTEMPTS}: ${code}"
+    fi
+    consecutive=0
+  fi
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    sleep "$SLEEP_SECONDS"
+  fi
+done
+
+echo "UNHEALTHY: ${url} never reached ${NEED_CONSECUTIVE} consecutive ${EXPECTED_STATUS} responses (last=${last_code})" >&2
+exit 1


### PR DESCRIPTION
# Description

`deploy-production.yml` shifted 100% traffic to the freshly built Cloud Run revision and only verified **config** (env/secret parity) — never **runtime** health — and had no rollback. `deploy-dev.yml` and `deploy-uat.yml` both classify the release and revert traffic to the pre-deploy revision on failure (`cloudrun-rollback.sh`); production had no equivalent. A crash-looping revision (passes the TCP startup probe, then dies serving requests) therefore sat at 100% traffic on a broken revision until caught and reverted by hand.

This ports the dev/uat self-heal pattern to production:

- Deploy backend **and** frontend with `_CLOUD_RUN_NO_TRAFFIC=true`, then promote traffic in an explicit, reversible step.
- Capture the pre-deploy ready revision up front as the rollback target.
- Add a post-deploy runtime health gate — `scripts/ci/cloudrun-http-health.sh` — that requires several **consecutive** 200s from `/health`. A flapping 200↔503 crash-loop can never reach a stable streak, while a normal cold start warms up and passes.
- Classify the release; on a **runtime-health** failure, revert traffic to the pre-deploy revision via `scripts/ci/cloudrun-rollback.sh` (the same helper dev/uat use). Rollback fires only on runtime health — **not** on a benign parity gap — so a revision that is actually serving is never auto-reverted.
- Fail the workflow when the release did not end healthy, and surface predeploy/candidate/serving revisions + gate outcomes in the job summary.

Motivated by `consent-protocol-00082-2rh`, which crash-looped in production on a missing production-only runtime requirement while 100% traffic stayed pinned to it.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `.github/workflows/deploy-production.yml` — the production deploy workflow itself.
    - `scripts/ci/cloudrun-http-health.sh` — new CI helper, invoked only by `deploy-production.yml` (sibling of the existing `scripts/ci/cloudrun-rollback.sh` / `cloudrun-retention.sh`).
- Trust boundary touched:
  - [x] **deploy** — changes how production traffic is promoted and reverted.
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below:
    - This PR **is** the rollback/safe-failure behavior. New revisions land with no traffic; traffic is promoted, health-gated, and auto-reverted to the pre-deploy revision on a runtime-health failure. On a promote failure the old revision keeps serving. Migrations still run before deploy (unchanged), matching the existing dev/uat forward-compatible-migration assumption.
- UI browser or Playwright proof:
  - [x] Not applicable (CI/deploy config only).
- Verification commands executed:
  - `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-production.yml'))"` — YAML parses; all 36 steps ordered correctly.
  - Reference-integrity check — every `steps.<id>` reference resolves to a defined step id (no dangling refs).
  - `bash -n scripts/ci/cloudrun-http-health.sh` + `shellcheck` — clean.
  - Behavioral test of the health probe against a live Cloud Run `/health` (passes on stable 200; correctly reports unhealthy on a non-200 path).

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this mirrors the proven `deploy-uat.yml` / `deploy-dev.yml` classify→rollback pattern rather than inventing a new one.
- [x] This PR changes a current reachable surface: the production deploy workflow.
- [x] Reachable production attach point: `deploy-production.yml` (`workflow_dispatch`).
- [x] Required checks are current on this head; commit is signed off (DCO).
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — CI/deploy workflow change, no application layer touched.
- [x] **iOS**: N/A
- [x] **Android**: N/A

## 🧪 Testing

- [x] YAML + reference-integrity + `shellcheck` + behavioral probe test (see Verification commands).
- [x] Commits are signed off (`git commit -s`).
- [x] No generated files changed.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [x] Sensitive surface touched: **deploy**.
- [x] Error path / rollback / safe-failure behavior proved: auto-rollback to pre-deploy revision on runtime-health failure; old revision retained when promotion fails.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4484
(retroactive board-linkage backfill, 2026-07-14)