### PR TITLE
fix(ria): prod verify guard accepts RIA intelligence, not IAPD-only

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_verification.py
+++ b/consent-protocol/hushh_mcp/services/ria_verification.py
@@ -34,11 +34,27 @@ def validate_regulated_runtime_configuration() -> None:
     if not _is_production():
         return
 
-    if not str(os.getenv("IAPD_VERIFY_BASE_URL", "")).strip():
-        raise RuntimeError("IAPD_VERIFY_BASE_URL is required in production.")
-
-    if not str(os.getenv("IAPD_VERIFY_API_KEY", "")).strip():
-        raise RuntimeError("IAPD_VERIFY_API_KEY is required in production.")
+    # Production must have at least one advisory verification provider
+    # configured. The runtime chain (FinraVerificationAdapter) tries the IAPD
+    # worker first and falls back to the RIA intelligence verifier, so either
+    # provider satisfies the requirement. Requiring IAPD specifically would
+    # demand a provider the app does not actually use today (UAT verifies via
+    # RIA intelligence), so this mirrors the runtime "IAPD or RIA intelligence"
+    # rule and the provider adapters' own configured checks.
+    iapd_configured = bool(
+        str(os.getenv("IAPD_VERIFY_BASE_URL", "")).strip()
+        and str(os.getenv("IAPD_VERIFY_API_KEY", "")).strip()
+    )
+    ria_intelligence_configured = bool(
+        str(os.getenv("RIA_INTELLIGENCE_VERIFY_URL", "")).strip()
+        or str(os.getenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "")).strip()
+    )
+    if not (iapd_configured or ria_intelligence_configured):
+        raise RuntimeError(
+            "An advisory verification provider must be configured in production: set "
+            "IAPD_VERIFY_BASE_URL and IAPD_VERIFY_API_KEY, or "
+            "RIA_INTELLIGENCE_VERIFY_BASE_URL (optionally RIA_INTELLIGENCE_VERIFY_URL)."
+        )
 
     if _env_truthy("ADVISORY_VERIFICATION_BYPASS_ENABLED") or _env_truthy("RIA_DEV_BYPASS_ENABLED"):
         raise RuntimeError(

--- a/consent-protocol/tests/test_ria_iam_service_architecture.py
+++ b/consent-protocol/tests/test_ria_iam_service_architecture.py
@@ -152,19 +152,39 @@ def test_ria_verified_status_helper_matches_expected_statuses():
     assert RIAIAMService._is_verified_ria_status("submitted") is False
 
 
-def test_regulated_runtime_guard_requires_iapd_in_production(monkeypatch):
+def test_regulated_runtime_guard_requires_a_provider_in_production(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.delenv("IAPD_VERIFY_BASE_URL", raising=False)
     monkeypatch.delenv("IAPD_VERIFY_API_KEY", raising=False)
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_URL", raising=False)
+    monkeypatch.delenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", raising=False)
     monkeypatch.setenv("ADVISORY_VERIFICATION_BYPASS_ENABLED", "false")
     monkeypatch.setenv("BROKER_VERIFICATION_BYPASS_ENABLED", "false")
 
     try:
         validate_regulated_runtime_configuration()
     except RuntimeError as exc:
-        assert "IAPD_VERIFY_BASE_URL" in str(exc)
+        assert "advisory verification provider must be configured" in str(exc)
     else:
-        raise AssertionError("Expected production runtime guard to require IAPD config")
+        raise AssertionError(
+            "Expected production runtime guard to require an advisory verification provider"
+        )
+
+
+def test_regulated_runtime_guard_accepts_ria_intelligence_only(monkeypatch):
+    # RIA intelligence is the provider actually used today (UAT verifies through
+    # it); the guard must accept it without IAPD configured.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("IAPD_VERIFY_BASE_URL", raising=False)
+    monkeypatch.delenv("IAPD_VERIFY_API_KEY", raising=False)
+    monkeypatch.setenv("RIA_INTELLIGENCE_VERIFY_BASE_URL", "https://ria-intel.example.com")
+    monkeypatch.setenv("ADVISORY_VERIFICATION_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("RIA_DEV_BYPASS_ENABLED", "false")
+    monkeypatch.setenv("BROKER_VERIFICATION_BYPASS_ENABLED", "false")
+    monkeypatch.delenv("RIA_DEV_ALLOWLIST", raising=False)
+
+    # Should not raise: a configured advisory provider is present.
+    validate_regulated_runtime_configuration()
 
 
 def test_regulated_runtime_guard_rejects_prod_bypass(monkeypatch):


### PR DESCRIPTION
# Description

`validate_regulated_runtime_configuration()` hard-required `IAPD_VERIFY_BASE_URL` + `IAPD_VERIFY_API_KEY` at **production boot** — but **nothing actually verifies CRD through IAPD today**:

- Those two vars are **unset in every environment** (UAT and prod).
- The runtime chain (`FinraVerificationAdapter`) tries IAPD **first**, gets `not_configured`, and **falls back to the RIA intelligence verifier** (`RIA_INTELLIGENCE_VERIFY_BASE_URL`) every time.
- **UAT verifies exclusively through RIA intelligence** (it has `RIA_INTELLIGENCE_VERIFY_BASE_URL`, no IAPD).
- The code's own both-unconfigured message already says *"Configure `IAPD_VERIFY_*` **or** `RIA_INTELLIGENCE_VERIFY_*`."*

So the boot guard was stricter than the runtime, stricter than the code's own error message, and stricter than how UAT actually runs — which **crash-looped the production revision on boot** (`consent-protocol-00082-2rh`: `RuntimeError: IAPD_VERIFY_BASE_URL is required in production` → workers failed to boot → 100% 503).

**Fix:** relax the guard to require **at least one** advisory verification provider — IAPD (base URL **and** API key) **or** RIA intelligence (`RIA_INTELLIGENCE_VERIFY_URL` / `RIA_INTELLIGENCE_VERIFY_BASE_URL`) — mirroring the runtime fallback and each adapter's own configured-check. The fail-closed protection is preserved: production still refuses to boot with **no** verifier configured, and the bypass / allowlist / broker guards are unchanged.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] None (behavior now matches the code's existing error message and `docs/reference/operations/env-and-secrets` provider list)
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] **consent / KYC** — this is the RIA advisory-verification production runtime guard. Change **loosens an over-strict requirement to match actual runtime behavior**; it does **not** weaken fail-closed protection (prod still refuses to boot with zero providers, and all bypass/allowlist/broker guards are untouched).
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Guard remains fail-closed with no provider configured. With a provider configured (IAPD or RIA intelligence), boot proceeds; the verification adapters still degrade gracefully to `provider_unavailable` at request time if a provider is unreachable.
- UI browser or Playwright proof:
  - [x] Not applicable (backend runtime guard).
- Verification commands executed:
  - `pytest tests/test_ria_iam_service_architecture.py` (CI-manifest file) — **43 passed** under CI env.
  - Guard tests: `requires_a_provider_in_production`, `accepts_ria_intelligence_only`, `rejects_prod_bypass`, plus `test_ria_verification_hardening.py::{rejects_ria_dev_allowlist,passes_without_allowlist}` — all pass.
  - `ruff check`, `mypy`, `bandit -ll` on `ria_verification.py` — clean.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation checked: the runtime `FinraVerificationAdapter` chain and both adapters' configured-checks; this guard now matches them.
- [x] This PR changes a current reachable surface: the production boot-time regulated-runtime guard (`server.py` calls it on startup).
- [x] Reachable production attach point: `server.py` startup → `validate_regulated_runtime_configuration()`.
- [x] New/updated tests import and exercise production code (`validate_regulated_runtime_configuration`), not mocks.
- [x] Required checks are current on this head; commit is signed off (DCO).
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — backend runtime guard, no client layer.
- [x] **iOS**: N/A
- [x] **Android**: N/A

## 🧪 Testing

- [x] Backend guard tests pass under CI env (see Verification commands).
- [x] Commits are signed off (`git commit -s`).
- [x] No generated files changed.
- Note: `tests/test_ria_verification_intelligence.py::test_stage1_lookup_maps_auth_and_rate_limit_failures_to_unavailable` fails on **clean `origin/main`** (Stage1 HTTP-error mapping, unrelated to this change) and is **not** in the CI manifest — out of scope here, flagged for a separate fix.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No.
- [x] Sensitive surface touched: **consent / KYC** (RIA advisory-verification guard).
- [x] Error path / rollback / safe-failure behavior proved: still fail-closed with no provider; bypass/allowlist/broker guards unchanged.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4485
(retroactive board-linkage backfill, 2026-07-14)