### PR TITLE
ci(deploy-prod): robust DB_HOST resolution + serving-revision rollback target

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -160,7 +160,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -168,7 +168,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -177,8 +177,12 @@ jobs:
           echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
           echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
           echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
-          echo "Predeploy backend ready revision: ${backend_revision:-none}"
-          echo "Predeploy frontend ready revision: ${frontend_revision:-none}"
+          # Rollback target is the revision currently SERVING traffic (status.traffic),
+          # not latestReadyRevisionName - the latest Ready revision can be a newer,
+          # broken-but-Ready revision (e.g. a crash-looped one left behind by a prior
+          # failed deploy), which would make auto-rollback revert to the broken one.
+          echo "Predeploy backend serving revision: ${backend_revision:-none}"
+          echo "Predeploy frontend serving revision: ${frontend_revision:-none}"
 
       - name: Set up Python + uv runtime
         uses: ./consent-protocol/.github/actions/setup-python-uv
@@ -256,9 +260,16 @@ jobs:
             --region="${{ env.GCP_REGION }}" \
             --format=json)"
 
-          DB_HOST="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_HOST") | .value' | tail -n 1)"
-          DB_PORT="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_PORT") | .value' | tail -n 1)"
-          DB_NAME="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_NAME") | .value' | tail -n 1)"
+          # DB host/port/name come from the deployed service when present, but newer
+          # revisions no longer expose DB_HOST as a plain env var (it moved into the
+          # runtime config JSON), so the template scrape can return empty. Fall back to
+          # the canonical prod DB host used by the secret-sync step above so the gate
+          # does not break just because a prior failed revision changed the env shape.
+          # `// empty` guards against jq emitting the literal string "null".
+          DB_HOST="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_HOST") | .value // empty' | tail -n 1)"
+          DB_PORT="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_PORT") | .value // empty' | tail -n 1)"
+          DB_NAME="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_NAME") | .value // empty' | tail -n 1)"
+          DB_HOST="${DB_HOST:-aws-1-us-east-1.pooler.supabase.com}"
 
           DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
           DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"


### PR DESCRIPTION
# Description

Two correctness fixes in `deploy-production.yml`, both surfaced by a **blocked** prod deploy (run `29243460513`). No prod state changed — the migration/DB-drift gate stopped the run before any deploy or migration apply.

**1. Migration governance gate — `DB_HOST` resolution (the blocker).**
The gate scraped `DB_HOST` from the service's **latest-revision template**. Newer revisions no longer expose `DB_HOST` as a plain env var (it moved into the runtime config JSON), so the scrape returned empty and the gate exited with *"Failed to resolve DB credentials/host"* — even though prod was perfectly healthy. The prior successful run passed only because the latest revision then still used the old env shape (the serving `00081-bdm` has plain `DB_HOST`; the crash-looped `00082-2rh` left behind by run #37 does not). Fix: resolve with `// empty` (guard against jq emitting `"null"`) and **fall back to the canonical prod DB host the secret-sync step already uses**, so the gate can't break just because a prior failed revision changed the env shape.

**2. Auto-rollback target — use the serving revision.**
`#4441` captured the rollback target as `latestReadyRevisionName`. That can be a newer **broken-but-Ready** revision (exactly `00082-2rh` here — it reached Ready, then crash-looped), so an auto-rollback would revert traffic *to the broken revision*. Fix: capture the revision currently **serving traffic** (`status.traffic[0].revisionName`) so rollback reverts to the actually-good serving revision (`00081-bdm`).

## 📌 Impact Map (Required)

- Routes / API / schema / cache / DB data-plane / world-model / mobile / docs:
  - [x] None
- Top-level / devex / config / generated files touched:
  - [x] `.github/workflows/deploy-production.yml` only.
- Trust boundary touched:
  - [x] **deploy** — production release pipeline (DB-governance gate + auto-rollback target). No app logic; no migration behavior change; still fail-closed (DB_USER/DB_PASSWORD emptiness still aborts).
- Rollback or safe-failure behavior:
  - [x] Directly improves it — rollback now targets the serving (good) revision, not a stale broken Ready revision.
- UI / Playwright proof:
  - [x] Not applicable (CI/deploy config).
- Verification commands executed:
  - `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid, 36 steps.
  - Reference-integrity check — every `steps.<id>` resolves (no dangling refs).
  - Confirmed both edits present (`status.traffic[0].revisionName` for predeploy rollback targets; `DB_HOST` fallback to the canonical prod host).

## ✅ Review-Ready Contract

- [x] Title, body, and diff describe the same contract.
- [x] Reachable production attach point: `deploy-production.yml` (migration gate + predeploy-state steps).
- [x] Commit signed off (DCO); maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web / iOS / Android**: N/A — CI/deploy workflow change.

## 🧪 Testing

- [x] YAML + reference integrity validated.
- [x] Commit signed off.

## 🛡️ Privacy & Consent

- [x] Accesses user data? No.
- [x] Sensitive surface: **deploy** (DB-governance gate). Still fail-closed on missing DB creds.

## 📜 Licensing

- [x] First-party Apache-2.0 compatible; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4486
(retroactive board-linkage backfill, 2026-07-14)