### PR TITLE
feat(one-location): mutual-share Pick Me Up — watch your helper approach + live ETA

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -51,6 +51,7 @@ class CreateGrantRequest(_CamelModel):
     recipient_key_id: str | None = Field(default=None, alias="recipientKeyId", max_length=160)
     duration_hours: float = Field(alias="durationHours", gt=0, le=24)
     reason: str | None = Field(default=None, max_length=300)
+    share_kind: str | None = Field(default=None, alias="shareKind", max_length=40)
 
 
 class StoreEnvelopeRequest(_CamelModel):
@@ -443,6 +444,7 @@ async def create_location_grant(
                 recipient_key_id=payload.recipient_key_id,
                 duration_hours=payload.duration_hours,
                 reason=payload.reason,
+                share_kind=payload.share_kind,
                 enforce_connection=True,
             )
         }

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -1523,7 +1523,8 @@ class OneLocationAgentService:
         # was selected without metadata (some callers), default to a plain share.
         metadata = _loads_json(row.get("metadata"))
         reason = metadata.get("reason") if isinstance(metadata, dict) else None
-        share_kind = _classify_share_kind(reason)
+        stored_kind = metadata.get("share_kind") if isinstance(metadata, dict) else None
+        share_kind = stored_kind or _classify_share_kind(reason)
         share_message = _visible_share_message(reason)
         return {
             "id": str(row.get("id") or ""),
@@ -2671,6 +2672,7 @@ class OneLocationAgentService:
         recipient_key_id: str | None,
         duration_hours: float,
         reason: str | None = None,
+        share_kind: str | None = None,
         require_recipient_phone_verified: bool = True,
         enforce_connection: bool = False,
     ) -> dict[str, Any]:
@@ -2701,6 +2703,7 @@ class OneLocationAgentService:
             recipient_key_id=recipient_key_id,
             require_phone_verified=require_recipient_phone_verified,
         )
+        resolved_kind = share_kind or _classify_share_kind(reason)
         owner_identity = self._identity_row(owner_user_id)
         owner_label = _identity_notification_label(owner_identity)
         key_id = str(recipient.get("key_id") or "")
@@ -2747,6 +2750,7 @@ class OneLocationAgentService:
                 "metadata_json": _json_param(
                     {
                         "reason": reason or "owner_approved",
+                        "share_kind": resolved_kind,
                         "capability_token": capability["token"],
                         "capability_scope": LOCATION_GRANT_CONSENT_SCOPE,
                     }
@@ -2777,17 +2781,26 @@ class OneLocationAgentService:
         # copy, and a plain share keeps the neutral line. Internal markers
         # ("owner_approved" / "request_approved" / "sos_panic") are never shown
         # as a raw message.
-        share_kind = _classify_share_kind(reason)
         share_message = _visible_share_message(reason)
-        if share_kind == "sos":
+        if resolved_kind == "sos":
             notification_title = "SOS alert"
             notification_body = (
                 f"{owner_label} triggered an SOS and is sharing live location with you."
             )
-        elif share_kind == "drive_to":
+        elif resolved_kind == "drive_to":
             notification_title = "Drive shared"
             notification_body = f"{owner_label} started sharing their drive and live ETA with you."
-        elif share_kind == "check_in":
+        elif resolved_kind == "pick_me_up":
+            notification_title = "Pickup requested"
+            notification_body = (
+                f"{owner_label}: {share_message}"
+                if share_message
+                else f"{owner_label} is requesting a pickup."
+            )
+        elif resolved_kind == "pickup_enroute":
+            notification_title = "Drive shared"
+            notification_body = f"{owner_label} started sharing their drive and live ETA with you."
+        elif resolved_kind == "check_in":
             notification_title = "Check-in shared"
             notification_body = (
                 f"{owner_label}: {share_message}"
@@ -2819,7 +2832,7 @@ class OneLocationAgentService:
                     "owner_display_label": owner_label,
                     "duration_hours": str(duration),
                     "expires_at": grant.get("expiresAt"),
-                    "share_kind": share_kind,
+                    "share_kind": resolved_kind,
                     **({"share_message": share_message} if share_message else {}),
                 },
             )

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -875,6 +875,7 @@ class FourUserMemoryService(OneLocationAgentService):
                 "updated_at": datetime.now(timezone.utc),
                 "revoked_at": None,
                 "latest_envelope_id": None,
+                "metadata": json.loads(params.get("metadata_json") or "{}"),
                 "recipient_display_name": params.get("recipient_display_name"),
                 "recipient_phone_number": params.get("recipient_phone_number"),
             }

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -649,3 +649,76 @@ def test_recipient_key_blob_is_returned_to_owner_and_never_leaks_to_others(monke
     for recipient in state_b["recipients"]:
         assert "encryptedPrivateKeyJwk" not in recipient
     assert "OWNER_ONLY_CIPHERTEXT" not in json.dumps(state_b)
+
+
+def test_create_grant_with_explicit_pick_me_up_share_kind(monkeypatch) -> None:
+    """Explicit shareKind wins over _classify_share_kind; reason carries the freeform note."""
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+
+    _register_key(client, current_user, "user_b")
+    service._seed_connection("user_a", "user_b")
+    current_user["user_id"] = "user_a"
+
+    resp = client.post(
+        "/api/one/location/grants",
+        json={
+            "recipientUserId": "user_b",
+            "recipientKeyId": "key-user_b",
+            "durationHours": 1,
+            "reason": "Pick me up at Starbucks on Main St",
+            "shareKind": "pick_me_up",
+        },
+    )
+    assert resp.status_code == 200
+    grant = resp.json()["grant"]
+
+    # Explicit kind overrides what _classify_share_kind would derive ("check_in").
+    assert grant["shareKind"] == "pick_me_up"
+    # Freeform reason is surfaced as the visible share message.
+    assert grant["shareMessage"] == "Pick me up at Starbucks on Main St"
+
+    # Notification sent to recipient carries the pick_me_up title + note.
+    notif = service.notifications[-1]
+    assert notif["title"] == "Pickup requested"
+    assert "Pick me up at Starbucks on Main St" in notif["body"]
+    assert notif["data"]["share_kind"] == "pick_me_up"
+
+
+def test_create_grant_without_share_kind_preserves_existing_classification(monkeypatch) -> None:
+    """Omitting shareKind must leave existing _classify_share_kind behaviour unchanged."""
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+
+    _register_key(client, current_user, "user_b")
+    service._seed_connection("user_a", "user_b")
+    current_user["user_id"] = "user_a"
+
+    # A freeform note (not an internal marker) → classified as "check_in".
+    resp = client.post(
+        "/api/one/location/grants",
+        json={
+            "recipientUserId": "user_b",
+            "recipientKeyId": "key-user_b",
+            "durationHours": 1,
+            "reason": "Meeting you at the airport",
+        },
+    )
+    assert resp.status_code == 200
+    grant = resp.json()["grant"]
+    assert grant["shareKind"] == "check_in"
+    assert grant["shareMessage"] == "Meeting you at the airport"
+
+    # Plain share (no reason) → classified as "share".
+    resp2 = client.post(
+        "/api/one/location/grants",
+        json={
+            "recipientUserId": "user_b",
+            "recipientKeyId": "key-user_b",
+            "durationHours": 1,
+        },
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["grant"]["shareKind"] == "share"

--- a/docs/superpowers/plans/2026-07-13-pickup-watch-helper.md
+++ b/docs/superpowers/plans/2026-07-13-pickup-watch-helper.md
@@ -1,0 +1,215 @@
+# Pick Me Up — watch your helper approach — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Pick Me Up mutual — when the helper taps "I'm on my way", they share live location + ETA back to the requester, who watches them approach on a Now-tab card.
+
+**Architecture:** Add an explicit `pick_me_up` share kind on the backend `create_grant`. The helper's received pickup card gets an "I'm on my way" action that reuses the Drive-To pipeline (destination = the requester's already-shared pickup point, marked `pickup_enroute`). The requester correlates their outbound `pick_me_up` grant with the inbound `pickup_enroute` grant and renders a live "on the way" card via existing `recipientLivePoint` + the drive ETA payload.
+
+**Tech Stack:** Next.js + React + TS, Vitest (frontend); FastAPI + pytest (backend).
+
+## Visual Map
+
+```mermaid
+flowchart TD
+  PMU[requester: onPickMeUp shareKind=pick_me_up] --> G1[grant requester→helper]
+  G1 --> CARD[helper: pickup card + 'I'm on my way']
+  CARD --> IMOW[handleImOnMyWay → handleDriveTo dest=requester pickup, shareKind=pickup_enroute]
+  IMOW --> G2[grant helper→requester, drive-style ETA]
+  G2 --> OTW[requester: 'Helper is on the way · ETA' card on Now tab]
+  BE[create_grant explicit share_kind] --> G1
+  BE --> G2
+```
+
+## Global Constraints
+
+- Reverse share reuses the existing `createGrant` + `publishEnvelope` + watch loop — no crypto/consent change. It needs the requester in the helper's `recipients` list (guaranteed by connection).
+- Backend adds an explicit optional `share_kind` on `create_grant`; when absent, classification is unchanged (`_classify_share_kind`). Requires a backend deploy.
+- Share kinds used: `pick_me_up` (requester→helper), `pickup_enroute` (helper→requester, drive-style).
+- Commits: `git commit -s` (DCO); NO `Co-Authored-By: Claude`.
+- Tests: `npx vitest run <file>` (from `hushh-webapp/`); `.venv/bin/python -m pytest <file>` (from `consent-protocol/`). `npx tsc --noEmit`.
+
+---
+
+### Task 1: Backend — explicit `pick_me_up` / `pickup_enroute` share kind
+
+**Files:**
+- Modify: `consent-protocol/api/routes/one/location.py` (`CreateGrantRequest`, `create_grant` route ~433)
+- Modify: `consent-protocol/hushh_mcp/services/one_location_agent_service.py` (`create_grant` ~2666, notification copy ~2782)
+- Test: `consent-protocol/tests/test_one_location_routes.py` (or the grants test file)
+
+**Interfaces:**
+- Produces: `POST /api/one/location/grants` accepts optional `shareKind` → persisted on the grant; overrides `_classify_share_kind` when present.
+
+- [ ] **Step 1: Add `share_kind` to the request model**
+
+In `location.py`, add to `CreateGrantRequest`:
+
+```python
+    share_kind: str | None = Field(default=None, alias="shareKind", max_length=40)
+```
+
+Pass it through in the `create_grant` route to the service call: add `share_kind=payload.share_kind`.
+
+- [ ] **Step 2: Honor explicit `share_kind` in the service**
+
+In `create_grant` (service ~2666), accept `share_kind: str | None = None`. Where the grant's kind is derived today (via `_classify_share_kind(reason)`), prefer the explicit value:
+
+```python
+    resolved_kind = share_kind or _classify_share_kind(reason)
+```
+
+Use `resolved_kind` wherever the classified kind is stored/used. Add `"pick_me_up"` and `"pickup_enroute"` to the notification copy switch (title "Pickup requested" / body `"<name>: <message>"` for `pick_me_up`; en-route can reuse drive copy). Keep `_visible_share_message(reason)` returning the freeform note so the pickup message surfaces.
+
+- [ ] **Step 3: Test + commit**
+
+Add a test: creating a grant with `shareKind: "pick_me_up"` + a freeform `reason` yields a grant whose kind is `pick_me_up` and whose visible message is the note. Run `.venv/bin/python -m pytest tests/test_one_location_routes.py -q`.
+
+```bash
+git commit -s -m "feat(one-location): explicit pick_me_up/pickup_enroute share kind on create_grant"
+```
+
+---
+
+### Task 2: Frontend service + handlePickMeUp share kind
+
+**Files:**
+- Modify: `hushh-webapp/lib/one-location/service.ts` (`createGrant` ~339)
+- Modify: `hushh-webapp/app/one/location/page.tsx` (`handlePickMeUp` createGrant call; `onPickMeUp` unchanged signature — pickup already carries a message)
+
+**Interfaces:**
+- Produces: `OneLocationService.createGrant({..., shareKind?: string})` passthrough.
+
+- [ ] **Step 1: Add `shareKind` passthrough**
+
+In `service.ts createGrant`, add `shareKind?: string` to params and include it in the body when present:
+
+```typescript
+        body: JSON.stringify({
+          recipientUserId: params.recipientUserId,
+          recipientKeyId: params.recipientKeyId,
+          durationHours: params.durationHours,
+          ...(params.reason ? { reason: params.reason } : {}),
+          ...(params.shareKind ? { shareKind: params.shareKind } : {}),
+        }),
+```
+
+- [ ] **Step 2: handlePickMeUp tags the grant**
+
+In `handlePickMeUp` (page.tsx ~4337), the `createGrant` call gains `shareKind: "pick_me_up"` (the pickup message stays as `reason`).
+
+- [ ] **Step 3: tsc + commit**
+
+Run `npx tsc --noEmit`.
+```bash
+git commit -s -m "feat(one-location): tag Pick Me Up grants with pick_me_up share kind"
+```
+
+---
+
+### Task 3: `handleDriveTo` shareKind override + `handleImOnMyWay`
+
+**Files:**
+- Modify: `hushh-webapp/app/one/location/page.tsx` (`handleDriveTo` ~4234 add optional `shareKind`; new `handleImOnMyWay`; vm binding)
+- Modify: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (`LocationHubViewModel`: add `onImOnMyWay`)
+
+**Interfaces:**
+- Produces: `handleDriveTo(destination, recipientIds, durationHours, shareKind?)` — when `shareKind` given, the createGrant call passes it (still drive-style/ETA via `reason:"drive_to"`).
+- Produces: `vm.onImOnMyWay(grant: OneLocationGrant)` → creates the reverse drive-style share to `grant.ownerUserId` with destination = the requester's shared pickup point.
+
+- [ ] **Step 1: Add optional `shareKind` to handleDriveTo**
+
+Add a 4th param `shareKind?: string`; in its `createGrant` call add `...(shareKind ? { shareKind } : {})`. Default callers (the Drive-To flow) are unaffected.
+
+- [ ] **Step 2: `handleImOnMyWay`**
+
+Add:
+
+```typescript
+  const handleImOnMyWay = useCallback(
+    async (grant: OneLocationGrant) => {
+      const helperUserId = String(grant.ownerUserId || "").trim();
+      const point = decryptedPoints[grant.id];
+      if (!helperUserId || !point) {
+        toast.error("Can't start yet — open their pickup first.");
+        return;
+      }
+      const destination: DriveDestination = {
+        label: `${receivedGrantOwnerLabel(grant)} · pickup`,
+        latitude: point.latitude,
+        longitude: point.longitude,
+      };
+      await handleDriveTo(destination, [helperUserId], "4", "pickup_enroute");
+    },
+    [decryptedPoints, handleDriveTo],
+  );
+```
+
+Wire `onImOnMyWay: (grant) => void handleImOnMyWay(grant)` in the vm object, and add `onImOnMyWay: (grant: OneLocationGrant) => void;` to `LocationHubViewModel`.
+
+Note: `handleDriveTo` filters `sosActionRecipients` by the given id — the requester must be in that trusted list (they are, as a connection). If the filter is empty it already toasts "select a trusted contact"; adjust that message path only if needed.
+
+- [ ] **Step 3: tsc + commit**
+
+```bash
+git commit -s -m "feat(one-location): handleImOnMyWay reverse pickup share (drive-style, pickup_enroute)"
+```
+
+---
+
+### Task 4: Helper card — show message + "I'm on my way"
+
+**Files:**
+- Modify: `hushh-webapp/components/one-location/redesign/cards.tsx` (`SharedWithMeCard` ~240)
+- Modify: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (`InboxHub` wiring ~1287)
+- Test: `components/one-location/redesign/__tests__/*` (add a card test)
+
+- [ ] **Step 1: Card props**
+
+Add optional `message?: string`, `isPickup?: boolean`, `onImOnMyWay?: () => void`, `enRoute?: boolean` to `SharedWithMeCard`. Render `message` (when present) above the actions. When `isPickup && onImOnMyWay && !enRoute`, render a primary "I'm on my way" button; when `enRoute`, render a muted "En route — sharing your location" state.
+
+- [ ] **Step 2: Inbox wiring**
+
+In `InboxHub`, pass `message={grant.shareMessage ?? undefined}`, `isPickup={grant.shareKind === "pick_me_up"}`, and `onImOnMyWay={() => vm.onImOnMyWay(grant)}`. Compute `enRoute` from whether an active outbound `pickup_enroute` grant to `grant.ownerUserId` already exists (so the button flips after tapping).
+
+- [ ] **Step 3: Test + commit**
+
+Test: a `pick_me_up` grant renders the message + "I'm on my way" and calls `onImOnMyWay`; a non-pickup grant does not. Run the card test + `npx tsc --noEmit`.
+```bash
+git commit -s -m "feat(one-location): pickup card shows message + I'm on my way"
+```
+
+---
+
+### Task 5: Requester — "[Helper] is on the way" card
+
+**Files:**
+- Create: `PickupEnRouteCard` in `hushh-webapp/components/one-location/redesign/cards.tsx`
+- Modify: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx` (Now tab ~598; derive en-route pairs)
+- Modify: `hushh-webapp/app/one/location/page.tsx` (expose the data the card needs, if not already on vm)
+- Test: card + derivation tests
+
+**Interfaces:**
+- Consumes: `vm.receivedGrants`, `vm.decryptedPoints`, `vm.recipientLivePoint`, `driveEtaText`, active outbound grants.
+
+- [ ] **Step 1: Derive en-route pairs**
+
+On the Now tab (or a small selector), compute helpers who are en route: for each **received** grant with `shareKind === "pickup_enroute"` that has a decrypted live point, and for whom the requester has an **active outbound** `pick_me_up` grant, produce `{ helperName, point, etaSeconds }` (ETA from `point.drive?.etaSeconds`).
+
+- [ ] **Step 2: `PickupEnRouteCard`**
+
+Render "[Helper] is on the way", `driveEtaText(etaSeconds)` (falls back to "on the way" when null), the helper's live map (`vm.renderMapPreview(point, false)` / `LiveMap`), and a "Cancel pickup" button (revokes the outbound grant via existing `onStopGrant`). Place it above `SharingStatusCard` on the Now tab.
+
+- [ ] **Step 3: Test + commit**
+
+Test: given a `pickup_enroute` received grant with a drive payload + a matching outbound pickup, the card shows the helper name + ETA. Run tests + `npx tsc --noEmit` + `npx eslint`.
+```bash
+git commit -s -m "feat(one-location): requester 'helper is on the way' live card + ETA"
+```
+
+---
+
+### Task 6: End-to-end verification
+
+- [ ] **Step 1: Suites** — `npx vitest run components/one-location lib/one-location && npx tsc --noEmit` (frontend); `.venv/bin/python -m pytest tests/test_one_location_routes.py tests/services/test_google_maps_service.py` (backend). All pass.
+- [ ] **Step 2: iOS sim** — build against UAT, drive two accounts (or two sims): requester asks pickup → helper sees message + taps "I'm on my way" → requester's Now tab shows "[Helper] is on the way · ETA" updating as the helper's simulated location moves. (Never pipe `xcodebuild` to `tail`; use a moving simulated location.)

--- a/docs/superpowers/specs/2026-07-13-pickup-watch-helper-design.md
+++ b/docs/superpowers/specs/2026-07-13-pickup-watch-helper-design.md
@@ -1,0 +1,152 @@
+# Pick Me Up — watch your helper approach (mutual live share + ETA) — design
+
+**Date:** 2026-07-13
+**Branch:** `feat/pickup-live-eta`
+**Status:** Proposed (awaiting review)
+
+## Visual Map
+
+```mermaid
+flowchart TD
+  subgraph Requester
+    PMU[Pick Me Up → onPickMeUp shareKind=pick_me_up] --> G1[grant: requester→helper, live pickup spot]
+    OTW["'Helper is on the way' card (Now tab)"] --> RLP[recipientLivePoint helper + drive ETA]
+  end
+  subgraph Helper
+    RCV[received pickup card: shows message + 'I'm on my way'] --> IMOW[onImOnMyWay]
+    IMOW --> G2[reverse grant: helper→requester, drive-style, dest = requester pickup point]
+  end
+  G1 --> RCV
+  G2 --> RLP
+  subgraph Backend
+    SK[create_grant share_kind=pick_me_up + notification copy]
+  end
+  PMU --> SK
+```
+
+## Goal
+
+Upgrade **Pick Me Up** from a one‑way share into a **mutual** pickup: when the
+helper accepts ("I'm on my way"), they share their **live location + ETA** back
+to the requester, who then watches the helper approach on a live "on the way"
+card. Today the helper's card is view‑only and the requester sees nothing after
+asking.
+
+## Key model facts (from code map)
+
+- Pick Me Up is a **share** (owner=requester → recipient=helper), pickup note in
+  `grant.shareMessage`. It is NOT an access request; received shares are
+  view‑only today.
+- The reverse share (helper → requester) reuses the **existing** `createGrant` +
+  `publishEnvelope` + foreground watch loop unchanged. It only needs the
+  requester present in the helper's `recipients` list (guaranteed — they're
+  connected, `enforce_connection`).
+- `vm.recipientLivePoint(userId)` already returns a contact's decrypted live
+  point once they share back — the requester needs no new fetch plumbing.
+- ETA rides inside the envelope as `DriveSharePayload` when the share is
+  **drive‑style** — so the helper's reverse share is a Drive‑To to the
+  requester's pickup point.
+
+## Scope
+
+In scope:
+- Backend: a `pick_me_up` **share kind** (explicit on `create_grant`) + pickup
+  notification copy.
+- Helper: received **pickup card** shows the message + an **"I'm on my way"**
+  action that creates the drive‑style reverse share (dest = requester's pickup
+  point).
+- Requester: an **"[Helper] is on the way · ETA"** live card on the Now tab.
+
+Out of scope:
+- Decline/negotiation flow, multi‑helper pickups, background tracking changes,
+  turn‑by‑turn navigation, arrival auto‑detection (future).
+
+## Components
+
+### 1. Backend — `pick_me_up` share kind
+
+Files: `consent-protocol/hushh_mcp/services/one_location_agent_service.py`
+(`create_grant`, `_classify_share_kind` ~322, `_send_metadata_notification`
+~2782), `consent-protocol/api/routes/one/location.py` (`CreateGrantRequest`,
+`create_grant` route ~433), tests.
+
+- Add an explicit optional `share_kind` param to `create_grant` (route request
+  model + service). When provided, it wins over `_classify_share_kind`; when
+  absent, behavior is unchanged. Persist on the grant (existing `shareKind`
+  field).
+- Recognize `"pick_me_up"` in notification copy: title "Pickup requested", body
+  `"<Requester>: <pickup message>"`, deep‑link to the Inbox shared card
+  (existing `_one_location_url`).
+- No change to encryption/consent; the reverse grant is a normal `create_grant`.
+
+Frontend `OneLocationService.createGrant` gains an optional `shareKind` passthrough;
+`handlePickMeUp` passes `shareKind: "pick_me_up"`.
+
+### 2. Helper side — pickup card + "I'm on my way"
+
+Files: `components/one-location/redesign/cards.tsx` (`SharedWithMeCard` ~240),
+`components/one-location/redesign/location-redesign-hub.tsx` (`InboxHub` ~1287
+wiring), `app/one/location/page.tsx` (new `handleImOnMyWay`), tests.
+
+- `SharedWithMeCard` gains optional `message` + `onImOnMyWay` props. Render the
+  pickup message; when the grant is a `pick_me_up` and not already responded,
+  show a primary **"I'm on my way"** button (and, after tapping, an "En route —
+  sharing your location" state).
+- `InboxHub` passes `grant.shareMessage` and, for `shareKind === "pick_me_up"`,
+  an `onImOnMyWay={() => vm.onImOnMyWay(grant)}` handler.
+- `handleImOnMyWay(grant)` (reuses the Drive‑To pipeline): destination =
+  `decryptedPoints[grant.id]` (the requester's shared pickup point) as a
+  `DriveDestination` (label "<requester> · pickup"); recipient =
+  `grant.ownerUserId` (looked up in the helper's `recipients` list for
+  `keyId`/`publicKeyJwk`); `shareKind: "pickup_enroute"`; duration = until
+  picked up. Calls the same `createGrant` + `publishEnvelopeWithRetry` + drive
+  ETA path so the helper's live position + ETA flow to the requester.
+- Guard: if the requester isn't in the helper's recipients list (edge), show a
+  clear toast ("Can't share back — reconnect first") rather than failing
+  silently.
+
+### 3. Requester side — "[Helper] is on the way" card
+
+Files: `components/one-location/redesign/location-redesign-hub.tsx` (Now tab,
+near `SharingStatusCard` ~598), a new `PickupEnRouteCard` in `cards.tsx`,
+`app/one/location/page.tsx` (derive the en‑route state), tests.
+
+- Derive, on the requester: for each **active outbound** `pick_me_up` grant
+  (owner=me, recipient=helper), check for a **received** grant from that helper
+  (`ownerUserId === helper`, `shareKind === "pickup_enroute"`) with a decrypted
+  live point. When found → show `PickupEnRouteCard`.
+- `PickupEnRouteCard` shows "[Helper] is on the way", their **live map**
+  (`renderMapPreview`/`LiveMap` on `recipientLivePoint(helper)`), and **ETA**
+  from the received drive payload (`point.drive.etaSeconds` via `driveEtaText`),
+  plus a "Cancel pickup" affordance that revokes the outbound grant.
+- No new fetch: `recipientLivePoint` + the envelope's drive payload already
+  carry position + ETA.
+
+## Data flow
+
+1. Requester → "Ask <helper> to pick me up" → `onPickMeUp(..., shareKind: pick_me_up)`.
+2. Helper gets a notification + a pickup card (message shown) → taps **"I'm on my way"**.
+3. Helper's app creates a drive‑style reverse grant to the requester (dest =
+   requester's pickup point) → shares live position + ETA.
+4. Requester's Now tab shows **"[Helper] is on the way · ETA"** with the helper's
+   live map, updating in real time.
+5. Either side cancels/expires → cards clear.
+
+## Error handling / fallbacks
+
+- Helper not connected to requester → toast, no silent failure.
+- Helper location permission denied → existing `ensureForegroundLocationReady`
+  toasts (reused).
+- Helper not sharing yet / no fix → requester card shows "Waiting for <helper> to
+  start sharing" until a point arrives.
+- ETA unavailable → card shows position without ETA ("on the way").
+
+## Testing
+
+- Backend: `create_grant` honors explicit `share_kind: pick_me_up`; notification
+  copy for pickup; classification unchanged when kind absent.
+- Frontend: `SharedWithMeCard` renders message + "I'm on my way" only for
+  `pick_me_up`; `handleImOnMyWay` calls `createGrant` with recipient =
+  requester, drive‑style, `pickup_enroute`; `PickupEnRouteCard` shows helper
+  name + ETA from the drive payload; requester en‑route derivation matches
+  outbound pickup ↔ inbound `pickup_enroute`.

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -169,6 +169,11 @@ import {
   addRecentDestination,
   loadRecentDestinations,
 } from "@/lib/one-location/drive-recents";
+import {
+  loadPersistedDriveSession,
+  restoreDriveSession,
+  saveDriveSession,
+} from "@/lib/one-location/drive-session-store";
 import { AccountIdentityService } from "@/lib/services/account-identity-service";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 import { toDurationBucket, trackEvent } from "@/lib/observability/client";
@@ -2765,6 +2770,26 @@ export function OneLocationAgentPageContent({
     [],
   );
 
+  // Rehydrate the drive/ETA session after a refresh/remount. `driveSessionRef`
+  // is in-memory, so without this the watch loop would resume publishing points
+  // WITHOUT the ETA payload after a reload (position keeps updating, ETA drops).
+  // Restore it from durable storage for still-active owner grants; only when the
+  // ref is empty (never clobber a live session).
+  useEffect(() => {
+    if (!auth.userId || driveSessionRef.current) return;
+    const activeIds = new Set(activeOwnerGrants.map((grant) => grant.id));
+    if (activeIds.size === 0) return;
+    let cancelled = false;
+    void loadPersistedDriveSession(auth.userId).then((persisted) => {
+      if (cancelled || driveSessionRef.current) return;
+      const restored = restoreDriveSession(persisted, activeIds);
+      if (restored) driveSessionRef.current = restored;
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.userId, activeOwnerGrants]);
+
   const resetShareComposer = useCallback(() => {
     suppressAutoRecipientSelectionRef.current = true;
     setSelectedRecipientId("");
@@ -4311,6 +4336,17 @@ export function OneLocationAgentPageContent({
           lastEtaPoint: point,
           lastEtaAt: Date.now(),
         };
+        // Persist the session so the live ETA survives a refresh/remount — the
+        // watch loop rehydrates it on mount and keeps attaching the ETA payload.
+        if (auth.userId) {
+          void saveDriveSession(auth.userId, {
+            grantIds: [...grantIds],
+            destination,
+            etaSeconds,
+            distanceMeters,
+            etaComputedAt,
+          });
+        }
 
         if (auth.userId) {
           await addRecentDestination(auth.userId, destination);
@@ -4562,6 +4598,17 @@ export function OneLocationAgentPageContent({
           lastEtaPoint: point,
           lastEtaAt: Date.now(),
         };
+        // Persist the session so the live ETA survives a refresh/remount — the
+        // watch loop rehydrates it on mount and keeps attaching the ETA payload.
+        if (auth.userId) {
+          void saveDriveSession(auth.userId, {
+            grantIds: [...grantIds],
+            destination,
+            etaSeconds,
+            distanceMeters,
+            etaComputedAt,
+          });
+        }
 
         if (auth.userId) {
           await addRecentDestination(auth.userId, destination);

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4236,6 +4236,7 @@ export function OneLocationAgentPageContent({
       destination: DriveDestination,
       recipientIds: string[],
       durationHoursValue: string,
+      shareKind?: string,
     ) => {
       if (!vaultOwnerToken || locationPermissionBlocksSharing(permission)) {
         toast.error("Location permission is required to share your drive.");
@@ -4295,6 +4296,7 @@ export function OneLocationAgentPageContent({
             recipientKeyId: recipient.keyId,
             durationHours: durationHoursNum,
             reason: "drive_to",
+            ...(shareKind ? { shareKind } : {}),
           });
           await publishEnvelopeWithRetry(grant, recipient, "manual", drivePoint);
           grantIds.add(grant.id);
@@ -4333,6 +4335,28 @@ export function OneLocationAgentPageContent({
       refresh,
       auth.userId,
     ],
+  );
+
+  // "I'm on my way" — helper-side reverse share: when a helper receives a
+  // Pick Me Up grant they tap "I'm on my way" which drives this handler. It
+  // creates a drive-style grant back to the requester (the grant owner) so the
+  // requester can watch the helper approaching their pickup point in real time.
+  const handleImOnMyWay = useCallback(
+    async (grant: OneLocationGrant) => {
+      const helperUserId = String(grant.ownerUserId || "").trim();
+      const point = decryptedPoints[grant.id];
+      if (!helperUserId || !point) {
+        toast.error("Can't start yet — open their pickup first.");
+        return;
+      }
+      const destination: DriveDestination = {
+        label: `${receivedGrantOwnerLabel(grant)} · pickup`,
+        latitude: point.latitude,
+        longitude: point.longitude,
+      };
+      await handleDriveTo(destination, [helperUserId], "4", "pickup_enroute");
+    },
+    [decryptedPoints, handleDriveTo],
   );
 
   // Pick Me Up quick action (INBOUND help): share your LIVE location + a pickup
@@ -4986,6 +5010,7 @@ export function OneLocationAgentPageContent({
         durationHoursValue,
         messageValue,
       ),
+    onImOnMyWay: (grant) => void handleImOnMyWay(grant),
   };
 
 

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4343,9 +4343,11 @@ export function OneLocationAgentPageContent({
   // requester can watch the helper approaching their pickup point in real time.
   const handleImOnMyWay = useCallback(
     async (grant: OneLocationGrant) => {
-      const helperUserId = String(grant.ownerUserId || "").trim();
+      // grant.ownerUserId is the REQUESTER (who asked for the pickup); we (the
+      // helper) share our live drive to their pickup point.
+      const requesterUserId = String(grant.ownerUserId || "").trim();
       const point = decryptedPoints[grant.id];
-      if (!helperUserId || !point) {
+      if (!requesterUserId || !point) {
         toast.error("Can't start yet — open their pickup first.");
         return;
       }
@@ -4354,7 +4356,7 @@ export function OneLocationAgentPageContent({
         latitude: point.latitude,
         longitude: point.longitude,
       };
-      await handleDriveTo(destination, [helperUserId], "4", "pickup_enroute");
+      await handleDriveTo(destination, [requesterUserId], "4", "pickup_enroute");
     },
     [decryptedPoints, handleDriveTo],
   );

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -4395,6 +4395,7 @@ export function OneLocationAgentPageContent({
             recipientKeyId: recipient.keyId,
             durationHours: durationHoursNum,
             reason: pickupMessage,
+            shareKind: "pick_me_up",
           });
           // Anchor the grant to the fixed-pickup session BEFORE publishing so a
           // mid-publish failure can't leave a created grant drifting to live GPS

--- a/hushh-webapp/components/one-location/redesign/__tests__/pickup-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/pickup-card.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SharedWithMeCard } from "@/components/one-location/redesign/cards";
+
+const baseProps = {
+  name: "Ankit",
+  statusLine: "Expires in 1h",
+  onView: vi.fn(),
+};
+
+describe("SharedWithMeCard — pickup card", () => {
+  it("renders the pickup message and I'm on my way button for a pick_me_up grant", () => {
+    const onImOnMyWay = vi.fn();
+    render(
+      <SharedWithMeCard
+        {...baseProps}
+        message="I'm at the coffee shop on 5th"
+        isPickup
+        onImOnMyWay={onImOnMyWay}
+        enRoute={false}
+      />,
+    );
+
+    expect(
+      screen.getByText("I'm at the coffee shop on 5th"),
+    ).toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: /i'm on my way/i });
+    expect(btn).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(onImOnMyWay).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows En route state instead of button when enRoute is true", () => {
+    const onImOnMyWay = vi.fn();
+    render(
+      <SharedWithMeCard
+        {...baseProps}
+        message="Pick me up please"
+        isPickup
+        onImOnMyWay={onImOnMyWay}
+        enRoute
+      />,
+    );
+
+    expect(
+      screen.getByText(/en route — sharing your location/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /i'm on my way/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders neither message nor pickup button for a non-pickup grant", () => {
+    render(
+      <SharedWithMeCard
+        {...baseProps}
+        message={undefined}
+        isPickup={false}
+        onImOnMyWay={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /i'm on my way/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/en route/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show pickup button when isPickup is false even if message provided", () => {
+    render(
+      <SharedWithMeCard
+        {...baseProps}
+        message="Some message"
+        isPickup={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /i'm on my way/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/__tests__/pickup-enroute-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/pickup-enroute-card.test.tsx
@@ -1,14 +1,14 @@
 /**
  * Tests for PickupEnRouteCard (cards.tsx) and the en-route helper derivation
- * logic that lives in NowHub (location-redesign-hub.tsx).
+ * logic extracted into pickup-enroute.ts.
  *
- * The derivation is tested via a thin helper function that mirrors the
- * production code exactly, exercising the predicate in isolation — which keeps
- * the test free of heavy component mocking while still asserting real logic.
+ * The derivation tests import the real exported function so they exercise
+ * production logic directly — no mirror copies.
  */
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { PickupEnRouteCard } from "@/components/one-location/redesign/cards";
+import { deriveEnRouteHelpers } from "@/components/one-location/redesign/pickup-enroute";
 import type { OneLocationGrant, PlainLocationPoint } from "@/lib/one-location/types";
 
 /* ------------------------------------------------------------------ */
@@ -48,48 +48,6 @@ function makePoint(etaSeconds?: number | null): PlainLocationPoint {
 }
 
 /* ------------------------------------------------------------------ */
-/* Mirror the production derivation so we can test it in isolation     */
-/* ------------------------------------------------------------------ */
-
-type EnRouteEntry = {
-  key: string;
-  helperName: string;
-  etaSeconds: number | null;
-  outboundGrantId: string;
-};
-
-function deriveEnRouteHelpers(
-  receivedGrants: OneLocationGrant[],
-  activeOwnerGrants: OneLocationGrant[],
-  decryptedPoints: Record<string, PlainLocationPoint>,
-  grantOwnerLabel: (g: OneLocationGrant) => string,
-): EnRouteEntry[] {
-  return receivedGrants
-    .filter(
-      (g) =>
-        g.shareKind === "pickup_enroute" &&
-        Boolean(decryptedPoints[g.id]),
-    )
-    .flatMap((receivedGrant) => {
-      const outboundGrant = activeOwnerGrants.find(
-        (g) =>
-          g.shareKind === "pick_me_up" &&
-          g.recipientUserId === receivedGrant.ownerUserId,
-      );
-      if (!outboundGrant) return [];
-      const point = decryptedPoints[receivedGrant.id]!;
-      return [
-        {
-          key: receivedGrant.id,
-          helperName: grantOwnerLabel(receivedGrant),
-          etaSeconds: point.drive?.etaSeconds ?? null,
-          outboundGrantId: outboundGrant.id,
-        },
-      ];
-    });
-}
-
-/* ------------------------------------------------------------------ */
 /* Tests: derivation                                                    */
 /* ------------------------------------------------------------------ */
 
@@ -106,7 +64,7 @@ describe("deriveEnRouteHelpers", () => {
     };
     const label = (g: OneLocationGrant) => (g.ownerUserId === "helper-1" ? "Ravi" : "?");
 
-    const result = deriveEnRouteHelpers(received, outbound, points, label);
+    const result = deriveEnRouteHelpers({ receivedGrants: received, activeOwnerGrants: outbound, decryptedPoints: points, labelFor: label });
 
     expect(result).toHaveLength(1);
     expect(result[0]!.helperName).toBe("Ravi");
@@ -123,7 +81,7 @@ describe("deriveEnRouteHelpers", () => {
       makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "helper-1" }),
     ];
     // No decrypted point
-    const result = deriveEnRouteHelpers(received, outbound, {}, () => "Ravi");
+    const result = deriveEnRouteHelpers({ receivedGrants: received, activeOwnerGrants: outbound, decryptedPoints: {}, labelFor: () => "Ravi" });
 
     expect(result).toHaveLength(0);
   });
@@ -138,7 +96,7 @@ describe("deriveEnRouteHelpers", () => {
     ];
     const points: Record<string, PlainLocationPoint> = { r1: makePoint(300) };
 
-    const result = deriveEnRouteHelpers(received, outbound, points, () => "Ravi");
+    const result = deriveEnRouteHelpers({ receivedGrants: received, activeOwnerGrants: outbound, decryptedPoints: points, labelFor: () => "Ravi" });
 
     expect(result).toHaveLength(0);
   });
@@ -152,7 +110,7 @@ describe("deriveEnRouteHelpers", () => {
     ];
     const points: Record<string, PlainLocationPoint> = { r1: makePoint(300) };
 
-    const result = deriveEnRouteHelpers(received, outbound, points, () => "Ravi");
+    const result = deriveEnRouteHelpers({ receivedGrants: received, activeOwnerGrants: outbound, decryptedPoints: points, labelFor: () => "Ravi" });
 
     expect(result).toHaveLength(0);
   });
@@ -174,7 +132,7 @@ describe("deriveEnRouteHelpers", () => {
       },
     };
 
-    const result = deriveEnRouteHelpers(received, outbound, points, () => "Ravi");
+    const result = deriveEnRouteHelpers({ receivedGrants: received, activeOwnerGrants: outbound, decryptedPoints: points, labelFor: () => "Ravi" });
 
     expect(result).toHaveLength(1);
     expect(result[0]!.etaSeconds).toBeNull();
@@ -194,7 +152,7 @@ describe("deriveEnRouteHelpers", () => {
       r2: makePoint(1200),
     };
 
-    const result = deriveEnRouteHelpers(received, outbound, points, (g) => g.ownerUserId);
+    const result = deriveEnRouteHelpers({ receivedGrants: received, activeOwnerGrants: outbound, decryptedPoints: points, labelFor: (g) => g.ownerUserId });
 
     expect(result).toHaveLength(2);
     expect(result.map((e) => e.outboundGrantId).sort()).toEqual(["o1", "o2"]);

--- a/hushh-webapp/components/one-location/redesign/__tests__/pickup-enroute-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/pickup-enroute-card.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Tests for PickupEnRouteCard (cards.tsx) and the en-route helper derivation
+ * logic that lives in NowHub (location-redesign-hub.tsx).
+ *
+ * The derivation is tested via a thin helper function that mirrors the
+ * production code exactly, exercising the predicate in isolation — which keeps
+ * the test free of heavy component mocking while still asserting real logic.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PickupEnRouteCard } from "@/components/one-location/redesign/cards";
+import type { OneLocationGrant, PlainLocationPoint } from "@/lib/one-location/types";
+
+/* ------------------------------------------------------------------ */
+/* Fixture helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+function makeGrant(overrides: Partial<OneLocationGrant> = {}): OneLocationGrant {
+  return {
+    id: "g-default",
+    ownerUserId: "owner-1",
+    recipientUserId: "recipient-1",
+    recipientKeyId: "key-1",
+    status: "active",
+    consentScope: "location",
+    capabilityScopes: [],
+    durationHours: 4,
+    shareKind: "share",
+    ...overrides,
+  };
+}
+
+function makePoint(etaSeconds?: number | null): PlainLocationPoint {
+  return {
+    latitude: 28.6562,
+    longitude: 77.241,
+    capturedAt: "2026-07-12T00:00:00Z",
+    sourcePlatform: "web",
+    drive: etaSeconds !== undefined
+      ? {
+          destination: { latitude: 28.7, longitude: 77.1, label: "Destination" },
+          etaSeconds: etaSeconds,
+          distanceMeters: 5000,
+          etaComputedAt: "2026-07-12T00:00:00Z",
+        }
+      : undefined,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Mirror the production derivation so we can test it in isolation     */
+/* ------------------------------------------------------------------ */
+
+type EnRouteEntry = {
+  key: string;
+  helperName: string;
+  etaSeconds: number | null;
+  outboundGrantId: string;
+};
+
+function deriveEnRouteHelpers(
+  receivedGrants: OneLocationGrant[],
+  activeOwnerGrants: OneLocationGrant[],
+  decryptedPoints: Record<string, PlainLocationPoint>,
+  grantOwnerLabel: (g: OneLocationGrant) => string,
+): EnRouteEntry[] {
+  return receivedGrants
+    .filter(
+      (g) =>
+        g.shareKind === "pickup_enroute" &&
+        Boolean(decryptedPoints[g.id]),
+    )
+    .flatMap((receivedGrant) => {
+      const outboundGrant = activeOwnerGrants.find(
+        (g) =>
+          g.shareKind === "pick_me_up" &&
+          g.recipientUserId === receivedGrant.ownerUserId,
+      );
+      if (!outboundGrant) return [];
+      const point = decryptedPoints[receivedGrant.id]!;
+      return [
+        {
+          key: receivedGrant.id,
+          helperName: grantOwnerLabel(receivedGrant),
+          etaSeconds: point.drive?.etaSeconds ?? null,
+          outboundGrantId: outboundGrant.id,
+        },
+      ];
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests: derivation                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("deriveEnRouteHelpers", () => {
+  it("yields a helper entry when pickup_enroute received + matching outbound pick_me_up exist", () => {
+    const received = [
+      makeGrant({ id: "r1", shareKind: "pickup_enroute", ownerUserId: "helper-1" }),
+    ];
+    const outbound = [
+      makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "helper-1" }),
+    ];
+    const points: Record<string, PlainLocationPoint> = {
+      r1: makePoint(720),
+    };
+    const label = (g: OneLocationGrant) => (g.ownerUserId === "helper-1" ? "Ravi" : "?");
+
+    const result = deriveEnRouteHelpers(received, outbound, points, label);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.helperName).toBe("Ravi");
+    expect(result[0]!.etaSeconds).toBe(720);
+    expect(result[0]!.outboundGrantId).toBe("o1");
+    expect(result[0]!.key).toBe("r1");
+  });
+
+  it("yields no entry when the received grant has no decrypted point yet", () => {
+    const received = [
+      makeGrant({ id: "r1", shareKind: "pickup_enroute", ownerUserId: "helper-1" }),
+    ];
+    const outbound = [
+      makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "helper-1" }),
+    ];
+    // No decrypted point
+    const result = deriveEnRouteHelpers(received, outbound, {}, () => "Ravi");
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("yields no entry when there is no matching outbound pick_me_up grant", () => {
+    const received = [
+      makeGrant({ id: "r1", shareKind: "pickup_enroute", ownerUserId: "helper-1" }),
+    ];
+    // Outbound exists but for a DIFFERENT recipient
+    const outbound = [
+      makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "other-user" }),
+    ];
+    const points: Record<string, PlainLocationPoint> = { r1: makePoint(300) };
+
+    const result = deriveEnRouteHelpers(received, outbound, points, () => "Ravi");
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores received grants that are not pickup_enroute", () => {
+    const received = [
+      makeGrant({ id: "r1", shareKind: "pick_me_up", ownerUserId: "helper-1" }),
+    ];
+    const outbound = [
+      makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "helper-1" }),
+    ];
+    const points: Record<string, PlainLocationPoint> = { r1: makePoint(300) };
+
+    const result = deriveEnRouteHelpers(received, outbound, points, () => "Ravi");
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns etaSeconds null when drive payload is absent", () => {
+    const received = [
+      makeGrant({ id: "r1", shareKind: "pickup_enroute", ownerUserId: "helper-1" }),
+    ];
+    const outbound = [
+      makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "helper-1" }),
+    ];
+    // Point with no drive payload
+    const points: Record<string, PlainLocationPoint> = {
+      r1: {
+        latitude: 28.6562,
+        longitude: 77.241,
+        capturedAt: "2026-07-12T00:00:00Z",
+        sourcePlatform: "web",
+      },
+    };
+
+    const result = deriveEnRouteHelpers(received, outbound, points, () => "Ravi");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.etaSeconds).toBeNull();
+  });
+
+  it("handles multiple en-route helpers independently", () => {
+    const received = [
+      makeGrant({ id: "r1", shareKind: "pickup_enroute", ownerUserId: "h1" }),
+      makeGrant({ id: "r2", shareKind: "pickup_enroute", ownerUserId: "h2" }),
+    ];
+    const outbound = [
+      makeGrant({ id: "o1", shareKind: "pick_me_up", recipientUserId: "h1" }),
+      makeGrant({ id: "o2", shareKind: "pick_me_up", recipientUserId: "h2" }),
+    ];
+    const points: Record<string, PlainLocationPoint> = {
+      r1: makePoint(600),
+      r2: makePoint(1200),
+    };
+
+    const result = deriveEnRouteHelpers(received, outbound, points, (g) => g.ownerUserId);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.outboundGrantId).sort()).toEqual(["o1", "o2"]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests: PickupEnRouteCard component                                  */
+/* ------------------------------------------------------------------ */
+
+describe("PickupEnRouteCard", () => {
+  it("renders helper name and ETA text", () => {
+    render(
+      <PickupEnRouteCard
+        helperName="Ravi"
+        etaText="~12 min away"
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Ravi is on the way")).toBeInTheDocument();
+    expect(screen.getByText("~12 min away")).toBeInTheDocument();
+  });
+
+  it("renders a cancel pickup button and calls onCancel when clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <PickupEnRouteCard
+        helperName="Ravi"
+        etaText="~12 min away"
+        onCancel={onCancel}
+      />,
+    );
+
+    const btn = screen.getByRole("button", { name: /cancel pickup/i });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders children (map preview) when provided", () => {
+    render(
+      <PickupEnRouteCard
+        helperName="Ravi"
+        etaText="~12 min away"
+        onCancel={vi.fn()}
+      >
+        <div data-testid="map-preview">map</div>
+      </PickupEnRouteCard>,
+    );
+
+    expect(screen.getByTestId("map-preview")).toBeInTheDocument();
+  });
+
+  it("shows Live status pill", () => {
+    render(
+      <PickupEnRouteCard
+        helperName="Ravi"
+        etaText="ETA unavailable"
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("shows cancelBusy loading state on the button when provided", () => {
+    render(
+      <PickupEnRouteCard
+        helperName="Ravi"
+        etaText="~5 min away"
+        onCancel={vi.fn()}
+        cancelBusy
+      />,
+    );
+
+    // Button should be disabled while loading
+    const btn = screen.getByRole("button", { name: /cancel pickup/i });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -247,6 +247,10 @@ export function SharedWithMeCard({
   viewBusy,
   previewExpanded,
   children,
+  message,
+  isPickup,
+  onImOnMyWay,
+  enRoute,
 }: {
   name: string;
   statusLine: string;
@@ -257,6 +261,10 @@ export function SharedWithMeCard({
   viewBusy?: boolean;
   previewExpanded?: boolean;
   children?: ReactNode;
+  message?: string;
+  isPickup?: boolean;
+  onImOnMyWay?: () => void;
+  enRoute?: boolean;
 }) {
   const canOpenMap = Boolean(previewExpanded && mapHref);
   const canDismissPreview = Boolean(previewExpanded && onDismiss);
@@ -275,6 +283,22 @@ export function SharedWithMeCard({
       </div>
       {metaLine ? <p className={MUTED_TEXT}>{metaLine}</p> : null}
       {children}
+      {message ? (
+        <p className={cn(MUTED_TEXT, "text-sm")}>{message}</p>
+      ) : null}
+      {isPickup && onImOnMyWay && !enRoute ? (
+        <Button
+          onClick={onImOnMyWay}
+          className="h-9 w-full rounded-full bg-[#007aff] text-sm font-semibold text-white hover:bg-[#007aff]/90"
+        >
+          I&apos;m on my way
+        </Button>
+      ) : null}
+      {isPickup && enRoute ? (
+        <p className={cn(MUTED_TEXT, "text-center text-sm")}>
+          En route — sharing your location
+        </p>
+      ) : null}
       <div
         className={cn(
           "grid gap-2",

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -12,6 +12,7 @@
 
 import type { ReactNode } from "react";
 import {
+  Car,
   Clock3,
   Copy,
   ExternalLink,
@@ -343,6 +344,52 @@ export function SharedWithMeCard({
           </Button>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* PickupEnRouteCard (Now tab: helper is driving to the requester)    */
+/* ------------------------------------------------------------------ */
+
+export function PickupEnRouteCard({
+  helperName,
+  etaText,
+  children,
+  onCancel,
+  cancelBusy,
+}: {
+  helperName: string;
+  etaText: string;
+  /** Live map preview rendered by the parent via vm.renderMapPreview(point, false). */
+  children?: ReactNode;
+  onCancel: () => void;
+  cancelBusy?: boolean;
+}) {
+  return (
+    <div className={cn(SUBCARD_SURFACE, "space-y-3 p-3.5")}>
+      <div className="flex items-center gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#007aff]/12 text-[#007aff]">
+          <Car className="h-5 w-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-semibold text-foreground">
+            {helperName} is on the way
+          </p>
+          <p className={cn(MUTED_TEXT, "truncate")}>{etaText}</p>
+        </div>
+        <StatusPill tone="live">Live</StatusPill>
+      </div>
+      {children}
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={onCancel}
+        isLoading={cancelBusy}
+        className="h-9 w-full rounded-full text-sm"
+      >
+        Cancel pickup
+      </Button>
     </div>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -212,6 +212,10 @@ export type LocationHubViewModel = {
     pickupPoint?: { latitude: number; longitude: number; label?: string },
   ) => void;
 
+  /* "I'm on my way" — helper reverse share: creates a drive-style grant back to
+     the requester so they can watch the helper approach their pickup point. */
+  onImOnMyWay: (grant: OneLocationGrant) => void;
+
   /* Safe Arrival (quick action) — outbound: share your live journey + ETA to a
      destination until you arrive, framed for peace-of-mind. Reuses the same
      encrypted drive pipeline as Drive To (destination + ETA ride inside the

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1344,6 +1344,11 @@ function InboxHub({
               const point = vm.decryptedPoints[grant.id];
               const previewExpanded =
                 Boolean(point) && !collapsedGrantIds.has(grant.id);
+              const enRoute = vm.activeOwnerGrants.some(
+                (g) =>
+                  g.shareKind === "pickup_enroute" &&
+                  g.recipientUserId === grant.ownerUserId,
+              );
               return (
                 <SharedWithMeCard
                   key={grant.id}
@@ -1359,6 +1364,10 @@ function InboxHub({
                   onView={() => onExpandGrant(grant)}
                   onDismiss={() => onCollapseGrant(grant.id)}
                   viewBusy={vm.busy === "view"}
+                  message={grant.shareMessage ?? undefined}
+                  isPickup={grant.shareKind === "pick_me_up"}
+                  onImOnMyWay={() => vm.onImOnMyWay(grant)}
+                  enRoute={enRoute}
                 >
                   {previewExpanded && point
                     ? vm.renderMapPreview(point, true)

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -97,6 +97,7 @@ import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 import { DriveToFlow } from "./drive-to-flow";
 import { PickMeUpFlow } from "./pick-me-up-flow";
 import { SafeArrivalFlow } from "./safe-arrival-flow";
+import { deriveEnRouteHelpers } from "./pickup-enroute";
 
 
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
@@ -573,30 +574,13 @@ function NowHub({
   // Condition: a received grant with shareKind === "pickup_enroute" that has a
   // decrypted live point AND for whom the current user has an active outbound
   // "pick_me_up" grant (i.e. the mutual-share pair is complete).
-  const enRouteHelpers = vm.receivedGrants
-    .filter(
-      (g) =>
-        g.shareKind === "pickup_enroute" &&
-        Boolean(vm.decryptedPoints[g.id]),
-    )
-    .flatMap((receivedGrant) => {
-      const outboundGrant = vm.activeOwnerGrants.find(
-        (g) =>
-          g.shareKind === "pick_me_up" &&
-          g.recipientUserId === receivedGrant.ownerUserId,
-      );
-      if (!outboundGrant) return [];
-      const point = vm.decryptedPoints[receivedGrant.id]!;
-      return [
-        {
-          key: receivedGrant.id,
-          helperName: vm.grantOwnerLabel(receivedGrant),
-          point,
-          etaSeconds: point.drive?.etaSeconds ?? null,
-          outboundGrantId: outboundGrant.id,
-        },
-      ];
-    });
+  const enRouteHelpers = deriveEnRouteHelpers({
+    receivedGrants: vm.receivedGrants,
+    // activeOwnerGrants is pre-filtered to status === "active" by the vm.
+    activeOwnerGrants: vm.activeOwnerGrants,
+    decryptedPoints: vm.decryptedPoints,
+    labelFor: vm.grantOwnerLabel,
+  });
   const deviceReadinessCard = (
     <SectionCard title="Device readiness">
       <DeviceReadinessCard

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -73,11 +73,13 @@ import { SharingStatusCard } from "./sharing-status-card";
 import {
   ActiveShareCard,
   DeviceReadinessCard,
+  PickupEnRouteCard,
   RequestCard,
   SharedWithMeCard,
   TemporaryLinkCard,
   TrustedPersonCard,
 } from "./cards";
+import { driveEtaText } from "@/app/one/location/drive-eta";
 import {
   DurationSelector,
   LocationTypeSelector,
@@ -566,6 +568,35 @@ function NowHub({
   // surface the Device readiness card at the very TOP so the user immediately
   // sees how to fix it, instead of it sitting in the middle of the page.
   const readinessBlocked = vm.readiness.tone === "blocked";
+
+  // Derive helpers who are en route to pick up this user.
+  // Condition: a received grant with shareKind === "pickup_enroute" that has a
+  // decrypted live point AND for whom the current user has an active outbound
+  // "pick_me_up" grant (i.e. the mutual-share pair is complete).
+  const enRouteHelpers = vm.receivedGrants
+    .filter(
+      (g) =>
+        g.shareKind === "pickup_enroute" &&
+        Boolean(vm.decryptedPoints[g.id]),
+    )
+    .flatMap((receivedGrant) => {
+      const outboundGrant = vm.activeOwnerGrants.find(
+        (g) =>
+          g.shareKind === "pick_me_up" &&
+          g.recipientUserId === receivedGrant.ownerUserId,
+      );
+      if (!outboundGrant) return [];
+      const point = vm.decryptedPoints[receivedGrant.id]!;
+      return [
+        {
+          key: receivedGrant.id,
+          helperName: vm.grantOwnerLabel(receivedGrant),
+          point,
+          etaSeconds: point.drive?.etaSeconds ?? null,
+          outboundGrantId: outboundGrant.id,
+        },
+      ];
+    });
   const deviceReadinessCard = (
     <SectionCard title="Device readiness">
       <DeviceReadinessCard
@@ -598,6 +629,20 @@ function NowHub({
   return (
     <div className="space-y-5">
       {readinessBlocked ? deviceReadinessCard : null}
+
+      {/* En-route helpers: show one card per helper who tapped "I'm on my way".
+          Each card shows the helper's name, live ETA, map, and a cancel button
+          that revokes the requester's outbound pick_me_up grant. */}
+      {enRouteHelpers.map(({ key, helperName, point, etaSeconds, outboundGrantId }) => (
+        <PickupEnRouteCard
+          key={key}
+          helperName={helperName}
+          etaText={driveEtaText(etaSeconds)}
+          onCancel={() => vm.onStopGrant(outboundGrantId)}
+        >
+          {vm.renderMapPreview(point, false)}
+        </PickupEnRouteCard>
+      ))}
 
       <SharingStatusCard
         isSharing={hasActiveShare}

--- a/hushh-webapp/components/one-location/redesign/pickup-enroute.ts
+++ b/hushh-webapp/components/one-location/redesign/pickup-enroute.ts
@@ -1,0 +1,75 @@
+/**
+ * pickup-enroute.ts
+ *
+ * Pure derivation logic for the "helper is on the way" (en-route) card shown
+ * in the Pick Me Up mutual-share flow.
+ *
+ * Extracted from NowHub so that unit tests can import and exercise the real
+ * production logic rather than a local mirror copy.
+ */
+
+import type { OneLocationGrant, PlainLocationPoint } from "@/lib/one-location/types";
+
+export type EnRouteHelper = {
+  /** Stable key for React list rendering (equals the received grant id). */
+  key: string;
+  /** Display name of the person coming to pick up the current user. */
+  helperName: string;
+  /** The helper's latest decrypted location point. */
+  point: PlainLocationPoint;
+  /** Drive ETA in seconds, or null when no drive payload is present. */
+  etaSeconds: number | null;
+  /** The current user's outbound pick_me_up grant id — used to cancel. */
+  outboundGrantId: string;
+};
+
+/**
+ * Derives the list of helpers currently en-route to pick up the current user.
+ *
+ * Matching criteria (both conditions must hold):
+ *  1. A received grant with shareKind === "pickup_enroute" that has an
+ *     available decrypted location point.
+ *  2. An active outbound grant with shareKind === "pick_me_up" whose
+ *     recipientUserId matches the received grant's ownerUserId — i.e. the
+ *     mutual-share pair is complete.
+ *
+ * @param params.receivedGrants   Grants the current user has received.
+ * @param params.activeOwnerGrants  Outbound grants owned by the current user —
+ *   pre-filtered to status === "active" by the view-model before being passed in.
+ * @param params.decryptedPoints  Map of grant-id → decrypted location point.
+ * @param params.labelFor         Callback that returns the display name for a grant owner.
+ */
+export function deriveEnRouteHelpers(params: {
+  receivedGrants: OneLocationGrant[];
+  activeOwnerGrants: OneLocationGrant[];
+  decryptedPoints: Record<string, PlainLocationPoint>;
+  labelFor: (grant: OneLocationGrant) => string;
+}): EnRouteHelper[] {
+  const { receivedGrants, activeOwnerGrants, decryptedPoints, labelFor } = params;
+
+  return receivedGrants
+    .filter(
+      (g) =>
+        g.shareKind === "pickup_enroute" &&
+        Boolean(decryptedPoints[g.id]),
+    )
+    .flatMap((receivedGrant) => {
+      // activeOwnerGrants is pre-filtered to status === "active" by the vm.
+      const outboundGrant = activeOwnerGrants.find(
+        (g) =>
+          g.shareKind === "pick_me_up" &&
+          g.recipientUserId === receivedGrant.ownerUserId,
+      );
+      if (!outboundGrant) return [];
+      const point = decryptedPoints[receivedGrant.id]!;
+      return [
+        {
+          key: receivedGrant.id,
+          helperName: labelFor(receivedGrant),
+          point,
+          etaSeconds: point.drive?.etaSeconds ?? null,
+          outboundGrantId: outboundGrant.id,
+        },
+      ];
+    });
+}

--- a/hushh-webapp/lib/one-location/__tests__/drive-session-store.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/drive-session-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  restoreDriveSession,
+  type PersistedDriveSession,
+} from "@/lib/one-location/drive-session-store";
+import type { DriveDestination } from "@/lib/one-location/types";
+
+const destination: DriveDestination = {
+  label: "Indira Gandhi Intl Airport · T3",
+  latitude: 28.55,
+  longitude: 77.1,
+};
+
+function persisted(grantIds: string[]): PersistedDriveSession {
+  return {
+    grantIds,
+    destination,
+    etaSeconds: 1080,
+    distanceMeters: 7200,
+    etaComputedAt: "2026-07-13T00:00:00.000Z",
+  };
+}
+
+describe("restoreDriveSession", () => {
+  it("returns null when there is no persisted session", () => {
+    expect(restoreDriveSession(null, new Set(["g1"]))).toBeNull();
+  });
+
+  it("returns null when none of the persisted grants are still active", () => {
+    expect(restoreDriveSession(persisted(["g1"]), new Set(["other"]))).toBeNull();
+  });
+
+  it("restores the session (filtered to active grants) with ETA preserved and a fresh recompute cursor", () => {
+    const restored = restoreDriveSession(
+      persisted(["g1", "expired"]),
+      new Set(["g1", "g2"]),
+    );
+    expect(restored).not.toBeNull();
+    expect([...restored!.grantIds]).toEqual(["g1"]); // "expired" dropped, "g2" not ours
+    expect(restored!.destination).toEqual(destination);
+    expect(restored!.etaSeconds).toBe(1080); // last-known ETA shown immediately
+    expect(restored!.lastEtaPoint).toBeNull(); // forces a recompute on next publish
+    expect(restored!.lastEtaAt).toBe(0);
+  });
+});

--- a/hushh-webapp/lib/one-location/drive-session-store.ts
+++ b/hushh-webapp/lib/one-location/drive-session-store.ts
@@ -1,0 +1,111 @@
+import type { DriveDestination, PlainLocationPoint } from "@/lib/one-location/types";
+
+/**
+ * Durable persistence for the owner-side drive/ETA session.
+ *
+ * The live ETA rides inside each shared point as a `drive` payload, attached by
+ * the publisher's watch loop only while the grant is in the in-memory
+ * `driveSessionRef`. That ref does NOT survive a page refresh/remount, so
+ * without this the ETA silently stops after a refresh (the point keeps updating
+ * but loses its ETA). We persist the session and rehydrate it on mount for
+ * still-active grants so the watch loop resumes attaching the ETA.
+ */
+
+/** Serializable session (persisted to localStorage). */
+export type PersistedDriveSession = {
+  grantIds: string[];
+  destination: DriveDestination;
+  etaSeconds: number | null;
+  distanceMeters: number | null;
+  etaComputedAt: string;
+};
+
+/** In-memory session shape (mirrors `driveSessionRef.current`). */
+export type DriveSession = {
+  grantIds: Set<string>;
+  destination: DriveDestination;
+  etaSeconds: number | null;
+  distanceMeters: number | null;
+  etaComputedAt: string;
+  lastEtaPoint: PlainLocationPoint | null;
+  lastEtaAt: number;
+};
+
+function storageKey(userId: string): string {
+  return `hushh.one-location.drive-session.${userId}`;
+}
+
+function readStore(): Storage | null {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveDriveSession(
+  userId: string,
+  session: PersistedDriveSession,
+): Promise<void> {
+  const store = readStore();
+  if (!store || !userId) return;
+  try {
+    store.setItem(storageKey(userId), JSON.stringify(session));
+  } catch {
+    // best-effort; a failed persist only means ETA won't survive a refresh.
+  }
+}
+
+export async function loadPersistedDriveSession(
+  userId: string,
+): Promise<PersistedDriveSession | null> {
+  const store = readStore();
+  if (!store || !userId) return null;
+  try {
+    const raw = store.getItem(storageKey(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedDriveSession;
+    if (!parsed || !Array.isArray(parsed.grantIds) || !parsed.destination) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearDriveSession(userId: string): Promise<void> {
+  const store = readStore();
+  if (!store || !userId) return;
+  try {
+    store.removeItem(storageKey(userId));
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Rebuild the in-memory session from a persisted one, keeping only grants that
+ * are still active. Returns null when there's nothing to restore. The recompute
+ * cursor (`lastEtaPoint`/`lastEtaAt`) is reset so the next publish recomputes a
+ * fresh ETA, while the last-known ETA is kept so the recipient sees a value
+ * immediately after the publisher's refresh. Pure — safe to unit-test.
+ */
+export function restoreDriveSession(
+  persisted: PersistedDriveSession | null,
+  activeGrantIds: Set<string>,
+): DriveSession | null {
+  if (!persisted) return null;
+  const stillActive = persisted.grantIds.filter((id) => activeGrantIds.has(id));
+  if (stillActive.length === 0) return null;
+  return {
+    grantIds: new Set(stillActive),
+    destination: persisted.destination,
+    etaSeconds: persisted.etaSeconds,
+    distanceMeters: persisted.distanceMeters,
+    etaComputedAt: persisted.etaComputedAt,
+    lastEtaPoint: null,
+    lastEtaAt: 0,
+  };
+}

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -342,6 +342,7 @@ export class OneLocationService {
     recipientKeyId: string;
     durationHours: number;
     reason?: string;
+    shareKind?: string;
   }): Promise<OneLocationGrant> {
     const response = await apiJson<{ grant: OneLocationGrant }>(
       "/api/one/location/grants",
@@ -353,6 +354,7 @@ export class OneLocationService {
           recipientKeyId: params.recipientKeyId,
           durationHours: params.durationHours,
           ...(params.reason ? { reason: params.reason } : {}),
+          ...(params.shareKind ? { shareKind: params.shareKind } : {}),
         }),
       },
     );


### PR DESCRIPTION
## Summary
Makes Pick Me Up **mutual**: when the helper taps "I'm on my way", they share their live location + ETA back to the requester, who watches them approach on a Now-tab card.

- **Backend:** explicit `pick_me_up` / `pickup_enroute` **share kind** on `create_grant` (additive — absent → unchanged classification) + pickup notification copy. *(Needs a backend deploy.)*
- **Helper:** received pickup card now shows the message + an **"I'm on my way"** button → creates a drive-style reverse share to the requester's pickup point (`handleImOnMyWay` reuses the Drive-To pipeline, tagged `pickup_enroute`).
- **Requester:** a live **"[Helper] is on the way · ETA"** card on the Now tab (derivation extracted to `pickup-enroute.ts`; correlates inbound `pickup_enroute` ↔ active outbound `pick_me_up`; ETA from the drive payload; "Cancel pickup" revokes the outbound grant).
- **Bug fix (also fixes Drive To):** the live ETA used to vanish after a refresh because the drive/ETA session (`driveSessionRef`) was in-memory only. Now it's **persisted + rehydrated on mount** for active grants, so the ETA survives a refresh/remount.

## Testing
- Backend: `pytest` (routes + agent service) incl. explicit-kind + regression cases.
- Frontend: `vitest` — reverse-share, helper card, requester card + derivation, drive-session persistence; **166 One Location tests** pass; `tsc` + `eslint` clean.
- Verified on two iOS simulators against a local backend (requester + helper), including the refresh scenario.

## Notes
- No crypto/consent change; reverse grant is a normal `create_grant` (`enforce_connection`). Client-supplied `shareKind` is a known follow-up to allowlist server-side.
- Design/plan under `docs/superpowers/`.