### PR TITLE
fix(ria): scope mobile chrome and copy polish

### DIFF
--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -31,6 +31,8 @@ describe("Navbar bottom chrome contract", () => {
     expect(agentBar).toContain('data-native-voice-control-id="one_voice_agent_bar_start"');
     expect(agentBar).toContain('onClick={handleVoiceStartClick}');
     expect(agentBar).toContain('aria-label="Start conversation"');
+    expect(agentBar).toContain('const isRiaChrome = isRiaRoute(pathname ?? "")');
+    expect(agentBar).not.toContain('const isRiaChrome = activePersona === "ria"');
     expect(agentBar).not.toContain('aria-label="Talk to your agent"');
     expect(agentBar).not.toContain("<Mic");
   });

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -52,17 +52,18 @@ describe("Top app bar responsive contract", () => {
     expect(source).toContain("router.push(nextRoute);");
   });
 
-  it("renders the RIA header cluster for RIA persona and the onboarding setup route", () => {
+  it("keeps the RIA header cluster route-scoped so One home keeps the Agents dropdown", () => {
     const source = read("components/app-ui/top-app-bar.tsx");
 
     // Display-only "RIA v" cluster shown across the RIA sub-agent.
     expect(source).toContain('data-testid="top-app-bar-ria-cluster"');
-    // RIA home remains persona-gated, while setup gets an explicit route
-    // exception because it can load before activePersona flips to RIA.
+    // RIA chrome must be route-scoped. If activePersona remains "ria" after
+    // returning to /one, the launcher still renders the build-48 Agents
+    // dropdown instead of the hardcoded RIA cluster.
     expect(source).toContain("const isRiaOnboardingScope");
     expect(source).toContain("normalizedPathname === ROUTES.RIA_ONBOARDING");
-    expect(source).toContain('activePersona === "ria" || isRiaOnboardingScope');
-    expect(source).not.toContain("normalizedPathname === ROUTES.RIA_HOME");
+    expect(source).toContain("isRiaRoute(normalizedPathname)");
+    expect(source).not.toContain('activePersona === "ria" || isRiaOnboardingScope');
   });
 
   it("uses deterministic breadcrumb parents instead of browser history for top-bar back", () => {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -3422,6 +3422,48 @@ body[data-persona-surface="ria"] [data-surface-tone] {
   border-color: var(--app-card-border-standard) !important;
 }
 
+/* Page/section header subtitle: the shared PageHeader clamps the description to
+   one line (line-clamp-1), which truncated the old verbose RIA copy to "…". The
+   copy is now crisp, so let it read fully inside the RIA scope only. */
+body[data-persona-surface="ria"] [data-slot="page-header-description"],
+body[data-persona-surface="ria"] [data-slot="section-header-description"] {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+
+body[data-persona-surface="ria"] [data-testid="ria-picks-active"] input[type="search"] {
+  min-height: 48px;
+  border: 1px solid var(--ria-divider-outer);
+  border-radius: 16px;
+  background: var(--card);
+  color: var(--ria-ink);
+  box-shadow: none;
+}
+
+body[data-persona-surface="ria"] [data-testid="ria-picks-active"] input[type="search"]::placeholder {
+  color: var(--ria-faint);
+}
+
+body[data-persona-surface="ria"] [data-testid="ria-picks-active"] [data-slot="surface-data-table-shell"] {
+  border-color: var(--ria-divider-outer);
+  border-radius: 18px;
+  background: var(--card);
+  box-shadow: var(--app-card-shadow-standard);
+}
+
+body[data-persona-surface="ria"] [data-testid="ria-picks-active"] [data-slot="surface-data-table-shell"] thead {
+  background: color-mix(in oklab, var(--ria-canvas) 88%, white);
+}
+
+body[data-persona-surface="ria"] [data-testid="ria-picks-active"] [data-slot="surface-data-table-shell"] th {
+  color: var(--ria-sublabel);
+}
+
+body[data-persona-surface="ria"] [data-testid="ria-picks-active"] [data-slot="surface-data-table-shell"] td {
+  border-color: var(--ria-divider-inner);
+}
+
 /* RIA primitive helper classes (composed by onboarding + surface restyles). */
 body[data-persona-surface="ria"] .ria-eyebrow {
   font-size: 13px;

--- a/hushh-webapp/app/marketplace/page.tsx
+++ b/hushh-webapp/app/marketplace/page.tsx
@@ -57,6 +57,7 @@ import {
   type MarketplaceRia,
   type RiaClientAccess,
 } from "@/lib/services/ria-service";
+import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { cn } from "@/lib/utils";
 
 type DiscoveryView = "swipe" | "list";
@@ -104,10 +105,12 @@ function ProfileAvatar({
   kind,
   label,
   className,
+  riaSurface = false,
 }: {
   kind: "ria" | "investor";
   label: string;
   className?: string;
+  riaSurface?: boolean;
 }) {
   const Icon = kind === "ria" ? Building2 : UserRound;
   const initials = label
@@ -121,14 +124,25 @@ function ProfileAvatar({
     <div
       className={cn(
         "flex h-14 w-14 items-center justify-center rounded-[20px] border shadow-[0_20px_50px_-34px_rgba(15,23,42,0.28)]",
-        kind === "ria"
+        riaSurface
+          ? "border-[color:var(--foundation-accent-border)] bg-[radial-gradient(circle_at_top,rgba(201,139,46,0.16),transparent_58%),linear-gradient(180deg,rgba(255,253,249,0.98),rgba(248,241,229,0.88))]"
+          : kind === "ria"
           ? "border-accent-border bg-[radial-gradient(circle_at_top,rgba(212,165,116,0.18),transparent_58%),linear-gradient(180deg,rgba(255,255,255,0.96),rgba(248,250,252,0.92))]"
           : "border-emerald-500/15 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.16),transparent_58%),linear-gradient(180deg,rgba(255,255,255,0.96),rgba(248,250,252,0.92))]",
         className
       )}
     >
       <div className="flex flex-col items-center justify-center gap-1">
-        <Icon className={cn("h-4 w-4", kind === "ria" ? "text-accent-strong" : "text-emerald-700")} />
+        <Icon
+          className={cn(
+            "h-4 w-4",
+            riaSurface
+              ? "text-[color:var(--ria-gold)]"
+              : kind === "ria"
+                ? "text-accent-strong"
+                : "text-emerald-700"
+          )}
+        />
         <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-foreground/72">
           {initials || (kind === "ria" ? "RIA" : "INV")}
         </span>
@@ -183,6 +197,7 @@ export default function MarketplacePage() {
   const kaiTestUserId = getKaiTestUserId();
   const currentPersona =
     personaState?.active_persona || personaState?.last_active_persona || "investor";
+  const isRiaConnectSurface = currentPersona === "ria";
   const directoryKind = currentPersona === "ria" ? "investors" : "rias";
   const searchPlaceholder = "Search people by name, advisor, or investor";
 
@@ -669,13 +684,11 @@ export default function MarketplacePage() {
         kind: "ria" as const,
         title: ria.display_name,
         headline: ria.headline || "Advisor profile available",
-        summary:
-          ria.strategy_summary ||
-          "Explore public fit cues first, then open the profile sheet before you connect.",
+        summary: ria.strategy_summary || RIA_COPY.connect.summaryFallback,
         metaLine:
           Array.isArray(ria.firms) && ria.firms.length > 0
             ? ria.firms.map((firm) => firm.legal_name).join(" • ")
-            : "Public advisory profile",
+            : RIA_COPY.connect.publicProfile,
         canConnect,
         isTestProfile: false,
         verificationStatus: ria.verification_status,
@@ -1089,17 +1102,21 @@ export default function MarketplacePage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow="SEBI-registered network"
-          title="Connect"
-          description="Find a registered advisor. Connect with consent."
+          eyebrow={RIA_COPY.connect.eyebrow}
+          title={RIA_COPY.connect.title}
+          description={RIA_COPY.connect.description}
           icon={Compass}
-          accent="marketplace"
+          accent={isRiaConnectSurface ? "ria" : "marketplace"}
           actions={
             <Button
               variant="none"
               effect="fade"
               size="sm"
-              className="rounded-full bg-card px-3 shadow-[var(--app-card-shadow-standard)]"
+              className={cn(
+                "rounded-full bg-card px-3 shadow-[var(--app-card-shadow-standard)]",
+                isRiaConnectSurface &&
+                  "border border-[color:var(--ria-divider-outer)] text-[color:var(--ria-ink)]"
+              )}
               onClick={() => router.push(connectionsRoute)}
             >
               Connections
@@ -1116,7 +1133,10 @@ export default function MarketplacePage() {
                 type="button"
                 className={cn(
                   "grid h-10 w-10 place-items-center rounded-full border-0 bg-card text-foreground transition-[background-color,transform] duration-200 hover:scale-105 active:scale-95",
-                  searchOpen && "bg-primary/10 text-primary"
+                  searchOpen &&
+                    (isRiaConnectSurface
+                      ? "bg-[color:var(--ria-nav-active)] text-[color:var(--ria-gold-deep)]"
+                      : "bg-primary/10 text-primary")
                 )}
                 aria-label="Toggle search"
                 onClick={() => setSearchOpen((current) => !current)}
@@ -1148,7 +1168,10 @@ export default function MarketplacePage() {
                 type="button"
                 className={cn(
                   "grid h-10 w-10 place-items-center rounded-full border-0 bg-card text-foreground transition-[background-color,transform] duration-200 hover:scale-105 active:scale-95",
-                  view === "swipe" && "bg-primary/10 text-primary"
+                  view === "swipe" &&
+                    (isRiaConnectSurface
+                      ? "bg-[color:var(--ria-nav-active)] text-[color:var(--ria-gold-deep)]"
+                      : "bg-primary/10 text-primary")
                 )}
                 aria-label="Swipe view"
                 onClick={() => setView("swipe")}
@@ -1159,7 +1182,10 @@ export default function MarketplacePage() {
                 type="button"
                 className={cn(
                   "grid h-10 w-10 place-items-center rounded-full border-0 bg-card text-foreground transition-[background-color,transform] duration-200 hover:scale-105 active:scale-95",
-                  view === "list" && "bg-primary/10 text-primary"
+                  view === "list" &&
+                    (isRiaConnectSurface
+                      ? "bg-[color:var(--ria-nav-active)] text-[color:var(--ria-gold-deep)]"
+                      : "bg-primary/10 text-primary")
                 )}
                 aria-label="List view"
                 onClick={() => setView("list")}
@@ -1227,6 +1253,7 @@ export default function MarketplacePage() {
                     kind={match.kind}
                     label={match.display_name}
                     className="h-11 w-11 rounded-2xl"
+                    riaSurface={isRiaConnectSurface}
                   />
                   <span className="min-w-0 flex-1">
                     <span className="block line-clamp-1 text-sm font-medium text-foreground">
@@ -1278,7 +1305,12 @@ export default function MarketplacePage() {
                 >
                   <div className="space-y-5">
                     <div className="flex items-center gap-4">
-                      <ProfileAvatar kind={swipeCard.kind} label={swipeCard.title} className="h-20 w-20 shrink-0 rounded-[24px]" />
+                      <ProfileAvatar
+                        kind={swipeCard.kind}
+                        label={swipeCard.title}
+                        className="h-20 w-20 shrink-0 rounded-[24px]"
+                        riaSurface={isRiaConnectSurface}
+                      />
                       <div className="min-w-0 space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <h3 className="text-[22px] font-semibold leading-tight tracking-normal text-foreground sm:text-[24px]">
@@ -1377,12 +1409,12 @@ export default function MarketplacePage() {
           ) : (
             <div className="flex flex-col items-center justify-center gap-4 px-6 py-14 text-center">
               <h3 className="text-[18px] font-semibold leading-tight tracking-normal text-foreground">
-                {investorDeckComplete ? "Deck complete" : "That&apos;s everyone for now"}
+                {investorDeckComplete ? "Deck complete" : RIA_COPY.connect.deckComplete.title}
               </h3>
               <p className="max-w-xl text-sm leading-6 text-muted-foreground">
                 {investorDeckComplete
-                  ? `You handled every eligible investor in this deck. ${investorSavedLeadCount} saved lead${investorSavedLeadCount === 1 ? "" : "s"} remain in your shortlist.`
-                  : `You've browsed through all available ${directoryKind === "rias" ? "advisors" : "investors"} in this session. New profiles appear as more people join the marketplace.`}
+                  ? `Deck cleared. ${investorSavedLeadCount} saved lead${investorSavedLeadCount === 1 ? "" : "s"} in your shortlist.`
+                  : RIA_COPY.connect.deckComplete.description}
               </p>
               {directoryKind === "investors" && investorDeckMeta ? (
                 <p className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
@@ -1417,7 +1449,11 @@ export default function MarketplacePage() {
                 className="flex h-full min-h-[286px] flex-col gap-4 rounded-[28px] p-4 sm:p-5"
               >
                 <div className="flex items-start gap-4">
-                  <ProfileAvatar kind={item.kind} label={item.title} />
+                  <ProfileAvatar
+                    kind={item.kind}
+                    label={item.title}
+                    riaSurface={isRiaConnectSurface}
+                  />
                   <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
                       <h3 className="text-[15.5px] font-medium leading-[1.24] tracking-normal text-foreground sm:text-[16px]">
@@ -1516,10 +1552,8 @@ export default function MarketplacePage() {
         }
         description={
           selectedProfile?.kind === "ria"
-            ? selectedAdvisor?.headline ||
-              "Review this advisor profile before you decide whether to connect."
-            : selectedInvestor?.headline ||
-              "Review this investor profile before you decide whether to connect."
+            ? selectedAdvisor?.headline || RIA_COPY.connect.detail.description
+            : selectedInvestor?.headline || RIA_COPY.connect.detail.description
         }
       >
         <div className="space-y-4">
@@ -1535,7 +1569,12 @@ export default function MarketplacePage() {
           {selectedProfile?.kind === "ria" && selectedAdvisor ? (
             <>
               <div className="flex items-start gap-4">
-                <ProfileAvatar kind="ria" label={selectedAdvisor.display_name} className="h-16 w-16" />
+                <ProfileAvatar
+                  kind="ria"
+                  label={selectedAdvisor.display_name}
+                  className="h-16 w-16"
+                  riaSurface={isRiaConnectSurface}
+                />
                 <div className="space-y-2">
                   {selectedInjectedRia ? (
                     <span className="inline-flex rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700">
@@ -1556,7 +1595,7 @@ export default function MarketplacePage() {
                   {selectedAdvisor.strategy_summary ||
                     selectedAdvisor.strategy ||
                     selectedAdvisor.bio ||
-                    "No public strategy summary is available yet."}
+                    RIA_COPY.connect.detail.strategyEmpty}
                 </p>
               </RiaSurface>
 
@@ -1599,7 +1638,12 @@ export default function MarketplacePage() {
           {selectedProfile?.kind === "investor" && selectedInvestor ? (
             <>
               <div className="flex items-start gap-4">
-                <ProfileAvatar kind="investor" label={selectedInvestor.display_name} className="h-16 w-16" />
+                <ProfileAvatar
+                  kind="investor"
+                  label={selectedInvestor.display_name}
+                  className="h-16 w-16"
+                  riaSurface={isRiaConnectSurface}
+                />
                 <div className="space-y-2">
                   {selectedInvestorIsTest ? (
                     <span className="inline-flex rounded-full border border-amber-500/20 bg-amber-500/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700">

--- a/hushh-webapp/app/ria/clients/page.tsx
+++ b/hushh-webapp/app/ria/clients/page.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/services/ria-service";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { RIA_TONE_BADGE } from "@/lib/ria/ria-tone";
+import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { cn } from "@/lib/utils";
 import { RiaCompatibilityState, RiaVerificationGate } from "@/components/ria/ria-page-shell";
 
@@ -159,8 +160,8 @@ export default function RiaClientsPage() {
           }}
         />
         <RiaCompatibilityState
-          title="Complete RIA onboarding"
-          description="Finish onboarding to access the client roster."
+          title={RIA_COPY.clients.setupGate.title}
+          description={RIA_COPY.clients.setupGate.description}
         />
       </>
     );
@@ -184,10 +185,10 @@ export default function RiaClientsPage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow="Clients"
+          eyebrow={RIA_COPY.clients.eyebrow}
           title={
             <span className="inline-flex flex-wrap items-center gap-2">
-              Client roster
+              {RIA_COPY.clients.title}
               {clientItems.length > 0 ? (
                 <Badge variant="secondary" className="text-[10px]">
                   {clientItems.length}
@@ -195,7 +196,7 @@ export default function RiaClientsPage() {
               ) : null}
             </span>
           }
-          description="Open dedicated client workspaces for relationship status, access management, Kai parity, and the structured explorer."
+          description={RIA_COPY.clients.description}
           icon={UserRound}
           accent="ria"
         />
@@ -206,17 +207,17 @@ export default function RiaClientsPage() {
         <div className="flex flex-col gap-8">
           <SettingsGroup
             embedded
-            title="Connected investors"
-            description="Open a client once and keep relationship state, access, Kai parity, and the explorer in the same workspace."
+            title={RIA_COPY.clients.section.title}
+            description={RIA_COPY.clients.section.description}
           >
             {clientsResource.loading ? (
               <div className="flex items-center gap-2 px-4 py-6 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
-                Loading clients...
+                {RIA_COPY.clients.loading}
               </div>
             ) : clientItems.length === 0 ? (
               <div className="space-y-3 px-4 py-8 text-center">
-                <p className="text-sm text-muted-foreground">No connected investors yet.</p>
+                <p className="text-sm text-muted-foreground">{RIA_COPY.clients.empty}</p>
                 <Button
                   variant="none"
                   effect="fade"
@@ -224,7 +225,7 @@ export default function RiaClientsPage() {
                   data-voice-control-id="ria_clients_browse_marketplace"
                   onClick={() => router.push(ROUTES.MARKETPLACE)}
                 >
-                  Browse the marketplace
+                  {RIA_COPY.clients.browse}
                 </Button>
               </div>
             ) : (

--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -18,6 +18,7 @@ import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metada
 import { ROUTES } from "@/lib/navigation/routes";
 import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
 import { RIA_TONE_BADGE, RIA_TONE_SURFACE } from "@/lib/ria/ria-tone";
+import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { cn } from "@/lib/utils";
 
 type HeroTone = "neutral" | "warning" | "success" | "critical";
@@ -25,36 +26,17 @@ type HeroTone = "neutral" | "warning" | "success" | "critical";
 const EMPTY_QUEUE_ITEMS: RiaHomeResponse["needs_attention"] = [];
 
 function verificationState(status?: string | null) {
+  const copy = RIA_COPY.home.verification;
   switch (status) {
     case "active":
     case "verified":
-      return {
-        label: "Ready",
-        title: "Your advisor workspace is ready.",
-        description: "Relationships, picks, and investor requests can move without extra setup.",
-        tone: "success" as HeroTone,
-      };
+      return { ...copy.active, tone: "success" as HeroTone };
     case "submitted":
-      return {
-        label: "In review",
-        title: "Verification is still moving.",
-        description: "The workflow stays readable while trust checks finish in the background.",
-        tone: "warning" as HeroTone,
-      };
+      return { ...copy.submitted, tone: "warning" as HeroTone };
     case "rejected":
-      return {
-        label: "Needs update",
-        title: "A few trust details need another pass.",
-        description: "Refresh the profile so investor access and advisor sharing can continue cleanly.",
-        tone: "critical" as HeroTone,
-      };
+      return { ...copy.rejected, tone: "critical" as HeroTone };
     default:
-      return {
-        label: "Draft",
-        title: "Finish the advisor setup once.",
-        description: "After that, the rest of the RIA workflow stays in the background.",
-        tone: "neutral" as HeroTone,
-      };
+      return { ...copy.draft, tone: "neutral" as HeroTone };
   }
 }
 
@@ -264,9 +246,9 @@ export default function RiaHomePage() {
   return (
     <RiaPageShell
       width="expanded"
-      eyebrow="RIA Home"
-      title="Trusted advisor ops"
-      description="See readiness, what needs attention, and where to go next without scanning a settings wall."
+      eyebrow={RIA_COPY.home.eyebrow}
+      title={RIA_COPY.home.title}
+      description={RIA_COPY.home.description}
       icon={BriefcaseBusiness}
       nativeTest={{
         routeId: "/ria",
@@ -305,30 +287,30 @@ export default function RiaHomePage() {
 
             <div className="grid gap-px overflow-hidden rounded-[22px] bg-border/60 sm:grid-cols-2 md:grid-cols-3 [&>*:last-child:nth-child(2n+1)]:sm:col-span-2 [&>*:last-child:nth-child(2n+1)]:md:col-span-1">
               <SummaryCell
-                label="Relationships"
+                label={RIA_COPY.home.summary.relationships.label}
                 value={String(activeClients)}
                 helper={
                   activeClients > 0
-                    ? "Investor connections with an active relationship."
-                    : "No client relationships are active yet."
+                    ? RIA_COPY.home.summary.relationships.has
+                    : RIA_COPY.home.summary.relationships.empty
                 }
               />
               <SummaryCell
-                label="Priority queue"
+                label={RIA_COPY.home.summary.priority.label}
                 value={String(needsAttention)}
                 helper={
                   needsAttention > 0
-                    ? "Only the next real decisions stay visible here."
-                    : "Home stays quiet until something truly needs action."
+                    ? RIA_COPY.home.summary.priority.has
+                    : RIA_COPY.home.summary.priority.empty
                 }
               />
               <SummaryCell
-                label="Open invites"
+                label={RIA_COPY.home.summary.invites.label}
                 value={String(inviteCount)}
                 helper={
                   inviteCount > 0
-                    ? "Private links still waiting for investor response."
-                    : "No invites are currently hanging in flight."
+                    ? RIA_COPY.home.summary.invites.has
+                    : RIA_COPY.home.summary.invites.empty
                 }
               />
             </div>
@@ -338,8 +320,8 @@ export default function RiaHomePage() {
     >
       {iamUnavailable ? (
         <RiaCompatibilityState
-          title="RIA home is waiting on the IAM rollout"
-          description="This environment still needs the IAM schema before advisor readiness and relationship data can load cleanly."
+          title={RIA_COPY.home.iam.title}
+          description={RIA_COPY.home.iam.description}
         />
       ) : null}
 
@@ -349,11 +331,10 @@ export default function RiaHomePage() {
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1">
                 <p className="text-sm font-semibold tracking-tight text-foreground">
-                  Priority queue
+                  {RIA_COPY.home.queue.heading}
                 </p>
                 <p className="text-sm leading-6 text-muted-foreground">
-                  Relationships, approvals, and invites only appear here when they still need a
-                  real move from you.
+                  {RIA_COPY.home.queue.description}
                 </p>
               </div>
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/55 bg-background/70 text-muted-foreground">
@@ -363,13 +344,12 @@ export default function RiaHomePage() {
 
             <div className="overflow-hidden rounded-[20px] border border-border/60 bg-background/70">
               {homeResource.loading && !homeResource.data ? (
-                <InlineLoadingState label="Pulling readiness, relationships, and picks state." />
+                <InlineLoadingState label={RIA_COPY.home.queue.loading} />
               ) : null}
 
               {!homeResource.loading && queueItems.length === 0 ? (
                 <div className="px-4 py-5 text-sm text-muted-foreground">
-                  Nothing urgent right now. When a relationship, consent request, or invite needs
-                  the next move, it will land here.
+                  {RIA_COPY.home.queue.empty}
                 </div>
               ) : null}
 
@@ -392,7 +372,7 @@ export default function RiaHomePage() {
                       </Badge>
                     </div>
                     <p className="text-sm leading-6 text-muted-foreground">
-                      {item.subtitle || item.next_action || "Review the next step."}
+                      {item.subtitle || item.next_action || RIA_COPY.home.queue.itemFallback}
                     </p>
                   </div>
                   <Link

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -54,6 +54,7 @@ import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { Button } from "@/lib/morphy-ux/button";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { useVault } from "@/lib/vault/vault-context";
 import {
   isIAMSchemaNotReadyError,
@@ -148,18 +149,18 @@ const DEFAULT_AVOID_CATEGORIES = [
 const SCREENING_SECTIONS: Array<{ key: ScreeningSectionKey; label: string; blurb: string }> = [
   {
     key: "investable_requirements",
-    label: "Investable requirements",
-    blurb: "Non-negotiables that a company must satisfy before it can enter the live debate universe.",
+    label: RIA_COPY.picks.screening.investable.title,
+    blurb: RIA_COPY.picks.screening.investable.description,
   },
   {
     key: "automatic_avoid_triggers",
-    label: "Automatic avoid triggers",
-    blurb: "Hard stops and fast-fail signals that should move a name out of consideration.",
+    label: RIA_COPY.picks.screening.avoidTriggers.title,
+    blurb: RIA_COPY.picks.screening.avoidTriggers.description,
   },
   {
     key: "the_math",
-    label: "The math",
-    blurb: "Repeatable thresholds, scorecards, and quantified hurdles the debate engine should carry into review.",
+    label: RIA_COPY.picks.screening.math.title,
+    blurb: RIA_COPY.picks.screening.math.description,
   },
 ];
 
@@ -443,12 +444,10 @@ function EmptyMyListState() {
     <SurfaceCard data-testid="ria-picks-active">
       <SurfaceCardContent className="p-6">
         <h3 className="text-base font-semibold tracking-tight text-foreground">
-          Build your live advisor package
+          {RIA_COPY.picks.emptyMyList.title}
         </h3>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-          Your linked investors will consume this package in Kai&apos;s debate flow. Start from
-          Kai&apos;s current universe, use the editor above to shape your tiers and thesis, or
-          upload a CSV that replaces top picks while keeping the same validation standards.
+          {RIA_COPY.picks.emptyMyList.description}
         </p>
       </SurfaceCardContent>
     </SurfaceCard>
@@ -2274,9 +2273,9 @@ export default function RiaPicksPage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow="Picks"
-          title="Stock universe"
-          description="Switch between Kai's reference package and your live advisor package without losing the avoid or screening context that feeds linked-investor debates."
+          eyebrow={RIA_COPY.picks.eyebrow}
+          title={RIA_COPY.picks.title}
+          description={RIA_COPY.picks.description}
           icon={FileSpreadsheet}
           accent="ria"
         />
@@ -2391,7 +2390,7 @@ export default function RiaPicksPage() {
                 </div>
                 {!isVaultUnlocked ? (
                   <p className="px-1 text-center text-xs text-muted-foreground">
-                    Unlock the vault to edit or publish your advisor package.
+                    {RIA_COPY.picks.unlockRail}
                   </p>
                 ) : null}
               </SurfaceCardContent>
@@ -2561,10 +2560,9 @@ export default function RiaPicksPage() {
               {source === "my" && !editing && myAvoidRows.length === 0 ? (
                 <SurfaceCard>
                   <SurfaceCardContent className="p-5">
-                    <p className="text-sm font-semibold text-foreground">Avoid list is empty</p>
+                    <p className="text-sm font-semibold text-foreground">{RIA_COPY.picks.avoidEmpty.title}</p>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      Add names you want Kai to treat as hard or soft exclusions before the linked
-                      investor debate begins.
+                      {RIA_COPY.picks.avoidEmpty.description}
                     </p>
                   </SurfaceCardContent>
                 </SurfaceCard>

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -46,6 +46,7 @@ import {
   ROUTES,
   isFoundationPublicRoute,
   isOneSetupRoute,
+  isRiaRoute,
 } from "@/lib/navigation/routes";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { usePersonaState } from "@/lib/persona/persona-context";
@@ -199,7 +200,7 @@ export function AgentBar() {
   const { user } = useAuth();
   const { resolvedTheme, setTheme } = useTheme();
   const { vaultOwnerToken } = useVault();
-  const { switchPersona, activePersona } = usePersonaState();
+  const { switchPersona } = usePersonaState();
   const busyOperations = useKaiSession((state) => state.busyOperations);
   const setAnalysisParams = useKaiSession((state) => state.setAnalysisParams);
   const appendMirrorEvent = useOneConversationSession(
@@ -927,7 +928,9 @@ export function AgentBar() {
   const { progress: hideBottomChromeProgress } =
     useKaiBottomChromeVisibility(allowScrollHide);
   // RIA sub-agent = Apple-style ALWAYS-PINNED ask-bar (matches the pinned nav).
-  const isRiaChrome = activePersona === "ria";
+  // This is route-scoped, not persona-scoped: /one must keep the build-48
+  // shared ask bar even if the last active persona is RIA.
+  const isRiaChrome = isRiaRoute(pathname ?? "");
 
   const hint = useMemo(() => resolveAgentBarHint(pathname), [pathname]);
 

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -76,7 +76,7 @@ import {
 } from "@/lib/flows/delete-account";
 import { VaultService } from "@/lib/services/vault-service";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
-import { ROUTES } from "@/lib/navigation/routes";
+import { ROUTES, isRiaRoute } from "@/lib/navigation/routes";
 import { DebateTaskCenter } from "@/components/app-ui/debate-task-center";
 import { AgentSectionDropdown } from "@/components/app-ui/agent-section-dropdown";
 import { getAgentSection } from "@/lib/navigation/agent-sections";
@@ -500,12 +500,12 @@ export function TopAppBar({ className }: TopAppBarProps) {
   const isRiaOnboardingScope =
     normalizedPathname === ROUTES.RIA_ONBOARDING ||
     normalizedPathname.startsWith(`${ROUTES.RIA_ONBOARDING}/`);
-  // RIA sub-agent header: 🤫 One (left) + center "RIA ⌄" cluster, per the
-  // onboarding design. During setup the route can load before the persona state
-  // flips to RIA, so include /ria/onboarding explicitly while keeping other RIA
-  // routes persona-gated.
+  // RIA sub-agent header is route-scoped, not persona-scoped. A user can return
+  // to /one while activePersona remains "ria"; the /one launcher must still
+  // show the canonical Agents dropdown from build 48.
   const isRiaScope =
-    (activePersona === "ria" || isRiaOnboardingScope) && !topShellBreadcrumb;
+    (isRiaRoute(normalizedPathname) || isRiaOnboardingScope) &&
+    !topShellBreadcrumb;
   const showKaiTabs = topShellMetrics.hasTabs;
   const [switchingPersona, setSwitchingPersona] = useState<Persona | null>(
     null,

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -5,6 +5,7 @@ import type { LucideIcon } from "lucide-react";
 import { BriefcaseBusiness, ShieldAlert, ShieldCheck, TriangleAlert } from "lucide-react";
 
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 
 import {
   AppPageContentRegion,
@@ -256,15 +257,14 @@ export function RiaVerificationGate({ children }: { children: ReactNode }) {
     return (
       <section className="space-y-3">
         <SectionHeader
-          eyebrow="Verification required"
-          title="Complete advisor verification first"
-          description="Non-verified advisors cannot access investor information. Finish the verification flow in onboarding, then come back."
+          eyebrow={RIA_COPY.clients.verifyGate.eyebrow}
+          title={RIA_COPY.clients.verifyGate.title}
+          description={RIA_COPY.clients.verifyGate.description}
           icon={ShieldAlert}
         />
         <RiaSurface tone="warning" className="border-dashed">
           <p className="text-sm leading-6 text-muted-foreground">
-            Investor data, client workspaces, and consent requests are locked until
-            regulatory verification is complete.
+            {RIA_COPY.clients.verifyGate.body}
           </p>
         </RiaSurface>
       </section>

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -1,0 +1,142 @@
+/**
+ * RIA screen copy — single source of truth for the user-facing strings on the
+ * RIA data screens (Home, Clients, Picks, Connect).
+ *
+ * Voice: Apple-clean and crisp — every line says the same thing in ~3 words.
+ * Real page components import this directly; isolated UI-Dev previews can reuse
+ * it so mockups do not drift from production copy.
+ * Copy-only: changing a string here changes wording, never behaviour.
+ *
+ * Deep Picks editor/validation micro-copy stays inline in the page (not shown
+ * in the mockups); only the primary visible strings live here.
+ */
+
+export const RIA_COPY = {
+  home: {
+    eyebrow: "RIA Home",
+    title: "Trusted advisor ops",
+    description: "See what's ready and what needs you.",
+    verification: {
+      active: {
+        label: "Ready",
+        title: "Your advisor workspace is ready.",
+        description: "Relationships, picks, and requests — no setup needed.",
+      },
+      submitted: {
+        label: "In review",
+        title: "Verification is still moving.",
+        description: "Trust checks are finishing in the background.",
+      },
+      rejected: {
+        label: "Needs update",
+        title: "A few details need another pass.",
+        description: "Refresh your profile to keep access flowing.",
+      },
+      draft: {
+        label: "Draft",
+        title: "Finish advisor setup once.",
+        description: "Then the rest stays in the background.",
+      },
+    },
+    summary: {
+      relationships: {
+        label: "Relationships",
+        has: "Active investor relationships.",
+        empty: "No active relationships yet.",
+      },
+      priority: {
+        label: "Priority queue",
+        has: "Only real decisions show here.",
+        empty: "Quiet until something needs action.",
+      },
+      invites: {
+        label: "Open invites",
+        has: "Links awaiting investor response.",
+        empty: "No invites pending.",
+      },
+    },
+    queue: {
+      heading: "Priority queue",
+      description: "Only things that need your move appear here.",
+      loading: "Loading readiness and relationships.",
+      empty: "Nothing urgent. New actions land here.",
+      itemFallback: "Review the next step.",
+      open: "Open",
+    },
+    iam: {
+      title: "RIA home needs the IAM rollout",
+      description: "This environment needs the IAM schema first.",
+    },
+  },
+
+  clients: {
+    eyebrow: "Clients",
+    title: "Client roster",
+    description: "One workspace per client — status, access, Kai, explorer.",
+    section: {
+      title: "Connected investors",
+      description: "Status, access, Kai, and explorer in one place.",
+    },
+    loading: "Loading clients…",
+    empty: "No connected investors yet.",
+    browse: "Browse the marketplace",
+    setupGate: {
+      title: "Complete RIA onboarding",
+      description: "Finish onboarding to open the roster.",
+    },
+    verifyGate: {
+      eyebrow: "Verification required",
+      title: "Verify your advisor account first",
+      description: "Finish verification in onboarding to access investors.",
+      body: "Locked until verification is complete.",
+    },
+  },
+
+  picks: {
+    eyebrow: "Picks",
+    title: "Stock universe",
+    description: "Switch Kai's package and yours — avoid and screening stay.",
+    screening: {
+      investable: {
+        title: "Investable requirements",
+        description: "Must-haves before a name enters debates.",
+      },
+      avoidTriggers: {
+        title: "Automatic avoid triggers",
+        description: "Hard stops that drop a name.",
+      },
+      math: {
+        title: "The math",
+        description: "Thresholds and scorecards for the engine.",
+      },
+    },
+    emptyMyList: {
+      title: "Build your live package",
+      description:
+        "Shape the package your investors debate. Start from Kai, edit tiers, or upload a CSV.",
+    },
+    avoidEmpty: {
+      title: "Avoid list is empty",
+      description: "Add names for Kai to exclude from debates.",
+    },
+    unlockRail: "Unlock the vault to edit or publish.",
+  },
+
+  connect: {
+    eyebrow: "SEBI-registered network",
+    title: "Connect",
+    description: "Find a registered advisor. Connect with consent.",
+    deckComplete: {
+      title: "That's everyone for now",
+      description: "You've seen everyone. More join soon.",
+    },
+    detail: {
+      description: "Review before you connect.",
+      strategyEmpty: "No public strategy yet.",
+    },
+    summaryFallback: "Check fit, then open the profile.",
+    publicProfile: "Public advisory profile",
+  },
+} as const;
+
+export type RiaScreenCopy = typeof RIA_COPY;


### PR DESCRIPTION
## Summary
- keep One home on the build-48 shared Agents header/ask-bar even when the last active persona is RIA
- add shared RIA screen copy for Home, Clients, Picks, and Connect
- polish RIA-scoped headers/table/search styling without touching backend behavior

## Verification
- npx vitest run __tests__/components/top-app-bar.contract.test.ts __tests__/components/navbar-agent-trigger.contract.test.ts __tests__/components/navbar-bottom-nav.test.tsx
- npm run typecheck
- npm run verify:design-system
- npm run verify:capacitor:static

## Deploy note
- frontend-only UAT deploy requested after merge
- no backend deploy
- no TestFlight build