### PR TITLE
fix(mobile): restore complete Capacitor static export

### DIFF
--- a/hushh-webapp/next.config.ts
+++ b/hushh-webapp/next.config.ts
@@ -30,12 +30,11 @@ const config: NextConfig = {
   // Trailing slash is important for static export routing
   trailingSlash: isCapacitorBuild,
 
-  // Page Extensions Strategy for Mobile Build
-  // Mobile static export still needs TS resolution for App Router internals.
-  // `cap:build` applies the app-page-only build-path filter that keeps web-only
-  // app/api route handlers out of Capacitor bundles.
+  // Capacitor only needs authored React routes. Keeping `.ts` out of the page
+  // extension set excludes web-only App Router handlers such as app/api/**/route.ts
+  // from the static export without relying on Next's selective build-path mode.
   pageExtensions: isCapacitorBuild
-    ? ["tsx", "ts"] // Mobile: Include TypeScript app-loader resolution.
+    ? ["tsx", "cap"] // Keep two entries: Next 16 mis-serializes singleton extension arrays.
     : ["tsx", "ts", "jsx", "js"], // Web: Include everything
 
   images: {

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -50,7 +50,7 @@
     "smoke:analytics:uat": "node ./scripts/testing/run-uat-analytics-smoke.mjs",
     "audit:cache-coherence": "node ./scripts/architecture/audit-cache-coherence.mjs --check",
     "audit:ui-surfaces": "node ./scripts/architecture/audit-ui-surfaces.mjs",
-    "cap:build": "npx cross-env CAPACITOR_BUILD=true next build --webpack --debug-build-paths \"app/**/page.tsx,!app/api/**\"",
+    "cap:build": "npx cross-env CAPACITOR_BUILD=true next build --webpack",
     "cap:sync:android": "npx cross-env CAPACITOR_PLATFORM=android npx cap sync android",
     "cap:sync:ios": "npx cross-env CAPACITOR_PLATFORM=ios npx cap sync ios",
     "ios:run": "npm run cap:build && npm run cap:sync:ios && npx cap run ios",

--- a/hushh-webapp/scripts/architecture/generate-surface-map.mjs
+++ b/hushh-webapp/scripts/architecture/generate-surface-map.mjs
@@ -19,6 +19,10 @@ function readJson(filePath) {
   return JSON.parse(read(filePath));
 }
 
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
 function routeValuesFromRoutesTs(source) {
   return [
     ...new Set(
@@ -31,10 +35,12 @@ function routeValuesFromRoutesTs(source) {
 
 function routeValuesFromAppPages() {
   return walkFiles(path.join(appRoot, "app"), (filePath) =>
-    filePath.endsWith("/page.tsx"),
+    toPosixPath(filePath).endsWith("/page.tsx"),
   )
     .map((filePath) => {
-      const relative = path.relative(path.join(appRoot, "app"), filePath);
+      const relative = toPosixPath(
+        path.relative(path.join(appRoot, "app"), filePath),
+      );
       const route = relative.replace(/(?:^|\/)page\.tsx$/, "");
       return route ? `/${route}` : "/";
     })
@@ -78,9 +84,11 @@ function routeToVoiceContractFile(route) {
 }
 
 function apiTemplateFromRouteFile(filePath) {
-  const relative = path.relative(path.join(appRoot, "app/api"), filePath);
+  const relative = toPosixPath(
+    path.relative(path.join(appRoot, "app/api"), filePath),
+  );
   const withoutRoute = relative.replace(/\/route\.ts$/, "");
-  const parts = withoutRoute.split(path.sep).map((part) => {
+  const parts = withoutRoute.split("/").map((part) => {
     const catchAll = part.match(/^\[\.\.\.(.+)\]$/);
     if (catchAll) return `{${catchAll[1]}*}`;
     const dynamic = part.match(/^\[(.+)\]$/);
@@ -396,11 +404,11 @@ function buildSurfaceMap() {
     (inventory.routes || []).map((route) => [route.route, route]),
   );
   const apiRoutes = walkFiles(path.join(appRoot, "app/api"), (filePath) =>
-    filePath.endsWith("/route.ts"),
+    toPosixPath(filePath).endsWith("/route.ts"),
   )
     .map((filePath) => ({
       template: apiTemplateFromRouteFile(filePath),
-      file: path.relative(appRoot, filePath),
+      file: toPosixPath(path.relative(appRoot, filePath)),
     }))
     .sort((left, right) => left.template.localeCompare(right.template));
 


### PR DESCRIPTION
## Summary
- replace the selective Next build-path export that silently emitted only the 404 shell
- exclude web-only TypeScript API handlers from Capacitor route discovery while preserving all TSX app routes
- make surface-map generation path-stable on Windows and Linux

## Verification
- npm run cap:build (Next 16.2.10): 106 static pages generated
- verified out/index.html and out/one/location/index.html
- npm run typecheck
- npm run verify:surface-map
- npm run verify:capacitor:static
- npm run verify:capacitor:plugins
- Gradle :app:assembleDebug and :app:assembleRelease
- APK v2 signature verification for the installable debug/UAT test artifact

## Release note
The repository still needs its existing Play/upload keystore configured before a production-signed APK/AAB can be issued.