### PR TITLE
fix(web): harden One setup redirect guard

### DIFF
--- a/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  pathname: "/one",
+  routerReplace: vi.fn(),
+  bootstrapState: vi.fn(),
+  auth: {
+    user: { uid: "user-1" },
+    loading: false,
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({
+    replace: mocks.routerReplace,
+  }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => mocks.auth,
+}));
+
+vi.mock("@/components/app-ui/hushh-loader", () => ({
+  HushhLoader: ({ label }: { label: string }) => (
+    <div data-testid="hushh-loader">{label}</div>
+  ),
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    bootstrapState: mocks.bootstrapState,
+    isSetupResolved: (state: { setupCompleted?: boolean | null }) =>
+      state?.setupCompleted === true,
+  },
+}));
+
+import { OnboardingJourneyGuard } from "@/components/onboarding/onboarding-journey-guard";
+
+const WEBAPP_ROOT = path.resolve(__dirname, "../..");
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+function incompleteSetupState() {
+  return {
+    userId: "user-1",
+    setupCompleted: false,
+    onboardingJourneyVersion: 1,
+    onboardingPhase: "setup_hub",
+    onboardingActiveCapability: null,
+  };
+}
+
+describe("OnboardingJourneyGuard", () => {
+  beforeEach(() => {
+    mocks.pathname = "/one";
+    mocks.routerReplace.mockReset();
+    mocks.bootstrapState.mockReset();
+    mocks.auth = {
+      user: { uid: "user-1" },
+      loading: false,
+    };
+    window.history.replaceState(null, "", "/one");
+  });
+
+  it("redirects an explicitly incomplete One journey to the setup hub", async () => {
+    mocks.bootstrapState.mockResolvedValue(incompleteSetupState());
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>one home</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.routerReplace).toHaveBeenCalledWith(
+        "/one/setup?return_to=%2Fone",
+      );
+    });
+    expect(screen.getByTestId("hushh-loader").textContent).toBe(
+      "Returning to setup...",
+    );
+  });
+
+  it("admits the canonical setup hub even when setup is incomplete", async () => {
+    mocks.pathname = "/one/setup";
+    window.history.replaceState(null, "", "/one/setup?return_to=%2Fone");
+    mocks.bootstrapState.mockResolvedValue(incompleteSetupState());
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>setup hub</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("setup hub")).toBeTruthy();
+    });
+    expect(mocks.routerReplace).not.toHaveBeenCalled();
+  });
+
+  it("keeps a hard setup fallback when App Router navigation does not commit", () => {
+    const source = read("components/onboarding/onboarding-journey-guard.tsx");
+
+    expect(source).toContain("SETUP_REDIRECT_WATCHDOG_MS");
+    expect(source).toContain("router.replace(setupRoute)");
+    expect(source).toContain("window.location.pathname !== ROUTES.ONE_SETUP");
+    expect(source).toContain("window.location.assign(setupRoute)");
+  });
+});

--- a/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
+++ b/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { HushhLoader } from "@/components/app-ui/hushh-loader";
@@ -17,6 +17,8 @@ import {
   PreVaultUserStateService,
   type PreVaultUserState,
 } from "@/lib/services/pre-vault-user-state-service";
+
+const SETUP_REDIRECT_WATCHDOG_MS = 2400;
 
 function hasExplicitIncompleteSetup(state: PreVaultUserState): boolean {
   if (PreVaultUserStateService.isSetupResolved(state)) return false;
@@ -51,6 +53,9 @@ export function OnboardingJourneyGuard({
   const [error, setError] = useState<string | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
   const [redirecting, setRedirecting] = useState(false);
+  const redirectWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const currentHref = useMemo(() => {
     if (typeof window === "undefined") return pathname;
@@ -59,6 +64,14 @@ export function OnboardingJourneyGuard({
 
   useEffect(() => {
     let cancelled = false;
+
+    function clearRedirectWatchdog() {
+      if (redirectWatchdogRef.current === null) return;
+      clearTimeout(redirectWatchdogRef.current);
+      redirectWatchdogRef.current = null;
+    }
+
+    clearRedirectWatchdog();
     setRedirecting(false);
 
     async function verifyAdmission() {
@@ -107,7 +120,17 @@ export function OnboardingJourneyGuard({
         }
 
         setRedirecting(true);
-        router.replace(buildOneSetupRoute({ returnTo: currentHref }));
+        const setupRoute = buildOneSetupRoute({ returnTo: currentHref });
+        router.replace(setupRoute);
+        redirectWatchdogRef.current = setTimeout(() => {
+          if (cancelled || typeof window === "undefined") return;
+          if (window.location.pathname !== ROUTES.ONE_SETUP) {
+            window.location.assign(setupRoute);
+            return;
+          }
+          setRedirecting(false);
+          setChecking(false);
+        }, SETUP_REDIRECT_WATCHDOG_MS);
       } catch (cause) {
         console.warn(
           "[OnboardingJourneyGuard] Failed to verify setup admission:",
@@ -123,6 +146,7 @@ export function OnboardingJourneyGuard({
     void verifyAdmission();
     return () => {
       cancelled = true;
+      clearRedirectWatchdog();
     };
   }, [
     authLoading,


### PR DESCRIPTION
## Summary
- add a watchdog fallback for incomplete One setup redirects so native/web cannot hang forever on Returning to setup
- add direct OnboardingJourneyGuard coverage for incomplete /one redirect and /one/setup admission

## Scope
- frontend-only: hushh-webapp guard + test
- no backend/API/schema changes

## Verification
- cd hushh-webapp && npx vitest run __tests__/components/onboarding-journey-guard.test.tsx __tests__/lib/onboarding-route-admission.test.ts __tests__/navigation/routes.test.ts __tests__/services/post-auth-route-service.test.ts __tests__/services/capability-setup-state-service.test.ts __tests__/components/one-dashboard-page.test.tsx __tests__/components/one-setup-hub-terminal-action.contract.test.ts __tests__/components/setup-completion-footer.contract.test.ts __tests__/components/top-app-bar.contract.test.ts __tests__/navigation/home-shell-contract.test.ts __tests__/components/navbar-agent-trigger.contract.test.ts __tests__/navigation/app-bottom-nav.test.ts __tests__/components/navbar-bottom-nav.test.tsx __tests__/app/one/one-onboarding-capability-client.test.tsx __tests__/utils/top-shell-breadcrumbs.test.ts __tests__/lib/kai-bottom-chrome-visibility.test.ts
- cd hushh-webapp && npm run typecheck
- python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py

## UAT deploy plan
- after merge and Main Post-Merge Smoke success, dispatch deploy-uat.yml with scope=frontend and exact merged main SHA
