### PR TITLE
feat(synthetic): planet-scale HumanProfile engine + Meta-glasses execution plans

### DIFF
--- a/consent-protocol/scripts/synthetic_profiles/README.md
+++ b/consent-protocol/scripts/synthetic_profiles/README.md
@@ -1,0 +1,91 @@
+# Synthetic HumanProfile v0 — a planet-scale, zero-PII population
+
+A pure, deterministic function `generate(seed) -> HumanProfile` over the seed
+range `[0, 8_000_000_000)` — one address per human alive. Same seed, same human,
+byte-identical, forever. No storage: any of the 8 billion profiles materializes
+on demand and is thrown away. No real person's data is used or reproduced.
+
+This is the substrate for training, evaluating, and red-teaming personal
+superintelligence **before it ever touches a real human's life** — a
+Scale-AI-caliber data asset with, structurally, none of the PII liability.
+
+## What the scale claims actually mean (be precise; it's the point)
+
+| Claim | What it means, exactly |
+|---|---|
+| **8B address space** | Seeds `[0, 8e9)`. Every seed is O(1)-addressable and reproducible. This is a *guarantee about coverage*, not a stored table. |
+| **1B baseline** | A materialized sample of that space (JSONL, or landed on app tables). Not stored by default — generated when needed. Cost below. |
+| **0 PII** | Names/emails/phones are synthetic anchors on reserved ranges (`@profiles.example`, `+999…`). Every document carries `synthetic: true`. |
+| **∞ scenarios** | Any seed, any cohort slice, any marginals version — an unbounded scenario generator, not a fixed corpus. |
+
+Measure it yourself — the benchmark reports real throughput and an *honest*
+extrapolation, never a marketing number:
+
+```
+python -m scripts.synthetic_profiles.cli bench --count 50000
+```
+
+On a single modern core this is ~7–8k profiles/sec, so the **1B baseline is
+tens of core-hours** (well under an hour on 64 cores) and the **full 8B is a few
+core-hours on a modest cluster** — generation is embarrassingly parallel (pure
+function of seed), so throughput scales ~linearly with cores. Storage stays at
+zero because the seed *is* the profile.
+
+## Design properties that survive scrutiny
+
+- **Deterministic & machine-independent.** The RNG is seeded from
+  `sha256(marginals_version : seed)`; output depends only on that. Frozen golden
+  hashes (`tests/synthetic/test_scale_hardening.py`) fail loudly if a Python or
+  stdlib upgrade ever perturbs the stream.
+- **Unique ids across the whole space.** `profile_id` is a 96-bit (24-hex)
+  sha256 truncation. Expected collisions across all 8B: ~4e-10. (A 64-bit id
+  would have collided ~1.7 times — fixed.)
+- **Self-describing provenance.** Every document embeds `synthetic: true` and
+  its `marginals_version`, so `(seed + marginals_version)` reproduces it from the
+  JSON alone — no out-of-band context, and nothing can be mistaken for real data.
+- **Representative, not the rich-web sliver.** Region, age, income tier,
+  urbanicity, education, occupation, household, devices, and consent posture are
+  drawn against coarse 2026 world marginals (`marginals.py`). `stats` reports
+  observed-vs-target deviation.
+- **Internally coherent.** A "Priya" is never emitted male; children aren't
+  investors; wealth tracks income tier; consent stance shapes share-willingness.
+
+## The 90-second demo (deterministic, reproducible from an integer)
+
+```bash
+# 1. A vivid, coherent human from a single number — regenerate anywhere, same result.
+python -m scripts.synthetic_profiles.cli generate --seed 4193772206
+
+# 2. The population is honest about the whole world, not the online rich.
+python -m scripts.synthetic_profiles.cli stats --count 20000
+
+# 3. Prove the scale claim — measured throughput + honest core-hour extrapolation.
+python -m scripts.synthetic_profiles.cli bench --count 50000
+
+# 4. Address any sub-population for targeted training/eval — with an honest yield.
+python -m scripts.synthetic_profiles.cli cohort --region sub_saharan_africa \
+    --stance fortress --min-age 30 --max-age 55
+
+# 5. Schema-valid, unique, deterministic — checked, not asserted.
+python -m scripts.synthetic_profiles.cli validate --count 1000
+```
+
+The four curated showcase humans (open → pragmatic → guarded → fortress, across
+regions) live in `heroes.py` and reproduce from their seeds alone.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `generator.py` | `generate(seed)` — the pure function. Stdlib only. |
+| `marginals.py` | Editable world distributions + name/gender banks. Bump `MARGINALS_VERSION` on change. |
+| `heroes.py` | Curated showcase seeds with headlines. |
+| `cli.py` | `generate` / `sample` / `stats` / `validate` / `bench` / `cohort`. |
+| `schema/humanprofile_v0.schema.json` | The document contract (JSON Schema 2020-12). |
+
+## Honest status
+
+The generation engine, marginals, CLI, schema, and tests are real and green.
+Landing profiles onto live app tables (vault keys, actor rows, PKM documents) and
+persisting/tiering a standing 1B baseline in BigQuery/GCS are the next
+increments — the engine makes them a throughput exercise, not a research risk.

--- a/consent-protocol/scripts/synthetic_profiles/__init__.py
+++ b/consent-protocol/scripts/synthetic_profiles/__init__.py
@@ -1,0 +1,25 @@
+"""Synthetic HumanProfile v0 system.
+
+An 8-billion-profile address space with zero storage: profile(seed) is a pure
+deterministic function, stratified against world marginals so the generated
+population honestly represents all kinds of humans. Every profile is synthetic;
+no real person's data is used or reproduced.
+
+Modules:
+- generator: seed -> HumanProfile v0 document (pure, stdlib-only)
+- marginals: the editable world-distribution data
+- cli: generate / sample / stats / validate / bench / cohort
+
+See README.md for the scale claims (what "8B address space" and "1B baseline"
+mean precisely), the demo script, and the properties that survive scrutiny.
+"""
+
+from .generator import ADDRESS_SPACE, SCHEMA_VERSION, canonical_json, generate, profile_id_for_seed
+
+__all__ = [
+    "ADDRESS_SPACE",
+    "SCHEMA_VERSION",
+    "canonical_json",
+    "generate",
+    "profile_id_for_seed",
+]

--- a/consent-protocol/scripts/synthetic_profiles/cli.py
+++ b/consent-protocol/scripts/synthetic_profiles/cli.py
@@ -1,0 +1,250 @@
+"""CLI for the synthetic HumanProfile system.
+
+Usage (from consent-protocol/):
+    .venv/bin/python -m scripts.synthetic_profiles.cli generate --seed 4193772206
+    .venv/bin/python -m scripts.synthetic_profiles.cli sample --count 1000 --out /tmp/profiles.jsonl
+    .venv/bin/python -m scripts.synthetic_profiles.cli stats --count 20000
+    .venv/bin/python -m scripts.synthetic_profiles.cli validate --count 500
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+import time
+from pathlib import Path
+
+from .generator import ADDRESS_SPACE, canonical_json, generate, load_schema
+from .marginals import MARGINALS_VERSION, REGION_WEIGHTS
+
+
+def _cmd_generate(args: argparse.Namespace) -> int:
+    profile = generate(args.seed)
+    print(json.dumps(profile, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _cmd_sample(args: argparse.Namespace) -> int:
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    step = max(1, ADDRESS_SPACE // args.count)
+    with out.open("w", encoding="utf-8") as handle:
+        for i in range(args.count):
+            seed = (args.offset + i * step) % ADDRESS_SPACE
+            handle.write(canonical_json(generate(seed)) + "\n")
+    print(f"wrote {args.count} profiles to {out} (stride {step}, marginals {MARGINALS_VERSION})")
+    return 0
+
+
+def _cmd_stats(args: argparse.Namespace) -> int:
+    counters: dict[str, collections.Counter] = collections.defaultdict(collections.Counter)
+    step = max(1, ADDRESS_SPACE // args.count)
+    for i in range(args.count):
+        p = generate((i * step) % ADDRESS_SPACE)
+        d = p["demographics"]
+        counters["region"][d["region"]] += 1
+        counters["income_tier"][d["income_tier"]] += 1
+        counters["urbanicity"][d["urbanicity"]] += 1
+        counters["occupation"][d["occupation"]["group"]] += 1
+        counters["privacy_stance"][p["consent_posture"]["privacy_stance"]] += 1
+        age = d["age"]
+        counters["age_band"][f"{(age // 15) * 15:>3}-{(age // 15) * 15 + 14}"] += 1
+
+    print(f"population sample: {args.count} profiles (marginals {MARGINALS_VERSION})\n")
+    for dim, counter in counters.items():
+        print(f"== {dim} ==")
+        for key, n in counter.most_common():
+            share = n / args.count
+            bar = "#" * int(share * 60)
+            print(f"  {key:<24} {share:6.1%}  {bar}")
+        print()
+
+    expected = dict(REGION_WEIGHTS)
+    worst = max(
+        (abs(counters["region"][r] / args.count - w), r) for r, w in expected.items()
+    )
+    print(f"max region deviation from target marginals: {worst[0]:.2%} ({worst[1]})")
+    return 0
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    try:
+        import jsonschema
+    except ImportError:
+        print("jsonschema not installed in this environment", file=sys.stderr)
+        return 1
+    schema = load_schema()
+    validator = jsonschema.Draft202012Validator(schema)
+    step = max(1, ADDRESS_SPACE // args.count)
+    seen_ids: set[str] = set()
+    for i in range(args.count):
+        seed = (i * step) % ADDRESS_SPACE
+        profile = generate(seed)
+        errors = sorted(validator.iter_errors(profile), key=str)
+        if errors:
+            print(f"seed {seed}: INVALID — {errors[0].message}", file=sys.stderr)
+            return 1
+        if profile["profile_id"] in seen_ids:
+            print(f"seed {seed}: duplicate profile_id", file=sys.stderr)
+            return 1
+        seen_ids.add(profile["profile_id"])
+        # Determinism: regenerating must be byte-identical.
+        if canonical_json(generate(seed)) != canonical_json(profile):
+            print(f"seed {seed}: NON-DETERMINISTIC", file=sys.stderr)
+            return 1
+    print(f"validated {args.count} profiles: schema-valid, unique, deterministic")
+    return 0
+
+
+def _cmd_bench(args: argparse.Namespace) -> int:
+    """Measure real generation throughput and extrapolate — honestly — to the 1B
+    baseline and the full 8B space. The address space is O(1)-addressable with
+    zero storage, so "planet scale" is a throughput fact, not a storage claim."""
+    n = args.count
+    step = max(1, ADDRESS_SPACE // n)
+
+    # Warm up (imports, name banks) so we time steady-state generation only.
+    for i in range(min(1000, n)):
+        generate((i * step) % ADDRESS_SPACE)
+
+    latencies_us: list[float] = []
+    start = time.perf_counter()
+    for i in range(n):
+        t0 = time.perf_counter()
+        generate((i * step) % ADDRESS_SPACE)
+        latencies_us.append((time.perf_counter() - t0) * 1e6)
+    elapsed = time.perf_counter() - start
+
+    per_sec = n / elapsed if elapsed > 0 else float("inf")
+    latencies_us.sort()
+
+    def pct(p: float) -> float:
+        return latencies_us[min(len(latencies_us) - 1, int(p * len(latencies_us)))]
+
+    def core_hours(target: int) -> float:
+        return target / per_sec / 3600 if per_sec else float("inf")
+
+    print(f"HumanProfile v0 generation benchmark (marginals {MARGINALS_VERSION})")
+    print(f"  measured:      {n:,} profiles in {elapsed:.3f}s")
+    print(f"  throughput:    {per_sec:,.0f} profiles/sec  (single core, this machine)")
+    print(f"  latency/profile: p50 {pct(0.50):.1f}us  p99 {pct(0.99):.1f}us")
+    print("  storage:       0 bytes — any of the 8B profiles is O(1) from its seed")
+    print("  --- honest extrapolation at the measured single-core rate ---")
+    print(f"  1B baseline:   ~{core_hours(1_000_000_000):,.1f} core-hours "
+          f"(~{core_hours(1_000_000_000) / 64:,.1f}h on 64 cores)")
+    print(f"  full 8B space: ~{core_hours(ADDRESS_SPACE):,.1f} core-hours "
+          f"(~{core_hours(ADDRESS_SPACE) / 64:,.1f}h on 64 cores)")
+    print("  note: generation is embarrassingly parallel (pure function of seed); "
+          "throughput scales ~linearly with cores.")
+    return 0
+
+
+def cohort_match(
+    profile: dict,
+    *,
+    region: str | None = None,
+    stance: str | None = None,
+    income_tier: str | None = None,
+    sex: str | None = None,
+    min_age: int = 0,
+    max_age: int = 105,
+) -> bool:
+    """True iff the profile falls in the requested sub-population. Pure predicate
+    so the cohort contract is independently testable."""
+    d = profile["demographics"]
+    if region and d["region"] != region:
+        return False
+    if stance and profile["consent_posture"]["privacy_stance"] != stance:
+        return False
+    if income_tier and d["income_tier"] != income_tier:
+        return False
+    if sex and d["sex"] != sex:
+        return False
+    return min_age <= d["age"] <= max_age
+
+
+def _cmd_cohort(args: argparse.Namespace) -> int:
+    """Address a sub-population by demographic/consent filters — the world-model
+    slice you'd hand a trainer or evaluator. Sweeps a strided sample and keeps
+    the profiles that match, reporting the yield so the cohort size is honest."""
+    step = max(1, ADDRESS_SPACE // args.scan)
+    matches: list[dict] = []
+    for i in range(args.scan):
+        p = generate((i * step) % ADDRESS_SPACE)
+        if not cohort_match(
+            p, region=args.region, stance=args.stance, income_tier=args.income_tier,
+            sex=args.sex, min_age=args.min_age, max_age=args.max_age,
+        ):
+            continue
+        matches.append(p)
+        if args.limit and len(matches) >= args.limit:
+            break
+
+    yield_rate = len(matches) / args.scan if args.scan else 0.0
+    est_in_space = int(yield_rate * ADDRESS_SPACE)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w", encoding="utf-8") as handle:
+            for p in matches:
+                handle.write(canonical_json(p) + "\n")
+        print(f"wrote {len(matches)} matching profiles to {out}")
+    else:
+        for p in matches[:5]:
+            idn = p["identity"]
+            d = p["demographics"]
+            print(f"  {idn['display_name']:<26} {d['region']:<20} age {d['age']:<3} "
+                  f"{d['income_tier']:<20} {p['consent_posture']['privacy_stance']}")
+        if len(matches) > 5:
+            print(f"  ... and {len(matches) - 5} more")
+    print(f"cohort yield: {len(matches)}/{args.scan} scanned = {yield_rate:.2%} "
+          f"→ ~{est_in_space:,} such humans across the 8B space")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="synthetic_profiles", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_gen = sub.add_parser("generate", help="print one profile as JSON")
+    p_gen.add_argument("--seed", type=int, required=True)
+    p_gen.set_defaults(func=_cmd_generate)
+
+    p_sample = sub.add_parser("sample", help="write N profiles as JSONL, strided across the 8B space")
+    p_sample.add_argument("--count", type=int, default=1000)
+    p_sample.add_argument("--offset", type=int, default=0)
+    p_sample.add_argument("--out", type=str, required=True)
+    p_sample.set_defaults(func=_cmd_sample)
+
+    p_stats = sub.add_parser("stats", help="distribution report vs target marginals")
+    p_stats.add_argument("--count", type=int, default=10000)
+    p_stats.set_defaults(func=_cmd_stats)
+
+    p_val = sub.add_parser("validate", help="schema + uniqueness + determinism check")
+    p_val.add_argument("--count", type=int, default=500)
+    p_val.set_defaults(func=_cmd_validate)
+
+    p_bench = sub.add_parser("bench", help="measure throughput; extrapolate to 1B/8B (honest)")
+    p_bench.add_argument("--count", type=int, default=50000)
+    p_bench.set_defaults(func=_cmd_bench)
+
+    p_cohort = sub.add_parser("cohort", help="address a sub-population by demographic/consent filters")
+    p_cohort.add_argument("--scan", type=int, default=20000, help="profiles to sweep across the 8B space")
+    p_cohort.add_argument("--limit", type=int, default=0, help="stop after this many matches (0 = no cap)")
+    p_cohort.add_argument("--region", type=str, default=None)
+    p_cohort.add_argument("--stance", type=str, default=None, choices=["open", "pragmatic", "guarded", "fortress"])
+    p_cohort.add_argument("--income-tier", dest="income_tier", type=str, default=None)
+    p_cohort.add_argument("--sex", type=str, default=None, choices=["female", "male", "intersex"])
+    p_cohort.add_argument("--min-age", dest="min_age", type=int, default=0)
+    p_cohort.add_argument("--max-age", dest="max_age", type=int, default=105)
+    p_cohort.add_argument("--out", type=str, default=None, help="write matches as JSONL (else print a preview)")
+    p_cohort.set_defaults(func=_cmd_cohort)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/consent-protocol/scripts/synthetic_profiles/generator.py
+++ b/consent-protocol/scripts/synthetic_profiles/generator.py
@@ -1,0 +1,353 @@
+"""HumanProfile v0 deterministic generator.
+
+profile(seed) is a PURE FUNCTION: the same seed always yields byte-identical
+JSON, on any machine, forever (given the same MARGINALS_VERSION). That is the
+whole scaling trick — an 8-billion-profile address space with zero storage.
+
+Stdlib only. No network, no clock (timestamps are seed-derived), no randomness
+outside random.Random(seed).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+from . import marginals as M
+
+SCHEMA_VERSION = "humanprofile/v0"
+ADDRESS_SPACE = 8_000_000_000  # seeds [0, 8e9): one per human alive
+
+# profile_id is sha256(seed) truncated to this many hex chars. 24 hex = 96 bits.
+# At the full 8B population the expected number of id collisions is
+# N^2 / (2 * 2^96) ~= 4e-10, so ids are unique across every human in the space.
+# (A 64-bit / 16-hex id would collide ~1.7 times over 8B — not acceptable for an
+# id that doubles as a stable user_id.)
+PROFILE_ID_HEX = 24
+
+SCHEMA_PATH = Path(__file__).parent / "schema" / "humanprofile_v0.schema.json"
+
+# Fixed epoch for seed-derived "recent activity" timestamps so generation is
+# reproducible (never wall-clock). 2026-01-01T00:00:00Z in epoch millis.
+_EPOCH_2026_MS = 1_767_225_600_000
+
+
+def _weighted(rng: random.Random, pairs: list[tuple[str, float]]) -> str:
+    total = sum(w for _, w in pairs)
+    x = rng.random() * total
+    acc = 0.0
+    for value, weight in pairs:
+        acc += weight
+        if x <= acc:
+            return value
+    return pairs[-1][0]
+
+
+def _pick(rng: random.Random, pool: list[str], k: int) -> list[str]:
+    k = max(0, min(k, len(pool)))
+    return rng.sample(pool, k)
+
+
+def _clamp(value: int, lo: int = 0, hi: int = 100) -> int:
+    return max(lo, min(hi, value))
+
+
+def profile_id_for_seed(seed: int) -> str:
+    digest = hashlib.sha256(f"humanprofile/v0:{seed}".encode()).hexdigest()
+    return f"synth_{digest[:PROFILE_ID_HEX]}"
+
+
+def generate(seed: int) -> dict[str, Any]:
+    """Generate the HumanProfile v0 document for a seed. Pure and deterministic."""
+    if not 0 <= seed < ADDRESS_SPACE:
+        raise ValueError(f"seed must be in [0, {ADDRESS_SPACE})")
+
+    # noqa on S311: deterministic simulation, not cryptography — the whole design
+    # is a reproducible pseudo-random stream keyed by (marginals_version, seed).
+    rng = random.Random(hashlib.sha256(f"{M.MARGINALS_VERSION}:{seed}".encode()).digest())  # noqa: S311
+    pid = profile_id_for_seed(seed)
+
+    # ---- demographics (stratified) ----
+    region = _weighted(rng, M.REGION_WEIGHTS)
+    zone = rng.choice(M.COUNTRY_ZONES[region])
+    band_index = int(_weighted(rng, [(str(i), w) for i, (_, _, w) in enumerate(M.AGE_BANDS)]))
+    lo, hi, _ = M.AGE_BANDS[band_index]
+    age = rng.randint(lo, hi)
+    sex = _weighted(rng, M.SEX_WEIGHTS)
+    urbanicity = _weighted(rng, M.URBANICITY[region])
+    income_tier = _weighted(rng, M.INCOME_TIERS[region])
+    education = (
+        "none_or_primary" if age < 12 else _weighted(rng, M.EDUCATION_BY_TIER[income_tier])
+    )
+
+    if age < 15:
+        occ_group, occ_status = "student", "student"
+    elif age < 23 and rng.random() < 0.55:
+        occ_group, occ_status = "student", "student"
+    elif age >= 66 and rng.random() < 0.7:
+        occ_group, occ_status = "retired", "retired"
+    else:
+        occ_group = _weighted(rng, M.OCCUPATION_BY_URBANICITY[urbanicity])
+        occ_status = {
+            "informal_gig": "gig",
+            "homemaker": "homemaker",
+            "unemployed": "unemployed",
+        }.get(occ_group, "self_employed" if rng.random() < 0.25 else "employed")
+    occ_title = rng.choice(M.OCCUPATION_TITLES[occ_group])
+
+    household_type = next(
+        _weighted(rng, dist) for cutoff, dist in M.HOUSEHOLD_BY_AGE if age <= cutoff
+    )
+    household_size = {
+        "single": 1,
+        "couple": 2,
+        "shared": rng.randint(2, 5),
+        "single_parent": rng.randint(2, 5),
+        "nuclear_family": rng.randint(3, 6),
+        "multigenerational": rng.randint(4, 10),
+        "institutional": rng.randint(6, 14),
+    }[household_type]
+    dependents = 0
+    if household_type in ("nuclear_family", "single_parent", "multigenerational") and age >= 20:
+        dependents = rng.randint(0, min(5, household_size - 1))
+
+    langs = M.LANGUAGES[region]
+    languages = [langs[rng.randrange(min(4, len(langs)))]]
+    while rng.random() < 0.45 and len(languages) < 3:
+        extra = rng.choice(langs)
+        if extra not in languages:
+            languages.append(extra)
+
+    disability: list[str] = []
+    if rng.random() < 0.16:
+        disability.append(rng.choice(["vision", "hearing", "mobility", "cognitive", "chronic_pain"]))
+    else:
+        disability.append("none")
+
+    # ---- identity ----
+    given_bank, family_bank = M.NAME_BANKS[region]
+    given = rng.choice(given_bank)
+    family = rng.choice(family_bank)
+    # Keep sex coherent with the given name (a "Priya" is never emitted as male).
+    # Intersex profiles keep their drawn sex and they/them pronouns regardless of
+    # the name. This overrides only the drawn sex; no other field depends on it, so
+    # every other value for a given seed is unchanged.
+    if sex != "intersex":
+        sex = M.GIVEN_NAME_SEX.get(given, sex)
+    lang_tag = {"south_asia": "en-IN", "east_asia": "zh-CN", "sub_saharan_africa": "en-KE",
+                "southeast_asia": "id-ID", "europe": "en-GB", "latam_caribbean": "es-MX",
+                "mena": "ar-EG", "north_america": "en-US", "central_asia_oceania": "en-AU"}[region]
+    email = f"{given.lower()}.{family.lower().replace(' ', '')}.{pid[-6:]}@profiles.example"
+    phone_anchor = f"+999{seed % 10_000_000_000:010d}"  # +999 reserved/fictional prefix
+
+    # ---- psychographics (mildly correlated axes) ----
+    base = rng.gauss(50, 18)
+    traits = {
+        "openness": _clamp(int(rng.gauss(50 + (education in ("tertiary", "postgraduate")) * 8, 16))),
+        "conscientiousness": _clamp(int(rng.gauss(52, 16))),
+        "extraversion": _clamp(int(rng.gauss(50, 18))),
+        "agreeableness": _clamp(int(rng.gauss(54, 15))),
+        "emotional_stability": _clamp(int(rng.gauss(base * 0.3 + 35, 14))),
+    }
+    risk_tolerance = _clamp(int(rng.gauss(
+        38 + traits["openness"] * 0.2 + (income_tier in ("t4_50_to_200usd_day", "t5_over_200usd_day")) * 10 - max(0, age - 50) * 0.4,
+        14,
+    )))
+
+    # ---- world model ----
+    relationships = []
+    rel_roles = ["parent", "sibling", "spouse", "child", "close friend", "cousin",
+                 "neighbor", "coworker", "mentor", "accountant", "doctor", "community elder"]
+    for role in _pick(rng, rel_roles, rng.randint(3, 7)):
+        closeness = _weighted(rng, [("inner_circle", 0.25), ("close", 0.35), ("regular", 0.3), ("peripheral", 0.1)])
+        trusted_for = []
+        if role in ("spouse", "parent") and closeness == "inner_circle":
+            trusted_for = ["attr.financial", "attr.health", "attr.location"]
+        elif role == "accountant":
+            trusted_for = ["attr.financial"]
+        elif role == "doctor":
+            trusted_for = ["attr.health"]
+        elif closeness in ("inner_circle", "close"):
+            trusted_for = [rng.choice(["attr.location", "attr.social", "attr.entertainment"])]
+        relationships.append({"role": role, "closeness": closeness, "trusted_for": trusted_for})
+
+    places = [{"kind": "home", "label": f"{urbanicity} home, {zone}"}]
+    if occ_status in ("employed", "self_employed", "gig"):
+        places.append({"kind": "work", "label": occ_title})
+    if occ_status == "student":
+        places.append({"kind": "school", "label": "campus"})
+    for kind in _pick(rng, ["market", "worship", "clinic", "gym", "third_place"], rng.randint(1, 3)):
+        places.append({"kind": kind, "label": kind})
+
+    routines = _pick(rng, [
+        "early riser", "evening market run", "weekly family call", "daily commute",
+        "weekend religious service", "morning exercise", "late-night study",
+        "seasonal harvest rhythm", "monthly remittance day", "weekly ledger day",
+    ], rng.randint(2, 4))
+
+    devices = [_weighted(rng, M.DEVICES_BY_TIER[income_tier])]
+    if rng.random() < 0.4:
+        extra_device = _weighted(rng, M.DEVICES_BY_TIER[income_tier])
+        if extra_device not in devices:
+            devices.append(extra_device)
+
+    # ---- knowledge model ----
+    has_bank = income_tier not in ("t1_under_2usd_day",) or rng.random() < 0.35
+    risk_profile = ("conservative", "balanced", "growth", "aggressive")[min(3, risk_tolerance // 26)]
+    holdings: list[dict[str, Any]] = []
+    total_value = 0.0
+    if age >= 18:
+        wealth_scale = {
+            "t1_under_2usd_day": 120,
+            "t2_2_to_10usd_day": 900,
+            "t3_10_to_50usd_day": 14_000,
+            "t4_50_to_200usd_day": 90_000,
+            "t5_over_200usd_day": 600_000,
+        }[income_tier]
+        n_holdings = 0 if wealth_scale < 500 else rng.randint(1, 3 + (wealth_scale > 50_000) * 4)
+        asset_pools = {
+            True: ["equity", "etf", "bond", "cash", "gold", "crypto", "real_estate"],
+            False: ["cash", "gold", "livestock", "informal_savings"],
+        }[wealth_scale >= 14_000]
+        tickers = ["VTI", "VXUS", "BND", "GLD", "AAPL", "MSFT", "NVDA", "RELIANCE", "TSM", "SAP", "VALE", "BTC"]
+        for _ in range(n_holdings):
+            asset = rng.choice(asset_pools)
+            value = round(wealth_scale * rng.uniform(0.1, 0.9), 2)
+            holdings.append({
+                "ticker": rng.choice(tickers) if asset in ("equity", "etf") else asset.upper()[:6],
+                "asset_class": asset,
+                "value_usd": value,
+            })
+            total_value += value
+        if has_bank:
+            cash = round(wealth_scale * rng.uniform(0.05, 0.4), 2)
+            holdings.append({"ticker": "CASH", "asset_class": "cash", "value_usd": cash})
+            total_value += cash
+    debts = _pick(rng, ["home loan", "vehicle loan", "education loan", "shop credit",
+                        "medical debt", "credit card", "family loan"], rng.randint(0, 2))
+    money_goals = _pick(rng, M.ASPIRATIONS_POOL, 2)
+
+    knowledge_model = {
+        "financial": {
+            "has_bank_account": bool(has_bank),
+            "risk_profile": risk_profile,
+            "risk_score": risk_tolerance,
+            "holdings": holdings,
+            "total_value_usd": round(total_value, 2),
+            "debts": debts,
+            "money_goals": money_goals,
+        },
+        "professional": {
+            "skills": _pick(rng, ["negotiation", "bookkeeping", "customer care", "coding",
+                                  "machine repair", "teaching", "logistics", "design",
+                                  "irrigation", "sales", "writing", "first aid"], rng.randint(2, 4)),
+            "years_experience": max(0, age - 18 - rng.randint(0, 6)) if occ_status not in ("student",) else 0,
+            "work_style": rng.choice(["steady and careful", "fast and improvisational",
+                                      "collaborative", "independent", "seasonal bursts"]),
+        },
+        "social": {
+            "community_roles": _pick(rng, ["religious group member", "sports club", "parents' association",
+                                           "savings circle", "union member", "volunteer", "online community mod"],
+                                     rng.randint(0, 2)),
+            "network_size_bucket": _weighted(rng, [("tight", 0.3), ("moderate", 0.4), ("wide", 0.24), ("very_wide", 0.06)]),
+        },
+        "health": {
+            "fitness_habit": _weighted(rng, [("sedentary", 0.28), ("light", 0.32), ("moderate", 0.24), ("active", 0.13), ("athlete", 0.03)]),
+            "conditions_bucket": (["none"] if age < 35 and rng.random() < 0.75
+                                  else _pick(rng, ["metabolic", "cardio", "respiratory", "musculoskeletal",
+                                                   "mental_wellness", "vision_hearing"], rng.randint(1, 2))),
+            "sleep_pattern": _weighted(rng, [("short", 0.22), ("irregular", 0.26), ("regular", 0.44), ("long", 0.08)]),
+        },
+        "interests": _pick(rng, M.INTERESTS_POOL, rng.randint(3, 6)),
+    }
+
+    # ---- behavioral signals ----
+    digital_hours = round(max(0.0, rng.gauss(
+        {"feature_phone": 1.2, "none": 0.2}.get(devices[0], 3.8) + (age < 30) * 1.2 - (age > 60) * 1.0, 1.4)), 1)
+    behavioral = {
+        "digital_hours_per_day": min(18.0, digital_hours),
+        "primary_jobs_to_be_done": _pick(rng, M.JOBS_TO_BE_DONE_POOL, rng.randint(2, 4)),
+        "shopping_style": _weighted(rng, [("necessity_only", 0.24), ("value_hunter", 0.30), ("planner", 0.20),
+                                          ("impulse", 0.14), ("premium", 0.07), ("ethical", 0.05)]),
+        "media_diet": _pick(rng, M.MEDIA_DIET_POOL, rng.randint(2, 4)),
+        "agent_use_cases": _pick(rng, ["taxes and paperwork", "price comparison", "appointment wrangling",
+                                       "family logistics", "money tracking", "learning plans",
+                                       "health reminders", "document vault", "job search", "translations"],
+                                 rng.randint(2, 4)),
+    }
+
+    # ---- consent posture ----
+    stance = _weighted(rng, [("open", 0.14), ("pragmatic", 0.46), ("guarded", 0.3), ("fortress", 0.1)])
+    stance_base = {"open": 72, "pragmatic": 55, "guarded": 34, "fortress": 15}[stance]
+    share = {
+        fam: _clamp(int(rng.gauss(stance_base + (12 if fam in ("attr.entertainment", "attr.shopping") else 0)
+                                  - (18 if fam in ("attr.health", "attr.financial") else 0), 12)))
+        for fam in M.SCOPE_FAMILIES
+    }
+    consent_posture = {
+        "privacy_stance": stance,
+        "default_grant_duration_days": rng.choice([7, 14, 30, 30, 60, 90]),
+        "share_willingness": share,
+        "revocation_tendency": _weighted(rng, [("rarely", 0.5), ("sometimes", 0.38), ("often", 0.12)]),
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        # Provenance: every document is self-describing and un-mistakable for real
+        # data. `synthetic` is always true; `marginals_version` pins WHICH world
+        # distributions produced this profile, so (seed + marginals_version) fully
+        # reproduces it — the JSON alone is enough, no out-of-band context needed.
+        "synthetic": True,
+        "marginals_version": M.MARGINALS_VERSION,
+        "seed": seed,
+        "profile_id": pid,
+        "identity": {
+            "display_name": f"{given} {family}",
+            "given_name": given,
+            "family_name": family,
+            "email": email,
+            "phone_anchor": phone_anchor,
+            "locale": lang_tag,
+            "pronouns": {"female": "she/her", "male": "he/him", "intersex": "they/them"}[sex],
+        },
+        "demographics": {
+            "region": region,
+            "country_zone": zone,
+            "age": age,
+            "sex": sex,
+            "urbanicity": urbanicity,
+            "household": {"size": household_size, "type": household_type, "dependents": dependents},
+            "education_level": education,
+            "occupation": {"group": occ_group, "title": occ_title, "status": occ_status},
+            "income_tier": income_tier,
+            "languages": languages,
+            "disability": disability,
+        },
+        "psychographics": {
+            "traits": traits,
+            "values": _pick(rng, M.VALUES_POOL, rng.randint(2, 4)),
+            "aspirations": _pick(rng, M.ASPIRATIONS_POOL, rng.randint(1, 3)),
+            "stressors": _pick(rng, M.STRESSORS_POOL, rng.randint(1, 3)),
+            "risk_tolerance": risk_tolerance,
+        },
+        "world_model": {
+            "relationships": relationships,
+            "places": places,
+            "routines": routines,
+            "devices": devices,
+        },
+        "knowledge_model": knowledge_model,
+        "behavioral_signals": behavioral,
+        "consent_posture": consent_posture,
+    }
+
+
+def canonical_json(profile: dict[str, Any]) -> str:
+    return json.dumps(profile, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text())

--- a/consent-protocol/scripts/synthetic_profiles/heroes.py
+++ b/consent-protocol/scripts/synthetic_profiles/heroes.py
@@ -1,0 +1,63 @@
+"""Curated showcase "hero" seeds for the synthetic HumanProfile system.
+
+Hand-picked seeds whose generated profiles make vivid, coherent demo stories
+spanning region, income, age, household, and the full consent spectrum
+(open -> pragmatic -> guarded -> fortress). Everything is deterministic: the
+same seed always yields the same human, so a teammate can reproduce any demo
+from the seed alone -- no PII, no fixtures to keep in sync, just an integer.
+
+Usage:
+    from scripts.synthetic_profiles.heroes import heroes, HERO_SEEDS
+    for h in heroes():
+        print(h["headline"], h["profile"]["identity"]["display_name"])
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .generator import generate
+
+# The showcase set. Keep the headlines honest to what the seed actually produces.
+HERO_SEEDS: list[dict[str, Any]] = [
+    {
+        "seed": 4193772206,
+        "stance": "open",
+        "headline": "MENA homemaker, comfortable, opens up: One lines up remittance day, "
+        "school fees, and a missed tax deduction to clear the family loan a year early.",
+    },
+    {
+        "seed": 480000000,
+        "stance": "pragmatic",
+        "headline": "Rural Sub-Saharan fisher, eight-person household: One syncs the whole "
+        "family's clinic visits to market days from just shopping and location.",
+    },
+    {
+        "seed": 2020202020,
+        "stance": "guarded",
+        "headline": "82-year-old North American lawyer who revokes often: One previews the "
+        "credit-card gap without reading a balance, then asks for one revocable look.",
+    },
+    {
+        "seed": 1618033988,
+        "stance": "fortress",
+        "headline": "European fortress-privacy postal worker: One still finds better work "
+        "touching only location and professional, never health or money.",
+    },
+]
+
+
+def hero(seed: int) -> dict[str, Any]:
+    """Generate one hero profile with its curated headline."""
+    match = next((h for h in HERO_SEEDS if h["seed"] == seed), None)
+    return {
+        "seed": seed,
+        "stance": match["stance"] if match else None,
+        "headline": match["headline"] if match else None,
+        "profile": generate(seed),
+    }
+
+
+def heroes() -> list[dict[str, Any]]:
+    """The full curated showcase set, each with its generated profile."""
+    return [hero(h["seed"]) for h in HERO_SEEDS]

--- a/consent-protocol/scripts/synthetic_profiles/marginals.py
+++ b/consent-protocol/scripts/synthetic_profiles/marginals.py
@@ -1,0 +1,283 @@
+"""World marginals for HumanProfile v0 — the representativeness layer.
+
+Approximate 2026 world-population distributions, coarse by design. These are
+editable data, not gospel: refine any band and every profile regenerated from
+the same seed shifts with it (the generator is a pure function of seed +
+marginals version). Values are rounded from public, commonly-cited population
+statistics; the point is honest coverage of ALL kinds of humans — not just the
+rich, urban, extremely-online sliver most test data over-represents.
+
+MARGINALS_VERSION participates in determinism: bump it when you change data so
+downstream consumers know profiles moved.
+"""
+
+from __future__ import annotations
+
+MARGINALS_VERSION = "2026.07-v1"
+
+# Region shares of world population (sums to 1.0).
+REGION_WEIGHTS: list[tuple[str, float]] = [
+    ("south_asia", 0.25),
+    ("east_asia", 0.20),
+    ("sub_saharan_africa", 0.15),
+    ("southeast_asia", 0.09),
+    ("europe", 0.09),
+    ("latam_caribbean", 0.08),
+    ("mena", 0.07),
+    ("north_america", 0.05),
+    ("central_asia_oceania", 0.02),
+]
+
+# Coarse sub-region labels per region (uniform within region).
+COUNTRY_ZONES: dict[str, list[str]] = {
+    "south_asia": ["indo_gangetic", "deccan", "himalayan", "bengal_delta", "indus_valley"],
+    "east_asia": ["north_china_plain", "yangtze_delta", "pearl_delta", "japan_archipelago", "korean_peninsula", "inner_continental"],
+    "sub_saharan_africa": ["west_african_coast", "sahel", "horn", "great_lakes", "southern_cone_africa"],
+    "southeast_asia": ["mekong", "malay_archipelago", "philippine_islands", "mainland_highlands"],
+    "europe": ["western", "southern", "northern", "central_eastern", "balkans"],
+    "latam_caribbean": ["mexico_central_america", "andes", "southern_cone", "brazil_atlantic", "caribbean"],
+    "mena": ["maghreb", "nile_valley", "levant", "gulf", "anatolia_iran_plateau"],
+    "north_america": ["us_coastal", "us_interior", "canada_corridor", "us_south"],
+    "central_asia_oceania": ["steppe", "oceania_pacific", "australia_nz"],
+}
+
+# Age-band weights (world). (band_lo, band_hi, weight)
+AGE_BANDS: list[tuple[int, int, float]] = [
+    (0, 14, 0.25),
+    (15, 24, 0.15),
+    (25, 39, 0.23),
+    (40, 54, 0.17),
+    (55, 69, 0.13),
+    (70, 90, 0.065),
+    (91, 105, 0.005),
+]
+
+SEX_WEIGHTS: list[tuple[str, float]] = [
+    ("male", 0.504),
+    ("female", 0.494),
+    ("intersex", 0.002),
+]
+
+# Urbanicity by region.
+URBANICITY: dict[str, list[tuple[str, float]]] = {
+    "south_asia": [("urban", 0.36), ("peri_urban", 0.14), ("rural", 0.50)],
+    "east_asia": [("urban", 0.64), ("peri_urban", 0.12), ("rural", 0.24)],
+    "sub_saharan_africa": [("urban", 0.42), ("peri_urban", 0.13), ("rural", 0.45)],
+    "southeast_asia": [("urban", 0.50), ("peri_urban", 0.14), ("rural", 0.36)],
+    "europe": [("urban", 0.75), ("peri_urban", 0.10), ("rural", 0.15)],
+    "latam_caribbean": [("urban", 0.81), ("peri_urban", 0.08), ("rural", 0.11)],
+    "mena": [("urban", 0.66), ("peri_urban", 0.12), ("rural", 0.22)],
+    "north_america": [("urban", 0.82), ("peri_urban", 0.10), ("rural", 0.08)],
+    "central_asia_oceania": [("urban", 0.58), ("peri_urban", 0.10), ("rural", 0.32)],
+}
+
+# Income tier weights by region (per-capita/day PPP-style tiers).
+INCOME_TIERS: dict[str, list[tuple[str, float]]] = {
+    "south_asia": [("t1_under_2usd_day", 0.10), ("t2_2_to_10usd_day", 0.62), ("t3_10_to_50usd_day", 0.24), ("t4_50_to_200usd_day", 0.035), ("t5_over_200usd_day", 0.005)],
+    "east_asia": [("t1_under_2usd_day", 0.01), ("t2_2_to_10usd_day", 0.22), ("t3_10_to_50usd_day", 0.55), ("t4_50_to_200usd_day", 0.20), ("t5_over_200usd_day", 0.02)],
+    "sub_saharan_africa": [("t1_under_2usd_day", 0.35), ("t2_2_to_10usd_day", 0.48), ("t3_10_to_50usd_day", 0.14), ("t4_50_to_200usd_day", 0.027), ("t5_over_200usd_day", 0.003)],
+    "southeast_asia": [("t1_under_2usd_day", 0.04), ("t2_2_to_10usd_day", 0.48), ("t3_10_to_50usd_day", 0.40), ("t4_50_to_200usd_day", 0.075), ("t5_over_200usd_day", 0.005)],
+    "europe": [("t1_under_2usd_day", 0.002), ("t2_2_to_10usd_day", 0.05), ("t3_10_to_50usd_day", 0.42), ("t4_50_to_200usd_day", 0.48), ("t5_over_200usd_day", 0.048)],
+    "latam_caribbean": [("t1_under_2usd_day", 0.04), ("t2_2_to_10usd_day", 0.32), ("t3_10_to_50usd_day", 0.48), ("t4_50_to_200usd_day", 0.15), ("t5_over_200usd_day", 0.01)],
+    "mena": [("t1_under_2usd_day", 0.05), ("t2_2_to_10usd_day", 0.34), ("t3_10_to_50usd_day", 0.44), ("t4_50_to_200usd_day", 0.155), ("t5_over_200usd_day", 0.015)],
+    "north_america": [("t1_under_2usd_day", 0.002), ("t2_2_to_10usd_day", 0.02), ("t3_10_to_50usd_day", 0.30), ("t4_50_to_200usd_day", 0.58), ("t5_over_200usd_day", 0.098)],
+    "central_asia_oceania": [("t1_under_2usd_day", 0.03), ("t2_2_to_10usd_day", 0.30), ("t3_10_to_50usd_day", 0.42), ("t4_50_to_200usd_day", 0.23), ("t5_over_200usd_day", 0.02)],
+}
+
+# Education by (region-tier proxy): keyed on income tier for simplicity.
+EDUCATION_BY_TIER: dict[str, list[tuple[str, float]]] = {
+    "t1_under_2usd_day": [("none_or_primary", 0.55), ("secondary", 0.35), ("vocational", 0.06), ("tertiary", 0.035), ("postgraduate", 0.005)],
+    "t2_2_to_10usd_day": [("none_or_primary", 0.28), ("secondary", 0.45), ("vocational", 0.12), ("tertiary", 0.13), ("postgraduate", 0.02)],
+    "t3_10_to_50usd_day": [("none_or_primary", 0.08), ("secondary", 0.38), ("vocational", 0.17), ("tertiary", 0.30), ("postgraduate", 0.07)],
+    "t4_50_to_200usd_day": [("none_or_primary", 0.02), ("secondary", 0.22), ("vocational", 0.14), ("tertiary", 0.44), ("postgraduate", 0.18)],
+    "t5_over_200usd_day": [("none_or_primary", 0.01), ("secondary", 0.10), ("vocational", 0.07), ("tertiary", 0.47), ("postgraduate", 0.35)],
+}
+
+# Occupation groups by urbanicity (adults; the generator handles child/student/retired by age first).
+OCCUPATION_BY_URBANICITY: dict[str, list[tuple[str, float]]] = {
+    "urban": [
+        ("services_and_sales", 0.22), ("trades_and_industry", 0.13), ("clerical_admin", 0.09),
+        ("professional", 0.09), ("technical_engineering", 0.07), ("health_care", 0.05),
+        ("education", 0.05), ("creative_media", 0.03), ("public_service", 0.04),
+        ("management", 0.05), ("informal_gig", 0.13), ("homemaker", 0.03), ("unemployed", 0.02),
+    ],
+    "peri_urban": [
+        ("services_and_sales", 0.20), ("trades_and_industry", 0.16), ("agriculture", 0.08),
+        ("clerical_admin", 0.06), ("professional", 0.05), ("technical_engineering", 0.05),
+        ("health_care", 0.04), ("education", 0.05), ("creative_media", 0.02),
+        ("public_service", 0.04), ("management", 0.03), ("informal_gig", 0.15),
+        ("homemaker", 0.04), ("unemployed", 0.03),
+    ],
+    "rural": [
+        ("agriculture", 0.38), ("trades_and_industry", 0.10), ("services_and_sales", 0.12),
+        ("education", 0.04), ("health_care", 0.02), ("public_service", 0.03),
+        ("informal_gig", 0.18), ("homemaker", 0.08), ("unemployed", 0.05),
+    ],
+}
+
+OCCUPATION_TITLES: dict[str, list[str]] = {
+    "agriculture": ["smallholder farmer", "dairy farmer", "orchard keeper", "fisher", "agri-equipment operator"],
+    "trades_and_industry": ["electrician", "garment worker", "machinist", "construction lead", "welder", "auto mechanic"],
+    "services_and_sales": ["shopkeeper", "retail associate", "restaurant server", "salon owner", "delivery rider", "hotel front desk"],
+    "clerical_admin": ["office administrator", "bookkeeper", "logistics coordinator", "bank teller"],
+    "professional": ["accountant", "lawyer", "financial analyst", "consultant", "architect"],
+    "technical_engineering": ["software engineer", "data analyst", "civil engineer", "IT support specialist", "electronics technician"],
+    "health_care": ["nurse", "community health worker", "pharmacist", "physiotherapist", "physician"],
+    "education": ["primary school teacher", "secondary school teacher", "tutor", "university lecturer"],
+    "creative_media": ["graphic designer", "video editor", "musician", "photographer", "content writer"],
+    "public_service": ["municipal clerk", "police officer", "postal worker", "social worker"],
+    "management": ["operations manager", "store manager", "product manager", "site supervisor"],
+    "informal_gig": ["rideshare driver", "street vendor", "domestic worker", "freelance laborer", "market porter"],
+    "student": ["student"],
+    "homemaker": ["homemaker"],
+    "retired": ["retired"],
+    "unemployed": ["between jobs"],
+}
+
+# Household type by age band of the profile owner.
+HOUSEHOLD_BY_AGE: list[tuple[int, list[tuple[str, float]]]] = [
+    (17, [("nuclear_family", 0.62), ("multigenerational", 0.24), ("single_parent", 0.12), ("institutional", 0.02)]),
+    (29, [("shared", 0.22), ("single", 0.16), ("couple", 0.16), ("nuclear_family", 0.26), ("multigenerational", 0.18), ("single_parent", 0.02)]),
+    (54, [("nuclear_family", 0.44), ("couple", 0.18), ("multigenerational", 0.20), ("single", 0.10), ("single_parent", 0.08)]),
+    (105, [("couple", 0.36), ("single", 0.26), ("multigenerational", 0.30), ("nuclear_family", 0.06), ("institutional", 0.02)]),
+]
+
+# Languages by region (first = mother-tongue cluster; profiles get 1-3).
+LANGUAGES: dict[str, list[str]] = {
+    "south_asia": ["Hindi", "Bengali", "Urdu", "Tamil", "Telugu", "Marathi", "Punjabi", "English"],
+    "east_asia": ["Mandarin", "Cantonese", "Japanese", "Korean", "English"],
+    "sub_saharan_africa": ["Swahili", "Hausa", "Yoruba", "Amharic", "Zulu", "French", "English", "Portuguese"],
+    "southeast_asia": ["Indonesian", "Vietnamese", "Thai", "Filipino", "Burmese", "Khmer", "English"],
+    "europe": ["English", "German", "French", "Spanish", "Italian", "Polish", "Ukrainian", "Dutch"],
+    "latam_caribbean": ["Spanish", "Portuguese", "Haitian Creole", "Quechua", "English"],
+    "mena": ["Arabic", "Turkish", "Farsi", "Kurdish", "French", "English"],
+    "north_america": ["English", "Spanish", "French"],
+    "central_asia_oceania": ["Russian", "Kazakh", "Uzbek", "English", "Maori", "Tok Pisin"],
+}
+
+# Name banks per region: composed synthetic banks (given, family). Uniqueness at
+# 8B scale comes from the seed-derived ids, not name collisions.
+NAME_BANKS: dict[str, tuple[list[str], list[str]]] = {
+    "south_asia": (
+        ["Aarav", "Ananya", "Rohan", "Priya", "Kavya", "Arjun", "Meera", "Farhan", "Zara", "Ishaan", "Diya", "Nikhil"],
+        ["Sharma", "Patel", "Reddy", "Khan", "Iyer", "Das", "Chowdhury", "Kaur", "Fernandes", "Bhatt"],
+    ),
+    "east_asia": (
+        ["Wei", "Mei", "Jian", "Xiu", "Haruto", "Yuna", "Minjun", "Seoyeon", "Takeshi", "Li", "Hana", "Cheng"],
+        ["Wang", "Li", "Zhang", "Chen", "Sato", "Tanaka", "Kim", "Park", "Nakamura", "Liu"],
+    ),
+    "sub_saharan_africa": (
+        ["Kwame", "Amara", "Chidi", "Zainab", "Tendai", "Abebe", "Nia", "Sekou", "Fatou", "Thabo", "Adaeze", "Kofi"],
+        ["Okafor", "Mensah", "Diallo", "Abebe", "Ndlovu", "Mwangi", "Traore", "Banda", "Osei", "Achieng"],
+    ),
+    "southeast_asia": (
+        ["Nguyen", "Siti", "Andi", "Maya", "Thanh", "Dewi", "Jose", "Ling", "Arif", "Chan", "Mai", "Rizal"],
+        ["Nguyen", "Tran", "Santos", "Reyes", "Wijaya", "Tan", "Lim", "Pham", "Susanto", "Cruz"],
+    ),
+    "europe": (
+        ["Lukas", "Emma", "Mateusz", "Sofia", "Liam", "Chloe", "Marco", "Elena", "Jonas", "Ida", "Pavlo", "Greta"],
+        ["Müller", "Novak", "Rossi", "Dubois", "Kowalski", "Andersson", "Papadopoulos", "Shevchenko", "Smith", "Jansen"],
+    ),
+    "latam_caribbean": (
+        ["Mateo", "Valentina", "Diego", "Camila", "Thiago", "Lucia", "Joao", "Isabela", "Andres", "Fernanda", "Rafael", "Ximena"],
+        ["Garcia", "Silva", "Rodriguez", "Souza", "Martinez", "Pereira", "Lopez", "Ramirez", "Castro", "Mendoza"],
+    ),
+    "mena": (
+        ["Omar", "Layla", "Youssef", "Amira", "Mehmet", "Yasmin", "Ali", "Nour", "Reza", "Dalia", "Karim", "Elif"],
+        ["Hassan", "Al-Sayed", "Yilmaz", "Haddad", "Farouk", "Rahimi", "Mansour", "Aziz", "Demir", "Nasser"],
+    ),
+    "north_america": (
+        ["James", "Olivia", "Noah", "Ava", "Ethan", "Maria", "Tyler", "Grace", "Carlos", "Emily", "Jamal", "Hannah"],
+        ["Johnson", "Williams", "Garcia", "Brown", "Martin", "Lee", "Thompson", "Rodriguez", "Wilson", "Tremblay"],
+    ),
+    "central_asia_oceania": (
+        ["Aigerim", "Timur", "Aroha", "Jack", "Nurlan", "Mia", "Rustam", "Moana", "Erlan", "Ruby", "Aziz", "Tane"],
+        ["Nazarbayeva", "Ibragimov", "Walker", "Ngata", "Karimov", "Taylor", "Abdullaev", "Kelly", "Smith", "Parata"],
+    ),
+}
+
+# Gender of each given name in NAME_BANKS, so a profile's ``sex`` is coherent with
+# its name (a "Priya" is not emitted as male). Intersex profiles keep their drawn
+# sex and they/them pronouns regardless of the name. Names absent here fall back to
+# the drawn sex. Keep in lock-step with the given-name pools above.
+GIVEN_NAME_SEX: dict[str, str] = {
+    # south_asia
+    "Aarav": "male", "Rohan": "male", "Arjun": "male", "Farhan": "male", "Ishaan": "male", "Nikhil": "male",
+    "Ananya": "female", "Priya": "female", "Kavya": "female", "Meera": "female", "Zara": "female", "Diya": "female",
+    # east_asia
+    "Wei": "male", "Jian": "male", "Haruto": "male", "Minjun": "male", "Takeshi": "male", "Li": "male", "Cheng": "male",
+    "Mei": "female", "Xiu": "female", "Yuna": "female", "Seoyeon": "female", "Hana": "female",
+    # sub_saharan_africa
+    "Kwame": "male", "Chidi": "male", "Tendai": "male", "Abebe": "male", "Sekou": "male", "Thabo": "male", "Kofi": "male",
+    "Amara": "female", "Zainab": "female", "Nia": "female", "Fatou": "female", "Adaeze": "female", "Achieng": "female",
+    # southeast_asia
+    "Nguyen": "male", "Andi": "male", "Thanh": "male", "Jose": "male", "Arif": "male", "Chan": "male", "Rizal": "male",
+    "Siti": "female", "Maya": "female", "Dewi": "female", "Ling": "female", "Mai": "female",
+    # europe
+    "Lukas": "male", "Mateusz": "male", "Liam": "male", "Marco": "male", "Jonas": "male", "Pavlo": "male",
+    "Emma": "female", "Sofia": "female", "Chloe": "female", "Elena": "female", "Ida": "female", "Greta": "female",
+    # latam_caribbean
+    "Mateo": "male", "Diego": "male", "Thiago": "male", "Joao": "male", "Andres": "male", "Rafael": "male",
+    "Valentina": "female", "Camila": "female", "Lucia": "female", "Isabela": "female", "Fernanda": "female", "Ximena": "female",
+    # mena
+    "Omar": "male", "Youssef": "male", "Mehmet": "male", "Ali": "male", "Reza": "male", "Karim": "male",
+    "Layla": "female", "Amira": "female", "Yasmin": "female", "Nour": "female", "Dalia": "female", "Elif": "female",
+    # north_america
+    "James": "male", "Noah": "male", "Ethan": "male", "Tyler": "male", "Carlos": "male", "Jamal": "male",
+    "Olivia": "female", "Ava": "female", "Maria": "female", "Grace": "female", "Emily": "female", "Hannah": "female",
+    # central_asia_oceania
+    "Timur": "male", "Jack": "male", "Nurlan": "male", "Rustam": "male", "Erlan": "male", "Aziz": "male", "Tane": "male",
+    "Aigerim": "female", "Aroha": "female", "Mia": "female", "Moana": "female", "Ruby": "female",
+}
+
+VALUES_POOL = [
+    "family first", "financial security", "faith and tradition", "learning and growth",
+    "community standing", "independence", "health and longevity", "creativity",
+    "fairness", "adventure", "stability", "generosity", "craftsmanship", "privacy",
+]
+
+ASPIRATIONS_POOL = [
+    "own a home", "children's education", "start a business", "get out of debt",
+    "retire comfortably", "move to the city", "move closer to family", "travel abroad",
+    "master a new skill", "grow the farm", "buy a vehicle", "build savings buffer",
+    "career promotion", "give back to the community", "write or create something lasting",
+]
+
+STRESSORS_POOL = [
+    "rising cost of living", "job insecurity", "health costs", "elder care",
+    "children's future", "debt payments", "long commute", "housing costs",
+    "climate and weather shocks", "family expectations", "workload", "safety",
+]
+
+INTERESTS_POOL = [
+    "cricket", "football", "cooking", "gardening", "street food", "music",
+    "movies and series", "reading", "board games", "motorcycles", "sewing and crafts",
+    "fishing", "photography", "volunteering", "chess", "history", "languages",
+    "gaming", "fitness", "tea and coffee culture", "markets and bargains", "poetry",
+]
+
+JOBS_TO_BE_DONE_POOL = [
+    "stretch the monthly budget", "send money to family safely", "find better work",
+    "keep documents in one place", "prepare taxes without stress", "compare loan offers",
+    "track the harvest and sales", "manage the shop's inventory", "plan children's school fees",
+    "stay on top of medical visits", "coordinate the household", "learn new skills cheaply",
+    "grow savings safely", "keep in touch across distance", "navigate government paperwork",
+]
+
+MEDIA_DIET_POOL = [
+    "short video", "messaging groups", "radio", "TV serials", "news apps", "podcasts",
+    "social feeds", "long-form video", "print newspaper", "streaming music", "forums",
+]
+
+DEVICES_BY_TIER: dict[str, list[tuple[str, float]]] = {
+    "t1_under_2usd_day": [("feature_phone", 0.45), ("android_low", 0.30), ("shared_device", 0.15), ("none", 0.10)],
+    "t2_2_to_10usd_day": [("android_low", 0.52), ("android_mid", 0.25), ("feature_phone", 0.15), ("shared_device", 0.08)],
+    "t3_10_to_50usd_day": [("android_mid", 0.48), ("android_low", 0.18), ("iphone", 0.16), ("laptop", 0.14), ("tablet", 0.04)],
+    "t4_50_to_200usd_day": [("iphone", 0.34), ("android_mid", 0.26), ("laptop", 0.26), ("wearable", 0.08), ("tablet", 0.06)],
+    "t5_over_200usd_day": [("iphone", 0.38), ("laptop", 0.30), ("wearable", 0.14), ("android_mid", 0.10), ("desktop", 0.08)],
+}
+
+SCOPE_FAMILIES = [
+    "attr.financial", "attr.health", "attr.professional", "attr.social",
+    "attr.location", "attr.identity", "attr.shopping", "attr.entertainment",
+]

--- a/consent-protocol/scripts/synthetic_profiles/schema/humanprofile_v0.schema.json
+++ b/consent-protocol/scripts/synthetic_profiles/schema/humanprofile_v0.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hushh.ai/schemas/humanprofile/v0/profile.json",
+  "title": "HumanProfile v0",
+  "description": "The world's simplest deep representation of a synthetic human for development and baselining. Every profile is generated — no real person's data. One document, readable in one sitting: identity, demographics, psychographics, world model, personal knowledge model, behavioral signals, and consent posture.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "synthetic",
+    "marginals_version",
+    "seed",
+    "profile_id",
+    "identity",
+    "demographics",
+    "psychographics",
+    "world_model",
+    "knowledge_model",
+    "behavioral_signals",
+    "consent_posture"
+  ],
+  "properties": {
+    "schema_version": { "const": "humanprofile/v0" },
+    "synthetic": {
+      "const": true,
+      "description": "Always true. Marks the document as generated data so no synthetic profile can ever be mistaken for a real person's record."
+    },
+    "marginals_version": {
+      "type": "string",
+      "description": "The world-distribution version that produced this profile. (seed + marginals_version) fully reproduces the document, so the JSON is self-describing."
+    },
+    "seed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The deterministic seed. profile(seed) is a pure function: same seed, same profile, forever. The 8B address space is seeds [0, 8e9)."
+    },
+    "profile_id": {
+      "type": "string",
+      "pattern": "^synth_[0-9a-f]{24}$",
+      "description": "Stable synthetic user id (doubles as the Firebase-UID-shaped user_id in app tables)."
+    },
+    "identity": {
+      "type": "object",
+      "required": ["display_name", "given_name", "family_name", "email", "locale"],
+      "properties": {
+        "display_name": { "type": "string" },
+        "given_name": { "type": "string" },
+        "family_name": { "type": "string" },
+        "email": {
+          "type": "string",
+          "description": "Synthetic anchor at a reserved documentation domain — never a deliverable address."
+        },
+        "phone_anchor": {
+          "type": "string",
+          "description": "Synthetic E.164-shaped anchor using reserved/fictional ranges."
+        },
+        "locale": { "type": "string", "description": "BCP-47, e.g. en-IN, pt-BR." },
+        "pronouns": { "type": "string" }
+      }
+    },
+    "demographics": {
+      "type": "object",
+      "required": ["region", "country_zone", "age", "sex", "urbanicity", "household", "education_level", "occupation", "income_tier", "languages"],
+      "properties": {
+        "region": {
+          "enum": ["south_asia", "east_asia", "southeast_asia", "sub_saharan_africa", "mena", "europe", "latam_caribbean", "north_america", "central_asia_oceania"]
+        },
+        "country_zone": { "type": "string", "description": "Coarse sub-region label, not a specific person's country of record." },
+        "age": { "type": "integer", "minimum": 0, "maximum": 105 },
+        "sex": { "enum": ["female", "male", "intersex"] },
+        "urbanicity": { "enum": ["urban", "peri_urban", "rural"] },
+        "household": {
+          "type": "object",
+          "required": ["size", "type"],
+          "properties": {
+            "size": { "type": "integer", "minimum": 1, "maximum": 14 },
+            "type": { "enum": ["single", "couple", "nuclear_family", "multigenerational", "single_parent", "shared", "institutional"] },
+            "dependents": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "education_level": { "enum": ["none_or_primary", "secondary", "vocational", "tertiary", "postgraduate"] },
+        "occupation": {
+          "type": "object",
+          "required": ["group", "title", "status"],
+          "properties": {
+            "group": { "enum": ["agriculture", "trades_and_industry", "services_and_sales", "clerical_admin", "professional", "technical_engineering", "health_care", "education", "creative_media", "public_service", "management", "informal_gig", "student", "homemaker", "retired", "unemployed"] },
+            "title": { "type": "string" },
+            "status": { "enum": ["employed", "self_employed", "gig", "student", "homemaker", "retired", "unemployed"] }
+          }
+        },
+        "income_tier": {
+          "enum": ["t1_under_2usd_day", "t2_2_to_10usd_day", "t3_10_to_50usd_day", "t4_50_to_200usd_day", "t5_over_200usd_day"],
+          "description": "Global income tiers (per-capita/day, PPP-style) so the population is honest about the world, not just the rich web."
+        },
+        "languages": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "disability": { "type": "array", "items": { "enum": ["vision", "hearing", "mobility", "cognitive", "chronic_pain", "none"] } }
+      }
+    },
+    "psychographics": {
+      "type": "object",
+      "required": ["traits", "values", "aspirations", "stressors"],
+      "properties": {
+        "traits": {
+          "type": "object",
+          "description": "0-100 axes (five-factor-style) with mild realistic correlations.",
+          "required": ["openness", "conscientiousness", "extraversion", "agreeableness", "emotional_stability"],
+          "additionalProperties": { "type": "integer", "minimum": 0, "maximum": 100 }
+        },
+        "values": { "type": "array", "minItems": 2, "items": { "type": "string" } },
+        "aspirations": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "stressors": { "type": "array", "items": { "type": "string" } },
+        "risk_tolerance": { "type": "integer", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "world_model": {
+      "type": "object",
+      "description": "The person's lived world: who, where, and the rhythm of their days.",
+      "required": ["relationships", "places", "routines", "devices"],
+      "properties": {
+        "relationships": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["role", "closeness"],
+            "properties": {
+              "role": { "type": "string" },
+              "name": { "type": "string" },
+              "closeness": { "enum": ["inner_circle", "close", "regular", "peripheral"] },
+              "trusted_for": { "type": "array", "items": { "type": "string" }, "description": "Scope families this person would plausibly be granted (feeds connection/consent test data)." }
+            }
+          }
+        },
+        "places": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["kind"],
+            "properties": {
+              "kind": { "enum": ["home", "work", "school", "worship", "market", "clinic", "gym", "third_place"] },
+              "label": { "type": "string" }
+            }
+          }
+        },
+        "routines": { "type": "array", "items": { "type": "string" } },
+        "devices": {
+          "type": "array",
+          "items": { "enum": ["feature_phone", "android_low", "android_mid", "iphone", "laptop", "desktop", "tablet", "wearable", "shared_device", "none"] }
+        }
+      }
+    },
+    "knowledge_model": {
+      "type": "object",
+      "description": "Per-domain personal knowledge, aligned to the shipped PKM domain registry so profiles exercise real product paths (attr.{domain}.* scopes).",
+      "required": ["financial", "professional", "social", "health", "interests"],
+      "properties": {
+        "financial": {
+          "type": "object",
+          "required": ["has_bank_account", "risk_profile"],
+          "properties": {
+            "has_bank_account": { "type": "boolean" },
+            "risk_profile": { "enum": ["conservative", "balanced", "growth", "aggressive"] },
+            "risk_score": { "type": "integer", "minimum": 0, "maximum": 100 },
+            "holdings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["ticker", "asset_class", "value_usd"],
+                "properties": {
+                  "ticker": { "type": "string" },
+                  "asset_class": { "enum": ["equity", "etf", "bond", "cash", "gold", "crypto", "real_estate", "livestock", "informal_savings"] },
+                  "value_usd": { "type": "number", "minimum": 0 }
+                }
+              }
+            },
+            "total_value_usd": { "type": "number", "minimum": 0 },
+            "debts": { "type": "array", "items": { "type": "string" } },
+            "money_goals": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "professional": {
+          "type": "object",
+          "properties": {
+            "skills": { "type": "array", "items": { "type": "string" } },
+            "years_experience": { "type": "integer", "minimum": 0 },
+            "work_style": { "type": "string" }
+          }
+        },
+        "social": {
+          "type": "object",
+          "properties": {
+            "community_roles": { "type": "array", "items": { "type": "string" } },
+            "network_size_bucket": { "enum": ["tight", "moderate", "wide", "very_wide"] }
+          }
+        },
+        "health": {
+          "type": "object",
+          "description": "Broad synthetic categories only — depth without diagnosis-level specificity.",
+          "properties": {
+            "fitness_habit": { "enum": ["sedentary", "light", "moderate", "active", "athlete"] },
+            "conditions_bucket": { "type": "array", "items": { "enum": ["none", "metabolic", "cardio", "respiratory", "musculoskeletal", "mental_wellness", "vision_hearing"] } },
+            "sleep_pattern": { "enum": ["short", "irregular", "regular", "long"] }
+          }
+        },
+        "interests": { "type": "array", "minItems": 2, "items": { "type": "string" } }
+      }
+    },
+    "behavioral_signals": {
+      "type": "object",
+      "description": "The needs/wants/desires layer: how this person actually behaves with technology and money day to day.",
+      "required": ["digital_hours_per_day", "primary_jobs_to_be_done", "shopping_style", "media_diet"],
+      "properties": {
+        "digital_hours_per_day": { "type": "number", "minimum": 0, "maximum": 18 },
+        "primary_jobs_to_be_done": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+        "shopping_style": { "enum": ["necessity_only", "value_hunter", "planner", "impulse", "premium", "ethical"] },
+        "media_diet": { "type": "array", "items": { "type": "string" } },
+        "agent_use_cases": { "type": "array", "items": { "type": "string" }, "description": "What a personal private agent would most help this human with." }
+      }
+    },
+    "consent_posture": {
+      "type": "object",
+      "description": "How this person tends to grant, deny, and revoke — drives realistic PCHP handshake test traffic.",
+      "required": ["privacy_stance", "default_grant_duration_days", "share_willingness"],
+      "properties": {
+        "privacy_stance": { "enum": ["open", "pragmatic", "guarded", "fortress"] },
+        "default_grant_duration_days": { "type": "integer", "minimum": 1, "maximum": 365 },
+        "share_willingness": {
+          "type": "object",
+          "description": "0-100 willingness to share each scope family with a trusted requester.",
+          "additionalProperties": { "type": "integer", "minimum": 0, "maximum": 100 }
+        },
+        "revocation_tendency": { "enum": ["rarely", "sometimes", "often"] }
+      }
+    }
+  }
+}

--- a/consent-protocol/tests/synthetic/test_humanprofile_generator.py
+++ b/consent-protocol/tests/synthetic/test_humanprofile_generator.py
@@ -1,0 +1,80 @@
+"""HumanProfile v0 generator contract tests.
+
+The three properties the 8B address space depends on:
+1. Determinism — profile(seed) is byte-identical across calls.
+2. Uniqueness — distinct seeds yield distinct profile_ids.
+3. Validity + representativeness — every profile validates against the JSON
+   Schema, and sampled marginals track the target world distributions.
+"""
+
+from __future__ import annotations
+
+import collections
+
+import jsonschema
+import pytest
+
+from scripts.synthetic_profiles.generator import (
+    ADDRESS_SPACE,
+    canonical_json,
+    generate,
+    load_schema,
+    profile_id_for_seed,
+)
+from scripts.synthetic_profiles.marginals import REGION_WEIGHTS
+
+SAMPLE = 400
+STRIDE = ADDRESS_SPACE // SAMPLE
+
+
+def _sample_seeds() -> list[int]:
+    return [(i * STRIDE) % ADDRESS_SPACE for i in range(SAMPLE)]
+
+
+def test_determinism_byte_identical() -> None:
+    for seed in (0, 1, 42, 7_999_999_999, 4_193_772_206):
+        assert canonical_json(generate(seed)) == canonical_json(generate(seed))
+
+
+def test_uniqueness_of_profile_ids() -> None:
+    ids = {profile_id_for_seed(seed) for seed in _sample_seeds()}
+    assert len(ids) == SAMPLE
+
+
+def test_schema_validity_across_sample() -> None:
+    validator = jsonschema.Draft202012Validator(load_schema())
+    for seed in _sample_seeds():
+        errors = list(validator.iter_errors(generate(seed)))
+        assert not errors, f"seed {seed}: {errors[0].message if errors else ''}"
+
+
+def test_seed_bounds() -> None:
+    with pytest.raises(ValueError):
+        generate(-1)
+    with pytest.raises(ValueError):
+        generate(ADDRESS_SPACE)
+
+
+def test_region_marginals_track_targets() -> None:
+    counter: collections.Counter[str] = collections.Counter()
+    for seed in _sample_seeds():
+        counter[generate(seed)["demographics"]["region"]] += 1
+    for region, weight in REGION_WEIGHTS:
+        share = counter[region] / SAMPLE
+        # Generous tolerance at n=400; the stats CLI reports tighter numbers at scale.
+        assert abs(share - weight) < 0.07, f"{region}: {share:.2%} vs target {weight:.0%}"
+
+
+def test_profiles_are_internally_consistent() -> None:
+    for seed in _sample_seeds()[:120]:
+        p = generate(seed)
+        d = p["demographics"]
+        fin = p["knowledge_model"]["financial"]
+        if d["age"] < 15:
+            assert d["occupation"]["group"] == "student"
+            assert fin["holdings"] == []
+        assert fin["total_value_usd"] == pytest.approx(
+            sum(h["value_usd"] for h in fin["holdings"]), abs=0.05
+        )
+        assert p["identity"]["email"].endswith("@profiles.example")
+        assert p["identity"]["phone_anchor"].startswith("+999")

--- a/consent-protocol/tests/synthetic/test_name_sex_coherence.py
+++ b/consent-protocol/tests/synthetic/test_name_sex_coherence.py
@@ -1,0 +1,76 @@
+"""Name/sex coherence + hero-fixture contract tests.
+
+A synthetic human is only good demo data if it is internally coherent: a profile
+named "Priya" must not be emitted as male. These tests lock that in, and pin the
+curated showcase heroes so their stories stay reproducible from a seed alone.
+"""
+
+from __future__ import annotations
+
+from scripts.synthetic_profiles.generator import ADDRESS_SPACE, generate
+from scripts.synthetic_profiles.heroes import HERO_SEEDS, heroes
+from scripts.synthetic_profiles.marginals import GIVEN_NAME_SEX
+
+
+def test_given_name_and_sex_agree_across_a_large_sample():
+    """Over a wide population sweep, no named male/female profile contradicts the
+    gender its given name implies. Intersex profiles keep they/them and are exempt."""
+    step = ADDRESS_SPACE // 20000
+    mismatches = []
+    for i in range(20000):
+        p = generate((i * step) % ADDRESS_SPACE)
+        sex = p["demographics"]["sex"]
+        if sex == "intersex":
+            continue
+        name = p["identity"]["given_name"]
+        implied = GIVEN_NAME_SEX.get(name)
+        if implied is not None and implied != sex:
+            mismatches.append((name, sex, implied))
+    assert not mismatches, f"name/sex mismatches: {mismatches[:10]} (total {len(mismatches)})"
+
+
+def test_pronouns_follow_sex():
+    expected = {"female": "she/her", "male": "he/him", "intersex": "they/them"}
+    step = ADDRESS_SPACE // 5000
+    for i in range(5000):
+        p = generate((i * step) % ADDRESS_SPACE)
+        assert p["identity"]["pronouns"] == expected[p["demographics"]["sex"]]
+
+
+def test_every_given_name_in_the_banks_has_a_gender():
+    """Guard against a name being added to a pool without a gender, which would
+    silently fall back to the drawn sex and reintroduce incoherence."""
+
+    # Names are allowed to be gendered even if a specific region never draws them;
+    # what we forbid is a *drawn* name lacking a gender. Sweep and assert coverage.
+    step = ADDRESS_SPACE // 20000
+    ungendered = set()
+    for i in range(20000):
+        p = generate((i * step) % ADDRESS_SPACE)
+        name = p["identity"]["given_name"]
+        if name not in GIVEN_NAME_SEX:
+            ungendered.add(name)
+    assert not ungendered, f"given names drawn but missing a gender: {sorted(ungendered)}"
+
+
+def test_hero_fixture_is_reproducible_and_coherent():
+    fixture = heroes()
+    assert len(fixture) == len(HERO_SEEDS) >= 4
+    for h in fixture:
+        # deterministic: regenerating the same seed is byte-identical
+        assert generate(h["seed"]) == h["profile"]
+        prof = h["profile"]
+        sex = prof["demographics"]["sex"]
+        if sex != "intersex":
+            implied = GIVEN_NAME_SEX.get(prof["identity"]["given_name"])
+            assert implied is None or implied == sex
+        assert h["headline"] and h["stance"]
+
+
+def test_heroes_span_regions_and_the_consent_spectrum():
+    fixture = heroes()
+    regions = {h["profile"]["demographics"]["region"] for h in fixture}
+    stances = {h["profile"]["consent_posture"]["privacy_stance"] for h in fixture}
+    assert len(regions) >= 3, f"heroes not regionally diverse: {regions}"
+    # the showcase should cover more than one point on the consent spectrum
+    assert len(stances) >= 3, f"heroes not consent-diverse: {stances}"

--- a/consent-protocol/tests/synthetic/test_scale_hardening.py
+++ b/consent-protocol/tests/synthetic/test_scale_hardening.py
@@ -1,0 +1,122 @@
+"""Scale + provenance hardening contract tests for HumanProfile v0.
+
+These lock the properties the "planet-scale" claim actually depends on when a
+skeptical engineer leans in:
+
+1. profile_id is wide enough that it is unique across the full 8B space (not
+   just across a small sample) — the 64-bit id it replaced collided ~1.7x.
+2. Every profile is self-describing: it carries its own provenance (synthetic
+   flag + marginals_version) so the JSON alone reproduces it.
+3. Determinism is frozen against a golden fixture, so a Python/library upgrade
+   that silently changes the RNG stream is caught instead of shipping.
+4. Cohort addressing returns only matching humans — sub-population slices are
+   honest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from scripts.synthetic_profiles.cli import cohort_match
+from scripts.synthetic_profiles.generator import (
+    ADDRESS_SPACE,
+    PROFILE_ID_HEX,
+    canonical_json,
+    generate,
+    profile_id_for_seed,
+)
+from scripts.synthetic_profiles.marginals import MARGINALS_VERSION
+
+
+def test_profile_id_is_wide_enough_to_be_unique_across_8b() -> None:
+    """The id is a truncated sha256. The expected number of birthday collisions
+    across the whole address space must be far below 1, or the id cannot double
+    as a stable user_id. 96 bits (24 hex) gives ~4e-10; 64 bits gave ~1.7."""
+    bits = PROFILE_ID_HEX * 4
+    expected_collisions = ADDRESS_SPACE * ADDRESS_SPACE / (2 * (2 ** bits))
+    assert expected_collisions < 1e-6, (
+        f"{bits}-bit profile_id expects {expected_collisions:.2e} collisions "
+        f"across {ADDRESS_SPACE:,} — widen PROFILE_ID_HEX"
+    )
+
+
+def test_profile_id_shape_matches_schema_pattern() -> None:
+    pid = profile_id_for_seed(4193772206)
+    assert pid.startswith("synth_")
+    hexpart = pid[len("synth_"):]
+    assert len(hexpart) == PROFILE_ID_HEX
+    assert all(c in "0123456789abcdef" for c in hexpart)
+
+
+def test_every_profile_carries_its_own_provenance() -> None:
+    """synthetic=true and the marginals_version are embedded, so no profile can
+    be mistaken for real data and (seed + marginals_version) reproduces it."""
+    step = ADDRESS_SPACE // 500
+    for i in range(500):
+        p = generate((i * step) % ADDRESS_SPACE)
+        assert p["synthetic"] is True
+        assert p["marginals_version"] == MARGINALS_VERSION
+
+
+# --- Golden determinism fixture -------------------------------------------------
+# canonical_json SHA-256 for pinned seeds (the four heroes + both boundary seeds),
+# frozen for schema humanprofile/v0, marginals 2026.07-v1, 96-bit id. If a Python
+# or stdlib upgrade perturbs the random stream, or a generator edit is unintended,
+# these hashes move and the test fails loudly instead of silently invalidating
+# every profile anyone reproduced from a seed.
+#
+# Regenerate ONLY on an intentional version bump:
+#   for s in 0 4193772206 480000000 2020202020 1618033988 7999999999; do \
+#     python -m scripts.synthetic_profiles.cli generate --seed $s \
+#     | python -c "import sys,json,hashlib; from scripts.synthetic_profiles.generator import canonical_json; \
+#       print(hashlib.sha256(canonical_json(json.load(sys.stdin)).encode()).hexdigest())"; done
+GOLDEN_HASHES: dict[int, str] = {
+    0: "ab5c880f084c83307fea5a20ecf973de75ad84d6e2d638efe01dc62fd9508760",
+    4193772206: "e1189bb2a3da32552c2c8d637a2ab590b7de1c9382c64fa0f4f0e453e4cb3ea6",
+    480000000: "4ccc10f6b911b93091f35f44f73692c624d5fb36fd8582d60f1dc65d59a906e5",
+    2020202020: "5182aa5aa36ebbcb40ae4451892f4f630c5d25eb1207aab1f4fd4f1e9df41f3a",
+    1618033988: "593badd024ef20b93ef1b1db287ca38e28d6704b48b9a7a36fdd14273028cd10",
+    7999999999: "12a18ea50360049b822ff06914d10877bae24ea176bb90e1216f2131eb51b83e",
+}
+
+
+def _golden_hash(seed: int) -> str:
+    return hashlib.sha256(canonical_json(generate(seed)).encode()).hexdigest()
+
+
+def test_golden_fixture_matches_committed_snapshot() -> None:
+    """Frozen hashes pinned to (schema humanprofile/v0, marginals 2026.07-v1).
+    A drift here means the deterministic stream changed under us — a Python or
+    stdlib upgrade, or an unintended generator edit — which would silently
+    invalidate every profile anyone reproduced from a seed. Fail loudly instead."""
+    assert MARGINALS_VERSION == "2026.07-v1", (
+        "marginals_version changed; regenerate GOLDEN_HASHES intentionally"
+    )
+    for seed, expected in GOLDEN_HASHES.items():
+        assert _golden_hash(seed) == expected, (
+            f"determinism drift at seed {seed}: got {_golden_hash(seed)}, "
+            f"expected {expected}"
+        )
+
+
+def test_cohort_addressing_returns_only_matching_humans() -> None:
+    """A cohort slice must be honest: every returned profile satisfies every
+    filter, and a real slice actually yields members."""
+    step = ADDRESS_SPACE // 6000
+    filters = dict(region="south_asia", stance="guarded", min_age=25, max_age=45)
+    matched = 0
+    for i in range(6000):
+        p = generate((i * step) % ADDRESS_SPACE)
+        if cohort_match(p, **filters):
+            matched += 1
+            d = p["demographics"]
+            assert d["region"] == "south_asia"
+            assert p["consent_posture"]["privacy_stance"] == "guarded"
+            assert 25 <= d["age"] <= 45
+    assert matched > 0, "cohort filter matched nobody — slice is not addressable"
+
+
+def test_empty_filters_match_everyone() -> None:
+    step = ADDRESS_SPACE // 500
+    for i in range(500):
+        assert cohort_match(generate((i * step) % ADDRESS_SPACE)) is True

--- a/docs/future/one-meta-glasses-ambient-agent-plan.md
+++ b/docs/future/one-meta-glasses-ambient-agent-plan.md
@@ -1,0 +1,111 @@
+# One on Meta Glasses — Ambient Private Agent Plan
+
+Status: **founder-approved — promoting to execution.** The founder has taken this up as real work, so it is no longer a speculative note: the in-our-control work streams are being promoted to tracked execution now, while the platform-level dependencies (Meta SDK entitlement, partnership/distribution) remain external blockers named below. This doc is the durable rationale + edge analysis the execution work references; it is not a current-state implementation contract, and no Meta Wearables / glasses SDK integration exists in this repo today. Classification: **founder-approved execution** (promoting out of `docs/future/` as owners land the work). Founder approval satisfies promotion criterion 1; criteria 2–5 below still gate the platform-dependent pieces.
+
+## Framing
+
+> **Hussh = `[hu]man [s]ecure [s]ocket [h]ost`.**
+>
+> One for macOS is the planned *host* on the Mac; the iPhone One is the host in your pocket. Meta glasses are proposed as a third host surface: the one you *wear*. One runs **ambiently in the background** as a private, system-level agent for the person wearing the glasses — available whenever they need it, silent when they do not — with the human always the owner and in control, and every read of their data completing a [PCHP](../../consent-protocol/docs/reference/consent-protocol.md) handshake.
+
+The ask has two halves, and they must not be conflated:
+
+1. **The owner's agent, on the glasses.** One works *for the wearer*, on-device, on their behalf — a private life-general-contractor that listens, remembers, decides, and acts, under the wearer's consent.
+2. **A developer ecosystem.** Meta glasses agent and application developers can build against One's consent surface out of the box, so any third-party glasses app can *request* scoped, revocable access to the wearer's world model through PCHP instead of harvesting it.
+
+Both halves sit on the same non-negotiable: the wearer owns their data; nothing leaves the wearer's control without a consent receipt.
+
+## Visual Map
+
+```mermaid
+flowchart TB
+  owner["Glasses wearer<br/>owner + in control<br/>BYOA + BYO infra"]
+  glasses["Meta glasses<br/>ambient One (system-level)<br/>audio-first, minimal display"]
+  consent["On-glasses PCHP handshake<br/>audio consent ceremony<br/>short-TTL device-bound CRT"]
+  index["On-device world-model cache<br/>AES-256-GCM, SE-wrapped keys<br/>ciphertext at rest"]
+  devs["Meta glasses app / agent devs<br/>request scoped, revocable access"]
+  cloud["Hushh cloud<br/>ciphertext + manifests only<br/>pkm_routes_shared.py"]
+  phone["iPhone / Mac One<br/>existing hosts, shared vault"]
+
+  owner --> glasses
+  glasses --> consent
+  glasses --> index
+  consent --> devs
+  glasses --> cloud
+  cloud --> phone
+```
+
+## Classification and scope
+
+- **This is future roadmap, not vision.** The durable thesis (human-owned data, consent-first, BYOA, on-device) already lives in `docs/vision/`; this doc does not restate or change it. It assesses one *surface* for that thesis.
+- **In scope:** the trust/architecture assessment, the reuse map, the missing primitives, and the promotion criteria.
+- **Out of scope (deliberately):** any claim that a Meta partnership, SDK entitlement, or distribution channel exists; any commitment to a ship date; any execution-owned technical spec (those are written only after promotion).
+
+## Current Overlap (what the repo already gives us)
+
+The glasses host is a *port* of primitives that already exist, not a greenfield build:
+
+- **The consent protocol itself.** [`consent-protocol/hushh_mcp/consent/token.py`](../../consent-protocol/hushh_mcp/consent/token.py) (the `HCT:` bearer format `user_id|agent_id|scope|issued_at|expires_at[|commercial]`) and the shipped consent MCP surface (`discover_user_domains`, `request_consent`, `check_consent_status`, `get_encrypted_scoped_export`, `validate_token`, `list_scopes`) are transport-agnostic — a glasses client speaks them the same way the iPhone does. The public spec is now on the website at `/research/pchp-specification`.
+- **The world model / PKM shapes.** [`consent-protocol/api/routes/pkm_routes_shared.py`](../../consent-protocol/api/routes/pkm_routes_shared.py) and `personal_knowledge_model_service.py` (`DomainSummary`, `PersonalKnowledgeModelIndex`) define the encrypted per-domain model the glasses cache would mirror, so the cloud stays a ciphertext-redundant mirror.
+- **The One-for-macOS host precedent.** [`docs/future/one-mac-knowledge-base-app.md`](./one-mac-knowledge-base-app.md) already worked out the host pattern — local encrypted index, secure socket, device-pairing CRT ceremony, OpenClaw reference target. The glasses host reuses that design language; it does not re-derive it.
+- **Voice-first runtime.** The One voice runtime (`consent-protocol` voice config + the ADK live WebSocket surface under `api/routes/one/`) is the natural interaction model for a screenless device; a glasses host is voice-first by necessity, not choice.
+- **On-device / BYOK posture.** The vault encryption (`consent-protocol/hushh_mcp/vault/encrypt.py`, AES-256-GCM, server holds ciphertext only) already assumes the key lives with the user — exactly what a wearable with a Secure-Enclave-class keystore needs.
+
+## Missing Primitives (what must be built before this is real)
+
+1. **A Meta Wearables / glasses SDK integration layer.** The single biggest unknown. Needs a capabilities audit of the actual SDK: background/system-level agent entitlements, audio-in/out access, on-device compute budget, display primitives, and whether a persistent ambient agent is even permitted by the platform. *Nothing in this repo touches this today.*
+2. **An ambient attention model.** When does One wake? Explicit wake word vs. context trigger vs. always-listening — each has a very different consent and battery profile. Always-listening on a body-worn camera/mic device is the sharpest privacy edge and needs its own assessment (below).
+3. **An audio-first PCHP consent ceremony.** The handshake today assumes a screen (tap + biometric). On glasses there may be no screen; the Offer→Consent phases need a spoken, legible, unspoofable ceremony (who is asking, exactly what, for how long) with an owner approval credential (voice + on-device biometric / paired-phone confirmation).
+4. **A short-TTL, device-bound CRT profile.** A `glasses_ambient_session` consent scope (sibling of the planned `local_mcp_session`) in `consent-protocol/hushh_mcp/constants.py`, with device binding and a short lifetime, so a lost/stolen pair of glasses cannot replay grants.
+5. **A low-power on-device world-model cache** mirroring the PKM shapes, sized for wearable storage/compute, with SE-wrapped keys and ciphertext at rest.
+6. **A developer SDK surface for Meta glasses app/agent devs.** A thin client that lets a third-party glasses app call `request_consent` / `get_encrypted_scoped_export` against the wearer's One — the "out of the box developer ecosystem" — with a conformance harness. This is the PCHP brand-side/requester story applied to wearables.
+7. **A trust-state clarity model for a screenless device.** How does a wearer *know* an agent is active, what it can see, and how to revoke — with audio and minimal display only? Revocation must be a single, always-available gesture/phrase.
+8. **A pairing ceremony** that provisions the glasses as a device against the existing vault (QR/audio + biometric), issuing a per-device key envelope recorded in both a local `device_pairings` store and the cloud device registry — reusing the One-mac desktop-pairing design.
+9. **A partnership / distribution path with Meta.** Purely commercial/legal, out of engineering scope, but a hard dependency: a "system-level agent available to all Meta glasses users" requires platform-level placement that only Meta can grant.
+
+## Edge-case assessment (per future-planner skill)
+
+- **Trust and authority boundaries.** The wearer is the owner. A body-worn device that can see and hear *other people* raises third-party consent questions the phone does not: bystanders are not parties to the wearer's PCHP grants. Any capture/inference about non-wearers must be out of scope for v1, or gated by its own explicit posture. This is the single most important boundary and must be resolved before any capture feature.
+- **BYOK / zero-knowledge compatibility.** Compatible in principle — the cache is ciphertext at rest with SE-wrapped keys — but wearable key custody (no full Secure Enclave equivalent on all glasses hardware) is an open hardware question. If the platform cannot hold an owner key securely, the glasses become a *thin client* to the phone's vault rather than a host, and the design must degrade to that.
+- **PKM vs runtime memory separation.** Ambient capture is runtime memory; it must NOT silently become durable PKM. A promotion step (owner-approved) must gate anything moving from ephemeral runtime buffer into the durable world model — the same PKM-vs-runtime line the rest of the system enforces.
+- **A2A / delegated execution.** A glasses One acting on the wearer's behalf toward another agent is a PCHP handshake like any other; no new protocol, but the *initiator* is now ambient, so delegation must be explicitly bounded (what may the ambient agent initiate without a fresh confirmation?).
+- **Connector permissions / on-demand consent.** Third-party glasses apps are requesters outside the trust boundary; they get scoped, revocable reads via PCHP, never standing access — identical to the web/app requester model.
+- **User-facing trust-state clarity.** Hardest on a screenless device; item 7 above. If we cannot make "what can see me / how do I revoke" instantly legible in audio, the feature should not ship.
+
+## What already exists · what is missing · what should stay out of scope
+
+- **Already exists:** the consent protocol, PKM shapes, host precedent (One-mac), voice runtime, BYOK/ZK posture.
+- **Missing new primitives:** the Meta SDK layer, ambient attention model, audio-first consent ceremony, device-bound glasses CRT scope, wearable world-model cache, developer SDK surface, screenless trust-state model, glasses pairing ceremony.
+- **Out of scope (for now):** any bystander/third-party capture or inference; any always-listening default; any claim of a Meta partnership; any durable-PKM write without owner-approved promotion.
+
+## Execution promotion (Founder Vision Execution Lane)
+
+The founder has approved this as real work, so per the future-planner Founder Vision Execution Lane, the streams grounded in existing primitives are promoted to tracked execution now, each with a named owner:
+
+| Work stream | Execution owner | First milestone | Gate |
+| --- | --- | --- | --- |
+| Wearable PCHP client + `glasses_ambient_session` device-bound CRT scope | consent/IAM (`iam-consent-governance`) + backend | scope + short-TTL device-bound token profile in `hushh_mcp/constants.py` and `token.py`, with tests | none — start now |
+| Developer SDK / requester surface for Meta glasses apps | MCP developer surface (`mcp-developer-surface`) | thin requester client calling `request_consent` / `get_encrypted_scoped_export`, with a conformance harness | none — start now |
+| On-device world-model cache (ciphertext, SE-wrapped) | backend + mobile-native | cache schema mirroring the PKM shapes, key-custody spike | needs key-custody answer (criterion 3) |
+| Audio-first PCHP consent + revocation ceremony | frontend / native surface owner | prototype spoken Offer→Consent→revoke with anti-spoof bar | none — start now |
+| Meta Wearables SDK integration + ambient runtime | (no glasses execution owner skill exists yet; owner assigned once the platform gate clears) | SDK capabilities audit | **blocked** on Meta SDK entitlement + partnership (criteria 2, 4, 5) |
+
+The bottom row is honest: there is no glasses execution owner skill today, and the platform pieces depend on Meta. Those stay blocked and named, not pretended-started.
+
+## Remaining external gates
+
+Founder approval cleared the future-planner "approved for execution" gate, which is why the in-our-control streams start now. These five platform/trust gates still block the platform-dependent streams (the bottom row of the table); the in-our-control streams do not wait on them:
+
+1. A Meta Wearables / glasses SDK capabilities audit confirms a background/system-level private agent is *technically permitted*, with the entitlements enumerated.
+2. The bystander / third-party-consent posture for a body-worn device is decided and written down (not just deferred).
+3. A wearable key-custody answer exists (true on-device key custody → host; otherwise → thin client to the phone vault), so the ZK posture is real, not aspirational.
+4. An audio-first PCHP consent + revocation ceremony is prototyped and passes a legibility/anti-spoof bar.
+5. A distribution path with Meta is at least in principle available (partnership or public SDK placement).
+
+On promotion, split into execution-owned docs: the SDK/client work → a package under `apps/` with its execution doc; the new consent scope + pairing route → `consent-protocol/docs/...`; the developer SDK surface → the MCP developer-surface owner; the trust-state UX → `hushh-webapp/docs/...` or the native surface owner. Do not promote this doc as a whole; it is a concept note, not a contract.
+
+## Sources
+
+- [PCHP / consent protocol](../../consent-protocol/docs/reference/consent-protocol.md) — the handshake the glasses host speaks.
+- [One for macOS — Knowledge-Base App Plan](./one-mac-knowledge-base-app.md) — the host pattern this reuses.
+- [Personal Knowledge Model reference](../../consent-protocol/docs/reference/personal-knowledge-model.md) — the world-model shapes the on-device cache mirrors.

--- a/docs/future/one-meta-glasses-dat-execution-plan.md
+++ b/docs/future/one-meta-glasses-dat-execution-plan.md
@@ -1,0 +1,134 @@
+# One on Meta Glasses — DAT Integration Execution Plan
+
+Status: **founder-approved — promoting to execution.** This is the concrete, research-grounded execution plan the founder asked for: get a working ambient 🤫 Private Agent One onto Meta glasses as fast as honestly possible, and set the path to reaching every Meta glasses user. It is the execution companion to the concept + trust rationale in [One on Meta Glasses — Ambient Private Agent Plan](./one-meta-glasses-ambient-agent-plan.md); read that first for the durable "why" and the full edge analysis. This doc adds the verified platform reality and a critical-path plan with named owners and gates.
+
+## Visual Map
+
+```mermaid
+flowchart TB
+  wearer["Glasses wearer<br/>owner + in control"]
+  glasses["Meta glasses<br/>mic in · open-ear speaker out<br/>(camera OFF for v1)"]
+  phone["🤫 One native phone app<br/>embeds Meta DAT SDK<br/>compute runs here"]
+  bridge["Audio bridge endpoint<br/>DAT stream ↔ voice/ADK-live"]
+  consent["glasses_ambient_session<br/>device-bound, short-TTL CRT"]
+  one["One backend<br/>A2A invoke · MCP consent · voice"]
+  cloud["Hushh cloud<br/>ciphertext + PCHP receipts"]
+
+  wearer --> glasses --> phone --> bridge
+  bridge --> consent
+  consent --> one
+  bridge --> one
+  one --> cloud
+  cloud --> phone --> glasses
+
+  metaAI["Meta AI 'Hey Meta' tool chain<br/>(brokered partnership · Lane C)"]
+  store["Public publishing / app store<br/>(Meta-gated · 2026 · Lane C)"]
+  phone -. "not in the public SDK" .-> metaAI
+  phone -. "partner-gated" .-> store
+```
+
+Lane A (wearer → glasses → phone → bridge → consent → One → cloud) is buildable now. The dotted paths to Meta AI and public publishing are Lane C: Meta-gated, named honestly, not pretended-started.
+
+## What the research changed about the ambition
+
+The founder's goal was "🤫 Agent One callable via Meta AI as part of its tool chain, available to every Meta glasses user, Monday if possible." A deep research pass against Meta's own developer docs and Connect 2025 material forces two honest corrections, and one real opportunity.
+
+**Correction 1 — there is no self-serve "Meta AI tool chain" for third-party agents yet.** The **Meta Wearables Device Access Toolkit (DAT)** is the public SDK, and in its current preview it exposes only the glasses **camera, microphone, and speaker** to a developer's own phone app. It does **not** let a third party register as a callable tool inside Meta AI, and it does **not** expose "Hey Meta" voice invocation. The "Hey Meta, Be My Eyes…" routing that looks like a tool chain is a **separately negotiated, Meta-brokered partnership**, not something the SDK grants. So "callable via Meta AI" is a *partnership* outcome, not an *SDK* outcome.
+
+**Correction 2 — "every user, Monday" is not reachable through the SDK.** DAT is a **v0.5 Developer Preview**. During preview, apps can only run on the developer's own glasses (developer mode) or be shared to testers inside the developer's org via invite-only release channels. **Public publishing to end users is limited to select partners; general public publishing is not available until later in 2026.** There is no glasses app store today.
+
+**The real opportunity — a working ambient One on our own glasses this week, with no Meta approval to build.** DAT lets us build a phone-tethered app that streams the glasses microphone to our own backend and speaks answers back through the glasses' open-ear speaker. Everything One already exposes (the MCP consent server, the A2A invoke surface, the voice/ADK-live runtime) is the backend for exactly that. That is buildable, testable on real glasses in developer mode, and demo-ready fast. It is **not** "every user" — that stays gated behind Meta's partner program and 2026 public publishing, named honestly below.
+
+## Verified platform reality (what we build against)
+
+Every line here is from the sources listed at the end; treat it as the design contract, and re-verify against the live docs before each milestone because the preview is moving.
+
+- **DAT is a phone-app SDK, not an on-glasses runtime.** Apps run on a paired iOS (15.2+) or Android (10+) phone and reach the glasses over the SDK. Compute is on the phone; results are sent back to the glasses for audio (or, on Display hardware, limited output). Official SDKs and samples are on GitHub (`facebook/meta-wearables-dat-ios`, `facebook/meta-wearables-dat-android`).
+- **Capabilities exposed:** camera POV video / real-time frame streaming and in-stream image capture, microphone audio input, open-ear speaker audio output. Per-app user permission is required for each.
+- **Not exposed (initial preview):** Meta AI / "Hey Meta" invocation, the Ray-Ban Display HUD imagery surface, Neural Band gestures, custom hardware-button triggers, and any "run my LLM inside Meta AI" hook. Developers using their own AI model must continuously stream sensor data to it, which costs battery.
+- **Hardware supported:** Ray-Ban Meta (Gen 1 & 2), Ray-Ban Meta Display, Oakley Meta HSTN, Oakley Meta Vanguard.
+- **Access + developer mode:** register via an interest form with a Meta Managed Account to reach the Wearables Developer Center (`wearables.developer.meta.com`). Enable developer mode by tapping the app version five times in the Meta AI app (Settings → App Info) and toggling Developer Mode; developer-mode apps appear under Meta AI settings → App connections. A **Mock Device Kit** simulates the glasses so we can build before hardware arrives (Mock does not cover Display).
+- **Distribution:** no public app store during preview; test on own device or invite-only release channels; public publishing is partner-gated until later 2026.
+- **How launch partners actually integrated:** camera + audio use cases (Be My Eyes, Microsoft Seeing AI, Aira, OOrion, HumanWare for accessibility; Twitch + Streamlabs for first-person streaming; Disney Imagineering and 18Birdies for contextual POV), all voice-forward. None of them are agentic Meta-AI tool calls; the agentic "Hey Meta, [partner]" routing (Be My Eyes) was a brokered deal, first shown at Connect 2024.
+
+## What the repo already gives us (this is a port, not a greenfield)
+
+The glasses-facing backend is largely already shipped; the integration is mostly wiring, not new invention.
+
+- **One is already invocable as an agent, with consent.** [`consent-protocol/api/routes/one/a2a.py`](../../consent-protocol/api/routes/one/a2a.py) serves an A2A agent card (`/api/one/a2a/card`) and an invoke endpoint (`/api/one/a2a/message`) gated by the `cap.one.invoke` scope with user-approved invocation tokens. A glasses phone-app is just another A2A requester.
+- **One is already an MCP server.** [`consent-protocol/mcp_server.py`](../../consent-protocol/mcp_server.py) (published as `@hushh/mcp`) exposes the consent tools to any MCP host, so a phone client can discover domains, request consent, and pull a scoped export the same way every other host does.
+- **One already has a voice / live runtime.** [`consent-protocol/api/routes/one/voice.py`](../../consent-protocol/api/routes/one/voice.py) and [`adk_live.py`](../../consent-protocol/api/routes/one/adk_live.py) are the screenless interaction surface a glasses mic-to-speaker loop needs.
+- **The consent primitives are shipped.** The HCT token ([`consent-protocol/hushh_mcp/consent/token.py`](../../consent-protocol/hushh_mcp/consent/token.py)) and the `ConsentScope` enum ([`consent-protocol/hushh_mcp/constants.py`](../../consent-protocol/hushh_mcp/constants.py)) are where the new device-bound glasses scope lands.
+- **A developer/requester model exists.** [`developer_registry_service.py`](../../consent-protocol/hushh_mcp/services/developer_registry_service.py) already models third-party requester apps, so the glasses phone-app registers as a requester like any other.
+
+The genuinely new pieces are: a device-bound short-TTL consent scope, an audio bridge between a DAT stream and the voice runtime, and a thin **native** phone app (One is a web app today; DAT requires a native iOS/Android host).
+
+## The plan, in three lanes
+
+Each lane names what it delivers, its owner, and its gate. The whole point is that Lane A moves now with no Meta dependency.
+
+### Lane A — Buildable now, entirely on our side (no Meta approval to build)
+
+The target is a working ambient loop: speak to the glasses → One hears it → One answers through the glasses speaker, every read gated by a consent handshake. Claude can build the backend end-to-end and scaffold the native client.
+
+| Work stream | Owner | First verifiable milestone | Gate |
+| --- | --- | --- | --- |
+| `glasses_ambient_session` device-bound, short-TTL CRT scope | consent/IAM (`iam-consent-governance`) + backend | scope value in `constants.py` + a device-bound token profile in `token.py` (short TTL, device id claim, replay-safe), with tests | none — start now |
+| Audio bridge: DAT mic stream ↔ voice/ADK-live ↔ speaker reply | backend | a WebSocket/relay endpoint that accepts a phone audio stream, runs the existing One voice loop under a `glasses_ambient_session` grant, returns audio, with a fixture-driven test | none — start now |
+| DAT phone-app client (native iOS/Android shell) | mobile-native | a minimal app embedding the DAT SDK that streams mic to the bridge and plays the reply, tested first on the **Mock Device Kit** | needs a Meta Managed Account for the SDK; buildable against Mock without hardware |
+| Audio-first PCHP consent + revocation ceremony (screenless) | frontend / native surface owner | spoken Offer→Consent→revoke prototype with an anti-spoof bar (voice + paired-phone confirmation) | none — start now |
+| Conformance harness for the glasses requester | MCP developer surface (`mcp-developer-surface`) | a test that drives `request_consent` / `get_encrypted_scoped_export` as the glasses app and asserts scope enforcement | none — start now |
+
+Claude builds the first two, the fourth, and the fifth in this repo directly. The native shell (third row) is code Claude can scaffold, but building, signing, and running it on device is a human Xcode/Android Studio step.
+
+### Lane B — Business + platform access, start in parallel (human, this week)
+
+| Action | Owner | Outcome |
+| --- | --- | --- |
+| Submit the DAT interest form + create a Meta Managed Account | founder / bizdev | reach the Wearables Developer Center and pull the SDK |
+| Acquire developer glasses (Ray-Ban Meta Gen 2 and/or Display) and enable developer mode | ops | real-hardware testing beyond Mock |
+| Apply to the Meta wearables partner track for public publishing | founder / bizdev | the only path off "developer mode only" to real users |
+| Open the brokered-integration conversation for a "Hey Meta, ask 🤫 One" routing | founder / partnerships | the only path to the Meta-AI tool-chain outcome (like Be My Eyes) |
+
+### Lane C — Meta-gated, cannot be pretended-started
+
+| Outcome | Blocked on |
+| --- | --- |
+| Public publishing to end users | Meta partner selection + general publishing (later 2026) |
+| "Hey Meta, ask 🤫 One" as a Meta-AI tool call | a Meta-brokered partnership; no public SDK path today |
+| Display HUD output, Neural Band gestures, hardware-button triggers | Meta exposing these APIs (not in the v0.5 preview) |
+
+## Edge-case assessment (per the concept doc, sharpened by the SDK reality)
+
+- **Bystander / third-party capture is now the sharpest line, because camera POV is the SDK's headline capability.** For v1 the ambient loop is **audio-only**; camera stays off. Any future camera use is its own gated posture, never a default, and never captures identifiable bystanders without an explicit, separate ceremony. This is the single most important constraint and it is a design rule, not a preference.
+- **Continuous streaming vs. privacy and battery.** DAT wants a continuous sensor stream to an external model; that is both a battery cost and a privacy surface. The ambient attention model must be **wake-word or explicit-tap gated**, not always-listening, so audio only leaves the glasses after the wearer starts a turn — which also fits the `glasses_ambient_session` short-TTL grant.
+- **Key custody / zero-knowledge.** Compute is on the phone, not the glasses, so the phone (which already holds the One vault posture) is the trust anchor; the glasses are a thin audio peripheral. This side-steps the open "can the glasses hold an owner key" question for v1 — the glasses never hold plaintext or keys.
+- **PKM vs runtime memory.** Ambient turns are runtime memory; nothing becomes durable PKM without the same owner-approved promotion step the rest of the system enforces.
+- **Trust-state clarity on a screenless device.** With no HUD in the preview, "what can hear me and how do I stop it" must be fully legible in audio: a spoken active-state cue and a single always-available revoke phrase/tap. If we cannot make that legible, the feature does not ship.
+
+## Critical path to a working demo (the honest "Monday")
+
+The fastest real result is **ambient One answering through our own Meta glasses in developer mode**, not "every user." Ordered:
+
+1. Lane B access started (interest form + Managed Account) so the SDK and Mock Device Kit are in hand.
+2. Backend `glasses_ambient_session` scope + audio bridge built and tested (Claude, Lane A rows 1–2).
+3. Native DAT shell app streaming mic → bridge → speaker, first on Mock, then on real glasses in developer mode (Lane A row 3).
+4. Spoken consent + revoke ceremony wired in (Lane A row 4).
+5. Demo: "🤫, what's on my plate today?" answered hands-free on the glasses, every read carrying a PCHP receipt.
+
+Realistically, steps 2 and 4 (backend + ceremony) can land in days because the runtime already exists; step 3 depends on the Managed Account and, for on-glasses testing, hardware. If hardware or account access slips, the Mock Device Kit still gets us an end-to-end demo without glasses. "Every Meta glasses user" is Lane C, targeted at Meta's 2026 public publishing, and is honestly out of our unilateral control.
+
+## Promotion note
+
+Per the future-planner Founder Vision Execution Lane, founder approval satisfies the "approved for execution" criterion, so Lane A promotes to tracked execution now. On landing, the scope + token work moves into `consent-protocol/docs/...`, the native client into an `apps/` package with its own execution doc, and the trust-state UX to the native surface owner. This doc stays the rationale + gate record until the platform lanes clear.
+
+## Sources
+
+- [Meta Wearables Device Access Toolkit — developer docs](https://wearables.developer.meta.com/docs/develop/dat/) — capabilities, architecture, getting started.
+- [Introducing the Meta Wearables Device Access Toolkit](https://developers.meta.com/blog/introducing-meta-wearables-device-access-toolkit/) — Connect 2025 announcement, launch partners, access model.
+- [Explore what's possible with the Wearables Device Access Toolkit](https://developers.meta.com/blog/explore-whats-possible-with-wearables-device-access-toolkit/) — sensor access and use cases.
+- [`facebook/meta-wearables-dat-ios`](https://github.com/facebook/meta-wearables-dat-ios) and [`meta-wearables-dat-android`](https://github.com/facebook/meta-wearables-dat-android) — official SDKs, samples, and the v0.5-preview maintainer notes.
+- [Getting started with the toolkit](https://wearables.developer.meta.com/docs/develop/dat/getting-started-toolkit/) — Managed Account, developer mode, Mock Device Kit, version dependencies.
+- [Build for display glasses](https://developers.meta.com/blog/build-for-display-glasses/) — Ray-Ban Display specifics and current output limits.
+- [Ray-Ban Meta glasses: new AI features and partner integrations (Meta newsroom, Sept 2024)](https://about.fb.com/news/2024/09/ray-ban-meta-glasses-new-ai-features-and-partner-integrations/) — the brokered "Hey Meta, Be My Eyes" partnership model.
+- [Be My Eyes + Meta accessibility functions](https://www.bemyeyes.com/news/be-my-eyes-and-meta-launch-new-accessibility-functions/) — a brokered, non-self-serve partner integration, for contrast.


### PR DESCRIPTION
# Description

Adds a **planet-scale synthetic HumanProfile engine** (dev/test tooling) and two Meta-glasses execution planning docs. Branch was restarted from latest `main` (prior branch history already merged), so the diff is **13 clean file additions with zero changes to existing files** — no regression surface.

The engine: `generate(seed)` is a pure, deterministic, stdlib-only function over an 8-billion seed address space — same seed → byte-identical profile, zero storage. Used to produce consented, zero-PII population data for training/eval/dev. 96-bit `profile_id` (expected collisions across the full 8B space ≈ 4e-10), self-describing provenance (`synthetic:true` + `marginals_version`), representative on coarse 2026 world marginals, internally coherent, JSON-Schema-validated, with a golden-hash determinism guard. CLI: `generate / sample / stats / validate / bench / cohort`.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None _(the JSON Schema is the synthetic tool's own output contract under `scripts/synthetic_profiles/schema/`, not a runtime API)_
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None
- Docs updated (exact files):
  - [x] Listed below:
    - `docs/future/one-meta-glasses-ambient-agent-plan.md`
    - `docs/future/one-meta-glasses-dat-execution-plan.md`
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed below with the existing workflow they attach to:
    - `consent-protocol/scripts/synthetic_profiles/**` — standalone devex tooling, invoked via `python -m scripts.synthetic_profiles.cli ...` from `consent-protocol/`; exercised by the `consent-protocol/tests/synthetic/` suite (runs under existing PR Validation).
- Trust boundary touched:
  - [x] None _(generates synthetic zero-PII data; touches no auth/consent/vault/PKM/finance/voice/KYC/deploy/ingress runtime)_
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable _(additive tooling; no runtime code path)_
- UI browser or Playwright proof:
  - [x] Not applicable _(no UI)_
- Verification commands executed:
  - `cd consent-protocol && .venv/bin/python -m pytest tests/synthetic/ -q` → **17 passed**
  - `cd consent-protocol && .venv/bin/ruff check scripts/synthetic_profiles/ tests/synthetic/` → **All checks passed**
  - `python -m scripts.synthetic_profiles.cli bench --count 50000` → ~7.7k profiles/sec single core; 1B ≈ 36 core-hours

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation checked; not a duplicate (the engine does not exist on `main`).
- [x] Explicitly scoped as test/dev tooling + planning docs.
- [x] Reachable attach point: the `scripts.synthetic_profiles.cli` module entrypoint + the `tests/synthetic/` suite.
- [x] New tests import and exercise production code (`scripts.synthetic_profiles.generator` / `.cli`), not mocks defined in-test.
- [x] New tooling is wired to a documented devex entrypoint (the CLI, documented in `scripts/synthetic_profiles/README.md`).
- [x] Branch is restarted from current `main`; mergeable.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: N/A — backend/dev tooling only.
- [x] **iOS**: N/A — no mobile surface.
- [x] **Android**: N/A — no mobile surface.

## 🧪 Testing

- [x] `pytest tests/synthetic/` — 17 passed; `ruff` clean.
- [ ] iOS / Android — N/A.

## 📸 Screenshots / Video

Not applicable — no UI. CLI proof: `bench` reports measured throughput + honest core-hour extrapolation; `validate` confirms schema-valid, unique, deterministic output.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? **No** — it *generates* synthetic, zero-PII data; accesses no real user data.
- [x] `checkConsentToken()` — N/A (no user-data access).
- [x] Sensitive surface touched: **none**.
- [x] Every profile is marked `synthetic:true` and uses reserved anchor ranges (`@profiles.example`, `+999…`) so it can never be mistaken for real data.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No new third-party dependencies (Python stdlib only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7YBE96MuXttLNjLmw1b4M)_

---
Closes #4495
(retroactive board-linkage backfill, 2026-07-14)