### PR TITLE
fix(one-setup): move RIA step to Complete once an RIA profile is onboarded

### DIFF
--- a/hushh-webapp/__tests__/services/capability-setup-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/capability-setup-state-service.test.ts
@@ -302,6 +302,49 @@ describe("resolveCapabilitySetupState — authored setup terminals", () => {
   });
 });
 
+describe("resolveCapabilitySetupState — RIA (onboarded)", () => {
+  it("is completed when an RIA profile is onboarded, even while locked", () => {
+    const status = resolveCapabilitySetupState(
+      "ria",
+      baseInputs({ isVaultUnlocked: false, riaOnboarded: true }),
+    );
+    expect(status.state).toBe("completed");
+  });
+
+  it("is not-started when unlocked, no profile, and the mirror is known", () => {
+    const status = resolveCapabilitySetupState(
+      "ria",
+      baseInputs({
+        isVaultUnlocked: true,
+        riaOnboarded: false,
+        preVaultState: makePreVaultState(),
+      }),
+    );
+    expect(status.state).toBe("not-started");
+  });
+
+  it("falls back to the honest 'Unlock to view' while locked and unknown", () => {
+    const status = resolveCapabilitySetupState(
+      "ria",
+      baseInputs({ isVaultUnlocked: false, riaOnboarded: undefined }),
+    );
+    expect(status.state).toBe("unknown");
+    expect(status.prerequisite).toBe("vault");
+    expect(status.requiresUnlock).toBe(true);
+  });
+
+  it("still completes from the durable terminal id regardless of the live signal", () => {
+    const status = resolveCapabilitySetupState(
+      "ria",
+      baseInputs({
+        riaOnboarded: false,
+        preVaultState: makePreVaultState({ setupCapabilityIds: ["ria"] }),
+      }),
+    );
+    expect(status.state).toBe("completed");
+  });
+});
+
 describe("resolveCapabilitySetupState — vault-gated (email, location)", () => {
   it("is unknown with vault prerequisite while locked", () => {
     for (const id of ["email", "location"]) {

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -59,6 +59,7 @@ export function OneSetupHub() {
   const { byId, isLoading } = useCapabilitySetupStates({
     enrichVault: true,
     enrichOauth: true,
+    enrichRia: true,
   });
   const [dismissing, setDismissing] = useState(false);
   const returnTo = useMemo(

--- a/hushh-webapp/lib/onboarding/use-capability-setup-states.ts
+++ b/hushh-webapp/lib/onboarding/use-capability-setup-states.ts
@@ -19,6 +19,7 @@ import {
 import { AuthService } from "@/lib/services/auth-service";
 import { CapabilityTourService } from "@/lib/services/capability-tour-service";
 import { OneLocationService } from "@/lib/one-location/service";
+import { RiaService } from "@/lib/services/ria-service";
 import { CacheService, CACHE_KEYS } from "@/lib/services/cache-service";
 
 /**
@@ -43,6 +44,8 @@ export interface UseCapabilitySetupStatesOptions {
   enrichVault?: boolean;
   /** Resolve OAuth connection status (Gmail, Connected Systems). Default false. */
   enrichOauth?: boolean;
+  /** Resolve whether an RIA profile is onboarded (getOnboardingStatus). Default false. */
+  enrichRia?: boolean;
 }
 
 export interface UseCapabilitySetupStatesResult {
@@ -63,7 +66,7 @@ export interface UseCapabilitySetupStatesResult {
 export function useCapabilitySetupStates(
   options: UseCapabilitySetupStatesOptions = {}
 ): UseCapabilitySetupStatesResult {
-  const { enrichVault = false, enrichOauth = false } = options;
+  const { enrichVault = false, enrichOauth = false, enrichRia = false } = options;
 
   const { user } = useAuth();
   const { isVaultUnlocked, getVaultKey, getVaultOwnerToken } = useVault();
@@ -92,6 +95,10 @@ export function useCapabilitySetupStates(
   const [locationRecipientKeyReady, setLocationRecipientKeyReady] = useState<
     boolean | undefined
   >(undefined);
+  // RIA onboarded: undefined until we've fetched (or when not opted in).
+  const [riaOnboarded, setRiaOnboarded] = useState<boolean | undefined>(
+    undefined
+  );
 
   // ---- ALWAYS: coarse pre-vault mirror ------------------------------------
   useEffect(() => {
@@ -277,6 +284,40 @@ export function useCapabilitySetupStates(
     };
   }, [userId, isVaultUnlocked, getVaultOwnerToken]);
 
+  // ---- OPT-IN: RIA onboarded status ---------------------------------------
+  // One lightweight, cached `getOnboardingStatus` so the RIA tile reads "Ready"
+  // (→ Complete) once an RIA profile exists — mirroring how location auto-
+  // completes from its recipient key. Not vault-gated (the profile exists
+  // regardless of unlock). Any failure leaves `undefined` so the resolver falls
+  // back to the honest vault-gated state instead of fabricating one.
+  useEffect(() => {
+    if (!enrichRia || !userId) {
+      setRiaOnboarded(undefined);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const idToken = await AuthService.getIdToken();
+        if (!idToken) {
+          if (!cancelled) setRiaOnboarded(undefined);
+          return;
+        }
+        const status = await RiaService.getOnboardingStatus(idToken, {
+          userId,
+        }).catch(() => null);
+        if (!cancelled) {
+          setRiaOnboarded(status ? status.exists === true : undefined);
+        }
+      } catch {
+        if (!cancelled) setRiaOnboarded(undefined);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enrichRia, userId]);
+
   const markExplored = useCallback(
     async (capabilityId: string) => {
       const id = capabilityId.trim();
@@ -313,6 +354,7 @@ export function useCapabilitySetupStates(
       oauthConnections,
       exploredCapabilityIds: exploredIds,
       locationRecipientKeyReady,
+      riaOnboarded,
     }),
     [
       userId,
@@ -324,6 +366,7 @@ export function useCapabilitySetupStates(
       oauthConnections,
       exploredIds,
       locationRecipientKeyReady,
+      riaOnboarded,
     ]
   );
 

--- a/hushh-webapp/lib/services/capability-setup-state-service.ts
+++ b/hushh-webapp/lib/services/capability-setup-state-service.ts
@@ -121,6 +121,15 @@ export interface CapabilitySetupInputs {
    * yet (or vault locked). Fed by a lightweight `getState` fetch when unlocked.
    */
   locationRecipientKeyReady?: boolean;
+  /**
+   * RIA readiness signal: whether the user has an onboarded RIA profile (a
+   * `ria_profiles` row exists, which the backend creates only on onboarding
+   * submit — never for a partial license check). `true` → onboarded, `false` →
+   * no profile, `undefined` → not fetched yet. Fed by a lightweight
+   * `getOnboardingStatus` fetch. Unlike location this does not require the vault,
+   * so an onboarded RIA reads as complete even before unlock.
+   */
+  riaOnboarded?: boolean;
 }
 
 /** Capabilities that require an OAuth connection to a third party. */
@@ -289,6 +298,20 @@ function resolveLocation(inputs: CapabilitySetupInputs): CapabilityStatus {
   return unknown("location", null, false);
 }
 
+/**
+ * Resolve the RIA capability. "Set up" means the user has an onboarded RIA
+ * profile (an existing `ria_profiles` row). When that live signal says onboarded
+ * we mark it `completed` regardless of vault state — the profile exists whether
+ * or not the vault is unlocked this session. Otherwise fall back to the generic
+ * vault-gated behaviour (locked → "Unlock to view", active journey →
+ * "in-progress", unlocked-but-none → "Set up RIA") so nothing is fabricated and
+ * the durable "Finish RIA setup" terminal id still completes it.
+ */
+function resolveRia(inputs: CapabilitySetupInputs): CapabilityStatus {
+  if (inputs.riaOnboarded === true) return simple("ria", "completed");
+  return resolveVaultGated("ria", inputs);
+}
+
 /** Resolve an OAuth-gated capability from caller-supplied connection booleans. */
 function resolveOauthGated(
   id: string,
@@ -322,6 +345,7 @@ export function resolveCapabilitySetupState(
   if (id === "finance") return resolveFinance(inputs);
   if (id === "consent") return resolveConsent(inputs);
   if (id === "location") return resolveLocation(inputs);
+  if (id === "ria") return resolveRia(inputs);
   if (OAUTH_GATED.has(id)) return resolveOauthGated(id, inputs);
 
   const capability = getOneCapability(id);


### PR DESCRIPTION
## What
On `/one/setup` (Finish setup), the **Set up RIA** step never moved into the **COMPLETE** section even after the user had created/onboarded an RIA profile — unlike **Set up location**, which auto-completes.

## Why
Completion is derived by `resolveCapabilitySetupState`. Location has a live-signal branch (`resolveLocation` reading `locationRecipientKeyReady`); RIA had none, so it only completed via the durable "Finish RIA setup" terminal id.

## Change
- `capability-setup-state-service.ts`: new `riaOnboarded` input + `resolveRia` branch (mirrors `resolveLocation`). `riaOnboarded === true` → `completed` (vault-independent); else falls back to existing vault-gated behaviour; durable terminal id still completes it.
- `use-capability-setup-states.ts`: opt-in `enrichRia` effect → cached `RiaService.getOnboardingStatus` → `exists === true`.
- `one-setup-hub.tsx`: pass `enrichRia: true`.
- Tests: 4 new resolver cases; existing RIA/location assertions preserved.

"Complete when onboarded" (profile exists) per product decision — backend creates the `ria_profiles` row only on onboarding submit, so `exists` is a clean signal. **No UI changes** — the generic tile renders COMPLETE placement + green check automatically.

## Verification
- `vitest run` resolver test: 35/35 pass
- `tsc --noEmit` clean on changed files
- `eslint --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)