### PR TITLE
perf(deploy): layer-cache Cloud Build (buildx mode=max) — kill 20-35min backend rebuilds

### DIFF
--- a/consent-protocol/Dockerfile
+++ b/consent-protocol/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Multi-stage build for Python FastAPI backend
 # Optimized for Google Cloud Run
 
@@ -17,9 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install uv map requirements to virtual environment
 RUN pip install uv
 
-# Copy requirements and install Python dependencies using uv with bytecode compilation
+# Copy requirements and install Python dependencies using uv with bytecode compilation.
+# The BuildKit cache mount keeps uv's wheel cache OUT of the image layer while still
+# speeding partial re-resolves; the layer itself is cached in the registry (mode=max),
+# so an unchanged requirements.txt makes this whole step a cache hit.
 COPY requirements.txt .
-RUN uv pip install --no-cache-dir --system --compile-bytecode -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system --compile-bytecode -r requirements.txt
 
 # Stage 2: Production runtime
 FROM python:3.13-slim

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -2,39 +2,38 @@
 # Deploy to: Cloud Run (service name configurable via substitutions)
 
 steps:
-  # Step 1: Build Docker image
+  # Step 1: Build + push with a registry LAYER CACHE (buildx, mode=max).
+  #
+  # Why: Cloud Build workers are ephemeral, so a plain `docker build` starts with an
+  # empty cache every run and reinstalls all ~159 pinned deps from scratch (20-35 min).
+  # buildx `--cache-to type=registry,mode=max` exports EVERY stage's layers (incl. the
+  # builder's `uv pip install` layer) to `:buildcache`; `--cache-from` restores them on
+  # the next run. Because the Dockerfile copies requirements.txt before the app source,
+  # an unchanged requirements.txt turns the dependency install into a cache HIT, so a
+  # code-only deploy drops to a couple of minutes.
+  #
+  # NOTE: the FIRST build after this lands is still cold — it seeds `:buildcache`.
+  # The payoff shows on the next backend deploy.
   - name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     args:
-      - "build"
-      - "-t"
-      - "gcr.io/$PROJECT_ID/consent-protocol:manual"
-      - "-t"
-      - "gcr.io/$PROJECT_ID/consent-protocol:latest"
-      - "-t"
-      - "gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}"
-      - "-f"
-      - "consent-protocol/Dockerfile"
-      - "consent-protocol"
+      - "-c"
+      - |
+        set -euo pipefail
+        # Ensure gcr.io auth is available to the buildx container driver.
+        gcloud auth configure-docker gcr.io --quiet || true
+        docker buildx create --use --name hushh-builder --driver docker-container \
+          >/dev/null 2>&1 || docker buildx use hushh-builder
+        docker buildx build \
+          --cache-from=type=registry,ref=gcr.io/$PROJECT_ID/consent-protocol:buildcache \
+          --cache-to=type=registry,ref=gcr.io/$PROJECT_ID/consent-protocol:buildcache,mode=max \
+          --tag gcr.io/$PROJECT_ID/consent-protocol:manual \
+          --tag gcr.io/$PROJECT_ID/consent-protocol:latest \
+          --tag gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG} \
+          --file consent-protocol/Dockerfile \
+          --push \
+          consent-protocol
     id: "build-backend-image"
-
-  # Step 2: Push Docker image to Container Registry
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/consent-protocol:manual"
-    id: "push-backend-image"
-
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/consent-protocol:latest"
-    id: "push-backend-latest"
-
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}"
-    id: "push-backend-version"
 
   # Step 3: Deploy to Cloud Run
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
@@ -163,14 +162,12 @@ steps:
         "${cmd[@]}"
     id: "deploy-backend"
 
-# Images to store in Container Registry
-images:
-  - "gcr.io/$PROJECT_ID/consent-protocol:manual"
-  - "gcr.io/$PROJECT_ID/consent-protocol:latest"
-  - "gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}"
+# NOTE: no top-level `images:` block — `docker buildx build --push` (Step 1) already
+# pushes every tag. Listing images here would make Cloud Build try to re-push them from
+# the local daemon, which is empty under the buildx docker-container driver, and fail.
 
-# Build timeout
-timeout: "1200s"
+# Build timeout: 1800s headroom for the one-time cold seeding build; cached builds are minutes.
+timeout: "1800s"
 
 substitutions:
   _BACKEND_SERVICE: consent-protocol

--- a/deploy/frontend.cloudbuild.yaml
+++ b/deploy/frontend.cloudbuild.yaml
@@ -28,7 +28,16 @@ steps:
             exit 1
           fi
         done
-        docker build \
+        # Registry layer cache (buildx, mode=max): caches the npm ci + next build layers
+        # so an unchanged package-lock turns dependency install into a cache hit. First
+        # build after this lands is cold (seeds :buildcache); later builds are minutes.
+        gcloud auth configure-docker gcr.io --quiet || true
+        docker buildx create --use --name hushh-builder --driver docker-container \
+          >/dev/null 2>&1 || docker buildx use hushh-builder
+        docker buildx build \
+          --cache-from=type=registry,ref=gcr.io/$PROJECT_ID/hushh-webapp:buildcache \
+          --cache-to=type=registry,ref=gcr.io/$PROJECT_ID/hushh-webapp:buildcache,mode=max \
+          --push \
           -t gcr.io/$PROJECT_ID/hushh-webapp:manual \
           -t gcr.io/$PROJECT_ID/hushh-webapp:latest \
           -t gcr.io/$PROJECT_ID/hushh-webapp:${_IMAGE_TAG} \
@@ -67,25 +76,6 @@ steps:
     ]
     id: "build-frontend-image"
 
-  # Step 2: Push Docker image to Container Registry
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/hushh-webapp:manual"
-    id: "push-frontend-image"
-
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/hushh-webapp:latest"
-    id: "push-frontend-latest"
-
-  - name: "gcr.io/cloud-builders/docker"
-    args:
-      - "push"
-      - "gcr.io/$PROJECT_ID/hushh-webapp:${_IMAGE_TAG}"
-    id: "push-frontend-version"
-
   # Step 3: Deploy to Cloud Run
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
@@ -117,14 +107,12 @@ steps:
         "${cmd[@]}"
     id: "deploy-frontend"
 
-# Images to store in Container Registry
-images:
-  - "gcr.io/$PROJECT_ID/hushh-webapp:manual"
-  - "gcr.io/$PROJECT_ID/hushh-webapp:latest"
-  - "gcr.io/$PROJECT_ID/hushh-webapp:${_IMAGE_TAG}"
+# NOTE: no top-level `images:` block — `docker buildx build --push` (Step 1) already
+# pushes every tag. Listing images here would make Cloud Build re-push from the local
+# daemon, which is empty under the buildx docker-container driver, and fail.
 
-# Build timeout
-timeout: "1200s"
+# Build timeout: 1800s headroom for the one-time cold seeding build; cached builds are minutes.
+timeout: "1800s"
 
 substitutions:
   _FRONTEND_SERVICE: hushh-webapp


### PR DESCRIPTION
## Problem
Backend (and frontend) Cloud Build used the legacy `gcr.io/cloud-builders/docker` builder with **no layer cache**. Cloud Build workers are ephemeral, so every deploy reinstalled all **~159 Python deps** from scratch — **20-35 min even for a one-line change**.

## Fix
Build both services with `docker buildx build` + a **registry layer cache** (`--cache-from/--cache-to type=registry,mode=max`) against a `:buildcache` tag. `mode=max` exports every stage's layers, incl. the builder's `uv pip install` layer, so an unchanged `requirements.txt` / `package-lock.json` makes the dependency install a **cache HIT** → code-only deploys drop to minutes.

- `consent-protocol/Dockerfile`: `# syntax=docker/dockerfile:1` + `--mount=type=cache` for uv (drop `--no-cache-dir`).
- `deploy/backend.cloudbuild.yaml` + `deploy/frontend.cloudbuild.yaml`: buildx build w/ registry cache + `--push`; remove redundant `images:` block + separate push steps; bump build `timeout` to 1800s for the one-time cold seed.

## Rollout / safety
- The **first** deploy after this lands is still cold — it **seeds** `:buildcache`. The speedup shows on the **next** backend deploy.
- A buildx/build/auth failure fails the Cloud Build step **before** `gcloud run deploy`, so **no bad revision can ship**. Reversible via a one-file YAML revert.
- Registry stays GCR; Artifact Registry migration is a separate follow-up.

## Verify
1. Land → deploy `scope=backend` (cold seed, ~20 min).
2. Second backend deploy → Cloud Build log shows `CACHED` on the `uv pip install` layer; `backend_cloud_build` duration drops to ~3-6 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)