### PR TITLE
fix(one-location): keep back button on Location hub across action flows

### DIFF
--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -672,7 +672,7 @@ function PeopleScreen({
         <p className="mt-3 text-[17px] leading-6 text-[#73777f] dark:text-[#b5bfcc]">
           Invite the people you want to keep connected with.
         </p>
-        <h2 className="mt-9 text-[13px] font-bold uppercase text-[#96999e] dark:text-[#8d99a8]">
+        <h2 className="mt-9 text-[13px] font-bold capitalize text-[#96999e] dark:text-[#8d99a8]">
           Contacts
         </h2>
 
@@ -1155,14 +1155,12 @@ export function OneLocationOnboardingFlow({
             <div className="flex min-h-0 flex-1 flex-col">
               <div className="shrink-0 pt-6 text-center sm:pt-10">
                 <p className="inline-flex items-center gap-2 text-[19px] font-bold">
-                  <LocateFixed className="h-6 w-6" /> Onepoint
+                  <LocateFixed className="h-6 w-6" /> One Location
                 </p>
+
                 <h1 className="mx-auto mt-6 max-w-[390px] text-[clamp(30px,4.6dvh,38px)] font-bold leading-[1.08]">
                   The people you love.<br />Always in reach.
                 </h1>
-                <p className="mx-auto mt-4 max-w-[370px] text-[clamp(16px,2dvh,18px)] leading-7 text-white/82">
-                  Private by default. Nothing is shared until you approve it.
-                </p>
               </div>
               <div className="flex min-h-0 flex-1 items-center justify-center py-2">
                 <WelcomeRadar people={people} />

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -365,11 +365,49 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const inboxCount = vm.pendingOwnerRequests.length;
   const hasActiveShare = vm.activeOwnerGrants.length > 0;
 
+  // Back-button navigation for focused task flows (Check In, Drive To, Pick Me
+  // Up, Safe Arrival, SOS, Share, Ask, Invite, Privacy, Temp link).
+  //
+  // Problem: /one/location is a single route. Without this, the OS/browser Back
+  // button (and the app chrome's back arrow) would leave the whole Location page
+  // and land on /one, even though the user only meant to leave the action screen.
+  //
+  // Fix: opening a flow pushes ONE history entry. Pressing Back pops it and we
+  // just close the flow, returning to the Location hub — the page itself only
+  // leaves once the user is back on the hub. `unwindFlowHistory` keeps history
+  // balanced for programmatic closes (Cancel button, share complete, deep link).
+  const flowHistoryPushedRef = useRef(false);
+
+  const unwindFlowHistory = () => {
+    if (typeof window !== "undefined" && flowHistoryPushedRef.current) {
+      flowHistoryPushedRef.current = false;
+      window.history.back();
+    }
+  };
+
   const closeFlow = () => {
     setFlow("none");
     setShareStep("person");
     vm.setShareReviewOpen(false);
+    unwindFlowHistory();
   };
+
+  useEffect(() => {
+    if (typeof window === "undefined" || flow === "none") return;
+    if (!flowHistoryPushedRef.current) {
+      window.history.pushState({ oneLocationFlow: flow }, "");
+      flowHistoryPushedRef.current = true;
+    }
+    const onPopState = () => {
+      // The pushed entry is being consumed by this Back press.
+      flowHistoryPushedRef.current = false;
+      setFlow("none");
+      setShareStep("person");
+      vm.setShareReviewOpen(false);
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [flow, vm]);
 
   // When a share completes successfully (page bumps shareCompletedTick), close
   // the 3-step share flow and return to the main One Location hub.
@@ -381,9 +419,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       // from the "Now" tab, so no explicit tab change is needed.
       setFlow("none");
       setShareStep("person");
+      unwindFlowHistory();
     }
 
   }, [vm.shareCompletedTick]);
+
 
 
   /* ----------------------------------------------------------------- */
@@ -456,8 +496,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   return (
     <div className="space-y-5">
       <LocationHeader
-        title="Onepoint"
+        title="One Location"
         subtitle={headerSubtitle}
+
         trailing={
           <button
             type="button"
@@ -878,8 +919,9 @@ function PrivacyFlow({
   return (
     <div>
       <TaskFlowHeader
-        eyebrow="Onepoint"
+        eyebrow="One Location"
         title="Privacy"
+
         description="You control who sees your location and when. Change this anytime."
         onBack={onClose}
       />


### PR DESCRIPTION
Opening a task flow (Check In, Drive To, Pick Me Up, Safe Arrival, SOS, Share, Ask, Invite, Privacy, Temp link) now pushes a single history entry so the OS/browser/app back button closes the flow and returns to the Location hub instead of leaving to /one. Programmatic closes (Cancel, share complete, deep link) unwind that entry to keep history balanced.

Also rename onboarding + hub 'Onepoint' to 'One Location' and remove the redundant 'Private by default...' subtitle from the welcome screen.

# Description

Briefly explain what you changed and why.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).
Green CI is intake only; merge readiness also requires a reachable attach point,
production-code proof, and a title/body that match the diff.

## 📌 Impact Map (Required)

- Routes touched:
  - [ ] None
  - [ ] Listed below:

- API / schema / type changes:
  - [ ] None
  - [ ] Listed below:

- Cache keys touched:
  - [ ] None
  - [ ] Listed below:

- Runtime DB data-plane changes:
  - [ ] None
  - [ ] Listed below:

- World-model domain summary effects:
  - [ ] None
  - [ ] Listed below:

- Mobile parity impacts:
  - [ ] None
  - [ ] Listed below:

- Docs updated (exact files):
  - [ ] None
  - [ ] Listed below:

- Top-level / devex / config / generated / ignore files touched:
  - [ ] None
  - [ ] Listed below with the existing workflow they attach to:

- Trust boundary touched:
  - [ ] None
  - [ ] Auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress listed below:

- Caller / proxy / backend pairing:
  - [ ] Not applicable
  - [ ] Listed below with contract proof:

- Rollback or safe-failure behavior:
  - [ ] Not applicable
  - [ ] Listed below:

- UI browser or Playwright proof:
  - [ ] Not applicable
  - [ ] Route/spec/command listed below:

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

## ✅ Review-Ready Contract

- [ ] Title, body, changed files, and tests describe the same contract.
- [ ] Existing implementation and related open PRs were checked; this PR does not duplicate:
- [ ] This PR changes a current reachable app/backend/package/docs surface, or it is explicitly scoped as test/devex hygiene.
- [ ] Reachable production attach point:
- [ ] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [ ] New helpers/components/services are wired to an existing route, caller, package export, generated contract, or documented devex entrypoint.
- [ ] Production surface proved:
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [ ] Maintainer edits are enabled, or the reason they cannot be enabled is listed here:
- [ ] If this is one PR in a stack, the predecessor PR is linked here:
- [ ] If this responds to requested changes, the new commit or material explanation is described here:

## 🛑 Tri-Flow Architecture Check

Every cross-platform feature must cover all affected layers or explicitly mark
the layer as not applicable with the reason.

- [ ] **Web**: Next.js implementation (`app/api/...`)
- [ ] **iOS**: Swift Capacitor Plugin (`ios/App/App/Plugins/...`)
- [ ] **Android**: Kotlin Capacitor Plugin (`android/app/.../plugins/...`)

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [ ] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated by the canonical repo command listed above

## 📸 Screenshots / Video

Attach proof of work here. For UI-visible changes, include the route plus
Playwright spec/command, screenshot, video, or why browser proof is not
applicable.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data?
- [ ] If yes, have you implemented `checkConsentToken()`?
- [ ] Sensitive surface touched: auth / consent / vault / PKM / finance / voice-action / KYC / schema / deploy / public ingress / none
- [ ] Error path, rollback, or safe-failure behavior proved:

## 📜 Licensing

- [ ] First-party changes remain Apache-2.0 compatible
- [ ] Third-party notice impact reviewed when dependencies changed
