### PR TITLE
fix(one-setup): dashboard setup count now includes RIA (1 of 6 → 2 of 6) + durable realtime

### DIFF
--- a/hushh-webapp/app/one/page.tsx
+++ b/hushh-webapp/app/one/page.tsx
@@ -13,9 +13,11 @@ import { useCapabilitySetupStates } from "@/lib/onboarding/use-capability-setup-
 export default function OneHomePage() {
   const router = useRouter();
   const { user, loading } = useAuth();
-  // Dashboard uses coarse states only (no vault/oauth enrichment) so it stays
-  // cheap; the /one/setup flow opts into full enrichment for skip-vs-continue.
-  const { byId } = useCapabilitySetupStates();
+  // Dashboard stays coarse (no vault/oauth enrichment) to stay cheap, but opts
+  // into `enrichRia` — a single cached getOnboardingStatus call — so the
+  // "N of 6 ready" count matches the /one/setup hub. Without it, an onboarded
+  // RIA counts on the hub but not here (the count read "1 of 6" vs "2 of 6").
+  const { byId } = useCapabilitySetupStates({ enrichRia: true });
 
   useEffect(() => {
     if (!loading && !user) {

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -55,6 +55,7 @@ import { trackEvent } from "@/lib/observability/client";
 import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
 import { resolveAppEnvironment } from "@/lib/app-env";
 import { openKaiCommandBar } from "@/lib/navigation/kai-command-bar-events";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 
 const LICENSE_VERIFICATION_TIMEOUT_MS = 90_000;
 const SCRAPE_POLL_INTERVAL_MS = 5_000;
@@ -811,6 +812,27 @@ export default function RiaOnboardingPage({
       }).catch(() => null);
 
       await refreshPersonaState({ force: true });
+
+      // Durably mark the RIA setup step complete so the /one dashboard "N of 6"
+      // count includes it (and updates live via the pre-vault bootstrap-cache
+      // "set" event the dashboard hook subscribes to). Only for the standalone
+      // path — in setupMode the setup-hub coordinator writes this on "Finish",
+      // so we avoid racing it. Best-effort + idempotent: enrichRia still
+      // reconciles the dashboard count on the next load if this write fails.
+      if (!setupMode) {
+        try {
+          const current = await PreVaultUserStateService.bootstrapState(user.uid);
+          if (!current.setupCapabilityIds.includes("ria")) {
+            const next = Array.from(
+              new Set([...current.setupCapabilityIds, "ria"]),
+            ).sort();
+            // syncSetupCapabilities REPLACES the stored set, so pass the union.
+            await PreVaultUserStateService.syncSetupCapabilities(user.uid, next);
+          }
+        } catch {
+          // best-effort; dashboard enrichRia reconciles the count on next load.
+        }
+      }
 
       if (advisoryOutcome === "verified" || advisoryOutcome === "active") {
         await RiaOnboardingDraftLocalService.clear(user.uid);


### PR DESCRIPTION
## Problem
The "Finish setup" completion count disagreed between surfaces:
- `/one` dashboard strip: **"1 of 6 setup steps ready"**
- `/one/setup` hub: **"2 of 6 ready"** (location + RIA under COMPLETE)

## Root cause (single diverging capability: RIA)
Both count the same 6 steps with the same predicate. The dashboard hook runs **coarse** (`useCapabilitySetupStates()` — no `enrichRia`), so `riaOnboarded` is `undefined` and RIA never resolves `completed` there. The hub passes `enrichRia: true`. Every other step completes via the durable terminal (same on both); **location** already counts on the dashboard because its recipient-key signal isn't enrich-gated. So RIA was the only gap.

Also: onboarding RIA via the **standalone** `/ria/onboarding` submit never wrote `"ria"` into the durable `setupCapabilityIds` (only the setup-hub coordinator's Finish did).

## Fix
- `app/one/page.tsx`: `useCapabilitySetupStates({ enrichRia: true })` — dashboard reads the same cached RIA signal → **2 of 6**, on every `/one` load.
- `app/ria/onboarding/page.tsx`: on standalone submit (`!setupMode`), best-effort **union** `"ria"` into `setupCapabilityIds`. Fixes the standalone gap and updates the dashboard **live** (the write hits `PRE_VAULT_BOOTSTRAP`, which the dashboard hook subscribes to). `setupMode` unchanged (coordinator owns its Finish write).

No resolver/UI changes (`resolveRia` already correct + unit-tested).

## Verify
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean; resolver tests 35/35.
- On UAT: `/one` shows **2 of 6** matching `/one/setup`; standalone RIA onboarding → dashboard reflects it (live if mounted, else on next load).

Frontend-only → `scope=auto` deploys frontend only (cached build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)