### PR TITLE
fix(one): recover setup across web and iOS

### DIFF
--- a/hushh-webapp/.gitignore
+++ b/hushh-webapp/.gitignore
@@ -22,6 +22,7 @@
 # next.js
 /.next/
 /.next-prod/
+/.next-native-uat/
 /out/
 
 # production

--- a/hushh-webapp/__tests__/components/agent-section-dropdown.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-section-dropdown.test.tsx
@@ -41,11 +41,10 @@ describe("AgentSectionDropdown", () => {
     expect(screen.getByTestId("top_agent_section_gmail")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_consent")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_pkm")).toBeTruthy();
-    expect(screen.getByTestId("top_agent_section_marketplace")).toBeTruthy();
     expect(screen.getByTestId("top_agent_section_connected-systems")).toBeTruthy();
     expect(
       document.querySelectorAll('[data-testid^="top_agent_section_"]').length,
-    ).toBe(9);
+    ).toBe(8);
     // cmdk must not replace a branded agent glyph with its shared explicit
     // theme contrast: dark in light mode and light in dark mode.
     expect(

--- a/hushh-webapp/__tests__/components/developer-docs-hub.test.tsx
+++ b/hushh-webapp/__tests__/components/developer-docs-hub.test.tsx
@@ -81,18 +81,19 @@ describe("DeveloperDocsHub", () => {
     render(<DeveloperDocsHub initialOrigin="https://uat.one.hushh.ai" />);
 
     await waitFor(() => {
-      expect(screen.getByText("API root ready")).toBeTruthy();
-      expect(screen.getByText("Tool catalog ready")).toBeTruthy();
-      expect(screen.getByText("Scope catalog ready")).toBeTruthy();
+      expect(screen.getByText("Live contract available")).toBeTruthy();
     });
 
-    expect(screen.getByRole("heading", { name: "Connect to Hussh with Remote MCP" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Connect with Remote MCP" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Build with consent, not around it." })).toBeTruthy();
+    expect(screen.getByText("Connect with Remote MCP")).toBeTruthy();
+    expect(screen.getByRole("navigation", { name: "Public knowledge" })).toBeTruthy();
     // Bare URL, no ?token= query: the live API rejects query-string tokens and
     // requires "Authorization: Bearer" instead.
     expect(screen.getAllByText(/https:\/\/api\.uat\.hushh\.ai\/mcp\//).length).toBeGreaterThan(0);
     expect(screen.getByText("Advanced: REST API and npm bridge")).toBeTruthy();
-    expect(screen.getAllByText("Remote MCP first").length).toBeGreaterThan(0);
+    expect(document.querySelectorAll("[data-state='open']").length).toBeGreaterThanOrEqual(9);
+    expect(document.querySelector("[data-slot='badge']")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Sections" })).toBeNull();
     expect(screen.queryByText("Production")).toBeNull();
     expect(screen.queryByText(/consent-protocol-uat-a1b2c3-uc\.a\.run\.app/)).toBeNull();
   });

--- a/hushh-webapp/__tests__/components/intro-step.test.tsx
+++ b/hushh-webapp/__tests__/components/intro-step.test.tsx
@@ -68,4 +68,20 @@ describe("IntroStep voice contract", () => {
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
   });
+
+  it("keeps the root public navigation to Research and Developers", () => {
+    render(<IntroStep onLogin={vi.fn()} />);
+
+    const publicNav = screen.getByRole("navigation", { name: "Explore Hushh" });
+    expect(publicNav.querySelectorAll("a")).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "Research" })).toHaveAttribute(
+      "href",
+      "/research",
+    );
+    expect(screen.getByRole("link", { name: "Developers" })).toHaveAttribute(
+      "href",
+      "/developers",
+    );
+    expect(screen.queryByRole("link", { name: "Blog" })).toBeNull();
+  });
 });

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -32,9 +32,14 @@ describe("Navbar bottom chrome contract", () => {
     expect(agentBar).toContain('data-native-voice-control-id="one_voice_agent_bar_start"');
     expect(agentBar).toContain('onClick={handleVoiceStartClick}');
     expect(agentBar).toContain('aria-label="Start conversation"');
+    expect(agentBar).toContain("loading: authLoading");
+    expect(agentBar).toContain("!agentPopover ||\n    authLoading ||");
     expect(agentBar).toContain('const isRiaChrome = isRiaRoute(pathname ?? "")');
     expect(agentBar).not.toContain('const isRiaChrome = activePersona === "ria"');
     expect(agentBar).toContain("useKaiBottomChromeElementTranslation");
+    expect(agentBar).toContain(
+      "max(var(--app-bottom-inset), calc(var(--bottom-nav-offset)",
+    );
     expect(agentBar).not.toContain("useKaiBottomChromeVisibility");
     expect(agentBar).not.toContain(
       "calc(var(--bottom-chrome-progress, 0) * var(--agent-bar-hide-distance))",

--- a/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
@@ -1,19 +1,21 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OnboardingJourneyGuard } from "@/components/onboarding/onboarding-journey-guard";
 
 const {
+  push,
   replace,
   bootstrapStateMock,
   getCachedBootstrapStateMock,
   isPersistentSetupResolvedMock,
 } = vi.hoisted(
   () => ({
+    push: vi.fn(),
     replace: vi.fn(),
     bootstrapStateMock: vi.fn(),
     getCachedBootstrapStateMock: vi.fn(),
@@ -25,7 +27,7 @@ let pathnameValue = "/one/setup";
 
 // App Router returns a stable router instance; an unstable identity would
 // spuriously re-run the guard effect (its deps include `router`).
-const stableRouter = { replace };
+const stableRouter = { push, replace };
 
 vi.mock("next/navigation", () => ({
   usePathname: () => pathnameValue,
@@ -41,15 +43,24 @@ vi.mock("@/components/app-ui/hushh-loader", () => ({
 }));
 
 vi.mock("@/lib/morphy-ux/button", () => ({
-  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
 }));
 
 vi.mock("@/lib/navigation/routes", () => ({
-  ROUTES: { ONE_SETUP: "/one/setup" },
+  ROUTES: { ONE_SETUP: "/one/setup", PROFILE: "/profile" },
   buildOneSetupRoute: ({ returnTo }: { returnTo: string }) =>
     `/one/setup?return_to=${encodeURIComponent(returnTo)}`,
   isCapabilityOnboardingRoute: () => false,
   isOnboardingAdmissionExemptRoute: () => false,
+  isOneSetupRoute: (pathname: string) =>
+    pathname.replace(/\/index\.html$/i, "").replace(/\/+$/, "") ===
+    "/one/setup",
   isOneSetupSurfaceRoute: (pathname: string) => pathname === "/one/setup",
 }));
 
@@ -85,6 +96,7 @@ function incompleteSetupState() {
 
 describe("OnboardingJourneyGuard", () => {
   beforeEach(() => {
+    push.mockReset();
     replace.mockReset();
     bootstrapStateMock.mockReset();
     getCachedBootstrapStateMock.mockReset();
@@ -162,6 +174,64 @@ describe("OnboardingJourneyGuard", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
+  it("retries one transient bootstrap failure with a forced read", async () => {
+    vi.useFakeTimers();
+    pathnameValue = "/one";
+    window.history.replaceState(null, "", "/one");
+    getCachedBootstrapStateMock.mockReturnValue(null);
+    bootstrapStateMock
+      .mockRejectedValueOnce(new Error("token provider not ready"))
+      .mockResolvedValueOnce({ setupCompleted: true });
+
+    const view = render(
+      <OnboardingJourneyGuard>
+        <div>one home</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("one home")).toBeTruthy();
+    expect(bootstrapStateMock).toHaveBeenNthCalledWith(1, "journey-user");
+    expect(bootstrapStateMock).toHaveBeenNthCalledWith(2, "journey-user", {
+      force: true,
+    });
+    view.unmount();
+    vi.useRealTimers();
+  });
+
+  it("keeps profile recovery reachable after a persistent bootstrap failure", async () => {
+    vi.useFakeTimers();
+    pathnameValue = "/one";
+    window.history.replaceState(null, "", "/one");
+    getCachedBootstrapStateMock.mockReturnValue(null);
+    bootstrapStateMock.mockRejectedValue(new Error("bootstrap unavailable"));
+
+    const view = render(
+      <OnboardingJourneyGuard>
+        <div>one home</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByText("Unable to verify setup progress. Please retry."),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByText("Open profile"));
+    expect(push).toHaveBeenCalledWith("/profile");
+    view.unmount();
+    vi.useRealTimers();
+  });
+
   it("preserves a query-bearing route in one idempotent setup redirect", async () => {
     pathnameValue = "/one/location";
     window.history.replaceState(null, "", "/one/location?tab=family");
@@ -185,6 +255,67 @@ describe("OnboardingJourneyGuard", () => {
       </OnboardingJourneyGuard>,
     );
     expect(replace).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles a Capacitor trailing-slash setup navigation without a false error", async () => {
+    vi.useFakeTimers();
+    pathnameValue = "/one";
+    window.history.replaceState(null, "", "/one");
+    bootstrapStateMock.mockResolvedValue(incompleteSetupState());
+    getCachedBootstrapStateMock.mockReturnValue(null);
+    replace.mockImplementation(() => {
+      window.history.replaceState(null, "", "/one/setup/");
+    });
+
+    const view = render(
+      <OnboardingJourneyGuard>
+        <div>one home</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(screen.getByText("one home")).toBeTruthy();
+    expect(screen.queryByText("Unable to open setup. Please retry.")).toBeNull();
+    view.unmount();
+    vi.useRealTimers();
+  });
+
+  it("clears a failed redirect target so Retry can navigate again", async () => {
+    vi.useFakeTimers();
+    pathnameValue = "/one";
+    window.history.replaceState(null, "", "/one");
+    bootstrapStateMock.mockResolvedValue(incompleteSetupState());
+    getCachedBootstrapStateMock.mockReturnValue(null);
+
+    const view = render(
+      <OnboardingJourneyGuard>
+        <div>one home</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(3600);
+    });
+    expect(screen.getByText("Unable to open setup. Please retry.")).toBeTruthy();
+    expect(replace).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByText("Retry"));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(replace).toHaveBeenCalledTimes(3);
+
+    view.unmount();
+    vi.useRealTimers();
   });
 
   it("keeps setup recovery inside the App Router", () => {

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -67,7 +67,7 @@ describe("OneDashboardPage", () => {
       bodyText.indexOf("Finish setup"),
     );
     expect(
-      screen.getByRole("heading", { name: "Agents (9)" }),
+      screen.getByRole("heading", { name: "Agents (8)" }),
     ).toBeTruthy();
 
     // Every dashboard tile enters the same static setup workspace as the hub.
@@ -138,7 +138,7 @@ describe("OneDashboardPage", () => {
     // The dashboard is the complete user-facing roster. Only six agents are
     // setup capabilities; Memory, Consent/Nav, and Marketplace are direct
     // workspaces and never inflate setup progress.
-    expect(container.querySelectorAll('a[aria-label^="Open "]').length).toBe(9);
+    expect(container.querySelectorAll('a[aria-label^="Open "]').length).toBe(8);
     expect(screen.getByRole("link", { name: "Open Memory" }).getAttribute("href")).toBe(
       ROUTES.PKM,
     );
@@ -146,10 +146,8 @@ describe("OneDashboardPage", () => {
       "/consents",
     );
     expect(
-      screen
-        .getByRole("link", { name: "Open Information Marketplace" })
-        .getAttribute("href"),
-    ).toBe(ROUTES.ONE_MARKETPLACE);
+      screen.queryByRole("link", { name: "Open Information Marketplace" }),
+    ).toBeNull();
     expect(screen.getByTestId("one-finish-setup")).toHaveTextContent(
       "2 of 6 setup steps ready",
     );
@@ -175,7 +173,7 @@ describe("OneDashboardPage", () => {
     // The exact six setup capabilities read Ready when completed.
     expect(screen.getAllByText("Ready")).toHaveLength(6);
     expect(
-      screen.getByRole("heading", { name: "Agents (9)" }),
+      screen.getByRole("heading", { name: "Agents (8)" }),
     ).toBeTruthy();
     expect(screen.queryByText("Finish setup")).toBeNull();
   });

--- a/hushh-webapp/__tests__/lib/firebase/native-auth-restore-epoch.test.ts
+++ b/hushh-webapp/__tests__/lib/firebase/native-auth-restore-epoch.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { NativeAuthRestoreEpoch } from "@/lib/firebase/native-auth-restore-epoch";
+
+describe("NativeAuthRestoreEpoch", () => {
+  it("rejects a launch restore after a newer Apple-auth operation", () => {
+    const epochs = new NativeAuthRestoreEpoch();
+    const launchRestore = epochs.begin();
+    const appleSignIn = epochs.begin();
+
+    expect(epochs.isCurrent(launchRestore)).toBe(false);
+    expect(epochs.isCurrent(appleSignIn)).toBe(true);
+  });
+
+  it("rejects a pending restore after sign-out invalidates it", () => {
+    const epochs = new NativeAuthRestoreEpoch();
+    const pendingRestore = epochs.begin();
+
+    epochs.invalidate();
+
+    expect(epochs.isCurrent(pendingRestore)).toBe(false);
+  });
+});

--- a/hushh-webapp/__tests__/lib/onboarding-route-admission.test.ts
+++ b/hushh-webapp/__tests__/lib/onboarding-route-admission.test.ts
@@ -35,7 +35,8 @@ describe("onboarding route admission", () => {
   it("does not exempt signed-in internal surfaces from unfinished setup", () => {
     expect(isOnboardingAdmissionExemptRoute("/")).toBe(true);
     expect(isOnboardingAdmissionExemptRoute("/login")).toBe(true);
-    expect(isOnboardingAdmissionExemptRoute("/profile")).toBe(false);
+    expect(isOnboardingAdmissionExemptRoute("/profile")).toBe(true);
+    expect(isOnboardingAdmissionExemptRoute("/profile/security")).toBe(true);
     expect(isOnboardingAdmissionExemptRoute("/marketplace")).toBe(false);
     expect(isOnboardingAdmissionExemptRoute("/ria")).toBe(false);
   });

--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -165,6 +165,8 @@ describe("navigation routes", () => {
   it("treats the /one/setup hub as the canonical setup surface", () => {
     // The setup hub is the root setup surface; the wizard is a sub-step.
     expect(isOneSetupRoute("/one/setup")).toBe(true);
+    expect(isOneSetupRoute("/one/setup/")).toBe(true);
+    expect(isOneSetupRoute("/one/setup/index.html")).toBe(true);
     expect(isOneSetupRoute("/one/setup/finance")).toBe(false);
     expect(isOneSetupRoute("/one/setup/kai")).toBe(false);
     expect(isOneSetupRoute("/one/onboarding")).toBe(false);
@@ -172,6 +174,7 @@ describe("navigation routes", () => {
 
     // The wizard predicate matches the canonical Finance setup surface.
     expect(isOneSetupWizardRoute("/one/setup/finance")).toBe(true);
+    expect(isOneSetupWizardRoute("/one/setup/finance/")).toBe(true);
     expect(isOneSetupWizardRoute("/one/setup/finance/import")).toBe(true);
     expect(isOneSetupWizardRoute("/one/setup/kai")).toBe(true);
     expect(isOneSetupWizardRoute("/one/setup/kai/complete")).toBe(false);
@@ -184,6 +187,7 @@ describe("navigation routes", () => {
     expect(isOneSetupSurfaceRoute("/one/setup")).toBe(true);
     expect(isOneSetupSurfaceRoute("/one/setup/kai")).toBe(true);
     expect(isOneSetupSurfaceRoute("/one/setup/gmail")).toBe(true);
+    expect(isOneSetupSurfaceRoute("/one/setup/gmail/")).toBe(true);
     expect(isOneSetupSurfaceRoute("/one")).toBe(false);
     expect(isOneSetupSurfaceRoute("/one/kai")).toBe(false);
   });

--- a/hushh-webapp/__tests__/onboarding/setup-warm-transition.contract.test.ts
+++ b/hushh-webapp/__tests__/onboarding/setup-warm-transition.contract.test.ts
@@ -25,7 +25,11 @@ describe("setup warm-transition contract", () => {
     const guard = read("components/onboarding/onboarding-journey-guard.tsx");
 
     expect(guard).toContain("getCachedBootstrapState?.(userId)");
-    expect(guard).not.toContain("force: true");
+    // The guard may force one bounded retry when native auth publishes the
+    // user before the token provider/proxy is ready. The cached admission path
+    // above still prevents a forced read on ordinary route changes.
+    expect(guard).toContain("bootstrapState(userId);");
+    expect(guard).toContain("force: true");
     expect(guard).toContain("cachedAdmissionAllowsCurrentRoute");
     expect(guard).toContain("OneSetupCompletionHintService.isResolved(userId)");
     expect(guard).not.toContain("primeSetupResolved");

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -757,3 +757,30 @@ describe("AuthService web provider popup continuity", () => {
     expect(mockSignInWithPopup).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("AuthService native Apple continuity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCapacitor.isNativePlatform.mockReturnValue(true);
+    mockAuth.currentUser = null;
+  });
+
+  it("does not pair a stale Firebase JS user with a new native Apple token", async () => {
+    const staleJsUser = { uid: "stale-js-user" };
+    mockAuth.currentUser = staleJsUser;
+    vi.mocked(HushhAuth.signInWithApple).mockResolvedValue({
+      user: {
+        uid: "native-apple-user",
+        email: "apple@example.com",
+        displayName: "Apple User",
+      },
+      idToken: createIdToken(60 * 60),
+      accessToken: "native-access-token",
+    } as any);
+
+    const result = await AuthService.signInWithApple();
+
+    expect(result.user.uid).toBe("native-apple-user");
+    expect(result.user).not.toBe(staleJsUser);
+  });
+});

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -185,6 +185,15 @@ describe("AuthService native custom-token continuity", () => {
     mockAuth.currentUser = null;
   });
 
+  it("does not call native token providers in a signed-out browser", async () => {
+    mockCapacitor.isNativePlatform.mockReturnValue(false);
+
+    await expect(AuthService.getIdToken()).resolves.toBeNull();
+
+    expect(FirebaseAuthentication.getIdToken).not.toHaveBeenCalled();
+    expect(HushhAuth.getIdToken).not.toHaveBeenCalled();
+  });
+
   it("persists the reviewer session in native Firebase", async () => {
     vi.mocked(FirebaseAuthentication.signInWithCustomToken).mockResolvedValue({
       user: {
@@ -205,6 +214,31 @@ describe("AuthService native custom-token continuity", () => {
     });
     expect(result.user.uid).toBe("reviewer-user");
     expect(result.idToken).toBe("native-id-token");
+  });
+
+  it("falls back to the iOS keychain token when FirebaseAuthentication fails", async () => {
+    const keychainToken = createIdToken(60 * 60);
+    vi.mocked(FirebaseAuthentication.getIdToken).mockRejectedValue(
+      new Error("firebase plugin session unavailable"),
+    );
+    vi.mocked(HushhAuth.getIdToken).mockResolvedValue({
+      idToken: keychainToken,
+    } as any);
+
+    await expect(AuthService.getIdToken()).resolves.toBe(keychainToken);
+    expect(HushhAuth.getIdToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses HushhAuth when FirebaseAuthentication has no token", async () => {
+    const keychainToken = createIdToken(60 * 60);
+    vi.mocked(FirebaseAuthentication.getIdToken).mockResolvedValue({
+      token: null,
+    } as any);
+    vi.mocked(HushhAuth.getIdToken).mockResolvedValue({
+      idToken: keychainToken,
+    } as any);
+
+    await expect(AuthService.getIdToken()).resolves.toBe(keychainToken);
   });
 });
 

--- a/hushh-webapp/app/global-error.tsx
+++ b/hushh-webapp/app/global-error.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+function safeErrorClass(error: GlobalErrorProps["error"]): string {
+  const name = String(error?.name || "Error").replace(/[^A-Za-z0-9_-]/g, "");
+  return name.slice(0, 48) || "Error";
+}
+
+/**
+ * Last-resort App Router boundary.
+ *
+ * Next's built-in production boundary hides the only useful native diagnostic.
+ * Publish only the error class and opaque digest; messages can contain request
+ * details and must never cross the native log boundary.
+ */
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  const errorClass = safeErrorClass(error);
+  const digest = String(error?.digest || "").slice(0, 96);
+
+  useEffect(() => {
+    console.error("[GlobalErrorBoundary]", { errorClass, digest });
+  }, [digest, errorClass]);
+
+  return (
+    <html lang="en">
+      <body>
+        <main
+          data-native-global-error={errorClass}
+          className="flex min-h-dvh items-center justify-center bg-background px-6 text-foreground"
+        >
+          <div className="w-full max-w-sm text-center">
+            <h1 className="text-2xl font-semibold">This page couldn&apos;t load</h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Retry the page, or go back to continue.
+            </p>
+            <div className="mt-5 flex justify-center gap-3">
+              <button
+                type="button"
+                className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background"
+                onClick={reset}
+              >
+                Retry
+              </button>
+              <button
+                type="button"
+                className="rounded-lg border border-border px-4 py-2 text-sm font-medium"
+                onClick={() => window.history.back()}
+              >
+                Back
+              </button>
+            </div>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/hushh-webapp/capacitor.config.ts
+++ b/hushh-webapp/capacitor.config.ts
@@ -4,6 +4,7 @@ import type { CapacitorConfig } from "@capacitor/cli";
 import type { KeyboardResize, KeyboardStyle } from "@capacitor/keyboard";
 
 const BACKEND_URL = (process.env.NEXT_PUBLIC_BACKEND_URL || "").trim();
+const WEB_DIR = process.env.NEXT_DIST_DIR?.trim() || "out";
 
 function hostFromUrl(raw: string | undefined): string | null {
   if (!raw) return null;
@@ -40,7 +41,10 @@ const NORMALIZED_BACKEND_URL = (() => {
 const config: CapacitorConfig = {
   appId: "com.hushh.app",
   appName: "Hussh One",
-  webDir: "out",
+  // Next writes static exports into `distDir` when it is overridden. Native
+  // release builds use that override to avoid colliding with a live web dev
+  // server, so Capacitor must consume the same directory.
+  webDir: WEB_DIR,
 
   // iOS-specific configuration
   ios: {

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -199,7 +199,7 @@ export function AgentBar() {
   // for tier-aware presentation and to detect the home/onboarding surfaces
   // consistently with the chat workspace, instead of recomputing locally.
   const runtime = useAgentRuntimeStateOptional();
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const { resolvedTheme, setTheme } = useTheme();
   const { vaultOwnerToken } = useVault();
   const { switchPersona } = usePersonaState();
@@ -1034,6 +1034,7 @@ export function AgentBar() {
 
   const unmountBar =
     !agentPopover ||
+    authLoading ||
     // Focused onboarding routes retain voice but use the voice-only rendering
     // branch above, so Agent Chat never appears over setup or phone entry.
     path === ROUTES.AGENT ||
@@ -1317,7 +1318,7 @@ export function AgentBar() {
           // it does not re-render the voice tree as the page scrolls.
           bottom: physicalNavbarAbsent
             ? "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)"
-            : "calc(var(--app-bottom-inset) + 0.5rem)",
+            : "calc(max(var(--app-bottom-inset), calc(var(--bottom-nav-offset) + var(--app-safe-area-bottom-effective) + var(--app-bottom-chrome-lift))) + 0.5rem)",
         } as CSSProperties
       }
       aria-hidden={barHidden}

--- a/hushh-webapp/components/app-ui/public-knowledge-nav.tsx
+++ b/hushh-webapp/components/app-ui/public-knowledge-nav.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { ROUTES } from "@/lib/navigation/routes";
+import { cn } from "@/lib/utils";
+
+const ITEMS = [
+  {
+    label: "Research",
+    href: ROUTES.RESEARCH,
+    active: (pathname: string) =>
+      pathname === ROUTES.RESEARCH ||
+      pathname.startsWith(`${ROUTES.RESEARCH}/`),
+  },
+  {
+    label: "Blog",
+    href: ROUTES.BLOG,
+    active: (pathname: string) =>
+      pathname === ROUTES.BLOG || pathname.startsWith(`${ROUTES.BLOG}/`),
+  },
+] as const;
+
+/** Shared, quiet navigation for the two public knowledge surfaces. */
+export function PublicKnowledgeNav() {
+  const pathname = usePathname() ?? "";
+
+  return (
+    <nav
+      aria-label="Public knowledge"
+      className="grid grid-cols-2 border-b border-border/60"
+    >
+      {ITEMS.map((item) => {
+        const active = item.active(pathname);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "relative flex min-h-11 items-center justify-center px-4 text-sm font-semibold transition-colors",
+              active
+                ? "text-foreground after:absolute after:inset-x-4 after:bottom-0 after:h-0.5 after:rounded-full after:bg-[color:var(--app-accent)]"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -46,7 +46,9 @@ const ONE_AGENT_TILE_WIDTH = "5.75rem";
 function buildModes(
   statusById: Record<string, CapabilityStatus>,
 ): OneAgentMode[] {
-  return ONE_CAPABILITIES.map((capability) => {
+  return ONE_CAPABILITIES.filter(
+    (capability) => capability.isVisibleOnRoster !== false,
+  ).map((capability) => {
     const setupCapability = getOneSetupCapability(capability.id);
     const status = statusById[capability.id];
     const copy = setupCapability

--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -5,12 +5,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Cable,
   ClipboardCopy,
-  Code2,
   Globe,
   KeyRound,
   LifeBuoy,
   LockKeyhole,
-  Menu,
   RefreshCcw,
   ScanSearch,
   ShieldCheck,
@@ -32,7 +30,6 @@ import {
   DEVELOPER_ACCESS_NOTES,
   DEVELOPER_SAMPLE_PAYLOADS,
   DEVELOPER_SECTIONS,
-  DEVELOPER_SCOPE_NOTES,
   FAQ_ITEMS,
   MCP_PUBLIC_LINKS,
   PUBLIC_SCOPE_PATTERNS,
@@ -59,7 +56,9 @@ import {
   AppPageHeaderRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
-import { PageHeader, SectionHeader } from "@/components/app-ui/page-sections";
+import { PublicKnowledgeNav } from "@/components/app-ui/public-knowledge-nav";
+import { Hero } from "@/components/app-ui/sections";
+import { SectionHeader } from "@/components/app-ui/page-sections";
 import {
   SurfaceCard,
   SurfaceCardContent,
@@ -75,8 +74,6 @@ import {
   SettingsSegmentedTabs,
 } from "@/components/profile/settings-ui";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { Badge } from "@/components/ui/badge";
-import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import {
   Empty,
   EmptyContent,
@@ -120,7 +117,7 @@ const EMPTY_PROFILE_DRAFT: ProfileDraft = {
   policy_url: "",
 };
 
-const MOBILE_DEFAULT_OPEN_SECTIONS = ["start", "mcp", "access", "faq"];
+const DEFAULT_OPEN_SECTIONS = DEVELOPER_SECTIONS.map((section) => section.id);
 
 function formatDeveloperAccessError(
   error: unknown,
@@ -181,55 +178,6 @@ function findDeveloperSection(sectionId: string) {
   return DEVELOPER_SECTIONS.find((section) => section.id === sectionId);
 }
 
-function ContentsNav({
-  onSelectSection,
-  framed = true,
-  compact = false,
-  showSummaries = true,
-}: {
-  onSelectSection: (sectionId: string) => void;
-  framed?: boolean;
-  compact?: boolean;
-  showSummaries?: boolean;
-}) {
-  const rows = DEVELOPER_SECTIONS.map((section) => (
-    <SettingsRow
-      key={section.id}
-      title={
-        <span className={compact ? "text-[13px] sm:text-sm" : undefined}>{section.label}</span>
-      }
-      description={
-        showSummaries ? (
-          <span className={compact ? "line-clamp-1 text-[11px] leading-5" : undefined}>
-            {section.summary}
-          </span>
-        ) : undefined
-      }
-      chevron
-      className={compact ? "px-3 py-2 sm:px-3.5 sm:py-2.5" : undefined}
-      onClick={() => onSelectSection(section.id)}
-    />
-  ));
-
-  if (!framed) {
-    return (
-      <SettingsGroup embedded className="space-y-0">
-        {rows}
-      </SettingsGroup>
-    );
-  }
-
-  return (
-    <SettingsGroup
-      eyebrow="Contents"
-      title="Jump between sections"
-      description="Use the same page for the contract, setup snippets, and self-serve access."
-    >
-      {rows}
-    </SettingsGroup>
-  );
-}
-
 function RuntimeValueRow({
   label,
   value,
@@ -282,6 +230,18 @@ function RuntimeValueRow({
   );
 }
 
+function CodeList({ values }: { values: readonly string[] }) {
+  return (
+    <div className="divide-y divide-border/60 rounded-2xl border border-border/60 bg-background/70">
+      {values.map((value) => (
+        <code key={value} className="block overflow-x-auto px-3 py-2.5 text-xs text-foreground">
+          {value}
+        </code>
+      ))}
+    </div>
+  );
+}
+
 function SnippetCard({
   title,
   description,
@@ -331,14 +291,12 @@ function DeveloperSectionShell({
   sectionId,
   header,
   children,
-  isMobile,
   mobileOpenSections,
   onMobileSectionChange,
 }: {
   sectionId: string;
   header: React.ReactNode;
   children: React.ReactNode;
-  isMobile: boolean;
   mobileOpenSections: string[];
   onMobileSectionChange: (sectionId: string, isOpen: boolean) => void;
 }) {
@@ -346,18 +304,6 @@ function DeveloperSectionShell({
 
   if (!section) {
     return null;
-  }
-
-  if (!isMobile) {
-    return (
-      <section
-        id={sectionId}
-        className="scroll-mt-28 space-y-5 animate-in fade-in slide-in-from-bottom-2 duration-500"
-      >
-        {header}
-        {children}
-      </section>
-    );
   }
 
   const isOpen = mobileOpenSections.includes(sectionId);
@@ -711,9 +657,9 @@ function AccessWorkspace({
                   <RefreshCcw className="size-4" />
                   Rotate token
                 </MorphyButton>
-                <Badge variant="outline" className="justify-center px-3 py-1.5 text-xs sm:w-auto">
+                <code className="text-xs text-muted-foreground">
                   Prefix: {access.active_token?.token_prefix}
-                </Badge>
+                </code>
               </div>
             </div>
           ) : null}
@@ -806,100 +752,17 @@ function AccessWorkspace({
             <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
               <SurfaceInset className="space-y-3">
                 <p className="text-sm font-semibold text-foreground">Public beta tools</p>
-                <div className="flex flex-wrap gap-2">
-                  {PUBLIC_TOOL_NAMES.map((toolName) => (
-                    <Badge key={toolName} variant="outline">
-                      {toolName}
-                    </Badge>
-                  ))}
-                </div>
+                <CodeList values={PUBLIC_TOOL_NAMES} />
               </SurfaceInset>
               <SurfaceInset className="space-y-3">
                 <p className="text-sm font-semibold text-foreground">Dynamic scope grammar</p>
-                <div className="flex flex-wrap gap-2">
-                  {PUBLIC_SCOPE_PATTERNS.map((scope) => (
-                    <Badge key={scope} variant="outline">
-                      {scope}
-                    </Badge>
-                  ))}
-                </div>
+                <CodeList values={PUBLIC_SCOPE_PATTERNS} />
               </SurfaceInset>
             </div>
           ) : null}
         </div>
       </SurfaceCardContent>
     </SurfaceCard>
-  );
-}
-
-function DesktopContentsRail({
-  onSelectSection,
-}: {
-  onSelectSection: (sectionId: string) => void;
-}) {
-  return (
-    <aside className="hidden lg:sticky lg:top-0 lg:block lg:self-start">
-      <SurfaceCard className="flex max-h-[calc(100dvh-3rem)] flex-col">
-        <SurfaceCardHeader className="gap-1 pb-2.5">
-          <SurfaceCardTitle>Sections</SurfaceCardTitle>
-          <SurfaceCardDescription>Jump anywhere on the page.</SurfaceCardDescription>
-        </SurfaceCardHeader>
-        <SurfaceCardContent className="pt-0 pb-3">
-          <ScrollArea className="max-h-[calc(100dvh-10rem)] pr-2">
-            <ContentsNav
-              onSelectSection={onSelectSection}
-              framed={false}
-              compact
-              showSummaries={false}
-            />
-          </ScrollArea>
-        </SurfaceCardContent>
-      </SurfaceCard>
-    </aside>
-  );
-}
-
-function MobileSectionsFab({
-  open,
-  onOpenChange,
-  onSelectSection,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onSelectSection: (sectionId: string) => void;
-}) {
-  return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      <div className="fixed right-4 z-[160] md:hidden" style={{ bottom: "calc(max(var(--app-safe-area-bottom-effective), 0.75rem) + 1rem)" }}>
-        <MorphyButton
-          variant="yellow-gradient"
-          effect="fill"
-          size="sm"
-          className="rounded-full px-4 shadow-[0_18px_60px_var(--morphy-cta-shadow)]"
-          onClick={() => onOpenChange(true)}
-        >
-          <Menu className="size-4" />
-          Sections
-        </MorphyButton>
-      </div>
-      <DrawerContent className="max-h-[78vh] rounded-t-[28px] border-t border-border/80 bg-background/98 md:hidden">
-        <DrawerHeader className="border-b border-border/80 bg-background/96 px-4 py-4 text-left backdrop-blur-xl">
-          <DrawerTitle>Jump to a section</DrawerTitle>
-          <DrawerDescription>
-            Move through the developer contract without scrolling the whole page.
-          </DrawerDescription>
-        </DrawerHeader>
-        <ScrollArea className="max-h-[56vh] px-4 py-4">
-          <ContentsNav
-            onSelectSection={(sectionId) => {
-              onSelectSection(sectionId);
-              onOpenChange(false);
-            }}
-            framed={false}
-          />
-        </ScrollArea>
-      </DrawerContent>
-    </Drawer>
   );
 }
 
@@ -914,8 +777,7 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
   const [integrationTab, setIntegrationTab] = useState<"rest" | "remote-mcp" | "npm">(
     "remote-mcp"
   );
-  const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const [mobileOpenSections, setMobileOpenSections] = useState<string[]>(MOBILE_DEFAULT_OPEN_SECTIONS);
+  const [mobileOpenSections, setMobileOpenSections] = useState<string[]>(DEFAULT_OPEN_SECTIONS);
   const [liveDocs, setLiveDocs] = useState<LiveDocsResponse | null>(null);
   const [liveDocsLoading, setLiveDocsLoading] = useState(true);
   const [access, setAccess] = useState<DeveloperPortalAccess | null>(null);
@@ -933,6 +795,11 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
   const apiRootReady = Boolean(liveDocs?.apiRoot);
   const toolCatalogReady = Boolean(liveDocs?.tools?.length);
   const scopeCatalogReady = Boolean(liveDocs?.scopes?.length);
+  const liveContractStatus = liveDocsLoading
+    ? "Checking live contract…"
+    : apiRootReady && toolCatalogReady && scopeCatalogReady
+      ? "Live contract available"
+      : "Live contract unavailable";
 
   useEffect(() => {
     let cancelled = false;
@@ -979,11 +846,6 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
   }, [access?.app]);
 
   useEffect(() => {
-    if (!isMobile) {
-      setMobileNavOpen(false);
-      return;
-    }
-
     if (initialHashHandledRef.current) {
       return;
     }
@@ -1002,7 +864,7 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
     }, 160);
 
     return () => window.clearTimeout(timer);
-  }, [isMobile]);
+  }, []);
 
   const refreshAccess = useCallback(async (currentUser = user) => {
     if (!currentUser) {
@@ -1153,20 +1015,11 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
     );
   }
 
-  function handleSectionSelect(sectionId: string) {
-    setMobileOpenSections((current) => addOpenSection(current, sectionId));
-    setMobileNavOpen(false);
-    window.setTimeout(() => {
-      scrollToSection(sectionId);
-    }, isMobile ? 180 : 0);
-  }
-
   return (
     <TooltipProvider>
       <AppPageShell
-        data-app-shell-top-spacer="true"
-        width="standard"
-        className="pb-[calc(6rem+var(--app-safe-area-bottom-effective))] md:pb-12 lg:pb-6"
+        width="reading"
+        className="pb-6 pt-0 sm:pb-10"
         nativeTest={{
           routeId: "/developers",
           marker: "native-route-developers",
@@ -1174,71 +1027,54 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
           dataState: "loaded",
         }}
       >
-        <AppPageContentRegion className="grid gap-6 lg:grid-cols-[248px_minmax(0,1fr)] xl:grid-cols-[272px_minmax(0,1fr)] 2xl:grid-cols-[288px_minmax(0,1fr)] 2xl:gap-8">
-          <DesktopContentsRail onSelectSection={handleSectionSelect} />
+        <AppPageHeaderRegion>
+          <div className="mb-5">
+            <PublicKnowledgeNav />
+          </div>
+          <Hero
+            kicker="Developers"
+            title="Build with consent, not around it."
+            lede="Connect with Remote MCP, request a scope, and read only the information the person approved."
+          />
+        </AppPageHeaderRegion>
 
-          <div className="min-w-0 space-y-6 md:space-y-8 lg:pr-2">
+        <AppPageContentRegion className="mt-8">
+          <div className="min-w-0 space-y-9">
             <section id="start" className="scroll-mt-24 space-y-6 md:space-y-8">
-              <AppPageHeaderRegion>
-                <PageHeader
-                  eyebrow="Developer Hub"
-                  title="Connect to Hussh with Remote MCP"
-                  description="Use the UAT streamable MCP endpoint to discover user-specific scopes, request consent inside Kai, and read only approved encrypted exports through one small contract."
-                  icon={Code2}
-                  accent="consent"
-                />
-              </AppPageHeaderRegion>
-
-              <SurfaceCard tone="feature" className="min-w-0">
+              <SurfaceCard className="min-w-0">
                 <SurfaceCardHeader>
                   <SurfaceCardTitle className="text-base sm:text-lg">
-                    Quick start: connect a remote-capable MCP host
+                    Connect with Remote MCP
                   </SurfaceCardTitle>
                   <SurfaceCardDescription className="max-w-3xl text-sm leading-6">
-                    The recommended path is the slash-safe streamable MCP URL. Sign in only when you
-                    want a personal developer token and app identity for consent prompts.
+                    Use the endpoint below with a developer token.
                   </SurfaceCardDescription>
                 </SurfaceCardHeader>
                 <SurfaceCardContent className="space-y-5">
-                  <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+                  <div className="grid min-w-0 gap-5">
                     <SnippetCard
-                      title="Connect with Remote MCP"
-                      description="Paste this into any host that supports streamable HTTP MCP. Replace the placeholder with the developer token revealed from your workspace."
+                      title="Host configuration"
+                      description="Paste this into a streamable HTTP MCP host."
                       code={mcpSnippets.remote}
                       copyLabel="Remote MCP config"
                     />
-                    <div className="min-w-0 space-y-4">
-                      <SurfaceInset className="space-y-3">
-                        <p className="text-sm font-semibold text-foreground">Test server</p>
-                        <RuntimeValueRow
-                          label="MCP"
-                          value={workspaceSnippets.remoteUrl}
-                          copyLabel="Remote MCP URL"
-                          isMobile={isMobile}
-                        />
-                        <RuntimeValueRow
-                          label="Env"
-                          value={workspaceSnippets.envVar}
-                          copyLabel="Developer env var"
-                          isMobile={isMobile}
-                        />
-                      </SurfaceInset>
-                      <SurfaceInset className="space-y-3">
-                        <p className="text-sm font-semibold text-foreground">Live status</p>
-                        <div className="flex flex-wrap gap-2">
-                          <Badge variant={apiRootReady ? "default" : "outline"}>
-                            API root {liveDocsLoading ? "checking" : apiRootReady ? "ready" : "unavailable"}
-                          </Badge>
-                          <Badge variant={toolCatalogReady ? "default" : "outline"}>
-                            Tool catalog {liveDocsLoading ? "checking" : toolCatalogReady ? "ready" : "unavailable"}
-                          </Badge>
-                          <Badge variant={scopeCatalogReady ? "default" : "outline"}>
-                            Scope catalog {liveDocsLoading ? "checking" : scopeCatalogReady ? "ready" : "unavailable"}
-                          </Badge>
-                          <Badge variant="secondary">MCP requires token</Badge>
-                        </div>
-                      </SurfaceInset>
-                    </div>
+                    <SurfaceInset className="space-y-3">
+                      <p role="status" className="text-sm font-semibold text-foreground">
+                        {liveContractStatus}
+                      </p>
+                      <RuntimeValueRow
+                        label="MCP"
+                        value={workspaceSnippets.remoteUrl}
+                        copyLabel="Remote MCP URL"
+                        isMobile={isMobile}
+                      />
+                      <RuntimeValueRow
+                        label="Env"
+                        value={workspaceSnippets.envVar}
+                        copyLabel="Developer env var"
+                        isMobile={isMobile}
+                      />
+                    </SurfaceInset>
                   </div>
                   <Accordion type="single" collapsible className="rounded-2xl border border-border/65 px-4">
                     <AccordionItem value="advanced-start" className="border-b-0">
@@ -1269,14 +1105,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="mcp"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="MCP"
-                  title="Remote MCP when possible, npm bridge when needed"
-                  description="Hosts that support HTTP MCP can connect directly. Everyone else can still use the npm launcher with the same developer token."
+                  title="Remote MCP first"
+                  description="Use the npm bridge only when a host requires stdio."
                   icon={Cable}
                   accent="consent"
                 />
@@ -1343,20 +1178,8 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
                         {PUBLIC_MCP_ENVIRONMENT.remoteUrlTemplate}
                       </div>
                     </SurfaceInset>
-                    <div className="flex flex-wrap gap-2">
-                      {PUBLIC_TOOL_NAMES.map((toolName) => (
-                        <Badge key={toolName} variant="outline">
-                          {toolName}
-                        </Badge>
-                      ))}
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      {PUBLIC_RESOURCE_URIS.map((resourceUri) => (
-                        <Badge key={resourceUri} variant="secondary">
-                          {resourceUri}
-                        </Badge>
-                      ))}
-                    </div>
+                    <CodeList values={PUBLIC_TOOL_NAMES} />
+                    <CodeList values={PUBLIC_RESOURCE_URIS} />
                     {liveDocs?.tools?.length ? (
                       <ScrollArea className="h-64 rounded-2xl border border-border/65 sm:h-72">
                         <div className="space-y-3 p-4">
@@ -1388,14 +1211,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="access"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
-                  eyebrow="Developer Access"
-                  title="Turn the docs into a working integration workspace"
-                  description="The page is fully readable without login. Sign in only when you want self-serve tokens and app identity controls."
+                  eyebrow="Access"
+                  title="Developer access"
+                  description="Sign in only to create a token or edit your app identity."
                   icon={KeyRound}
                   accent="emerald"
                 />
@@ -1460,14 +1282,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="overview"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="Overview"
-                  title="The trust model stays simple"
-                  description="Authentication identifies your developer app. User consent in Kai is the separate programmable boundary that grants access to a discovered scope."
+                  title="Authentication is not consent"
+                  description="A token identifies the app. The person approves each scope."
                   icon={ShieldCheck}
                   accent="emerald"
                 />
@@ -1509,14 +1330,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="dynamic-scopes"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="Dynamic Scopes"
-                  title="Scopes are discovered from the user’s indexed PKM"
-                  description="The public grammar is fixed, but the user-specific scope strings are generated from the indexed Personal Knowledge Model and the domain registry."
+                  title="Discover scopes first"
+                  description="Available scopes come from the person’s indexed information."
                   icon={ScanSearch}
                   accent="violet"
                   actions={
@@ -1537,23 +1357,7 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
             >
               <SurfaceCard className="min-w-0">
                 <SurfaceCardContent className="space-y-5 pt-6">
-                  <SurfaceInset className="space-y-3">
-                    <p className="text-sm font-semibold text-foreground">Current status</p>
-                    <div className="space-y-2">
-                      {DEVELOPER_SCOPE_NOTES.map((note) => (
-                        <p key={note} className="text-sm leading-6 text-muted-foreground">
-                          {note}
-                        </p>
-                      ))}
-                    </div>
-                  </SurfaceInset>
-                  <div className="flex flex-wrap gap-2">
-                    {PUBLIC_SCOPE_PATTERNS.map((scopePattern) => (
-                      <Badge key={scopePattern} variant="outline">
-                        {scopePattern}
-                      </Badge>
-                    ))}
-                  </div>
+                  <CodeList values={PUBLIC_SCOPE_PATTERNS} />
                   {liveDocsLoading ? (
                     <div className="grid gap-3 lg:grid-cols-2">
                       <Skeleton className="h-28 rounded-3xl" />
@@ -1595,14 +1399,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="consent-flow"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="Consent Flow"
-                  title="The user journey stays explicit"
-                  description="External agents can ask, but only Kai can approve. That separation is what keeps the contract trustworthy."
+                  title="Discover, request, approve, read"
+                  description="Every read follows a person-approved scope."
                   icon={Workflow}
                   accent="amber"
                 />
@@ -1612,7 +1415,9 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
                 {CONSENT_FLOW_STEPS.map((step, index) => (
                   <SurfaceCard key={step.title} className="min-w-0">
                     <SurfaceCardContent className="space-y-3 pt-6">
-                      <Badge variant="outline">Step {index + 1}</Badge>
+                      <span className="text-xs font-semibold text-muted-foreground">
+                        {String(index + 1).padStart(2, "0")}
+                      </span>
                       <h3 className="text-base font-semibold text-foreground">{step.title}</h3>
                       <p className="text-sm leading-6 text-muted-foreground">{step.detail}</p>
                     </SurfaceCardContent>
@@ -1623,14 +1428,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="modes"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="Advanced"
-                  title="Use REST or npm only when the host needs it"
-                  description="Remote MCP is the recommended path. These options stay available for direct HTTP integrations and stdio-only MCP hosts."
+                  title="REST and npm fallbacks"
+                  description="Use these only when Remote MCP does not fit the host."
                   icon={Cable}
                   accent="sky"
                 />
@@ -1639,14 +1443,18 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
               <SettingsGroup
                 eyebrow="Transport options"
                 title="Remote MCP first"
-                description="All modes use the same consent contract. The transport choice only changes how your host connects."
+                description="The transport changes; the consent contract does not."
               >
                 {integrationModes.map((mode) => (
                   <SettingsRow
                     key={mode.id}
                     title={mode.title}
                     description={mode.summary}
-                    trailing={integrationTab === mode.id ? <Badge variant="default">Active</Badge> : undefined}
+                    trailing={
+                      integrationTab === mode.id ? (
+                        <span className="text-sm font-semibold text-foreground">Selected</span>
+                      ) : undefined
+                    }
                     stackTrailingOnMobile
                     onClick={() => setIntegrationTab(mode.id)}
                   />
@@ -1656,14 +1464,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="api"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="REST API"
-                  title="Versioned endpoints for discovery and consent"
-                  description="The public API is intentionally small. Everything else builds on top of these primitives."
+                  title="REST reference"
+                  description="Versioned endpoints for discovery, consent, status, and scoped reads."
                   icon={Globe}
                   accent="sky"
                 />
@@ -1675,12 +1482,16 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
                     <SettingsGroup
                       eyebrow="Endpoint map"
                       title="Small on purpose"
-                      description="Everything public builds on these primitives for discovery, consent, status, and scoped reads."
+                      description="The public contract stays narrow."
                     >
                       {REST_ENDPOINTS.map((endpoint) => (
                         <SettingsRow
                           key={endpoint.path}
-                          leading={<Badge variant="outline">{endpoint.method}</Badge>}
+                          leading={
+                            <span className="font-mono text-xs font-semibold text-muted-foreground">
+                              {endpoint.method}
+                            </span>
+                          }
                           title={<code className="text-xs sm:text-[13px]">{endpoint.path}</code>}
                           description={
                             <div className="space-y-1">
@@ -1720,14 +1531,13 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
 
             <DeveloperSectionShell
               sectionId="faq"
-              isMobile={isMobile}
               mobileOpenSections={mobileOpenSections}
               onMobileSectionChange={handleMobileSectionChange}
               header={
                 <SectionHeader
                   eyebrow="Troubleshooting"
-                  title="Common questions from external developers"
-                  description="These answers stay aligned with the runtime contract and the trust model users see in Kai."
+                  title="Common questions"
+                  description="Answers from the current runtime contract."
                   icon={LifeBuoy}
                   accent="default"
                 />
@@ -1763,13 +1573,6 @@ export function DeveloperDocsHub({ initialOrigin = null }: { initialOrigin?: str
         </AppPageContentRegion>
       </AppPageShell>
 
-      {isMobile ? (
-        <MobileSectionsFab
-          open={mobileNavOpen}
-          onOpenChange={setMobileNavOpen}
-          onSelectSection={handleSectionSelect}
-        />
-      ) : null}
     </TooltipProvider>
   );
 }

--- a/hushh-webapp/components/onboarding/IntroStep.module.css
+++ b/hushh-webapp/components/onboarding/IntroStep.module.css
@@ -210,7 +210,7 @@
 
 .links {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   margin-top: 16px;
   border-top: 1px solid var(--foundation-hairline);
   color: var(--foundation-dim);

--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -135,8 +135,9 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
           </div>
 
           <p className={styles.description}>
-            Everything stays encrypted in your vault. Nothing moves without your
-            consent.
+            Everything stays encrypted in your vault.
+            <br />
+            Nothing moves without your consent.
           </p>
         </div>
 
@@ -176,12 +177,6 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
               className={styles.link}
             >
               Research
-            </Link>
-            <Link
-              href={ROUTES.BLOG}
-              className={styles.link}
-            >
-              Blog
             </Link>
             <Link
               href={ROUTES.DEVELOPERS}

--- a/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
+++ b/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
@@ -10,6 +10,7 @@ import {
   buildOneSetupRoute,
   isCapabilityOnboardingRoute,
   isOnboardingAdmissionExemptRoute,
+  isOneSetupRoute,
   isOneSetupSurfaceRoute,
   ROUTES,
 } from "@/lib/navigation/routes";
@@ -21,6 +22,11 @@ import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completi
 
 const SETUP_REDIRECT_RETRY_MS = 1200;
 const SETUP_REDIRECT_FAILURE_MS = 2400;
+const SETUP_BOOTSTRAP_RETRY_MS = 300;
+
+function waitForBootstrapRetry(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, SETUP_BOOTSTRAP_RETRY_MS));
+}
 
 function hasExplicitIncompleteSetup(state: PreVaultUserState): boolean {
   if (PreVaultUserStateService.isSetupResolved(state)) return false;
@@ -157,9 +163,21 @@ export function OnboardingJourneyGuard({
       setChecking(true);
       setError(null);
       try {
-        const state =
-          cachedState ??
-          (await PreVaultUserStateService.bootstrapState(userId));
+        let state = cachedState;
+        if (!state) {
+          try {
+            state = await PreVaultUserStateService.bootstrapState(userId);
+          } catch {
+            // Native auth restoration and cross-tab web auth can publish the
+            // user before the token provider or proxy is ready. Retry once
+            // with a forced read; never create an unbounded setup loop.
+            await waitForBootstrapRetry();
+            if (cancelled) return;
+            state = await PreVaultUserStateService.bootstrapState(userId, {
+              force: true,
+            });
+          }
+        }
         if (cancelled) return;
 
         // A missing legacy mirror is not evidence that an established account
@@ -190,7 +208,7 @@ export function OnboardingJourneyGuard({
         // indefinitely. Retry once, then expose a recoverable error.
         redirectWatchdogRef.current = setTimeout(() => {
           if (cancelled || typeof window === "undefined") return;
-          if (window.location.pathname === ROUTES.ONE_SETUP) {
+          if (isOneSetupRoute(window.location.pathname)) {
             setRedirecting(false);
             setChecking(false);
             return;
@@ -198,11 +216,12 @@ export function OnboardingJourneyGuard({
           router.replace(redirectTarget);
           redirectWatchdogRef.current = setTimeout(() => {
             if (cancelled || typeof window === "undefined") return;
-            if (window.location.pathname === ROUTES.ONE_SETUP) {
+            if (isOneSetupRoute(window.location.pathname)) {
               setRedirecting(false);
               setChecking(false);
               return;
             }
+            redirectTargetRef.current = null;
             setRedirecting(false);
             setChecking(false);
             setError("Unable to open setup. Please retry.");
@@ -260,6 +279,15 @@ export function OnboardingJourneyGuard({
             }}
           >
             Retry
+          </Button>
+          <Button
+            size="sm"
+            variant="muted"
+            effect="fade"
+            className="mt-3"
+            onClick={() => router.push(ROUTES.PROFILE)}
+          >
+            Open profile
           </Button>
         </div>
       </div>

--- a/hushh-webapp/components/research/blog-index.tsx
+++ b/hushh-webapp/components/research/blog-index.tsx
@@ -5,19 +5,17 @@ import {
   AppPageContentRegion,
 } from "@/components/app-ui/app-page-shell";
 import { Hero } from "@/components/app-ui/sections";
-import { ResearchSubNav } from "@/components/research/research-sub-nav";
+import { PublicKnowledgeNav } from "@/components/app-ui/public-knowledge-nav";
 import { ROUTES } from "@/lib/navigation/routes";
 import { BLOG_POSTS } from "@/lib/research/blog";
 import { formatBlogDate } from "@/lib/research/format-blog-date";
-import { summerColorForKey } from "@/lib/research/summer-theme";
-import { cn } from "@/lib/utils";
 
 export function BlogIndex() {
   return (
-    <AppPageShell width="reading" className="py-6 sm:py-10">
+    <AppPageShell width="reading" className="pb-6 pt-0 sm:pb-10">
       <AppPageHeaderRegion>
         <div className="mb-5">
-          <ResearchSubNav />
+          <PublicKnowledgeNav />
         </div>
         <Hero
           kicker="Blog"
@@ -35,21 +33,6 @@ export function BlogIndex() {
                   <time dateTime={post.date}>{formatBlogDate(post.date)}</time>
                   <span aria-hidden>·</span>
                   <span>{post.readingMinutes} min read</span>
-                  {post.tags.slice(0, 2).map((tag) => {
-                    const c = summerColorForKey(tag);
-                    return (
-                      <span
-                        key={tag}
-                        className={cn(
-                          "rounded-full px-2 py-0.5 text-[11px] font-medium",
-                          c.softBg,
-                          c.text
-                        )}
-                      >
-                        {tag}
-                      </span>
-                    );
-                  })}
                 </div>
                 <h2 className="text-xl font-medium tracking-tight text-foreground transition-colors group-hover:text-sky-700 dark:group-hover:text-sky-300">
                   {post.title}

--- a/hushh-webapp/components/research/blog-post-view.tsx
+++ b/hushh-webapp/components/research/blog-post-view.tsx
@@ -6,17 +6,19 @@ import {
   AppPageContentRegion,
 } from "@/components/app-ui/app-page-shell";
 import { Figure } from "@/components/app-ui/sections";
+import { PublicKnowledgeNav } from "@/components/app-ui/public-knowledge-nav";
 import { ProseMarkdown } from "@/components/research/prose-markdown";
 import { ROUTES } from "@/lib/navigation/routes";
 import type { BlogPost } from "@/lib/research/blog";
 import { formatBlogDate } from "@/lib/research/format-blog-date";
-import { summerColorForKey } from "@/lib/research/summer-theme";
-import { cn } from "@/lib/utils";
 
 export function BlogPostView({ post }: { post: BlogPost }) {
   return (
-    <AppPageShell width="reading" className="py-6 sm:py-10">
+    <AppPageShell width="reading" className="pb-6 pt-0 sm:pb-10">
       <AppPageHeaderRegion>
+        <div className="mb-5">
+          <PublicKnowledgeNav />
+        </div>
         <Link
           href={ROUTES.BLOG}
           className="mb-6 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-sky-700 dark:hover:text-sky-300"
@@ -29,24 +31,9 @@ export function BlogPostView({ post }: { post: BlogPost }) {
           <time dateTime={post.date}>{formatBlogDate(post.date)}</time>
           <span aria-hidden>·</span>
           <span>{post.readingMinutes} min read</span>
-          {post.tags.map((tag) => {
-            const c = summerColorForKey(tag);
-            return (
-              <span
-                key={tag}
-                className={cn(
-                  "rounded-full px-2 py-0.5 text-[11px] font-medium",
-                  c.softBg,
-                  c.text
-                )}
-              >
-                {tag}
-              </span>
-            );
-          })}
         </div>
 
-        <h1 className="bg-gradient-to-r from-sky-600 via-fuchsia-600 to-orange-500 bg-clip-text text-[30px] font-semibold leading-[1.12] tracking-tight text-transparent sm:text-[36px] dark:from-sky-300 dark:via-fuchsia-300 dark:to-amber-300">
+        <h1 className="text-[30px] font-semibold leading-[1.12] tracking-tight text-foreground sm:text-[36px]">
           {post.title}
         </h1>
         <p className="mt-3 text-lg leading-8 text-muted-foreground">{post.subtitle}</p>

--- a/hushh-webapp/components/research/research-landing.tsx
+++ b/hushh-webapp/components/research/research-landing.tsx
@@ -6,30 +6,28 @@ import {
   AppPageContentRegion,
 } from "@/components/app-ui/app-page-shell";
 import { Hero, Band, Figure } from "@/components/app-ui/sections";
+import { PublicKnowledgeNav } from "@/components/app-ui/public-knowledge-nav";
 import { ROUTES } from "@/lib/navigation/routes";
 import { PCHP_SPEC_META } from "@/lib/research/pchp-spec";
 import { BLOG_POSTS } from "@/lib/research/blog";
-import { ResearchSubNav } from "@/components/research/research-sub-nav";
-import { summerColorForKey } from "@/lib/research/summer-theme";
-import { cn } from "@/lib/utils";
 
 export function ResearchLanding() {
   const latestPosts = BLOG_POSTS.slice(0, 3);
 
   return (
-    <AppPageShell width="reading" className="py-6 sm:py-10">
+    <AppPageShell width="reading" className="pb-6 pt-0 sm:pb-10">
       <AppPageHeaderRegion>
         <div className="mb-5">
-          <ResearchSubNav />
+          <PublicKnowledgeNav />
         </div>
         <Hero
-          kicker="Research & Papers"
+          kicker="Research"
           title="Open protocols, given to the commons."
-          lede="We publish our protocol work in the open and give it away. Our flagship is PCHP — the Personal Consent Handshake Protocol — an open standard for sharing personal data with consent and control built into every transaction."
+          lede="PCHP is an open consent protocol for sharing information without giving up control."
         />
       </AppPageHeaderRegion>
 
-      <AppPageContentRegion className="mt-8 space-y-10" data-app-shell-top-spacer="true">
+      <AppPageContentRegion className="mt-8 space-y-9">
         <ul className="space-y-3">
           <li>
             <Link
@@ -44,7 +42,7 @@ export function ResearchLanding() {
                   PCHP Specification
                 </span>
                 <span className="mt-1 block pl-0 text-sm leading-6 text-muted-foreground mr-4">
-                  The full protocol — six-phase handshake, token wire formats, scope grammar, zero-knowledge envelope, transparency log, conformance levels.
+                  Handshake, wire formats, scope grammar, encryption, and conformance.
                 </span>
               </div>
               <div className="hidden sm:flex shrink-0 pt-1 text-muted-foreground items-center gap-1">
@@ -66,7 +64,7 @@ export function ResearchLanding() {
                   Blog
                 </span>
                 <span className="mt-1 block pl-0 text-sm leading-6 text-muted-foreground mr-4">
-                  Why consent-first information sharing matters, what it unlocks, and how to adopt PCHP — written working backwards from the human.
+                  Notes on consent, control, and building from the person outward.
                 </span>
               </div>
               <div className="hidden sm:flex shrink-0 pt-1 text-muted-foreground items-center gap-1">
@@ -85,44 +83,25 @@ export function ResearchLanding() {
                 PCHP {PCHP_SPEC_META.version} · {PCHP_SPEC_META.status}
               </h3>
               <p className="mt-1 text-sm leading-6 text-muted-foreground">
-                Specification text under CC0 (public domain); schema and reference code
-                under Apache-2.0. Learned from the best — MCP, LSP, SSH, OAuth, WebAuthn —
-                and credited in full. Updated {PCHP_SPEC_META.updated}.
+                CC0 specification · Apache-2.0 schema and reference code · Updated {PCHP_SPEC_META.updated}.
               </p>
             </div>
           </div>
         </Figure>
 
         <Band title="Latest writing">
-          <ul className="mt-4 space-y-2.5">
-            {latestPosts.map((post) => {
-              const c = summerColorForKey(post.slug);
-              return (
-                <li key={post.slug}>
-                  <Link
-                    href={`${ROUTES.BLOG}/${post.slug}`}
-                    className="group flex items-start gap-3 rounded-[var(--app-card-radius-feature)] border border-transparent px-2 py-2.5 transition-colors hover:border-border/60 hover:bg-muted/30 hover:px-4"
-                  >
-                    <span
-                      className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", c.dot)}
-                    />
-                    <span className="min-w-0">
-                      <span
-                        className={cn(
-                          "block text-[15px] font-medium transition-opacity group-hover:opacity-80",
-                          c.text
-                        )}
-                      >
-                        {post.title}
-                      </span>
-                      <span className="mt-0.5 block text-sm leading-6 text-muted-foreground">
-                        {post.excerpt}
-                      </span>
-                    </span>
-                  </Link>
-                </li>
-              );
-            })}
+          <ul className="mt-3 divide-y divide-border/60">
+            {latestPosts.map((post) => (
+              <li key={post.slug}>
+                <Link
+                  href={`${ROUTES.BLOG}/${post.slug}`}
+                  className="group flex min-h-12 items-center justify-between gap-4 py-3 text-[15px] font-medium text-foreground"
+                >
+                  <span>{post.title}</span>
+                  <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                </Link>
+              </li>
+            ))}
           </ul>
         </Band>
       </AppPageContentRegion>

--- a/hushh-webapp/ios/App/App/AppDelegate.swift
+++ b/hushh-webapp/ios/App/App/AppDelegate.swift
@@ -18,7 +18,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Ensure Firebase is initialized once for native plugins and auth flows.
-        if FirebaseApp.app() == nil {
+        // `FirebaseApp.app()` logs an error when no default app exists, even
+        // when that is the normal first-launch state. Inspect the registry so
+        // cold starts stay clean before configuring the default app.
+        if FirebaseApp.allApps?.isEmpty != false {
             if Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil {
                 FirebaseApp.configure()
                 print("✅ [AppDelegate] Firebase configured")

--- a/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhAuthPlugin.swift
@@ -214,7 +214,9 @@ public class HushhAuthPlugin: CAPPlugin, CAPBridgedPlugin {
 
     // Ensure Firebase is initialized before any FirebaseAuth call.
     private func ensureFirebaseConfigured() -> Bool {
-        if FirebaseApp.app() != nil {
+        // Avoid FirebaseApp.app(): it logs an error for the expected
+        // first-launch state before this plugin configures Firebase.
+        if FirebaseApp.allApps?.isEmpty == false {
             return true
         }
         guard Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil else {

--- a/hushh-webapp/ios/App/AppUITests/AppUITests.swift
+++ b/hushh-webapp/ios/App/AppUITests/AppUITests.swift
@@ -65,6 +65,21 @@ final class AppUITests: XCTestCase {
         ])
     }
 
+    func testAuthenticatedSetupBootstrapRoute() throws {
+        try assertRoutes([
+            RouteCase(
+                name: "one-setup",
+                initialRoute: "/login?redirect=%2Fone%2Fsetup",
+                expectedMarker: "native-route-one-setup",
+                expectedRoute: "/one/setup",
+                expectedRoutePrefix: nil,
+                autoReviewerLogin: true,
+                expectedAuth: "authenticated",
+                allowedDataStates: ["loaded"]
+            ),
+        ])
+    }
+
     func testInvestorRoutes() throws {
         try assertRoutes([
             reviewerRoute(name: "kai-home", redirect: "/kai", marker: "native-route-kai-home"),

--- a/hushh-webapp/lib/developers/content.ts
+++ b/hushh-webapp/lib/developers/content.ts
@@ -109,47 +109,47 @@ export const DEVELOPER_SECTIONS: DeveloperSection[] = [
   {
     id: "start",
     label: "Quick Start",
-    summary: "Remote MCP setup, the UAT server, and the one copy-ready happy path.",
+    summary: "One copy-ready Remote MCP setup.",
   },
   {
     id: "mcp",
     label: "Remote MCP",
-    summary: "Streamable MCP setup for remote-capable hosts.",
+    summary: "Direct streamable HTTP connection.",
   },
   {
     id: "access",
     label: "Developer Access",
-    summary: "Sign in, enable access, rotate tokens, and update your app identity.",
+    summary: "Tokens and app identity.",
   },
   {
     id: "overview",
     label: "Trust Model",
-    summary: "Auth identifies your app; user consent grants each scope.",
+    summary: "Authentication and consent stay separate.",
   },
   {
     id: "dynamic-scopes",
     label: "Dynamic Scopes",
-    summary: "Scopes come from the user’s indexed Personal Knowledge Model, not a hardcoded list.",
+    summary: "Discover available scopes per person.",
   },
   {
     id: "consent-flow",
     label: "Consent Flow",
-    summary: "Discover, request, approve in Kai, then read approved scoped information.",
+    summary: "Discover, request, approve, read.",
   },
   {
     id: "modes",
     label: "Advanced",
-    summary: "REST API and npm bridge options for non-default host needs.",
+    summary: "REST and npm fallbacks.",
   },
   {
     id: "api",
     label: "REST API",
-    summary: "Advanced direct HTTP endpoints for discovery, consent, and status checks.",
+    summary: "Versioned endpoint reference.",
   },
   {
     id: "faq",
     label: "Troubleshooting",
-    summary: "Answers to the common integration and trust-model questions.",
+    summary: "Answers from the current runtime contract.",
   },
 ];
 
@@ -178,7 +178,7 @@ export const CONSENT_FLOW_STEPS: ConsentFlowStep[] = [
   {
     title: "Request",
     detail:
-      "Send one discovered scope at a time to POST /api/v1/request-consent?token=... with your developer token and connector public-key bundle so Hussh can wrap the export key for client-side decryption.",
+      "Send one discovered scope at a time to POST /api/v1/request-consent with a Bearer developer token and connector public-key bundle so Hussh can wrap the export key for client-side decryption.",
   },
   {
     title: "Approve",
@@ -308,7 +308,6 @@ export const DEVELOPER_SAMPLE_PAYLOADS: DeveloperSamplePayload[] = [
   "user_id": "kai_test_user",
   "available_domains": ["financial"],
   "scopes": [
-    "pkm.read",
     "attr.financial.*",
     "attr.financial.portfolio.*",
     "attr.financial.profile.*",
@@ -419,7 +418,7 @@ export function buildIntegrationModes(_runtime: DeveloperRuntime): IntegrationMo
       id: "remote-mcp",
       title: "Remote/Streamable MCP",
       summary:
-        `Point remote-capable hosts at ${MCP_PUBLIC_DOCS.promotedEnvironment.label} and use the exact /mcp/?token=... URL shape.`,
+        `Point remote-capable hosts at ${MCP_PUBLIC_DOCS.promotedEnvironment.label} and use the trailing-slash /mcp/ endpoint with a Bearer token.`,
     },
     {
       id: "rest",

--- a/hushh-webapp/lib/firebase/auth-context.tsx
+++ b/hushh-webapp/lib/firebase/auth-context.tsx
@@ -132,6 +132,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const router = useRouter();
   const userRef = useRef<User | null>(null);
   const authRecoveryInFlightRef = useRef(false);
+  // Firebase JS commonly emits `null` before the native keychain/provider has
+  // finished restoring. Until this flips, native restoration owns the loading
+  // state and the JS listener must not publish a false signed-out transition.
+  const nativeRestoreSettledRef = useRef(!IS_NATIVE);
 
   const applyAuthUser = useCallback((nextUser: User | null) => {
     userRef.current = nextUser;
@@ -193,6 +197,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const checkAuth = useCallback(async () => {
     // 1. Native Session Restoration
     if (Capacitor.isNativePlatform()) {
+      nativeRestoreSettledRef.current = false;
       try {
         const nativeUser = await AuthService.restoreNativeSession();
 
@@ -211,6 +216,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         applyAuthUser(null);
         // User will need to log in again
       } finally {
+        nativeRestoreSettledRef.current = true;
         // ✅ CRITICAL: Always set loading to false after native check
         // This ensures VaultLockGuard can proceed (to login or vault unlock)
         setLoading(false);
@@ -286,6 +292,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // The Firebase JS SDK often fires 'null' on startup or network change in Capacitor apps
       // Use ref to check current user without adding `user` to dependencies
       if (IS_NATIVE) {
+        if (!firebaseUser && !nativeRestoreSettledRef.current) {
+          console.log(
+            "🍎 [AuthContext] Ignoring Firebase Null State While Native Restore Is Pending"
+          );
+          return;
+        }
         if (!firebaseUser && userRef.current) {
           console.log(
             "🍎 [AuthContext] Ignoring Firebase Null State (Native Mode)"

--- a/hushh-webapp/lib/firebase/auth-context.tsx
+++ b/hushh-webapp/lib/firebase/auth-context.tsx
@@ -30,6 +30,7 @@ import {
   onAuthStateChanged,
 } from "firebase/auth";
 import { auth, prepareRecaptchaVerifier, resetRecaptcha } from "./config";
+import { NativeAuthRestoreEpoch } from "./native-auth-restore-epoch";
 import { Capacitor } from "@capacitor/core";
 import { AuthService } from "@/lib/services/auth-service";
 import { AccountIdentityService } from "@/lib/services/account-identity-service";
@@ -136,6 +137,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // finished restoring. Until this flips, native restoration owns the loading
   // state and the JS listener must not publish a false signed-out transition.
   const nativeRestoreSettledRef = useRef(!IS_NATIVE);
+  const nativeRestoreEpochRef = useRef(new NativeAuthRestoreEpoch());
 
   const applyAuthUser = useCallback((nextUser: User | null) => {
     userRef.current = nextUser;
@@ -171,10 +173,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const refreshUser = useCallback(async (): Promise<User | null> => {
     if (Capacitor.isNativePlatform()) {
-      const nativeUser = await AuthService.restoreNativeSession();
-      applyAuthUser(nativeUser);
-      setLoading(false);
-      return nativeUser;
+      const restoreEpoch = nativeRestoreEpochRef.current.begin();
+      nativeRestoreSettledRef.current = false;
+      try {
+        const nativeUser = await AuthService.restoreNativeSession();
+        if (!nativeRestoreEpochRef.current.isCurrent(restoreEpoch)) {
+          return userRef.current;
+        }
+        applyAuthUser(nativeUser);
+        return nativeUser;
+      } finally {
+        if (nativeRestoreEpochRef.current.isCurrent(restoreEpoch)) {
+          nativeRestoreSettledRef.current = true;
+          setLoading(false);
+        }
+      }
     }
 
     const currentUser = auth.currentUser;
@@ -197,25 +210,33 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const checkAuth = useCallback(async () => {
     // 1. Native Session Restoration
     if (Capacitor.isNativePlatform()) {
+      const restoreEpoch = nativeRestoreEpochRef.current.begin();
       nativeRestoreSettledRef.current = false;
       try {
         const nativeUser = await AuthService.restoreNativeSession();
 
+        if (!nativeRestoreEpochRef.current.isCurrent(restoreEpoch)) {
+          return;
+        }
+
         if (nativeUser) {
-          console.log(
-            "🍎 [AuthProvider] Native session restored:",
-            nativeUser.uid
-          );
+          console.log("🍎 [AuthProvider] Native session restored");
           applyAuthUser(nativeUser);
         } else {
           console.log("🍎 [AuthProvider] No native session found");
           applyAuthUser(null);
         }
-      } catch (e) {
-        console.warn("🍎 [AuthProvider] Native restore error:", e);
+      } catch (_error) {
+        if (!nativeRestoreEpochRef.current.isCurrent(restoreEpoch)) {
+          return;
+        }
+        console.warn("🍎 [AuthProvider] Native restore error");
         applyAuthUser(null);
         // User will need to log in again
       } finally {
+        if (!nativeRestoreEpochRef.current.isCurrent(restoreEpoch)) {
+          return;
+        }
         nativeRestoreSettledRef.current = true;
         // ✅ CRITICAL: Always set loading to false after native check
         // This ensures VaultLockGuard can proceed (to login or vault unlock)
@@ -322,6 +343,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     redirectTo?: string;
     skipFcmCleanup?: boolean;
   }): Promise<void> => {
+    // A restore that began before sign-out must never repopulate auth state.
+    nativeRestoreEpochRef.current.invalidate();
+    nativeRestoreSettledRef.current = true;
     const currentUid = user?.uid ?? null;
     const redirectTo = options?.redirectTo || ROUTES.HOME;
     try {
@@ -386,17 +410,27 @@ export function AuthProvider({ children }: AuthProviderProps) {
         authRecoveryInFlightRef.current = true;
         try {
           if (Capacitor.isNativePlatform()) {
+            const restoreEpoch = nativeRestoreEpochRef.current.begin();
+            nativeRestoreSettledRef.current = false;
             const [nativeUser, refreshedToken] = await Promise.all([
               AuthService.restoreNativeSession(),
               AuthService.getIdToken(true),
             ]);
 
-            if (nativeUser && refreshedToken) {
+            if (!nativeRestoreEpochRef.current.isCurrent(restoreEpoch)) {
+              return;
+            }
+
+            if (
+              nativeUser &&
+              refreshedToken
+            ) {
               console.info("🍎 [AuthProvider] Recovered native session after auth invalidation");
               applyAuthUser(nativeUser);
               setLoading(false);
               return;
             }
+            nativeRestoreSettledRef.current = true;
           }
 
           await signOut({ redirectTo: ROUTES.LOGIN });
@@ -670,6 +704,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     refreshUser,
     setNativeUser: (user: User | null) => {
       console.log("🍎 [AuthContext] Manually setting Native User");
+      // AuthStep has a confirmed native Apple result. Invalidate any launch or
+      // resume restore that started before the Apple sheet completed.
+      nativeRestoreEpochRef.current.invalidate();
+      nativeRestoreSettledRef.current = true;
       applyAuthUser(user);
       setLoading(false);
     },

--- a/hushh-webapp/lib/firebase/native-auth-restore-epoch.ts
+++ b/hushh-webapp/lib/firebase/native-auth-restore-epoch.ts
@@ -1,0 +1,22 @@
+/**
+ * Orders native auth restores without persisting identity or token material.
+ *
+ * Capacitor can trigger a launch restore and an app-active restore around the
+ * native Apple sheet. Only the newest operation is allowed to publish state.
+ */
+export class NativeAuthRestoreEpoch {
+  private currentEpoch = 0;
+
+  begin(): number {
+    this.currentEpoch += 1;
+    return this.currentEpoch;
+  }
+
+  invalidate(): void {
+    this.currentEpoch += 1;
+  }
+
+  isCurrent(epoch: number): boolean {
+    return epoch === this.currentEpoch;
+  }
+}

--- a/hushh-webapp/lib/navigation/agent-sections.ts
+++ b/hushh-webapp/lib/navigation/agent-sections.ts
@@ -156,7 +156,8 @@ function toAgentSection(capability: OneCapability): AgentSection {
 
 export function getAgentSections(): readonly AgentSection[] {
   const sections = ONE_CAPABILITIES.filter(
-    (capability) => capability.id !== "ria",
+    (capability) =>
+      capability.id !== "ria" && capability.isVisibleOnRoster !== false,
   ).map(toAgentSection);
   // RIA sits directly after Investor so the two finance personas stay
   // adjacent while remaining standalone top-level agents.

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -271,10 +271,10 @@ export function resolveOnboardingCapabilityForRoute(
 }
 
 /**
- * Anonymous/editorial and prerequisite routes that never participate in the
- * authenticated root-setup admission decision. `/profile` is intentionally
- * not exempt: once signed in it is an internal surface and must not bypass an
- * explicitly incomplete setup journey.
+ * Anonymous/editorial, prerequisite, and account-recovery routes that never
+ * participate in the authenticated root-setup admission decision. Profile is
+ * deliberately exempt so a failed setup/bootstrap dependency can never trap a
+ * signed-in user away from sign-out or account deletion.
  */
 export function isOnboardingAdmissionExemptRoute(pathname: string): boolean {
   return (
@@ -288,6 +288,8 @@ export function isOnboardingAdmissionExemptRoute(pathname: string): boolean {
     pathname === ROUTES.GETTING_STARTED ||
     pathname === ROUTES.PHONE_MANDATE ||
     pathname === ROUTES.LOGOUT ||
+    pathname === ROUTES.PROFILE ||
+    pathname.startsWith(`${ROUTES.PROFILE}/`) ||
     pathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`)
   );
 }
@@ -422,7 +424,22 @@ export function buildKaiAnalysisPreviewRoute(entries?: {
  * lives at `/one/setup/finance`.
  */
 export function isOneSetupRoute(pathname: string): boolean {
-  return pathname === ROUTES.ONE_SETUP;
+  return normalizeStaticExportPathname(pathname) === ROUTES.ONE_SETUP;
+}
+
+/**
+ * Capacitor uses Next's static export, which represents directory routes with
+ * a trailing slash (and may expose the backing index document while settling
+ * a WebView navigation). Route admission must compare the logical app route,
+ * not that transport-specific pathname shape.
+ */
+function normalizeStaticExportPathname(pathname: string): string {
+  const withoutIndexDocument = String(pathname || "/").replace(
+    /\/index\.html$/i,
+    "",
+  );
+  const withoutTrailingSlash = withoutIndexDocument.replace(/\/+$/, "");
+  return withoutTrailingSlash || "/";
 }
 
 /**
@@ -435,7 +452,9 @@ export function isOneSetupRoute(pathname: string): boolean {
  * reserved wizard and compatibility sub-paths are unaffected.
  */
 export function isOneSetupCapabilityRoute(pathname: string): boolean {
-  return Object.values(SETUP_CAPABILITY_ROUTES).includes(pathname);
+  return Object.values(SETUP_CAPABILITY_ROUTES).includes(
+    normalizeStaticExportPathname(pathname),
+  );
 }
 
 /**
@@ -447,10 +466,11 @@ export function isOneSetupCapabilityRoute(pathname: string): boolean {
  * the capability handoff is a transient redirector.
  */
 export function isOneSetupWizardRoute(pathname: string): boolean {
+  const normalizedPathname = normalizeStaticExportPathname(pathname);
   return (
-    pathname === ROUTES.ONE_SETUP_FINANCE ||
-    pathname === ROUTES.ONE_SETUP_FINANCE_IMPORT ||
-    pathname === ROUTES.ONE_SETUP_KAI
+    normalizedPathname === ROUTES.ONE_SETUP_FINANCE ||
+    normalizedPathname === ROUTES.ONE_SETUP_FINANCE_IMPORT ||
+    normalizedPathname === ROUTES.ONE_SETUP_KAI
   );
 }
 

--- a/hushh-webapp/lib/onboarding/one-capabilities.ts
+++ b/hushh-webapp/lib/onboarding/one-capabilities.ts
@@ -74,6 +74,8 @@ export interface OneCapability {
    * full `description` would truncate mid-word. Falls back to `description`.
    */
   previewLabel?: string;
+  /** Hide this capability from the primary One agent roster while its route remains available. */
+  isVisibleOnRoster?: boolean;
   href: string;
   icon: LucideIcon;
   tone: OneCapabilityTone;
@@ -216,6 +218,7 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
     tone: "pkm",
     group: "access",
     isExploreOnly: true,
+    isVisibleOnRoster: false,
   },
   {
     id: "connected-systems",
@@ -237,8 +240,9 @@ export const ONE_CAPABILITIES: readonly OneCapability[] = [
  * This order is product-authored and must not be re-ranked by status: people
  * should always see the same calm sequence while individual rows update.
  *
- * Memory, Consent, and Information Marketplace remain available in One; they
- * are not account-setup requirements.
+ * Memory and Consent remain available in One; they are not account-setup
+ * requirements. Information Marketplace remains route-addressable but is not
+ * shown in the primary agent roster while the surface is disabled.
  */
 export type OneSetupCapability = OneCapability & {
   id: OneSetupCapabilityId;

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -710,6 +710,10 @@ export class AuthService {
 
       const idToken = result.idToken;
       const nativeAuthUser = result.user;
+      const nativeUid = this.getNativeUserField(
+        nativeAuthUser as unknown as Record<string, unknown>,
+        ["uid", "id"],
+      );
 
       this.debugLog("✅ [AuthService] Got Apple ID token");
 
@@ -754,9 +758,23 @@ export class AuthService {
         }
       }
 
-      // Construct final User object
+      // A stale Firebase JS session can survive while the native Apple sheet
+      // establishes a new account. It must not be paired with the new native
+      // token; use the native wrapper until JS reports the matching UID.
+      const matchingFirebaseUser =
+        firebaseUser && nativeUid && firebaseUser.uid === nativeUid
+          ? firebaseUser
+          : null;
+      if (firebaseUser && !matchingFirebaseUser) {
+        this.debugLog(
+          "🍎 [AuthService] Ignoring stale Firebase JS user after native Apple sign-in",
+        );
+      }
+
+      // Construct final User object.
       const user =
-        firebaseUser || this.createUserFromNativeApple(nativeAuthUser, idToken);
+        matchingFirebaseUser ||
+        this.createUserFromNativeApple(nativeAuthUser, idToken);
 
       toast.success("Signed in successfully", { id: toastId });
 

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -1405,13 +1405,33 @@ export class AuthService {
       }
     }
 
-    // Fallback to Capacitor Firebase plugin
+    // Browser auth is owned exclusively by the Firebase JS SDK. Calling the
+    // Capacitor plugin's web shim here turns a normal signed-out state into a
+    // noisy runtime error and cannot recover a browser session.
+    if (!Capacitor.isNativePlatform()) return null;
+
+    // Prefer the shared Capacitor Firebase plugin when it owns the native
+    // session. On iOS, Apple/Google sign-in may instead be restored by the
+    // app-owned HushhAuth keychain plugin, so a FirebaseAuthentication runtime
+    // error is not evidence that the authenticated session has no token.
     try {
       const result = await FirebaseAuthentication.getIdToken();
-      return result.token;
-    } catch {
-      return null;
+      if (result.token) return result.token;
+    } catch (error) {
+      this.debugError(
+        "[AuthService] FirebaseAuthentication token lookup failed",
+        error,
+      );
     }
+
+    try {
+      const result = await HushhAuth.getIdToken();
+      return result.idToken || null;
+    } catch (error) {
+      this.debugError("[AuthService] HushhAuth token lookup failed", error);
+    }
+
+    return null;
   }
 
   /**

--- a/hushh-webapp/next.config.ts
+++ b/hushh-webapp/next.config.ts
@@ -16,6 +16,11 @@ import path from "path";
 const isCapacitorBuild = process.env.CAPACITOR_BUILD === "true";
 
 const config: NextConfig = {
+  // Native static exports may run while the local web dev server is active.
+  // Keep their compiler caches isolated so `next build` cannot corrupt the
+  // live `.next` module graph and turn local API routes into transient 500s.
+  distDir: process.env.NEXT_DIST_DIR || ".next",
+
   // Keep file tracing and workspace discovery scoped to this monorepo.
   outputFileTracingRoot: path.join(process.cwd(), ".."),
 

--- a/hushh-webapp/scripts/native/prepare-ios-uat-archive.mjs
+++ b/hushh-webapp/scripts/native/prepare-ios-uat-archive.mjs
@@ -42,7 +42,21 @@ function applyEnvValues(values = {}) {
 }
 
 function ensureUatEnv() {
-  const uatValues = parseEnvFile(uatEnvPath);
+  // CI and isolated release worktrees inject the public UAT build contract
+  // through the process environment. Keep the ignored local overlay as the
+  // developer default, but let an explicit environment value win so the
+  // archive is reproducible from the exact release SHA.
+  const uatValues = {
+    ...parseEnvFile(uatEnvPath),
+    ...Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([key, value]) =>
+          (key === "APP_RUNTIME_PROFILE" || key.startsWith("NEXT_PUBLIC_")) &&
+          typeof value === "string" &&
+          value.trim().length > 0,
+      ),
+    ),
+  };
   const backendUrl = String(uatValues.NEXT_PUBLIC_BACKEND_URL || "").trim().replace(/\/$/, "");
 
   if (!backendUrl || isLocalBackend(backendUrl)) {
@@ -52,6 +66,7 @@ function ensureUatEnv() {
   }
 
   applyEnvValues({
+    NEXT_DIST_DIR: ".next-native-uat",
     APP_RUNTIME_PROFILE: uatValues.APP_RUNTIME_PROFILE || "uat",
     NEXT_PUBLIC_APP_ENV: uatValues.NEXT_PUBLIC_APP_ENV || "uat",
     NEXT_PUBLIC_BACKEND_URL: backendUrl,


### PR DESCRIPTION
## Summary
- recover setup bootstrap across static iOS and web routes
- retain native auth while the keychain restore settles
- leave Profile reachable as an account recovery escape hatch

## Verification
- npm run typecheck
- focused Vitest: 48 passing
- focused ESLint
- iOS simulator reviewer setup + cold-launch Profile persistence
- DCO and secret scan