### PR TITLE
test(utils): characterize formatCompleteJson formatting contracts for sparse array inputs

### DIFF
--- a/hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts
+++ b/hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts
@@ -62,7 +62,9 @@ describe("formatCompleteJson — sparse array inputs", () => {
     expect(out).toBe(
       [
         "",
-        "--- Misc (3 items) ---",
+        // Header reports the FULL array length (5), holes included — the slice
+        // to 3 only affects how many bullets render, not the '(N items)' count.
+        "--- Misc (5 items) ---",
         "  • 1",
         "  • undefined",
         "  • 3",

--- a/hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts
+++ b/hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompleteJson } from "@/lib/utils/json-to-human";
+
+// Characterization tests for `formatCompleteJson`
+// (hushh-webapp/lib/utils/json-to-human.ts) focused on SPARSE JavaScript arrays
+// carrying explicit index holes, e.g. `[1, , 3]`.
+//
+// TRUTH-FIRST CORRECTION TO THE TASK PREMISE
+// ------------------------------------------
+// The task asked to document how the loop handles missing array slots "during
+// `Object.entries` sequence evaluation." That framing is FALSE for arrays.
+// Verified in json-to-human.ts:
+//
+//   • `Object.entries(json)` is used ONLY for the TOP-LEVEL record and for plain
+//     OBJECT sections/nested objects. Arrays never reach `Object.entries`.
+//   • Array section values are detected by `Array.isArray(...)` FIRST and are
+//     iterated with `sectionValue.slice(0, N)` + `for (const item of ...)`.
+//
+// This distinction matters for holes:
+//   • `Object.entries` / `Array.prototype.forEach` SKIP holes.
+//   • `for...of` (used here) does NOT skip holes — it MATERIALIZES each hole as
+//     `undefined` and visits it like any other element.
+//
+// Consequence (the actual contract): a hole is NOT skipped. In the GENERIC array
+// branch each hole is stringified via `String(item)` → produces a literal
+// "  • undefined" PLACEHOLDER line. Holes are also counted in the `(${length}
+// items)` header and in the "... and N more" arithmetic, because `.length`
+// includes holes.
+//
+// One more honest boundary: JSON has no concept of holes, so `JSON.parse` (and
+// therefore `tryFormatComplete`) can never PRODUCE a sparse array. Sparse arrays
+// only reach `formatCompleteJson` when it is called directly on an in-memory JS
+// object — which is exactly the surface these tests pin.
+
+describe("formatCompleteJson — sparse array inputs", () => {
+  it("materializes a hole as a literal 'undefined' placeholder line (NOT skipped)", () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const out = formatCompleteJson({ misc: [1, , 3] });
+    expect(out).toBe(
+      ["", "--- Misc (3 items) ---", "  • 1", "  • undefined", "  • 3"].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("counts holes in the array-length header ('(N items)')", () => {
+    // `[, ,]` has length 2 (two holes), so the header reports 2 items.
+    // eslint-disable-next-line no-sparse-arrays
+    const out = formatCompleteJson({ misc: [, ,] });
+    expect(out).toContain("--- Misc (2 items) ---");
+    // Both holes surface as placeholder bullet lines.
+    expect(out).toBe(
+      ["", "--- Misc (2 items) ---", "  • undefined", "  • undefined"].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("includes holes when computing the '... and N more' overflow tail", () => {
+    // Length 5 (three real values + two holes); generic branch renders slice(0,3)
+    // then reports the remaining 2 as overflow. Holes are part of that count.
+    // eslint-disable-next-line no-sparse-arrays
+    const out = formatCompleteJson({ misc: [1, , 3, , 5] });
+    expect(out).toBe(
+      [
+        "",
+        "--- Misc (3 items) ---",
+        "  • 1",
+        "  • undefined",
+        "  • 3",
+        "  ... and 2 more",
+      ].join("\n"),
+    );
+  });
+
+  it("treats a fully-holey array (length > 0) as non-empty and emits placeholders", () => {
+    // `Array(3)` has length 3 with all holes. The empty-array guard only skips
+    // length === 0, so this is processed and yields three 'undefined' bullets.
+    const out = formatCompleteJson({ misc: Array(3) });
+    expect(out).toBe(
+      [
+        "",
+        "--- Misc (3 items) ---",
+        "  • undefined",
+        "  • undefined",
+        "  • undefined",
+      ].join("\n"),
+    );
+  });
+
+  it("still skips a genuinely EMPTY array (length === 0), holes or not", () => {
+    // A zero-length array (no holes possible) is skipped entirely — no header.
+    expect(formatCompleteJson({ misc: [] })).toBe("");
+  });
+
+  it("THROWS on a sparse OBJECT-array section (holdings), documenting the hole is not hole-safe", () => {
+    // The holdings branch coerces each item to a record and reads fields off it.
+    // A hole becomes `undefined`, so `undefined.symbol_cusip` throws. This pins
+    // that object-array sections are NOT resilient to holes (unlike the generic
+    // primitive path, which stringifies to "undefined").
+    expect(() =>
+      // eslint-disable-next-line no-sparse-arrays
+      formatCompleteJson({ holdings: [{ symbol_cusip: "AAPL" }, ,] }),
+    ).toThrow();
+  });
+});

--- a/hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts
+++ b/hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts
@@ -35,7 +35,6 @@ import { formatCompleteJson } from "@/lib/utils/json-to-human";
 
 describe("formatCompleteJson — sparse array inputs", () => {
   it("materializes a hole as a literal 'undefined' placeholder line (NOT skipped)", () => {
-    // eslint-disable-next-line no-sparse-arrays
     const out = formatCompleteJson({ misc: [1, , 3] });
     expect(out).toBe(
       ["", "--- Misc (3 items) ---", "  • 1", "  • undefined", "  • 3"].join(
@@ -46,7 +45,6 @@ describe("formatCompleteJson — sparse array inputs", () => {
 
   it("counts holes in the array-length header ('(N items)')", () => {
     // `[, ,]` has length 2 (two holes), so the header reports 2 items.
-    // eslint-disable-next-line no-sparse-arrays
     const out = formatCompleteJson({ misc: [, ,] });
     expect(out).toContain("--- Misc (2 items) ---");
     // Both holes surface as placeholder bullet lines.
@@ -60,7 +58,6 @@ describe("formatCompleteJson — sparse array inputs", () => {
   it("includes holes when computing the '... and N more' overflow tail", () => {
     // Length 5 (three real values + two holes); generic branch renders slice(0,3)
     // then reports the remaining 2 as overflow. Holes are part of that count.
-    // eslint-disable-next-line no-sparse-arrays
     const out = formatCompleteJson({ misc: [1, , 3, , 5] });
     expect(out).toBe(
       [
@@ -100,7 +97,6 @@ describe("formatCompleteJson — sparse array inputs", () => {
     // that object-array sections are NOT resilient to holes (unlike the generic
     // primitive path, which stringifies to "undefined").
     expect(() =>
-      // eslint-disable-next-line no-sparse-arrays
       formatCompleteJson({ holdings: [{ symbol_cusip: "AAPL" }, ,] }),
     ).toThrow();
   });


### PR DESCRIPTION
### Summary

Adds a **test-only** characterization suite pinning how `formatCompleteJson`
(`hushh-webapp/lib/utils/json-to-human.ts`) handles **sparse JavaScript arrays**
carrying explicit index holes, e.g. `[1, , 3]`. No production code is changed.

### Truth-first correction to the premise

The task asked to document how holes are handled *"during `Object.entries`
sequence evaluation."* That framing is **inaccurate** for arrays. Verified in
`json-to-human.ts`:

- `Object.entries(...)` is used **only** for the top-level record and for plain
  **object** sections / nested objects.
- **Array** section values are matched by `Array.isArray(...)` *first* and are
  iterated with `sectionValue.slice(0, N)` + `for (const item of ...)`. Arrays
  never reach `Object.entries`.

This matters for holes:

- `Object.entries` / `Array.prototype.forEach` **skip** holes.
- `for...of` (what this code uses) does **not** skip holes — it **materializes**
  each hole as `undefined` and visits it like any other element.

### Literal contract characterized (verified against source)

- **Holes are NOT skipped.** In the generic array branch each hole is stringified
  via `String(item)` → a literal `  • undefined` placeholder line.
- **Holes count toward `.length`.** They inflate the `(${length} items)` header
  and the `... and N more` overflow arithmetic.
- **A fully-holey array with `length > 0`** (`Array(3)`) is treated as non-empty
  (the guard only skips `length === 0`) → three `undefined` bullets.
- **A genuinely empty array (`[]`)** is still skipped entirely (no header).
- **Object-array sections are NOT hole-safe.** In `holdings` (and similar), a
  hole becomes `undefined` and the code reads fields off it (`undefined.symbol_cusip`),
  so the call **throws** — pinned explicitly to contrast with the primitive path.

### Honest boundary

JSON has no concept of holes, so `JSON.parse` (and therefore `tryFormatComplete`)
can **never produce** a sparse array. Sparse arrays only reach `formatCompleteJson`
via a direct in-memory call — exactly the surface these tests pin.

### Tests added

`hushh-webapp/__tests__/utils/formatter-sparse-arrays.test.ts` (6 cases).

### Proofs & Verification

- **Workspace Isolation:** single added file; `1 file changed, 107 insertions(+)`;
  `git status` showed only this untracked test before staging.
- **DCO:** commit created with `git commit -s` (Signed-off-by trailer present).
- **Import parity:** uses `@/lib/utils/json-to-human`, identical to sibling
  formatter specs already merged on `integration/pr-train`. (Any IDE "cannot find
  module" hint is only because the editor resolves from the repo root, not the
  `hushh-webapp/` tsconfig `@/*` alias; not a real build/test error.)
- **Local test run caveat (honest disclosure):** the Vitest runner in my
  environment aborts with `Vitest failed to find the runner` before loading any
  spec (reproduces against already-merged suites too), so I could **not** produce
  a local green run. CI is the authoritative gate. Every expectation was derived
  directly from the current source control flow.

### CI Gate Checklist
- [x] PR Base Policy — targets `integration/pr-train`
- [x] DCO Verified (`-s`)
- [x] Test Only Surface Change (single new spec, no production edits)
