### PR TITLE
fix(one-kyc): ground consent scopes to real PKM paths + redact passport MRZ

### DIFF
--- a/consent-protocol/api/routes/pkm_routes_shared.py
+++ b/consent-protocol/api/routes/pkm_routes_shared.py
@@ -671,7 +671,12 @@ async def store_domain(
                 },
             )
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to store domain data"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "code": store_result.get("code") or "PKM_STORE_DOMAIN_FAILED",
+                "message": "Failed to store domain data",
+                "error": store_result.get("error"),
+            },
         )
 
     return StoreDomainResponse(

--- a/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
+++ b/consent-protocol/hushh_mcp/services/one_email_kyc_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import copy
 import email.utils
 import hashlib
 import html
@@ -452,6 +453,137 @@ def _validate_one_email_data_scope(scope: str) -> str:
             },
         )
     return normalized
+
+
+def _canonical_one_email_scope(scope: Any) -> str | None:
+    """Coerce a proposed scope to the ``attr.<domain>[.<path>][.*]`` lane grammar.
+
+    Pass-1 LLM routing (``classify_kyc_request``) can emit bare scopes such as
+    ``identity.passport`` or ``financial.cash_positions``. ``confirm_proposal``
+    subset-checks those against the raw proposal, but ``select_scopes`` then runs
+    ``_validate_one_email_data_scope`` which requires the ``attr.`` prefix — so an
+    un-normalized proposal is un-confirmable. Prefixing here (rather than
+    collapsing to ``attr.<domain>.*``) preserves scope granularity for data
+    minimization. Returns None for scopes that cannot be made well-formed.
+    """
+    normalized = _clean_text(scope).lower()
+    if not normalized:
+        return None
+    if not normalized.startswith("attr."):
+        normalized = f"attr.{normalized}"
+    return normalized if _ONE_EMAIL_ATTR_SCOPE_RE.fullmatch(normalized) else None
+
+
+# Keyword -> preferred segment groups for snapping invented scope paths onto real
+# PKM segments. Ordered; first group whose keyword appears in the path wins.
+_SCOPE_PATH_SNAP_GROUPS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("passport",), "passport"),
+    (("license", "licence", "driver", "dl"), "drivers_license"),
+    (("tax", "ssn", "tin", "itin", "w9", "w8", "w-9", "w-8", "taxpayer"), "tax"),
+    (
+        (
+            "bank",
+            "account",
+            "routing",
+            "cash",
+            "iban",
+            "swift",
+            "cheque",
+            "check",
+            "deposit",
+            "payout",
+            "funds",
+        ),
+        "bank",
+    ),
+    (
+        (
+            "address",
+            "name",
+            "contact",
+            "phone",
+            "email",
+            "dob",
+            "birth",
+            "nationality",
+            "citizen",
+            "profile",
+        ),
+        "profile",
+    ),
+)
+
+
+def _snap_kyc_scope(scope: str, available_scope_paths: dict[str, list[str]]) -> str:
+    """Snap a canonical ``attr.<domain>.<path>`` scope onto a real PKM segment.
+
+    Prompt-level grounding does not reliably stop the LLM from emitting familiar
+    but non-existent paths (``identity.tax_id``, ``identity.cash_positions``).
+    This deterministically maps the proposed path to an actually-stored top-level
+    segment for that domain (``tax_id`` -> ``tax``, ``cash_positions`` -> ``bank``),
+    so the eye-icon preview and export resolve to real data. Falls back to the
+    original scope when no confident match exists.
+    """
+    parts = scope.split(".")
+    if len(parts) < 3 or parts[0] != "attr":
+        return scope
+    domain = parts[1]
+    path_first = parts[2]
+    domain_paths = available_scope_paths.get(domain) or []
+    if not domain_paths or path_first in domain_paths:
+        return scope
+    # Substring match either direction (e.g. tax_id -> tax).
+    for candidate in domain_paths:
+        if candidate and (candidate in path_first or path_first in candidate):
+            return f"attr.{domain}.{candidate}"
+    # Keyword-group match (e.g. cash_positions -> bank).
+    for keywords, preferred in _SCOPE_PATH_SNAP_GROUPS:
+        if any(keyword in path_first for keyword in keywords) and preferred in domain_paths:
+            return f"attr.{domain}.{preferred}"
+    return scope
+
+
+def _resolve_kyc_scope_against_paths(
+    scope: Any, available_scope_paths: dict[str, list[str]]
+) -> str | None:
+    """Resolve any scope-ish string to a real ``attr.<domain>.<segment>`` using the
+    user's actual PKM paths.
+
+    Handles the failure modes seen from LLM routing: a missing domain
+    (``passport`` -> ``attr.identity.passport``), a wrong domain
+    (``financial.cash_positions`` -> ``attr.identity.bank``), and an invented
+    segment (``tax_id`` -> ``tax``). Falls back to plain canonicalization when no
+    confident match exists so the lane grammar is still satisfied.
+    """
+    if not available_scope_paths:
+        return _canonical_one_email_scope(scope)
+    raw = _clean_text(scope).lower()
+    if raw.startswith("attr."):
+        raw = raw[len("attr.") :]
+    parts = [part for part in raw.split(".") if part and part != "*"]
+    if not parts:
+        return _canonical_one_email_scope(scope)
+    # 1) Exact domain.segment already valid.
+    if (
+        len(parts) >= 2
+        and parts[0] in available_scope_paths
+        and parts[1] in available_scope_paths[parts[0]]
+    ):
+        return f"attr.{parts[0]}.{parts[1]}"
+    # 2) Substring match of any part against a real segment in any domain.
+    for domain, segments in available_scope_paths.items():
+        for segment in segments:
+            for part in parts:
+                if part == segment or segment in part or part in segment:
+                    return f"attr.{domain}.{segment}"
+    # 3) Keyword-group snap (cash/account -> bank, ssn/w9 -> tax, ...).
+    for part in parts:
+        for keywords, preferred in _SCOPE_PATH_SNAP_GROUPS:
+            if any(keyword in part for keyword in keywords):
+                for domain, segments in available_scope_paths.items():
+                    if preferred in segments:
+                        return f"attr.{domain}.{preferred}"
+    return _canonical_one_email_scope(scope)
 
 
 def _scope_description(scope: str) -> str:
@@ -1974,10 +2106,42 @@ class OneEmailKycService:
 
         # Pass 1: LLM routing — runs after sender match so we have user_id for PKM index.
         pkm_index = await self._load_pkm_index_for_user(user_match["user_id"])
+        available_scope_paths = await self._load_domain_scope_paths(
+            user_match["user_id"], list(pkm_index.get("available_domains") or [])
+        )
         proposal = await self.classify_kyc_request(
             subject=subject,
             body=body_text,
             pkm_index=pkm_index,
+            available_scope_paths=available_scope_paths,
+        )
+
+        # Canonicalize LLM-proposed scopes to the attr.<domain>[.path] grammar the
+        # consent lane enforces. classify_kyc_request can emit bare scopes
+        # (identity.passport); without this, confirm_proposal accepts them but the
+        # downstream select_scopes -> _validate_one_email_data_scope rejects them,
+        # making the proposal impossible to confirm. Drop any item that cannot be
+        # coerced to a well-formed scope.
+        if isinstance(proposal.get("requested_items"), list):
+            canonical_items = []
+            for item in proposal["requested_items"]:
+                if not isinstance(item, dict):
+                    continue
+                canonical_scope = _canonical_one_email_scope(item.get("scope"))
+                if not canonical_scope:
+                    continue
+                # Deterministically snap invented paths (tax_id, cash_positions)
+                # onto real stored segments (tax, bank) since prompt grounding
+                # alone doesn't reliably constrain the model.
+                canonical_scope = _snap_kyc_scope(canonical_scope, available_scope_paths)
+                canonical_items.append({**item, "scope": canonical_scope})
+            proposal["requested_items"] = canonical_items
+
+        logger.info(
+            "kyc.routing.grounded user=%s available_scope_paths=%s final_scopes=%s",
+            user_match.get("user_id"),
+            available_scope_paths,
+            [item.get("scope") for item in (proposal.get("requested_items") or [])],
         )
 
         # Build candidate_scopes from the proposal's requested_items so the existing
@@ -2085,6 +2249,59 @@ class OneEmailKycService:
             "computed_tags": index.computed_tags,
         }
 
+    # Top-level manifest keys that are structural metadata, not real data scopes.
+    _NON_DATA_SCOPE_PATHS = frozenset(
+        {
+            "schema_version",
+            "last_updated",
+            "updated_at",
+            "created_at",
+            "domain_intent",
+            "sources",
+            "source_metadata",
+            "analytics",
+            "raw_extract_v2",
+        }
+    )
+
+    async def _load_domain_scope_paths(
+        self, user_id: str, domains: list[str]
+    ) -> dict[str, list[str]]:
+        """Return real top-level scope paths (segment names) per domain.
+
+        Grounds Pass-1 routing in what the user actually has stored, so the model
+        proposes existing scopes (identity.tax, identity.bank) instead of inventing
+        paths that resolve to no data. Reads pkm_manifest_paths; fails soft to {}.
+        """
+        result: dict[str, list[str]] = {}
+        for domain in domains:
+            clean_domain = _clean_text(domain)
+            if not clean_domain:
+                continue
+            try:
+                rows = (
+                    self.db.execute_raw(
+                        "SELECT DISTINCT split_part(json_path, '.', 1) AS top_path "
+                        "FROM pkm_manifest_paths "
+                        "WHERE user_id = :user_id AND domain = :domain "
+                        "ORDER BY top_path",
+                        {"user_id": user_id, "domain": clean_domain},
+                    ).data
+                    or []
+                )
+            except Exception as exc:  # pragma: no cover - best-effort grounding
+                logger.warning("kyc.scope_paths_load_failed domain=%s: %s", clean_domain, exc)
+                continue
+            paths = [
+                str(row.get("top_path"))
+                for row in rows
+                if row.get("top_path")
+                and str(row.get("top_path")) not in self._NON_DATA_SCOPE_PATHS
+            ]
+            if paths:
+                result[clean_domain] = paths
+        return result
+
     async def _llm_generate_structured(
         self,
         *,
@@ -2131,7 +2348,12 @@ class OneEmailKycService:
         return parsed if isinstance(parsed, dict) else None
 
     async def classify_kyc_request(
-        self, *, subject: str, body: str, pkm_index: dict[str, Any]
+        self,
+        *,
+        subject: str,
+        body: str,
+        pkm_index: dict[str, Any],
+        available_scope_paths: dict[str, list[str]] | None = None,
     ) -> dict[str, Any]:
         """Pass 1 — route the request to the correct PKM domain + fields.
 
@@ -2139,9 +2361,23 @@ class OneEmailKycService:
         summaries, NO raw values) to Gemini. Never sees real data. Replaces the
         keyword detectors (_looks_like_kyc / _detect_scope_candidates /
         _extract_required_fields).
+
+        ``available_scope_paths`` maps each available domain to its real
+        top-level scope paths (segment names) so the model routes to scopes that
+        actually exist in the user's PKM (e.g. ``identity.tax``, ``identity.bank``)
+        instead of inventing paths (``identity.tax_id``, ``financial.cash_positions``)
+        that resolve to no stored data.
         """
         if not _require_gemini_ready():
             return _gemini_unavailable_payload("Gemini unavailable for KYC routing")
+        scope_paths = available_scope_paths or {}
+        scope_paths_block = (
+            "Available scope paths per domain — you MUST choose scopes ONLY from "
+            "these (each scope is exactly 'attr.<domain>.<path>'):\n"
+            f"{json.dumps(scope_paths)}\n\n"
+            if scope_paths
+            else ""
+        )
         prompt = (
             "You classify an inbound email that requests personal data, and map it "
             "to the correct domain(s) in the user's personal knowledge model.\n"
@@ -2149,18 +2385,43 @@ class OneEmailKycService:
             "Example: 'provide your information to confirm a hotel booking' is a "
             "request for IDENTITY data (name, address), NOT travel itinerary data.\n\n"
             f"Available domains and summaries (NO values):\n{json.dumps(pkm_index)}\n\n"
+            f"{scope_paths_block}"
             f"Email subject: {_truncate(subject, 500)}\n"
             f"Email body: {_truncate(body, 4000)}\n\n"
-            "Return the routing JSON. For each requested item, pick the single most "
-            "appropriate domain and scope. Set confidence 0..1. If the email does not "
-            "request personal data, set classification='unsupported' and requested_items=[]."
+            "Return the routing JSON. For each requested item, set 'domain' to one of "
+            "the available domains and 'scope' to exactly 'attr.<domain>.<path>' where "
+            "<path> is one of that domain's available scope paths listed above. Do NOT "
+            "invent scope paths; pick the closest existing path (e.g. an SSN or tax form "
+            "maps to the 'tax' path, bank account details map to the 'bank' path). Set "
+            "confidence 0..1. If the email does not request personal data, set "
+            "classification='unsupported' and requested_items=[]."
         )
-        result = await self._llm_generate_structured(
-            prompt=prompt, response_schema=_KYC_ROUTING_SCHEMA
-        )
+        # Constrain the model to the user's REAL scopes via a schema enum, so it
+        # cannot invent paths (tax_id, bank_accounts) even if it ignores the
+        # prompt. Falls back to the free-text schema when no paths are known.
+        response_schema = self._kyc_routing_schema_for_paths(scope_paths)
+        result = await self._llm_generate_structured(prompt=prompt, response_schema=response_schema)
         if result is None:
             return _gemini_unavailable_payload("KYC routing produced no parseable result")
         return result
+
+    @staticmethod
+    def _kyc_routing_schema_for_paths(
+        scope_paths: dict[str, list[str]],
+    ) -> dict[str, Any]:
+        """Build a routing schema whose ``scope``/``domain`` fields are enums of
+        the user's real scopes, forcing grounded output. Returns the base
+        free-text schema when no scope paths are available."""
+        valid_scopes = sorted(
+            {f"attr.{domain}.{path}" for domain, paths in scope_paths.items() for path in paths}
+        )
+        if not valid_scopes:
+            return _KYC_ROUTING_SCHEMA
+        schema = copy.deepcopy(_KYC_ROUTING_SCHEMA)
+        item_props = schema["properties"]["requested_items"]["items"]["properties"]
+        item_props["scope"] = {"type": "STRING", "enum": valid_scopes}
+        item_props["domain"] = {"type": "STRING", "enum": sorted(scope_paths.keys())}
+        return schema
 
     def _looks_like_kyc(self, *, subject: str, body: str) -> bool:
         haystack = f"{subject}\n{body}".lower()
@@ -2902,12 +3163,24 @@ class OneEmailKycService:
                 code="ONE_KYC_NOT_AWAITING_CONFIRM",
             )
         proposal = (workflow.get("metadata") or {}).get("kyc_proposal") or {}
+        # Resolve both sides against the user's REAL PKM paths so malformed/bare
+        # routing output (identity.passport, attr.passport, financial.cash_positions)
+        # aligns on the same real scope (attr.identity.passport / attr.identity.bank)
+        # for the subset check and downstream consent creation.
+        available_scope_paths = await self._load_domain_scope_paths(
+            user_id,
+            list((await self._load_pkm_index_for_user(user_id)).get("available_domains") or []),
+        )
+
+        def _resolve(scope: Any) -> str | None:
+            return _resolve_kyc_scope_against_paths(scope, available_scope_paths)
+
         proposed_scopes = {
-            str(item.get("scope"))
+            resolved
             for item in proposal.get("requested_items", [])
-            if item.get("scope")
+            if (resolved := _resolve(item.get("scope")))
         }
-        approved = _dedupe(approved_scopes)
+        approved = _dedupe([resolved for scope in approved_scopes if (resolved := _resolve(scope))])
         invalid = [s for s in approved if s not in proposed_scopes]
         if not approved or invalid:
             raise OneEmailKycError(
@@ -2919,8 +3192,11 @@ class OneEmailKycService:
                     "proposed_scopes": sorted(proposed_scopes),
                 },
             )
+        approved_set = set(approved)
         confirmed_items = [
-            item for item in proposal.get("requested_items", []) if item.get("scope") in approved
+            item
+            for item in proposal.get("requested_items", [])
+            if _resolve(item.get("scope")) in approved_set
         ]
         self._update_workflow(
             workflow_id,
@@ -2950,16 +3226,36 @@ class OneEmailKycService:
                 code="ONE_KYC_SCOPE_SELECTION_NOT_ALLOWED",
             )
         metadata = workflow.get("metadata", {})
+        # Resolve every scope against the user's REAL PKM paths so malformed
+        # routing output (missing domain like `passport`, wrong domain like
+        # `financial.cash_positions`, invented segment like `tax_id`) becomes a
+        # real `attr.<domain>.<segment>` that the consent export can actually
+        # fulfill. Runs here because this is the code path that creates the
+        # consent requests.
+        available_scope_paths = await self._load_domain_scope_paths(
+            user_id,
+            list((await self._load_pkm_index_for_user(user_id)).get("available_domains") or []),
+        )
+
+        def _resolve(scope: Any) -> str | None:
+            return _resolve_kyc_scope_against_paths(scope, available_scope_paths)
+
         candidate_scopes = (
             [
-                _clean_text(candidate.get("scope"))
+                resolved
                 for candidate in metadata.get("candidate_scopes", [])
-                if isinstance(candidate, dict)
+                if isinstance(candidate, dict) and (resolved := _resolve(candidate.get("scope")))
             ]
             if isinstance(metadata, dict)
             else []
         )
-        selected = [_validate_one_email_data_scope(scope) for scope in _dedupe(selected_scopes)]
+        # Resolve incoming scopes before validation so callers (and older stored
+        # workflows) may pass bare/malformed scopes; _validate raises with the
+        # original scope when it cannot be coerced to the lane grammar.
+        selected = [
+            _validate_one_email_data_scope(_resolve(scope) or scope)
+            for scope in _dedupe(selected_scopes)
+        ]
         if not selected:
             raise OneEmailKycError(
                 "Select at least one scope for this One request.",

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -3838,7 +3838,9 @@ class PersonalKnowledgeModelService:
             result["updated_at"] = resolved_updated_at
             return result if return_result else True
         except Exception as e:
-            logger.error("pkm.store_domain_data.error: %s", e)
+            logger.exception("pkm.store_domain_data.error: %s", e)
+            result["code"] = result.get("code") or "PKM_STORE_DOMAIN_ERROR"
+            result["error"] = f"{type(e).__name__}: {e}"
             return result if return_result else False
 
     async def get_encrypted_data(self, user_id: str) -> Optional[dict]:

--- a/consent-protocol/tests/services/test_one_email_kyc_service.py
+++ b/consent-protocol/tests/services/test_one_email_kyc_service.py
@@ -26,7 +26,46 @@ from hushh_mcp.services.one_email_kyc_service import (
     OneEmailKycConfig,
     OneEmailKycError,
     OneEmailKycService,
+    _canonical_one_email_scope,
+    _snap_kyc_scope,
+    _validate_one_email_data_scope,
 )
+
+
+def test_snap_kyc_scope_maps_invented_paths_to_real_segments():
+    available = {
+        "identity": ["bank", "drivers_license", "passport", "profile", "tax"],
+        "financial": ["documents", "portfolio"],
+    }
+    # substring: tax_id -> tax
+    assert _snap_kyc_scope("attr.identity.tax_id", available) == "attr.identity.tax"
+    # keyword group: cash_positions -> bank
+    assert _snap_kyc_scope("attr.identity.cash_positions", available) == "attr.identity.bank"
+    # exact match is preserved
+    assert _snap_kyc_scope("attr.identity.passport", available) == "attr.identity.passport"
+    # unknown path with no confident match is left as-is
+    assert _snap_kyc_scope("attr.identity.zzz", available) == "attr.identity.zzz"
+    # no available paths for domain -> unchanged
+    assert _snap_kyc_scope("attr.identity.tax_id", {}) == "attr.identity.tax_id"
+
+
+def test_canonical_one_email_scope_prefixes_bare_llm_scopes():
+    # Pass-1 LLM can emit bare scopes; they must survive select_scopes validation.
+    for bare in ("identity.passport", "identity.tax_id", "financial.cash_positions"):
+        canonical = _canonical_one_email_scope(bare)
+        assert canonical == f"attr.{bare}"
+        # Canonical form must pass the lane grammar that select_scopes enforces.
+        assert _validate_one_email_data_scope(canonical) == canonical
+
+
+def test_canonical_one_email_scope_preserves_valid_and_rejects_junk():
+    assert _canonical_one_email_scope("attr.identity.*") == "attr.identity.*"
+    assert (
+        _canonical_one_email_scope("  ATTR.Financial.Portfolio.*  ") == "attr.financial.portfolio.*"
+    )
+    assert _canonical_one_email_scope("") is None
+    assert _canonical_one_email_scope(None) is None
+    assert _canonical_one_email_scope("attr..bad") is None
 
 
 def _b64url(value: str) -> str:

--- a/hushh-webapp/lib/consent/export-builder.ts
+++ b/hushh-webapp/lib/consent/export-builder.ts
@@ -115,6 +115,69 @@ function mergeSegmentIds(...groups: Array<string[] | null | undefined>): string[
   ];
 }
 
+// Concept keywords -> canonical segment, for snapping scopes whose path does not
+// exist in the manifest (e.g. a consent granted for identity.tax_id / cash_positions
+// when the data actually lives under identity.tax / identity.bank).
+const KYC_SEGMENT_KEYWORDS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/passport/, "passport"],
+  [/licen[sc]e|driver|(^|_)dl(_|$)/, "drivers_license"],
+  [/tax|ssn|tin|itin|w-?9|w-?8|taxpayer/, "tax"],
+  [/bank|account|routing|cash|iban|swift|cheque|check|deposit|payout/, "bank"],
+];
+
+function realTopLevelSegments(
+  manifest: {
+    externalizable_paths?: string[];
+    paths?: Array<{ json_path?: string }>;
+  } | null
+): string[] {
+  const leaf = (manifest?.paths || [])
+    .map((entry) => entry.json_path)
+    .filter((path): path is string => typeof path === "string");
+  return topLevelSegmentsForPaths([...leaf, ...(manifest?.externalizable_paths || [])]);
+}
+
+/**
+ * If the scope's top-level path does not correspond to a real segment in the
+ * manifest, snap it to the closest existing segment. Data-driven: the target set
+ * is the manifest's own top-level paths, so this never invents a segment. Returns
+ * the original scope for domain-wide scopes or when no confident match exists.
+ */
+function snapScopeToManifest(
+  scope: string,
+  manifest: {
+    externalizable_paths?: string[];
+    paths?: Array<{ json_path?: string }>;
+  } | null
+): string {
+  const parsed = parseAttrScope(scope);
+  if (!parsed || !parsed.path) return scope;
+  const requestedTop = normalizeSegmentCandidate(parsed.path);
+  if (!requestedTop) return scope;
+  const segments = realTopLevelSegments(manifest);
+  if (segments.includes(requestedTop)) return scope;
+  let snapped =
+    segments.find((seg) => seg.includes(requestedTop) || requestedTop.includes(seg)) || null;
+  if (!snapped) {
+    for (const [pattern, seg] of KYC_SEGMENT_KEYWORDS) {
+      if (pattern.test(requestedTop) && segments.includes(seg)) {
+        snapped = seg;
+        break;
+      }
+    }
+  }
+  return snapped ? `attr.${parsed.domain}.${snapped}` : scope;
+}
+
+// Paths never included in a consent export/reply even when they fall under an
+// approved scope. MRZ encodes the entire passport in machine-readable form, so
+// it is redundant with the human-readable fields and needlessly sensitive to share.
+const REDACTED_EXPORT_PATH_RE = /(^|\.)mrz(_line\d+)?$/i;
+
+function isRedactedExportPath(path: string): boolean {
+  return REDACTED_EXPORT_PATH_RE.test(path);
+}
+
 function assertShareablePayload(scope: string, payload: Record<string, unknown>): void {
   if (hasShareableValue(payload)) return;
   throw new ConsentExportNoDataError(
@@ -166,17 +229,24 @@ export async function buildConsentExportForScope(params: {
     return { payload: {} };
   }
 
-  const parsedScope = parseAttrScope(params.scope);
-  if (!parsedScope) {
+  const requestedScope = parseAttrScope(params.scope);
+  if (!requestedScope) {
     return { payload: {} };
   }
 
   const manifest = await PersonalKnowledgeModelService.getDomainManifest(
     params.userId,
-    parsedScope.domain,
+    requestedScope.domain,
     params.vaultOwnerToken
   ).catch(() => null);
-  const approvedPaths = resolveApprovedPaths(params.scope, manifest);
+  // Snap the granted scope onto a real manifest segment when its path does not
+  // exist (e.g. identity.tax_id -> identity.tax, identity/financial cash_positions
+  // -> identity.bank), so the export resolves to actually-stored data.
+  const effectiveScope = snapScopeToManifest(params.scope, manifest);
+  const parsedScope = parseAttrScope(effectiveScope) ?? requestedScope;
+  const approvedPaths = resolveApprovedPaths(effectiveScope, manifest).filter(
+    (path) => !isRedactedExportPath(path)
+  );
   const isDomainWideScope = !parsedScope.path;
   const manifestSegmentIds = isDomainWideScope
     ? []
@@ -216,12 +286,13 @@ export async function buildConsentExportForScope(params: {
   ) => ({
     ...projectDomainDataForScope({
       domain: parsedScope.domain,
-      scope: params.scope,
+      scope: effectiveScope,
       domainData,
       approvedPaths,
     }),
     __export_metadata: {
       scope: params.scope,
+      resolved_scope: effectiveScope !== params.scope ? effectiveScope : undefined,
       source_domain: parsedScope.domain,
       manifest_version: manifest?.manifest_version ?? null,
       approved_paths: approvedPaths,

--- a/hushh-webapp/lib/one-kyc/workflow-state.ts
+++ b/hushh-webapp/lib/one-kyc/workflow-state.ts
@@ -1,19 +1,57 @@
 import type { OneKycScopeCandidate, OneKycWorkflow } from "@/lib/services/one-kyc-service";
 
+/**
+ * Coerce a scope to the canonical `attr.<domain>[.path]` grammar the KYC lane
+ * uses. Some workflows persist bare candidate scopes (e.g. `identity.passport`)
+ * while `selected_scopes`/`consent_requests` are canonical (`attr.identity.passport`).
+ * Without normalization, the UI compares bare vs canonical: checkboxes never
+ * appear selected, the eye-icon preview (parseAttrScope) fails, and the scope
+ * selection looks "changed". Prefix `attr.` when missing so every consumer sees
+ * one consistent form.
+ */
+// KYC concept -> real identity segment. The LLM routing sometimes emits paths
+// that don't exist in the PKM (identity.tax_id, financial.bank_accounts,
+// financial.cash_positions). This snaps those onto the segments that actually
+// hold the data so the eye-icon preview and the selection checkboxes resolve.
+// Applied identically to candidate and selected scopes so they always match.
+const KYC_SCOPE_SNAP: ReadonlyArray<readonly [RegExp, string]> = [
+  [/passport/, "attr.identity.passport"],
+  [/licen[sc]e|driver|(^|[._])dl([._]|$)/, "attr.identity.drivers_license"],
+  [/\btax\b|tax_id|ssn|tin|itin|w-?9|w-?8|taxpayer/, "attr.identity.tax"],
+  [/bank|account|routing|cash|iban|swift|cheque|check|deposit|payout/, "attr.identity.bank"],
+];
+
+export function canonicalKycScope(scope: string): string {
+  const value = String(scope || "").trim().toLowerCase();
+  if (!value) return value;
+  for (const [pattern, mapped] of KYC_SCOPE_SNAP) {
+    if (pattern.test(value)) return mapped;
+  }
+  return value.startsWith("attr.") ? value : `attr.${value}`;
+}
+
 export function scopeCandidates(workflow: OneKycWorkflow): OneKycScopeCandidate[] {
+  const normalize = (candidates: OneKycScopeCandidate[]): OneKycScopeCandidate[] =>
+    candidates.map((candidate) => ({
+      ...candidate,
+      scope: canonicalKycScope(candidate.scope),
+    }));
+
   const direct = workflow.candidate_scopes;
-  if (Array.isArray(direct) && direct.length) return direct;
+  if (Array.isArray(direct) && direct.length) return normalize(direct);
   const metadataCandidates = workflow.metadata?.candidate_scopes;
   if (Array.isArray(metadataCandidates)) {
-    return metadataCandidates.filter(
-      (candidate): candidate is OneKycScopeCandidate =>
-        Boolean(candidate && typeof candidate === "object" && "scope" in candidate)
+    return normalize(
+      metadataCandidates.filter(
+        (candidate): candidate is OneKycScopeCandidate =>
+          Boolean(candidate && typeof candidate === "object" && "scope" in candidate)
+      )
     );
   }
   return workflow.requested_scope
     ? [
         {
-          scope: workflow.requested_scope,
+          scope: canonicalKycScope(workflow.requested_scope),
           domain: workflow.requested_scope.includes("financial") ? "financial" : "identity",
           label: friendlyScopeLabel(workflow.requested_scope),
         },
@@ -26,15 +64,15 @@ export function selectedScopesForWorkflow(
   localSelections: Record<string, string[]>
 ): string[] {
   const local = localSelections[workflow.workflow_id];
-  if (local) return local;
+  if (local) return local.map(canonicalKycScope);
   if (Array.isArray(workflow.selected_scopes) && workflow.selected_scopes.length) {
-    return workflow.selected_scopes;
+    return workflow.selected_scopes.map(canonicalKycScope);
   }
   if (Array.isArray(workflow.requested_scopes) && workflow.requested_scopes.length) {
-    return workflow.requested_scopes;
+    return workflow.requested_scopes.map(canonicalKycScope);
   }
   if (workflow.requested_scope) {
-    return [workflow.requested_scope];
+    return [canonicalKycScope(workflow.requested_scope)];
   }
   const recommended = scopeCandidates(workflow)
     .filter((candidate) => candidate.recommended !== false)


### PR DESCRIPTION
# Description

One Email KYC routing (Gemini Pass-1) emitted scope paths that do not exist in the user's PKM — `identity.tax_id`, `financial.cash_positions`, and bare `passport`/`tax_id` with no domain. Those scopes passed `confirm_proposal` but then failed `select_scopes` grammar validation (`ONE_KYC_SCOPE_NOT_ALLOWED`) or produced a consent export with no resolvable data (`ConsentExportNoDataError`), so KYC replies could never be prepared.

This grounds every KYC scope to a **real** `attr.<domain>.<segment>` that exists in the user's PKM, at the layers that create and consume consent requests, and redacts passport MRZ from shared exports.

**Backend (consent-protocol / `one_email_kyc_service.py`, `personal_knowledge_model_service.py`, `pkm_routes_shared.py`):**
- Add scope canonicalization / snap / resolution helpers + `_load_domain_scope_paths`; `confirm_proposal` and `select_scopes` resolve each scope against the user's real top-level PKM segments (fixes missing domain, wrong domain, and invented segment).
- Constrain `classify_kyc_request` output with a JSON-schema `enum` of the user's real scopes so the model cannot invent paths; ground the prompt with the available paths.
- Surface the underlying `store_domain_data` failure code/message instead of a generic `500`.

**Frontend (hushh-webapp / `workflow-state.ts`, `export-builder.ts`):**
- Canonicalize candidate/selected KYC scopes on read so the picker + eye-icon preview resolve.
- Snap consent-export scopes onto real manifest segments.
- Redact passport MRZ (`mrz_line1`/`mrz_line2`) from every consent export payload.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (behavior of existing `POST /api/pkm/store-domain` error response refined; no new routes)
- API / schema / type changes:
  - [x] Listed below: `POST /api/pkm/store-domain` now returns `detail: { code, message, error }` on non-conflict failure instead of a bare string.
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None (reads `pkm_manifest_paths`; no schema/migration changes)
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None (web + backend consent logic; no native plugin surface)
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] **KYC / consent / PKM** — scope resolution feeds consent-request creation and the encrypted export; MRZ redaction narrows shared data.
- Caller / proxy / backend pairing:
  - [x] Listed below: frontend `export-builder` and backend `select_scopes`/`confirm_proposal` now resolve scopes the same way (both snap to real PKM segments), so the consent request scope and the export projection agree.
- Rollback or safe-failure behavior:
  - [x] Listed below: resolver falls back to plain canonicalization when no confident match exists; MRZ redaction is additive (removes only `mrz_line*`); no data migration.
- UI browser or Playwright proof:
  - [x] Listed below: verified locally against a running webapp + local/UAT backend — eye-icon preview resolves passport/SSN, Approve builds the export, MRZ absent from payload. No new Playwright spec added.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr` (not run locally; relying on CI)
  - [x] `cd hushh-webapp && npm run typecheck`
  - [ ] `cd hushh-webapp && npm test`
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:test`
  - [x] `cd consent-protocol && pytest tests/services/test_one_email_kyc_service.py` (59 passed)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app/backend surface (One Email KYC consent flow).
- [x] Reachable production attach point: `confirm_proposal` / `select_scopes` (consent creation) and `buildConsentExportForScope` (approve/export).
- [x] New tests import and exercise production code (scope helpers), not mock-only helpers.
- [x] New helpers are wired to existing callers (routing/confirm/select and the export builder).
- [x] Commits are signed off.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js consent export + KYC picker (`hushh-webapp/lib/...`)
- [x] **iOS**: N/A — consent scope resolution is web+backend; no Capacitor plugin surface.
- [x] **Android**: N/A — same reason.

## 🧪 Testing

- [x] Tested on Web (Chrome) against local + UAT backend
- [ ] Tested on iOS Simulator/Device (N/A)
- [ ] Tested on Android Emulator/Device (N/A)
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data? Yes — KYC identity/tax data via the consented export path.
- [x] Consent enforced: changes operate inside the existing vault-owner-token + consent-request flow; no new unauthenticated data access.
- [x] Sensitive surface touched: consent / vault / PKM / KYC.
- [x] Error path / safe-failure proved: resolver falls back to canonicalization; MRZ is redacted from exports; store failures surface a typed error.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
