### PR TITLE
fix(db): allow needs_confirm in migration 050 status check (unblock UAT deploy)

### DIFF
--- a/consent-protocol/db/migrations/050_one_kyc_client_connector_registry.sql
+++ b/consent-protocol/db/migrations/050_one_kyc_client_connector_registry.sql
@@ -36,11 +36,16 @@ CREATE INDEX IF NOT EXISTS idx_one_kyc_client_connectors_fingerprint
 ALTER TABLE one_kyc_workflows
   DROP CONSTRAINT IF EXISTS one_kyc_workflows_status_check;
 
+-- NOTE: 'needs_confirm' is included here (added later by migration 095) because
+-- the release lane REPLAYS every migration in order on each deploy. Without it,
+-- replaying this DROP/ADD re-validates existing rows and fails once any
+-- 'needs_confirm' workflow exists, before 095 can widen the constraint again.
 ALTER TABLE one_kyc_workflows
   ADD CONSTRAINT one_kyc_workflows_status_check
     CHECK (status IN (
       'needs_client_connector',
       'needs_scope',
+      'needs_confirm',
       'needs_documents',
       'drafting',
       'waiting_on_user',

--- a/consent-protocol/tests/test_one_kyc_needs_confirm_status_migration.py
+++ b/consent-protocol/tests/test_one_kyc_needs_confirm_status_migration.py
@@ -50,3 +50,24 @@ def test_migration_095_is_in_release_manifest():
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     assert _STATUS_MIGRATION in manifest["ordered_migrations"]
     assert _STATUS_MIGRATION in manifest["groups"]["iam"]
+
+
+def test_every_replayed_status_check_allows_needs_confirm():
+    # The release lane REPLAYS every migration in order on each deploy. Any file
+    # that (re)defines one_kyc_workflows_status_check must allow the full current
+    # status set — otherwise replaying it re-validates existing rows and fails
+    # once a newer status (e.g. needs_confirm) is in use, before a later
+    # migration can widen the constraint again. Regression guard for the UAT
+    # deploy break caused by migration 050 omitting 'needs_confirm'.
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    offenders = []
+    for name in manifest["ordered_migrations"]:
+        values = _status_constraint_values(name)
+        if values is None:
+            continue
+        if "needs_confirm" not in values:
+            offenders.append(name)
+    assert not offenders, (
+        "these replayed migrations re-add one_kyc_workflows_status_check without "
+        f"'needs_confirm' and will break deploys: {offenders}"
+    )


### PR DESCRIPTION
# Description

**Unblocks the UAT deploy**, which is currently rolling back at the predeploy schema gate:

```
CheckViolationError: check constraint "one_kyc_workflows_status_check"
of relation "one_kyc_workflows" is violated by some row
```

## Root cause

The release lane replays **every** migration file in order on each deploy (no "already-applied" tracking). Migration **050** re-adds `one_kyc_workflows_status_check` with a status set that **omits `needs_confirm`**; migration **095** widens it to include `needs_confirm` later in the same replay.

Once any `needs_confirm` workflow row exists, replaying **050** does `DROP CONSTRAINT` → `ADD CONSTRAINT` (narrow), which re-validates all rows and fails **before 095 can widen it again**. Before the first `needs_confirm` row existed the replay happened to pass, so this was latent. A *new* migration can't fix it — 050 fails first in the replay — so 050 itself must stop rejecting `needs_confirm`.

## Fix

- Add `needs_confirm` to migration 050's `one_kyc_workflows_status_check` CHECK so its replay matches 095 (idempotent, consistent replay).
- Add a regression guard: every replayed migration that (re)defines the status CHECK must allow `needs_confirm`.

No data migration; no schema shape change (the effective constraint is unchanged — it already ends as 095's wide set). Purely fixes the transient mid-replay failure.

## 📌 Impact Map (Required)

- Routes touched: [x] None
- API / schema / type changes: [x] None (constraint end-state unchanged; only the intermediate replay state is corrected)
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] Listed below: migration 050 `one_kyc_workflows_status_check` now includes `needs_confirm` (matches 095).
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None
- Docs updated: [x] None
- Top-level / devex / config / generated / ignore files touched: [x] None
- Trust boundary touched: [x] None (constraint set unchanged in end-state; KYC status enum only)
- Caller / proxy / backend pairing: [x] Not applicable
- Rollback or safe-failure behavior: [x] Listed below: idempotent — the constraint's final state is identical; this only removes a mid-replay validation failure. Safe to re-run.
- UI browser or Playwright proof: [x] Not applicable (DB migration only)
- Verification commands executed:
  - [x] `cd consent-protocol && pytest tests/test_one_kyc_needs_confirm_status_migration.py` (4 passed, incl. new replay guard)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Reachable production attach point: UAT/prod release migration lane (`run_release_migration`).
- [x] New test exercises production migration files (parses the SQL, asserts the constraint set).
- [x] Commits are signed off.

## 🧪 Testing

- [x] `pytest tests/test_one_kyc_needs_confirm_status_migration.py` — 4 passed
- [x] Commits are signed off (`git commit -s`)

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — DB constraint enum only.
- [x] Sensitive surface touched: none (KYC workflow status enum; no PII).

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
