### PR TITLE
fix(one-location): single top-left back button on every quick-action screen

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -340,6 +340,61 @@ describe("top shell breadcrumbs", () => {
     );
   });
 
+  it("returns the single top-bar back button to the Location hub while a quick-action flow is open", () => {
+    // Location quick-action screens (Check-In, Drive To, Pick Me Up, Safe
+    // Arrival, SOS/Alert, Share, Ask, Invite, Privacy, Temp link) are tracked
+    // via /one/location?action=<slug>. The one top-left back button must return
+    // to the Location hub (strip the action param) rather than leaving to /one —
+    // this is the fix for the "two back buttons" UX. The in-content back arrows
+    // were removed so this is the ONLY back affordance on those screens.
+    const cases: Array<[string, string]> = [
+      ["check-in", "Check-In"],
+      ["drive-to", "Drive To"],
+      ["pick-me-up", "Pick Me Up"],
+      ["safe-arrival", "Safe Arrival"],
+      ["sos", "Safety"],
+      ["share", "Share location"],
+      ["ask", "Ask someone"],
+      ["invite", "Invite to Circle"],
+      ["temp-link", "Public link"],
+      ["privacy", "Privacy"],
+    ];
+
+    for (const [action, label] of cases) {
+      const params = new URLSearchParams();
+      params.set("action", action);
+      expect(resolveTopShellBreadcrumb("/one/location", params)).toEqual({
+        backHref: "/one/location",
+        width: "profile",
+        align: "center",
+        items: [
+          { label: "One", href: "/one" },
+          { label: "Location", href: "/one/location" },
+          { label },
+        ],
+      });
+    }
+
+    // Opened from Profile: the leading crumb reflects the real origin, but back
+    // still returns to the Location hub (not Profile) while the flow is open.
+    const fromProfile = new URLSearchParams();
+    fromProfile.set("from", "/profile");
+    fromProfile.set("action", "check-in");
+    expect(resolveTopShellBreadcrumb("/one/location", fromProfile)).toEqual({
+      backHref: "/one/location",
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "Profile", href: "/profile" },
+        { label: "Location", href: "/one/location" },
+        { label: "Check-In" },
+      ],
+    });
+
+    // No action param → unchanged hub behavior (back leaves to /one).
+    expect(resolveTopShellBreadcrumb("/one/location")?.backHref).toBe("/one");
+  });
+
   it("retraces setup-hub-opened capabilities through their terminal acknowledgement", () => {
     // From the Set up One hub, capability handoffs carry ?from=/one/setup so the
     // top-bar back returns to the hub (not Profile/dashboard) — "jaise aaya waise

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -706,6 +706,22 @@ export function TopAppBar({ className }: TopAppBarProps) {
                           });
                           return;
                         }
+                        // Location quick-action flows (Check-In, Drive To, Pick
+                        // Me Up, Safe Arrival, SOS, Share, Ask, Invite, Privacy,
+                        // Temp link) are tracked via `/one/location?action=…`.
+                        // This is the SINGLE back button for those screens: strip
+                        // the action param via replace so it returns to the
+                        // Location hub without leaving a re-openable history entry
+                        // (a plain push would let OS-back reopen the flow).
+                        if (
+                          normalizedPathname === ROUTES.ONE_LOCATION &&
+                          (searchParams?.get("action") || "").trim()
+                        ) {
+                          router.replace(topShellBreadcrumb.backHref, {
+                            scroll: false,
+                          });
+                          return;
+                        }
                         router.push(topShellBreadcrumb.backHref, {
                           scroll: false,
                         });

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 
 import {
@@ -273,6 +273,31 @@ type FlowKind =
   | "sos"
   | "privacy";
 
+// The open action flow is reflected in the URL as `?action=<slug>` so the single
+// top-left back button in the app chrome (and the OS/hardware back button) knows
+// to return to the Location hub instead of leaving the whole page to /one.
+const FLOW_ACTION_PARAM = "action";
+
+const FLOW_TO_ACTION: Record<Exclude<FlowKind, "none">, string> = {
+  share: "share",
+  ask: "ask",
+  invite: "invite",
+  "temp-link": "temp-link",
+  "check-in": "check-in",
+  "drive-to": "drive-to",
+  "pick-me-up": "pick-me-up",
+  "safe-arrival": "safe-arrival",
+  sos: "sos",
+  privacy: "privacy",
+};
+
+const ACTION_TO_FLOW: Record<string, FlowKind> = Object.fromEntries(
+  Object.entries(FLOW_TO_ACTION).map(([flow, action]) => [
+    action,
+    flow as FlowKind,
+  ]),
+);
+
 
 const BUSY = (vm: LocationHubViewModel, key: string) => vm.busy === key;
 
@@ -287,6 +312,8 @@ const ACTIVE_SHARE_LIST_SCROLL_CLASS =
   "max-h-[470px] overflow-y-auto overscroll-contain pr-1 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/20";
 
 export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const [tab, setTab] = useState<LocationHubTab>("now");
   const [flow, setFlow] = useState<FlowKind>("none");
@@ -369,11 +396,57 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const inboxCount = vm.pendingOwnerRequests.length;
   const hasActiveShare = vm.activeOwnerGrants.length > 0;
 
-  const closeFlow = () => {
+  // A location action flow (Check-In, Drive To, Pick Me Up, Safe Arrival, SOS,
+  // Share, Ask, Invite, Privacy, Temp link) is a sub-screen of /one/location.
+  // The open flow is mirrored into the URL (`?action=…`) so the SINGLE top-left
+  // back button in the app chrome (and the OS/hardware back button) returns to
+  // the Location hub instead of leaving to /one. Because that one chrome back
+  // arrow now owns "return to hub", the redundant in-content back arrows have
+  // been removed from the flows — each action screen shows exactly one back
+  // affordance plus its own Cancel/Done control.
+  const openFlow = useCallback(
+    (next: Exclude<FlowKind, "none">) => {
+      setFlow(next);
+      if (next === "share") setShareStep("person");
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(FLOW_ACTION_PARAM, FLOW_TO_ACTION[next]);
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  const closeFlow = useCallback(() => {
     setFlow("none");
     setShareStep("person");
     vm.setShareReviewOpen(false);
-  };
+    if ((searchParams.get(FLOW_ACTION_PARAM) || "").trim()) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete(FLOW_ACTION_PARAM);
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    }
+  }, [pathname, router, searchParams, vm]);
+
+  // Keep the flow view in sync with the URL action param: the chrome/OS back
+  // button strips the param, which closes the flow back to the hub. A direct
+  // deep-link to `?action=…` opens the matching flow on load. Resetting the
+  // Share sub-step + review flag on close ensures re-opening Share always starts
+  // clean at step 1 (never jumps back into the consent-review screen).
+  useEffect(() => {
+    const action = (searchParams.get(FLOW_ACTION_PARAM) || "").trim();
+    const desired: FlowKind = action
+      ? (ACTION_TO_FLOW[action] ?? "none")
+      : "none";
+    setFlow((current) => (current === desired ? current : desired));
+    if (desired === "none") {
+      setShareStep("person");
+      vm.setShareReviewOpen(false);
+    }
+    // `vm.setShareReviewOpen` is a stable useState setter; depend on searchParams
+    // only so this runs on every URL change (open/close) without re-firing on
+    // unrelated vm re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   // When a share completes successfully (page bumps shareCompletedTick), close
   // the 3-step share flow and return to the main One Location hub.
@@ -385,9 +458,16 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       // from the "Now" tab, so no explicit tab change is needed.
       setFlow("none");
       setShareStep("person");
+      // Drop the action param so the hub URL is clean after a completed share.
+      if ((searchParams.get(FLOW_ACTION_PARAM) || "").trim()) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.delete(FLOW_ACTION_PARAM);
+        const qs = params.toString();
+        router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      }
     }
 
-  }, [vm.shareCompletedTick]);
+  }, [vm.shareCompletedTick, pathname, router, searchParams]);
 
 
   /* ----------------------------------------------------------------- */
@@ -422,12 +502,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           <SafeArrivalFlow vm={vm} onClose={closeFlow} />
         ) : flow === "sos" ? (
 
-          <SosFlow vm={vm} onClose={closeFlow} />
+          <SosFlow vm={vm} />
         ) : flow === "invite" ? (
           <InviteFlow vm={vm} onClose={closeFlow} />
         ) : flow === "privacy" ? (
           <PrivacyFlow
-            onClose={closeFlow}
             onManageSharing={() => {
               closeFlow();
               setTab("people");
@@ -488,31 +567,25 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         <NowHub
           vm={vm}
           hasActiveShare={hasActiveShare}
-          onStartShare={() => {
-            setShareStep("person");
-            setFlow("share");
-          }}
-          onAsk={() => setFlow("ask")}
-          onCheckIn={() => setFlow("check-in")}
-          onDriveTo={() => setFlow("drive-to")}
-          onPickMeUp={() => setFlow("pick-me-up")}
-          onSafeArrival={() => setFlow("safe-arrival")}
-          onSos={() => setFlow("sos")}
-          onOpenPrivacy={() => setFlow("privacy")}
+          onStartShare={() => openFlow("share")}
+          onAsk={() => openFlow("ask")}
+          onCheckIn={() => openFlow("check-in")}
+          onDriveTo={() => openFlow("drive-to")}
+          onPickMeUp={() => openFlow("pick-me-up")}
+          onSafeArrival={() => openFlow("safe-arrival")}
+          onSos={() => openFlow("sos")}
+          onOpenPrivacy={() => openFlow("privacy")}
         />
 
       ) : tab === "people" ? (
         <PeopleHub
           vm={vm}
-          onInvite={() => setFlow("invite")}
-          onStartShare={() => {
-            setShareStep("person");
-            setFlow("share");
-          }}
-          onAsk={() => setFlow("ask")}
+          onInvite={() => openFlow("invite")}
+          onStartShare={() => openFlow("share")}
+          onAsk={() => openFlow("ask")}
         />
       ) : tab === "links" ? (
-        <LinksHub vm={vm} onCreateTempLink={() => setFlow("temp-link")} />
+        <LinksHub vm={vm} onCreateTempLink={() => openFlow("temp-link")} />
       ) : (
         <InboxHub
           vm={vm}
@@ -892,10 +965,8 @@ function LocationToggle({
 }
 
 function PrivacyFlow({
-  onClose,
   onManageSharing,
 }: {
-  onClose: () => void;
   onManageSharing: () => void;
 }) {
   // Inert local state for now — real auto-share / pause wiring comes later.
@@ -908,7 +979,6 @@ function PrivacyFlow({
         eyebrow="Location"
         title="Privacy"
         description="You control who sees your location and when. Change this anytime."
-        onBack={onClose}
       />
 
       <p className="mt-6 px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
@@ -1606,25 +1676,16 @@ function SosHelpRow({
 
 function SosFlow({
   vm,
-  onClose,
 }: {
   vm: LocationHubViewModel;
-  onClose: () => void;
 }) {
   const recipients = vm.sosRecipients;
   const sharedCount = recipients.length;
 
   return (
     <div className="space-y-3.5">
-      {/* Back + title (design: circular back button, then "Safety"). */}
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Back"
-        className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-black/[0.05] text-foreground dark:bg-white/10"
-      >
-        <ChevronRight className="h-[18px] w-[18px] rotate-180" />
-      </button>
+      {/* Title only — the single back affordance is the top-left app-chrome back
+          arrow, which returns to the Location hub. */}
       <h1 className="text-[33px] font-bold tracking-[-0.6px] text-foreground">
         Safety
       </h1>
@@ -1775,7 +1836,6 @@ function ShareFlow({
           eyebrow="Step 3 of 3 · Consent check"
           title="Before you start"
           description="Confirm exactly who can see you, what they see, and when access ends."
-          onBack={() => vm.setShareReviewOpen(false)}
         />
         <SectionCard>
           <div className="space-y-3">
@@ -1825,7 +1885,6 @@ function ShareFlow({
         <TaskFlowHeader
           eyebrow="Step 2 of 3 · Details"
           title="What are you sharing?"
-          onBack={() => setStep("person")}
         />
         <SectionCard>
           <div className="space-y-5">
@@ -1872,7 +1931,6 @@ function ShareFlow({
         eyebrow="Step 1 of 3 · Choose person"
         title="Who can see you?"
         description="Only trusted and location-ready people can receive private live location."
-        onBack={onClose}
       />
       <PersonSearchInput
         value={vm.recipientSearch}
@@ -1976,7 +2034,6 @@ function AskFlow({
         eyebrow="Request with context"
         title="Make it comfortable"
         description="Requests should explain why. The other person chooses whether to share."
-        onBack={onClose}
       />
 
       <SectionCard title="Person">
@@ -2078,7 +2135,6 @@ function InviteFlow({
           eyebrow="Share invite link"
           title="Invite link created"
           description="They must approve before location sharing starts."
-          onBack={onClose}
         />
         <SectionCard>
           <div className="flex items-center gap-3">
@@ -2143,7 +2199,6 @@ function InviteFlow({
         eyebrow="Invite to One / Circle"
         title="Invite to Circle"
         description="Use this when the person is not ready for private location sharing yet."
-        onBack={onClose}
       />
       <SectionCard title="What happens next?">
         <p className="text-sm text-muted-foreground">
@@ -2202,7 +2257,6 @@ function TemporaryLinkFlow({
         <TaskFlowHeader
           eyebrow="Copy, share or revoke"
           title="Public location link active"
-          onBack={onClose}
         />
         <WarningCard
           title="Anyone with this link can view your location until it expires."
@@ -2236,7 +2290,6 @@ function TemporaryLinkFlow({
         eyebrow="Share with anyone outside Circle"
         title="Share outside your Circle"
         description="Use only when the person is not in your trusted Circle."
-        onBack={onClose}
       />
       <WarningCard
         title="Important"

--- a/hushh-webapp/components/one-location/redesign/safe-arrival-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/safe-arrival-flow.tsx
@@ -251,7 +251,6 @@ export function SafeArrivalFlow({
         eyebrow="Safe Arrival"
         title="Let people know you got there safely"
         description="Share your live journey and ETA until you reach your destination."
-        onBack={onClose}
       />
 
       {/* WHERE ARE YOU HEADED? */}

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -38,6 +38,27 @@ function titleizeSegment(segment: string): string {
     .join(" ");
 }
 
+/**
+ * Human label for an open Location quick-action flow (the `?action=…` slug).
+ * Used as the third breadcrumb crumb while the flow is open so the top-bar
+ * reads "One › Location › Check-In" etc. Falls back to a titleized slug.
+ */
+function oneLocationActionLabel(action: string): string {
+  const labels: Record<string, string> = {
+    share: "Share location",
+    ask: "Ask someone",
+    invite: "Invite to Circle",
+    "temp-link": "Public link",
+    "check-in": "Check-In",
+    "drive-to": "Drive To",
+    "pick-me-up": "Pick Me Up",
+    "safe-arrival": "Safe Arrival",
+    sos: "Safety",
+    privacy: "Privacy",
+  };
+  return labels[action] ?? titleizeSegment(action);
+}
+
 function profilePanelLabel(panel: ProfilePanel | null): string | null {
   if (panel === "account") return "Account";
   if (panel === "my-data") return "Memory";
@@ -461,6 +482,28 @@ export function resolveTopShellBreadcrumb(
   if (pathname === ROUTES.ONE_LOCATION) {
     const originHref = normalizeInternalRouteHref(searchParams?.get("from"));
     const fromProfile = originHref === ROUTES.PROFILE;
+    // A Location quick-action flow (Check-In, Drive To, Pick Me Up, Safe
+    // Arrival, SOS/Alert, Share, Ask, Invite, Privacy, Temp link) is a
+    // sub-screen of the Location hub, tracked via `?action=…`. While one is
+    // open, the SINGLE top-left back button must return to the Location hub
+    // (strip the action param) rather than leaving to /one. This is the only
+    // back affordance on those screens — the in-content back arrows were
+    // removed to fix the "two back buttons" UX.
+    const action = String(searchParams?.get("action") || "").trim();
+    if (action) {
+      return {
+        backHref: ROUTES.ONE_LOCATION,
+        width: "profile",
+        align: "center",
+        items: [
+          fromProfile
+            ? { label: "Profile", href: ROUTES.PROFILE }
+            : { label: "One", href: ROUTES.ONE_HOME },
+          { label: "Location", href: ROUTES.ONE_LOCATION },
+          { label: oneLocationActionLabel(action) },
+        ],
+      };
+    }
     return {
       backHref:
         resolveCapabilitySetupBackHref(pathname, originHref) || ROUTES.ONE_HOME,


### PR DESCRIPTION
## Description

Fixes the "two back buttons" UX on the One Location quick-action screens.

Previously every Location action screen (Check-In, Drive To, Pick Me Up, Safe
Arrival, Alert/SOS, Share, Ask, Invite, Privacy, Public link) showed **two**
back affordances: the global app-chrome back arrow (which left the whole page to
`/one`) plus an in-content back arrow added per flow to return to the hub. That
double-back was confusing.

Now the open flow is mirrored into the URL as `/one/location?action=<slug>`, so
the **single** top-left chrome back button (and the OS/hardware back) returns to
the Location hub instead of leaving to `/one`. All redundant in-content back
arrows are removed. Existing `Cancel`/`Done` buttons are untouched.

Key changes:
- `location-redesign-hub.tsx`: `openFlow`/`closeFlow` keep the flow in sync with
  `?action`; the Share sub-step + consent-review flag reset on close; the param is
  dropped after a completed share.
- `top-shell-breadcrumbs.ts`: while `?action` is set, back points to the Location
  hub with a `One › Location › <Action>` crumb (new unit test added).
- `top-app-bar.tsx`: strips the action param via `router.replace` so back lands
  cleanly on the hub without a re-openable history entry.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
    - `/one/location` — no new route; adds an in-page `?action=<slug>` query state for open quick-action flows.

- API / schema / type changes:
  - [x] None

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below:
    - Presentation-only navigation fix in the shared webapp shell; the single back button now also makes OS/hardware back on native return to the Location hub instead of leaving the page.

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None (presentation + local view-routing only; no consent/vault/crypto path changed)

- Caller / proxy / backend pairing:
  - [x] Not applicable

- Rollback or safe-failure behavior:
  - [x] Listed below:
    - Pure UI/navigation change. Reverting the commit restores prior behavior; no data migration.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Route: `/one/location` → open any quick action → single top-left back returns to the hub.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` (0 errors)
  - [x] `cd hushh-webapp && npm test` (breadcrumb 15 + drive-to/pick-me-up/sos flow suites pass)

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (`/one/location`).
- [x] Reachable production attach point: `LocationRedesignHub` rendered by `app/one/location/page.tsx`; back button owned by `TopAppBar` via `resolveTopShellBreadcrumb`.
- [x] New tests import and exercise production code (`resolveTopShellBreadcrumb`).
- [x] New helpers are wired to an existing route/caller (top-shell breadcrumb resolver + top-app-bar).
- [x] Commits are signed off (DCO).

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (navigation shell + One Location hub)
- [x] **iOS**: N/A — shared webapp shell; OS back now returns to hub via URL state (no native plugin change)
- [x] **Android**: N/A — same as iOS

## 🧪 Testing

- [x] Tested on Web (Chrome)
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

UI-visible navigation change on `/one/location`. Each quick-action screen now
renders exactly one back button (top-left) that returns to the Location hub;
existing Cancel/Done buttons remain.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? — No.
- [x] Sensitive surface touched: none (presentation + local view-routing).
- [x] Error path / safe-failure behavior proved: pure UI navigation; revert restores prior state.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed (no dependency changes)
