### PR TITLE
fix(web): update vulnerable websocket driver

### DIFF
--- a/hushh-webapp/package-lock.json
+++ b/hushh-webapp/package-lock.json
@@ -16169,9 +16169,9 @@
       "optional": true
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
## Description

Updates the Firebase database transitive `websocket-driver` lock entry from 0.7.4 to 0.7.5, resolving newly published critical and moderate advisories that appeared immediately after MCP v0.3.0 merged.

## 📌 Impact Map (Required)

- Routes, API, schema, cache, DB, world model, mobile: none.
- Top-level / generated: npm lockfile only; produced by `npm audit fix --package-lock-only` and reduced to the exact transitive package update.
- Trust boundary: dependency security only.
- Rollback: revert the lock entry, but that would restore known vulnerabilities.
- Verification: clean `npm ci`, `npm ls websocket-driver`, `npm audit --audit-level=moderate`, `bash scripts/ci/orchestrate.sh web-core`, `bash scripts/ci/orchestrate.sh secret`.

## ✅ Review-Ready Contract

- [x] Existing dependency chain verified: Firebase database → faye-websocket → websocket-driver.
- [x] Reachable production attach point is the existing web dependency graph.
- [x] Branch is current with main and commit is signed off.
- [x] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] Web: lockfile security update.
- [x] iOS: not applicable.
- [x] Android: not applicable.

## 🧪 Testing

- [x] Clean install resolves `websocket-driver@0.7.5`.
- [x] npm audit reports zero vulnerabilities.
- [x] Full web core typecheck, lint, and production build pass.
- [x] Commit signed off.

## 📸 Screenshots / Video

Not applicable; dependency-only security fix.

## 🛡️ Privacy & Consent

- [x] No information-access behavior changes.
- [x] Removes two known websocket parser/resource-limit vulnerabilities.

## 📜 Licensing

- [x] websocket-driver remains Apache-2.0.
- [x] No new dependency or notice impact.