### PR TITLE
fix(mcp): bypass route limiter for consent projection

### DIFF
--- a/consent-protocol/api/routes/developer.py
+++ b/consent-protocol/api/routes/developer.py
@@ -1594,9 +1594,7 @@ async def get_mcp_consent_status(
     }
 
 
-@developer_api_router.post("/request-consent")
-@limiter.limit(RateLimits.CONSENT_REQUEST)
-async def request_consent(
+async def _request_consent_impl(
     payload: DeveloperConsentRequest,
     request: Request,
     token: Optional[str] = Query(None, max_length=2048),
@@ -1917,6 +1915,24 @@ async def request_consent(
     }
 
 
+@developer_api_router.post("/request-consent")
+@limiter.limit(RateLimits.CONSENT_REQUEST)
+async def request_consent(
+    payload: DeveloperConsentRequest,
+    request: Request,
+    token: Optional[str] = Query(None, max_length=2048),
+    authorization: Optional[str] = Header(None),
+):
+    """Rate-limited raw developer consent route."""
+
+    return await _request_consent_impl(
+        payload,
+        request=request,
+        token=token,
+        authorization=authorization,
+    )
+
+
 @developer_api_router.post("/mcp/request-consent")
 async def request_mcp_consent(
     payload: MCPConsentRequest,
@@ -1935,7 +1951,10 @@ async def request_mcp_consent(
         country_iso2=payload.country_iso2,
         country=payload.country,
     )
-    raw = await request_consent(
+    # Call the undecorated implementation. Invoking the SlowAPI-decorated route
+    # directly makes its wrapper search positional arguments for ``Request``
+    # and can raise IndexError instead of executing the consent lifecycle.
+    raw = await _request_consent_impl(
         DeveloperConsentRequest(
             user_id=user_id,
             scope=payload.scope,

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -1951,7 +1951,11 @@ def test_mcp_request_sanitizes_raw_consent_response(monkeypatch):
             "consent_token": "HCT:must-not-pass-through",
         }
 
-    monkeypatch.setattr(developer, "request_consent", _raw_request)
+    async def _decorated_route_must_not_be_called(*_args, **_kwargs):
+        raise AssertionError("MCP projection called the SlowAPI-decorated route")
+
+    monkeypatch.setattr(developer, "_request_consent_impl", _raw_request)
+    monkeypatch.setattr(developer, "request_consent", _decorated_route_must_not_be_called)
     client = TestClient(_build_app())
     response = client.post(
         "/api/v1/mcp/request-consent",


### PR DESCRIPTION
## Summary
- move raw consent logic behind an undecorated internal implementation
- keep SlowAPI rate limiting on the public raw HTTP route
- have the MCP projection invoke the internal implementation instead of the decorated FastAPI endpoint
- prove the MCP route never calls the decorated wrapper

## RCA
The MCP projection called the SlowAPI-decorated `request_consent` route directly. SlowAPI then attempted to locate a positional `Request` and raised `IndexError`, producing a 500 that the MCP public tool safely mapped to `UPSTREAM_REJECTED`. Scope discovery and PKM storage were healthy.

## Verification
- focused MCP/developer route suite: 97 passed
- `./bin/hushh codex pre-pr`
- web: 334 files / 2,150 tests
- protocol, packed MCP runtime, PKM upgrade gate: 204 tests
- DCO, secret, governance, schema, docs, and license gates