### PR TITLE
fix(ci): use protocol Python for PKM UAT gate

### DIFF
--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -50,17 +50,19 @@ npx vitest run "${FRONTEND_TESTS[@]}"
 
 echo "Running backend compatibility and consent/RIA suites..."
 cd "$PROTOCOL_DIR"
-if [ -x .venv/bin/pytest ]; then
-  PYTEST_RUNNER=".venv/bin/pytest"
+if [ -n "${PROTOCOL_PYTHON:-}" ] && [ -x "$PROTOCOL_PYTHON" ]; then
+  PYTHON_RUNNER="$PROTOCOL_PYTHON"
+elif [ -x .venv/bin/python ]; then
+  PYTHON_RUNNER=".venv/bin/python"
 else
-  PYTEST_RUNNER="python3 -m pytest"
+  PYTHON_RUNNER="python3"
 fi
 TESTING="${TESTING:-true}" \
 APP_SIGNING_KEY="${APP_SIGNING_KEY:-test_secret_key_for_ci_only_32chars_min}" \
 VAULT_DATA_KEY="${VAULT_DATA_KEY:-0000000000000000000000000000000000000000000000000000000000000000}" \
 HUSHH_DEVELOPER_TOKEN="${HUSHH_DEVELOPER_TOKEN:-test_hushh_developer_token_for_ci}" \
 PYTHONPATH=. \
-  $PYTEST_RUNNER -q "${BACKEND_TESTS[@]}"
+  "$PYTHON_RUNNER" -m pytest -q "${BACKEND_TESTS[@]}"
 
 if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ "${PKM_UPGRADE_REVIEWER_SHAPE_AUDIT:-}" != "1" ]; then
   echo "Protected UAT requires PKM_UPGRADE_REVIEWER_SHAPE_AUDIT=1." >&2
@@ -112,14 +114,14 @@ if [ "${PKM_UPGRADE_REVIEWER_SHAPE_AUDIT:-}" = "1" ]; then
   if [ -n "${PKM_UPGRADE_REVIEWER_SECRET_VERSION:-}" ]; then
     SHAPE_AUDIT_ARGS+=(--gcp-secret-version "$PKM_UPGRADE_REVIEWER_SECRET_VERSION")
   fi
-  python3 scripts/audit_active_pkm_shape_readonly.py "${SHAPE_AUDIT_ARGS[@]}" >/tmp/hushh-pkm-shape-audit.json
-  python3 -c 'import json; p=json.load(open("/tmp/hushh-pkm-shape-audit.json")); assert p["schema_version"] == "pkm_reviewer_shape_audit.v2"; assert p["pagination"]["has_more"] is False; assert p["preservation_receipt"]["complete"] is True; assert p["preservation_receipt"]["rejected"] == 0'
+  "$PYTHON_RUNNER" scripts/audit_active_pkm_shape_readonly.py "${SHAPE_AUDIT_ARGS[@]}" >/tmp/hushh-pkm-shape-audit.json
+  "$PYTHON_RUNNER" -c 'import json; p=json.load(open("/tmp/hushh-pkm-shape-audit.json")); assert p["schema_version"] == "pkm_reviewer_shape_audit.v2"; assert p["pagination"]["has_more"] is False; assert p["preservation_receipt"]["complete"] is True; assert p["preservation_receipt"]["rejected"] == 0'
   echo "Reviewer-backed active PKM shape audit passed with redacted output."
 fi
 
 if [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL:-}" = "1" ]; then
   echo "Running chained PKM structure-agent evaluation..."
-  python3 scripts/eval_pkm_structure_agent.py \
+  "$PYTHON_RUNNER" scripts/eval_pkm_structure_agent.py \
     --phase fresh_chain_60 \
     --enforce-gates \
     --json-out /tmp/hushh-pkm-structure-agent-eval.json


### PR DESCRIPTION
## Summary

- make the protected PKM UAT gate use the workflow-provided `PROTOCOL_PYTHON` interpreter
- fall back to the protocol virtualenv, then system Python only when no governed interpreter exists
- use the same interpreter for backend tests, reviewer shape audit, receipt validation, and structure-agent evaluation

## Root cause

UAT run `29479552359` safely failed before any build or traffic change. Migration v98, 127 frontend tests, 241 backend tests, and the transaction-rolled-back PostgreSQL rehearsal all passed. The reviewer audit then ran under system `python3`, which did not contain the protocol environment's `cryptography` dependency.

## Verification

- `bash -n scripts/ci/pkm-upgrade-gate.sh`
- full PKM gate with the exact absolute `PROTOCOL_PYTHON` contract: 127 frontend + 241 backend tests passed
- complete local PR mirror: build, typecheck, lint, 2,162 frontend tests, 402 protocol tests, MCP package, security, integration, and PKM gate passed
- staged secret scan and DCO passed

## Release

- land through the governed exact-head path
- require Main Post-Merge Smoke on the landed SHA
- rerun `deploy-uat.yml` with `scope=all` and that exact SHA
- production remains out of scope
