### PR TITLE
fix(ci): load reviewer secrets for PKM runtime audit

### DIFF
--- a/consent-protocol/tests/test_active_pkm_shape_audit.py
+++ b/consent-protocol/tests/test_active_pkm_shape_audit.py
@@ -44,3 +44,15 @@ def test_protected_gate_rejects_partial_shape_audit():
 
     assert 'p["pagination"]["has_more"] is False' in gate
     assert 'p["preservation_receipt"]["complete"] is True' in gate
+
+
+def test_live_runtime_audit_loads_canonical_reviewer_secrets_in_memory():
+    gate = (ROOT.parent / "scripts/ci/pkm-upgrade-gate.sh").read_text()
+
+    assert "load_reviewer_runtime_secrets" in gate
+    assert "--secret=REVIEWER_UID" in gate
+    assert "--secret=REVIEWER_VAULT_PASSPHRASE" in gate
+    assert "export REVIEWER_UID REVIEWER_VAULT_PASSPHRASE" in gate
+    assert gate.index("load_reviewer_runtime_secrets\n  cd") < gate.index(
+        "node ./scripts/testing/verify-signed-in-routes.mjs"
+    )

--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -94,6 +94,39 @@ if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ -z "${PKM_UPGRADE_RUNTIME_AUD
   exit 1
 fi
 
+load_reviewer_runtime_secrets() {
+  if [ -n "${REVIEWER_UID:-}" ] && [ -n "${REVIEWER_VAULT_PASSPHRASE:-}" ]; then
+    return 0
+  fi
+
+  local secret_project="${PKM_UPGRADE_REVIEWER_SECRET_PROJECT:-}"
+  local secret_version="${PKM_UPGRADE_REVIEWER_SECRET_VERSION:-latest}"
+  if [ -z "$secret_project" ]; then
+    echo "Live reviewer runtime audits require reviewer credentials or PKM_UPGRADE_REVIEWER_SECRET_PROJECT." >&2
+    return 1
+  fi
+  if ! command -v gcloud >/dev/null 2>&1; then
+    echo "Live reviewer runtime audits require gcloud for Secret Manager resolution." >&2
+    return 1
+  fi
+
+  if [ -z "${REVIEWER_UID:-}" ]; then
+    REVIEWER_UID="$(gcloud secrets versions access "$secret_version" \
+      --secret=REVIEWER_UID \
+      --project="$secret_project")"
+  fi
+  if [ -z "${REVIEWER_VAULT_PASSPHRASE:-}" ]; then
+    REVIEWER_VAULT_PASSPHRASE="$(gcloud secrets versions access "$secret_version" \
+      --secret=REVIEWER_VAULT_PASSPHRASE \
+      --project="$secret_project")"
+  fi
+  if [ -z "$REVIEWER_UID" ] || [ -z "$REVIEWER_VAULT_PASSPHRASE" ]; then
+    echo "Live reviewer runtime audits could not resolve the canonical reviewer identity." >&2
+    return 1
+  fi
+  export REVIEWER_UID REVIEWER_VAULT_PASSPHRASE
+}
+
 if [ -n "$POSTGRES_REHEARSAL_TARGET" ]; then
   if ! command -v psql >/dev/null 2>&1; then
     echo "PostgreSQL rehearsal requested, but psql is unavailable." >&2
@@ -129,6 +162,7 @@ fi
 
 if [ -n "${PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL:-}" ]; then
   echo "Running live PKM, investor, and RIA runtime audits..."
+  load_reviewer_runtime_secrets
   cd "$WEB_DIR"
   for route_filter in one/pkm one/kai ria; do
     HUSHH_APP_ORIGIN="$PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL" \


### PR DESCRIPTION
## Summary

- load the canonical reviewer UID and vault passphrase from UAT Secret Manager into the protected runtime-audit process only
- fail closed when the reviewer identity cannot be resolved
- cover the memory-only reviewer secret handoff in the PKM gate contract test

## Why

The protected Python PKM shape audit already resolved the reviewer identity from Secret Manager, but the subsequent Node signed-in route audits did not receive that identity. UAT therefore failed after all zero-loss and structure-agent gates had passed, before any candidate build or traffic change.

## Verification

- `bash -n scripts/ci/pkm-upgrade-gate.sh`
- `consent-protocol/.venv/bin/python -m pytest -q consent-protocol/tests/test_active_pkm_shape_audit.py consent-protocol/tests/test_pkm_v7_recovery_migration.py` (10 passed)
- `PROTOCOL_PYTHON="$(pwd)/consent-protocol/.venv/bin/python" ./scripts/ci/pkm-upgrade-gate.sh` (127 frontend and 242 backend tests passed)
- `git diff --check`

The prior protected UAT run independently proved the reviewer shape audit and chained structure-agent evaluation passed; the candidate was rejected only because the Node runtime audit lacked the reviewer identity.
