### PR TITLE
fix(test): accept reviewer onboarding bootstrap

### DIFF
--- a/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
+++ b/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const scripts = [
+  "../../scripts/testing/verify-signed-in-routes.mjs",
+  "../../scripts/testing/run-kai-import-e2e.mjs",
+];
+
+describe("reviewer route bootstrap contract", () => {
+  it.each(scripts)("accepts the governed RIA onboarding redirect in %s", (relativePath) => {
+    const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+    expect(source).toContain(
+      'const REVIEWER_BOOTSTRAP_ROUTE_IDS = [REVIEWER_BOOTSTRAP_ROUTE, "/ria/onboarding"]'
+    );
+    expect(source).toContain("waitForRouteBeacon(page, REVIEWER_BOOTSTRAP_ROUTE_IDS)");
+  });
+});

--- a/hushh-webapp/scripts/testing/run-kai-import-e2e.mjs
+++ b/hushh-webapp/scripts/testing/run-kai-import-e2e.mjs
@@ -33,6 +33,7 @@ const appOrigin = (
 ).replace(/\/$/, "");
 const headless = process.env.PLAYWRIGHT_HEADLESS !== "0";
 const REVIEWER_BOOTSTRAP_ROUTE = "/ria";
+const REVIEWER_BOOTSTRAP_ROUTE_IDS = [REVIEWER_BOOTSTRAP_ROUTE, "/ria/onboarding"];
 const NAVIGATION_TIMEOUT_MS = 120_000;
 const IMPORT_TIMEOUT_MS = Number(process.env.KAI_IMPORT_E2E_TIMEOUT_MS || 10 * 60_000);
 const TERMINAL_DATA_STATES = [
@@ -307,7 +308,7 @@ async function ensureReviewerSession(page) {
     }
   }
 
-  await waitForRouteBeacon(page, [REVIEWER_BOOTSTRAP_ROUTE]);
+  await waitForRouteBeacon(page, REVIEWER_BOOTSTRAP_ROUTE_IDS);
 }
 
 async function firstVisible(locator) {

--- a/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
+++ b/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
@@ -59,6 +59,7 @@ const NAVIGATION_TIMEOUT_MS = 120000;
 const CLIENT_NAVIGATION_CONTEXT_KEY = "__hushhSignedInRouteContextProbe";
 const INTERNAL_APP_NAVIGATION_REQUEST_EVENT = "app-internal-navigation-requested";
 const REVIEWER_BOOTSTRAP_ROUTE = "/ria";
+const REVIEWER_BOOTSTRAP_ROUTE_IDS = [REVIEWER_BOOTSTRAP_ROUTE, "/ria/onboarding"];
 const SAME_SESSION_SHELL_ROUTES = new Set([
   "/agent",
   "/one",
@@ -583,7 +584,7 @@ async function ensureReviewerSession(page) {
 
   process.stdout.write(`→ wait for reviewer route beacon\n`);
   try {
-    await waitForRouteBeacon(page, [REVIEWER_BOOTSTRAP_ROUTE]);
+    await waitForRouteBeacon(page, REVIEWER_BOOTSTRAP_ROUTE_IDS);
   } catch (error) {
     const diagnostics = await captureRouteDiagnostics(page);
     throw new Error(

--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -20,6 +20,7 @@ FRONTEND_TESTS=(
   "__tests__/services/ria-onboarding-flow.test.ts"
   "__tests__/api/consent/api-service-consent.test.ts"
   "__tests__/api/consent/events-proxy.test.ts"
+  "__tests__/scripts/reviewer-route-bootstrap-contract.test.ts"
   "__tests__/utils/top-shell-breadcrumbs.test.ts"
 )
 


### PR DESCRIPTION
## Summary
- accept the governed /ria/onboarding redirect when bootstrapping reviewer browser sessions
- preserve the same BYOK-unlocked browser context before navigating to PKM
- add the regression to the mandatory PKM upgrade gate

## Verification
- focused live reviewer route proof against UAT: /ria/onboarding to /one/pkm passed
- PKM upgrade gate: 129 frontend tests passed; 242 backend tests passed
- node syntax checks and diff check passed

## Release boundary
This is a reviewer-harness correction. It does not change PKM storage, scopes, authorization, production data, or application routing.