### PR TITLE
fix(pkm): bound structure-agent timeout retries

### DIFF
--- a/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
@@ -395,6 +395,9 @@ _AGENT_CONTRACT_TIMEOUT_SECONDS = max(
     # tail latency and forced valid model responses into fallback.
     float(os.getenv("PKM_AGENT_LAB_AGENT_TIMEOUT_SECONDS", "8") or "8"),
 )
+# One retry absorbs transient provider tail latency without introducing another
+# runtime configuration surface or extending the shared preview deadline.
+_AGENT_CONTRACT_MAX_ATTEMPTS = 2
 _PREVIEW_TOTAL_BUDGET_SECONDS = max(
     4.0,
     # Keep a finite user-facing budget while allowing the sequential contract
@@ -1361,53 +1364,82 @@ class PKMAgentLabService:
     ) -> dict[str, Any] | None:
         if self.client is None:
             return None
-        effective_timeout = _AGENT_CONTRACT_TIMEOUT_SECONDS
-        if timeout_seconds is not None:
-            if timeout_seconds <= 0.25:
+        deadline = time.perf_counter() + timeout_seconds if timeout_seconds is not None else None
+        from google.genai import types as genai_types
+
+        config = genai_types.GenerateContentConfig(
+            temperature=0.0,
+            response_mime_type="application/json",
+            automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(disable=True),
+            response_schema=response_schema,
+        )
+        for attempt in range(1, _AGENT_CONTRACT_MAX_ATTEMPTS + 1):
+            remaining_seconds = (
+                max(0.0, deadline - time.perf_counter()) if deadline is not None else None
+            )
+            if remaining_seconds is not None and remaining_seconds <= 0.25:
                 logger.info(
-                    "pkm.agent_contract_skipped_budget agent=%s timeout_seconds=%s",
+                    "pkm.agent_contract_skipped_budget agent=%s attempt=%s "
+                    "budget_remaining_seconds=%s",
                     getattr(manifest, "id", "unknown"),
-                    round(timeout_seconds, 3),
+                    attempt,
+                    round(remaining_seconds, 3),
                 )
                 return None
-            effective_timeout = max(0.25, min(_AGENT_CONTRACT_TIMEOUT_SECONDS, timeout_seconds))
-        try:
-            from google.genai import types as genai_types
-
-            config = genai_types.GenerateContentConfig(
-                temperature=0.0,
-                response_mime_type="application/json",
-                automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(disable=True),
-                response_schema=response_schema,
-            )
-            response = await asyncio.wait_for(
-                self.client.aio.models.generate_content(
-                    model=model_override or manifest.model or GEMINI_MODEL,
-                    contents=prompt,
-                    config=config,
-                ),
-                timeout=effective_timeout,
-            )
-            parsed = (
-                response.parsed if isinstance(getattr(response, "parsed", None), dict) else None
-            )
-            if parsed is None:
-                parsed = json.loads((response.text or "").strip() or "{}")
-            return parsed if isinstance(parsed, dict) else None
-        except asyncio.TimeoutError:
-            logger.warning(
-                "pkm.agent_contract_timeout agent=%s timeout_seconds=%s",
-                getattr(manifest, "id", "unknown"),
-                round(effective_timeout, 3),
-            )
-            return None
-        except Exception as exc:
-            logger.warning(
-                "pkm.agent_contract_failed agent=%s error=%s",
-                getattr(manifest, "id", "unknown"),
-                exc,
-            )
-            return None
+            effective_timeout = _AGENT_CONTRACT_TIMEOUT_SECONDS
+            if remaining_seconds is not None:
+                effective_timeout = max(
+                    0.25,
+                    min(_AGENT_CONTRACT_TIMEOUT_SECONDS, remaining_seconds),
+                )
+            try:
+                response = await asyncio.wait_for(
+                    self.client.aio.models.generate_content(
+                        model=model_override or manifest.model or GEMINI_MODEL,
+                        contents=prompt,
+                        config=config,
+                    ),
+                    timeout=effective_timeout,
+                )
+                parsed = (
+                    response.parsed if isinstance(getattr(response, "parsed", None), dict) else None
+                )
+                if parsed is None:
+                    parsed = json.loads((response.text or "").strip() or "{}")
+                return parsed if isinstance(parsed, dict) else None
+            except asyncio.TimeoutError:
+                can_retry = attempt < _AGENT_CONTRACT_MAX_ATTEMPTS
+                retry_budget_seconds = (
+                    max(0.0, deadline - time.perf_counter()) if deadline is not None else None
+                )
+                if can_retry and (retry_budget_seconds is None or retry_budget_seconds > 0.25):
+                    logger.warning(
+                        "pkm.agent_contract_timeout_retry agent=%s attempt=%s "
+                        "max_attempts=%s timeout_seconds=%s budget_remaining_seconds=%s",
+                        getattr(manifest, "id", "unknown"),
+                        attempt,
+                        _AGENT_CONTRACT_MAX_ATTEMPTS,
+                        round(effective_timeout, 3),
+                        round(retry_budget_seconds, 3)
+                        if retry_budget_seconds is not None
+                        else None,
+                    )
+                    continue
+                logger.warning(
+                    "pkm.agent_contract_timeout agent=%s attempts=%s timeout_seconds=%s",
+                    getattr(manifest, "id", "unknown"),
+                    attempt,
+                    round(effective_timeout, 3),
+                )
+                return None
+            except Exception as exc:
+                logger.warning(
+                    "pkm.agent_contract_failed agent=%s error=%s",
+                    getattr(manifest, "id", "unknown"),
+                    exc,
+                )
+                return None
+        return None
 
     @staticmethod
     def _remaining_preview_budget_seconds(deadline: float | None) -> float | None:

--- a/consent-protocol/scripts/eval_pkm_structure_agent.py
+++ b/consent-protocol/scripts/eval_pkm_structure_agent.py
@@ -37,6 +37,9 @@ DEFAULT_REPORT_PATH = CONSENT_PROTOCOL_ROOT / "artifacts" / "pkm_structure_agent
 DEFAULT_PRIMARY_MODEL = "gemini-3.5-flash"
 DEFAULT_SECONDARY_MODEL = ""
 DEFAULT_REFERENCE_MODEL = ""
+# The evaluator must outlive the runtime preview's 30-second deadline so it
+# records the service result instead of manufacturing an earlier timeout.
+DEFAULT_PER_PROMPT_TIMEOUT_SECONDS = 35.0
 DEFAULT_SHADOW_USERS = [
     "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2",
     "s3xmA4lNSAQFrIaOytnSGAOzXlL2",
@@ -415,7 +418,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--per-prompt-timeout-seconds",
         type=float,
-        default=25.0,
+        default=DEFAULT_PER_PROMPT_TIMEOUT_SECONDS,
         help="Per-prompt live model timeout in seconds.",
     )
     parser.add_argument(

--- a/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
+++ b/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from hushh_mcp.services import pkm_agent_lab_service as pkm_agent_lab_module
 from scripts import eval_pkm_structure_agent as eval_script
 
 
@@ -9,6 +10,15 @@ def test_persona_chain_keeps_hundred_case_crud_surface():
     assert len(prompts) == 100
     categories = {prompt.category for prompt in prompts}
     assert {"correction", "deletion", "ambiguous", "finance"}.issubset(categories)
+
+
+def test_evaluator_timeout_outlives_runtime_preview_budget(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["eval_pkm_structure_agent.py"])
+
+    args = eval_script.parse_args()
+
+    assert args.per_prompt_timeout_seconds == eval_script.DEFAULT_PER_PROMPT_TIMEOUT_SECONDS
+    assert args.per_prompt_timeout_seconds > pkm_agent_lab_module._PREVIEW_TOTAL_BUDGET_SECONDS
 
 
 def test_quality_gate_flags_fallback_fragmentation_and_mutation_drift():

--- a/consent-protocol/tests/services/test_pkm_agent_lab_service.py
+++ b/consent-protocol/tests/services/test_pkm_agent_lab_service.py
@@ -1,8 +1,10 @@
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
+from hushh_mcp.services import pkm_agent_lab_service as pkm_agent_lab_module
 from hushh_mcp.services.pkm_agent_lab_service import PKMAgentLabService
 
 
@@ -75,6 +77,32 @@ def _single_segment(message: str):
         "source_agent": "memory_segmentation_agent",
         "contract_version": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_agent_contract_retries_one_timeout_within_preview_budget(monkeypatch):
+    service = PKMAgentLabService()
+    generate_content = AsyncMock(
+        side_effect=[
+            asyncio.TimeoutError,
+            SimpleNamespace(parsed={"status": "ok"}, text=""),
+        ]
+    )
+    service._client = SimpleNamespace(
+        aio=SimpleNamespace(models=SimpleNamespace(generate_content=generate_content))
+    )
+    monkeypatch.setattr(pkm_agent_lab_module, "_AGENT_CONTRACT_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(pkm_agent_lab_module, "_AGENT_CONTRACT_MAX_ATTEMPTS", 2)
+
+    result = await service._run_agent_contract(
+        manifest=SimpleNamespace(id="agent_test", model="test-model"),
+        prompt="Return a valid structured response.",
+        response_schema={"type": "OBJECT"},
+        timeout_seconds=1.0,
+    )
+
+    assert result == {"status": "ok"}
+    assert generate_content.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- retry transient PKM structure-agent provider timeouts once within the existing preview deadline
- keep schema/semantic errors non-retriable and preserve all release thresholds
- align the live evaluator timeout with the 30-second runtime preview budget

## Evidence
- live 60-prompt evaluation: quality gate pass; schema/domain/intent 1.0, mutation 0.9167, fallback 0.05, zero evaluator timeouts
- PKM upgrade gate: 129 frontend + 243 backend tests passed
- Ruff and diff integrity passed

## Risk controls
- no PKM stored-data shape, scope, authorization, migration, or release threshold changes
- retry remains bounded by the existing shared runtime deadline