### PR TITLE
fix(test): accept state-aware Kai onboarding redirect

### DIFF
--- a/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
+++ b/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
@@ -16,4 +16,15 @@ describe("reviewer route bootstrap contract", () => {
     );
     expect(source).toContain("waitForRouteBeacon(page, REVIEWER_BOOTSTRAP_ROUTE_IDS)");
   });
+
+  it("accepts state-aware destinations for Kai onboarding compatibility redirects", () => {
+    const verifierPath = scripts[0];
+    const source = readFileSync(new URL(verifierPath, import.meta.url), "utf8");
+
+    expect(source).toContain('"/one/setup/finance"');
+    expect(source).toContain('"/one/kai"');
+    expect(source).toMatch(
+      /if \(route\.mode === "redirect"\) \{[\s\S]*const override = ROUTE_OVERRIDES\[route\.route\];[\s\S]*override\?\.allowedPathnames/,
+    );
+  });
 });

--- a/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
+++ b/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
@@ -152,14 +152,26 @@ const DYNAMIC_ROUTE_FIXTURES = {
   },
 };
 
+const KAI_ONBOARDING_COMPATIBILITY_PATHNAMES = [
+  "/one/setup/finance",
+  "/one/setup/kai",
+  "/one",
+  "/one/kai",
+];
+const KAI_ONBOARDING_COMPATIBILITY_ROUTE_IDS = ["/one/setup/kai", "/one", "/one/kai"];
+
 const ROUTE_OVERRIDES = {
+  "/kai/onboarding": {
+    allowedPathnames: KAI_ONBOARDING_COMPATIBILITY_PATHNAMES,
+    allowedRouteIds: KAI_ONBOARDING_COMPATIBILITY_ROUTE_IDS,
+  },
   "/one/kai/onboarding": {
-    allowedPathnames: ["/one/kai/onboarding", "/one/kai"],
-    allowedRouteIds: ["/one/kai/onboarding", "/one/kai"],
+    allowedPathnames: KAI_ONBOARDING_COMPATIBILITY_PATHNAMES,
+    allowedRouteIds: KAI_ONBOARDING_COMPATIBILITY_ROUTE_IDS,
   },
   "/one/setup/kai": {
-    allowedPathnames: ["/one/setup/kai", "/one"],
-    allowedRouteIds: ["/one/setup/kai", "/one"],
+    allowedPathnames: KAI_ONBOARDING_COMPATIBILITY_PATHNAMES,
+    allowedRouteIds: KAI_ONBOARDING_COMPATIBILITY_ROUTE_IDS,
   },
   "/ria/onboarding": {
     allowedPathnames: ["/ria/onboarding", "/ria"],
@@ -465,12 +477,18 @@ function routeSpec(route) {
     if (!expectation) {
       throw new Error(`Missing redirect expectation for ${route.route}`);
     }
+    const override = ROUTE_OVERRIDES[route.route];
     return {
       kind: "redirect",
       route: route.route,
-      allowedPathnames: [expectation.expectedPathname],
-      expectedQueryIncludes: expectation.expectedQueryIncludes || [],
       ...expectation,
+      allowedPathnames:
+        override?.allowedPathnames ||
+        expectation.allowedPathnames ||
+        [expectation.expectedPathname].filter(Boolean),
+      allowedRouteIds:
+        override?.allowedRouteIds || expectation.allowedRouteIds || [route.route],
+      expectedQueryIncludes: expectation.expectedQueryIncludes || [],
     };
   }
 


### PR DESCRIPTION
## Summary
- apply route overrides to redirect-mode reviewer specs instead of bypassing them
- accept only the valid Finance setup, generic home, or investor-home destinations for Kai onboarding compatibility routes
- add a regression contract for resolved reviewer accounts

## Evidence
- exact-SHA UAT PKM gates passed: 130 frontend, 243 backend, reviewer PKM shape audit, PostgreSQL rollback rehearsal, and 60+20 prompt structure-agent evaluation
- UAT failure reproduced only at `/one/kai/onboarding`, which resolved to `/one/kai` with an authenticated, unlocked reviewer and a healthy `/one/kai` beacon
- targeted Vitest, Node syntax, ESLint, diff integrity, and full PKM upgrade gate passed

## Risk controls
- test-harness only; no app redirect, auth, scope, PKM storage, or production runtime behavior changes
- allowed outcomes are bounded to existing account-state routes and their existing beacons