### PR TITLE
fix(db): keep PKM event migrations replay-safe

### DIFF
--- a/consent-protocol/db/migrations/030_pkm_cutover.sql
+++ b/consent-protocol/db/migrations/030_pkm_cutover.sql
@@ -158,7 +158,9 @@ ALTER TABLE pkm_events
       'legacy_cutover',
       'scope_exposure_update',
       'default_projection_publish',
-      'default_projection_revoke'
+      'default_projection_revoke',
+      'upgrade_commit',
+      'upgrade_rollback'
     )
   );
 

--- a/consent-protocol/db/migrations/063_pkm_default_available_visibility.sql
+++ b/consent-protocol/db/migrations/063_pkm_default_available_visibility.sql
@@ -87,7 +87,9 @@ ALTER TABLE pkm_events
       'legacy_cutover',
       'scope_exposure_update',
       'default_projection_publish',
-      'default_projection_revoke'
+      'default_projection_revoke',
+      'upgrade_commit',
+      'upgrade_rollback'
     )
   );
 

--- a/consent-protocol/tests/test_pkm_event_operation_type_migration_contract.py
+++ b/consent-protocol/tests/test_pkm_event_operation_type_migration_contract.py
@@ -20,24 +20,22 @@ def _pkm_event_constraint_operations(migration_name: str) -> set[str] | None:
     return set(re.findall(r"'([^']+)'", match.group("body")))
 
 
-def test_pkm_cutover_replay_constraint_allows_later_event_operation_types():
+def test_replayed_pkm_event_constraints_allow_all_later_operation_types():
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     ordered = manifest["ordered_migrations"]
-    cutover = "030_pkm_cutover.sql"
-    cutover_index = ordered.index(cutover)
-    cutover_operations = _pkm_event_constraint_operations(cutover)
+    constraint_migrations = [
+        (migration_name, operations)
+        for migration_name in ordered
+        if (operations := _pkm_event_constraint_operations(migration_name)) is not None
+    ]
 
-    assert cutover_operations is not None
-
-    for migration_name in ordered[cutover_index + 1 :]:
-        later_operations = _pkm_event_constraint_operations(migration_name)
-        if later_operations is None:
-            continue
-        assert later_operations <= cutover_operations, (
-            f"{cutover} must allow every pkm_events.operation_type allowed by "
-            f"{migration_name}; release migrations replay {cutover} before later "
-            "constraint wideners on existing UAT/production data."
-        )
+    for index, (migration_name, operations) in enumerate(constraint_migrations):
+        for later_name, later_operations in constraint_migrations[index + 1 :]:
+            assert later_operations <= operations, (
+                f"{migration_name} must allow every pkm_events.operation_type allowed by "
+                f"{later_name}; release migrations replay historical constraints before "
+                "later wideners on existing UAT/production data."
+            )
 
 
 def test_pkm_cutover_replay_constraint_allows_current_service_events():

--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -28,6 +28,7 @@ BACKEND_TESTS=(
   "tests/test_pkm_upgrade_routes.py"
   "tests/test_pkm_upgrade_service.py"
   "tests/test_pkm_v7_recovery_migration.py"
+  "tests/test_pkm_event_operation_type_migration_contract.py"
   "tests/test_active_pkm_shape_audit.py"
   "tests/test_offline_db.py"
   "tests/services/test_account_service_cleanup_tables.py"


### PR DESCRIPTION
## Summary
- keep replayed PKM event constraints compatible with v7 upgrade commit/rollback events
- generalize the migration contract across every historical PKM event constraint
- make that contract mandatory in the PKM upgrade gate

## Evidence
- UAT aggregate-only audit: 985 events; two `upgrade_commit` rows exposed migration 030 narrowing the current valid constraint
- transaction-rolled-back constraint replacement validated against all UAT event rows; zero rows changed
- PKM upgrade gate: 130 frontend + 245 backend tests passed
- focused migration contract/recovery tests, Ruff, shell syntax, and diff integrity passed

## Zero-loss boundary
- no event rows, payloads, user identifiers, or encrypted information are changed
- no operation is renamed or coerced
- historical constraints now allow the final current operation set before later migrations replay