### PR TITLE
fix(test): preserve RIA compatibility route beacons

### DIFF
--- a/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
+++ b/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
@@ -27,4 +27,28 @@ describe("reviewer route bootstrap contract", () => {
       /if \(route\.mode === "redirect"\) \{[\s\S]*const override = ROUTE_OVERRIDES\[route\.route\];[\s\S]*override\?\.allowedPathnames/,
     );
   });
+
+  it.each([
+    [
+      "../../components/ria/ria-client-workspace.tsx",
+      "/ria/clients/[userId]",
+      "native-route-ria-client-workspace",
+    ],
+    [
+      "../../components/ria/ria-client-account-detail.tsx",
+      "/ria/clients/[userId]/accounts/[accountId]",
+      "native-route-ria-client-account-detail",
+    ],
+    [
+      "../../components/ria/ria-client-request-detail.tsx",
+      "/ria/clients/[userId]/requests/[requestId]",
+      "native-route-ria-client-request-detail",
+    ],
+  ])("keeps a terminal reviewer beacon in RIA compatibility mode for %s", (relativePath, routeId, marker) => {
+    const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+    expect(source).toContain(`routeId: "${routeId}"`);
+    expect(source).toContain(`marker: "${marker}"`);
+    expect(source).toContain('dataState: "unavailable-valid"');
+  });
 });

--- a/hushh-webapp/components/ria/ria-client-account-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-account-detail.tsx
@@ -110,6 +110,12 @@ export function RiaClientAccountDetail({
       <RiaCompatibilityState
         title="Complete RIA onboarding"
         description="Finish onboarding before opening account detail routes."
+        nativeTest={{
+          routeId: "/ria/clients/[userId]/accounts/[accountId]",
+          marker: "native-route-ria-client-account-detail",
+          authState: user ? "authenticated" : "pending",
+          dataState: "unavailable-valid",
+        }}
       />
     );
   }
@@ -119,6 +125,12 @@ export function RiaClientAccountDetail({
       <RiaCompatibilityState
         title="Account detail is unavailable in this environment"
         description="The route is wired, but this environment still needs the full IAM schema before advisor-side account detail can load."
+        nativeTest={{
+          routeId: "/ria/clients/[userId]/accounts/[accountId]",
+          marker: "native-route-ria-client-account-detail",
+          authState: user ? "authenticated" : "pending",
+          dataState: "unavailable-valid",
+        }}
       />
     );
   }

--- a/hushh-webapp/components/ria/ria-client-request-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-request-detail.tsx
@@ -105,6 +105,12 @@ export function RiaClientRequestDetail({
       <RiaCompatibilityState
         title="Complete RIA onboarding"
         description="Finish onboarding before opening request detail routes."
+        nativeTest={{
+          routeId: "/ria/clients/[userId]/requests/[requestId]",
+          marker: "native-route-ria-client-request-detail",
+          authState: user ? "authenticated" : "pending",
+          dataState: "unavailable-valid",
+        }}
       />
     );
   }
@@ -114,6 +120,12 @@ export function RiaClientRequestDetail({
       <RiaCompatibilityState
         title="Request detail is unavailable in this environment"
         description="The route is wired, but this environment still needs the full IAM schema before advisor-side request detail can load."
+        nativeTest={{
+          routeId: "/ria/clients/[userId]/requests/[requestId]",
+          marker: "native-route-ria-client-request-detail",
+          authState: user ? "authenticated" : "pending",
+          dataState: "unavailable-valid",
+        }}
       />
     );
   }

--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -477,6 +477,12 @@ export function RiaClientWorkspace({
       <RiaCompatibilityState
         title="Complete RIA onboarding"
         description="Finish onboarding before opening dedicated client workspaces."
+        nativeTest={{
+          routeId: "/ria/clients/[userId]",
+          marker: "native-route-ria-client-workspace",
+          authState: user ? "authenticated" : "pending",
+          dataState: "unavailable-valid",
+        }}
       />
     );
   }

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -14,6 +14,11 @@ import {
   type AppPageShellWidth,
 } from "@/components/app-ui/app-page-shell";
 import {
+  NativeTestBeacon,
+  type NativeTestAuthState,
+  type NativeTestDataState,
+} from "@/components/app-ui/native-test-beacon";
+import {
   PageHeader,
   SectionHeader,
 } from "@/components/app-ui/page-sections";
@@ -117,12 +122,20 @@ export function RiaSurface({
 export function RiaCompatibilityState({
   title,
   description,
+  nativeTest,
 }: {
   title: string;
   description: string;
+  nativeTest?: {
+    routeId: string;
+    marker: string;
+    authState: NativeTestAuthState;
+    dataState: NativeTestDataState;
+  };
 }) {
   return (
     <section className="space-y-3">
+      {nativeTest ? <NativeTestBeacon {...nativeTest} /> : null}
       <SectionHeader
         eyebrow="Compatibility Mode"
         title={title}


### PR DESCRIPTION
## Summary
- emit exact terminal reviewer beacons from RIA dynamic compatibility states
- preserve strict route IDs and mark legitimate setup/IAM fallback as unavailable-valid
- add reviewer contract coverage for workspace, account, and request detail routes

## Root cause
The reviewer account can legitimately be in RIA setup compatibility mode. The clients index emitted an unavailable-valid beacon, but dynamic detail components returned compatibility UI without a beacon, causing the protected UAT verifier to wait 120 seconds and fail.

## Verification
- npx vitest run __tests__/scripts/reviewer-route-bootstrap-contract.test.ts
- focused ESLint with zero warnings
- npm run typecheck
- ./scripts/ci/reviewer-app-testing-check.sh
- git diff --check

## UAT evidence
Run 29493328591 passed migrations, PKM zero-loss gates, structure evaluation, /one/pkm, and all Kai routes; it failed only on /ria/clients/[userId] before any build or traffic promotion.