### PR TITLE
fix(uat): audit reviewer runtime after promotion

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -319,7 +319,7 @@ jobs:
           PKM_UPGRADE_REVIEWER_SECRET_PROJECT="${{ env.GCP_PROJECT_ID }}" \
           PKM_UPGRADE_REVIEWER_ENV_FILE="$reviewer_env_file" \
           PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1 \
-          PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL="${{ env.APP_FRONTEND_ORIGIN }}" \
+          PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1 \
             ./scripts/ci/pkm-upgrade-gate.sh
 
       - name: Deploy backend using Cloud Build
@@ -618,6 +618,17 @@ jobs:
           node .codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs \
             2>&1 | tee /tmp/uat-reviewer-byok.log
 
+      - name: Verify live PKM, investor, and RIA runtime audits
+        id: verify-pkm-runtime-audit
+        continue-on-error: true
+        shell: bash
+        env:
+          PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL: ${{ env.APP_FRONTEND_ORIGIN }}
+          PKM_UPGRADE_REVIEWER_SECRET_PROJECT: ${{ env.GCP_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          ./scripts/ci/pkm-runtime-audit.sh 2>&1 | tee /tmp/uat-pkm-runtime-audit.log
+
       - name: Classify UAT release outcome
         if: always()
         id: classify-uat-release
@@ -633,6 +644,7 @@ jobs:
           SEMANTIC_ATTEMPT_1: ${{ steps.verify-uat-1.outcome }}
           SEMANTIC_ATTEMPT_2: ${{ steps.verify-uat-2.outcome }}
           REVIEWER_BYOK_OUTCOME: ${{ steps.verify-reviewer-byok.outcome }}
+          PKM_RUNTIME_AUDIT_OUTCOME: ${{ steps.verify-pkm-runtime-audit.outcome }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -680,6 +692,7 @@ jobs:
           semantic_success = os.environ.get("SEMANTIC_ATTEMPT_1") == "success" or os.environ.get("SEMANTIC_ATTEMPT_2") == "success"
           db_outcome = os.environ.get("DB_OUTCOME", "")
           reviewer_byok_success = os.environ.get("REVIEWER_BYOK_OUTCOME") == "success"
+          pkm_runtime_audit_success = os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME") == "success"
 
           blocking: list[str] = []
           backend_failure = False
@@ -760,6 +773,13 @@ jobs:
               if os.environ.get("DEPLOY_FRONTEND") == "true":
                   frontend_failure = True
 
+          if not pkm_runtime_audit_success:
+              append_unique(blocking, ["pkm_runtime_audit_failed"])
+              if os.environ.get("DEPLOY_BACKEND") == "true":
+                  backend_failure = True
+              if os.environ.get("DEPLOY_FRONTEND") == "true":
+                  frontend_failure = True
+
           blocking = list(dict.fromkeys(blocking))
           release_failed = bool(blocking)
 
@@ -802,6 +822,10 @@ jobs:
                   "outcome": os.environ.get("REVIEWER_BYOK_OUTCOME", ""),
                   "success": reviewer_byok_success,
               },
+              "pkm_runtime_audit": {
+                  "outcome": os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME", ""),
+                  "success": pkm_runtime_audit_success,
+              },
           }
 
           Path("/tmp/uat-release-classification.json").write_text(
@@ -818,6 +842,7 @@ jobs:
               handle.write(f"provenance_success={'true' if backend_provenance_success and frontend_provenance_success else 'false'}\n")
               handle.write(f"semantic_success={'true' if semantic_success else 'false'}\n")
               handle.write(f"reviewer_byok_success={'true' if reviewer_byok_success else 'false'}\n")
+              handle.write(f"pkm_runtime_audit_success={'true' if pkm_runtime_audit_success else 'false'}\n")
           PY
 
       - name: Roll back backend revision
@@ -939,6 +964,7 @@ jobs:
                   "semantic_success": "${{ steps.classify-uat-release.outputs.semantic_success }}",
                   "db_contract": "${{ steps.postdeploy-db-gate.outcome }}",
                   "reviewer_byok": "${{ steps.verify-reviewer-byok.outcome }}",
+                  "pkm_runtime_audit": "${{ steps.verify-pkm-runtime-audit.outcome }}",
                   "blocking_classifications": "${{ steps.classify-uat-release.outputs.blocking_classifications }}",
               },
               "rollback_targets": {
@@ -973,6 +999,7 @@ jobs:
             /tmp/uat-release-verify-attempt-1.json
             /tmp/uat-release-verify-attempt-2.json
             /tmp/uat-reviewer-byok.log
+            /tmp/uat-pkm-runtime-audit.log
             /tmp/uat-release-classification.json
             /tmp/uat-release-status.json
 

--- a/consent-protocol/tests/test_active_pkm_shape_audit.py
+++ b/consent-protocol/tests/test_active_pkm_shape_audit.py
@@ -47,12 +47,12 @@ def test_protected_gate_rejects_partial_shape_audit():
 
 
 def test_live_runtime_audit_loads_canonical_reviewer_secrets_in_memory():
-    gate = (ROOT.parent / "scripts/ci/pkm-upgrade-gate.sh").read_text()
+    audit = (ROOT.parent / "scripts/ci/pkm-runtime-audit.sh").read_text()
 
-    assert "load_reviewer_runtime_secrets" in gate
-    assert "--secret=REVIEWER_UID" in gate
-    assert "--secret=REVIEWER_VAULT_PASSPHRASE" in gate
-    assert "export REVIEWER_UID REVIEWER_VAULT_PASSPHRASE" in gate
-    assert gate.index("load_reviewer_runtime_secrets\n  cd") < gate.index(
+    assert "load_reviewer_runtime_secrets" in audit
+    assert "--secret=REVIEWER_UID" in audit
+    assert "--secret=REVIEWER_VAULT_PASSPHRASE" in audit
+    assert "export REVIEWER_UID REVIEWER_VAULT_PASSPHRASE" in audit
+    assert audit.index("load_reviewer_runtime_secrets\ncd") < audit.index(
         "node ./scripts/testing/verify-signed-in-routes.mjs"
     )

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -103,6 +103,8 @@ def test_protected_uat_gate_requires_live_recovery_rehearsal():
     assert "PKM_UPGRADE_POSTGRES_REHEARSAL_URL" in gate
     assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL" in gate
     assert "PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL" in gate
+    assert "PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED" in gate
+    assert "pkm-runtime-audit.sh" in gate
     assert "pkm_v7_zero_loss_rehearsal.sql" in gate
     assert "primary_method" in rehearsal
     assert "get_pkm_domain_snapshot_v1" in rehearsal
@@ -128,5 +130,14 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     assert "PKM_UPGRADE_PROTECTED_UAT=1" in workflow
     assert "PKM_UPGRADE_REVIEWER_SHAPE_AUDIT=1" in workflow
     assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1" in workflow
+    assert "PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1" in workflow
     assert "verify-reviewer-byok" in workflow
     assert "reviewer_byok_continuity_failed" in workflow
+    assert "verify-pkm-runtime-audit" in workflow
+    assert "pkm_runtime_audit_failed" in workflow
+    assert workflow.index("Promote deployed revisions to UAT traffic") < workflow.index(
+        "Verify live PKM, investor, and RIA runtime audits"
+    )
+    assert workflow.index("Verify live PKM, investor, and RIA runtime audits") < workflow.index(
+        "Classify UAT release outcome"
+    )

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -31,8 +31,15 @@ def test_uat_deploy_builds_candidates_without_serving_traffic() -> None:
     )
 
 
-def test_production_deploy_keeps_default_traffic_behavior() -> None:
+def test_production_deploy_builds_candidates_without_serving_traffic() -> None:
     production_workflow = _read(".github/workflows/deploy-production.yml")
 
-    assert "_CLOUD_RUN_NO_TRAFFIC" not in production_workflow
-    assert "--no-traffic" not in production_workflow
+    assert "_CLOUD_RUN_NO_TRAFFIC=true" in production_workflow
+    assert (
+        '--to-revisions="${{ steps.candidate-state.outputs.backend_revision }}=100"'
+        in production_workflow
+    )
+    assert (
+        '--to-revisions="${{ steps.candidate-state.outputs.frontend_revision }}=100"'
+        in production_workflow
+    )

--- a/scripts/ci/pkm-runtime-audit.sh
+++ b/scripts/ci/pkm-runtime-audit.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WEB_DIR="$REPO_ROOT/hushh-webapp"
+BASE_URL="${PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL:-}"
+
+if [ -z "$BASE_URL" ]; then
+  echo "PKM runtime audit requires PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL." >&2
+  exit 1
+fi
+
+load_reviewer_runtime_secrets() {
+  if [ -n "${REVIEWER_UID:-}" ] && [ -n "${REVIEWER_VAULT_PASSPHRASE:-}" ]; then
+    return 0
+  fi
+
+  local secret_project="${PKM_UPGRADE_REVIEWER_SECRET_PROJECT:-}"
+  local secret_version="${PKM_UPGRADE_REVIEWER_SECRET_VERSION:-latest}"
+  if [ -z "$secret_project" ]; then
+    echo "Live reviewer runtime audits require reviewer credentials or PKM_UPGRADE_REVIEWER_SECRET_PROJECT." >&2
+    return 1
+  fi
+  if ! command -v gcloud >/dev/null 2>&1; then
+    echo "Live reviewer runtime audits require gcloud for Secret Manager resolution." >&2
+    return 1
+  fi
+
+  if [ -z "${REVIEWER_UID:-}" ]; then
+    REVIEWER_UID="$(gcloud secrets versions access "$secret_version" \
+      --secret=REVIEWER_UID \
+      --project="$secret_project")"
+  fi
+  if [ -z "${REVIEWER_VAULT_PASSPHRASE:-}" ]; then
+    REVIEWER_VAULT_PASSPHRASE="$(gcloud secrets versions access "$secret_version" \
+      --secret=REVIEWER_VAULT_PASSPHRASE \
+      --project="$secret_project")"
+  fi
+  if [ -z "$REVIEWER_UID" ] || [ -z "$REVIEWER_VAULT_PASSPHRASE" ]; then
+    echo "Live reviewer runtime audits could not resolve the canonical reviewer identity." >&2
+    return 1
+  fi
+  export REVIEWER_UID REVIEWER_VAULT_PASSPHRASE
+}
+
+echo "Running live PKM, investor, and RIA runtime audits..."
+load_reviewer_runtime_secrets
+cd "$WEB_DIR"
+for route_filter in one/pkm one/kai ria; do
+  HUSHH_APP_ORIGIN="$BASE_URL" \
+  HUSHH_VIEWPORT_FILTER=phone \
+  HUSHH_ROUTE_FILTER="$route_filter" \
+    node ./scripts/testing/verify-signed-in-routes.mjs
+done

--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -91,43 +91,12 @@ if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ "${PKM_UPGRADE_STRUCTURE_AGEN
   exit 1
 fi
 
-if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ -z "${PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL:-}" ]; then
-  echo "Protected UAT requires PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL." >&2
+if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] \
+  && [ -z "${PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL:-}" ] \
+  && [ "${PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED:-}" != "1" ]; then
+  echo "Protected UAT requires a live runtime audit or an explicit postdeploy deferral." >&2
   exit 1
 fi
-
-load_reviewer_runtime_secrets() {
-  if [ -n "${REVIEWER_UID:-}" ] && [ -n "${REVIEWER_VAULT_PASSPHRASE:-}" ]; then
-    return 0
-  fi
-
-  local secret_project="${PKM_UPGRADE_REVIEWER_SECRET_PROJECT:-}"
-  local secret_version="${PKM_UPGRADE_REVIEWER_SECRET_VERSION:-latest}"
-  if [ -z "$secret_project" ]; then
-    echo "Live reviewer runtime audits require reviewer credentials or PKM_UPGRADE_REVIEWER_SECRET_PROJECT." >&2
-    return 1
-  fi
-  if ! command -v gcloud >/dev/null 2>&1; then
-    echo "Live reviewer runtime audits require gcloud for Secret Manager resolution." >&2
-    return 1
-  fi
-
-  if [ -z "${REVIEWER_UID:-}" ]; then
-    REVIEWER_UID="$(gcloud secrets versions access "$secret_version" \
-      --secret=REVIEWER_UID \
-      --project="$secret_project")"
-  fi
-  if [ -z "${REVIEWER_VAULT_PASSPHRASE:-}" ]; then
-    REVIEWER_VAULT_PASSPHRASE="$(gcloud secrets versions access "$secret_version" \
-      --secret=REVIEWER_VAULT_PASSPHRASE \
-      --project="$secret_project")"
-  fi
-  if [ -z "$REVIEWER_UID" ] || [ -z "$REVIEWER_VAULT_PASSPHRASE" ]; then
-    echo "Live reviewer runtime audits could not resolve the canonical reviewer identity." >&2
-    return 1
-  fi
-  export REVIEWER_UID REVIEWER_VAULT_PASSPHRASE
-}
 
 if [ -n "$POSTGRES_REHEARSAL_TARGET" ]; then
   if ! command -v psql >/dev/null 2>&1; then
@@ -163,15 +132,7 @@ if [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL:-}" = "1" ]; then
 fi
 
 if [ -n "${PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL:-}" ]; then
-  echo "Running live PKM, investor, and RIA runtime audits..."
-  load_reviewer_runtime_secrets
-  cd "$WEB_DIR"
-  for route_filter in one/pkm one/kai ria; do
-    HUSHH_APP_ORIGIN="$PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL" \
-    HUSHH_VIEWPORT_FILTER=phone \
-    HUSHH_ROUTE_FILTER="$route_filter" \
-      node ./scripts/testing/verify-signed-in-routes.mjs
-  done
+  "$REPO_ROOT/scripts/ci/pkm-runtime-audit.sh"
 fi
 
 echo "✅ PKM upgrade gate passed."


### PR DESCRIPTION
## Summary
- keep schema, PostgreSQL rollback, reviewer shape, and structure-agent gates before any build
- defer live PKM/Kai/RIA reviewer route audits until the candidate is serving UAT traffic
- make that live audit blocking and roll back every touched service on failure
- resolve reviewer BYOK credentials in memory through the canonical Secret Manager lane
- update the stale production no-traffic contract assertion

## Root cause
Protected UAT audited the currently serving frontend inside the predeploy PKM gate. A candidate that fixed a live reviewer-route defect could never be built because the old revision failed first.

## Verification
- 12 focused deploy/PKM contract tests
- mandatory PKM gate: 133 frontend + 245 backend tests
- bash syntax for both PKM scripts
- reviewer app skill checks
- Ruff lint/format and git diff integrity

## Runtime evidence
Runs 29493328591 and 29495103106 both passed migrations, zero-loss PostgreSQL rehearsal, reviewer shape audit, structure-agent evaluation, /one/pkm, and all Kai routes, then failed against the old serving RIA dynamic route before any build or traffic promotion.