### PR TITLE
fix(reviewer): harden BYOK and RIA UAT gates

### DIFF
--- a/.codex/skills/reviewer-app-testing/scripts/reviewer-session-harness.mjs
+++ b/.codex/skills/reviewer-app-testing/scripts/reviewer-session-harness.mjs
@@ -144,19 +144,61 @@ export async function createReviewerSessionHarness({
     };
   }
 
-  async function waitForUnlock(page) {
+  async function waitForUnlock(page, unlockTimeoutMs = timeoutMs) {
     const reviewerButton = page.getByRole("button", { name: /continue as reviewer/i });
-    if (await reviewerButton.isVisible().catch(() => false)) await reviewerButton.click();
-    await page.waitForFunction(
-      (expectedUserId) => {
+    const unlockInput = page.locator("#unlock-passphrase");
+    const unlockButton = page
+      .getByRole("button", { name: /unlock with passphrase/i })
+      .first();
+    const terminalFailures = new Set(["auth_error", "uid_mismatch", "vault_error"]);
+    const deadline = Date.now() + unlockTimeoutMs;
+    let reviewerLoginSubmitted = false;
+    let manualPassphraseFilled = false;
+    let manualUnlockSubmitted = false;
+
+    const safeBootstrapState = async () =>
+      page.evaluate((expectedUserId) => {
         const bridge = window.__HUSHH_NATIVE_TEST__;
-        return (
-          bridge?.bootstrapState === "vault_unlocked" &&
-          bridge?.bootstrapUserId === expectedUserId
+        const bootstrapUserId = String(bridge?.bootstrapUserId || "");
+        return {
+          state: String(bridge?.bootstrapState || ""),
+          errorClass: String(bridge?.bootstrapErrorClass || ""),
+          path: window.location.pathname,
+          userMatches: Boolean(bootstrapUserId && bootstrapUserId === expectedUserId),
+        };
+      }, reviewerUid);
+
+    while (Date.now() < deadline) {
+      const bootstrap = await safeBootstrapState();
+      if (bootstrap.state === "vault_unlocked" && bootstrap.userMatches) return;
+      if (terminalFailures.has(bootstrap.state)) {
+        throw new Error(
+          `Reviewer vault bootstrap failed (state=${bootstrap.state}, error_class=${bootstrap.errorClass || "unknown"}, path=${bootstrap.path}, user_match=${bootstrap.userMatches}).`
         );
-      },
-      reviewerUid,
-      { timeout: timeoutMs }
+      }
+
+      if (!reviewerLoginSubmitted && await reviewerButton.isVisible().catch(() => false)) {
+        await reviewerButton.click({ noWaitAfter: true });
+        reviewerLoginSubmitted = true;
+      }
+
+      if (!manualUnlockSubmitted && await unlockInput.isVisible().catch(() => false)) {
+        if (!manualPassphraseFilled) {
+          await unlockInput.fill(reviewerPassphrase);
+          manualPassphraseFilled = true;
+        }
+        if (await unlockButton.isEnabled().catch(() => false)) {
+          await unlockButton.click({ noWaitAfter: true });
+          manualUnlockSubmitted = true;
+        }
+      }
+
+      await page.waitForTimeout(250);
+    }
+
+    const bootstrap = await safeBootstrapState();
+    throw new Error(
+      `Reviewer vault bootstrap timed out (state=${bootstrap.state || "unknown"}, error_class=${bootstrap.errorClass || "none"}, path=${bootstrap.path}, user_match=${bootstrap.userMatches}).`
     );
   }
 
@@ -188,17 +230,32 @@ export async function createReviewerSessionHarness({
   }
 
   async function openSession(browser, redirect) {
-    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
-    const page = await context.newPage();
-    page.setDefaultTimeout(timeoutMs);
-    page.setDefaultNavigationTimeout(timeoutMs);
-    const capture = attachMemoryOnlyCapture(page);
-    await installBridge(page);
-    await page.goto(`${normalizedOrigin}/login?redirect=${encodeURIComponent(redirect)}`, {
-      waitUntil: "domcontentloaded",
+    const maxAttempts = 3;
+    const attemptTimeoutMs = Math.max(20_000, Math.floor(timeoutMs / maxAttempts));
+    let lastError = null;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+      const page = await context.newPage();
+      page.setDefaultTimeout(attemptTimeoutMs);
+      page.setDefaultNavigationTimeout(attemptTimeoutMs);
+      const capture = attachMemoryOnlyCapture(page);
+      await installBridge(page);
+      try {
+        await page.goto(`${normalizedOrigin}/login?redirect=${encodeURIComponent(redirect)}`, {
+          waitUntil: "domcontentloaded",
+        });
+        await waitForUnlock(page, attemptTimeoutMs);
+        return { context, page, capture };
+      } catch (error) {
+        lastError = error;
+        await context.close().catch(() => undefined);
+      }
+    }
+
+    throw new Error(`Reviewer session bootstrap failed after ${maxAttempts} attempts.`, {
+      cause: lastError,
     });
-    await waitForUnlock(page);
-    return { context, page, capture };
   }
 
   async function fetchOwnerJson(pathname, ownerToken, { allow404 = false } = {}) {

--- a/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
+++ b/hushh-webapp/__tests__/scripts/reviewer-route-bootstrap-contract.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
@@ -50,5 +51,34 @@ describe("reviewer route bootstrap contract", () => {
     expect(source).toContain(`routeId: "${routeId}"`);
     expect(source).toContain(`marker: "${marker}"`);
     expect(source).toContain('dataState: "unavailable-valid"');
+  });
+
+  it("keeps a terminal reviewer beacon in RIA picks setup compatibility mode", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "app/ria/picks/page.tsx"),
+      "utf8",
+    );
+
+    expect(source).toMatch(
+      /riaCapability === "setup"[\s\S]*routeId: "\/ria\/picks"[\s\S]*marker: "native-route-ria-picks"[\s\S]*dataState: "unavailable-valid"/,
+    );
+  });
+
+  it("keeps the BYOK reviewer harness on the memory-only passphrase fallback", () => {
+    const source = readFileSync(
+      resolve(
+        process.cwd(),
+        "../.codex/skills/reviewer-app-testing/scripts/reviewer-session-harness.mjs",
+      ),
+      "utf8",
+    );
+
+    expect(source).toContain('page.locator("#unlock-passphrase")');
+    expect(source).toContain("unlock with passphrase");
+    expect(source).toContain("unlockInput.fill(reviewerPassphrase)");
+    expect(source).toContain("bootstrapErrorClass");
+    expect(source).toContain("userMatches");
+    expect(source).toContain("const maxAttempts = 3");
+    expect(source).toContain("await context.close().catch(() => undefined)");
   });
 });

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -2249,6 +2249,12 @@ export default function RiaPicksPage() {
       <RiaCompatibilityState
         title="Complete RIA onboarding"
         description="Finish onboarding to manage picks."
+        nativeTest={{
+          routeId: "/ria/picks",
+          marker: "native-route-ria-picks",
+          authState: user ? "authenticated" : "pending",
+          dataState: "unavailable-valid",
+        }}
       />
     );
   }


### PR DESCRIPTION
## Summary
- make the reviewer BYOK harness fail fast with redacted bootstrap diagnostics and retry at most three fresh, memory-only browser contexts
- preserve the real passphrase UI fallback without logging or persisting credentials, tokens, vault keys, or decrypted information
- emit the governed `unavailable-valid` reviewer beacon for `/ria/picks` setup compatibility mode
- add regression contracts for both UAT failures

## UAT evidence
Run 29496810624 correctly rolled back backend and frontend after classifying:
- `reviewer_byok_continuity_failed`
- `pkm_runtime_audit_failed` (`/ria/picks` beacon timeout)

The updated harness passes against the rolled-back UAT service with three same-session protected routes and one cold-session re-unlock.

## Verification
- focused Vitest: 13 passed
- PKM upgrade gate: 135 frontend + 245 backend passed
- frontend typecheck, targeted ESLint, `git diff --check`: passed
- reviewer app skill check and routed workflow check: passed
- docs/runtime parity: passed
- security quality suite: 73 passed, 1 unrelated pre-existing architecture failure in `api/routes/one/relay_auth.py`
