### PR TITLE
fix(release): bound database fanout and fail closed

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,7 +46,8 @@ env:
   # dev. See consent-protocol/docs/reference/dev-environment-setup.md.
   DEV_ONE_EMAIL_PUBSUB_TOPIC: projects/hushh-pda/topics/one-email-kyc-uat
   DEV_ONE_EMAIL_WEBHOOK_AUDIENCE: https://consent-protocol-621416509462.us-central1.run.app/api/one/email/webhook
-  CLOUD_RUN_REVISION_RETENTION: "10"
+  BACKEND_REVISION_RETENTION: "3"
+  FRONTEND_REVISION_RETENTION: "10"
   PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
 
 concurrency:
@@ -166,7 +167,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -174,7 +175,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -329,7 +330,7 @@ jobs:
         run: |
           set -euo pipefail
           started_at="$(date +%s)"
-          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.DEV_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=${{ env.DEV_ONE_EMAIL_PUBSUB_TOPIC }}##_ONE_EMAIL_WEBHOOK_AUDIENCE=${{ env.DEV_ONE_EMAIL_WEBHOOK_AUDIENCE }}##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=dev##_DEPLOY_SOURCE=deploy-dev##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.DEV_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=${{ env.DEV_ONE_EMAIL_PUBSUB_TOPIC }}##_ONE_EMAIL_WEBHOOK_AUDIENCE=${{ env.DEV_ONE_EMAIL_WEBHOOK_AUDIENCE }}##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true##_DB_POOL_MIN_SIZE=1##_DB_POOL_MAX_SIZE=8##_CLOUD_RUN_MIN_INSTANCES=1##_CLOUD_RUN_MAX_INSTANCES=5##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=dev-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=dev##_DEPLOY_SOURCE=deploy-dev##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
           # Skew guard (same class as #4399/#4401/#4402): the workflow file
           # (from main) may pass substitutions the train SHA's cloudbuild
           # template doesn't declare — gcloud rejects unmatched keys. Filter
@@ -356,7 +357,7 @@ jobs:
       - name: Retain latest backend revisions
         if: steps.scope.outputs.deploy_backend == 'true'
         continue-on-error: true
-        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.BACKEND_REVISION_RETENTION }}"
 
       - name: Deploy frontend using Cloud Build
         id: deploy-frontend
@@ -377,7 +378,7 @@ jobs:
       - name: Retain latest frontend revisions
         if: steps.scope.outputs.deploy_frontend == 'true'
         continue-on-error: true
-        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.FRONTEND_REVISION_RETENTION }}"
 
       - name: Resolve deployed candidate revisions
         id: candidate-state
@@ -425,7 +426,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)')"
+            --format='value(status.traffic[0].revisionName)')"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -433,7 +434,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)')"
+            --format='value(status.traffic[0].revisionName)')"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -840,7 +841,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -848,7 +849,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -43,7 +43,9 @@ env:
   BACKEND_SERVICE: consent-protocol
   FRONTEND_SERVICE: hushh-webapp
   APP_FRONTEND_ORIGIN: https://one.hushh.ai
-  CLOUD_RUN_REVISION_RETENTION: "10"
+  CONSENT_API_PUBLIC_ORIGIN: https://api.hushh.ai
+  BACKEND_REVISION_RETENTION: "3"
+  FRONTEND_REVISION_RETENTION: "10"
   BACKUP_BUCKET: hushh-pda-prod-db-backups
   BACKUP_PREFIX: prod/supabase-logical
   BACKUP_MAX_AGE_HOURS: "30"
@@ -317,7 +319,7 @@ jobs:
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/backend.cloudbuild.yaml \
-            "--substitutions=_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID,_PLAID_SECRET_SECRET=PLAID_SECRET,_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY,_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY,_PMP_API_KEY_SECRET=PMP_API_KEY,_NEWSAPI_KEY_SECRET=NEWSAPI_KEY,_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID,_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET,_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI,_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY,_OPENAI_API_KEY_SECRET=OPENAI_API_KEY,_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY,_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON,_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN,_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+            "--substitutions=_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID,_PLAID_SECRET_SECRET=PLAID_SECRET,_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY,_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY,_PMP_API_KEY_SECRET=PMP_API_KEY,_NEWSAPI_KEY_SECRET=NEWSAPI_KEY,_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID,_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET,_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI,_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY,_OPENAI_API_KEY_SECRET=OPENAI_API_KEY,_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY,_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON,_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN,_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL,_CONSENT_API_PUBLIC_ORIGIN=${{ env.CONSENT_API_PUBLIC_ORIGIN }},_DB_POOL_MIN_SIZE=1,_DB_POOL_MAX_SIZE=8,_CLOUD_RUN_MIN_INSTANCES=1,_CLOUD_RUN_MAX_INSTANCES=5,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
 
       - name: Get backend URL
         if: steps.scope.outputs.deploy_backend == 'true'
@@ -333,7 +335,7 @@ jobs:
       - name: Retain latest backend revisions
         if: steps.scope.outputs.deploy_backend == 'true'
         continue-on-error: true
-        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.BACKEND_REVISION_RETENTION }}"
 
       - name: Deploy frontend using Cloud Build
         if: steps.scope.outputs.deploy_frontend == 'true'
@@ -357,7 +359,7 @@ jobs:
       - name: Retain latest frontend revisions
         if: steps.scope.outputs.deploy_frontend == 'true'
         continue-on-error: true
-        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.FRONTEND_REVISION_RETENTION }}"
 
       - name: Resolve deployed candidate revisions
         id: candidate-state
@@ -383,11 +385,30 @@ jobs:
           echo "Backend candidate revision: ${backend_revision:-n/a}"
           echo "Frontend candidate revision: ${frontend_revision:-n/a}"
 
+      - name: Verify production candidate runtime env parity
+        id: verify-parity
+        if: steps.scope.outputs.deploy_backend == 'true' || steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
+        run: |
+          python3 scripts/ops/verify-env-secrets-parity.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --backend-service "${{ env.BACKEND_SERVICE }}" \
+            --frontend-service "${{ env.FRONTEND_SERVICE }}" \
+            --backend-revision "${{ steps.candidate-state.outputs.backend_revision }}" \
+            --frontend-revision "${{ steps.candidate-state.outputs.frontend_revision }}" \
+            --require-plaid \
+            --require-market-data \
+            --require-gmail \
+            --require-voice \
+            --assert-runtime-env-contract
+
       # New revisions are deployed with --no-traffic (see _CLOUD_RUN_NO_TRAFFIC=true
       # above), so promotion is an explicit, reversible step: shift 100% to the
       # freshly built revision, then health-gate it, then auto-roll-back on failure.
       - name: Promote deployed revisions to production traffic
         id: promote-traffic
+        if: steps.verify-parity.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |
@@ -429,22 +450,6 @@ jobs:
           bash scripts/ci/cloudrun-http-health.sh \
             "${{ steps.frontend-url.outputs.url }}" "/" 3 30 5 200
 
-      - name: Verify production runtime env parity
-        id: verify-parity
-        if: steps.scope.outputs.deploy_backend == 'true' || steps.scope.outputs.deploy_frontend == 'true'
-        continue-on-error: true
-        run: |
-          python3 scripts/ops/verify-env-secrets-parity.py \
-            --project "${{ env.GCP_PROJECT_ID }}" \
-            --region "${{ env.GCP_REGION }}" \
-            --backend-service "${{ env.BACKEND_SERVICE }}" \
-            --frontend-service "${{ env.FRONTEND_SERVICE }}" \
-            --require-plaid \
-            --require-market-data \
-            --require-gmail \
-            --require-voice \
-            --assert-runtime-env-contract
-
       - name: Classify production release outcome
         id: classify
         if: always()
@@ -463,10 +468,9 @@ jobs:
           parity_failed=false
           promote_failed=false
 
-          # Runtime health is the rollback trigger: only revert traffic when the
-          # newly promoted revision is not actually serving. A parity gap (e.g. a
-          # benign missing optional secret) fails the workflow for visibility but
-          # does NOT auto-revert a revision that is serving traffic healthily.
+          # Runtime health remains the rollback trigger after promotion. Candidate
+          # parity is a pre-traffic gate, so a parity failure leaves serving traffic
+          # untouched and fails the release without invoking rollback.
           if [ "$DEPLOY_BACKEND" = "true" ] && [ "$HEALTH_BACKEND" = "failure" ]; then
             backend_failure=true
           fi
@@ -480,23 +484,13 @@ jobs:
             promote_failed=true
           fi
 
-          # release_failed drives the workflow's final pass/fail. It is gated on
-          # things that mean prod is NOT correctly serving the new revision:
-          # a runtime-health failure (also triggers rollback) or a promote
-          # failure (traffic never cut over). A parity gap is NOT included: the
-          # runtime health gate already fails+rolls-back when a genuinely
-          # boot-critical secret is missing (the app crashes), so a parity
-          # mismatch that survives a healthy promote is a benign optional-feature
-          # gap (e.g. voice/Gmail secrets not yet provisioned). It is surfaced as
-          # a warning for visibility instead of failing a healthy production release.
+          # release_failed drives the workflow's final pass/fail. Required runtime
+          # parity is not optional: missing consent origins, provider credentials,
+          # or key mounts must fail closed before promotion.
           release_failed=false
           if [ "$backend_failure" = "true" ] || [ "$frontend_failure" = "true" ] \
-             || [ "$promote_failed" = "true" ]; then
+             || [ "$parity_failed" = "true" ] || [ "$promote_failed" = "true" ]; then
             release_failed=true
-          fi
-
-          if [ "$parity_failed" = "true" ] && [ "$release_failed" = "false" ]; then
-            echo "::warning title=Env parity gap::Production runtime env parity reported missing optional secrets, but the promoted revision is serving healthily. Provision the missing secrets to close the gap; not failing the release."
           fi
 
           {
@@ -507,7 +501,7 @@ jobs:
             echo "release_failed=$release_failed"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Release classification: release_failed=$release_failed backend_failure=$backend_failure frontend_failure=$frontend_failure parity_failed=$parity_failed (warning-only) promote_failed=$promote_failed"
+          echo "Release classification: release_failed=$release_failed backend_failure=$backend_failure frontend_failure=$frontend_failure parity_failed=$parity_failed promote_failed=$promote_failed"
 
       - name: Roll back backend revision
         id: rollback-backend

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -31,7 +31,8 @@ env:
   CONSENT_API_PUBLIC_ORIGIN: https://api.uat.hushh.ai
   UAT_CLOUDSQL_INSTANCE: hushh-pda-uat:us-central1:hushh-uat-pg
   UAT_DB_UNIX_SOCKET: /cloudsql/hushh-pda-uat:us-central1:hushh-uat-pg
-  CLOUD_RUN_REVISION_RETENTION: "10"
+  BACKEND_REVISION_RETENTION: "3"
+  FRONTEND_REVISION_RETENTION: "10"
   PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
 
 concurrency:
@@ -151,7 +152,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -159,7 +160,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -329,7 +330,7 @@ jobs:
         run: |
           set -euo pipefail
           started_at="$(date +%s)"
-          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.UAT_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=projects/hushh-pda/topics/one-email-kyc-uat##_ONE_EMAIL_WEBHOOK_AUDIENCE=https://consent-protocol-f2gsa4kfsq-uc.a.run.app/api/one/email/webhook##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true##_CLOUD_RUN_NO_TRAFFIC=true##_IMAGE_TAG=uat-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=uat##_DEPLOY_SOURCE=deploy-uat##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.UAT_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET=ONE_EMAIL_WATCH_RENEW_TOKEN##_ONE_EMAIL_ADDRESS=one@hushh.ai##_ONE_EMAIL_DELEGATED_USER=one@hushh.ai##_ONE_EMAIL_PUBSUB_TOPIC=projects/hushh-pda/topics/one-email-kyc-uat##_ONE_EMAIL_WEBHOOK_AUDIENCE=https://consent-protocol-f2gsa4kfsq-uc.a.run.app/api/one/email/webhook##_ONE_EMAIL_WEBHOOK_SERVICE_ACCOUNT_EMAIL=one-email-pubsub-push@hushh-pda.iam.gserviceaccount.com##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=true##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=true##_ONE_EMAIL_KYC_DEFAULT_SCOPE=attr.identity.*##_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED=true##_APP_REVIEW_MODE=true##_DB_POOL_MIN_SIZE=1##_DB_POOL_MAX_SIZE=8##_CLOUD_RUN_MIN_INSTANCES=1##_CLOUD_RUN_MAX_INSTANCES=5##_CLOUD_RUN_NO_TRAFFIC=true##_IMAGE_TAG=uat-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=uat##_DEPLOY_SOURCE=deploy-uat##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
           SUBSTITUTIONS="${SUBSTITUTIONS}##_CONSENT_API_PUBLIC_ORIGIN=${{ env.CONSENT_API_PUBLIC_ORIGIN }}"
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
@@ -343,7 +344,7 @@ jobs:
       - name: Retain latest backend revisions
         if: steps.scope.outputs.deploy_backend == 'true'
         continue-on-error: true
-        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.BACKEND_REVISION_RETENTION }}"
 
       - name: Deploy frontend using Cloud Build
         id: deploy-frontend
@@ -364,7 +365,7 @@ jobs:
       - name: Retain latest frontend revisions
         if: steps.scope.outputs.deploy_frontend == 'true'
         continue-on-error: true
-        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.CLOUD_RUN_REVISION_RETENTION }}"
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.FRONTEND_REVISION_RETENTION }}"
 
       - name: Resolve deployed candidate revisions
         id: candidate-state
@@ -412,7 +413,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)')"
+            --format='value(status.traffic[0].revisionName)')"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -420,7 +421,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)')"
+            --format='value(status.traffic[0].revisionName)')"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -870,7 +871,7 @@ jobs:
           backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
@@ -878,7 +879,7 @@ jobs:
           frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \
-            --format='value(status.latestReadyRevisionName)' 2>/dev/null || true)"
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
           frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --region="${{ env.GCP_REGION }}" \

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -43,3 +43,50 @@ def test_production_deploy_builds_candidates_without_serving_traffic() -> None:
         '--to-revisions="${{ steps.candidate-state.outputs.frontend_revision }}=100"'
         in production_workflow
     )
+
+
+def test_hosted_backend_bounds_database_connection_fanout() -> None:
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+    uat_workflow = _read(".github/workflows/deploy-uat.yml")
+    production_workflow = _read(".github/workflows/deploy-production.yml")
+
+    assert '"DB_POOL_MIN_SIZE=${_DB_POOL_MIN_SIZE}"' in backend_build
+    assert '"DB_POOL_MAX_SIZE=${_DB_POOL_MAX_SIZE}"' in backend_build
+    assert '"--max=${_CLOUD_RUN_MAX_INSTANCES}"' in backend_build
+    assert '"--min=${_CLOUD_RUN_MIN_INSTANCES}"' in backend_build
+    assert '"--min-instances=0"' in backend_build
+    assert '_DB_POOL_MIN_SIZE: "1"' in backend_build
+    assert '_DB_POOL_MAX_SIZE: "8"' in backend_build
+
+    for workflow in (uat_workflow, production_workflow):
+        assert "_DB_POOL_MIN_SIZE=1" in workflow
+        assert "_DB_POOL_MAX_SIZE=8" in workflow
+        assert "_CLOUD_RUN_MIN_INSTANCES=1" in workflow
+        assert "_CLOUD_RUN_MAX_INSTANCES=5" in workflow
+        assert 'BACKEND_REVISION_RETENTION: "3"' in workflow
+        assert 'FRONTEND_REVISION_RETENTION: "10"' in workflow
+
+
+def test_production_secret_parity_fails_closed_before_traffic() -> None:
+    workflow = _read(".github/workflows/deploy-production.yml")
+
+    parity_position = workflow.index("- name: Verify production candidate runtime env parity")
+    promote_position = workflow.index("- name: Promote deployed revisions to production traffic")
+    assert parity_position < promote_position
+    assert "if: steps.verify-parity.outcome == 'success'" in workflow
+    assert '--backend-revision "${{ steps.candidate-state.outputs.backend_revision }}"' in workflow
+    assert (
+        '--frontend-revision "${{ steps.candidate-state.outputs.frontend_revision }}"' in workflow
+    )
+    assert '|| [ "$parity_failed" = "true" ]' in workflow
+    assert "parity_failed=$parity_failed (warning-only)" not in workflow
+    assert "CONSENT_API_PUBLIC_ORIGIN: https://api.hushh.ai" in workflow
+    assert "_CONSENT_API_PUBLIC_ORIGIN=${{ env.CONSENT_API_PUBLIC_ORIGIN }}" in workflow
+
+
+def test_nonproduction_rollback_targets_are_traffic_bearing_revisions() -> None:
+    for path in (".github/workflows/deploy-uat.yml", ".github/workflows/deploy-dev.yml"):
+        workflow = _read(path)
+        assert workflow.count("status.latestReadyRevisionName") == 0
+        assert workflow.count("status.latestCreatedRevisionName") == 2
+        assert workflow.count("status.traffic[0].revisionName") >= 6

--- a/consent-protocol/tests/test_verify_env_secrets_parity.py
+++ b/consent-protocol/tests/test_verify_env_secrets_parity.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/ops/verify-env-secrets-parity.py"
+SPEC = importlib.util.spec_from_file_location("verify_env_secrets_parity", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+parity = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(parity)
+
+
+def _revision(service: str) -> dict[str, object]:
+    return {
+        "metadata": {"labels": {"serving.knative.dev/service": service}},
+        "spec": {
+            "template": {
+                "spec": {"containers": [{"env": [{"name": "DB_POOL_MAX_SIZE", "value": "8"}]}]}
+            }
+        },
+    }
+
+
+def test_candidate_revision_is_inspected_before_it_serves(monkeypatch) -> None:
+    monkeypatch.setattr(parity, "_describe_run_revision", lambda *_args: _revision("backend"))
+
+    env, revisions = parity._selected_container_env_map(
+        "project", "region", "backend", {}, "backend-00001-candidate"
+    )
+
+    assert revisions == ["backend-00001-candidate"]
+    assert env["DB_POOL_MAX_SIZE"]["value"] == "8"
+
+
+def test_candidate_revision_from_another_service_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(parity, "_describe_run_revision", lambda *_args: _revision("frontend"))
+
+    env, revisions = parity._selected_container_env_map(
+        "project", "region", "backend", {}, "frontend-00001-candidate"
+    )
+
+    assert revisions == ["frontend-00001-candidate"]
+    assert env == {}

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -94,6 +94,36 @@ steps:
           runtime_environment="${_DEPLOY_ENV}"
         fi
 
+        require_non_negative_int() {
+          local name="$1"
+          local value="$2"
+          if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+            echo "${name} must be a non-negative integer, got '${value}'." >&2
+            exit 1
+          fi
+        }
+        require_positive_int() {
+          local name="$1"
+          local value="$2"
+          require_non_negative_int "${name}" "${value}"
+          if [[ "${value}" -lt 1 ]]; then
+            echo "${name} must be at least 1, got '${value}'." >&2
+            exit 1
+          fi
+        }
+        require_non_negative_int "_DB_POOL_MIN_SIZE" "${_DB_POOL_MIN_SIZE}"
+        require_positive_int "_DB_POOL_MAX_SIZE" "${_DB_POOL_MAX_SIZE}"
+        require_non_negative_int "_CLOUD_RUN_MIN_INSTANCES" "${_CLOUD_RUN_MIN_INSTANCES}"
+        require_positive_int "_CLOUD_RUN_MAX_INSTANCES" "${_CLOUD_RUN_MAX_INSTANCES}"
+        if [[ "${_DB_POOL_MAX_SIZE}" -lt "${_DB_POOL_MIN_SIZE}" ]]; then
+          echo "_DB_POOL_MAX_SIZE must be greater than or equal to _DB_POOL_MIN_SIZE." >&2
+          exit 1
+        fi
+        if [[ "${_CLOUD_RUN_MAX_INSTANCES}" -lt "${_CLOUD_RUN_MIN_INSTANCES}" ]]; then
+          echo "_CLOUD_RUN_MAX_INSTANCES must be greater than or equal to _CLOUD_RUN_MIN_INSTANCES." >&2
+          exit 1
+        fi
+
         env_vars=(
           "ENVIRONMENT=${runtime_environment}"
           "HUSHH_DEPLOY_ENV=${_DEPLOY_ENV}"
@@ -101,6 +131,8 @@ steps:
           "HUSHH_DEPLOY_SHA=${_DEPLOY_SHA}"
           "HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID}"
           "CONSENT_API_PUBLIC_ORIGIN=${_CONSENT_API_PUBLIC_ORIGIN}"
+          "DB_POOL_MIN_SIZE=${_DB_POOL_MIN_SIZE}"
+          "DB_POOL_MAX_SIZE=${_DB_POOL_MAX_SIZE}"
           "RIA_INTELLIGENCE_CRD_SCRAPER_TIMEOUT_SECONDS=${_RIA_INTELLIGENCE_CRD_SCRAPER_TIMEOUT_SECONDS}"
           "RIA_ONBOARDING_PROVIDER_TIMEOUT_SECONDS=${_RIA_ONBOARDING_PROVIDER_TIMEOUT_SECONDS}"
         )
@@ -145,8 +177,13 @@ steps:
           "--cpu=1"
           "--timeout=3600"
           "--session-affinity"
-          "--max-instances=10"
-          "--min-instances=1"
+          # Service-level limits bound aggregate database fan-out across traffic
+          # splits. Revision min=0 prevents no-traffic/retired revisions from
+          # pinning their own warm database pools.
+          "--max=${_CLOUD_RUN_MAX_INSTANCES}"
+          "--min=${_CLOUD_RUN_MIN_INSTANCES}"
+          "--max-instances=${_CLOUD_RUN_MAX_INSTANCES}"
+          "--min-instances=0"
           "--labels=${deploy_labels}"
           "--set-env-vars=^|^${env_var_string}"
           "--set-secrets=${secrets}"
@@ -214,6 +251,10 @@ substitutions:
   _APP_REVIEW_MODE: ""
   _CLOUD_RUN_NO_TRAFFIC: "false"
   _CONSENT_API_PUBLIC_ORIGIN: ""
+  _DB_POOL_MIN_SIZE: "1"
+  _DB_POOL_MAX_SIZE: "8"
+  _CLOUD_RUN_MIN_INSTANCES: "1"
+  _CLOUD_RUN_MAX_INSTANCES: "5"
   _RUNTIME_ENVIRONMENT: ""
   _IMAGE_TAG: v2.1.0
   _DEPLOY_ENV: manual

--- a/scripts/ops/verify-env-secrets-parity.py
+++ b/scripts/ops/verify-env-secrets-parity.py
@@ -435,6 +435,29 @@ def _serving_container_env_map(
     return common, revisions
 
 
+def _selected_container_env_map(
+    project: str,
+    region: str,
+    service: str,
+    service_json: dict[str, Any] | None,
+    revision: str | None,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    selected_revision = str(revision or "").strip()
+    if not selected_revision:
+        return _serving_container_env_map(project, region, service_json)
+
+    revision_json = _describe_run_revision(project, region, selected_revision)
+    revision_service = str(
+        (revision_json or {})
+        .get("metadata", {})
+        .get("labels", {})
+        .get("serving.knative.dev/service", "")
+    ).strip()
+    if revision_service != service:
+        return {}, [selected_revision]
+    return _container_env_map(revision_json), [selected_revision]
+
+
 def _runtime_source_label(entry: dict[str, Any]) -> str:
     value_from = entry.get("valueFrom")
     if isinstance(value_from, dict):
@@ -545,6 +568,14 @@ def main() -> int:
         help="Reserved for parity interface",
     )
     parser.add_argument(
+        "--backend-revision",
+        help="Optional exact no-traffic backend candidate revision to inspect.",
+    )
+    parser.add_argument(
+        "--frontend-revision",
+        help="Optional exact no-traffic frontend candidate revision to inspect.",
+    )
+    parser.add_argument(
         "--require-native-artifacts",
         action="store_true",
         help="Also require native Firebase artifact secrets for native release checks.",
@@ -617,6 +648,8 @@ def main() -> int:
         "region": args.region,
         "backend_service": args.backend_service,
         "frontend_service": args.frontend_service,
+        "backend_revision": args.backend_revision,
+        "frontend_revision": args.frontend_revision,
         "required": {
             "backend": list(BACKEND_REQUIRED),
             "frontend": list(FRONTEND_REQUIRED),
@@ -705,11 +738,19 @@ def main() -> int:
     if args.assert_runtime_env_contract:
         frontend_json = _describe_run_service(args.project, args.region, args.frontend_service)
         backend_json = _describe_run_service(args.project, args.region, args.backend_service)
-        frontend_env, frontend_revisions = _serving_container_env_map(
-            args.project, args.region, frontend_json
+        frontend_env, frontend_revisions = _selected_container_env_map(
+            args.project,
+            args.region,
+            args.frontend_service,
+            frontend_json,
+            args.frontend_revision,
         )
-        backend_env, backend_revisions = _serving_container_env_map(
-            args.project, args.region, backend_json
+        backend_env, backend_revisions = _selected_container_env_map(
+            args.project,
+            args.region,
+            args.backend_service,
+            backend_json,
+            args.backend_revision,
         )
 
         frontend_entries = [


### PR DESCRIPTION
## Summary
- bound hosted backend database fan-out to 5 Cloud Run instances × 8 connections and stop retired revisions from pinning warm pools
- capture traffic-bearing rollback targets and retain three backend revisions
- fail production secret/runtime parity against exact no-traffic candidates before promotion
- inject the canonical production consent API origin

## Verification
- `./scripts/ci/pkm-upgrade-gate.sh` (135 frontend + 245 backend)
- `./bin/hushh codex data-model-audit`
- `./scripts/ci/reviewer-app-testing-check.sh`
- focused release/runtime tests (15 passed)
- workflow/cloudbuild YAML parse, runtime contract check, diff check

## Safety
No stored PKM information, schema, reviewer key, passphrase, or production secret value is changed.