### PR TITLE
fix(pkm): absorb valid structure-agent tail latency

### DIFF
--- a/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
@@ -390,19 +390,20 @@ _PREVIEW_CACHE_MAX_SIZE = max(
 )
 _AGENT_CONTRACT_TIMEOUT_SECONDS = max(
     1.5,
-    # A structured preview can call segmentation, financial guard, intent,
-    # merge, and structure contracts. Four seconds is below normal Vertex
-    # tail latency and forced valid model responses into fallback.
-    float(os.getenv("PKM_AGENT_LAB_AGENT_TIMEOUT_SECONDS", "8") or "8"),
+    # Protected UAT evidence showed valid Gemini 3.5 Flash responses regularly
+    # arriving after eight seconds. Ten seconds avoids cancelling healthy tail
+    # responses and then paying for a duplicate retry.
+    float(os.getenv("PKM_AGENT_LAB_AGENT_TIMEOUT_SECONDS", "10") or "10"),
 )
 # One retry absorbs transient provider tail latency without introducing another
 # runtime configuration surface or extending the shared preview deadline.
 _AGENT_CONTRACT_MAX_ATTEMPTS = 2
 _PREVIEW_TOTAL_BUDGET_SECONDS = max(
     4.0,
-    # Keep a finite user-facing budget while allowing the sequential contract
-    # graph to complete under normal provider tail latency.
-    float(os.getenv("PKM_AGENT_LAB_PREVIEW_BUDGET_SECONDS", "30") or "30"),
+    # The graph is bounded but sequential after segmentation. Five additional
+    # seconds absorb one provider-tail response without making fallback the
+    # normal path for otherwise valid memory decisions.
+    float(os.getenv("PKM_AGENT_LAB_PREVIEW_BUDGET_SECONDS", "35") or "35"),
 )
 _PREVIEW_CACHE: OrderedDict[str, tuple[float, dict[str, Any]]] = OrderedDict()
 _PREVIEW_INFLIGHT: dict[str, asyncio.Task[dict[str, Any]]] = {}

--- a/consent-protocol/scripts/eval_pkm_structure_agent.py
+++ b/consent-protocol/scripts/eval_pkm_structure_agent.py
@@ -37,9 +37,9 @@ DEFAULT_REPORT_PATH = CONSENT_PROTOCOL_ROOT / "artifacts" / "pkm_structure_agent
 DEFAULT_PRIMARY_MODEL = "gemini-3.5-flash"
 DEFAULT_SECONDARY_MODEL = ""
 DEFAULT_REFERENCE_MODEL = ""
-# The evaluator must outlive the runtime preview's 30-second deadline so it
+# The evaluator must outlive the runtime preview's 35-second deadline so it
 # records the service result instead of manufacturing an earlier timeout.
-DEFAULT_PER_PROMPT_TIMEOUT_SECONDS = 35.0
+DEFAULT_PER_PROMPT_TIMEOUT_SECONDS = 40.0
 DEFAULT_SHADOW_USERS = [
     "UWHGeUyfUAbmEl5xwIPoWJ7Cyft2",
     "s3xmA4lNSAQFrIaOytnSGAOzXlL2",

--- a/consent-protocol/tests/services/test_pkm_agent_lab_service.py
+++ b/consent-protocol/tests/services/test_pkm_agent_lab_service.py
@@ -79,6 +79,15 @@ def _single_segment(message: str):
     }
 
 
+def test_default_preview_budget_outlives_one_tail_contract_without_unbounded_wait() -> None:
+    assert pkm_agent_lab_module._AGENT_CONTRACT_TIMEOUT_SECONDS == 10.0
+    assert pkm_agent_lab_module._PREVIEW_TOTAL_BUDGET_SECONDS == 35.0
+    assert (
+        pkm_agent_lab_module._PREVIEW_TOTAL_BUDGET_SECONDS
+        < pkm_agent_lab_module._AGENT_CONTRACT_TIMEOUT_SECONDS * 4
+    )
+
+
 @pytest.mark.asyncio
 async def test_agent_contract_retries_one_timeout_within_preview_budget(monkeypatch):
     service = PKMAgentLabService()


### PR DESCRIPTION
## Summary
- raise each bounded structure-agent contract tail window from 8s to 10s
- raise the total preview budget from 30s to 35s and evaluator timeout to 40s
- keep one retry, the 10% fallback gate, and every semantic/preservation threshold unchanged

## Evidence
Protected UAT stopped pre-traffic because provider-tail fallbacks were 18.33% (11/60); schema/domain/intent were 100% with no whole-preview timeout or contamination. With this change, the full real-model benchmark passed: synthetic fallback 3.33%, shadow 6.67%, schema/domain/intent 100%, no timeouts/contamination/unresolved domains.

## Verification
- real-model strict evaluation: 60 synthetic + 30 shadow, quality gate pass
- PKM upgrade gate: 135 frontend + 246 backend
- data-model audit: 96/96 classified, zero failures
- reviewer app skill check
- focused service/evaluator tests: 51 passed

No PKM information, schema, key, grant, export, or production state is changed.