### PR TITLE
fix(release): harden MCP packaging and PKM UAT gates

### DIFF
--- a/.codex/skills/pkm-upgrade-rehearsal/references/reviewer-pkm-upgrade-contract.md
+++ b/.codex/skills/pkm-upgrade-rehearsal/references/reviewer-pkm-upgrade-contract.md
@@ -28,14 +28,15 @@ The rehearsal must:
 5. naturally ask the private agent to remember a durable financial preference
 6. require the visible `Save to PKM?` review and explicit owner confirmation
 7. prove no previously observed canonical scope disappeared
-8. fetch one coherent encrypted financial snapshot and decrypt all segments locally
-9. close the context, reauthenticate and re-unlock in a fresh context, then require equal encrypted and decrypted readback
-10. replace exact output artifacts only after every assertion passes
+8. fetch one coherent encrypted financial snapshot; browser unlock and protected-route readback remain the default decryption proof
+9. close the context, reauthenticate and re-unlock in a fresh context, then require equal encrypted readback and equal vault-key commitment
+10. decrypt and write exact payload evidence only when the operator explicitly requests it with `PKM_REVIEWER_REHEARSAL_ALLOW_DECRYPTED_OUTPUT=1`; otherwise the Node harness never derives or decrypts a vault key
+11. replace exact output artifacts only after every assertion passes
 
 ## Exact artifacts
 
 - `tmp/reviewer-pkm-encrypted-payload.json`: exact final encrypted financial response
-- `tmp/reviewer-pkm-decrypted-payload.json`: exact locally decrypted financial domain
+- `tmp/reviewer-pkm-decrypted-payload.json`: exact locally decrypted financial domain, only when `PKM_REVIEWER_REHEARSAL_ALLOW_DECRYPTED_OUTPUT=1` is explicitly set
 
 Do not wrap payloads in audit bundles or duplicate samples. Keep runtime output aggregate-only. Write files with mode `0600` and never commit them.
 

--- a/.codex/skills/pkm-upgrade-rehearsal/scripts/reviewer-pkm-app-rehearsal.mjs
+++ b/.codex/skills/pkm-upgrade-rehearsal/scripts/reviewer-pkm-app-rehearsal.mjs
@@ -7,8 +7,8 @@ import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
 import {
   createReviewerSessionHarness,
-  decryptAesGcm,
 } from "../../reviewer-app-testing/scripts/reviewer-session-harness.mjs";
+import { defaultReviewerIdentityEnvFiles, resolveReviewerTestIdentity } from "../../../../hushh-webapp/scripts/testing/reviewer-test-identity.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,6 +18,7 @@ const appOrigin = String(
   process.env.PKM_REVIEWER_REHEARSAL_ORIGIN || "https://uat.one.hushh.ai"
 ).replace(/\/$/, "");
 const allowMutation = process.env.PKM_REVIEWER_REHEARSAL_ALLOW_MUTATION === "1";
+const allowDecryptedOutput = process.env.PKM_REVIEWER_REHEARSAL_ALLOW_DECRYPTED_OUTPUT === "1";
 const naturalPrompt =
   process.env.PKM_REVIEWER_REHEARSAL_PROMPT ||
   "Remember that I prefer index funds for long-term investing.";
@@ -40,7 +41,9 @@ function assertPrivateOutputPath(filePath, label) {
 }
 
 assertPrivateOutputPath(encryptedOutput, "Encrypted reviewer output");
-assertPrivateOutputPath(decryptedOutput, "Decrypted reviewer output");
+if (allowDecryptedOutput || process.env.PKM_REVIEWER_DECRYPTED_OUTPUT) {
+  assertPrivateOutputPath(decryptedOutput, "Decrypted reviewer output");
+}
 
 if (process.argv.includes("--help")) {
   process.stdout.write(
@@ -49,6 +52,7 @@ if (process.argv.includes("--help")) {
       "",
       "Required gate:",
       "  PKM_REVIEWER_REHEARSAL_ALLOW_MUTATION=1",
+      "  PKM_REVIEWER_REHEARSAL_ALLOW_DECRYPTED_OUTPUT=1 (only for explicitly requested local payload evidence)",
       "",
       "Optional:",
       "  PKM_REVIEWER_REHEARSAL_ORIGIN=https://uat.one.hushh.ai",
@@ -70,11 +74,22 @@ if (encryptedOutput === decryptedOutput) {
   throw new Error("Encrypted and decrypted output paths must be different.");
 }
 
+const explicitOutputCrypto = allowDecryptedOutput
+  ? await import("./reviewer-pkm-decrypted-output.mjs")
+  : null;
+const explicitOutputIdentity = allowDecryptedOutput
+  ? resolveReviewerTestIdentity({
+      envFiles: defaultReviewerIdentityEnvFiles({
+        repoRoot,
+        webDir: path.join(repoRoot, "hushh-webapp"),
+      }),
+    })
+  : null;
+
 const reviewer = await createReviewerSessionHarness({ repoRoot, appOrigin, timeoutMs });
 const {
   assertVaultContinuity,
   chromium,
-  deriveVaultKey,
   endpointPath,
   fetchOwnerJson,
   navigateInApp,
@@ -91,11 +106,14 @@ function encryptedBlobFromPayload(payload) {
 }
 
 function decryptDomainPayload(payload, domain, vaultKey) {
+  if (!explicitOutputCrypto) {
+    throw new Error("Decrypted reviewer output was not explicitly authorized.");
+  }
   const blob = encryptedBlobFromPayload(payload);
   const segments = blob.segments && typeof blob.segments === "object" ? blob.segments : {};
   if (Object.keys(segments).length === 0) {
     const decoded = JSON.parse(
-      decryptAesGcm(
+      explicitOutputCrypto.decryptAesGcm(
         { ciphertext: blob.ciphertext, iv: blob.iv, tag: blob.tag },
         vaultKey
       ).toString("utf8")
@@ -109,7 +127,7 @@ function decryptDomainPayload(payload, domain, vaultKey) {
   const domainData = {};
   for (const [segmentId, encryptedSegment] of Object.entries(segments)) {
     const parsed = JSON.parse(
-      decryptAesGcm(
+      explicitOutputCrypto.decryptAesGcm(
         {
           ciphertext: encryptedSegment.ciphertext,
           iv: encryptedSegment.iv,
@@ -286,7 +304,12 @@ let freshVaultKey;
 try {
   firstSession = await openReviewerSession(browser, "/one/kai/import");
   const firstVaultState = await firstSession.capture.vaultState();
-  firstVaultKey = deriveVaultKey(firstVaultState);
+  if (explicitOutputCrypto && explicitOutputIdentity) {
+    firstVaultKey = explicitOutputCrypto.deriveVaultKeyForExplicitOutput(
+      firstVaultState,
+      explicitOutputIdentity.reviewerVaultPassphrase
+    );
+  }
 
   const holdingsCount = await loadSampleBrokerage(firstSession.page);
   const firstOwnerToken = await firstSession.capture.ownerToken();
@@ -308,27 +331,31 @@ try {
   }
 
   const firstEncryptedPayload = await fetchExactFinancialPayload(firstOwnerToken);
-  const firstDecryptedPayload = decryptDomainPayload(
-    firstEncryptedPayload,
-    "financial",
-    firstVaultKey
-  );
+  const firstDecryptedPayload = firstVaultKey
+    ? decryptDomainPayload(firstEncryptedPayload, "financial", firstVaultKey)
+    : null;
 
   await firstSession.context.close();
   firstSession = null;
 
   freshSession = await openReviewerSession(browser, "/one/kai/portfolio");
   const freshVaultState = await freshSession.capture.vaultState();
-  freshVaultKey = deriveVaultKey(freshVaultState);
+  if (explicitOutputCrypto && explicitOutputIdentity) {
+    freshVaultKey = explicitOutputCrypto.deriveVaultKeyForExplicitOutput(
+      freshVaultState,
+      explicitOutputIdentity.reviewerVaultPassphrase
+    );
+  }
   const freshOwnerToken = await freshSession.capture.ownerToken();
   const freshEncryptedPayload = await fetchExactFinancialPayload(freshOwnerToken);
-  const freshDecryptedPayload = decryptDomainPayload(
-    freshEncryptedPayload,
-    "financial",
-    freshVaultKey
-  );
+  const freshDecryptedPayload = freshVaultKey
+    ? decryptDomainPayload(freshEncryptedPayload, "financial", freshVaultKey)
+    : null;
 
-  if (!isDeepStrictEqual(firstDecryptedPayload, freshDecryptedPayload)) {
+  if (
+    firstDecryptedPayload &&
+    !isDeepStrictEqual(firstDecryptedPayload, freshDecryptedPayload)
+  ) {
     throw new Error("Fresh-session PKM decrypt does not match the write session.");
   }
   if (!isDeepStrictEqual(firstEncryptedPayload, freshEncryptedPayload)) {
@@ -336,9 +363,11 @@ try {
   }
 
   writePrivateJson(encryptedOutput, freshEncryptedPayload);
-  writePrivateJson(decryptedOutput, freshDecryptedPayload);
+  if (freshDecryptedPayload) {
+    writePrivateJson(decryptedOutput, freshDecryptedPayload);
+  }
   process.stdout.write(
-    `[reviewer-pkm-rehearsal] PASS holdings=${holdingsCount} scopes=${updatedScopes.length} outputs=2\n`
+    `[reviewer-pkm-rehearsal] PASS holdings=${holdingsCount} scopes=${updatedScopes.length} outputs=${freshDecryptedPayload ? 2 : 1}\n`
   );
 } finally {
   firstVaultKey?.fill(0);

--- a/.codex/skills/pkm-upgrade-rehearsal/scripts/reviewer-pkm-decrypted-output.mjs
+++ b/.codex/skills/pkm-upgrade-rehearsal/scripts/reviewer-pkm-decrypted-output.mjs
@@ -1,0 +1,58 @@
+import { createDecipheriv, createHash, pbkdf2Sync } from "node:crypto";
+
+function decodeBinary(value) {
+  const text = String(value || "").trim();
+  if (!text) throw new Error("Encrypted binary field is empty.");
+  if (text.length % 2 === 0 && /^[0-9a-f]+$/i.test(text) && !/[+/=_-]/.test(text)) {
+    return Buffer.from(text, "hex");
+  }
+  let normalized = text.replace(/-/g, "+").replace(/_/g, "/");
+  while (normalized.length % 4 !== 0) normalized += "=";
+  return Buffer.from(normalized, "base64");
+}
+
+export function decryptAesGcm({ ciphertext, iv, tag }, key) {
+  const encrypted = decodeBinary(ciphertext);
+  const authTag = tag ? decodeBinary(tag) : encrypted.subarray(encrypted.length - 16);
+  const body = tag ? encrypted : encrypted.subarray(0, encrypted.length - 16);
+  const decipher = createDecipheriv("aes-256-gcm", key, decodeBinary(iv));
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(body), decipher.final()]);
+}
+
+export function deriveVaultKeyForExplicitOutput(vaultState, passphrase) {
+  const wrappers = Array.isArray(vaultState?.wrappers) ? vaultState.wrappers : [];
+  const wrapper = wrappers.find(
+    (candidate) => String(candidate?.method || "").toLowerCase() === "passphrase"
+  );
+  if (!wrapper) throw new Error("Reviewer vault has no passphrase wrapper.");
+  const derived = pbkdf2Sync(
+    Buffer.from(passphrase, "utf8"),
+    decodeBinary(wrapper.salt),
+    100_000,
+    32,
+    "sha256"
+  );
+  let vaultKey;
+  try {
+    vaultKey = decryptAesGcm(
+      {
+        ciphertext: wrapper.encryptedVaultKey || wrapper.encrypted_vault_key,
+        iv: wrapper.iv,
+      },
+      derived
+    );
+  } finally {
+    derived.fill(0);
+  }
+  if (vaultKey.length !== 32) throw new Error("Reviewer vault key is not 256 bits.");
+  const expectedHash = String(vaultState.vaultKeyHash || vaultState.vault_key_hash || "");
+  const actualHash = createHash("sha256")
+    .update(vaultKey.toString("hex"), "utf8")
+    .digest("hex");
+  if (expectedHash && actualHash !== expectedHash) {
+    vaultKey.fill(0);
+    throw new Error("Reviewer vault key integrity check failed.");
+  }
+  return vaultKey;
+}

--- a/.codex/skills/reviewer-app-testing/references/byok-reviewer-browser-contract.md
+++ b/.codex/skills/reviewer-app-testing/references/byok-reviewer-browser-contract.md
@@ -11,7 +11,7 @@ Use this contract for browser rehearsals whose result depends on protected infor
 ## Memory-only BYOK boundary
 
 1. The vault passphrase, Firebase credential, owner token, wrapper-derived vault key, decrypted PKM, and raw source information stay in process or browser memory.
-2. Derive the 256-bit vault key locally from the passphrase wrapper and verify it against `vaultKeyHash` before trusting decrypted information.
+2. The browser derives the 256-bit vault key locally from the passphrase wrapper and verifies it against `vaultKeyHash` before trusting decrypted information. Playwright's Node harness may observe only encrypted vault state and the key commitment; it must never derive, decrypt, or compare raw vault keys.
 3. Never place secrets or decrypted information in URLs, Playwright traces, screenshots, videos, console output, test snapshots, CI artifacts, model prompts, docs, or commits.
 4. Exact decrypted evidence may be written only when explicitly requested, only beneath ignored `tmp/`, with mode `0600`, and never as a default test artifact.
 
@@ -27,7 +27,7 @@ An unlocked browser context is a security state, not merely a signed-in cookie j
 
 ## Reusable harness
 
-`scripts/reviewer-session-harness.mjs` owns identity resolution, passphrase-wrapper decryption, vault-key integrity proof, memory-only owner-token capture, same-session client navigation, and fresh-context construction.
+`scripts/reviewer-session-harness.mjs` owns identity resolution, encrypted-state/key-commitment observation, memory-only owner-token capture, same-session client navigation, and fresh-context construction. Browser application code owns passphrase-wrapper decryption and vault-key integrity proof.
 
 Run the read-only baseline:
 

--- a/.codex/skills/reviewer-app-testing/scripts/reviewer-session-harness.mjs
+++ b/.codex/skills/reviewer-app-testing/scripts/reviewer-session-harness.mjs
@@ -1,4 +1,3 @@
-import { createDecipheriv, createHash, pbkdf2Sync } from "node:crypto";
 import path from "node:path";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
@@ -9,26 +8,6 @@ function endpointPath(rawUrl) {
   } catch {
     return "";
   }
-}
-
-function decodeBinary(value) {
-  const text = String(value || "").trim();
-  if (!text) throw new Error("Encrypted binary field is empty.");
-  if (text.length % 2 === 0 && /^[0-9a-f]+$/i.test(text) && !/[+/=_-]/.test(text)) {
-    return Buffer.from(text, "hex");
-  }
-  let normalized = text.replace(/-/g, "+").replace(/_/g, "/");
-  while (normalized.length % 4 !== 0) normalized += "=";
-  return Buffer.from(normalized, "base64");
-}
-
-export function decryptAesGcm({ ciphertext, iv, tag }, key) {
-  const encrypted = decodeBinary(ciphertext);
-  const authTag = tag ? decodeBinary(tag) : encrypted.subarray(encrypted.length - 16);
-  const body = tag ? encrypted : encrypted.subarray(0, encrypted.length - 16);
-  const decipher = createDecipheriv("aes-256-gcm", key, decodeBinary(iv));
-  decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(body), decipher.final()]);
 }
 
 async function waitForValue(readValue, label, timeoutMs) {
@@ -59,42 +38,12 @@ export async function createReviewerSessionHarness({
   const reviewerPassphrase = identity.reviewerVaultPassphrase;
   const normalizedOrigin = String(appOrigin).replace(/\/$/, "");
 
-  function deriveVaultKey(vaultState) {
-    const wrappers = Array.isArray(vaultState?.wrappers) ? vaultState.wrappers : [];
-    const wrapper = wrappers.find(
-      (candidate) => String(candidate?.method || "").toLowerCase() === "passphrase"
-    );
-    if (!wrapper) throw new Error("Reviewer vault has no passphrase wrapper.");
-    const derived = pbkdf2Sync(
-      Buffer.from(reviewerPassphrase, "utf8"),
-      decodeBinary(wrapper.salt),
-      100_000,
-      32,
-      "sha256"
-    );
-    let vaultKey;
-    try {
-      vaultKey = decryptAesGcm(
-        {
-          ciphertext: wrapper.encryptedVaultKey || wrapper.encrypted_vault_key,
-          iv: wrapper.iv,
-        },
-        derived
-      );
-    } finally {
-      derived.fill(0);
+  function vaultKeyCommitment(vaultState) {
+    const commitment = String(vaultState?.vaultKeyHash || vaultState?.vault_key_hash || "");
+    if (!commitment) {
+      throw new Error("Reviewer vault state has no key commitment.");
     }
-    if (vaultKey.length !== 32) throw new Error("Reviewer vault key is not 256 bits.");
-    const expectedHash = String(vaultState.vaultKeyHash || vaultState.vault_key_hash || "");
-    if (expectedHash) {
-      const actualHash = createHash("sha256")
-        .update(vaultKey.toString("hex"), "utf8")
-        .digest("hex");
-      if (actualHash !== expectedHash) {
-        throw new Error("Reviewer vault key integrity check failed.");
-      }
-    }
-    return vaultKey;
+    return commitment;
   }
 
   async function installBridge(page) {
@@ -281,11 +230,11 @@ export async function createReviewerSessionHarness({
   return {
     assertVaultContinuity,
     chromium,
-    deriveVaultKey,
     endpointPath,
     fetchOwnerJson,
     navigateInApp,
     openSession,
     reviewerUid,
+    vaultKeyCommitment,
   };
 }

--- a/.codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs
+++ b/.codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -38,11 +37,11 @@ const browser = await reviewer.chromium.launch({
 });
 let firstSession;
 let freshSession;
-let firstKey;
-let freshKey;
+let firstKeyCommitment;
+let freshKeyCommitment;
 try {
   firstSession = await reviewer.openSession(browser, routes[0] || "/agent");
-  firstKey = reviewer.deriveVaultKey(await firstSession.capture.vaultState());
+  firstKeyCommitment = reviewer.vaultKeyCommitment(await firstSession.capture.vaultState());
   for (const route of routes.slice(1)) {
     await reviewer.navigateInApp(firstSession.page, route);
   }
@@ -51,16 +50,14 @@ try {
   firstSession = null;
 
   freshSession = await reviewer.openSession(browser, routes.at(-1) || "/agent");
-  freshKey = reviewer.deriveVaultKey(await freshSession.capture.vaultState());
-  if (firstKey.length !== freshKey.length || !timingSafeEqual(firstKey, freshKey)) {
-    throw new Error("Fresh-session reviewer unlock produced a different vault key.");
+  freshKeyCommitment = reviewer.vaultKeyCommitment(await freshSession.capture.vaultState());
+  if (firstKeyCommitment !== freshKeyCommitment) {
+    throw new Error("Fresh-session reviewer unlock resolved a different vault key commitment.");
   }
   process.stdout.write(
     `[reviewer-app-testing] PASS same_session_routes=${routes.length} cold_session_reunlock=1\n`
   );
 } finally {
-  firstKey?.fill(0);
-  freshKey?.fill(0);
   await firstSession?.context.close().catch(() => undefined);
   await freshSession?.context.close().catch(() => undefined);
   await browser.close().catch(() => undefined);

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -299,26 +299,12 @@ jobs:
           BOOTSTRAP_FOCUS_PROFILE=uat bash scripts/env/bootstrap_profiles.sh --strict
           bash scripts/env/use_profile.sh uat
 
-          reviewer_env_file="$(mktemp /tmp/uat-pkm-reviewer-env.XXXXXX)"
-          trap 'rm -f "${reviewer_env_file}"; kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
-          umask 077
-          {
-            printf 'DB_HOST=%s\n' "$DB_HOST"
-            printf 'DB_PORT=%s\n' "$DB_PORT"
-            printf 'DB_NAME=%s\n' "$DB_NAME"
-            printf 'DB_USER=%s\n' "$DB_USER"
-            printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD"
-          } >"$reviewer_env_file"
-
           export PGHOST="$DB_HOST"
           export PGPORT="$DB_PORT"
           export PGDATABASE="$DB_NAME"
           export PGUSER="$DB_USER"
           export PGPASSWORD="$DB_PASSWORD"
           PKM_UPGRADE_PROTECTED_UAT=1 \
-          PKM_UPGRADE_REVIEWER_SHAPE_AUDIT=1 \
-          PKM_UPGRADE_REVIEWER_SECRET_PROJECT="${{ env.GCP_PROJECT_ID }}" \
-          PKM_UPGRADE_REVIEWER_ENV_FILE="$reviewer_env_file" \
           PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1 \
           PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1 \
             ./scripts/ci/pkm-upgrade-gate.sh

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -305,7 +305,7 @@ jobs:
           export PGUSER="$DB_USER"
           export PGPASSWORD="$DB_PASSWORD"
           PKM_UPGRADE_PROTECTED_UAT=1 \
-          PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1 \
+          PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED=1 \
           PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1 \
             ./scripts/ci/pkm-upgrade-gate.sh
 
@@ -370,6 +370,14 @@ jobs:
 
           echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
           echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify candidate PKM evaluator in Cloud Run
+        id: verify-candidate-pkm-evaluator
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        env:
+          BACKEND_REVISION: ${{ steps.candidate-state.outputs.backend_revision }}
+        run: ./scripts/ci/run-candidate-pkm-structure-agent-eval.sh
 
       - name: Promote deployed revisions to UAT traffic
         shell: bash

--- a/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
@@ -1362,8 +1362,26 @@ class PKMAgentLabService:
         response_schema: dict[str, Any],
         model_override: str | None = None,
         timeout_seconds: float | None = None,
+        execution_trace: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any] | None:
+        started_at = time.perf_counter()
+        agent_id = str(getattr(manifest, "id", "unknown") or "unknown")
+
+        def record(status: str, *, attempts: int, error_type: str = "") -> None:
+            if execution_trace is None:
+                return
+            execution_trace.append(
+                {
+                    "agent_id": agent_id,
+                    "status": status,
+                    "attempts": attempts,
+                    "latency_ms": round((time.perf_counter() - started_at) * 1000, 2),
+                    "error_type": error_type,
+                }
+            )
+
         if self.client is None:
+            record("client_unavailable", attempts=0)
             return None
         deadline = time.perf_counter() + timeout_seconds if timeout_seconds is not None else None
         from google.genai import types as genai_types
@@ -1386,6 +1404,7 @@ class PKMAgentLabService:
                     attempt,
                     round(remaining_seconds, 3),
                 )
+                record("budget_exhausted", attempts=attempt - 1)
                 return None
             effective_timeout = _AGENT_CONTRACT_TIMEOUT_SECONDS
             if remaining_seconds is not None:
@@ -1407,7 +1426,11 @@ class PKMAgentLabService:
                 )
                 if parsed is None:
                     parsed = json.loads((response.text or "").strip() or "{}")
-                return parsed if isinstance(parsed, dict) else None
+                if isinstance(parsed, dict):
+                    record("success", attempts=attempt)
+                    return parsed
+                record("invalid_response", attempts=attempt)
+                return None
             except asyncio.TimeoutError:
                 can_retry = attempt < _AGENT_CONTRACT_MAX_ATTEMPTS
                 retry_budget_seconds = (
@@ -1432,6 +1455,7 @@ class PKMAgentLabService:
                     attempt,
                     round(effective_timeout, 3),
                 )
+                record("timeout", attempts=attempt)
                 return None
             except Exception as exc:
                 logger.warning(
@@ -1439,6 +1463,7 @@ class PKMAgentLabService:
                     getattr(manifest, "id", "unknown"),
                     exc,
                 )
+                record("error", attempts=attempt, error_type=type(exc).__name__)
                 return None
         return None
 
@@ -4170,6 +4195,7 @@ class PKMAgentLabService:
         strict_small_model: bool = False,
         domain_registry_override: list[dict[str, Any]] | None = None,
         deadline: float | None = None,
+        execution_trace: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         normalized_domains = [
             self._normalize_segment(domain) for domain in (current_domains or []) if domain
@@ -4199,6 +4225,7 @@ class PKMAgentLabService:
             response_schema=_FINANCIAL_GUARD_SCHEMA,
             model_override=model_override,
             timeout_seconds=self._remaining_preview_budget_seconds(deadline),
+            execution_trace=execution_trace,
         )
         financial_guard_used_fallback = financial_guard_raw is None
         financial_guard = self._sanitize_financial_guard_decision(
@@ -4262,6 +4289,7 @@ class PKMAgentLabService:
                     response_schema=_INTENT_FRAME_SCHEMA,
                     model_override=model_override,
                     timeout_seconds=self._remaining_preview_budget_seconds(deadline),
+                    execution_trace=execution_trace,
                 )
                 intent_used_fallback = intent_raw is None
                 intent_frame = self._sanitize_intent_frame(
@@ -4294,6 +4322,7 @@ class PKMAgentLabService:
                     response_schema=_MERGE_DECISION_SCHEMA,
                     model_override=model_override,
                     timeout_seconds=self._remaining_preview_budget_seconds(deadline),
+                    execution_trace=execution_trace,
                 )
                 merge_used_fallback = merge_raw is None
             merge_decision = self._sanitize_merge_decision(
@@ -4335,6 +4364,7 @@ class PKMAgentLabService:
                     response_schema=_STRUCTURE_PREVIEW_SCHEMA,
                     model_override=model_override,
                     timeout_seconds=self._remaining_preview_budget_seconds(deadline),
+                    execution_trace=execution_trace,
                 )
                 structure_used_fallback = structure_raw is None
             normalized_preview = self._normalize_structure_preview(
@@ -4412,6 +4442,7 @@ class PKMAgentLabService:
         model_override: str | None = None,
         strict_small_model: bool = False,
         domain_registry_override: list[dict[str, Any]] | None = None,
+        capture_execution_trace: bool = False,
     ) -> dict[str, Any]:
         total_started_at = time.perf_counter()
         normalized_domains = [
@@ -4427,17 +4458,19 @@ class PKMAgentLabService:
             strict_small_model=strict_small_model,
             domain_registry_override=domain_registry_override,
         )
-        cached_preview = self._get_cached_structure_preview(preview_cache_key)
-        if cached_preview is not None:
-            logger.info("pkm.agent_lab.preview_cache_hit user_id=%s", user_id)
-            return cached_preview
-        inflight_preview = _PREVIEW_INFLIGHT.get(preview_cache_key)
-        if inflight_preview is not None:
-            logger.info("pkm.agent_lab.preview_inflight_hit user_id=%s", user_id)
-            return deepcopy(await inflight_preview)
+        if not capture_execution_trace:
+            cached_preview = self._get_cached_structure_preview(preview_cache_key)
+            if cached_preview is not None:
+                logger.info("pkm.agent_lab.preview_cache_hit user_id=%s", user_id)
+                return cached_preview
+            inflight_preview = _PREVIEW_INFLIGHT.get(preview_cache_key)
+            if inflight_preview is not None:
+                logger.info("pkm.agent_lab.preview_inflight_hit user_id=%s", user_id)
+                return deepcopy(await inflight_preview)
 
         async def _build_preview() -> dict[str, Any]:
             errors: list[str] = []
+            execution_trace: list[dict[str, Any]] | None = [] if capture_execution_trace else None
             preview_deadline = time.perf_counter() + _PREVIEW_TOTAL_BUDGET_SECONDS
 
             segmentation_started_at = time.perf_counter()
@@ -4450,6 +4483,7 @@ class PKMAgentLabService:
                 response_schema=_SEGMENTATION_SCHEMA,
                 model_override=model_override,
                 timeout_seconds=self._remaining_preview_budget_seconds(preview_deadline),
+                execution_trace=execution_trace,
             )
             segmentation_latency_ms = round(
                 (time.perf_counter() - segmentation_started_at) * 1000, 2
@@ -4484,6 +4518,7 @@ class PKMAgentLabService:
                     strict_small_model=strict_small_model,
                     domain_registry_override=domain_registry_override,
                     deadline=preview_deadline,
+                    execution_trace=execution_trace,
                 )
                 preview_latency_ms = round((time.perf_counter() - preview_started_at) * 1000, 2)
                 card_id = f"card_{index:02d}"
@@ -4550,6 +4585,8 @@ class PKMAgentLabService:
                     self._remaining_preview_budget_seconds(preview_deadline) or 0.0, 3
                 ),
             }
+            if execution_trace is not None:
+                performance["agent_execution"] = execution_trace
 
             if primary_preview is None:
                 empty_manifest = self._build_manifest_from_payload(
@@ -4607,7 +4644,8 @@ class PKMAgentLabService:
                     "performance": performance,
                     "context_plan": context_plan,
                 }
-                self._set_cached_structure_preview(preview_cache_key, response_payload)
+                if not capture_execution_trace:
+                    self._set_cached_structure_preview(preview_cache_key, response_payload)
                 return response_payload
 
             validation_hints = list(primary_preview.get("validation_hints") or [])
@@ -4633,9 +4671,12 @@ class PKMAgentLabService:
                 merge_used_fallback=bool(response_payload.get("merge_used_fallback")),
                 structure_used_fallback=bool(response_payload.get("structure_used_fallback")),
             )
-            self._set_cached_structure_preview(preview_cache_key, response_payload)
+            if not capture_execution_trace:
+                self._set_cached_structure_preview(preview_cache_key, response_payload)
             return response_payload
 
+        if capture_execution_trace:
+            return deepcopy(await _build_preview())
         task = asyncio.create_task(_build_preview())
         _PREVIEW_INFLIGHT[preview_cache_key] = task
         try:

--- a/consent-protocol/scripts/eval_pkm_structure_agent.py
+++ b/consent-protocol/scripts/eval_pkm_structure_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import importlib.metadata
 import json
 import os
 import sys
@@ -26,6 +27,7 @@ MONOREPO_ROOT = CONSENT_PROTOCOL_ROOT.parent
 if str(CONSENT_PROTOCOL_ROOT) not in sys.path:
     sys.path.insert(0, str(CONSENT_PROTOCOL_ROOT))
 
+from hushh_mcp.services import pkm_agent_lab_service as pkm_agent_lab_module  # noqa: E402
 from hushh_mcp.services.domain_contracts import CANONICAL_DOMAIN_REGISTRY  # noqa: E402
 from hushh_mcp.services.personal_knowledge_model_service import (  # noqa: E402
     PersonalKnowledgeModelService,
@@ -210,6 +212,9 @@ class EvaluationResult:
     timed_out: bool
     finance_contamination: bool
     unresolved_domain: bool
+    inner_timeout_count: int
+    inner_budget_exhausted_count: int
+    inner_failure_count: int
     save_class_ok: bool
     intent_ok: bool
     mutation_ok: bool
@@ -3005,6 +3010,7 @@ async def _evaluate_case(
                 model_override=model_override,
                 strict_small_model=strict_small_model,
                 domain_registry_override=domain_registry_override,
+                capture_execution_trace=True,
             ),
             timeout=per_prompt_timeout_seconds,
         )
@@ -3031,6 +3037,17 @@ async def _evaluate_case(
         bool(frame.get("requires_confirmation")) or actual_write_mode == "confirm_first"
     )
     validation_hints = list(result.get("validation_hints") or [])
+    execution_trace = (result.get("performance") or {}).get("agent_execution") or []
+    trace_statuses = [
+        str(item.get("status") or "") for item in execution_trace if isinstance(item, dict)
+    ]
+    inner_timeout_count = trace_statuses.count("timeout")
+    inner_budget_exhausted_count = trace_statuses.count("budget_exhausted")
+    inner_failure_count = sum(
+        1
+        for status in trace_statuses
+        if status in {"client_unavailable", "invalid_response", "error"}
+    )
     finance_contamination = (
         actual_domain == "financial"
         and "financial" not in case.expected_domains
@@ -3066,6 +3083,9 @@ async def _evaluate_case(
         timed_out=timed_out,
         finance_contamination=finance_contamination,
         unresolved_domain=unresolved_domain,
+        inner_timeout_count=inner_timeout_count,
+        inner_budget_exhausted_count=inner_budget_exhausted_count,
+        inner_failure_count=inner_failure_count,
         save_class_ok=str(frame.get("save_class") or "") == case.expected_save_class,
         intent_ok=str(frame.get("intent_class") or "") == case.expected_intent_class,
         mutation_ok=str(frame.get("mutation_intent") or "") == case.expected_mutation_intent,
@@ -3333,6 +3353,9 @@ def _summarize_results(results: list[EvaluationResult]) -> dict[str, Any]:
             "confirmation_ok_rate": 0.0,
             "fallback_rate": 0.0,
             "timeout_count": 0,
+            "inner_timeout_count": 0,
+            "inner_budget_exhausted_count": 0,
+            "inner_failure_count": 0,
             "finance_contamination_count": 0,
             "unresolved_domain_count": 0,
             "fragmentation_score": 0.0,
@@ -3369,6 +3392,9 @@ def _summarize_results(results: list[EvaluationResult]) -> dict[str, Any]:
         "confirmation_ok_rate": _rate("confirmation_ok"),
         "fallback_rate": fallback_rate,
         "timeout_count": sum(1 for item in results if item.timed_out),
+        "inner_timeout_count": sum(item.inner_timeout_count for item in results),
+        "inner_budget_exhausted_count": sum(item.inner_budget_exhausted_count for item in results),
+        "inner_failure_count": sum(item.inner_failure_count for item in results),
         "finance_contamination_count": finance_contamination_count,
         "unresolved_domain_count": unresolved_domain_count,
         "fragmentation_score": fragmentation_score,
@@ -3537,7 +3563,46 @@ def _gate_failures_for_summary(
         )
     if int(summary.get("unresolved_domain_count") or 0) > 0:
         failures.append(f"{label}:unresolved_domain {summary.get('unresolved_domain_count')}")
+    for key, display_name in (
+        ("timeout_count", "outer_timeout"),
+        ("inner_timeout_count", "inner_timeout"),
+        ("inner_budget_exhausted_count", "inner_budget_exhausted"),
+        ("inner_failure_count", "inner_agent_failure"),
+    ):
+        count = int(summary.get(key) or 0)
+        if count > 0:
+            failures.append(f"{label}:{display_name} {count}")
     return failures
+
+
+def _execution_context(args: argparse.Namespace) -> dict[str, Any]:
+    """Return reproducibility evidence without recording credentials or prompts."""
+
+    api_key_source = next(
+        (
+            name
+            for name in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY")
+            if os.getenv(name)
+        ),
+        "none",
+    )
+    try:
+        genai_sdk_version = importlib.metadata.version("google-genai")
+    except importlib.metadata.PackageNotFoundError:
+        genai_sdk_version = "not-installed"
+    return {
+        "model": str(args.model or "").strip(),
+        "strict_small_model": True,
+        "per_prompt_timeout_seconds": float(args.per_prompt_timeout_seconds),
+        "runtime_preview_budget_seconds": pkm_agent_lab_module._PREVIEW_TOTAL_BUDGET_SECONDS,
+        "agent_contract_timeout_seconds": pkm_agent_lab_module._AGENT_CONTRACT_TIMEOUT_SECONDS,
+        "agent_contract_max_attempts": pkm_agent_lab_module._AGENT_CONTRACT_MAX_ATTEMPTS,
+        "google_genai_sdk_version": genai_sdk_version,
+        "api_key_source": api_key_source,
+        "github_actions": os.getenv("GITHUB_ACTIONS") == "true",
+        "deployment_environment": str(os.getenv("ENVIRONMENT") or os.getenv("DEPLOY_ENV") or ""),
+        "shadow_replay_enabled": not bool(args.skip_shadow),
+    }
 
 
 def _build_quality_gate(
@@ -3627,6 +3692,7 @@ async def main() -> int:
         "duration_seconds": round(time.time() - started_at, 2),
         "env_file": str(env_file) if env_file else "",
         "phase": args.phase,
+        "execution_context": _execution_context(args),
         "shadow_users": shadow_users,
         "synthetic_persona_count": len(personas),
         "synthetic_prompt_count": sum(len(persona["prompts"]) for persona in personas),

--- a/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
+++ b/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from hushh_mcp.services import pkm_agent_lab_service as pkm_agent_lab_module
 from scripts import eval_pkm_structure_agent as eval_script
 
@@ -35,6 +37,9 @@ def test_quality_gate_flags_fallback_fragmentation_and_mutation_drift():
                     "fragmentation_score": 0.50,
                     "finance_contamination_count": 1,
                     "unresolved_domain_count": 1,
+                    "inner_timeout_count": 1,
+                    "inner_budget_exhausted_count": 1,
+                    "inner_failure_count": 1,
                 },
             }
         ],
@@ -57,6 +62,9 @@ def test_quality_gate_flags_fallback_fragmentation_and_mutation_drift():
     assert "fragmentation" in failures
     assert "finance_contamination" in failures
     assert "unresolved_domain" in failures
+    assert "inner_timeout" in failures
+    assert "inner_budget_exhausted" in failures
+    assert "inner_agent_failure" in failures
 
 
 def test_fragmentation_ignores_non_durable_alternative_domains():
@@ -85,3 +93,64 @@ def test_fragmentation_ignores_non_durable_alternative_domains():
     ]
 
     assert eval_script._durable_domain_fragmentation_score(results) == 1.0
+
+
+@pytest.mark.asyncio
+async def test_evaluator_fails_closed_on_hidden_inner_agent_timeout():
+    class TraceService:
+        async def generate_structure_preview(self, **kwargs):
+            assert kwargs["capture_execution_trace"] is True
+            return {
+                "intent_frame": {
+                    "save_class": "durable",
+                    "intent_class": "preference",
+                    "mutation_intent": "create",
+                    "requires_confirmation": False,
+                },
+                "structure_decision": {"target_domain": "food"},
+                "write_mode": "confirm_first",
+                "validation_hints": [],
+                "used_fallback": True,
+                "performance": {
+                    "agent_execution": [{"agent_id": "memory_intent_agent", "status": "timeout"}]
+                },
+            }
+
+    case = eval_script.PromptCase(
+        case_id="trace-timeout",
+        message="I prefer Thai food.",
+        expected_save_class="durable",
+        expected_intent_class="preference",
+        expected_mutation_intent="create",
+        expected_domains=("food",),
+        expect_confirmation=True,
+        category="preference",
+    )
+    result = await eval_script._evaluate_case(
+        service=TraceService(),
+        case=case,
+        state={"domains": [], "memories": []},
+        user_id="synthetic-user",
+        model_override="test-model",
+        strict_small_model=True,
+        per_prompt_timeout_seconds=1.0,
+        domain_registry_override=[],
+    )
+    summary = eval_script._summarize_results([result])
+    failures = eval_script._gate_failures_for_summary(
+        label="synthetic:candidate_minimal",
+        summary=summary,
+        thresholds={
+            "schema_ok_rate": 0.0,
+            "domain_ok_rate": 0.0,
+            "mutation_ok_rate": 0.0,
+            "intent_ok_rate": 0.0,
+            "fallback_rate": 1.0,
+            "fragmentation_score_min": 0.0,
+            "fragmentation_score_max": 2.0,
+        },
+    )
+
+    assert result.timed_out is False
+    assert summary["inner_timeout_count"] == 1
+    assert failures == ["synthetic:candidate_minimal:inner_timeout 1"]

--- a/consent-protocol/tests/test_active_pkm_shape_audit.py
+++ b/consent-protocol/tests/test_active_pkm_shape_audit.py
@@ -39,11 +39,11 @@ def test_shape_audit_contract_has_no_event_sample_lane():
     assert '"complete": segment_offset == 0' in source
 
 
-def test_protected_gate_rejects_partial_shape_audit():
+def test_gate_prohibits_reviewer_decryption_audit_in_ci():
     gate = (ROOT.parent / "scripts/ci/pkm-upgrade-gate.sh").read_text()
 
-    assert 'p["pagination"]["has_more"] is False' in gate
-    assert 'p["preservation_receipt"]["complete"] is True' in gate
+    assert "PKM_UPGRADE_REVIEWER_SHAPE_AUDIT is prohibited in CI" in gate
+    assert "audit_active_pkm_shape_readonly.py" not in gate
 
 
 def test_live_runtime_audit_loads_canonical_reviewer_secrets_in_memory():

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -128,8 +128,8 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     workflow = (ROOT.parent / ".github/workflows/deploy-uat.yml").read_text()
 
     assert "PKM_UPGRADE_PROTECTED_UAT=1" in workflow
-    assert "PKM_UPGRADE_REVIEWER_SHAPE_AUDIT=1" in workflow
     assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1" in workflow
+    assert "--skip-shadow" in (ROOT.parent / "scripts/ci/pkm-upgrade-gate.sh").read_text()
     assert "PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1" in workflow
     assert "verify-reviewer-byok" in workflow
     assert "reviewer_byok_continuity_failed" in workflow

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -126,10 +126,21 @@ def test_protected_uat_gate_requires_live_recovery_rehearsal():
 
 def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     workflow = (ROOT.parent / ".github/workflows/deploy-uat.yml").read_text()
+    gate = (ROOT.parent / "scripts/ci/pkm-upgrade-gate.sh").read_text()
+    candidate_evaluator = (
+        ROOT.parent / "scripts/ci/run-candidate-pkm-structure-agent-eval.sh"
+    ).read_text()
 
     assert "PKM_UPGRADE_PROTECTED_UAT=1" in workflow
-    assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1" in workflow
-    assert "--skip-shadow" in (ROOT.parent / "scripts/ci/pkm-upgrade-gate.sh").read_text()
+    assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED=1" in workflow
+    assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED" in gate
+    assert "Verify candidate PKM evaluator in Cloud Run" in workflow
+    assert workflow.index("Verify candidate PKM evaluator in Cloud Run") < workflow.index(
+        "Promote deployed revisions to UAT traffic"
+    )
+    assert "--skip-shadow" in candidate_evaluator
+    assert "GOOGLE_API_KEY=GOOGLE_API_KEY:latest" in candidate_evaluator
+    assert "REVIEWER_" not in candidate_evaluator
     assert "PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1" in workflow
     assert "verify-reviewer-byok" in workflow
     assert "reviewer_byok_continuity_failed" in workflow

--- a/packages/hushh-mcp/scripts/verify-packed-runtime.mjs
+++ b/packages/hushh-mcp/scripts/verify-packed-runtime.mjs
@@ -20,11 +20,31 @@ function run(command, args, cwd) {
   return result.stdout;
 }
 
-function nextJsonLine(lines, timeoutMs = 15000) {
+function testPythonPath() {
+  const executable = process.platform === "win32" ? "python.exe" : "python";
+  const candidate = path.resolve(
+    packageDir,
+    "..",
+    "..",
+    "consent-protocol",
+    ".venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+    executable,
+  );
+  return fs.existsSync(candidate) ? candidate : "";
+}
+
+function nextJsonLine(lines, { child, stderr, label, timeoutMs = 15000 }) {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       lines.removeListener("line", onLine);
-      reject(new Error("Packed MCP runtime response timed out"));
+      child.kill("SIGTERM");
+      const exit = child.exitCode === null ? "running" : String(child.exitCode);
+      reject(
+        new Error(
+          `Packed MCP ${label} response timed out (exit=${exit}; stderr=${stderr().slice(0, 500)})`,
+        ),
+      );
     }, timeoutMs);
     const onLine = (line) => {
       clearTimeout(timeout);
@@ -71,6 +91,7 @@ try {
       VAULT_DATA_KEY: "0".repeat(64),
       HUSHH_MCP_SKIP_BOOTSTRAP: "1",
       HUSHH_MCP_CACHE_DIR: path.join(tempRoot, "runtime-cache"),
+      HUSHH_MCP_PYTHON: process.env.HUSHH_MCP_PYTHON || testPythonPath(),
       HUSHH_DEVELOPER_TOKEN: "",
     },
     stdio: ["pipe", "pipe", "pipe"],
@@ -92,7 +113,8 @@ try {
       },
     })}\n`,
   );
-  const initialized = await nextJsonLine(lines);
+  const responseOptions = (label) => ({ child, stderr: () => stderr, label });
+  const initialized = await nextJsonLine(lines, responseOptions("initialization"));
   if (initialized?.result?.serverInfo?.version !== "0.3.0") {
     throw new Error(`Packed MCP initialization mismatch: ${JSON.stringify(initialized)}`);
   }
@@ -100,7 +122,7 @@ try {
   child.stdin.write(
     `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} })}\n`,
   );
-  const listed = await nextJsonLine(lines);
+  const listed = await nextJsonLine(lines, responseOptions("tool-list"));
   const names = listed?.result?.tools?.map((tool) => tool.name);
   const expected = [
     "search_user_scopes",
@@ -123,7 +145,7 @@ try {
       },
     })}\n`,
   );
-  const called = await nextJsonLine(lines);
+  const called = await nextJsonLine(lines, responseOptions("tool-call"));
   if (called?.result?.structuredContent?.error_code !== "AUTHENTICATION_REQUIRED") {
     throw new Error(`Packed MCP tool-call mismatch: ${JSON.stringify(called)}`);
   }
@@ -147,7 +169,7 @@ try {
       },
     })}\n`,
   );
-  const rejected = await nextJsonLine(lines);
+  const rejected = await nextJsonLine(lines, responseOptions("schema-rejection"));
   if (rejected?.result?.structuredContent?.error_code !== "INVALID_ARGUMENTS") {
     throw new Error(`Packed MCP strict-schema mismatch: ${JSON.stringify(rejected)}`);
   }

--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -66,8 +66,8 @@ HUSHH_DEVELOPER_TOKEN="${HUSHH_DEVELOPER_TOKEN:-test_hushh_developer_token_for_c
 PYTHONPATH=. \
   "$PYTHON_RUNNER" -m pytest -q "${BACKEND_TESTS[@]}"
 
-if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ "${PKM_UPGRADE_REVIEWER_SHAPE_AUDIT:-}" != "1" ]; then
-  echo "Protected UAT requires PKM_UPGRADE_REVIEWER_SHAPE_AUDIT=1." >&2
+if [ -n "${PKM_UPGRADE_REVIEWER_SHAPE_AUDIT:-}" ]; then
+  echo "PKM_UPGRADE_REVIEWER_SHAPE_AUDIT is prohibited in CI. Use the post-deploy browser BYOK rehearsal." >&2
   exit 1
 fi
 
@@ -109,26 +109,28 @@ if [ -n "$POSTGRES_REHEARSAL_TARGET" ]; then
     -f "$PROTOCOL_DIR/db/verify/pkm_v7_zero_loss_rehearsal.sql"
 fi
 
-if [ "${PKM_UPGRADE_REVIEWER_SHAPE_AUDIT:-}" = "1" ]; then
-  echo "Running reviewer-backed active PKM shape audit..."
-  SHAPE_AUDIT_ARGS=(--env-file "${PKM_UPGRADE_REVIEWER_ENV_FILE:-.env}")
-  if [ -n "${PKM_UPGRADE_REVIEWER_SECRET_PROJECT:-}" ]; then
-    SHAPE_AUDIT_ARGS+=(--gcp-secret-project "$PKM_UPGRADE_REVIEWER_SECRET_PROJECT")
-  fi
-  if [ -n "${PKM_UPGRADE_REVIEWER_SECRET_VERSION:-}" ]; then
-    SHAPE_AUDIT_ARGS+=(--gcp-secret-version "$PKM_UPGRADE_REVIEWER_SECRET_VERSION")
-  fi
-  "$PYTHON_RUNNER" scripts/audit_active_pkm_shape_readonly.py "${SHAPE_AUDIT_ARGS[@]}" >/tmp/hushh-pkm-shape-audit.json
-  "$PYTHON_RUNNER" -c 'import json; p=json.load(open("/tmp/hushh-pkm-shape-audit.json")); assert p["schema_version"] == "pkm_reviewer_shape_audit.v2"; assert p["pagination"]["has_more"] is False; assert p["preservation_receipt"]["complete"] is True; assert p["preservation_receipt"]["rejected"] == 0'
-  echo "Reviewer-backed active PKM shape audit passed with redacted output."
-fi
-
 if [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL:-}" = "1" ]; then
-  echo "Running chained PKM structure-agent evaluation..."
-  "$PYTHON_RUNNER" scripts/eval_pkm_structure_agent.py \
-    --phase fresh_chain_60 \
-    --enforce-gates \
-    --json-out /tmp/hushh-pkm-structure-agent-eval.json
+  EVAL_RUNS="${PKM_UPGRADE_STRUCTURE_AGENT_EVAL_RUNS:-1}"
+  if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ]; then
+    EVAL_RUNS=2
+  fi
+  if ! [[ "$EVAL_RUNS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "PKM_UPGRADE_STRUCTURE_AGENT_EVAL_RUNS must be a positive integer." >&2
+    exit 1
+  fi
+  for eval_run in $(seq 1 "$EVAL_RUNS"); do
+    echo "Running chained PKM structure-agent evaluation ${eval_run}/${EVAL_RUNS}..."
+    EVAL_ARGS=(
+      --phase fresh_chain_60
+      --enforce-gates
+      --json-out "/tmp/hushh-pkm-structure-agent-eval-${eval_run}.json"
+    )
+    if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ]; then
+      # Synthetic-only: no reviewer data, manifests, or decrypted PKM values enter the model.
+      EVAL_ARGS+=(--skip-shadow)
+    fi
+    "$PYTHON_RUNNER" scripts/eval_pkm_structure_agent.py "${EVAL_ARGS[@]}"
+  done
 fi
 
 if [ -n "${PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL:-}" ]; then

--- a/scripts/ci/pkm-upgrade-gate.sh
+++ b/scripts/ci/pkm-upgrade-gate.sh
@@ -86,8 +86,16 @@ if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ -z "$POSTGRES_REHEARSAL_TARGE
   exit 1
 fi
 
-if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] && [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL:-}" != "1" ]; then
-  echo "Protected UAT requires PKM_UPGRADE_STRUCTURE_AGENT_EVAL=1." >&2
+if [ "${PKM_UPGRADE_PROTECTED_UAT:-}" = "1" ] \
+  && [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL:-}" != "1" ] \
+  && [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED:-}" != "1" ]; then
+  echo "Protected UAT requires a local structure-agent evaluation or an explicit candidate-runtime evaluation deferral." >&2
+  exit 1
+fi
+
+if [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL:-}" = "1" ] \
+  && [ "${PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED:-}" = "1" ]; then
+  echo "Choose one structure-agent evaluation location: local gate or candidate runtime." >&2
   exit 1
 fi
 

--- a/scripts/ci/reviewer-app-testing-check.sh
+++ b/scripts/ci/reviewer-app-testing-check.sh
@@ -6,6 +6,11 @@ cd "$repo_root"
 
 node --check .codex/skills/reviewer-app-testing/scripts/reviewer-session-harness.mjs
 node --check .codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs
+if rg -q 'createDecipheriv|pbkdf2Sync|decryptAesGcm|deriveVaultKey' \
+  .codex/skills/reviewer-app-testing/scripts; then
+  echo "Reviewer Node harness must not derive or decrypt vault keys." >&2
+  exit 1
+fi
 node --check .codex/skills/pkm-upgrade-rehearsal/scripts/reviewer-pkm-app-rehearsal.mjs
 node .codex/skills/pkm-upgrade-rehearsal/scripts/reviewer-pkm-app-rehearsal.mjs --help >/dev/null
 if PKM_REVIEWER_DECRYPTED_OUTPUT="$repo_root/AGENTS.md" \

--- a/scripts/ci/run-candidate-pkm-structure-agent-eval.sh
+++ b/scripts/ci/run-candidate-pkm-structure-agent-eval.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_env=(GCP_PROJECT_ID GCP_REGION BACKEND_SERVICE BACKEND_REVISION GITHUB_RUN_ID)
+for name in "${required_env[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    echo "${name} is required for candidate PKM evaluation." >&2
+    exit 1
+  fi
+done
+
+job_name="uat-pkm-eval-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT:-1}"
+job_name="${job_name,,}"
+job_name="${job_name:0:63}"
+
+image="$(gcloud run revisions describe "$BACKEND_REVISION" \
+  --project "$GCP_PROJECT_ID" \
+  --region "$GCP_REGION" \
+  --format='value(spec.containers[0].image)')"
+runtime_service_account="$(gcloud run services describe "$BACKEND_SERVICE" \
+  --project "$GCP_PROJECT_ID" \
+  --region "$GCP_REGION" \
+  --format='value(spec.template.spec.serviceAccountName)')"
+
+if [ -z "$image" ] || [ -z "$runtime_service_account" ]; then
+  echo "Unable to resolve the candidate image or runtime service account." >&2
+  exit 1
+fi
+
+cleanup() {
+  gcloud run jobs delete "$job_name" \
+    --project "$GCP_PROJECT_ID" \
+    --region "$GCP_REGION" \
+    --quiet >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+gcloud run jobs create "$job_name" \
+  --project "$GCP_PROJECT_ID" \
+  --region "$GCP_REGION" \
+  --image "$image" \
+  --service-account "$runtime_service_account" \
+  --tasks 1 \
+  --parallelism 1 \
+  --max-retries 0 \
+  --task-timeout 45m \
+  --set-env-vars "ENVIRONMENT=uat,HUSHH_DEPLOY_ENV=uat" \
+  --set-secrets "GOOGLE_API_KEY=GOOGLE_API_KEY:latest" \
+  --command python \
+  --args "scripts/eval_pkm_structure_agent.py,--phase,fresh_chain_60,--skip-shadow,--enforce-gates,--json-out,/tmp/pkm-structure-agent-eval.json" \
+  --quiet
+
+for attempt in 1 2; do
+  echo "Running synthetic candidate PKM evaluator ${attempt}/2..."
+  gcloud run jobs execute "$job_name" \
+    --project "$GCP_PROJECT_ID" \
+    --region "$GCP_REGION" \
+    --wait \
+    --quiet
+done
+
+echo "Candidate PKM evaluator passed twice with synthetic-only input."


### PR DESCRIPTION
## Release safety fixes

- Runs the packed MCP verifier with the repository-synced Python runtime and surfaces bounded child diagnostics.
- Makes PKM evaluator inner contract timeouts, exhausted budgets, and agent failures release failures; records only safe aggregate execution evidence.
- Runs the UAT PKM evaluator twice as a no-traffic Cloud Run Job using the exact candidate image, runtime service account, and model secret. The GitHub predeploy gate still runs migration and compatibility proofs, but no longer treats GitHub-runner latency as application-runtime evidence.
- Removes CI-side reviewer PKM decryption. The candidate evaluator is synthetic-only; browser BYOK continuity remains post-deploy before release classification.
- Removes raw vault-key derivation from the Playwright Node harness. Browser code now remains the sole default decryption location; exact decrypted payload output requires an explicit local-only opt-in and stays in `tmp/`.

## Verification

- `./scripts/ci/pkm-upgrade-gate.sh` — 135 frontend + 246 backend checks passed locally.
- Focused evaluator, PKM service, recovery, and reviewer-audit tests passed (62).
- `./scripts/ci/reviewer-app-testing-check.sh` passed, including the new Node-side decryption guard.
- Candidate-job shell syntax and UAT service-account permissions were verified; the job itself will run only in the governed UAT deployment.

No user PKM payloads or credentials are included in the evaluator output or CI artifacts.

---
Closes #4573
(retroactive board-linkage backfill)

---
Closes #4591
(retroactive board-linkage backfill)