### PR TITLE
fix(uat): isolate synthetic PKM evaluator from vault config

### DIFF
--- a/consent-protocol/hushh_mcp/services/__init__.py
+++ b/consent-protocol/hushh_mcp/services/__init__.py
@@ -1,20 +1,22 @@
 # hushh_mcp/services/__init__.py
-"""
-Service Layer
-=============
+"""Service-layer public exports.
 
-Unified service layer for agent-mediated database access.
-All database operations should go through these services.
-
-CONSENT-FIRST ARCHITECTURE:
-    All services validate consent tokens before database access.
-    API routes should use these services, never access database directly.
+Keep package import free of database and vault configuration side effects.  A
+number of callers import a narrow service module (including the synthetic PKM
+evaluator); eagerly importing the legacy database services here would make
+that narrow operation require unrelated runtime keys.
 """
 
-from .consent_db import ConsentDBService
-from .investor_db import InvestorDBService
-from .vault_db import VaultDBService
-from .vault_keys_service import VaultKeysService
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .consent_db import ConsentDBService
+    from .investor_db import InvestorDBService
+    from .vault_db import VaultDBService
+    from .vault_keys_service import VaultKeysService
 
 __all__ = [
     "VaultDBService",
@@ -22,3 +24,20 @@ __all__ = [
     "InvestorDBService",
     "VaultKeysService",
 ]
+
+_EXPORT_MODULES = {
+    "ConsentDBService": ".consent_db",
+    "InvestorDBService": ".investor_db",
+    "VaultDBService": ".vault_db",
+    "VaultKeysService": ".vault_keys_service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve legacy package exports only when a caller asks for one."""
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value

--- a/consent-protocol/scripts/eval_pkm_structure_agent.py
+++ b/consent-protocol/scripts/eval_pkm_structure_agent.py
@@ -3645,7 +3645,10 @@ async def main() -> int:
     report_path.parent.mkdir(parents=True, exist_ok=True)
 
     service = get_pkm_agent_lab_service()
-    pkm_service = PersonalKnowledgeModelService()
+    # A synthetic-only rehearsal must not initialize the PKM database path.
+    # Besides keeping the job read-only, this lets the no-traffic Cloud Run
+    # candidate run with only its model credential.
+    pkm_service = PersonalKnowledgeModelService() if not args.skip_shadow else None
     personas, chain_state = build_phase_personas(
         phase=args.phase,
         max_prompts_per_persona=args.max_prompts_per_persona,
@@ -3670,6 +3673,8 @@ async def main() -> int:
             )
         )
         if not args.skip_shadow:
+            if pkm_service is None:
+                raise RuntimeError("Shadow replay requires a PKM service instance")
             shadow_reports.append(
                 await _run_shadow_mode(
                     service=service,

--- a/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
+++ b/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -154,3 +155,46 @@ async def test_evaluator_fails_closed_on_hidden_inner_agent_timeout():
     assert result.timed_out is False
     assert summary["inner_timeout_count"] == 1
     assert failures == ["synthetic:candidate_minimal:inner_timeout 1"]
+
+
+@pytest.mark.asyncio
+async def test_synthetic_only_main_never_initializes_pkm_service(monkeypatch, tmp_path):
+    args = SimpleNamespace(
+        env_file=None,
+        json_out=str(tmp_path / "report.json"),
+        phase="fresh_chain_60",
+        max_prompts_per_persona=1,
+        skip_shadow=True,
+        shadow_users="",
+        model="",
+        per_prompt_timeout_seconds=1.0,
+        enforce_gates=False,
+    )
+    monkeypatch.setattr(eval_script, "parse_args", lambda: args)
+    monkeypatch.setattr(eval_script, "get_pkm_agent_lab_service", lambda: object())
+    monkeypatch.setattr(
+        eval_script,
+        "PersonalKnowledgeModelService",
+        lambda: pytest.fail("synthetic-only evaluation must not initialize PKM storage"),
+    )
+    monkeypatch.setattr(
+        eval_script,
+        "build_phase_personas",
+        lambda **_: ([{"user_id": "synthetic", "prompts": []}], {}),
+    )
+    monkeypatch.setattr(eval_script, "_mode_matrix", lambda _: [("test", "", False)])
+    monkeypatch.setattr(eval_script, "resolve_shadow_users", lambda _: [])
+    monkeypatch.setattr(eval_script, "_gate_thresholds", lambda _: {})
+    monkeypatch.setattr(
+        eval_script,
+        "_run_synthetic_mode",
+        lambda **_: asyncio.sleep(0, result={"mode": "test", "summary": {}}),
+    )
+    monkeypatch.setattr(
+        eval_script,
+        "_build_quality_gate",
+        lambda **_: {"status": "pass", "failures": [], "thresholds": {}},
+    )
+    monkeypatch.setattr(eval_script, "_manual_kpi_summary", lambda **_: {})
+
+    assert await eval_script.main() == 0


### PR DESCRIPTION
## RCA
The no-traffic Cloud Run candidate evaluator failed before evaluation because importing `hushh_mcp.services` eagerly initialized vault configuration.

## Fix
- make legacy package exports lazy
- do not initialize PKM storage for `--skip-shadow` synthetic runs
- add a regression proving synthetic evaluation does not initialize PKM storage

## Verification
- `./scripts/ci/pkm-upgrade-gate.sh` (135 frontend, 246 backend)
- narrow evaluator imports succeed with signing and vault keys unset

---
Closes #4572
(retroactive board-linkage backfill)

---
Closes #4590
(retroactive board-linkage backfill)