### PR TITLE
fix(uat): keep manifest-only ADK imports keyless

### DIFF
--- a/consent-protocol/hushh_mcp/hushh_adk/__init__.py
+++ b/consent-protocol/hushh_mcp/hushh_adk/__init__.py
@@ -1,7 +1,19 @@
-from .context import HushhContext
-from .core import HushhAgent
-from .manifest import AgentManifest, AgentManifestV2, ManifestLoader
-from .tools import hushh_tool
+"""Public ADK exports without eager runtime-security initialization.
+
+Manifest-only consumers, such as the synthetic PKM evaluator, must not load
+the consent-token runtime merely by importing :mod:`hushh_mcp.hushh_adk`.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .context import HushhContext
+    from .core import HushhAgent
+    from .manifest import AgentManifest, AgentManifestV2, ManifestLoader
+    from .tools import hushh_tool
 
 __all__ = [
     "HushhAgent",
@@ -11,3 +23,22 @@ __all__ = [
     "AgentManifest",
     "AgentManifestV2",
 ]
+
+_EXPORT_MODULES = {
+    "HushhAgent": ".core",
+    "HushhContext": ".context",
+    "hushh_tool": ".tools",
+    "ManifestLoader": ".manifest",
+    "AgentManifest": ".manifest",
+    "AgentManifestV2": ".manifest",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve public exports only when the caller needs that surface."""
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value

--- a/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
+++ b/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
@@ -216,8 +216,14 @@ def test_synthetic_evaluator_import_needs_no_core_vault_or_signing_key():
         [
             sys.executable,
             "-c",
-            "import hushh_mcp.services.pkm_agent_lab_service; "
-            "import scripts.eval_pkm_structure_agent",
+            "import asyncio; "
+            "from hushh_mcp.services.pkm_agent_lab_service import get_pkm_agent_lab_service; "
+            "service = get_pkm_agent_lab_service(); "
+            "assert service.structure_manifest.name; "
+            "service._client = object(); "
+            "preview = asyncio.run(service.generate_structure_preview("
+            "user_id='synthetic', message='I prefer Thai food.', current_domains=[])); "
+            "assert preview['structure_decision']['target_domain'] == 'food'",
         ],
         cwd=CONSENT_PROTOCOL_ROOT,
         env=environment,

--- a/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
+++ b/consent-protocol/tests/scripts/test_eval_pkm_structure_agent.py
@@ -1,10 +1,16 @@
 import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from hushh_mcp.services import pkm_agent_lab_service as pkm_agent_lab_module
 from scripts import eval_pkm_structure_agent as eval_script
+
+CONSENT_PROTOCOL_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_persona_chain_keeps_hundred_case_crud_surface():
@@ -198,3 +204,26 @@ async def test_synthetic_only_main_never_initializes_pkm_service(monkeypatch, tm
     monkeypatch.setattr(eval_script, "_manual_kpi_summary", lambda **_: {})
 
     assert await eval_script.main() == 0
+
+
+def test_synthetic_evaluator_import_needs_no_core_vault_or_signing_key():
+    environment = os.environ.copy()
+    environment.pop("APP_SIGNING_KEY", None)
+    environment.pop("VAULT_DATA_KEY", None)
+    environment["PYTHONPATH"] = str(CONSENT_PROTOCOL_ROOT)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import hushh_mcp.services.pkm_agent_lab_service; "
+            "import scripts.eval_pkm_structure_agent",
+        ],
+        cwd=CONSENT_PROTOCOL_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
## RCA
The candidate evaluator correctly avoided vault storage initialization, but the manifest loader package still eagerly imported the ADK core and therefore required signing/vault configuration.

## Fix
- make ADK package exports lazy
- preserve normal public exports
- add a clean-environment subprocess regression for the evaluator import path

## Verification
- `./scripts/ci/pkm-upgrade-gate.sh` (135 frontend, 246 backend)
- focused evaluator import regression with signing and vault keys unset

---
Closes #4571
(retroactive board-linkage backfill)

---
Closes #4589
(retroactive board-linkage backfill)