### PR TITLE
fix(ci): scope heavy PKM UAT gates to upgrades

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -126,23 +126,6 @@ jobs:
           python-version: "3.13"
           protocol-dir: ./consent-protocol
 
-      - name: Set up Node runtime for protected PKM verification
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: hushh-webapp/package-lock.json
-
-      - name: Install protected PKM browser dependencies
-        shell: bash
-        run: |
-          set -euo pipefail
-          npm ci --prefix hushh-webapp
-          (
-            cd hushh-webapp
-            npx playwright install --with-deps chromium
-          )
-
       - name: Capture predeploy Cloud Run state
         id: predeploy-state
         shell: bash
@@ -200,6 +183,38 @@ jobs:
             --frontend-base-sha "${{ steps.predeploy-state.outputs.frontend_sha }}" \
             --github-output "$GITHUB_OUTPUT" \
             --json
+
+      - name: Resolve UAT verification plan
+        id: verification-plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/resolve-uat-verification-plan.py \
+            --target-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --backend-base-sha "${{ steps.predeploy-state.outputs.backend_sha }}" \
+            --frontend-base-sha "${{ steps.predeploy-state.outputs.frontend_sha }}" \
+            --deploy-backend "${{ steps.scope.outputs.deploy_backend }}" \
+            --deploy-frontend "${{ steps.scope.outputs.deploy_frontend }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Set up Node runtime for protected PKM verification
+        if: steps.verification-plan.outputs.requires_web_dependencies == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: hushh-webapp/package-lock.json
+
+      - name: Install protected PKM browser dependencies
+        if: steps.verification-plan.outputs.requires_web_dependencies == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci --prefix hushh-webapp
+          (
+            cd hushh-webapp
+            npx playwright install --with-deps chromium
+          )
 
       - name: Sync canonical hosted runtime secrets
         shell: bash
@@ -299,15 +314,17 @@ jobs:
           BOOTSTRAP_FOCUS_PROFILE=uat bash scripts/env/bootstrap_profiles.sh --strict
           bash scripts/env/use_profile.sh uat
 
-          export PGHOST="$DB_HOST"
-          export PGPORT="$DB_PORT"
-          export PGDATABASE="$DB_NAME"
-          export PGUSER="$DB_USER"
-          export PGPASSWORD="$DB_PASSWORD"
-          PKM_UPGRADE_PROTECTED_UAT=1 \
-          PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED=1 \
-          PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1 \
-            ./scripts/ci/pkm-upgrade-gate.sh
+          if [ "${{ steps.verification-plan.outputs.run_pkm_upgrade_gate }}" = "true" ]; then
+            export PGHOST="$DB_HOST"
+            export PGPORT="$DB_PORT"
+            export PGDATABASE="$DB_NAME"
+            export PGUSER="$DB_USER"
+            export PGPASSWORD="$DB_PASSWORD"
+            PKM_UPGRADE_PROTECTED_UAT=1 \
+            PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED=1 \
+            PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1 \
+              ./scripts/ci/pkm-upgrade-gate.sh
+          fi
 
       - name: Deploy backend using Cloud Build
         id: deploy-backend
@@ -373,7 +390,7 @@ jobs:
 
       - name: Verify candidate PKM evaluator in Cloud Run
         id: verify-candidate-pkm-evaluator
-        if: steps.scope.outputs.deploy_backend == 'true'
+        if: steps.scope.outputs.deploy_backend == 'true' && steps.verification-plan.outputs.pkm_evaluator_runs != '0'
         shell: bash
         env:
           BACKEND_REVISION: ${{ steps.candidate-state.outputs.backend_revision }}
@@ -573,6 +590,25 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_ENV"
 
+          if [ "${{ steps.verification-plan.outputs.run_reviewer_byok }}" = "true" ]; then
+            reviewer_uid="$(gcloud secrets versions access latest \
+              --secret=REVIEWER_UID \
+              --project="${{ env.GCP_PROJECT_ID }}")"
+            reviewer_passphrase="$(gcloud secrets versions access latest \
+              --secret=REVIEWER_VAULT_PASSPHRASE \
+              --project="${{ env.GCP_PROJECT_ID }}")"
+            echo "::add-mask::$reviewer_uid"
+            echo "::add-mask::$reviewer_passphrase"
+            {
+              echo "REVIEWER_UID<<EOF"
+              printf '%s\n' "$reviewer_uid"
+              echo "EOF"
+              echo "REVIEWER_VAULT_PASSPHRASE<<EOF"
+              printf '%s\n' "$reviewer_passphrase"
+              echo "EOF"
+            } >> "$GITHUB_ENV"
+          fi
+
       - name: Semantic UAT verification
         id: verify-uat-1
         continue-on-error: true
@@ -603,6 +639,7 @@ jobs:
 
       - name: Verify reviewer BYOK navigation and cold re-unlock
         id: verify-reviewer-byok
+        if: steps.verification-plan.outputs.run_reviewer_byok == 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -615,6 +652,7 @@ jobs:
 
       - name: Verify live PKM, investor, and RIA runtime audits
         id: verify-pkm-runtime-audit
+        if: steps.verification-plan.outputs.run_pkm_runtime_audit == 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -640,6 +678,10 @@ jobs:
           SEMANTIC_ATTEMPT_2: ${{ steps.verify-uat-2.outcome }}
           REVIEWER_BYOK_OUTCOME: ${{ steps.verify-reviewer-byok.outcome }}
           PKM_RUNTIME_AUDIT_OUTCOME: ${{ steps.verify-pkm-runtime-audit.outcome }}
+          REVIEWER_BYOK_REQUIRED: ${{ steps.verification-plan.outputs.run_reviewer_byok }}
+          PKM_RUNTIME_AUDIT_REQUIRED: ${{ steps.verification-plan.outputs.run_pkm_runtime_audit }}
+          PKM_EVALUATOR_RUNS: ${{ steps.verification-plan.outputs.pkm_evaluator_runs }}
+          VERIFICATION_PLAN_REASON: ${{ steps.verification-plan.outputs.reason }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -686,8 +728,16 @@ jobs:
           )
           semantic_success = os.environ.get("SEMANTIC_ATTEMPT_1") == "success" or os.environ.get("SEMANTIC_ATTEMPT_2") == "success"
           db_outcome = os.environ.get("DB_OUTCOME", "")
-          reviewer_byok_success = os.environ.get("REVIEWER_BYOK_OUTCOME") == "success"
-          pkm_runtime_audit_success = os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME") == "success"
+          reviewer_byok_required = os.environ.get("REVIEWER_BYOK_REQUIRED") == "true"
+          pkm_runtime_audit_required = os.environ.get("PKM_RUNTIME_AUDIT_REQUIRED") == "true"
+          reviewer_byok_success = (
+              not reviewer_byok_required
+              or os.environ.get("REVIEWER_BYOK_OUTCOME") == "success"
+          )
+          pkm_runtime_audit_success = (
+              not pkm_runtime_audit_required
+              or os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME") == "success"
+          )
 
           blocking: list[str] = []
           backend_failure = False
@@ -814,12 +864,18 @@ jobs:
                   "outcome": db_outcome,
               },
               "reviewer_byok": {
+                  "required": reviewer_byok_required,
                   "outcome": os.environ.get("REVIEWER_BYOK_OUTCOME", ""),
                   "success": reviewer_byok_success,
               },
               "pkm_runtime_audit": {
+                  "required": pkm_runtime_audit_required,
                   "outcome": os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME", ""),
                   "success": pkm_runtime_audit_success,
+              },
+              "verification_plan": {
+                  "reason": os.environ.get("VERIFICATION_PLAN_REASON", ""),
+                  "pkm_evaluator_runs": int(os.environ.get("PKM_EVALUATOR_RUNS") or "0"),
               },
           }
 
@@ -948,6 +1004,11 @@ jobs:
                   "frontend_url": "${{ steps.final-state.outputs.frontend_url }}",
               },
               "verification": {
+                  "plan_reason": "${{ steps.verification-plan.outputs.reason }}",
+                  "pkm_evaluator_runs": "${{ steps.verification-plan.outputs.pkm_evaluator_runs }}",
+                  "pkm_upgrade_gate_required": "${{ steps.verification-plan.outputs.run_pkm_upgrade_gate }}",
+                  "reviewer_byok_required": "${{ steps.verification-plan.outputs.run_reviewer_byok }}",
+                  "pkm_runtime_audit_required": "${{ steps.verification-plan.outputs.run_pkm_runtime_audit }}",
                   "parity_attempt_1": "${{ steps.verify-parity-1.outcome }}",
                   "parity_attempt_2": "${{ steps.verify-parity-2.outcome }}",
                   "parity_success": "${{ steps.classify-uat-release.outputs.parity_success }}",
@@ -1021,6 +1082,11 @@ jobs:
             echo "- Requested scope: \`${{ github.event.inputs.scope }}\`"
             echo "- Scope: \`${{ steps.scope.outputs.scope }}\`"
             echo "- Scope reason: \`${{ steps.scope.outputs.reason }}\`"
+            echo "- Verification plan: \`${{ steps.verification-plan.outputs.reason }}\`"
+            echo "- PKM evaluator runs: \`${{ steps.verification-plan.outputs.pkm_evaluator_runs }}\`"
+            echo "- PKM upgrade gate required: \`${{ steps.verification-plan.outputs.run_pkm_upgrade_gate }}\`"
+            echo "- Reviewer BYOK required: \`${{ steps.verification-plan.outputs.run_reviewer_byok }}\`"
+            echo "- PKM runtime audit required: \`${{ steps.verification-plan.outputs.run_pkm_runtime_audit }}\`"
             echo "- Backend deployed SHA before run: \`${{ steps.predeploy-state.outputs.backend_sha || 'unknown' }}\`"
             echo "- Frontend deployed SHA before run: \`${{ steps.predeploy-state.outputs.frontend_sha || 'unknown' }}\`"
             echo "- Status: \`$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/uat-release-status.json').read_text(encoding='utf-8'))['status'])")\`"

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -135,6 +135,10 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED=1" in workflow
     assert "PKM_UPGRADE_STRUCTURE_AGENT_EVAL_DEFERRED" in gate
     assert "Verify candidate PKM evaluator in Cloud Run" in workflow
+    assert "Resolve UAT verification plan" in workflow
+    assert "resolve-uat-verification-plan.py" in workflow
+    assert "outputs.pkm_evaluator_runs != '0'" in workflow
+    assert "outputs.run_pkm_upgrade_gate" in workflow
     assert workflow.index("Verify candidate PKM evaluator in Cloud Run") < workflow.index(
         "Promote deployed revisions to UAT traffic"
     )
@@ -151,8 +155,14 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     assert "REVIEWER_" not in candidate_evaluator
     assert "PKM_UPGRADE_RUNTIME_AUDIT_DEFERRED=1" in workflow
     assert "verify-reviewer-byok" in workflow
+    assert "outputs.run_reviewer_byok == 'true'" in workflow
+    assert "--secret=REVIEWER_UID" in workflow
+    assert "--secret=REVIEWER_VAULT_PASSPHRASE" in workflow
     assert "reviewer_byok_continuity_failed" in workflow
     assert "verify-pkm-runtime-audit" in workflow
+    assert "outputs.run_pkm_runtime_audit == 'true'" in workflow
+    assert "REVIEWER_BYOK_REQUIRED" in workflow
+    assert "PKM_RUNTIME_AUDIT_REQUIRED" in workflow
     assert "pkm_runtime_audit_failed" in workflow
     assert workflow.index("Promote deployed revisions to UAT traffic") < workflow.index(
         "Verify live PKM, investor, and RIA runtime audits"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,6 +29,15 @@ The green `main` SHA is the deployment source of truth for a manual UAT dispatch
 7. records the deployment in the canonical `uat` GitHub environment
 8. loads the maintainer-only `REVIEWER_UID` / `REVIEWER_VAULT_PASSPHRASE` overlay and runs semantic release verification with bounded retry/rollback
 
+The UAT lane selects expensive verification from the diff between the exact
+deployed service revisions and the target SHA. The synthetic structure-agent
+evaluation, historical zero-loss rehearsal, and full PKM runtime browser audit
+run only when PKM upgrade machinery, stored-shape contracts, upgrade migrations,
+or upgrade fixtures change. Ordinary PKM reads/writes, prompts, model-provider
+changes, and unrelated releases use the standard release checks. Vault or
+reviewer-auth changes independently enable the BYOK navigation rehearsal. If a
+deployed SHA cannot be proven, selection fails closed to the complete suite.
+
 ### Backend Deployment
 
 ```bash

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -14,6 +14,7 @@ python3 scripts/ci/verify-pr-base-policy.py --self-test
 python3 scripts/ci/verify-branch-governance-doc-consistency.py
 python3 scripts/ci/verify-branch-governance-doc-consistency.py --self-test
 python3 scripts/ci/test_resolve_deploy_scope.py
+python3 scripts/ci/test_resolve_uat_verification_plan.py
 ./bin/hushh docs verify
 ./bin/hushh codex data-model-audit
 python3 scripts/licenses/verify_apache_surface.py

--- a/scripts/ci/resolve-uat-verification-plan.py
+++ b/scripts/ci/resolve-uat-verification-plan.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Select UAT release gates from the service revisions actually being deployed."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+
+def _normalize(raw: str) -> str:
+    value = str(raw or "").strip().replace("\\", "/")
+    if not value:
+        return ""
+    normalized = PurePosixPath(value).as_posix()
+    return normalized[2:] if normalized.startswith("./") else normalized
+
+
+def _git_diff(base_sha: str, target_sha: str) -> set[str]:
+    if not base_sha or not target_sha or base_sha == target_sha:
+        return set()
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_sha}..{target_sha}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return {_normalize(item) for item in result.stdout.splitlines() if _normalize(item)}
+
+
+def _is_pkm_upgrade(path: str) -> bool:
+    return (
+        path in {
+            "consent-protocol/hushh_mcp/services/pkm_upgrade_service.py",
+            "consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py",
+            "consent-protocol/scripts/eval_pkm_structure_agent.py",
+            "consent-protocol/db/verify/pkm_v7_zero_loss_rehearsal.sql",
+            "scripts/ci/pkm-upgrade-gate.sh",
+            "scripts/ci/run-candidate-pkm-structure-agent-eval.sh",
+        }
+        or path.startswith(
+            (
+                "hushh-webapp/lib/services/pkm-upgrade-",
+                "hushh-webapp/__tests__/services/pkm-upgrade-",
+                "hushh-webapp/__tests__/services/pkm-historical-rehearsal",
+                "hushh-webapp/__tests__/services/financial-v7-reader-compatibility",
+                "consent-protocol/tests/test_pkm_upgrade_",
+                "consent-protocol/tests/test_pkm_v7_recovery_",
+                ".codex/skills/pkm-upgrade-rehearsal/",
+                ".codex/workflows/pkm-upgrade-rehearsal/",
+            )
+        )
+        or (
+            path.startswith("consent-protocol/db/migrations/")
+            and "pkm" in path.lower()
+        )
+    )
+
+
+def _is_reviewer_byok(path: str) -> bool:
+    return path.startswith(".codex/skills/reviewer-app-testing/") or path.startswith(
+        (
+            "hushh-webapp/components/app-ui/native-test-",
+            "hushh-webapp/lib/testing/",
+            "hushh-webapp/lib/vault/",
+            "hushh-webapp/components/vault/",
+            "consent-protocol/api/routes/vault",
+            "consent-protocol/hushh_mcp/services/vault_",
+        )
+    ) or path in {
+        "hushh-webapp/scripts/testing/reviewer-test-identity.mjs",
+        "hushh-webapp/lib/services/vault-service.ts",
+        "consent-protocol/api/routes/app_review.py",
+    }
+
+
+def _is_pkm_runtime(path: str) -> bool:
+    return _is_pkm_upgrade(path)
+
+
+@dataclass(frozen=True)
+class VerificationPlan:
+    changed_files: tuple[str, ...]
+    pkm_evaluator_runs: int
+    run_pkm_upgrade_gate: bool
+    run_reviewer_byok: bool
+    run_pkm_runtime_audit: bool
+    reason: str
+
+    def as_dict(self) -> dict[str, object]:
+        requires_web_dependencies = (
+            self.run_pkm_upgrade_gate or self.run_reviewer_byok or self.run_pkm_runtime_audit
+        )
+        return {
+            "changed_files": list(self.changed_files),
+            "pkm_evaluator_runs": self.pkm_evaluator_runs,
+            "run_pkm_upgrade_gate": self.run_pkm_upgrade_gate,
+            "run_reviewer_byok": self.run_reviewer_byok,
+            "run_pkm_runtime_audit": self.run_pkm_runtime_audit,
+            "requires_web_dependencies": requires_web_dependencies,
+            "reason": self.reason,
+        }
+
+
+def resolve_plan(
+    *,
+    target_sha: str,
+    backend_base_sha: str,
+    frontend_base_sha: str,
+    deploy_backend: bool,
+    deploy_frontend: bool,
+) -> VerificationPlan:
+    missing_base = (deploy_backend and not backend_base_sha) or (
+        deploy_frontend and not frontend_base_sha
+    )
+    if missing_base:
+        return VerificationPlan((), 1, True, True, True, "conservative:missing_deployed_sha")
+
+    changed: set[str] = set()
+    if deploy_backend:
+        changed.update(_git_diff(backend_base_sha, target_sha))
+    if deploy_frontend:
+        changed.update(_git_diff(frontend_base_sha, target_sha))
+
+    pkm_upgrade = any(_is_pkm_upgrade(path) for path in changed)
+    evaluator_runs = 1 if pkm_upgrade else 0
+    reviewer_byok = any(_is_reviewer_byok(path) for path in changed)
+    pkm_runtime = any(_is_pkm_runtime(path) for path in changed)
+    active = [
+        name
+        for name, enabled in (
+            ("pkm_upgrade", pkm_upgrade),
+            ("reviewer_byok", reviewer_byok),
+            ("pkm_runtime", pkm_runtime),
+        )
+        if enabled
+    ]
+    return VerificationPlan(
+        tuple(sorted(changed)),
+        evaluator_runs,
+        pkm_upgrade,
+        reviewer_byok,
+        pkm_runtime,
+        f"changed_paths:{','.join(active) if active else 'standard'}",
+    )
+
+
+def _bool(raw: str) -> bool:
+    return str(raw).strip().lower() == "true"
+
+
+def _write_outputs(path: str, payload: dict[str, object]) -> None:
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in payload.items():
+            if isinstance(value, list):
+                rendered = ",".join(value)
+            elif isinstance(value, bool):
+                rendered = str(value).lower()
+            else:
+                rendered = value
+            handle.write(f"{key}={rendered}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-sha", required=True)
+    parser.add_argument("--backend-base-sha", default="")
+    parser.add_argument("--frontend-base-sha", default="")
+    parser.add_argument("--deploy-backend", required=True)
+    parser.add_argument("--deploy-frontend", required=True)
+    parser.add_argument("--github-output", default="")
+    args = parser.parse_args()
+    plan = resolve_plan(
+        target_sha=args.target_sha.strip(),
+        backend_base_sha=args.backend_base_sha.strip(),
+        frontend_base_sha=args.frontend_base_sha.strip(),
+        deploy_backend=_bool(args.deploy_backend),
+        deploy_frontend=_bool(args.deploy_frontend),
+    )
+    payload = plan.as_dict()
+    if args.github_output:
+        _write_outputs(args.github_output, payload)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run-candidate-pkm-structure-agent-eval.sh
+++ b/scripts/ci/run-candidate-pkm-structure-agent-eval.sh
@@ -49,13 +49,11 @@ gcloud run jobs create "$job_name" \
   --args "scripts/eval_pkm_structure_agent.py,--phase,fresh_chain_60,--skip-shadow,--enforce-gates,--json-out,/tmp/pkm-structure-agent-eval.json" \
   --quiet
 
-for attempt in 1 2; do
-  echo "Running synthetic candidate PKM evaluator ${attempt}/2..."
-  gcloud run jobs execute "$job_name" \
-    --project "$GCP_PROJECT_ID" \
-    --region "$GCP_REGION" \
-    --wait \
-    --quiet
-done
+echo "Running synthetic candidate PKM upgrade evaluator..."
+gcloud run jobs execute "$job_name" \
+  --project "$GCP_PROJECT_ID" \
+  --region "$GCP_REGION" \
+  --wait \
+  --quiet
 
-echo "Candidate PKM evaluator passed twice with synthetic-only input."
+echo "Candidate PKM upgrade evaluator passed with synthetic-only input."

--- a/scripts/ci/test_resolve_uat_verification_plan.py
+++ b/scripts/ci/test_resolve_uat_verification_plan.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Unit checks for the changed-surface UAT verification plan."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("resolve-uat-verification-plan.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("resolve_uat_verification_plan", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def plan_for(monkeypatch_files: set[str], *, backend: bool = True, frontend: bool = False):
+    resolver = load_module()
+    resolver._git_diff = lambda _base, _target: set(monkeypatch_files)
+    return resolver.resolve_plan(
+        target_sha="target",
+        backend_base_sha="backend-base",
+        frontend_base_sha="frontend-base",
+        deploy_backend=backend,
+        deploy_frontend=frontend,
+    )
+
+
+def test_standard_backend_change_uses_lean_gate() -> None:
+    plan = plan_for({"consent-protocol/api/routes/health.py"})
+    assert plan.pkm_evaluator_runs == 0
+    assert plan.run_pkm_upgrade_gate is False
+    assert plan.run_reviewer_byok is False
+    assert plan.run_pkm_runtime_audit is False
+
+
+def test_provider_change_does_not_run_pkm_upgrade_evaluator() -> None:
+    plan = plan_for({"consent-protocol/hushh_mcp/runtime_providers/factory.py"})
+    assert plan.pkm_evaluator_runs == 0
+    assert plan.run_pkm_upgrade_gate is False
+    assert plan.run_reviewer_byok is False
+    assert plan.run_pkm_runtime_audit is False
+
+
+def test_ordinary_pkm_agent_change_does_not_run_upgrade_gate() -> None:
+    plan = plan_for({"consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py"})
+    assert plan.pkm_evaluator_runs == 0
+    assert plan.run_pkm_upgrade_gate is False
+    assert plan.run_pkm_runtime_audit is False
+
+
+def test_pkm_upgrade_change_keeps_full_zero_loss_gate() -> None:
+    plan = plan_for({"consent-protocol/hushh_mcp/services/pkm_upgrade_service.py"})
+    assert plan.pkm_evaluator_runs == 1
+    assert plan.run_pkm_upgrade_gate is True
+    assert plan.run_pkm_runtime_audit is True
+
+
+def test_frontend_vault_change_requires_byok_browser() -> None:
+    plan = plan_for(
+        {"hushh-webapp/lib/services/vault-service.ts"}, backend=False, frontend=True
+    )
+    assert plan.pkm_evaluator_runs == 0
+    assert plan.run_reviewer_byok is True
+    assert plan.as_dict()["requires_web_dependencies"] is True
+
+
+def test_missing_deployed_sha_fails_closed() -> None:
+    resolver = load_module()
+    plan = resolver.resolve_plan(
+        target_sha="target",
+        backend_base_sha="",
+        frontend_base_sha="frontend-base",
+        deploy_backend=True,
+        deploy_frontend=False,
+    )
+    assert plan.pkm_evaluator_runs == 1
+    assert plan.run_pkm_upgrade_gate is True
+    assert plan.run_reviewer_byok is True
+    assert plan.run_pkm_runtime_audit is True
+
+
+def main() -> int:
+    tests = [
+        test_standard_backend_change_uses_lean_gate,
+        test_provider_change_does_not_run_pkm_upgrade_evaluator,
+        test_ordinary_pkm_agent_change_does_not_run_upgrade_gate,
+        test_pkm_upgrade_change_keeps_full_zero_loss_gate,
+        test_frontend_vault_change_requires_byok_browser,
+        test_missing_deployed_sha_fails_closed,
+    ]
+    for test in tests:
+        test()
+        print(f"ok {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- select UAT verification from the exact deployed-to-target service diff
- run the hosted PKM evaluator and zero-loss/runtime rehearsal only for PKM upgrade surfaces
- reduce the hosted evaluator from two identical sequential executions to one
- fix reviewer BYOK identity continuity by loading the canonical reviewer secrets only when that rehearsal is required
- preserve fail-closed full verification when deployed provenance is unavailable

## Verification
- `./bin/hushh codex pre-pr`
- frontend: 2,179 passed, 6 skipped; production build/typecheck/lint passed
- backend: 402 passed
- PKM gate: 135 frontend and 249 backend tests passed
- focused UAT plan and PKM recovery contract tests passed
- workflow YAML, shell syntax, protected-pipeline governance, MCP package/runtime, docs, and security checks passed

---
Closes #4570
(retroactive board-linkage backfill)

---
Closes #4588
(retroactive board-linkage backfill)