### PR TITLE
ci(uat): remove postdeploy runtime audit gate

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -653,18 +653,6 @@ jobs:
           node .codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs \
             2>&1 | tee /tmp/uat-reviewer-byok.log
 
-      - name: Verify live PKM, investor, and RIA runtime audits
-        id: verify-pkm-runtime-audit
-        if: steps.verification-plan.outputs.run_pkm_runtime_audit == 'true' && (steps.verify-uat-1.outcome == 'success' || steps.verify-uat-2.outcome == 'success')
-        continue-on-error: true
-        shell: bash
-        env:
-          PKM_UPGRADE_RUNTIME_AUDIT_BASE_URL: ${{ env.APP_FRONTEND_ORIGIN }}
-          PKM_UPGRADE_REVIEWER_SECRET_PROJECT: ${{ env.GCP_PROJECT_ID }}
-        run: |
-          set -euo pipefail
-          ./scripts/ci/pkm-runtime-audit.sh 2>&1 | tee /tmp/uat-pkm-runtime-audit.log
-
       - name: Classify UAT release outcome
         if: always()
         id: classify-uat-release
@@ -680,9 +668,7 @@ jobs:
           SEMANTIC_ATTEMPT_1: ${{ steps.verify-uat-1.outcome }}
           SEMANTIC_ATTEMPT_2: ${{ steps.verify-uat-2.outcome }}
           REVIEWER_BYOK_OUTCOME: ${{ steps.verify-reviewer-byok.outcome }}
-          PKM_RUNTIME_AUDIT_OUTCOME: ${{ steps.verify-pkm-runtime-audit.outcome }}
           REVIEWER_BYOK_REQUIRED: ${{ steps.verification-plan.outputs.run_reviewer_byok }}
-          PKM_RUNTIME_AUDIT_REQUIRED: ${{ steps.verification-plan.outputs.run_pkm_runtime_audit }}
           PKM_EVALUATOR_RUNS: ${{ steps.verification-plan.outputs.pkm_evaluator_runs }}
           VERIFICATION_PLAN_REASON: ${{ steps.verification-plan.outputs.reason }}
         run: |
@@ -738,16 +724,10 @@ jobs:
           )
           browser_authority_ready = semantic_required and semantic_success
           reviewer_byok_required = os.environ.get("REVIEWER_BYOK_REQUIRED") == "true"
-          pkm_runtime_audit_required = os.environ.get("PKM_RUNTIME_AUDIT_REQUIRED") == "true"
           reviewer_byok_success = (
               not reviewer_byok_required
               or not browser_authority_ready
               or os.environ.get("REVIEWER_BYOK_OUTCOME") == "success"
-          )
-          pkm_runtime_audit_success = (
-              not pkm_runtime_audit_required
-              or not browser_authority_ready
-              or os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME") == "success"
           )
 
           blocking: list[str] = []
@@ -829,13 +809,6 @@ jobs:
               if os.environ.get("DEPLOY_FRONTEND") == "true":
                   frontend_failure = True
 
-          if not pkm_runtime_audit_success:
-              append_unique(blocking, ["pkm_runtime_audit_failed"])
-              if os.environ.get("DEPLOY_BACKEND") == "true":
-                  backend_failure = True
-              if os.environ.get("DEPLOY_FRONTEND") == "true":
-                  frontend_failure = True
-
           blocking = list(dict.fromkeys(blocking))
           release_failed = bool(blocking)
 
@@ -882,13 +855,6 @@ jobs:
                   "outcome": os.environ.get("REVIEWER_BYOK_OUTCOME", ""),
                   "success": reviewer_byok_success,
               },
-              "pkm_runtime_audit": {
-                  "required": pkm_runtime_audit_required,
-                  "authority_ready": browser_authority_ready,
-                  "skipped_reason": "" if browser_authority_ready or not pkm_runtime_audit_required else "upstream_authority_failed",
-                  "outcome": os.environ.get("PKM_RUNTIME_AUDIT_OUTCOME", ""),
-                  "success": pkm_runtime_audit_success,
-              },
               "verification_plan": {
                   "reason": os.environ.get("VERIFICATION_PLAN_REASON", ""),
                   "pkm_evaluator_runs": int(os.environ.get("PKM_EVALUATOR_RUNS") or "0"),
@@ -909,7 +875,6 @@ jobs:
               handle.write(f"provenance_success={'true' if backend_provenance_success and frontend_provenance_success else 'false'}\n")
               handle.write(f"semantic_success={'true' if semantic_success else 'false'}\n")
               handle.write(f"reviewer_byok_success={'true' if reviewer_byok_success else 'false'}\n")
-              handle.write(f"pkm_runtime_audit_success={'true' if pkm_runtime_audit_success else 'false'}\n")
           PY
 
       - name: Roll back backend revision
@@ -1024,7 +989,6 @@ jobs:
                   "pkm_evaluator_runs": "${{ steps.verification-plan.outputs.pkm_evaluator_runs }}",
                   "pkm_upgrade_gate_required": "${{ steps.verification-plan.outputs.run_pkm_upgrade_gate }}",
                   "reviewer_byok_required": "${{ steps.verification-plan.outputs.run_reviewer_byok }}",
-                  "pkm_runtime_audit_required": "${{ steps.verification-plan.outputs.run_pkm_runtime_audit }}",
                   "parity_attempt_1": "${{ steps.verify-parity-1.outcome }}",
                   "parity_attempt_2": "${{ steps.verify-parity-2.outcome }}",
                   "parity_success": "${{ steps.classify-uat-release.outputs.parity_success }}",
@@ -1036,7 +1000,6 @@ jobs:
                   "semantic_success": "${{ steps.classify-uat-release.outputs.semantic_success }}",
                   "db_contract": "${{ steps.postdeploy-db-gate.outcome }}",
                   "reviewer_byok": "${{ steps.verify-reviewer-byok.outcome }}",
-                  "pkm_runtime_audit": "${{ steps.verify-pkm-runtime-audit.outcome }}",
                   "blocking_classifications": "${{ steps.classify-uat-release.outputs.blocking_classifications }}",
               },
               "rollback_targets": {
@@ -1071,7 +1034,6 @@ jobs:
             /tmp/uat-release-verify-attempt-1.json
             /tmp/uat-release-verify-attempt-2.json
             /tmp/uat-reviewer-byok.log
-            /tmp/uat-pkm-runtime-audit.log
             /tmp/uat-release-classification.json
             /tmp/uat-release-status.json
 
@@ -1102,7 +1064,6 @@ jobs:
             echo "- PKM evaluator runs: \`${{ steps.verification-plan.outputs.pkm_evaluator_runs }}\`"
             echo "- PKM upgrade gate required: \`${{ steps.verification-plan.outputs.run_pkm_upgrade_gate }}\`"
             echo "- Reviewer BYOK required: \`${{ steps.verification-plan.outputs.run_reviewer_byok }}\`"
-            echo "- PKM runtime audit required: \`${{ steps.verification-plan.outputs.run_pkm_runtime_audit }}\`"
             echo "- Backend deployed SHA before run: \`${{ steps.predeploy-state.outputs.backend_sha || 'unknown' }}\`"
             echo "- Frontend deployed SHA before run: \`${{ steps.predeploy-state.outputs.frontend_sha || 'unknown' }}\`"
             echo "- Status: \`$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/uat-release-status.json').read_text(encoding='utf-8'))['status'])")\`"

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -162,23 +162,16 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     assert "--secret=REVIEWER_UID" in workflow
     assert "--secret=REVIEWER_VAULT_PASSPHRASE" in workflow
     assert "reviewer_byok_continuity_failed" in workflow
-    assert "verify-pkm-runtime-audit" in workflow
-    assert "outputs.run_pkm_runtime_audit == 'true'" in workflow
     assert "steps.postdeploy-db-gate.outcome != 'failure'" in workflow
     assert (
         workflow.count(
             "steps.verify-uat-1.outcome == 'success' || steps.verify-uat-2.outcome == 'success'"
         )
-        == 2
+        == 1
     )
     assert '"upstream_authority_failed"' in workflow
     assert 'semantic_required = db_outcome != "failure"' in workflow
     assert "REVIEWER_BYOK_REQUIRED" in workflow
-    assert "PKM_RUNTIME_AUDIT_REQUIRED" in workflow
-    assert "pkm_runtime_audit_failed" in workflow
-    assert workflow.index("Promote deployed revisions to UAT traffic") < workflow.index(
-        "Verify live PKM, investor, and RIA runtime audits"
-    )
-    assert workflow.index("Verify live PKM, investor, and RIA runtime audits") < workflow.index(
-        "Classify UAT release outcome"
-    )
+    assert "verify-pkm-runtime-audit" not in workflow
+    assert "PKM_RUNTIME_AUDIT_REQUIRED" not in workflow
+    assert "pkm_runtime_audit_failed" not in workflow

--- a/scripts/ci/resolve-uat-verification-plan.py
+++ b/scripts/ci/resolve-uat-verification-plan.py
@@ -76,29 +76,21 @@ def _is_reviewer_byok(path: str) -> bool:
     }
 
 
-def _is_pkm_runtime(path: str) -> bool:
-    return _is_pkm_upgrade(path)
-
-
 @dataclass(frozen=True)
 class VerificationPlan:
     changed_files: tuple[str, ...]
     pkm_evaluator_runs: int
     run_pkm_upgrade_gate: bool
     run_reviewer_byok: bool
-    run_pkm_runtime_audit: bool
     reason: str
 
     def as_dict(self) -> dict[str, object]:
-        requires_web_dependencies = (
-            self.run_pkm_upgrade_gate or self.run_reviewer_byok or self.run_pkm_runtime_audit
-        )
+        requires_web_dependencies = self.run_pkm_upgrade_gate or self.run_reviewer_byok
         return {
             "changed_files": list(self.changed_files),
             "pkm_evaluator_runs": self.pkm_evaluator_runs,
             "run_pkm_upgrade_gate": self.run_pkm_upgrade_gate,
             "run_reviewer_byok": self.run_reviewer_byok,
-            "run_pkm_runtime_audit": self.run_pkm_runtime_audit,
             "requires_web_dependencies": requires_web_dependencies,
             "reason": self.reason,
         }
@@ -116,7 +108,7 @@ def resolve_plan(
         deploy_frontend and not frontend_base_sha
     )
     if missing_base:
-        return VerificationPlan((), 1, True, True, True, "conservative:missing_deployed_sha")
+        return VerificationPlan((), 1, True, True, "conservative:missing_deployed_sha")
 
     changed: set[str] = set()
     if deploy_backend:
@@ -127,13 +119,11 @@ def resolve_plan(
     pkm_upgrade = any(_is_pkm_upgrade(path) for path in changed)
     evaluator_runs = 1 if pkm_upgrade else 0
     reviewer_byok = any(_is_reviewer_byok(path) for path in changed)
-    pkm_runtime = any(_is_pkm_runtime(path) for path in changed)
     active = [
         name
         for name, enabled in (
             ("pkm_upgrade", pkm_upgrade),
             ("reviewer_byok", reviewer_byok),
-            ("pkm_runtime", pkm_runtime),
         )
         if enabled
     ]
@@ -142,7 +132,6 @@ def resolve_plan(
         evaluator_runs,
         pkm_upgrade,
         reviewer_byok,
-        pkm_runtime,
         f"changed_paths:{','.join(active) if active else 'standard'}",
     )
 

--- a/scripts/ci/test_resolve_uat_verification_plan.py
+++ b/scripts/ci/test_resolve_uat_verification_plan.py
@@ -36,7 +36,6 @@ def test_standard_backend_change_uses_lean_gate() -> None:
     assert plan.pkm_evaluator_runs == 0
     assert plan.run_pkm_upgrade_gate is False
     assert plan.run_reviewer_byok is False
-    assert plan.run_pkm_runtime_audit is False
 
 
 def test_provider_change_does_not_run_pkm_upgrade_evaluator() -> None:
@@ -44,21 +43,18 @@ def test_provider_change_does_not_run_pkm_upgrade_evaluator() -> None:
     assert plan.pkm_evaluator_runs == 0
     assert plan.run_pkm_upgrade_gate is False
     assert plan.run_reviewer_byok is False
-    assert plan.run_pkm_runtime_audit is False
 
 
 def test_ordinary_pkm_agent_change_does_not_run_upgrade_gate() -> None:
     plan = plan_for({"consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py"})
     assert plan.pkm_evaluator_runs == 0
     assert plan.run_pkm_upgrade_gate is False
-    assert plan.run_pkm_runtime_audit is False
 
 
 def test_pkm_upgrade_change_keeps_full_zero_loss_gate() -> None:
     plan = plan_for({"consent-protocol/hushh_mcp/services/pkm_upgrade_service.py"})
     assert plan.pkm_evaluator_runs == 1
     assert plan.run_pkm_upgrade_gate is True
-    assert plan.run_pkm_runtime_audit is True
 
 
 def test_frontend_vault_change_requires_byok_browser() -> None:
@@ -82,7 +78,6 @@ def test_missing_deployed_sha_fails_closed() -> None:
     assert plan.pkm_evaluator_runs == 1
     assert plan.run_pkm_upgrade_gate is True
     assert plan.run_reviewer_byok is True
-    assert plan.run_pkm_runtime_audit is True
 
 
 def main() -> int:


### PR DESCRIPTION
Removes the flaky broad post-deploy PKM/investor/RIA browser sweep from the UAT release classifier. Keeps provenance, runtime parity, schema, semantic UAT verification, candidate PKM evaluation, and the focused reviewer BYOK continuity check.

---
Closes #4568
(retroactive board-linkage backfill)

---
Closes #4586
(retroactive board-linkage backfill)