### PR TITLE
fix: harden connected systems registry and MCP catalog

### DIFF
--- a/consent-protocol/api/routes/connected_systems.py
+++ b/consent-protocol/api/routes/connected_systems.py
@@ -172,8 +172,11 @@ async def list_connected_systems(
     firebase_uid: str = Depends(_require_signed_in_lister),
 ):
     _ = firebase_uid
-    service = get_connected_systems_service()
-    return ConnectedSystemsResponse(systems=service.list_systems())
+    try:
+        service = get_connected_systems_service()
+        return ConnectedSystemsResponse(systems=service.list_systems())
+    except ConnectedSystemsError as error:
+        _raise_connected_system_error(error)
 
 
 @router.get("/{system_id}/schema")

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 100,
+  "expected_migration_version": 101,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -790,7 +790,8 @@
       "tool_name",
       "http_method",
       "path",
-      "description"
+      "description",
+      "mcp_endpoint"
     ],
     "trusted_connections": [
       "id",

--- a/consent-protocol/db/migrations/101_backfill_crm_operation_endpoints.sql
+++ b/consent-protocol/db/migrations/101_backfill_crm_operation_endpoints.sql
@@ -1,0 +1,48 @@
+-- Backfill the legacy Salesforce registry rows into the per-operation MCP
+-- contract. Runtime no longer infers these tools: every executable operation
+-- must be declared by its registry row.
+--
+-- Future CRMs are configured by inserting their own operation rows with their
+-- own tool names and endpoints; this migration is only for pre-existing
+-- Salesforce records created before the capability-safe registry existed.
+
+BEGIN;
+
+INSERT INTO crm_operation_endpoints (
+  crm_id,
+  operation,
+  tool_name,
+  description,
+  mcp_endpoint
+)
+SELECT
+  registry.crm_id,
+  mapping.operation,
+  mapping.tool_name,
+  mapping.description,
+  CASE
+    WHEN mapping.operation = 'delete'
+      THEN COALESCE(registry.crm_delete_endpoint, registry.crm_mcp_endpoint)
+    ELSE registry.crm_mcp_endpoint
+  END
+FROM enterprise_crm_registry AS registry
+CROSS JOIN (
+  VALUES
+    ('schema', 'object-schema', 'Discover the registered primary object schema.'),
+    ('read', 'read-crm-record', 'Read a record using the registered lookup.'),
+    ('create', 'create-crm-record', 'Create a record after explicit approval.'),
+    ('update', 'update-crm-record', 'Update a record after explicit approval.'),
+    ('delete', 'delete-crm-record', 'Delete a record after explicit approval.')
+) AS mapping(operation, tool_name, description)
+WHERE LOWER(COALESCE(registry.crm_type, '')) = 'salesforce'
+  AND registry.is_active = TRUE
+  AND (
+    mapping.operation = 'schema'
+    OR (mapping.operation = 'read' AND registry.supports_read)
+    OR (mapping.operation = 'create' AND registry.supports_create)
+    OR (mapping.operation = 'update' AND registry.supports_update)
+    OR (mapping.operation = 'delete' AND registry.supports_delete)
+  )
+ON CONFLICT (crm_id, operation) DO NOTHING;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -78,7 +78,8 @@
     "097_redact_legacy_pkm_message_excerpts.sql",
     "098_pkm_v7_recovery_foundation.sql",
     "099_developer_oauth_pkce.sql",
-    "100_connected_system_capability_contract.sql"
+    "100_connected_system_capability_contract.sql",
+    "101_backfill_crm_operation_endpoints.sql"
   ],
   "groups": {
     "iam": [
@@ -121,7 +122,8 @@
       "093_consent_audit_request_id_text.sql",
       "094_one_onboarding_callback_attempt_v1.sql",
       "095_one_kyc_needs_confirm_status.sql",
-      "100_connected_system_capability_contract.sql"
+      "100_connected_system_capability_contract.sql",
+      "101_backfill_crm_operation_endpoints.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/docs/mcp-setup.md
+++ b/consent-protocol/docs/mcp-setup.md
@@ -46,6 +46,12 @@ Use the trailing-slash endpoint shape:
 - authenticate with `Authorization: Bearer <developer-token>`
 - query-string tokens are rejected
 
+The hosted Streamable HTTP transport returns the complete public catalog from
+`tools/list`; no ResourceLink download or extra catalog endpoint is involved.
+Each advertised input and output schema has a root `type: object` for strict
+MCP clients. Configure the bearer header, call `initialize`, then call
+`tools/list`.
+
 ## Public Tool Surface
 
 The hosted public developer lane exposes four core consent tools:

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -1459,7 +1459,16 @@ class ConnectedSystemsService:
     def _load_registry(self) -> tuple[ConnectedSystemDefinition, ...]:
         from hushh_mcp.services import crm_registry_repo
 
-        return crm_registry_repo.load_active_definitions()
+        try:
+            return crm_registry_repo.load_active_definitions()
+        except ConnectedSystemsError:
+            raise
+        except DatabaseExecutionError as error:
+            logger.exception("crm_registry.load_failed")
+            raise ConnectedSystemConfigurationError(
+                "Connected Systems configuration is temporarily unavailable.",
+                code="CONNECTED_SYSTEM_REGISTRY_UNAVAILABLE",
+            ) from error
 
     def _adapter_for_system(
         self, system: ConnectedSystemDefinition
@@ -1524,7 +1533,9 @@ class ConnectedSystemsService:
         registry = self.registry if self._registry_explicit else self._load_registry()
         return [
             system.to_summary(
-                endpoint_configured=bool(system.transport_endpoint),
+                endpoint_configured=all(
+                    system.supports(operation) for operation in system.capabilities
+                ),
                 delete_enabled=self.delete_enabled,
             )
             for system in registry

--- a/consent-protocol/hushh_mcp/services/crm_registry_repo.py
+++ b/consent-protocol/hushh_mcp/services/crm_registry_repo.py
@@ -25,7 +25,6 @@ from hushh_mcp.runtime_settings import (
     get_omnigateway_transport_headers,
 )
 from hushh_mcp.services.connected_systems_service import (
-    EXTERNAL_CRM_TOOL_CATALOG,
     REGISTRY_MCP_ENDPOINT,
     ConnectedSystemConfigurationError,
     ConnectedSystemDefinition,
@@ -157,7 +156,10 @@ def _tool_catalog(row_crm_id: str, database: Any) -> tuple[dict[str, Any], ...]:
         """,
         {"crm_id": row_crm_id},
     ).data
-    return _tool_catalog_from_rows(operation_rows) or EXTERNAL_CRM_TOOL_CATALOG
+    # The database registry is the executable source of truth. A legacy
+    # in-code catalog here would advertise CRUD operations which the active
+    # CRM row has not explicitly mapped, defeating capability-safe rollout.
+    return _tool_catalog_from_rows(operation_rows)
 
 
 def _definition_from_row(

--- a/consent-protocol/mcp_modules/tools/public_contract.json
+++ b/consent-protocol/mcp_modules/tools/public_contract.json
@@ -58,6 +58,7 @@
         "required": ["user_identifier"]
       },
       "outputSchema": {
+        "type": "object",
         "oneOf": [
           {
             "type": "object",
@@ -123,6 +124,7 @@
         "anyOf": [{"required": ["user_id"]}, {"required": ["user_identifier"]}]
       },
       "outputSchema": {
+        "type": "object",
         "oneOf": [
           {
             "type": "object",
@@ -179,6 +181,7 @@
         "required": ["user_identifier", "scope", "purpose"]
       },
       "outputSchema": {
+        "type": "object",
         "oneOf": [
           {
             "type": "object",
@@ -218,6 +221,7 @@
         "required": ["request_ref"]
       },
       "outputSchema": {
+        "type": "object",
         "oneOf": [
           {
             "type": "object",
@@ -256,6 +260,7 @@
         "required": ["grant_ref", "expected_scope"]
       },
       "outputSchema": {
+        "type": "object",
         "oneOf": [
           {
             "type": "object",

--- a/consent-protocol/tests/test_connected_systems_routes.py
+++ b/consent-protocol/tests/test_connected_systems_routes.py
@@ -5,7 +5,10 @@ from fastapi.testclient import TestClient
 
 from api.middleware import require_vault_owner_token
 from api.routes import connected_systems
-from hushh_mcp.services.connected_systems_service import ConnectedSystemBlockedError
+from hushh_mcp.services.connected_systems_service import (
+    ConnectedSystemBlockedError,
+    ConnectedSystemConfigurationError,
+)
 
 
 class FakeConnectedSystemsService:
@@ -148,6 +151,28 @@ def test_list_connected_systems_route_returns_salesforce_registry_entry(monkeypa
     assert payload["systems"][0]["customerDisplayName"] == "Macy's"
     assert payload["systems"][0]["systemType"] == "Salesforce"
     assert payload["systems"][0]["systemName"] == "FSC"
+
+
+def test_list_connected_systems_returns_typed_registry_unavailable_error(monkeypatch):
+    monkeypatch.setattr(
+        connected_systems,
+        "get_connected_systems_service",
+        lambda: (_ for _ in ()).throw(
+            ConnectedSystemConfigurationError(
+                "Connected Systems configuration is temporarily unavailable.",
+                code="CONNECTED_SYSTEM_REGISTRY_UNAVAILABLE",
+            )
+        ),
+    )
+    client = TestClient(_build_app())
+
+    response = client.get("/api/connected-systems", headers={"Authorization": "Bearer HCT:test"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == {
+        "code": "CONNECTED_SYSTEM_REGISTRY_UNAVAILABLE",
+        "message": "Connected Systems configuration is temporarily unavailable.",
+    }
 
 
 def test_create_intent_route_accepts_live_mcp_camel_case_shape(monkeypatch):

--- a/consent-protocol/tests/test_crm_registry_repo.py
+++ b/consent-protocol/tests/test_crm_registry_repo.py
@@ -65,6 +65,7 @@ def _operation_rows() -> list[dict]:
             "http_method": None,
             "path": None,
             "description": "Discover Contact schema.",
+            "mcp_endpoint": MCP_ENDPOINT,
         },
         {
             "crm_id": "salesforce-fsc-customer0",
@@ -73,6 +74,7 @@ def _operation_rows() -> list[dict]:
             "http_method": None,
             "path": None,
             "description": "Read by email/phone.",
+            "mcp_endpoint": MCP_ENDPOINT,
         },
         {
             "crm_id": "salesforce-fsc-customer0",
@@ -81,6 +83,7 @@ def _operation_rows() -> list[dict]:
             "http_method": None,
             "path": None,
             "description": "Create a Contact.",
+            "mcp_endpoint": MCP_ENDPOINT,
         },
         {
             "crm_id": "salesforce-fsc-customer0",
@@ -89,6 +92,7 @@ def _operation_rows() -> list[dict]:
             "http_method": None,
             "path": None,
             "description": "Update by id.",
+            "mcp_endpoint": MCP_ENDPOINT,
         },
         {
             "crm_id": "salesforce-fsc-customer0",
@@ -97,6 +101,7 @@ def _operation_rows() -> list[dict]:
             "http_method": None,
             "path": None,
             "description": "Delete by id.",
+            "mcp_endpoint": MCP_ENDPOINT,
         },
     ]
 
@@ -148,6 +153,18 @@ def test_load_active_definition_missing_row_returns_none(monkeypatch):
     monkeypatch.setattr(crm_registry_repo, "_vault_key_hex", lambda: TEST_VAULT_KEY)
     db = _FakeDb([], [])
     assert crm_registry_repo.load_active_definition("does-not-exist", db=db) is None
+
+
+def test_missing_operation_rows_do_not_fall_back_to_a_global_crud_catalog(monkeypatch):
+    monkeypatch.setattr(crm_registry_repo, "_vault_key_hex", lambda: TEST_VAULT_KEY)
+    definition = crm_registry_repo.load_active_definition(
+        "salesforce-fsc-customer0", db=_FakeDb([_encrypted_row()], [])
+    )
+
+    assert definition is not None
+    assert definition.tool_catalog == ()
+    assert not definition.supports("schema")
+    assert not definition.supports("create")
 
 
 def test_load_active_definition_bad_key_raises_configuration_error(monkeypatch):

--- a/consent-protocol/tests/test_developer_oauth.py
+++ b/consent-protocol/tests/test_developer_oauth.py
@@ -266,4 +266,4 @@ def test_oauth_migration_is_in_the_developer_release_lane():
     uat = json.loads((root / "db/contracts/uat_integrated_schema.json").read_text())
     assert "099_developer_oauth_pkce.sql" in manifest["ordered_migrations"]
     assert "099_developer_oauth_pkce.sql" in manifest["groups"]["developer"]
-    assert uat["expected_migration_version"] == 100
+    assert uat["expected_migration_version"] == 101

--- a/consent-protocol/tests/test_mcp_protocol_negotiation_v030.py
+++ b/consent-protocol/tests/test_mcp_protocol_negotiation_v030.py
@@ -93,6 +93,9 @@ def test_live_stdio_negotiates_supported_versions_and_lists_exact_tools(
             for tool in listed["result"]["tools"]
         )
         assert all("outputSchema" in tool for tool in listed["result"]["tools"])
+        assert all(
+            tool["outputSchema"].get("type") == "object" for tool in listed["result"]["tools"]
+        )
 
         process.stdin.write(
             json.dumps(

--- a/consent-protocol/tests/test_mcp_public_contract_v030.py
+++ b/consent-protocol/tests/test_mcp_public_contract_v030.py
@@ -80,6 +80,7 @@ def test_every_tool_schema_is_strict_bounded_and_structured() -> None:
         jsonschema.Draft202012Validator.check_schema(tool["inputSchema"])
         jsonschema.Draft202012Validator.check_schema(tool["outputSchema"])
         assert tool["inputSchema"]["additionalProperties"] is False
+        assert tool["outputSchema"]["type"] == "object"
         assert tool["annotations"]["idempotentHint"] is True
         assert tool["description"]
 

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -13,7 +13,7 @@ def test_recovery_migration_is_registered_and_additive():
 
     assert MIGRATION.name in release["ordered_migrations"]
     assert MIGRATION.name in release["groups"]["pkm"]
-    assert uat["expected_migration_version"] == 100
+    assert uat["expected_migration_version"] == 101
     assert dev["expected_migration_version"] == 99
     assert "DROP FUNCTION commit_pkm_domain_mutation_v2" not in sql
     assert "DROP FUNCTION commit_pkm_domain_mutation_v3" not in sql

--- a/hushh-webapp/__tests__/app/providers-bottom-clearance.contract.test.ts
+++ b/hushh-webapp/__tests__/app/providers-bottom-clearance.contract.test.ts
@@ -16,5 +16,6 @@ describe("app shell bottom-clearance contract", () => {
 
   it("keeps Agent Bar placement outside the scroll-root layout contract", () => {
     expect(source).not.toContain("<AgentBar bottom=");
+    expect(source).toContain('"var(--agent-bar-with-nav-bottom)"');
   });
 });

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -17,7 +17,7 @@ describe("Navbar bottom chrome contract", () => {
     expect(navbar).toContain("const BOTTOM_GAP_PX = 4;");
     expect(navbar).toContain("flex justify-center");
     expect(agentBar).toContain(
-      '"calc(var(--app-bottom-inset) - 0.58rem)",',
+      '"var(--agent-bar-with-nav-bottom)",',
     );
     expect(agentBar).not.toContain(
       'calc(max(var(--app-bottom-inset), calc(var(--bottom-nav-offset) + var(--app-safe-area-bottom-effective) + var(--app-bottom-chrome-lift))) + 0.5rem)',

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -373,6 +373,10 @@ a, button, input, select, textarea {
   --app-bottom-inset: calc(
     var(--app-bottom-fixed-ui) + var(--app-safe-area-bottom-effective) + var(--app-bottom-chrome-lift)
   );
+  /* The Agent Bar is a separate fixed control above the nav, never a layer
+   * within it. Keep a visible gap so text/input hit targets cannot underlap
+   * the centered navigation at any measured nav height. */
+  --agent-bar-with-nav-bottom: calc(var(--app-bottom-inset) + 0.75rem);
   /*
    * Onboarding has no bottom navigation, but does retain the persistent Agent
    * Bar. Keep its geometry in one token family so setup terminal controls,

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -148,7 +148,7 @@ function SharedBottomChromeGlass({ hideCommandBar }: { hideCommandBar?: boolean 
           className="pointer-events-none fixed inset-x-0 z-[108] hidden md:block"
           style={{
             bottom:
-              "calc(max(var(--app-bottom-inset), calc(var(--bottom-nav-offset) + var(--app-safe-area-bottom-effective) + var(--app-bottom-chrome-lift))) + 0.5rem)",
+              "var(--agent-bar-with-nav-bottom)",
           }}
         >
           <div

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -1312,7 +1312,7 @@ export function AgentBar() {
           // it does not re-render the voice tree as the page scrolls.
           bottom: physicalNavbarAbsent
             ? "calc(var(--app-safe-area-bottom-effective) + 0.75rem)"
-            : "calc(var(--app-bottom-inset) - 0.58rem)",
+            : "var(--agent-bar-with-nav-bottom)",
         } as CSSProperties
       }
       aria-hidden={barHidden}


### PR DESCRIPTION
## Summary
- return a typed unavailable response when the CRM registry schema is unavailable
- backfill explicit per-operation Salesforce MCP mappings and fail closed when a mapping is absent
- make MCP output schemas host-compatible at the root object level
- reserve Agent Bar clearance above bottom navigation

## Verification
- 132 focused backend tests passed
- Connected Systems and Agent Bar UI tests passed
- `npm run typecheck`, `npm run verify:docs`, `npm run docs:check`, and migration manifest verification passed

## Runtime note
- The local Cloud SQL-backed schema was migrated through version 101; ten operation mappings are present.