### PR TITLE
fix: resolve relative CRM operation endpoints

### DIFF
--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -651,10 +651,16 @@ class ConnectedSystemDefinition:
 
     def operation_endpoint(self, operation: str) -> str | None:
         tool = self.operation(operation) or {}
+        configured = str(tool.get("mcpEndpoint") or "").strip()
+        # A legacy registry could contain a path-only operation endpoint. It is
+        # not a valid Streamable HTTP target on its own; preserve the system's
+        # registered absolute transport endpoint until that row is explicitly
+        # configured with an absolute per-operation URL.
+        if configured.startswith(("https://", "http://", "registry://")):
+            return configured
         return (
             str(
-                tool.get("mcpEndpoint")
-                or (self.delete_transport_endpoint if operation == "delete" else None)
+                (self.delete_transport_endpoint if operation == "delete" else None)
                 or self.transport_endpoint
                 or ""
             ).strip()

--- a/consent-protocol/tests/test_connected_systems_service.py
+++ b/consent-protocol/tests/test_connected_systems_service.py
@@ -218,6 +218,31 @@ def test_default_service_reloads_active_registry_for_each_list(monkeypatch):
     assert service.list_systems() == []
 
 
+def test_relative_operation_endpoint_uses_registered_absolute_transport() -> None:
+    definition = ConnectedSystemDefinition(
+        system_id="legacy-relative-operation-endpoint",
+        display_name="Legacy CRM",
+        customer_display_name="Legacy CRM",
+        system_type="Salesforce",
+        system_name="Salesforce",
+        target="Legacy CRM",
+        object_type_default="Contact",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="https://gateway.example.test/mcp",
+        registry_source="test",
+        tool_catalog=(
+            {
+                "name": "object-schema",
+                "operation": "schema",
+                "mcpEndpoint": "/crm-connect/v1/mcp",
+            },
+        ),
+        capabilities=frozenset({"schema"}),
+    )
+
+    assert definition.operation_endpoint("schema") == "https://gateway.example.test/mcp"
+
+
 @pytest.mark.asyncio
 async def test_registry_simulator_path_remains_available_for_deterministic_local_tests():
     adapter = ExternalCrmStreamableMcpAdapter(

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -17,7 +17,7 @@ describe("Navbar bottom chrome contract", () => {
     expect(navbar).toContain("const BOTTOM_GAP_PX = 4;");
     expect(navbar).toContain("flex justify-center");
     expect(agentBar).toContain(
-      '"var(--agent-bar-with-nav-bottom)",',
+      '"calc(var(--app-bottom-inset) + 0.12rem)",',
     );
     expect(agentBar).not.toContain(
       'calc(max(var(--app-bottom-inset), calc(var(--bottom-nav-offset) + var(--app-safe-area-bottom-effective) + var(--app-bottom-chrome-lift))) + 0.5rem)',

--- a/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
+++ b/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
@@ -54,13 +54,16 @@ describe("Navbar bottom utilities", () => {
     ROUTES.KAI_ANALYSIS,
     ROUTES.RIA_PICKS,
     ROUTES.PROFILE,
-  ])("keeps One, Connect, and Search grouped on %s", (pathname) => {
+  ])("keeps the shared workspace tabs grouped on %s", (pathname) => {
     navigationMock.pathname = pathname;
     const { unmount } = render(<Navbar />);
     const routeNav = screen.getByRole("radiogroup", { name: "Route navigation" });
 
     expect(within(routeNav).getAllByRole("radio").map((radio) => radio.textContent?.trim())).toEqual([
       "One",
+      "Market",
+      "Portfolio",
+      "Analysis",
       "Connect",
       "Search",
     ]);
@@ -77,10 +80,10 @@ describe("Navbar bottom utilities", () => {
     expect(navigationMock.push).toHaveBeenLastCalledWith(ROUTES.ONE_HOME);
   });
 
-  it("uses three equal primary bottom-nav slots", () => {
+  it("uses six equal workspace bottom-nav slots", () => {
     render(<Navbar />);
     expect(screen.getByRole("radiogroup", { name: "Route navigation" }).getAttribute("style")).toContain(
-      "grid-template-columns: repeat(3, minmax(0, 1fr))",
+      "grid-template-columns: repeat(6, minmax(0, 1fr))",
     );
     expect(screen.getByTestId("app-bottom-nav-frame").className).toContain(
       "max-w-[min(calc(100vw-2rem),42rem)]",

--- a/hushh-webapp/__tests__/navigation/app-bottom-nav.test.ts
+++ b/hushh-webapp/__tests__/navigation/app-bottom-nav.test.ts
@@ -71,8 +71,8 @@ describe("app bottom navigation", () => {
     expect(resolveOneActiveNav(ROUTES.PKM)).toBe("pkm");
     expect(resolveOneActiveNav(ROUTES.ONE_MARKETPLACE)).toBe("marketplace");
     expect(resolveOneActiveNav(ROUTES.CONNECTED_SYSTEMS)).toBe("connected");
-    // Global destinations keep their own fixed tab; profile subroutes stay on
-    // the Profile tab.
+    // Global destinations keep their own fixed tab; Profile belongs to One
+    // because Profile is not a persistent bottom-bar option.
     expect(resolveOneActiveNav(ROUTES.AGENT)).toBe("search");
     expect(resolveOneActiveNav(ROUTES.PROFILE)).toBe("profile");
     expect(resolveOneActiveNav(ROUTES.PROFILE_RECEIPTS)).toBe("profile");
@@ -106,7 +106,7 @@ describe("app bottom navigation", () => {
     expect(resolveRiaActiveNav(ROUTES.RIA_HOME)).toBe("ria-home");
   });
 
-  it("keeps primary utilities constant across One, Finance, and RIA", () => {
+  it("keeps the shared workspace navigation available across route families", () => {
     for (const [pathname, scope] of [
       [ROUTES.CONNECTED_SYSTEMS, "one"],
       [ROUTES.KAI_ANALYSIS, "investor"],
@@ -114,6 +114,9 @@ describe("app bottom navigation", () => {
     ] as const) {
       expect(resolveBottomNavOptionKeys(pathname, scope)).toEqual([
         "dashboard",
+        "finance",
+        "portfolio",
+        "analysis",
         "connect",
         "search",
       ]);
@@ -155,15 +158,15 @@ describe("app bottom navigation", () => {
     expect(resolveRiaNavSlot(ROUTES.RIA_PICKS)).toBe("picks");
   });
 
-  it("keeps bottom utility selection independent of workspace scope", () => {
-    expect(resolveBottomNavActiveKey(ROUTES.AGENT, "one")).toBe("dashboard");
+  it("selects the active workspace destination", () => {
+    expect(resolveBottomNavActiveKey(ROUTES.AGENT, "one")).toBe("search");
     expect(resolveBottomNavActiveKey(ROUTES.KAI_ANALYSIS, "investor")).toBe(
       "analysis",
     );
     expect(resolveBottomNavActiveKey(ROUTES.RIA_CLIENTS, "ria")).toBe(
-      "clients",
+      "dashboard",
     );
-    expect(resolveBottomNavActiveKey(ROUTES.PROFILE, "ria")).toBe("profile");
+    expect(resolveBottomNavActiveKey(ROUTES.PROFILE, "ria")).toBe("dashboard");
     expect(resolveBottomNavContextKey(ROUTES.CONNECTED_SYSTEMS, "one")).toBe(
       "connected",
     );

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -1312,7 +1312,7 @@ export function AgentBar() {
           // it does not re-render the voice tree as the page scrolls.
           bottom: physicalNavbarAbsent
             ? "calc(var(--app-safe-area-bottom-effective) + 0.75rem)"
-            : "var(--agent-bar-with-nav-bottom)",
+            : "calc(var(--app-bottom-inset) + 0.12rem)",
         } as CSSProperties
       }
       aria-hidden={barHidden}

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -47,8 +47,8 @@ import {
 import { resolveAgentNavigationContextForPath } from "@/lib/navigation/agent-sections";
 import { openKaiCommandBar } from "@/lib/navigation/kai-command-bar-events";
 
-const BOTTOM_NAV_MAX_SLOT_COUNT = 3;
-const BOTTOM_NAV_SLOT_WIDTH_REM = 5.4;
+const BOTTOM_NAV_MAX_SLOT_COUNT = 6;
+const BOTTOM_NAV_SLOT_WIDTH_REM = 4.1;
 function resolveBottomNavMaxWidth(count: number): string {
   const slotCount = Math.min(Math.max(count, 1), BOTTOM_NAV_MAX_SLOT_COUNT);
   return `${slotCount * BOTTOM_NAV_SLOT_WIDTH_REM}rem`;
@@ -342,14 +342,7 @@ export const Navbar = () => {
     return null;
   }
 
-  const activeNav =
-    normalizedPathname === ROUTES.AGENT
-      ? "search"
-      : normalizedPathname.startsWith(ROUTES.CONNECT)
-        ? "connect"
-        : resolveBottomNavActiveKey(normalizedPathname, "one") === "profile"
-          ? "dashboard"
-          : "dashboard";
+  const activeNav = resolveBottomNavActiveKey(normalizedPathname, bottomNavScope);
   const activeSpecialistNav = resolveBottomNavContextKey(
     normalizedPathname,
     bottomNavScope,

--- a/hushh-webapp/lib/navigation/app-bottom-nav.ts
+++ b/hushh-webapp/lib/navigation/app-bottom-nav.ts
@@ -231,18 +231,35 @@ export function resolveRiaActiveNav(
 
 export function resolveBottomNavActiveKey(
   pathname: string | null | undefined,
-  scope: AppBottomNavScope,
+  _scope: AppBottomNavScope,
 ): AppBottomNavKey {
   const normalizedPathname = normalizeBottomNavPathname(pathname);
-  if (scope === "investor") {
-    return resolveInvestorActiveNav(pathname);
+  if (
+    normalizedPathname === ROUTES.HOME ||
+    normalizedPathname === ROUTES.ONE_HOME
+  ) {
+    return "dashboard";
   }
-  if (scope === "ria") {
-    return resolveRiaActiveNav(pathname);
+  if (normalizedPathname === ROUTES.AGENT) return "search";
+  if (isBottomNavRoute(normalizedPathname, ROUTES.CONNECT)) {
+    return "connect";
   }
-  return isBottomNavRoute(normalizedPathname, ROUTES.PROFILE)
-    ? "profile"
-    : "dashboard";
+  if (isBottomNavRoute(normalizedPathname, ROUTES.PROFILE)) {
+    return "profile";
+  }
+
+  if (
+    normalizedPathname.startsWith(ROUTES.KAI_HOME) ||
+    normalizedPathname.startsWith(ROUTES.LEGACY_KAI_HOME)
+  ) {
+    const activeTab = activeKaiRouteTabFromPath(normalizedPathname);
+    if (activeTab === "market") return "finance";
+    if (activeTab === "dashboard") return "portfolio";
+    if (activeTab === "analysis") return "analysis";
+    return "finance";
+  }
+
+  return "dashboard";
 }
 
 export function resolveBottomNavContextKey(
@@ -259,15 +276,13 @@ export function resolveBottomNavOptionKeys(
   _scope: AppBottomNavScope,
   _context?: AppBottomNavContext,
 ): AppBottomNavKey[] {
-  return ["dashboard", "connect", "search"];
+  return ["dashboard", "finance", "portfolio", "analysis", "connect", "search"];
 }
 
 /** Contextual workspace tabs render beside the stable primary navigation. */
 export function resolveBottomNavSpecialistOptionKeys(
-  scope: AppBottomNavScope,
+  _scope: AppBottomNavScope,
 ): AppBottomNavKey[] {
-  if (scope === "investor") return ["finance", "portfolio", "analysis"];
-  if (scope === "ria") return ["ria-home", "clients", "picks"];
   return [];
 }
 

--- a/hushh-webapp/lib/navigation/app-bottom-nav.ts
+++ b/hushh-webapp/lib/navigation/app-bottom-nav.ts
@@ -245,7 +245,9 @@ export function resolveBottomNavActiveKey(
     return "connect";
   }
   if (isBottomNavRoute(normalizedPathname, ROUTES.PROFILE)) {
-    return "profile";
+    // Profile is reached from One but is not a persistent bottom-bar option.
+    // Keep the visible control selected rather than pointing at a removed tab.
+    return "dashboard";
   }
 
   if (


### PR DESCRIPTION
## Summary
Fallback to the registered absolute transport endpoint when a legacy per-operation CRM endpoint is relative.

## Verification
- `pytest tests/test_connected_systems_service.py -q`
- Live schema rehearsal reached the MuleSoft endpoint; gateway currently returns 401, so no UAT deploy is claimed.

---
Closes #4562
(retroactive board-linkage backfill)

---
Closes #4580
(retroactive board-linkage backfill)