### PR TITLE
feat(crm): enforce schema capability contracts

### DIFF
--- a/consent-protocol/api/routes/connected_systems.py
+++ b/consent-protocol/api/routes/connected_systems.py
@@ -140,6 +140,19 @@ def _user_id(token_data: dict) -> str:
     return str(token_data.get("user_id") or "")
 
 
+def _legacy_create_aliases_to_record_fields(body: CrmCreateIntentRequest) -> dict[str, Any]:
+    """Keep Macy's wire aliases behind the schema-driven mutation boundary."""
+    fields = dict(body.additional_fields or {})
+    aliases = {
+        "Email": body.email,
+        "Phone": body.phone,
+        "FirstName": body.first_name,
+        "LastName": body.last_name,
+    }
+    fields.update({key: value for key, value in aliases.items() if value not in (None, "")})
+    return fields
+
+
 async def _require_signed_in_lister(
     background_tasks: BackgroundTasks,
     authorization: Optional[str] = Header(
@@ -269,24 +282,16 @@ async def create_connected_system_record_intent(
 ):
     service = get_connected_systems_service()
     try:
-        if body.record_fields is not None:
-            return await service.create_record_intent_from_fields(
-                user_id=_user_id(token_data),
-                system_id=system_id,
-                object_type=body.object_type,
-                record_fields=body.record_fields,
-            )
-        payload = {
-            "user_id": _user_id(token_data),
-            "system_id": system_id,
-            "object_type": body.object_type,
-            "email": body.email,
-            "phone": body.phone,
-            "first_name": body.first_name,
-            "last_name": body.last_name,
-            "additional_fields": body.additional_fields,
-        }
-        return service.create_record_intent(**payload)
+        return await service.create_record_intent_from_fields(
+            user_id=_user_id(token_data),
+            system_id=system_id,
+            object_type=body.object_type,
+            record_fields=(
+                body.record_fields
+                if body.record_fields is not None
+                else _legacy_create_aliases_to_record_fields(body)
+            ),
+        )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
 
@@ -299,24 +304,18 @@ async def update_connected_system_record_intent(
 ):
     service = get_connected_systems_service()
     try:
-        if body.record_fields is not None:
-            return await service.update_record_intent_from_fields(
-                user_id=_user_id(token_data),
-                system_id=system_id,
-                object_type=body.object_type,
-                record_id=body.record_id,
-                record_fields=body.record_fields,
-                readback_locator=body.readback_locator,
-            )
-        payload = {
-            "user_id": _user_id(token_data),
-            "system_id": system_id,
-            "object_type": body.object_type,
-            "record_id": body.record_id,
-            "additional_fields": body.additional_fields,
-            "readback_locator": body.readback_locator,
-        }
-        return service.update_record_intent(**payload)
+        return await service.update_record_intent_from_fields(
+            user_id=_user_id(token_data),
+            system_id=system_id,
+            object_type=body.object_type,
+            record_id=body.record_id,
+            record_fields=(
+                body.record_fields
+                if body.record_fields is not None
+                else dict(body.additional_fields or {})
+            ),
+            readback_locator=body.readback_locator,
+        )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
 

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -716,7 +716,8 @@
       "tool_name",
       "http_method",
       "path",
-      "description"
+      "description",
+      "response_contract"
     ],
     "trusted_connections": [
       "id",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 101,
+  "expected_migration_version": 102,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -791,7 +791,8 @@
       "http_method",
       "path",
       "description",
-      "mcp_endpoint"
+      "mcp_endpoint",
+      "response_contract"
     ],
     "trusted_connections": [
       "id",

--- a/consent-protocol/db/migrations/102_crm_operation_response_contract.sql
+++ b/consent-protocol/db/migrations/102_crm_operation_response_contract.sql
@@ -1,0 +1,42 @@
+-- Per-operation response contracts make the CRM registry the complete
+-- executable integration definition. The values are non-secret MCP response
+-- mappings; credentials remain on the parent registry row.
+--
+-- Schema contract v1 requires an explicit path to the field collection and
+-- field access metadata. A missing or incomplete field access declaration is
+-- display-only: runtime must never infer that a CRM field is readable or
+-- writable.
+
+BEGIN;
+
+ALTER TABLE crm_operation_endpoints
+  ADD COLUMN IF NOT EXISTS response_contract JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE crm_operation_endpoints
+  DROP CONSTRAINT IF EXISTS crm_operation_endpoints_response_contract_object;
+
+ALTER TABLE crm_operation_endpoints
+  ADD CONSTRAINT crm_operation_endpoints_response_contract_object
+  CHECK (jsonb_typeof(response_contract) = 'object');
+
+-- Existing Salesforce rows currently return their describe payload at
+-- details[0].fields. Backfill the response shape so the runtime can display
+-- the discovered field catalogue while it keeps record operations disabled
+-- until MuleSoft adds the v1 access flags to every descriptor.
+UPDATE crm_operation_endpoints
+SET response_contract = jsonb_build_object(
+  'version', 'crm-primary-object-schema.v1',
+  'fieldsPath', jsonb_build_array('payload', 'details', 0, 'fields'),
+  'objectPath', jsonb_build_array('payload', 'details', 0),
+  'requireFieldAccess', true
+)
+WHERE response_contract = '{}'::jsonb
+  AND operation = 'schema'
+  AND EXISTS (
+    SELECT 1
+    FROM enterprise_crm_registry registry
+    WHERE registry.crm_id = crm_operation_endpoints.crm_id
+      AND LOWER(COALESCE(registry.crm_type, '')) = 'salesforce'
+  );
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -79,7 +79,8 @@
     "098_pkm_v7_recovery_foundation.sql",
     "099_developer_oauth_pkce.sql",
     "100_connected_system_capability_contract.sql",
-    "101_backfill_crm_operation_endpoints.sql"
+    "101_backfill_crm_operation_endpoints.sql",
+    "102_crm_operation_response_contract.sql"
   ],
   "groups": {
     "iam": [
@@ -123,7 +124,8 @@
       "094_one_onboarding_callback_attempt_v1.sql",
       "095_one_kyc_needs_confirm_status.sql",
       "100_connected_system_capability_contract.sql",
-      "101_backfill_crm_operation_endpoints.sql"
+      "101_backfill_crm_operation_endpoints.sql",
+      "102_crm_operation_response_contract.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/docs/reference/developer-api.md
+++ b/consent-protocol/docs/reference/developer-api.md
@@ -94,7 +94,7 @@ Only authorization-code and refresh-token grants are supported. Client credentia
 | `GET` | `/api/v1/user-scopes/{user_id}` | Bearer header | Per-user discovered domains and scopes |
 | `GET` | `/api/v1/consent-status` | Bearer header | App-scoped consent status by scope or request id |
 | `POST` | `/api/v1/request-consent` | Bearer header | Create or reuse consent for one discovered scope |
-| `POST` | `/api/v1/scoped-export` | Bearer header | Return envelope metadata plus an authenticated ciphertext resource link |
+| `POST` | `/api/v1/scoped-export` | Bearer header | Return an encrypted-inline envelope and ciphertext in the response |
 
 ---
 
@@ -173,7 +173,7 @@ Authorization: Bearer <developer-token>
 }
 ```
 
-The response contains envelope metadata and an authenticated ciphertext resource link:
+The response contains envelope metadata and ciphertext directly in the authenticated response:
 
 ```json
 {

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -1,4 +1,4 @@
-"""Connected Systems registry and Salesforce CRM MCP adapter."""
+"""Capability-safe Connected Systems registry and CRM MCP adapter."""
 
 from __future__ import annotations
 
@@ -197,6 +197,158 @@ def _ensure_list(value: Any) -> list[Any]:
     return []
 
 
+def _response_contract(value: Any) -> dict[str, Any]:
+    """Return a defensive copy of non-secret registry response metadata."""
+    return _ensure_dict(value)
+
+
+def _contract_path(contract: dict[str, Any], key: str) -> tuple[str | int, ...] | None:
+    raw = contract.get(key)
+    if not isinstance(raw, (list, tuple)) or not raw:
+        return None
+    path: list[str | int] = []
+    for segment in raw:
+        if isinstance(segment, int) and segment >= 0:
+            path.append(segment)
+        elif isinstance(segment, str) and segment.strip() and len(segment.strip()) <= 80:
+            path.append(segment.strip())
+        else:
+            return None
+    return tuple(path)
+
+
+def _value_at_contract_path(value: Any, path: tuple[str | int, ...] | None) -> Any:
+    if not path:
+        return None
+    current = value
+    for segment in path:
+        if isinstance(segment, int):
+            if not isinstance(current, list) or segment >= len(current):
+                return None
+            current = current[segment]
+        else:
+            if not isinstance(current, dict):
+                return None
+            current = current.get(segment)
+    return current
+
+
+def _operation_response_contract(
+    system: "ConnectedSystemDefinition", operation: str
+) -> dict[str, Any]:
+    return _response_contract((system.operation(operation) or {}).get("responseContract"))
+
+
+def _has_contract_path(contract: dict[str, Any], key: str) -> bool:
+    return _contract_path(contract, key) is not None
+
+
+def _valid_operation_response_contract(operation: str, contract: dict[str, Any]) -> bool:
+    """Validate the small, non-executable response-mapping language.
+
+    The registry deliberately stores fixed path segments rather than JSONPath
+    expressions. A malformed mapping is configuration unavailable, never an
+    invitation to heuristically inspect an upstream CRM response.
+    """
+    version = str(contract.get("version") or "")
+    if operation == "schema":
+        return (
+            version == "crm-primary-object-schema.v1"
+            and _has_contract_path(contract, "fieldsPath")
+            and _has_contract_path(contract, "objectPath")
+            and isinstance(contract.get("requireFieldAccess"), bool)
+        )
+    if operation == "read":
+        return (
+            version == "crm-record-collection.v1"
+            and _has_contract_path(contract, "recordsPath")
+            and _has_contract_path(contract, "recordIdPath")
+        )
+    if operation in {"create", "update", "delete"}:
+        return (
+            version == "crm-mutation-result.v1"
+            and _has_contract_path(contract, "successPath")
+            and _has_contract_path(contract, "recordIdPath")
+            and isinstance(contract.get("successValue"), bool)
+        )
+    return False
+
+
+def _record_id_from_result(
+    result: dict[str, Any], *, response_contract: dict[str, Any] | None = None
+) -> str | None:
+    path = _contract_path(_response_contract(response_contract), "recordIdPath")
+    if path:
+        return _clean_text(_value_at_contract_path(result, path), max_length=128)
+    # The in-code test/demo connector predates registry response contracts.
+    # Production registry calls always provide a contract before reaching here.
+    return _extract_record_id(result)
+
+
+def _mutation_succeeded(
+    result: dict[str, Any], *, response_contract: dict[str, Any] | None = None
+) -> bool:
+    if result.get("isError"):
+        return False
+    contract = _response_contract(response_contract)
+    path = _contract_path(contract, "successPath")
+    if path:
+        return _value_at_contract_path(result, path) is contract.get("successValue")
+    # Compatibility for the deterministic in-code test adapter only.
+    return not result.get("isError")
+
+
+def _safe_record_value(value: Any) -> str | int | float | bool | None:
+    """Keep a normalized record projection scalar-only.
+
+    Related-record blobs and arbitrary nested tool content are not safe to
+    surface merely because the outer field name happened to be requested.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return None
+
+
+def _sanitize_read_records(
+    result: dict[str, Any],
+    *,
+    response_contract: dict[str, Any] | None,
+    allowed_fields: list[str],
+) -> list[dict[str, Any]]:
+    """Project a registered read collection onto explicitly requested fields."""
+    contract = _response_contract(response_contract)
+    records_path = _contract_path(contract, "recordsPath")
+    raw_records = _value_at_contract_path(result, records_path) if records_path else None
+    if not isinstance(raw_records, list):
+        # Compatibility-only fallback for the in-code adapter. Registry-backed
+        # connectors cannot reach this branch because their contract is checked
+        # before the outbound call.
+        raw_records = (
+            _records_from_payload(_ensure_dict(result.get("payload"))) if not contract else []
+        )
+    allowed = [str(field) for field in dict.fromkeys(allowed_fields) if str(field).strip()]
+    sanitized: list[dict[str, Any]] = []
+    for record in raw_records:
+        if not isinstance(record, dict):
+            continue
+        record_allowed = allowed if contract else [str(key) for key in record]
+        by_lower = {str(key).lower(): value for key, value in record.items()}
+        fields: dict[str, str | int | float | bool | None] = {}
+        for field_name in record_allowed:
+            value = record.get(field_name, by_lower.get(field_name.lower()))
+            safe_value = _safe_record_value(value)
+            if value is None or safe_value is not None:
+                fields[field_name] = safe_value
+        record_id = _clean_text(
+            _value_at_contract_path(record, _contract_path(contract, "recordIdPath")),
+            max_length=128,
+        )
+        if not record_id and not contract:
+            record_id = _extract_record_id({"payload": record})
+        sanitized.append({"recordId": record_id, "fields": fields})
+    return sanitized
+
+
 def _normalize_object_type(object_type: str | None, *, default: str) -> str:
     value = _clean_text(object_type or default, max_length=80)
     if not value:
@@ -214,7 +366,7 @@ def _normalize_field_name(field_name: str) -> str:
     canonical = canonical or raw
     if canonical not in SUPPORTED_CRM_FIELDS:
         raise ConnectedSystemValidationError(
-            f"Unsupported Salesforce CRM field: {raw}",
+            f"Unsupported CRM field: {raw}",
             code="UNSUPPORTED_CRM_FIELD",
         )
     return canonical
@@ -227,7 +379,7 @@ def _canonical_schema_field_name(field_name: Any) -> str | None:
     canonical = _CRM_FIELD_ALIASES.get(raw.replace(" ", "").lower()) or _CRM_FIELD_ALIASES.get(
         raw.lower()
     )
-    # Schema field names are owned by the active CRM. The Salesforce aliases
+    # Schema field names are owned by the active CRM. The legacy aliases
     # remain only for the compatibility adapter below; never discard a field
     # simply because another CRM uses a different vocabulary.
     return canonical or raw
@@ -265,7 +417,82 @@ def _schema_type_from_descriptor(descriptor: Any) -> str | None:
     return None
 
 
-def _collect_schema_field_descriptors(node: Any) -> list[Any]:
+def _schema_constraints_from_descriptor(descriptor: Any) -> dict[str, Any]:
+    """Normalize the portable subset of schema constraints for the UI/API."""
+    source = _ensure_dict(descriptor)
+    constraints = _ensure_dict(source.get("constraints"))
+    max_length = source.get("maxLength", source.get("length"))
+    if isinstance(max_length, int) and max_length > 0:
+        constraints["maxLength"] = max_length
+    allowed_values = source.get("allowedValues", source.get("picklistValues"))
+    if isinstance(allowed_values, list):
+        normalized_values: list[str] = []
+        for value in allowed_values:
+            if isinstance(value, str) and value.strip():
+                normalized_values.append(value.strip())
+            elif isinstance(value, dict):
+                candidate = _clean_text(value.get("value", value.get("label")), max_length=240)
+                if candidate:
+                    normalized_values.append(candidate)
+        if normalized_values:
+            constraints["allowedValues"] = list(dict.fromkeys(normalized_values))
+    return constraints
+
+
+def _schema_object_metadata(
+    result: dict[str, Any],
+    *,
+    response_contract: dict[str, Any] | None,
+    default_object_type: str,
+) -> dict[str, str]:
+    """Expose only registered primary-object metadata, never its raw envelope."""
+    contract = _response_contract(response_contract)
+    object_node = _value_at_contract_path(result, _contract_path(contract, "objectPath"))
+    source = _ensure_dict(object_node)
+    name = (
+        _clean_text(
+            source.get(
+                "objectType", source.get("apiName", source.get("name", default_object_type))
+            ),
+            max_length=80,
+        )
+        or default_object_type
+    )
+    label = (
+        _clean_text(
+            source.get("objectLabel", source.get("displayName", source.get("label", name))),
+            max_length=120,
+        )
+        or name
+    )
+    return {"name": name, "label": label}
+
+
+def _collect_schema_field_descriptors(
+    node: Any, *, response_contract: dict[str, Any] | None = None
+) -> list[Any]:
+    """Collect descriptors only from the registered schema response shape.
+
+    The legacy recursive extractor is retained for deterministic in-code test
+    fixtures. Registry-backed integrations must declare ``fieldsPath`` so a
+    new CRM cannot become writable because its response happened to contain a
+    similarly named nested key.
+    """
+    contract = _response_contract(response_contract)
+    fields_path = _contract_path(contract, "fieldsPath")
+    if fields_path:
+        value = _value_at_contract_path(node, fields_path)
+        if isinstance(value, (list, tuple)):
+            return list(value)
+        if isinstance(value, dict):
+            return [
+                {"name": str(field_name), **descriptor}
+                if isinstance(descriptor, dict)
+                else str(field_name)
+                for field_name, descriptor in value.items()
+            ]
+        return []
+
     descriptors: list[Any] = []
     if not isinstance(node, dict):
         return descriptors
@@ -297,7 +524,9 @@ def _collect_schema_field_descriptors(node: Any) -> list[Any]:
     return descriptors
 
 
-def _collect_schema_required_candidates(node: Any) -> list[str]:
+def _collect_schema_required_candidates(
+    node: Any, *, response_contract: dict[str, Any] | None = None
+) -> list[str]:
     candidates: list[str] = []
     if not isinstance(node, dict):
         return candidates
@@ -330,10 +559,14 @@ def _descriptor_bool(descriptor: Any, *names: str) -> bool | None:
     return None
 
 
-def _schema_fields_from_schema_result(result: dict[str, Any]) -> list[dict[str, Any]]:
+def _schema_fields_from_schema_result(
+    result: dict[str, Any], *, response_contract: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    contract = _response_contract(response_contract)
+    strict_access = bool(contract.get("requireFieldAccess"))
     required_fields = {
         canonical
-        for candidate in _collect_schema_required_candidates(result)
+        for candidate in _collect_schema_required_candidates(result, response_contract=contract)
         if (canonical := _canonical_schema_field_name(candidate))
     }
     fields: list[dict[str, Any]] = []
@@ -354,10 +587,33 @@ def _schema_fields_from_schema_result(result: dict[str, Any]) -> list[dict[str, 
         )
         immutable = _descriptor_bool(descriptor, "immutable", "readOnly")
         readable = _descriptor_bool(descriptor, "readable", "isReadable")
-        writable = _descriptor_bool(
-            descriptor, "writable", "isWritable", "updateable", "createable"
-        )
+        createable = _descriptor_bool(descriptor, "createable", "isCreateable")
+        updateable = _descriptor_bool(descriptor, "updateable", "isUpdateable")
         descriptor_required = _descriptor_bool(descriptor, "required", "isRequired")
+        permissions_declared = all(
+            value is not None for value in (identity, immutable, readable, createable, updateable)
+        )
+        if strict_access:
+            # Missing field permissions are unknown, never an allow. In
+            # particular, writable is *derived* from the two operation-specific
+            # declarations; an upstream `writable` convenience bit cannot
+            # expand create or update authority.
+            identity = bool(identity)
+            immutable = bool(immutable)
+            readable = bool(readable)
+            createable = bool(createable)
+            updateable = bool(updateable)
+            writable = bool(createable or updateable)
+        else:
+            # Deterministic in-code fixtures predate the database registry.
+            # They remain wire-compatible only; all registry rows set
+            # requireFieldAccess and take the fail-closed branch above.
+            immutable = bool(immutable)
+            identity = bool(identity)
+            readable = True if readable is None else readable
+            createable = (not immutable) if createable is None else createable
+            updateable = (not immutable) if updateable is None else updateable
+            writable = bool(createable or updateable)
         fields.append(
             {
                 "key": canonical,
@@ -366,15 +622,18 @@ def _schema_fields_from_schema_result(result: dict[str, Any]) -> list[dict[str, 
                 "dataType": _schema_type_from_descriptor(descriptor) or "string",
                 "required": bool(descriptor_required) or canonical in required_fields,
                 "identityField": bool(identity),
-                "readable": True if readable is None else readable,
-                "writable": (not bool(immutable)) if writable is None else writable,
+                "readable": bool(readable),
+                "createable": bool(createable),
+                "updateable": bool(updateable),
+                "writable": bool(writable),
                 "immutable": bool(immutable),
-                "constraints": _ensure_dict(descriptor).get("constraints") or {},
+                "permissionsDeclared": permissions_declared,
+                "constraints": _schema_constraints_from_descriptor(descriptor),
                 "source": source,
             }
         )
 
-    for descriptor in _collect_schema_field_descriptors(result):
+    for descriptor in _collect_schema_field_descriptors(result, response_contract=contract):
         raw_name = _schema_field_name_from_descriptor(descriptor)
         canonical = _canonical_schema_field_name(raw_name)
         if canonical:
@@ -417,7 +676,7 @@ def _normalize_search_field_name(field_name: str) -> str:
     canonical = canonical or raw
     if canonical not in SUPPORTED_CRM_SEARCH_FIELDS:
         raise ConnectedSystemValidationError(
-            f"Unsupported Salesforce CRM search field: {raw}",
+            f"Unsupported CRM search field: {raw}",
             code="UNSUPPORTED_CRM_FIELD",
         )
     return canonical
@@ -458,6 +717,30 @@ def _binding_id() -> str:
 def _safe_error_message(error: Exception) -> str:
     message = _redact_error_text(_clean_text(str(error), max_length=240))
     return message or "Connected Systems request failed."
+
+
+def _http_status_from_error(error: BaseException, *, _seen: set[int] | None = None) -> int | None:
+    """Find a nested HTTP status without serialising a provider exception."""
+    seen = _seen if _seen is not None else set()
+    if id(error) in seen:
+        return None
+    seen.add(id(error))
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+    nested = getattr(error, "exceptions", None)
+    if isinstance(nested, (tuple, list)):
+        for child in nested:
+            status = _http_status_from_error(child, _seen=seen)
+            if status is not None:
+                return status
+    for nested_error in (getattr(error, "__cause__", None), getattr(error, "__context__", None)):
+        if isinstance(nested_error, BaseException):
+            status = _http_status_from_error(nested_error, _seen=seen)
+            if status is not None:
+                return status
+    return None
 
 
 def _connected_systems_storage_error(error: DatabaseExecutionError) -> ConnectedSystemsError:
@@ -676,6 +959,13 @@ class ConnectedSystemDefinition:
             return False
         if operation != "schema" and not self.operation("schema"):
             return False
+        if (
+            self.registry_source == "enterprise_crm_registry"
+            and not _valid_operation_response_contract(
+                operation, _operation_response_contract(self, operation)
+            )
+        ):
+            return False
         return bool(self.operation_endpoint("schema"))
 
     def to_summary(self, *, endpoint_configured: bool, delete_enabled: bool) -> dict[str, Any]:
@@ -696,7 +986,14 @@ class ConnectedSystemDefinition:
             "transportLabel": "External CRM MCP",
             "endpointConfigured": endpoint_configured,
             "registrySource": self.registry_source,
-            "toolCatalog": [_deepcopy_json(tool) for tool in self.tool_catalog],
+            "toolCatalog": [
+                {
+                    key: _deepcopy_json(value)
+                    for key, value in tool.items()
+                    if key != "responseContract"
+                }
+                for tool in self.tool_catalog
+            ],
             "supportedActions": supported_actions,
             "capabilities": {
                 "operations": [
@@ -725,7 +1022,7 @@ SALESFORCE_CRM_SYSTEM = ConnectedSystemDefinition(
 
 
 class ExternalCrmStreamableMcpAdapter:
-    """Calls the Salesforce external CRM through MCP streamable HTTP."""
+    """Calls a registered external CRM through MCP Streamable HTTP."""
 
     def __init__(
         self,
@@ -825,7 +1122,12 @@ class ExternalCrmStreamableMcpAdapter:
         resolved_endpoint = endpoint or self.endpoint
         if not resolved_endpoint:
             raise ConnectedSystemConfigurationError(
-                "Connected Systems registry does not include a Salesforce CRM MCP endpoint."
+                "Connected Systems registry does not include a CRM MCP endpoint."
+            )
+        if resolved_endpoint == REGISTRY_MCP_ENDPOINT and not self.headers:
+            raise ConnectedSystemConfigurationError(
+                "This connected system is not configured in this environment.",
+                code="CONNECTED_SYSTEM_GATEWAY_AUTH_UNCONFIGURED",
             )
         if resolved_endpoint.startswith("registry://"):
             return self._call_registry_tool(name, arguments)
@@ -859,21 +1161,39 @@ class ExternalCrmStreamableMcpAdapter:
             raise
         except TimeoutError as error:
             raise ConnectedSystemsError(
-                "Salesforce CRM MCP request timed out.",
+                "Connected system request timed out.",
                 code="CONNECTED_SYSTEM_MCP_TIMEOUT",
                 status_code=504,
             ) from error
         except Exception as error:
+            gateway_status = _http_status_from_error(error)
             logger.exception(
                 "connected_systems.crm_mcp_request_failed tool=%s endpoint_configured=%s "
-                "headers_present=%s tool_argument_keys=%s",
+                "headers_present=%s gateway_status=%s tool_argument_keys=%s",
                 name,
                 bool(self.endpoint),
                 bool(self.headers),
+                gateway_status,
                 _stable_keys(tool_arguments),
             )
+            if gateway_status in {401, 403}:
+                code = (
+                    "CONNECTED_SYSTEM_MCP_AUTH_FAILED"
+                    if gateway_status == 401
+                    else "CONNECTED_SYSTEM_MCP_ACCESS_DENIED"
+                )
+                message = (
+                    "The connected system gateway rejected this environment's authentication."
+                    if gateway_status == 401
+                    else "The connected system gateway denied this environment access."
+                )
+                raise ConnectedSystemConfigurationError(
+                    message,
+                    code=code,
+                    status_code=502,
+                ) from error
             raise ConnectedSystemsError(
-                "Salesforce CRM MCP request failed.",
+                "Connected system request failed.",
                 code="CONNECTED_SYSTEM_MCP_FAILED",
                 status_code=502,
             ) from error
@@ -1515,7 +1835,7 @@ class ConnectedSystemsService:
             # never use this override for a real HTTP endpoint.
             if str(getattr(adapter, "endpoint", "")).startswith("registry://"):
                 endpoint = str(adapter.endpoint)
-            return await adapter.call_operation(
+            result = await adapter.call_operation(
                 operation=operation,
                 tool_name=str(config.get("name") or ""),
                 endpoint=endpoint,
@@ -1523,14 +1843,22 @@ class ConnectedSystemsService:
                 retry_count=system.retry_count,
                 arguments=payload,
             )
-        legacy_method = {
-            "schema": "object_schema",
-            "read": "read_record",
-            "create": "create_record",
-            "update": "update_record",
-            "delete": "delete_record",
-        }[operation]
-        return await getattr(adapter, legacy_method)(payload)
+        else:
+            legacy_method = {
+                "schema": "object_schema",
+                "read": "read_record",
+                "create": "create_record",
+                "update": "update_record",
+                "delete": "delete_record",
+            }[operation]
+            result = await getattr(adapter, legacy_method)(payload)
+        if result.get("isError"):
+            raise ConnectedSystemsError(
+                _mcp_error_message(result),
+                code="CONNECTED_SYSTEM_MCP_TOOL_ERROR",
+                status_code=502,
+            )
+        return result
 
     def list_systems(self) -> list[dict[str, Any]]:
         # Registry entries are operational configuration. Unlike an explicit
@@ -1588,25 +1916,85 @@ class ConnectedSystemsService:
     async def get_schema(self, *, system_id: str, object_type: str | None = None) -> dict[str, Any]:
         system = self.get_system(system_id)
         self._require_operation(system, "schema")
+        response_contract = _operation_response_contract(system, "schema")
+        if system.registry_source == "enterprise_crm_registry" and (
+            response_contract.get("version") != "crm-primary-object-schema.v1"
+            or not _contract_path(response_contract, "fieldsPath")
+            or not _contract_path(response_contract, "objectPath")
+        ):
+            raise ConnectedSystemConfigurationError(
+                "This connected system needs an updated field contract before it can be used.",
+                code="CONNECTED_SYSTEM_SCHEMA_CONTRACT_UNCONFIGURED",
+            )
         payload = {
             "target": system.target,
             "objectType": _normalize_object_type(object_type, default=system.object_type_default),
         }
         result = await self._call_operation(system=system, operation="schema", payload=payload)
-        schema_fields = _schema_fields_from_schema_result(result)
+        schema_fields = _schema_fields_from_schema_result(
+            result, response_contract=response_contract
+        )
         if not schema_fields:
             raise ConnectedSystemConfigurationError(
                 "The connected system did not return a usable primary-object schema.",
                 code="CONNECTED_SYSTEM_SCHEMA_UNAVAILABLE",
             )
+        object_metadata = _schema_object_metadata(
+            result,
+            response_contract=response_contract,
+            default_object_type=payload["objectType"],
+        )
+        permissions_complete = (
+            all(field.get("permissionsDeclared") for field in schema_fields)
+            if response_contract.get("requireFieldAccess") is True
+            else True
+        )
+        has_readable_identity = (
+            any(field.get("readable") and field.get("identityField") for field in schema_fields)
+            or response_contract.get("requireFieldAccess") is not True
+        )
+        effective_actions = {
+            "schema": True,
+            "read": bool(
+                permissions_complete and has_readable_identity and system.supports("read")
+            ),
+            "create": bool(
+                permissions_complete
+                and any(field.get("createable") for field in schema_fields)
+                and system.supports("create")
+            ),
+            "update": bool(
+                permissions_complete
+                and any(field.get("updateable") for field in schema_fields)
+                and system.supports("update")
+            ),
+            "delete": bool(
+                permissions_complete and system.supports("delete") and self.delete_enabled
+            ),
+        }
         return {
             "systemId": system.system_id,
             "target": system.target,
             "objectType": payload["objectType"],
+            "objectMetadata": object_metadata,
             "supportedFields": [field["key"] for field in schema_fields],
             "fields": schema_fields,
-            "mcp": result,
+            "schemaStatus": "ready" if permissions_complete else "capability_metadata_missing",
+            "effectiveActions": effective_actions,
+            "configurationMessage": (
+                None
+                if permissions_complete
+                else "This connected system needs an update before its fields can be used."
+            ),
         }
+
+    @staticmethod
+    def _require_schema_action(schema: dict[str, Any], action: str) -> None:
+        if not _ensure_dict(schema.get("effectiveActions")).get(action):
+            raise ConnectedSystemBlockedError(
+                "This connected system does not currently authorize that record action.",
+                code="CONNECTED_SYSTEM_SCHEMA_CAPABILITY_UNAVAILABLE",
+            )
 
     @staticmethod
     def _validated_schema_fields(
@@ -1628,13 +2016,17 @@ class ConnectedSystemsService:
                     code="CONNECTED_SYSTEM_SCHEMA_FIELD_UNAVAILABLE",
                 )
             if action == "update" and (
-                field.get("immutable") or field.get("identityField") or not field.get("writable")
+                field.get("immutable")
+                or field.get("identityField")
+                or field.get("updateable") is not True
             ):
                 raise ConnectedSystemValidationError(
                     f"Field cannot be updated: {key}",
                     code="CONNECTED_SYSTEM_SCHEMA_FIELD_READ_ONLY",
                 )
-            if action == "create" and (field.get("immutable") or not field.get("writable")):
+            if action == "create" and (
+                field.get("immutable") or field.get("createable") is not True
+            ):
                 raise ConnectedSystemValidationError(
                     f"Field cannot be written: {key}",
                     code="CONNECTED_SYSTEM_SCHEMA_FIELD_READ_ONLY",
@@ -1666,6 +2058,7 @@ class ConnectedSystemsService:
         system = self.get_system(system_id)
         self._require_operation(system, "create")
         schema = await self.get_schema(system_id=system_id, object_type=object_type)
+        self._require_schema_action(schema, "create")
         fields = {str(field["key"]): field for field in schema["fields"]}
         normalized = self._validated_schema_fields(
             fields, record_fields, action="create", require_required_fields=True
@@ -1724,6 +2117,7 @@ class ConnectedSystemsService:
         if not record_id_value:
             raise ConnectedSystemValidationError("id is required for update.")
         schema = await self.get_schema(system_id=system_id, object_type=object_type)
+        self._require_schema_action(schema, "update")
         fields = {str(field["key"]): field for field in schema["fields"]}
         normalized = self._validated_schema_fields(fields, record_fields, action="update")
         object_type_value = str(schema["objectType"])
@@ -1811,7 +2205,21 @@ class ConnectedSystemsService:
             return_fields=return_fields,
         )
         system = self.get_system(system_id)
+        read_contract = _operation_response_contract(system, "read")
+        if system.registry_source == "enterprise_crm_registry" and (
+            read_contract.get("version") != "crm-record-collection.v1"
+            or not _contract_path(read_contract, "recordsPath")
+        ):
+            raise ConnectedSystemConfigurationError(
+                "This connected system needs an updated record contract before it can be used.",
+                code="CONNECTED_SYSTEM_READ_CONTRACT_UNCONFIGURED",
+            )
         result = await self._call_operation(system=system, operation="read", payload=payload)
+        records = _sanitize_read_records(
+            result,
+            response_contract=read_contract,
+            allowed_fields=list(payload.get("returnFields") or []),
+        )
         self._audit(
             user_id=user_id or "",
             system_id=system_id,
@@ -1830,8 +2238,11 @@ class ConnectedSystemsService:
             "target": payload["target"],
             "objectType": payload["objectType"],
             "resultClass": "succeeded" if not result.get("isError") else "failed",
-            "recordId": _extract_record_id(result),
-            "mcp": result,
+            "recordId": next(
+                (record["recordId"] for record in records if record.get("recordId")),
+                _record_id_from_result(result, response_contract=read_contract),
+            ),
+            "records": records,
         }
 
     async def _build_schema_read_payload(
@@ -1846,8 +2257,9 @@ class ConnectedSystemsService:
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
         schema = await self.get_schema(system_id=system_id, object_type=object_type)
+        self._require_schema_action(schema, "read")
         fields = {
-            str(field["key"]): field for field in schema["fields"] if field.get("readable", True)
+            str(field["key"]): field for field in schema["fields"] if field.get("readable") is True
         }
         by_name = {str(field["name"]): field for field in fields.values()}
         # Macy's aliases remain a compatibility input only. They cannot make a
@@ -2018,6 +2430,11 @@ class ConnectedSystemsService:
         record_fields: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
+        if system.registry_source == "enterprise_crm_registry":
+            raise ConnectedSystemBlockedError(
+                "Use the schema-driven recordFields contract for this connected system.",
+                code="CONNECTED_SYSTEM_SCHEMA_FIELDS_REQUIRED",
+            )
         object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
         email_value = _clean_text(email, max_length=320)
         phone_value = _normalize_crm_phone_for_mcp(phone)
@@ -2079,6 +2496,11 @@ class ConnectedSystemsService:
         readback_locator: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
+        if system.registry_source == "enterprise_crm_registry":
+            raise ConnectedSystemBlockedError(
+                "Use the schema-driven recordFields contract for this connected system.",
+                code="CONNECTED_SYSTEM_SCHEMA_FIELDS_REQUIRED",
+            )
         object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
         record_id_value = _clean_text(record_id, max_length=128)
         if not record_id_value:
@@ -2177,6 +2599,14 @@ class ConnectedSystemsService:
         if intent.get("approval_id") != approval:
             return self._public_intent(intent)
         try:
+            if system.registry_source == "enterprise_crm_registry":
+                schema = await self.get_schema(
+                    system_id=system_id, object_type=intent.get("object_type")
+                )
+                self._require_schema_action(schema, str(intent.get("action") or ""))
+            response_contract = _operation_response_contract(
+                system, str(intent.get("action") or "")
+            )
             if intent["action"] == "create":
                 result = await self._call_operation(
                     system=system, operation="create", payload=intent["request_payload"]
@@ -2191,20 +2621,27 @@ class ConnectedSystemsService:
                 )
             else:
                 raise ConnectedSystemValidationError("Unsupported approval action.")
-            record_id = intent.get("record_id") or _extract_record_id(result)
+            mutation_succeeded = _mutation_succeeded(result, response_contract=response_contract)
+            record_id = intent.get("record_id") or _record_id_from_result(
+                result, response_contract=response_contract
+            )
             readback = (
                 {"resultClass": "succeeded", "reason": "delete_confirmed"}
-                if intent["action"] == "delete" and not result.get("isError")
+                if intent["action"] == "delete" and mutation_succeeded
                 else await self._readback(intent, system=system)
             )
-            if not record_id and isinstance(readback.get("mcp"), dict):
-                record_id = _extract_record_id(readback.get("mcp") or {})
+            if not record_id:
+                record_id = _clean_text(readback.get("recordId"), max_length=128)
             readback_class = self._classify_readback(intent, readback)
-            result_class = "failed" if result.get("isError") else readback_class
+            result_class = "failed" if not mutation_succeeded else readback_class
             status = "succeeded" if result_class == "succeeded" else result_class
-            if result.get("isError"):
+            if not mutation_succeeded:
                 status = "failed"
-            mcp_error_message = _mcp_error_message(result) if status == "failed" else None
+            mcp_error_message = (
+                "The connected system did not confirm this mutation."
+                if status == "failed"
+                else None
+            )
             terminal_updates = _scrub_terminal_intent_updates(
                 intent,
                 {
@@ -2214,7 +2651,9 @@ class ConnectedSystemsService:
                     "result_class": result_class,
                     "result_payload": result,
                     "readback_result": readback,
-                    "error_code": None if status != "failed" else "MCP_RESULT_ERROR",
+                    "error_code": None
+                    if status != "failed"
+                    else "CONNECTED_SYSTEM_MUTATION_UNCONFIRMED",
                     "error_message": mcp_error_message,
                 },
             )
@@ -2237,7 +2676,7 @@ class ConnectedSystemsService:
                 binding = self._upsert_binding_for_intent(updated, record_id=record_id)
             self._audit_for_intent(
                 updated,
-                mcp_result_class="succeeded" if not result.get("isError") else "failed",
+                mcp_result_class="succeeded" if mutation_succeeded else "failed",
                 readback_result_class=readback_class,
                 status=status,
             )
@@ -2303,59 +2742,11 @@ class ConnectedSystemsService:
         object_type: str | None,
         record_id: str | None = None,
     ) -> dict[str, Any]:
-        system = self.get_system(system_id)
-        self._require_operation(system, "delete")
-        object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
-        binding = None
-        if user_id:
-            binding = self._store_call(
-                self.store.get_binding,
-                user_id=user_id,
-                system_id=system_id,
-                object_type=object_type_value,
-            )
-        bound_record_id = _clean_text((binding or {}).get("record_id"), max_length=128)
-        requested_record_id = _clean_text(record_id, max_length=128)
-        record_id_value = requested_record_id or bound_record_id
-        payload = {
-            "target": system.target,
-            "objectType": object_type_value,
-            "id": record_id_value,
-        }
-        if not payload["id"]:
-            raise ConnectedSystemValidationError("id is required for delete.")
-        result = await self._call_operation(system=system, operation="delete", payload=payload)
-        status = "failed" if result.get("isError") else "succeeded"
-        deleted_binding = None
-        if user_id and status == "succeeded":
-            deleted_binding = self._store_call(
-                self.store.mark_binding_deleted,
-                user_id=user_id,
-                system_id=system_id,
-                object_type=object_type_value,
-                record_id=payload["id"],
-            )
-        self._audit(
-            user_id=user_id or "",
-            system_id=system_id,
-            action="delete",
-            object_type=object_type_value,
-            record_id=payload["id"],
-            field_names=[],
-            mcp_result_class=status,
-            readback_result_class=None,
-            status=status,
-            metadata=_summarize_mcp_result(result),
+        _ = (user_id, system_id, object_type, record_id)
+        raise ConnectedSystemBlockedError(
+            "Delete must be created and approved as a CRM intent.",
+            code="CONNECTED_SYSTEM_DELETE_INTENT_REQUIRED",
         )
-        return {
-            "systemId": system_id,
-            "target": system.target,
-            "objectType": object_type_value,
-            "recordId": payload["id"],
-            "resultClass": status,
-            "mcp": result,
-            "binding": self._public_binding(deleted_binding) if deleted_binding else None,
-        }
 
     def _build_read_payload(
         self,
@@ -2455,9 +2846,19 @@ class ConnectedSystemsService:
             result = await self._call_operation(
                 system=system, operation="read", payload=readback_payload
             )
+            response_contract = _operation_response_contract(system, "read")
+            records = _sanitize_read_records(
+                result,
+                response_contract=response_contract,
+                allowed_fields=list(readback_payload.get("returnFields") or []),
+            )
             return {
-                "resultClass": "succeeded" if not result.get("isError") else "failed",
-                "mcp": result,
+                "resultClass": "succeeded",
+                "recordId": next(
+                    (record["recordId"] for record in records if record.get("recordId")),
+                    _record_id_from_result(result, response_contract=response_contract),
+                ),
+                "records": records,
             }
         except Exception as error:
             return {
@@ -2651,8 +3052,14 @@ def _extract_record_id(result: dict[str, Any]) -> str | None:
 
 
 def _records_from_readback(readback: dict[str, Any]) -> list[dict[str, Any]]:
-    payload = _ensure_dict(_ensure_dict(readback.get("mcp")).get("payload"))
-    return _records_from_payload(payload)
+    records: list[dict[str, Any]] = []
+    for record in _ensure_list(readback.get("records")):
+        if not isinstance(record, dict):
+            continue
+        fields = _ensure_dict(record.get("fields"))
+        if fields:
+            records.append(fields)
+    return records
 
 
 def _records_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
@@ -2669,6 +3076,8 @@ def _records_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _expected_readback_fields(intent: dict[str, Any]) -> dict[str, Any]:
     payload = intent.get("request_payload") or {}
+    if isinstance(payload.get("recordFields"), dict):
+        return _ensure_dict(payload.get("recordFields"))
     if intent.get("action") == "update":
         return _ensure_dict(payload.get("additionalFields"))
     if intent.get("action") == "create":

--- a/consent-protocol/hushh_mcp/services/crm_registry_repo.py
+++ b/consent-protocol/hushh_mcp/services/crm_registry_repo.py
@@ -12,6 +12,7 @@ request path.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 from urllib.parse import urljoin
@@ -150,7 +151,7 @@ def _public_system_id(row: dict[str, Any]) -> str:
 def _tool_catalog(row_crm_id: str, database: Any) -> tuple[dict[str, Any], ...]:
     operation_rows = database.execute_raw(
         """
-        SELECT operation, tool_name, http_method, path, description, mcp_endpoint
+        SELECT operation, tool_name, http_method, path, description, mcp_endpoint, response_contract
         FROM crm_operation_endpoints
         WHERE crm_id = :crm_id
         """,
@@ -332,9 +333,25 @@ def _tool_catalog_from_rows(rows: list[dict[str, Any]]) -> tuple[dict[str, Any],
                 "operation": operation,
                 "description": str(row.get("description") or "").strip(),
                 "mcpEndpoint": str(row.get("mcp_endpoint") or "").strip() or None,
+                # This is non-secret registry metadata. It controls how the
+                # backend decodes a tool response and is never supplied by a
+                # browser request.
+                "responseContract": _response_contract(row.get("response_contract")),
             }
         )
     return tuple(catalog)
+
+
+def _response_contract(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
 
 
 def load_active_definition(

--- a/consent-protocol/tests/test_connected_systems_migration.py
+++ b/consent-protocol/tests/test_connected_systems_migration.py
@@ -49,3 +49,22 @@ def test_connected_systems_tables_are_contract_required_and_secret_free():
     assert "endpoint" not in all_columns
     assert "token" not in all_columns
     assert "credential" not in all_columns
+
+
+def test_response_contract_migration_is_registered_and_fail_closed_by_default():
+    migration = ROOT / "db" / "migrations" / "102_crm_operation_response_contract.sql"
+    manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text())
+    uat_contract = json.loads(
+        (ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text()
+    )
+
+    assert migration.exists()
+    assert manifest["ordered_migrations"][-1] == "102_crm_operation_response_contract.sql"
+    assert "102_crm_operation_response_contract.sql" in manifest["groups"]["iam"]
+    assert "response_contract JSONB NOT NULL DEFAULT '{}'::jsonb" in migration.read_text()
+    migration_text = migration.read_text()
+    assert "AND operation = 'schema'" in migration_text
+    assert "'objectPath'" in migration_text
+    assert "'requireFieldAccess', true" in migration_text
+    assert "response_contract" in uat_contract["required_tables"]["crm_operation_endpoints"]
+    assert uat_contract["expected_migration_version"] == 102

--- a/consent-protocol/tests/test_connected_systems_routes.py
+++ b/consent-protocol/tests/test_connected_systems_routes.py
@@ -35,7 +35,7 @@ class FakeConnectedSystemsService:
             }
         ]
 
-    def create_record_intent(self, **kwargs):
+    async def create_record_intent_from_fields(self, **kwargs):
         self.created_payload = kwargs
         return {
             "intentId": "csi_test",
@@ -84,7 +84,7 @@ class FakeConnectedSystemsService:
             "mcp": {"isError": False, "payload": {"Contact": [{"Id": "003gK00000demoQAA"}]}},
         }
 
-    def update_record_intent(self, **kwargs):
+    async def update_record_intent_from_fields(self, **kwargs):
         self.updated_payload = kwargs
         return {
             "intentId": "csi_update_test",
@@ -199,11 +199,13 @@ def test_create_intent_route_accepts_live_mcp_camel_case_shape(monkeypatch):
         "user_id": "user_123",
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
-        "email": "doe.john@abc.com",
-        "phone": "1234567899",
-        "first_name": "John",
-        "last_name": "Doe",
-        "additional_fields": {"Title": "VP Sales"},
+        "record_fields": {
+            "Email": "doe.john@abc.com",
+            "Phone": "1234567899",
+            "FirstName": "John",
+            "LastName": "Doe",
+            "Title": "VP Sales",
+        },
     }
 
 
@@ -308,7 +310,7 @@ def test_update_intent_route_accepts_updated_mcp_id_and_additional_fields(monkey
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
         "record_id": "003gK00000m36zhQAA",
-        "additional_fields": {"MailingCity": "New York"},
+        "record_fields": {"MailingCity": "New York"},
         "readback_locator": None,
     }
 

--- a/consent-protocol/tests/test_connected_systems_service.py
+++ b/consent-protocol/tests/test_connected_systems_service.py
@@ -7,8 +7,10 @@ import pytest
 from hushh_mcp.services.connected_systems_service import (
     CONNECTED_SYSTEM_SALESFORCE_ID,
     EXTERNAL_CRM_TOOL_CATALOG,
+    REGISTRY_MCP_ENDPOINT,
     SALESFORCE_CRM_SYSTEM,
     ConnectedSystemBlockedError,
+    ConnectedSystemConfigurationError,
     ConnectedSystemDefinition,
     ConnectedSystemNotFoundError,
     ConnectedSystemsService,
@@ -89,6 +91,97 @@ class GenericCrmAdapter:
                 },
             }
         return {"isError": False, "payload": {"id": "company-42"}}
+
+
+class ContractMappedCrmAdapter:
+    configured = True
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str | None, dict]] = []
+
+    async def call_operation(self, *, operation, tool_name, endpoint, arguments, **_kwargs):
+        self.calls.append((operation, tool_name, endpoint, arguments))
+        if operation == "schema" and arguments["target"] == "Bluebird":
+            return {
+                "isError": False,
+                "payload": {
+                    "details": [
+                        {
+                            "apiName": "Account",
+                            "label": "Account holder",
+                            "fields": [
+                                {
+                                    "name": "externalId",
+                                    "label": "External ID",
+                                    "type": "string",
+                                    "required": True,
+                                    "readable": True,
+                                    "identityField": True,
+                                    "immutable": True,
+                                    "createable": True,
+                                    "updateable": False,
+                                },
+                                {
+                                    "name": "publicName",
+                                    "label": "Public name",
+                                    "type": "string",
+                                    "required": False,
+                                    "readable": True,
+                                    "identityField": False,
+                                    "immutable": False,
+                                    "createable": True,
+                                    "updateable": True,
+                                },
+                            ],
+                        }
+                    ]
+                },
+            }
+        if operation == "schema":
+            return {
+                "isError": False,
+                "payload": {
+                    "details": [
+                        {
+                            "fields": [
+                                {"name": "candidateId", "label": "Candidate ID", "type": "string"}
+                            ]
+                        }
+                    ]
+                },
+            }
+        if operation == "read":
+            return {
+                "isError": False,
+                "payload": {
+                    "rows": [
+                        {
+                            "id": "blue-42",
+                            "externalId": "external-42",
+                            "publicName": "A. Example",
+                            "privateNote": "must not be projected",
+                        }
+                    ]
+                },
+            }
+        return {"isError": False, "payload": {"success": True, "id": "blue-42"}}
+
+
+def enterprise_schema_contract() -> dict:
+    return {
+        "version": "crm-primary-object-schema.v1",
+        "fieldsPath": ["payload", "details", 0, "fields"],
+        "objectPath": ["payload", "details", 0],
+        "requireFieldAccess": True,
+    }
+
+
+def enterprise_read_contract() -> dict:
+    return {
+        "version": "crm-record-collection.v1",
+        "recordsPath": ["payload", "rows"],
+        "recordIdPath": ["id"],
+    }
 
 
 def build_service(
@@ -177,6 +270,261 @@ async def test_generic_crm_uses_its_registered_schema_tool_endpoint_and_field_co
         )
 
 
+@pytest.mark.asyncio
+async def test_registry_contracts_keep_two_crms_isolated_and_sanitize_read_records():
+    bluebird = ConnectedSystemDefinition(
+        system_id="bluebird-accounts",
+        display_name="Bluebird",
+        customer_display_name="Bluebird",
+        system_type="Bluebird CRM",
+        system_name="Accounts",
+        target="Bluebird",
+        object_type_default="Account",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="https://example.invalid/bluebird",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(
+            {
+                "name": "bluebird-schema",
+                "operation": "schema",
+                "mcpEndpoint": "https://example.invalid/bluebird/schema",
+                "responseContract": enterprise_schema_contract(),
+            },
+            {
+                "name": "bluebird-read",
+                "operation": "read",
+                "mcpEndpoint": "https://example.invalid/bluebird/read",
+                "responseContract": enterprise_read_contract(),
+            },
+        ),
+        capabilities=frozenset({"schema", "read"}),
+    )
+    greenhouse = ConnectedSystemDefinition(
+        system_id="greenhouse-candidates",
+        display_name="Greenhouse",
+        customer_display_name="Greenhouse",
+        system_type="Greenhouse CRM",
+        system_name="Candidates",
+        target="Greenhouse",
+        object_type_default="Candidate",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="https://example.invalid/greenhouse",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(
+            {
+                "name": "greenhouse-schema",
+                "operation": "schema",
+                "mcpEndpoint": "https://example.invalid/greenhouse/schema",
+                "responseContract": enterprise_schema_contract(),
+            },
+        ),
+        capabilities=frozenset({"schema"}),
+    )
+    adapter = ContractMappedCrmAdapter()
+    service = ConnectedSystemsService(
+        adapter=adapter,
+        store=InMemoryConnectedSystemIntentStore(),
+        registry=(bluebird, greenhouse),
+    )
+
+    summaries = {row["systemId"]: row for row in service.list_systems()}
+    assert summaries[bluebird.system_id]["supportedActions"] == {
+        "schema": True,
+        "read": True,
+        "create": False,
+        "update": False,
+        "delete": False,
+    }
+    assert summaries[greenhouse.system_id]["supportedActions"]["read"] is False
+    assert "responseContract" not in str(summaries)
+
+    schema = await service.get_schema(system_id=bluebird.system_id)
+    assert schema["objectMetadata"] == {"name": "Account", "label": "Account holder"}
+    assert schema["schemaStatus"] == "ready"
+    read = await service.read_record(
+        user_id="user-1",
+        system_id=bluebird.system_id,
+        object_type=None,
+        email=None,
+        phone=None,
+        search_fields={"externalId": "external-42"},
+        return_fields=["publicName"],
+    )
+    assert read["records"] == [{"recordId": "blue-42", "fields": {"publicName": "A. Example"}}]
+    assert adapter.calls[-1][:3] == (
+        "read",
+        "bluebird-read",
+        "https://example.invalid/bluebird/read",
+    )
+
+    greenhouse_schema = await service.get_schema(system_id=greenhouse.system_id)
+    assert greenhouse_schema["schemaStatus"] == "capability_metadata_missing"
+    before = len(adapter.calls)
+    with pytest.raises(ConnectedSystemBlockedError):
+        await service.read_record(
+            user_id="user-1",
+            system_id=greenhouse.system_id,
+            object_type=None,
+            email=None,
+            phone=None,
+            search_fields={"candidateId": "candidate-42"},
+            return_fields=["candidateId"],
+        )
+    assert len(adapter.calls) == before + 1  # schema refresh, never a read MCP call
+    assert adapter.calls[-1][0] == "schema"
+
+
+@pytest.mark.asyncio
+async def test_registry_schema_catalogue_without_access_metadata_blocks_record_tools():
+    class MetadataOnlyAdapter:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def call_operation(self, *, operation, **_kwargs):
+            self.calls.append(operation)
+            return {
+                "isError": False,
+                "payload": {
+                    "details": [
+                        {
+                            "fields": [
+                                {
+                                    "name": "Email",
+                                    "label": "Email",
+                                    "type": "email",
+                                    "required": False,
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+
+    definition = ConnectedSystemDefinition(
+        system_id="metadata-only-crm",
+        display_name="Metadata CRM",
+        customer_display_name="Metadata CRM",
+        system_type="CRM",
+        system_name="CRM",
+        target="Metadata CRM",
+        object_type_default="Person",
+        transport="external_crm_streamable_mcp",
+        transport_endpoint="https://example.invalid/mcp",
+        registry_source="enterprise_crm_registry",
+        tool_catalog=(
+            {
+                "name": "describe-person",
+                "operation": "schema",
+                "mcpEndpoint": "https://example.invalid/mcp",
+                "responseContract": {
+                    "version": "crm-primary-object-schema.v1",
+                    "fieldsPath": ["payload", "details", 0, "fields"],
+                    "objectPath": ["payload", "details", 0],
+                    "requireFieldAccess": True,
+                },
+            },
+            {
+                "name": "read-person",
+                "operation": "read",
+                "mcpEndpoint": "https://example.invalid/mcp",
+            },
+        ),
+        capabilities=frozenset({"schema", "read"}),
+    )
+    adapter = MetadataOnlyAdapter()
+    service = ConnectedSystemsService(
+        adapter=adapter,
+        store=InMemoryConnectedSystemIntentStore(),
+        registry=(definition,),
+    )
+
+    schema = await service.get_schema(system_id=definition.system_id)
+    assert schema["schemaStatus"] == "capability_metadata_missing"
+    assert schema["objectMetadata"] == {"name": "Person", "label": "Person"}
+    assert schema["fields"][0]["readable"] is False
+    assert schema["effectiveActions"] == {
+        "schema": True,
+        "read": False,
+        "create": False,
+        "update": False,
+        "delete": False,
+    }
+
+    with pytest.raises(ConnectedSystemBlockedError):
+        await service.read_record(
+            user_id="user-1",
+            system_id=definition.system_id,
+            object_type=None,
+            email=None,
+            phone=None,
+            search_fields={"Email": "person@example.test"},
+            return_fields=["Email"],
+        )
+    assert adapter.calls == ["schema", "schema"]
+
+
+@pytest.mark.asyncio
+async def test_missing_omni_gateway_headers_fail_before_streamable_http_call():
+    adapter = ExternalCrmStreamableMcpAdapter(endpoint=REGISTRY_MCP_ENDPOINT)
+
+    with pytest.raises(ConnectedSystemConfigurationError) as error:
+        await adapter.call_operation(
+            operation="schema",
+            tool_name="object-schema",
+            endpoint=REGISTRY_MCP_ENDPOINT,
+            timeout_seconds=1,
+            retry_count=0,
+            arguments={"target": "Example", "objectType": "Person"},
+        )
+
+    assert error.value.code == "CONNECTED_SYSTEM_GATEWAY_AUTH_UNCONFIGURED"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("gateway_status", "expected_code"),
+    [
+        (401, "CONNECTED_SYSTEM_MCP_AUTH_FAILED"),
+        (403, "CONNECTED_SYSTEM_MCP_ACCESS_DENIED"),
+    ],
+)
+async def test_gateway_auth_failures_return_safe_configuration_errors(
+    monkeypatch, gateway_status, expected_code
+):
+    import contextlib
+
+    import mcp.client.streamable_http as streamable_mod
+
+    class GatewayStatusError(Exception):
+        def __init__(self, status_code: int):
+            self.response = type("Response", (), {"status_code": status_code})()
+            super().__init__(f"HTTP {status_code}")
+
+    @contextlib.asynccontextmanager
+    async def rejected_streamable(*_args, **_kwargs):
+        raise GatewayStatusError(gateway_status)
+        yield  # pragma: no cover - required only to make this an async generator
+
+    monkeypatch.setattr(streamable_mod, "streamablehttp_client", rejected_streamable)
+    adapter = ExternalCrmStreamableMcpAdapter(
+        endpoint="https://gateway.invalid/mcp",
+        headers=(("client_id", "test-client"), ("client_secret", "test-secret")),
+    )
+
+    with pytest.raises(ConnectedSystemConfigurationError) as error:
+        await adapter.call_operation(
+            operation="schema",
+            tool_name="object-schema",
+            endpoint="https://gateway.invalid/mcp",
+            timeout_seconds=1,
+            retry_count=0,
+            arguments={"target": "Example", "objectType": "Person"},
+        )
+
+    assert error.value.code == expected_code
+    assert "gateway" in str(error.value).lower()
+
+
 def test_default_service_lists_real_registry_backed_salesforce_endpoint_without_env_endpoint():
     service = ConnectedSystemsService(
         store=InMemoryConnectedSystemIntentStore(),
@@ -261,7 +609,8 @@ async def test_registry_simulator_path_remains_available_for_deterministic_local
         object_type=None,
     )
     assert schema["objectType"] == "Contact"
-    assert schema["mcp"]["payload"]["source"] == "customer0_connected_system_registry"
+    assert "mcp" not in schema
+    assert schema["fields"]
 
     read = await service.read_record(
         user_id="user_123",
@@ -271,7 +620,8 @@ async def test_registry_simulator_path_remains_available_for_deterministic_local
         phone="123456789",
     )
     assert read["resultClass"] == "succeeded"
-    assert read["mcp"]["payload"]["Contact"][0]["Id"] == "003gK00000jlmaLQAQ"
+    assert "mcp" not in read
+    assert read["records"][0]["recordId"] == "003gK00000jlmaLQAQ"
 
 
 @pytest.mark.asyncio
@@ -698,15 +1048,15 @@ async def test_failed_create_intent_returns_sanitized_mcp_error_message():
         additional_fields={"MailingCity": "Dallas"},
     )
 
-    approved = await service.approve_intent(
-        user_id="user_123",
-        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
-        intent_id=intent["intentId"],
-    )
-
-    assert approved["status"] == "failed"
-    assert approved["errorMessage"] == "Duplicate Contact for [email] and [phone]"
+    with pytest.raises(Exception, match=r"Duplicate Contact for \[email\] and \[phone\]"):
+        await service.approve_intent(
+            user_id="user_123",
+            system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+            intent_id=intent["intentId"],
+        )
     stored = service.store.intents[intent["intentId"]]
+    assert stored["status"] == "failed"
+    assert stored["error_message"] == "Duplicate Contact for [email] and [phone]"
     serialized = json.dumps(stored, sort_keys=True)
     assert "doe.john@abc.com" not in serialized
     assert "+1 (415) 555-1212" not in serialized
@@ -752,7 +1102,7 @@ async def test_terminal_intent_scrubs_raw_payload_values_after_approval():
 
 
 @pytest.mark.asyncio
-async def test_delete_is_blocked_unless_maintainer_flag_enabled():
+async def test_delete_requires_the_intent_lifecycle_even_when_enabled():
     service, adapter = build_service(delete_enabled=False)
 
     with pytest.raises(ConnectedSystemBlockedError):
@@ -764,46 +1114,15 @@ async def test_delete_is_blocked_unless_maintainer_flag_enabled():
     assert adapter.calls == []
 
     enabled_service, enabled_adapter = build_service(delete_enabled=True)
-    enabled_service.store.upsert_binding(
-        {
-            "binding_id": "csb_test",
-            "user_id": "user_123",
-            "system_id": CONNECTED_SYSTEM_SALESFORCE_ID,
-            "target": "Macys",
-            "object_type": "Contact",
-            "record_id": "003gK00000demoQAA",
-            "created_intent_id": None,
-            "last_intent_id": None,
-        }
-    )
-    result = await enabled_service.delete_record(
-        user_id="user_123",
-        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
-        object_type=None,
-        record_id="003gK00000demoQAA",
-    )
-
-    assert result["mcp"]["payload"]["deleted"] is True
-    assert result["resultClass"] == "succeeded"
-    assert result["binding"]["status"] == "deleted"
-    assert (
-        enabled_service.store.get_binding(
+    with pytest.raises(ConnectedSystemBlockedError) as error:
+        await enabled_service.delete_record(
             user_id="user_123",
             system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
-            object_type="Contact",
+            object_type=None,
+            record_id="003gK00000demoQAA",
         )
-        is None
-    )
-    assert enabled_adapter.calls == [
-        (
-            "delete-crm-record",
-            {
-                "target": "Macys",
-                "objectType": "Contact",
-                "id": "003gK00000demoQAA",
-            },
-        )
-    ]
+    assert error.value.code == "CONNECTED_SYSTEM_DELETE_INTENT_REQUIRED"
+    assert enabled_adapter.calls == []
 
 
 def test_definition_default_transport_headers_empty_and_not_in_summary():

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -279,11 +279,13 @@ own external CRM record through a schema-driven lifecycle: search for an
 existing Contact, create if missing, update allowed fields, and delete the
 bound external record when requested.
 The first shipped entry is Customer 0 Salesforce CRM over an external CRM MCP
-streamable HTTP transport. Customer 0 loads the Macy's CloudHub MCP endpoint
-from the backend connected-system registry row with a declared MCP tool catalog,
-not from `.env` endpoint config. The deterministic `registry://` simulator is
-kept for tests only. Production can swap that registry row to a MuleSoft
-VPC/private proxy without changing Profile or Agent flows.
+streamable HTTP transport through MuleSoft Managed Omni Gateway in CloudHub 2.0
+Private Spaces. The backend uses its Secret Manager-injected Omni Gateway
+client-enforcement headers while MuleSoft receives the CRM-specific encrypted
+credential arguments from the active registry row. The deterministic
+`registry://` simulator is kept for tests only. The Cloud Run service itself
+does not require a Hussh GCP VPC connector for this managed-gateway transport;
+MuleSoft owns the private-space network boundary behind its ingress.
 
 The canonical registry entry is:
 

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -274,49 +274,43 @@ RIA relationship bundle note:
 
 #### Connected Systems
 
-Connected Systems are vault-owner authenticated. The One user operates their
-own external CRM record through a schema-driven lifecycle: search for an
-existing Contact, create if missing, update allowed fields, and delete the
-bound external record when requested.
-The first shipped entry is Customer 0 Salesforce CRM over an external CRM MCP
-streamable HTTP transport through MuleSoft Managed Omni Gateway in CloudHub 2.0
-Private Spaces. The backend uses its Secret Manager-injected Omni Gateway
-client-enforcement headers while MuleSoft receives the CRM-specific encrypted
-credential arguments from the active registry row. The deterministic
-`registry://` simulator is kept for tests only. The Cloud Run service itself
-does not require a Hussh GCP VPC connector for this managed-gateway transport;
-MuleSoft owns the private-space network boundary behind its ingress.
+Connected Systems are vault-owner authenticated and registry-driven. Every
+active CRM declares one primary object, enabled operation names, direct
+Streamable HTTP MCP tool/endpoint mappings, timeout/retry policy, and a
+validated non-secret response contract per operation. Cloud Run reaches
+MuleSoft Managed Omni Gateway, which owns the CloudHub Private Space network
+boundary; no Hussh GCP VPC connector or ResourceLink transport belongs to this
+integration.
 
-The canonical registry entry is:
+The schema response is normalized from its registered object and field paths
+into `objectMetadata` and `fields[]` descriptors with `name`, `label`,
+`dataType`, `required`, `readable`, `identityField`, `immutable`,
+`createable`, `updateable`, derived `writable`, and portable constraints such
+as `allowedValues` and `maxLength`. A missing response mapping or permission
+descriptor fails closed. The current MuleSoft `details[0].fields` response is
+therefore a display-only catalogue until schema v1 publishes all access flags.
+List responses expose only the exact active row's capabilities; schema
+responses expose `schemaStatus` and `effectiveActions`. The UI cannot expose a
+record action that those effective capabilities do not authorize.
 
-- `systemId`: `salesforce-fsc-customer0`
-- `displayName`: `Macy's`
-- `target`: `Macys`
-- `objectTypeDefault`: `Contact`
-- `transport`: `external_crm_streamable_mcp`
-
-Supported Contact fields for create/update v1 are `FirstName`, `LastName`,
-`Email`, `Phone`, `MobilePhone`, `Title`, `Department`, `MailingCity`,
-`MailingStreet`, and `LeadSource`. The schema route calls the live MCP
-`object-schema` tool and returns normalized `fields` descriptors derived from
-that response, filtered through the Hussh allowlist above. Unsupported fields
-are rejected before an MCP call. Create/update stay intent-backed internally
-for audit, but the One UI exposes a single user action. Successful search/create
-binds the current One user to the external CRM record id. Delete removes the
-Salesforce Contact through the MCP tool and marks the local binding deleted;
-binding rows store no raw email, phone, or CRM field values.
+Read and search requests use generic `searchFields` and `returnFields` and
+return only normalized, requested, explicitly readable fields. Create and
+update use `recordFields`; email, phone, name, and `additionalFields` remain
+Macy's compatibility aliases only and are routed through the same schema
+validation. Create, update, and delete are auditable, idempotently approved
+intents. Only intent approval issues the registered direct MCP mutation.
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | GET | `/api/connected-systems` | List connected systems visible to the vault owner |
-| GET | `/api/connected-systems/{system_id}/schema?objectType=Contact` | Fetch current Salesforce Contact schema through the configured MCP transport and return normalized `fields` descriptors for dynamic UI rendering |
+| GET | `/api/connected-systems/{system_id}/schema?objectType={primary_object}` | Fetch the registered primary-object schema and return normalized fields, `schemaStatus`, and exact `effectiveActions` |
 | GET | `/api/connected-systems/{system_id}/record-binding?objectType=Contact` | Return the current One user binding for this external CRM record, or `unbound` |
-| POST | `/api/connected-systems/{system_id}/records/read` | Read a CRM Contact with `{ objectType, email, phone, searchFields?, returnFields? }` |
-| POST | `/api/connected-systems/{system_id}/records/search` | Search by email and phone; bind the One user when a Contact record id is returned |
-| POST | `/api/connected-systems/{system_id}/records/create-intents` | Create a pending CRM create intent; requires `{ objectType, email, phone, lastName }` plus optional `firstName` and `additionalFields` |
-| POST | `/api/connected-systems/{system_id}/records/update-intents` | Create a pending CRM update intent; requires `{ objectType, id, additionalFields }` plus optional readback locator |
-| POST | `/api/connected-systems/{system_id}/records/delete` | Delete the bound CRM Contact by `{ objectType, id? }`; id may be omitted when an active binding exists |
-| POST | `/api/connected-systems/{system_id}/intents/{intent_id}/approve` | Approve and execute a pending create/update intent, then attempt readback |
+| POST | `/api/connected-systems/{system_id}/records/read` | Read using generic `{ objectType, searchFields, returnFields }`; returns a sanitized normalized projection only |
+| POST | `/api/connected-systems/{system_id}/records/search` | Search and bind the One user when the registered record id mapping resolves a record |
+| POST | `/api/connected-systems/{system_id}/records/create-intents` | Create a pending schema-validated `{ objectType, recordFields }` intent |
+| POST | `/api/connected-systems/{system_id}/records/update-intents` | Create a pending schema-validated `{ objectType, id, recordFields }` intent |
+| POST | `/api/connected-systems/{system_id}/records/delete` | Compatibility path that creates a reviewable delete intent; it never deletes immediately |
+| POST | `/api/connected-systems/{system_id}/intents/{intent_id}/approve` | Idempotently approve and execute a pending mutation through its registered MCP tool |
 | POST | `/api/connected-systems/{system_id}/intents/{intent_id}/reject` | Reject a pending intent without calling MCP |
 
 #### Kai Chat

--- a/docs/reference/operations/README.md
+++ b/docs/reference/operations/README.md
@@ -115,6 +115,7 @@ Use `github-contribution-governance` when contribution graph visibility, verifie
 - [env-and-secrets.md](./env-and-secrets.md): environment and secret contract.
 - [env-secrets-key-matrix.md](./env-secrets-key-matrix.md): key-by-key environment matrix.
 - [migration-governance.md](./migration-governance.md): canonical migration authority, frozen-vs-integrated DB contracts, and allowed SQL surfaces.
+- [mulesoft-managed-omni-gateway-private-space.md](./mulesoft-managed-omni-gateway-private-space.md): current CRM transport, credential boundary, and UAT handshake proof.
 - [brand-and-compatibility-contract.md](./brand-and-compatibility-contract.md): Hussh public naming rule and compatibility boundaries.
 - [naming-policy.md](./naming-policy.md): compatibility pointer to the canonical brand contract.
 - [developer-access-matrix.md](./developer-access-matrix.md): org-level developer IAM baseline, runtime identities, and DB access path.

--- a/docs/reference/operations/hussh-mcp-partner-integration-guide.md
+++ b/docs/reference/operations/hussh-mcp-partner-integration-guide.md
@@ -34,12 +34,40 @@ are not part of this catalog. Discovery is performed through
 3. If the request is still awaiting approval, retain the returned `request_ref` and call `check_consent_status` at the supplied interval.
 4. After approval, Hussh returns a `grant_ref`. Call `get_encrypted_scoped_export` with that reference and the expected scope.
 
+| Reference | Meaning | Retain until |
+| --- | --- | --- |
+| `request_ref` | The pending approval lifecycle request. | It reaches a terminal status. |
+| `grant_ref` | The approved, scoped authority used for one encrypted export. | It expires, is revoked, or the export is no longer needed. |
+
+## Connector setup
+
+Use one transport mode per connector. The hosted connector is a Streamable HTTP
+MCP client; it does not download a second resource after a tool call.
+
+| Mode | Connector responsibility | Hussh responsibility |
+| --- | --- | --- |
+| Local stdio | Keep its private key locally and decrypt bounded approved information locally. | Return only the approved result to the local connector process. |
+| Hosted Streamable HTTP | Send the developer Bearer header and its X25519 public-key bundle; decrypt ciphertext in its connector process. | Authenticate the tool call and return the encrypted inline envelope. |
+
+```json
+{
+  "mcpServers": {
+    "hushh-consent": {
+      "url": "https://api.uat.hushh.ai/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${HUSHH_DEVELOPER_TOKEN}"
+      }
+    }
+  }
+}
+```
+
 ## Export transport
 
 The approved export stays entirely on MCP transport. Hosted connectors receive
-`delivery: encrypted_inline`, ciphertext, and its X25519-AES256-GCM envelope in
-the tool result; decryption happens in the connector process with its private
-key. Local stdio connectors receive `delivery: decrypted_local` with bounded
+`delivery: encrypted_inline`, `resource: null`, ciphertext, and its
+X25519-AES256-GCM envelope in the tool result; decryption happens in the
+connector process with its private key. Local stdio connectors receive `delivery: decrypted_local` with bounded
 approved information after local decryption.
 
 No `ResourceLink`, plaintext fallback, query-token authentication, or
@@ -60,3 +88,27 @@ avoid duplicate records.
 CRM records hold only narrow CRM-native workflow fields. Hussh PKM, vault keys,
 KYC documents, email bodies, and broad personal memory are not CRM replication
 payloads.
+
+### CRM schema contract v1
+
+CRM integration is a separate backend-to-MuleSoft plane. Each active operation
+has a registry-owned response contract; a missing or invalid mapping is
+unavailable before Hussh opens an MCP call. The current schema tool response
+maps its primary object metadata from `details[0]` and field catalogue from
+`details[0].fields`. That shape is display-only until every
+field carries explicit `readable`, `identityField`, `immutable`, `createable`,
+and `updateable` booleans, plus normalized constraints where applicable such
+as `allowedValues` and `maxLength`.
+
+Hussh derives `writable` only from `createable` or `updateable`. It never
+interprets an omitted permission as allowed. Until MuleSoft publishes this
+schema v1 contract, the Connected Systems interface shows a searchable field
+catalogue and exposes no CRM read, create, update, or delete action.
+
+## Partner checklist
+
+- Use the UAT endpoint with its trailing slash and a Bearer header.
+- Discover a narrow scope before requesting consent; do not guess scope names.
+- Store `request_ref` while polling and use `grant_ref` only after approval.
+- Expect encrypted-inline delivery with `resource: null`; do not implement a ResourceLink download step.
+- Treat CRM MCP operations as a private Hussh backend integration, not as additions to the public Consent MCP tool catalog.

--- a/docs/reference/operations/mulesoft-crm-schema-contract-v1.json
+++ b/docs/reference/operations/mulesoft-crm-schema-contract-v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MuleSoft CRM object-schema response v1",
+  "description": "Field access metadata required before Hussh enables CRM record operations.",
+  "type": "object",
+  "required": ["details"],
+  "properties": {
+    "details": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["fields"],
+        "properties": {
+          "name": { "type": "string" },
+          "label": { "type": "string" },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "label",
+                "type",
+                "required",
+                "readable",
+                "identityField",
+                "immutable",
+                "createable",
+                "updateable"
+              ],
+              "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "label": { "type": "string", "minLength": 1 },
+                "type": { "type": "string", "minLength": 1 },
+                "required": { "type": "boolean" },
+                "readable": { "type": "boolean" },
+                "identityField": { "type": "boolean" },
+                "immutable": { "type": "boolean" },
+                "createable": { "type": "boolean" },
+                "updateable": { "type": "boolean" },
+                "length": { "type": "integer", "minimum": 1 },
+                "picklistValues": { "type": "array" }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/reference/operations/mulesoft-managed-omni-gateway-private-space.md
+++ b/docs/reference/operations/mulesoft-managed-omni-gateway-private-space.md
@@ -1,0 +1,46 @@
+# MuleSoft Managed Omni Gateway Private Space
+
+## Visual Context
+
+Canonical visual owner: [Operations Index](README.md).
+
+```text
+Cloud Run -- Streamable HTTP + gateway headers --> Omni Gateway -- Private Space --> CRM
+```
+
+## Current transport
+
+Connected Systems reaches Salesforce through MuleSoft Managed Omni Gateway in
+CloudHub 2.0 Private Spaces:
+
+```text
+Hussh Cloud Run -> Managed Omni Gateway Streamable HTTP ingress -> MuleSoft private space -> CRM
+```
+
+The Cloud Run service does not attach to a Hussh GCP VPC connector for this
+integration. The private-network boundary is owned by MuleSoft behind its
+managed gateway ingress; a public CloudHub hostname does not mean the
+downstream CRM path is public.
+
+## Credentials and registry
+
+- `OMNIGATEWAY_CLIENT_ID` and `OMNIGATEWAY_CLIENT_SECRET` are Secret Manager
+  values injected into the backend runtime. They authenticate Hussh to Omni
+  Gateway as `client_id` and `client_secret` request headers.
+- Each active CRM row in `enterprise_crm_registry` holds encrypted CRM
+  credential fields. MuleSoft-managed rows forward those opaque values to the
+  gateway as tool arguments; Hussh never logs or decrypts them in that path.
+- The generic CRM adapter uses Streamable HTTP MCP. A valid session performs
+  `initialize`, retains the returned `Mcp-Session-Id`, then calls `tools/list`
+  or the declared tool. No CRM records are needed to prove the handshake.
+
+## UAT verification boundary
+
+The read-only connectivity proof is complete only when the deployed UAT
+Secret Manager references authenticate `initialize` and `tools/list` and the
+gateway returns its expected catalog. This proves the Hussh-to-Omni-Gateway
+leg. Schema/read/write verification remains a separate CRM capability check;
+writes always stay behind the intent and explicit-confirmation lifecycle.
+
+Never put live gateway URLs, private CIDRs, VPN/tunnel material, secret values,
+or encrypted credential blobs in the repository, logs, screenshots, or docs.

--- a/docs/reference/operations/mulesoft-managed-omni-gateway-private-space.md
+++ b/docs/reference/operations/mulesoft-managed-omni-gateway-private-space.md
@@ -34,6 +34,21 @@ downstream CRM path is public.
   `initialize`, retains the returned `Mcp-Session-Id`, then calls `tools/list`
   or the declared tool. No CRM records are needed to prove the handshake.
 
+## CRM schema contract v1
+
+The `object-schema` tool must return an operation-contract-mapped primary
+object metadata node and field collection according to the checked-in
+`docs/reference/operations/mulesoft-crm-schema-contract-v1.json`. For the current rollout the collection is
+`details[0]` and `details[0].fields`. Every field must declare `readable`, `identityField`,
+`immutable`, `createable`, and `updateable`; it should also provide portable
+constraints such as picklist values and maximum length. Hussh derives
+`writable` from the create/update flags and never infers an omitted permission.
+
+Until all descriptors validate, Hussh treats the result as a display-only
+catalogue. Read, create, update, and delete are unavailable before their MCP
+tool is called. Read and mutation result mappings are likewise registry-owned;
+they are not guessed from raw MuleSoft envelopes.
+
 ## UAT verification boundary
 
 The read-only connectivity proof is complete only when the deployed UAT

--- a/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
@@ -7,101 +7,20 @@ import { ConnectedSystemsService } from "@/lib/services/connected-systems-servic
 const routerPushMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: routerPushMock,
-    replace: vi.fn(),
-    prefetch: vi.fn(),
-    back: vi.fn(),
-  }),
+  useRouter: () => ({ push: routerPushMock, replace: vi.fn(), prefetch: vi.fn(), back: vi.fn() }),
 }));
 
 vi.mock("@/lib/services/auth-service", () => ({
-  AuthService: {
-    getIdToken: vi.fn().mockResolvedValue("firebase-id-token"),
-  },
+  AuthService: { getIdToken: vi.fn().mockResolvedValue("firebase-id-token") },
 }));
 
 vi.mock("@/lib/services/connected-systems-service", () => ({
-  SALESFORCE_CRM_SYSTEM_ID: "salesforce-fsc-customer0",
   ConnectedSystemsService: {
-    listSystems: vi.fn().mockResolvedValue([
-      {
-        systemId: "salesforce-fsc-customer0",
-        displayName: "Macy's",
-        customerDisplayName: "Macy's",
-        systemType: "Salesforce",
-        systemName: "FSC",
-        status: "connected",
-        target: "Macys",
-        objectTypeDefault: "Contact",
-        transport: "external_crm_streamable_mcp",
-        transportLabel: "External CRM MCP",
-        endpointConfigured: true,
-        registrySource: "customer0_connected_system_registry",
-        toolCatalog: [
-          { name: "object-schema", operation: "schema" },
-          { name: "read-crm-record", operation: "read" },
-          { name: "create-crm-record", operation: "create" },
-          { name: "update-crm-record", operation: "update" },
-          { name: "delete-crm-record", operation: "delete" },
-        ],
-        supportedActions: {
-          schema: true,
-          read: true,
-          create: true,
-          update: true,
-          delete: true,
-        },
-        fieldAllowlist: ["Email", "Phone", "LastName", "MailingCity"],
-      },
-    ]),
-    getRecordBinding: vi.fn().mockResolvedValue({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      status: "unbound",
-      binding: null,
-    }),
-    getSchema: vi.fn().mockResolvedValue({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      supportedFields: ["Email", "Phone", "MobilePhone", "LastName", "MailingCity"],
-      fields: [
-        { key: "Email", name: "Email", label: "Email", dataType: "email", identityField: true },
-        { key: "Phone", name: "Phone", label: "Phone", dataType: "phone", identityField: true },
-        {
-          key: "MobilePhone",
-          name: "MobilePhone",
-          label: "Mobile number",
-          dataType: "phone",
-        },
-        { key: "LastName", name: "LastName", label: "Last name", required: true },
-        { key: "MailingCity", name: "MailingCity", label: "Mailing city" },
-      ],
-      mcp: {
-        isError: false,
-        payload: { fields: ["Email", "Phone", "MobilePhone", "LastName", "MailingCity"] },
-      },
-    }),
-    searchRecord: vi.fn().mockResolvedValue({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: null,
-      bindingStatus: "unbound",
-      binding: null,
-      mcp: { isError: false, payload: { Contact: [] } },
-    }),
-    readRecord: vi.fn().mockResolvedValue({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: null,
-      mcp: { isError: false, payload: { Contact: [] } },
-    }),
+    listSystems: vi.fn(),
+    getSchema: vi.fn(),
+    getRecordBinding: vi.fn(),
+    readRecord: vi.fn(),
+    searchRecord: vi.fn(),
     createRecordIntent: vi.fn(),
     updateRecordIntent: vi.fn(),
     approveIntent: vi.fn(),
@@ -110,523 +29,186 @@ vi.mock("@/lib/services/connected-systems-service", () => ({
   },
 }));
 
+const system = {
+  systemId: "customer-crm",
+  displayName: "Customer CRM",
+  customerDisplayName: "Customer CRM",
+  systemType: "Example",
+  systemName: "CRM",
+  status: "connected",
+  target: "Customer CRM",
+  objectTypeDefault: "Person",
+  transport: "external_crm_streamable_mcp",
+  transportLabel: "External CRM MCP",
+  endpointConfigured: true,
+  registrySource: "enterprise_crm_registry",
+  supportedActions: { schema: true, read: false, create: false, update: false, delete: false },
+};
+
+const metadataOnlySchema = {
+  systemId: system.systemId,
+  target: system.target,
+  objectType: system.objectTypeDefault,
+  supportedFields: ["Email", "PreferredLanguage", "Birthdate"],
+  schemaStatus: "capability_metadata_missing",
+  effectiveActions: { schema: true, read: false, create: false, update: false, delete: false },
+  configurationMessage: "This connected system needs an update before its fields can be used.",
+  fields: [
+    { key: "Email", name: "Email", label: "Email", dataType: "email", required: false, readable: false, createable: false, updateable: false, immutable: false, identityField: false, permissionsDeclared: false },
+    { key: "PreferredLanguage", name: "PreferredLanguage", label: "Preferred language", dataType: "picklist", required: false, readable: false, createable: false, updateable: false, immutable: false, identityField: false, permissionsDeclared: false, constraints: { allowedValues: ["English", "French"] } },
+    { key: "Birthdate", name: "Birthdate", label: "Birth date", dataType: "date", required: false, readable: false, createable: false, updateable: false, immutable: false, identityField: false, permissionsDeclared: false },
+  ],
+};
+
+const readySchema = {
+  ...metadataOnlySchema,
+  schemaStatus: "ready",
+  effectiveActions: { schema: true, read: true, create: true, update: true, delete: true },
+  fields: [
+    { key: "Email", name: "Email", label: "Email", dataType: "email", required: true, readable: true, createable: true, updateable: false, immutable: true, identityField: true, permissionsDeclared: true },
+    { key: "PreferredLanguage", name: "PreferredLanguage", label: "Preferred language", dataType: "picklist", required: false, readable: true, createable: true, updateable: true, immutable: false, identityField: false, permissionsDeclared: true, constraints: { allowedValues: ["English", "French"] } },
+  ],
+};
+
 describe("ConnectedSystemsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("renders the CRM overview as responsive inset rows with name, type, and status", async () => {
-    render(<ConnectedSystemsPanel vaultOwnerToken="HCT:test" mode="list" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Macy's")).toBeTruthy();
-    });
-
-    expect(screen.getByText("Available systems")).toBeTruthy();
-    expect(screen.getByText("Salesforce FSC")).toBeTruthy();
-    expect(screen.getByText("Connected")).toBeTruthy();
-    expect(screen.getByAltText("Macy's logo")).toBeTruthy();
-    // No redundant chrome: no explainer copy, no Connected CRM badge, no
-    // per-row transport subheader.
-    expect(screen.queryByText(/Open a connected system to inspect/i)).toBeNull();
-    expect(screen.queryByText("Connected CRM")).toBeNull();
-    expect(screen.queryByText(/Macy's \/ Contact \/ External CRM MCP/)).toBeNull();
-    expect(screen.queryByAltText("CRM platform logo")).toBeNull();
-  });
-
-  it("navigates to the system workspace when a table row is clicked", async () => {
-    render(<ConnectedSystemsPanel vaultOwnerToken="HCT:test" mode="list" />);
-
-    const nameCell = await screen.findByText("Macy's");
-    fireEvent.click(nameCell);
-
-    expect(routerPushMock).toHaveBeenCalledWith(
-      "/one/connected-systems/salesforce-fsc-customer0",
-    );
-  });
-
-  it("lists CRM systems without requiring vault unlock", async () => {
-    render(<ConnectedSystemsPanel vaultOwnerToken={null} mode="list" />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Macy's")).toBeTruthy();
-    });
-    expect(ConnectedSystemsService.listSystems).toHaveBeenCalledWith("firebase-id-token");
-    expect(screen.queryByText(/Unlock your vault/i)).toBeNull();
-  });
-
-  it("renders Macy's as a connected CRM system with a first-time create lifecycle", async () => {
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(/Salesforce FSC \/ Contact\./)).toBeTruthy();
-    });
-
-    expect(screen.getByRole("heading", { name: "Macy's" })).toBeTruthy();
-    expect(screen.getByAltText("Macy's logo")).toBeTruthy();
-    expect(screen.queryByAltText("CRM platform logo")).toBeNull();
-    expect(screen.getByText(/Connected through External CRM MCP/)).toBeTruthy();
-    expect(screen.queryByText(/MCP tools/i)).toBeNull();
-    expect(screen.queryByText("Registry backed")).toBeNull();
-    expect(screen.queryByText(/My Macy's Contact/i)).toBeNull();
-    expect(screen.queryByText(/No CRM record is connected/i)).toBeNull();
-    expect(screen.queryByText(/Record ID 003gK00000jlmaLQAQ/)).toBeNull();
-    expect(screen.queryByDisplayValue("maria.joe@abc.com")).toBeNull();
-    expect(screen.queryByDisplayValue("123456789")).toBeNull();
-    expect(await screen.findByText("Registered email")).toBeTruthy();
-    expect(screen.getByText("kushal@example.com")).toBeTruthy();
-    expect(screen.getByText("Registered phone")).toBeTruthy();
-    expect(screen.getByText("4155551212")).toBeTruthy();
-    expect(screen.queryByText("CRM lookup email")).toBeNull();
-    expect(screen.queryByText("CRM lookup phone")).toBeNull();
-    await waitFor(() => {
-      expect(screen.getByText("Mobile number")).toBeTruthy();
-    });
-    expect(screen.getAllByText(/Mailing city/).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/Stored CRM information/i)).toBeNull();
-    expect(screen.getByText("Link my Macy's record")).toBeTruthy();
-    expect(screen.queryByText("Find existing record")).toBeNull();
-    expect(screen.queryByText("Create my Macy's record")).toBeNull();
-    expect(screen.queryByRole("button", { name: /Suggest sample details/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /Suggest a sample change/i })).toBeNull();
-    expect(screen.getByRole("button", { name: /Link this system/i })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /^Find my record$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Create record$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /^Approve$/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /Random new Contact/i })).toBeNull();
-    expect(screen.queryByText(/Delete Macy's Contact/i)).toBeNull();
-  });
-
-  it("waits for the saved CRM binding before showing create actions", async () => {
-    let resolveBinding!: (value: Awaited<ReturnType<typeof ConnectedSystemsService.getRecordBinding>>) => void;
-    vi.mocked(ConnectedSystemsService.getRecordBinding).mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveBinding = resolve;
-      }) as ReturnType<typeof ConnectedSystemsService.getRecordBinding>
-    );
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    expect(await screen.findByText("Looking for your saved CRM record")).toBeTruthy();
-    expect(screen.queryByText("Link my Macy's record")).toBeNull();
-
-    resolveBinding({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      status: "active",
-      binding: {
-        bindingId: "csb_existing",
-        systemId: "salesforce-fsc-customer0",
-        target: "Macys",
-        objectType: "Contact",
-        recordId: "003gK00000existingQAA",
-        status: "active",
-      },
-    });
-
-    expect(await screen.findByText("Update my Macy's information")).toBeTruthy();
-    expect(screen.queryByText("Link my Macy's record")).toBeNull();
-  });
-
-  it("refreshes CRM record details without an id search field", async () => {
-    vi.mocked(ConnectedSystemsService.getRecordBinding).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      status: "active",
-      binding: {
-        bindingId: "csb_bound",
-        systemId: "salesforce-fsc-customer0",
-        target: "Macys",
-        objectType: "Contact",
-        recordId: "003gK00000boundQAA",
-        status: "active",
-      },
-    });
-    vi.mocked(ConnectedSystemsService.readRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: "003gK00000boundQAA",
-      binding: {
-        bindingId: "csb_bound",
-        systemId: "salesforce-fsc-customer0",
-        target: "Macys",
-        objectType: "Contact",
-        recordId: "003gK00000boundQAA",
-        status: "active",
-      },
-      mcp: {
-        isError: false,
-        payload: {
-          Contact: [
-            {
-              Id: "003gK00000boundQAA",
-              Email: "kushal@example.com",
-              Phone: "4155551212",
-              LastName: "Trivedi",
-              MailingCity: "New York",
-            },
-          ],
-        },
-      },
-    });
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    expect(await screen.findByText("Update my Macy's information")).toBeTruthy();
-    await waitFor(() => {
-      expect(ConnectedSystemsService.readRecord).toHaveBeenCalledWith(
-        "HCT:test",
-        expect.objectContaining({
-          email: "kushal@example.com",
-          phone: "4155551212",
-        })
-      );
-      expect(
-        vi.mocked(ConnectedSystemsService.readRecord).mock.calls[0]?.[1].searchFields
-      ).toBeUndefined();
-    });
-    expect(await screen.findByDisplayValue("New York")).toBeTruthy();
-    expect(screen.queryByText("Create my Macy's record")).toBeNull();
-  });
-
-  it("keeps the CRM lifecycle visible when binding storage is not ready", async () => {
-    vi.mocked(ConnectedSystemsService.getRecordBinding).mockRejectedValueOnce(
-      new Error("Connected Systems workflow storage is not ready.")
-    );
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    expect(await screen.findByText("Link my Macy's record")).toBeTruthy();
-    expect(screen.queryByText(/Record linking is still being prepared/i)).toBeNull();
-    expect(screen.queryByText(/Record linking is temporarily unavailable/i)).toBeNull();
-    expect(screen.queryByText("Connected Systems workflow storage is not ready.")).toBeNull();
-  });
-
-  it("does not invent sample CRM values", async () => {
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    await screen.findByRole("button", { name: /Link this system/i });
-    expect(screen.queryByRole("button", { name: /Suggest sample details/i })).toBeNull();
-    expect(screen.queryByDisplayValue(/New York|Chicago|San Francisco|Atlanta/)).toBeNull();
-  });
-
-  it("surfaces failed create intent messages without rendering audit field metadata", async () => {
-    vi.mocked(ConnectedSystemsService.createRecordIntent).mockResolvedValueOnce({
-      intentId: "csi_create_failed",
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      action: "create",
-      status: "pending",
-      fieldNames: ["Email", "Phone", "LastName"],
-    });
-    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
-      intentId: "csi_create_failed",
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      action: "create",
-      status: "failed",
-      recordId: null,
-      fieldNames: ["Email", "Phone", "LastName"],
-      errorMessage: "CRM rejected the create request.",
-    });
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    await screen.findByRole("button", { name: /Link this system/i });
-    fireEvent.click(screen.getByRole("button", { name: /Link this system/i }));
-    fireEvent.click(await screen.findByRole("button", { name: /Confirm create/i }));
-
-    expect(await screen.findByText("CRM rejected the create request.")).toBeTruthy();
-    expect(screen.queryByText("Last update")).toBeNull();
-    expect(screen.queryByText(/Create result/i)).toBeNull();
-    expect(screen.queryByText(/Fields: Email/i)).toBeNull();
-  });
-
-  it("switches to update and delete mode after a created CRM record is bound", async () => {
-    vi.mocked(ConnectedSystemsService.createRecordIntent).mockResolvedValueOnce({
-      intentId: "csi_create_succeeded",
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      action: "create",
-      status: "pending",
-      fieldNames: ["Email", "Phone", "LastName"],
-    });
-    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
-      intentId: "csi_create_succeeded",
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      action: "create",
-      status: "succeeded",
-      recordId: "003gK00000createdQAA",
-      fieldNames: ["Email", "Phone", "LastName"],
-      binding: {
-        bindingId: "csb_created",
-        systemId: "salesforce-fsc-customer0",
-        target: "Macys",
-        objectType: "Contact",
-        recordId: "003gK00000createdQAA",
-        status: "active",
-        createdIntentId: "csi_create_succeeded",
-        lastIntentId: "csi_create_succeeded",
-      },
-    });
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    await screen.findByRole("button", { name: /Link this system/i });
-    fireEvent.click(screen.getByRole("button", { name: /Link this system/i }));
-    fireEvent.click(await screen.findByRole("button", { name: /Confirm create/i }));
-
-    expect(await screen.findByText("Update my Macy's information")).toBeTruthy();
-    expect(screen.queryByText("Link my Macy's record")).toBeNull();
-    expect(screen.getByText("Delete record")).toBeTruthy();
-    expect(screen.getAllByText(/003gK00000createdQAA/).length).toBeGreaterThan(0);
-  });
-
-  it("stays bound after create when silent readback returns no binding", async () => {
-    vi.mocked(ConnectedSystemsService.createRecordIntent).mockResolvedValueOnce({
-      intentId: "csi_create_record_id_only",
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      action: "create",
-      status: "pending",
-      fieldNames: ["Email", "Phone", "LastName"],
-    });
-    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
-      intentId: "csi_create_record_id_only",
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      action: "create",
-      status: "succeeded",
-      recordId: "003gK00000recordOnlyQAA",
-      fieldNames: ["Email", "Phone", "LastName"],
+    vi.mocked(ConnectedSystemsService.listSystems).mockResolvedValue([system]);
+    vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValue(metadataOnlySchema);
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockResolvedValue({
+      systemId: system.systemId,
+      target: system.target,
+      objectType: system.objectTypeDefault,
+      status: "unbound",
       binding: null,
     });
+    vi.mocked(ConnectedSystemsService.readRecord).mockResolvedValue({
+      systemId: system.systemId,
+      target: system.target,
+      objectType: system.objectTypeDefault,
+      resultClass: "succeeded",
+      records: [],
+    });
+  });
+
+  it("lists dynamically registered CRM systems without requiring vault unlock", async () => {
+    render(<ConnectedSystemsPanel vaultOwnerToken={null} mode="list" />);
+
+    expect(await screen.findByText("Customer CRM")).toBeTruthy();
+    expect(screen.getByText("Example CRM")).toBeTruthy();
+    fireEvent.click(screen.getByText("Customer CRM"));
+    expect(routerPushMock).toHaveBeenCalledWith("/one/connected-systems/customer-crm");
+  });
+
+  it("renders a searchable, paginated schema catalogue and blocks incomplete CRM actions", async () => {
+    const fields = Array.from({ length: 139 }, (_, index) => ({
+      key: `Field${index + 1}`,
+      name: `Field${index + 1}`,
+      label: `Field ${index + 1}`,
+      dataType: "string",
+      required: false,
+      readable: false,
+      createable: false,
+      updateable: false,
+      immutable: false,
+      identityField: false,
+      permissionsDeclared: false,
+    }));
+    vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValueOnce({
+      ...metadataOnlySchema,
+      supportedFields: fields.map((field) => field.key),
+      fields,
+    });
+    render(<ConnectedSystemsPanel vaultOwnerToken="HCT:test" systemId={system.systemId} />);
+
+    expect(await screen.findByText("Customer CRM field catalogue")).toBeTruthy();
+    expect(screen.getByText(/Configuration update required/)).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search fields")).toBeTruthy();
+    expect(screen.getAllByText("not declared")).toHaveLength(16);
+    expect(screen.getByText("Showing 1-16 of 139")).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText("Search fields"), { target: { value: "Field 139" } });
+    await waitFor(() => expect(screen.getByText("Field 139")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /Link this system/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Update record$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Delete$/i })).toBeNull();
+    expect(ConnectedSystemsService.readRecord).not.toHaveBeenCalled();
+    expect(ConnectedSystemsService.createRecordIntent).not.toHaveBeenCalled();
+  });
+
+  it("keeps a ready schema display-only when record operation mappings are unavailable", async () => {
+    vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValueOnce({
+      ...readySchema,
+      effectiveActions: { schema: true, read: false, create: false, update: false, delete: false },
+    });
+    render(<ConnectedSystemsPanel vaultOwnerToken="HCT:test" systemId={system.systemId} />);
+
+    expect(await screen.findByText("Customer CRM field catalogue")).toBeTruthy();
+    expect(
+      screen.getByText(/does not currently have a complete registered record-operation contract/i),
+    ).toBeTruthy();
+    expect(screen.getByText("Preferred language")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Link this system/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Update record$/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Delete$/i })).toBeNull();
+  });
+
+  it("uses normalized records and stages one explicitly updateable field for confirmation", async () => {
+    vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValueOnce(readySchema);
+    vi.mocked(ConnectedSystemsService.getRecordBinding).mockResolvedValueOnce({
+      systemId: system.systemId,
+      target: system.target,
+      objectType: system.objectTypeDefault,
+      status: "active",
+      binding: {
+        systemId: system.systemId,
+        objectType: system.objectTypeDefault,
+        recordId: "person-42",
+        status: "active",
+      },
+    });
     vi.mocked(ConnectedSystemsService.readRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
+      systemId: system.systemId,
+      target: system.target,
+      objectType: system.objectTypeDefault,
       resultClass: "succeeded",
-      recordId: null,
-      mcp: { isError: false, payload: { Contact: [] } },
+      recordId: "person-42",
+      records: [{ recordId: "person-42", fields: { Email: "person@example.test", PreferredLanguage: "English" } }],
+    });
+    vi.mocked(ConnectedSystemsService.updateRecordIntent).mockResolvedValueOnce({
+      intentId: "intent-42",
+      systemId: system.systemId,
+      action: "update",
+      status: "pending",
+      fieldNames: ["PreferredLanguage"],
     });
 
     render(
       <ConnectedSystemsPanel
         vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
+        systemId={system.systemId}
+        profile={{ email: "person@example.test" }}
+      />,
     );
 
-    await screen.findByRole("button", { name: /Link this system/i });
-    fireEvent.click(screen.getByRole("button", { name: /Link this system/i }));
-    fireEvent.click(await screen.findByRole("button", { name: /Confirm create/i }));
+    expect(await screen.findByText("Update my Customer CRM information")).toBeTruthy();
+    expect(await screen.findByText("English")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const editor = await screen.findByRole("combobox");
+    fireEvent.change(editor, { target: { value: "French" } });
+    fireEvent.click(screen.getByRole("button", { name: "Stage change" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update record" }));
 
-    expect(await screen.findByText("Update my Macy's information")).toBeTruthy();
     await waitFor(() => {
-      expect(screen.queryByText("Link my Macy's record")).toBeNull();
-      expect(screen.getByText("Delete record")).toBeTruthy();
-      expect(screen.getAllByText(/003gK00000recordOnlyQAA/).length).toBeGreaterThan(0);
-    });
-  });
-
-  it("auto-links an existing CRM record by registered profile lookup and shows delete", async () => {
-    vi.mocked(ConnectedSystemsService.searchRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: "003gK00000linkedQAA",
-      bindingStatus: "active",
-      binding: {
-        bindingId: "csb_linked",
-        systemId: "salesforce-fsc-customer0",
-        target: "Macys",
-        objectType: "Contact",
-        recordId: "003gK00000linkedQAA",
-        status: "active",
-      },
-      mcp: {
-        isError: false,
-        payload: {
-          Contact: [
-            {
-              Id: "003gK00000linkedQAA",
-              Email: "kushal@example.com",
-              Phone: "4155551212",
-              LastName: "Trivedi",
-              MailingCity: "Dallas",
-            },
-          ],
-        },
-      },
-    });
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        profile={{
-          displayName: "Kushal Trivedi",
-          email: "kushal@example.com",
-          phone: "4155551212",
-        }}
-      />
-    );
-
-    expect(await screen.findByText("Update my Macy's information")).toBeTruthy();
-    expect(screen.queryByText("Find existing record")).toBeNull();
-    expect(screen.queryByText("Create my Macy's record")).toBeNull();
-    expect(screen.getByText("Delete record")).toBeTruthy();
-    expect(screen.getAllByText(/003gK00000linkedQAA/).length).toBeGreaterThan(0);
-    expect(ConnectedSystemsService.searchRecord).toHaveBeenCalledWith(
-      "HCT:test",
-      expect.objectContaining({
-        email: "kushal@example.com",
-        phone: "4155551212",
-      })
-    );
-  });
-
-  it("uses Agent One email and phone slots to find the CRM record before proposing updates", async () => {
-    vi.mocked(ConnectedSystemsService.searchRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: "003gK00000agentQAA",
-      bindingStatus: "active",
-      binding: {
-        bindingId: "csb_agent",
-        systemId: "salesforce-fsc-customer0",
-        target: "Macys",
-        objectType: "Contact",
-        recordId: "003gK00000agentQAA",
-        status: "active",
-      },
-      mcp: {
-        isError: false,
-        payload: {
-          Contact: [
-            {
-              Id: "003gK00000agentQAA",
-              Email: "agent@example.com",
-              Phone: "415-555-1212",
-              LastName: "Trivedi",
-              MailingCity: "Dallas",
-            },
-          ],
-        },
-      },
-    });
-
-    render(
-      <ConnectedSystemsPanel
-        vaultOwnerToken="HCT:test"
-        mode="detail"
-        systemId="salesforce-fsc-customer0"
-        profile={{
-          displayName: "Kushal Trivedi",
-        }}
-        agentInstruction={{
-          actionId: "connected_system.crm.update.propose",
-          slots: {
-            systemId: "salesforce-fsc-customer0",
-            email: "agent@example.com",
-            phone: "415-555-1212",
-            additionalFieldsJson: JSON.stringify({ MailingCity: "New York" }),
-          },
-        }}
-      />
-    );
-
-    expect(await screen.findByText("Update my Macy's information")).toBeTruthy();
-    await waitFor(() => {
-      expect(ConnectedSystemsService.searchRecord).toHaveBeenCalledWith(
+      expect(ConnectedSystemsService.updateRecordIntent).toHaveBeenCalledWith(
         "HCT:test",
         expect.objectContaining({
-          email: "agent@example.com",
-          phone: "415-555-1212",
-          returnFields: expect.arrayContaining(["Email", "Phone"]),
-        })
+          id: "person-42",
+          recordFields: { PreferredLanguage: "French" },
+        }),
       );
     });
-    expect(await screen.findByDisplayValue("New York")).toBeTruthy();
+    expect(await screen.findByText("Review update request")).toBeTruthy();
+    expect(screen.getByText("PreferredLanguage")).toBeTruthy();
   });
 });

--- a/hushh-webapp/__tests__/services/agent-action-runtime.test.ts
+++ b/hushh-webapp/__tests__/services/agent-action-runtime.test.ts
@@ -52,4 +52,15 @@ describe("executeAgentGatewayAction connected systems", () => {
     expect(result.status).toBe("blocked");
     expect(result.reason).toBe("crm_delete_manual_only");
   });
+
+  it("requires an explicitly selected CRM instead of defaulting to Salesforce", async () => {
+    const input = baseInput("connected_system.crm.read");
+    input.slots = {};
+
+    const result = await executeAgentGatewayAction(input);
+
+    expect(input.router.push).not.toHaveBeenCalled();
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("connected_system_selection_required");
+  });
 });

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowLeft, Users } from "lucide-react";
+import { ArrowLeft, Users, Search as SearchIcon } from "lucide-react";
 
 import {
   AppPageContentRegion,
@@ -11,7 +11,6 @@ import {
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
-import { PageHeader } from "@/components/app-ui/page-sections";
 import { ROUTES } from "@/lib/navigation/routes";
 import { useRequireAuth } from "@/hooks/use-auth";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -165,26 +164,42 @@ export default function ConnectPageClient() {
       }}
     >
       <AppPageHeaderRegion>
-        <PageHeader
-          eyebrow="One"
-          title="Connect"
-          description="Find people on Hushh and send a connection request."
-          icon={Users}
-          accent="neutral"
-          leading={
-            <Button
-              type="button"
-              variant="none"
-              effect="fade"
-              size="sm"
-              onClick={() => router.push(ROUTES.ONE_HOME)}
-              className="mr-2 h-10 w-10 p-0 rounded-full border border-border/60 bg-white/40 dark:bg-black/10 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-white/80 dark:hover:bg-white/10"
-              aria-label="Back to dashboard"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-          }
-        />
+        <div className="relative w-full hidden sm:block h-6" /> {/* spacer below top bar */}
+        <div className="w-full flex justify-between items-center px-0.5 sm:px-1 mb-6">
+          <Button
+            type="button"
+            variant="none"
+            effect="fade"
+            size="sm"
+            onClick={() => router.push(ROUTES.ONE_HOME)}
+            className="h-10 w-10 p-0 rounded-full border border-border/60 bg-white/40 dark:bg-black/10 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-white/80 dark:hover:bg-white/10"
+            aria-label="Back to dashboard"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div className="w-10 h-10" /> {/* Symmetry spacer */}
+        </div>
+
+        <header
+          className="flex w-full min-w-0 flex-col items-center gap-3 px-4 text-center sm:px-6"
+          data-slot="page-header"
+          data-page-primary="true"
+        >
+          {/* Centered Squinircle Glow Icon */}
+          <div className="relative inline-flex items-center justify-center h-16 w-16 rounded-[22px] bg-white/80 dark:bg-[rgba(30,30,45,0.7)] shadow-[0_12px_24px_rgba(0,0,0,0.12)] dark:shadow-[0_16px_32px_rgba(0,0,0,0.4)] ring-1 ring-white/60 dark:ring-white/10 animate-fade-in duration-300">
+            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-[90%] w-[90%] blur-[14px] rounded-full opacity-35 dark:opacity-20 scale-90 bg-sky-400" aria-hidden />
+            <Users className="h-7 w-7 text-sky-500 relative z-10" />
+          </div>
+
+          <div className="min-w-0 max-w-full space-y-1.5">
+            <h1 className="text-[28px] font-medium leading-[1.08] tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[34px]">
+              Connect
+            </h1>
+            <p className="text-sm text-muted-foreground max-w-[280px] sm:max-w-md mx-auto leading-relaxed">
+              Find people on Hushh and send a connection request.
+            </p>
+          </div>
+        </header>
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
@@ -249,15 +264,20 @@ export default function ConnectPageClient() {
             )}
           </SettingsGroup>
 
-          <div className="space-y-3">
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search people by name or email"
-              aria-label="Search people"
-              className="min-h-11 w-full rounded-[var(--app-control-radius)] border border-border bg-background px-4 text-sm text-foreground outline-none transition-[border-color,box-shadow] placeholder:text-muted-foreground focus:border-accent focus:ring-2 focus:ring-accent/20"
-            />
+          <div className="space-y-4">
+            <div className="relative w-full">
+              <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
+                <SearchIcon className="h-4.5 w-4.5" />
+              </span>
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search people by name or email"
+                aria-label="Search people"
+                className="min-h-12 w-full rounded-2xl border border-border/85 bg-white/70 dark:bg-black/20 pl-11 pr-4 text-sm text-foreground outline-none backdrop-blur-md transition-all placeholder:text-muted-foreground/60 focus:border-accent focus:ring-4 focus:ring-accent/10 shadow-sm"
+              />
+            </div>
             <SettingsGroup
               title="People"
               description="Find people on Hushh and send a connection request."

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -1312,7 +1312,7 @@ export function AgentBar() {
           // it does not re-render the voice tree as the page scrolls.
           bottom: physicalNavbarAbsent
             ? "calc(var(--app-safe-area-bottom-effective) + 0.75rem)"
-            : "calc(var(--app-bottom-inset) + 0.12rem)",
+            : "calc(var(--app-bottom-inset) + 0.58rem)",
         } as CSSProperties
       }
       aria-hidden={barHidden}

--- a/hushh-webapp/components/navbar.tsx
+++ b/hushh-webapp/components/navbar.tsx
@@ -30,6 +30,7 @@ import { useConsentPendingSummaryCount } from "@/lib/consent/use-consent-pending
 import { useKaiSession } from "@/lib/stores/kai-session-store";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
 import { SegmentedPill, type SegmentedPillOption } from "@/lib/morphy-ux/ui";
+import { useKaiBottomChromeElementTranslation } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
@@ -230,25 +231,32 @@ export const Navbar = () => {
     pathname === ROUTES.BLOG ||
     Boolean(pathname?.startsWith(`${ROUTES.BLOG}/`));
 
-  const navOptions = useMemo<SegmentedPillOption[]>(() => {
-    const keys = resolveBottomNavOptionKeys(
-      normalizedPathname,
-      "one",
-    );
-    return keys.map((key) =>
-      navOptionForKey(key, pendingConsents),
-    );
-  }, [normalizedPathname, pendingConsents]);
   const bottomNavScope = useMemo(
     () => resolveBottomNavigationScope(normalizedPathname, null),
     [normalizedPathname],
   );
+
+  const navOptions = useMemo<SegmentedPillOption[]>(() => {
+    const keys = resolveBottomNavOptionKeys(
+      normalizedPathname,
+      bottomNavScope,
+    );
+    return keys.map((key) =>
+      navOptionForKey(key, pendingConsents),
+    );
+  }, [normalizedPathname, bottomNavScope, pendingConsents]);
+
   const specialistOptions = useMemo<SegmentedPillOption[]>(
     () =>
       resolveBottomNavSpecialistOptionKeys(bottomNavScope).map((key) =>
         navOptionForKey(key, pendingConsents),
       ),
     [bottomNavScope, pendingConsents],
+  );
+
+  useKaiBottomChromeElementTranslation(
+    pillRef,
+    !useOnboardingChrome && isAuthenticated,
   );
 
   React.useLayoutEffect(() => {
@@ -321,7 +329,7 @@ export const Navbar = () => {
     navOptions.length > 0 ? resolveBottomNavMaxWidth(navOptions.length) : "0px";
   const bottomNavWidth =
     navOptions.length > 0
-      ? `min(calc(100vw - 6rem), ${bottomNavMaxWidth})`
+      ? `min(calc(100vw - 1.5rem), ${bottomNavMaxWidth})`
       : "0px";
   if (hideNavbar) {
     return null;

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
 import {
   Building2,
   Database,
@@ -23,7 +24,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { SettingsGroup, SettingsRow } from "@/components/profile/settings-ui";
+import { SettingsDetailPanel, SettingsGroup, SettingsRow } from "@/components/profile/settings-ui";
+import { DataTable } from "@/components/app-ui/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { SurfaceInset } from "@/components/app-ui/surfaces";
@@ -33,7 +35,6 @@ import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
 import { buildConnectedSystemRoute } from "@/lib/navigation/routes";
 import {
   ConnectedSystemsService,
-  SALESFORCE_CRM_SYSTEM_ID,
   type ConnectedSystemMcpResponse,
   type ConnectedSystemIntent,
   type ConnectedSystemRecordBinding,
@@ -74,20 +75,8 @@ export type ConnectedSystemAgentInstruction = {
   createdAt?: string;
 };
 
-type LegacyCrmProfileFieldKey =
-  | "FirstName"
-  | "LastName"
-  | "Email"
-  | "Phone"
-  | "MobilePhone"
-  | "Title"
-  | "Department"
-  | "MailingCity"
-  | "MailingStreet"
-  | "LeadSource";
-
 type CrmProfileFieldKey = string;
-type CrmFieldValues = Record<LegacyCrmProfileFieldKey, string> & Record<string, string>;
+type CrmFieldValues = Record<string, string>;
 
 type CrmProfileField = {
   key: CrmProfileFieldKey;
@@ -97,10 +86,24 @@ type CrmProfileField = {
   required?: boolean;
   identityField?: boolean;
   readable?: boolean;
+  createable?: boolean;
+  updateable?: boolean;
   writable?: boolean;
   immutable?: boolean;
   rawName?: string;
   source?: string;
+  dataType?: string;
+  constraints?: Record<string, unknown>;
+};
+
+type CrmFieldTableRow = {
+  key: string;
+  label: string;
+  dataType: string;
+  access: string;
+  required: string;
+  currentValue: string;
+  field: CrmProfileField;
 };
 
 function statusBadge(status: string | undefined | null): string {
@@ -113,114 +116,7 @@ function statusBadge(status: string | undefined | null): string {
 }
 
 const MACYS_LOGO_SRC = "/brand/macys-logo.svg";
-const CRM_FIELD_PLACEHOLDERS: Record<LegacyCrmProfileFieldKey, string> = {
-  FirstName: "Maria",
-  LastName: "Joe",
-  Email: "name@example.com",
-  Phone: "1234567899",
-  MobilePhone: "(415) 555-1212",
-  Title: "VP Sales",
-  Department: "Retail Partnerships",
-  MailingCity: "Dallas",
-  MailingStreet: "170 O'Farrell St",
-  LeadSource: "Connected Systems",
-};
-
-const CRM_PROFILE_FIELD_KEYS: LegacyCrmProfileFieldKey[] = [
-  "FirstName",
-  "LastName",
-  "Email",
-  "Phone",
-  "MobilePhone",
-  "Title",
-  "Department",
-  "MailingCity",
-  "MailingStreet",
-  "LeadSource",
-];
-
-const CRM_PROFILE_FIELD_METADATA: Record<LegacyCrmProfileFieldKey, CrmProfileField> =
-  {
-    FirstName: {
-      key: "FirstName",
-      label: "First name",
-      placeholder: CRM_FIELD_PLACEHOLDERS.FirstName,
-    },
-    LastName: {
-      key: "LastName",
-      label: "Last name",
-      placeholder: CRM_FIELD_PLACEHOLDERS.LastName,
-    },
-    Email: {
-      key: "Email",
-      label: "Email",
-      placeholder: CRM_FIELD_PLACEHOLDERS.Email,
-      inputType: "email",
-    },
-    Phone: {
-      key: "Phone",
-      label: "Phone",
-      placeholder: CRM_FIELD_PLACEHOLDERS.Phone,
-      inputType: "tel",
-    },
-    MobilePhone: {
-      key: "MobilePhone",
-      label: "Mobile phone",
-      placeholder: CRM_FIELD_PLACEHOLDERS.MobilePhone,
-      inputType: "tel",
-    },
-    Title: {
-      key: "Title",
-      label: "Title",
-      placeholder: CRM_FIELD_PLACEHOLDERS.Title,
-    },
-    Department: {
-      key: "Department",
-      label: "Department",
-      placeholder: CRM_FIELD_PLACEHOLDERS.Department,
-    },
-    MailingCity: {
-      key: "MailingCity",
-      label: "Mailing city",
-      placeholder: CRM_FIELD_PLACEHOLDERS.MailingCity,
-    },
-    MailingStreet: {
-      key: "MailingStreet",
-      label: "Mailing street",
-      placeholder: CRM_FIELD_PLACEHOLDERS.MailingStreet,
-    },
-    LeadSource: {
-      key: "LeadSource",
-      label: "Lead source",
-      placeholder: CRM_FIELD_PLACEHOLDERS.LeadSource,
-    },
-  };
-
-const CRM_PROFILE_FIELDS: CrmProfileField[] = CRM_PROFILE_FIELD_KEYS.map(
-  (key) => CRM_PROFILE_FIELD_METADATA[key],
-);
-
-const READ_ONLY_CRM_IDENTITY_FIELDS = new Set<CrmProfileFieldKey>([
-  "Email",
-  "Phone",
-]);
-
-const DEFAULT_CRM_PROFILE_VALUES: CrmFieldValues = {
-  FirstName: "",
-  LastName: "",
-  Email: "",
-  Phone: "",
-  MobilePhone: "",
-  Title: "",
-  Department: "",
-  MailingCity: "",
-  MailingStreet: "",
-  LeadSource: "",
-};
-
-function isCrmProfileFieldKey(value: unknown): value is LegacyCrmProfileFieldKey {
-  return CRM_PROFILE_FIELD_KEYS.includes(value as LegacyCrmProfileFieldKey);
-}
+const DEFAULT_CRM_PROFILE_VALUES: CrmFieldValues = {};
 
 function inputTypeFromSchema(dataType?: string): string | undefined {
   const normalized = String(dataType || "")
@@ -238,28 +134,26 @@ function crmFieldFromSchemaDescriptor(
 ): CrmProfileField | null {
   const key = String(descriptor.key || descriptor.name || "").trim();
   if (!key) return null;
-  const fallback = isCrmProfileFieldKey(key)
-    ? CRM_PROFILE_FIELD_METADATA[key]
-    : undefined;
-  const label = String(descriptor.label || fallback?.label || key)
+  const label = String(descriptor.label || key)
     .replace(/([a-z])([A-Z])/g, "$1 $2")
     .replace(/[_-]+/g, " ")
     .trim();
   return {
     key,
     label: label || key,
-    placeholder: fallback?.placeholder || `Enter ${label || key}`,
-    inputType: inputTypeFromSchema(descriptor.dataType) || fallback?.inputType,
+    placeholder: `Enter ${label || key}`,
+    inputType: inputTypeFromSchema(descriptor.dataType),
     required: descriptor.required === true,
     identityField: descriptor.identityField === true,
-    readable: descriptor.readable !== false,
-    writable:
-      descriptor.writable !== false &&
-      descriptor.immutable !== true &&
-      descriptor.identityField !== true,
+    readable: descriptor.readable === true,
+    createable: descriptor.createable === true,
+    updateable: descriptor.updateable === true,
+    writable: descriptor.updateable === true && descriptor.immutable !== true && descriptor.identityField !== true,
     immutable: descriptor.immutable === true,
     rawName: String(descriptor.name || key).trim() || key,
     source: String(descriptor.source || "mcp_schema").trim() || "mcp_schema",
+    dataType: String(descriptor.dataType || "string"),
+    constraints: descriptor.constraints,
   };
 }
 
@@ -318,73 +212,16 @@ function ConnectedSystemLogo({
 function extractRecords(
   result: ConnectedSystemMcpResponse | null,
 ): Record<string, unknown>[] {
-  const mcp = result?.mcp;
-  const payload =
-    mcp && typeof mcp === "object" && "payload" in mcp
-      ? ((mcp as { payload?: unknown }).payload as
-          Record<string, unknown> | undefined)
-      : undefined;
-  if (!payload || typeof payload !== "object") return [];
-  return collectCrmRecords(payload);
-}
-
-function looksLikeCrmRecord(record: Record<string, unknown>): boolean {
-  return (
-    CRM_PROFILE_FIELD_KEYS.some((key) => key in record) ||
-    [
-      "Id",
-      "id",
-      "recordId",
-      "record_id",
-      "Name",
-      "firstName",
-      "lastName",
-      "mailingCity",
-    ].some((key) => key in record)
-  );
-}
-
-function collectCrmRecords(
-  value: unknown,
-  depth = 0,
-): Record<string, unknown>[] {
-  if (!value || depth > 3) return [];
-  if (Array.isArray(value)) {
-    const directRecords = value.filter(
-      (item): item is Record<string, unknown> =>
-        Boolean(item) &&
-        typeof item === "object" &&
-        !Array.isArray(item) &&
-        looksLikeCrmRecord(item as Record<string, unknown>),
-    );
-    if (directRecords.length > 0) return directRecords;
-    return value.flatMap((item) => collectCrmRecords(item, depth + 1));
-  }
-  if (typeof value !== "object") return [];
-  const record = value as Record<string, unknown>;
-  for (const key of [
-    "records",
-    "Contact",
-    "contacts",
-    "data",
-    "result",
-    "records_",
-  ]) {
-    const nested = collectCrmRecords(record[key], depth + 1);
-    if (nested.length > 0) return nested;
-  }
-  if (looksLikeCrmRecord(record)) return [record];
-  for (const nestedValue of Object.values(record)) {
-    const nested = collectCrmRecords(nestedValue, depth + 1);
-    if (nested.length > 0) return nested;
-  }
-  return [];
+  return (result?.records || []).map((record) => ({
+    ...record.fields,
+    __connectedSystemRecordId: record.recordId || "",
+  }));
 }
 
 function recordIdFromRecord(record?: Record<string, unknown> | null): string {
   if (!record) return "";
   return cleanFieldValue(
-    record.Id || record.id || record.recordId || record.record_id,
+    record.__connectedSystemRecordId || record.Id || record.id || record.recordId || record.record_id,
   );
 }
 
@@ -429,35 +266,28 @@ function agentInstructionSlot(
 
 function agentInstructionFields(
   instruction: ConnectedSystemAgentInstruction | null | undefined,
-): Partial<Record<CrmProfileFieldKey, string>> {
+): Record<string, string> {
+  const out: Record<string, string> = {};
   const raw = agentInstructionSlot(instruction, "additionalFieldsJson");
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-      return {};
-    const out: Partial<Record<CrmProfileFieldKey, string>> = {};
-    for (const field of CRM_PROFILE_FIELDS) {
-      const value = (parsed as Record<string, unknown>)[field.key];
-      const cleaned = cleanFieldValue(value);
-      if (cleaned && !READ_ONLY_CRM_IDENTITY_FIELDS.has(field.key)) {
-        out[field.key] = cleaned;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        for (const [key, value] of Object.entries(parsed)) {
+          const cleaned = cleanFieldValue(value);
+          if (cleaned) out[key] = cleaned;
+        }
       }
+    } catch {
+      // The private agent proposal is optional. Invalid proposal fields are
+      // ignored and the backend remains the schema-validation authority.
     }
-    return out;
-  } catch {
-    return {};
   }
-}
-
-function crmLookupPhoneCandidates(phone: string): string[] {
-  const clean = cleanFieldValue(phone);
-  const digits = clean.replace(/\D/g, "");
-  const withoutCountryCode =
-    digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : "";
-  return Array.from(
-    new Set([clean, digits, withoutCountryCode].filter(Boolean)),
-  );
+  const email = agentInstructionSlot(instruction, "email");
+  const phone = agentInstructionSlot(instruction, "phone");
+  if (email) out.email = email;
+  if (phone) out.phone = phone;
+  return out;
 }
 
 function isWorkflowStorageNotReady(message: string): boolean {
@@ -493,7 +323,7 @@ function mutationResultError(value: unknown): string | null {
   return (
     cleanFieldValue(record.errorMessage) ||
     cleanFieldValue(record.errorCode) ||
-    "Macy's CRM request failed."
+    "CRM request failed."
   );
 }
 
@@ -565,6 +395,8 @@ export function ConnectedSystemsPanel({
   const [pendingIntent, setPendingIntent] = useState<ConnectedSystemIntent | null>(null);
   const [busy, setBusy] = useState<BusyState>(null);
   const [error, setError] = useState<string | null>(null);
+  const [editingField, setEditingField] = useState<CrmProfileField | null>(null);
+  const [editingValue, setEditingValue] = useState("");
 
   const [crmFieldValues, setCrmFieldValues] = useState<
     CrmFieldValues
@@ -577,11 +409,7 @@ export function ConnectedSystemsPanel({
   const [bindingResolvedKey, setBindingResolvedKey] = useState<string | null>(
     null,
   );
-  const [autoLinkResolvedKey, setAutoLinkResolvedKey] = useState<string | null>(
-    null,
-  );
   const [readResolvedKey, setReadResolvedKey] = useState<string | null>(null);
-  const autoLinkAttemptKeyRef = useRef<string | null>(null);
   const consumedAgentInstructionRef = useRef<string | null>(null);
   // Tracks which systems (by systemId) have an active record binding, across
   // ALL available systems, not just the one currently open in detail view.
@@ -594,21 +422,22 @@ export function ConnectedSystemsPanel({
   const selectedSystemKey = selectedSystem
     ? `${selectedSystem.systemId}:${selectedSystem.objectTypeDefault || "Contact"}`
     : "";
-  const supportedFields = useMemo(
-    () => schema?.supportedFields || selectedSystem?.fieldAllowlist || [],
-    [schema?.supportedFields, selectedSystem?.fieldAllowlist],
-  );
   const canUseBackend = Boolean(vaultOwnerToken);
+  const schemaReady = schema?.schemaStatus === "ready";
   const supportsAction = (action: "schema" | "read" | "create" | "update" | "delete") =>
-    selectedSystem?.supportedActions?.[action] === true;
+    action === "schema"
+      ? selectedSystem?.supportedActions?.schema === true
+      : schemaReady && schema?.effectiveActions?.[action] === true;
   const customerName = selectedSystem?.customerDisplayName || "Connected CRM";
   const systemType = selectedSystem?.systemType || "CRM";
   const systemName = selectedSystem?.systemName || "FSC";
   const systemLabel = crmTypeDisplayLabel({ systemType, systemName });
-  const registeredEmail = cleanFieldValue(profile?.email);
-  const registeredPhone = cleanFieldValue(profile?.phone);
-  const isLegacyMacys = selectedSystem?.systemId === SALESFORCE_CRM_SYSTEM_ID;
-  const hasRegisteredLookup = Boolean(registeredEmail && registeredPhone);
+  const primaryObjectLabel =
+    schema?.objectMetadata?.label ||
+    schema?.objectType ||
+    selectedSystem?.capabilities?.primaryObject ||
+    selectedSystem?.objectTypeDefault ||
+    "record";
   const crmRecords = useMemo(() => extractRecords(readResult), [readResult]);
   const hasReadback = Boolean(readResult);
   const activeBinding = binding?.status === "active" ? binding : null;
@@ -619,10 +448,6 @@ export function ConnectedSystemsPanel({
   useEffect(() => {
     onSetupReadinessChange?.(anySystemBound);
   }, [anySystemBound, onSetupReadinessChange]);
-  const schemaFieldSet = useMemo(
-    () => new Set(supportedFields),
-    [supportedFields],
-  );
   const schemaDrivenProfileFields = useMemo(() => {
     const liveFields = Array.isArray(schema?.fields) ? schema.fields : [];
     return liveFields
@@ -631,9 +456,8 @@ export function ConnectedSystemsPanel({
   }, [schema?.fields]);
   const visibleProfileFields = useMemo(() => {
     if (schemaDrivenProfileFields.length > 0) return schemaDrivenProfileFields;
-    if (schemaFieldSet.size === 0) return [];
-    return CRM_PROFILE_FIELDS.filter((field) => schemaFieldSet.has(field.key));
-  }, [schemaDrivenProfileFields, schemaFieldSet]);
+    return [];
+  }, [schemaDrivenProfileFields]);
   const changedProfileFields = useMemo(
     () =>
       changedFieldsFromValues(
@@ -661,9 +485,7 @@ export function ConnectedSystemsPanel({
     ),
     [crmFieldValues, lookupFields],
   );
-  const hasLookup = isLegacyMacys
-    ? hasRegisteredLookup
-    : lookupFields.length > 0 && Object.keys(schemaLookupValues).length === lookupFields.length;
+  const hasLookup = lookupFields.length > 0 && Object.keys(schemaLookupValues).length === lookupFields.length;
   const currentReadRecord = useMemo(
     () => selectRecordForId(readResult, currentRecordId),
     [currentRecordId, readResult],
@@ -677,36 +499,13 @@ export function ConnectedSystemsPanel({
             selectedSystem.systemId,
             selectedSystem.objectTypeDefault || "Contact",
             currentRecordId,
-            registeredEmail,
-            registeredPhone,
           ].join(":")
         : "",
-    [currentRecordId, registeredEmail, registeredPhone, selectedSystem],
+    [currentRecordId, selectedSystem],
   );
   const bindingResolved = Boolean(
     selectedSystemKey && bindingResolvedKey === selectedSystemKey,
   );
-  const autoLinkKey = useMemo(
-    () =>
-      selectedSystem
-        ? [
-            selectedSystem.systemId,
-            selectedSystem.objectTypeDefault || "Contact",
-            registeredEmail,
-            registeredPhone,
-          ].join(":")
-        : "",
-    [registeredEmail, registeredPhone, selectedSystem],
-  );
-  const shouldAutoLink =
-    mode === "detail" &&
-    bindingResolved &&
-    !activeBinding &&
-    !currentRecordId &&
-    isLegacyMacys && hasRegisteredLookup &&
-    Boolean(autoLinkKey);
-  const autoLinkResolved =
-    !shouldAutoLink || autoLinkResolvedKey === autoLinkKey;
   const boundRecordReadResolved =
     !hasBoundRecord ||
     !hasLookup ||
@@ -717,7 +516,7 @@ export function ConnectedSystemsPanel({
     canUseBackend &&
     !error &&
     hasBoundRecord &&
-    hasLookup &&
+    schemaReady && supportsAction("read") && hasLookup &&
     !boundRecordReadResolved;
   const isRecordStateLoading =
     mode === "detail" &&
@@ -725,38 +524,44 @@ export function ConnectedSystemsPanel({
     !error &&
     (!selectedSystem ||
       !bindingResolved ||
-      !autoLinkResolved ||
       isBoundRecordHydrating);
   const canShowUnboundRecordActions =
     !hasBoundRecord &&
     !isRecordStateLoading &&
+    schemaReady &&
     visibleProfileFields.length > 0 &&
     (supportsAction("read") || supportsAction("create"));
   const canShowBoundRecordActions =
-    hasBoundRecord && !isRecordStateLoading && supportsAction("update");
+    hasBoundRecord && !isRecordStateLoading && schemaReady && supportsAction("update");
+  const showCatalogueOnly = Boolean(
+    schema &&
+      (!schemaReady ||
+        (hasBoundRecord ? !canShowBoundRecordActions : !canShowUnboundRecordActions)),
+  );
 
   useEffect(() => {
     const email = cleanFieldValue(profile?.email);
     const phone = cleanFieldValue(profile?.phone);
-    const displayName = cleanFieldValue(profile?.displayName);
-    const [firstName, ...lastNameParts] = displayName
-      .split(/\s+/)
-      .filter(Boolean);
-    setCrmFieldValues((current) => ({
-      ...current,
-      FirstName: current.FirstName || firstName || "",
-      LastName: current.LastName || lastNameParts.join(" "),
-      Email: email,
-      Phone: phone,
-    }));
-    setCrmBaselineValues((current) => ({
-      ...current,
-      FirstName: current.FirstName || firstName || "",
-      LastName: current.LastName || lastNameParts.join(" "),
-      Email: email,
-      Phone: phone,
-    }));
-  }, [profile?.displayName, profile?.email, profile?.phone]);
+    if (visibleProfileFields.length === 0 || (!email && !phone)) return;
+    setCrmFieldValues((current) => {
+      const next = { ...current };
+      let changed = false;
+      for (const field of visibleProfileFields) {
+        if (!field.identityField || next[field.key]) continue;
+        const descriptor = `${field.key} ${field.rawName} ${field.label}`.toLowerCase();
+        const value = descriptor.includes("email")
+          ? email
+          : descriptor.includes("phone") || descriptor.includes("telephone") || descriptor.includes("mobile")
+            ? phone
+            : "";
+        if (value) {
+          next[field.key] = value;
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [profile?.email, profile?.phone, visibleProfileFields]);
 
   useEffect(() => {
     if (mode !== "detail") return;
@@ -880,11 +685,7 @@ export function ConnectedSystemsPanel({
   }, [mode, refreshBinding, selectedSystem, vaultOwnerToken]);
 
   const resetWorkingCopy = () => {
-    setCrmFieldValues({
-      ...crmBaselineValues,
-      Email: registeredEmail,
-      Phone: registeredPhone,
-    });
+    setCrmFieldValues({ ...crmBaselineValues });
     setDeleteResult(null);
   };
 
@@ -970,22 +771,6 @@ export function ConnectedSystemsPanel({
     }
   };
 
-  useEffect(() => {
-    if (
-      mode !== "detail" ||
-      !selectedSystem ||
-      !vaultOwnerToken ||
-      !supportsAction("schema") ||
-      schema?.systemId === selectedSystem.systemId
-    ) {
-      return;
-    }
-    void loadSchema({ silent: true });
-    // The effect is intentionally keyed by the selected registry row; a schema
-    // refresh is user initiated through the visible control below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, schema?.systemId, selectedSystem?.systemId, vaultOwnerToken]);
-
   const applyReadResult = (result: ConnectedSystemMcpResponse) => {
     setReadResult(result);
     const nextBinding =
@@ -1003,11 +788,8 @@ export function ConnectedSystemsPanel({
     );
     if (record) {
       const values = crmValuesFromRecord(record, visibleProfileFields);
-      const identityLockedValues = isLegacyMacys
-        ? { ...values, Email: registeredEmail || values.Email, Phone: registeredPhone || values.Phone }
-        : values;
-      setCrmFieldValues(identityLockedValues);
-      setCrmBaselineValues(identityLockedValues);
+      setCrmFieldValues(values);
+      setCrmBaselineValues(values);
     }
     const recordId = result.recordId || extractFirstRecordId(result);
     if (recordId && (nextBinding || currentRecordId)) {
@@ -1020,55 +802,37 @@ export function ConnectedSystemsPanel({
     options: {
       silent?: boolean;
       bindSearch?: boolean;
-      email?: string;
-      phone?: string;
     } = {},
   ) => {
     const result = await runAction(
       "read",
       async () => {
-        const returnFields = visibleProfileFields.map((field) => field.key);
-        const lookupEmail = options.email ?? registeredEmail;
-        const lookupPhone = options.phone ?? registeredPhone;
+        const returnFields = visibleProfileFields
+          .filter((field) => field.readable)
+          .map((field) => field.rawName || field.key);
         const completedReadKey =
           !options.bindSearch && selectedSystem && currentRecordId
             ? [
                 selectedSystem.systemId,
                 selectedSystem.objectTypeDefault || "Contact",
                 currentRecordId,
-                lookupEmail,
-                lookupPhone,
               ].join(":")
             : "";
-        const buildPayload = (phone: string) => ({
+        const payload = {
           systemId: selectedSystem?.systemId,
           objectType: selectedSystem?.objectTypeDefault,
-          email: isLegacyMacys ? lookupEmail : undefined,
-          phone: isLegacyMacys ? phone : undefined,
-          searchFields: isLegacyMacys ? undefined : schemaLookupValues,
+          searchFields: schemaLookupValues,
           returnFields,
-        });
-        const callRead = (phone: string) => {
-          const payload = buildPayload(phone);
-          return options.bindSearch
-            ? ConnectedSystemsService.searchRecord(
-                vaultOwnerToken || "",
-                payload,
-              )
-            : ConnectedSystemsService.readRecord(
-                vaultOwnerToken || "",
-                payload,
-              );
         };
-        const phoneCandidates = isLegacyMacys ? crmLookupPhoneCandidates(lookupPhone) : [""];
-        const firstPhone = phoneCandidates[0] || lookupPhone;
-        let nextResult = await callRead(firstPhone);
-        if (!options.bindSearch && extractRecords(nextResult).length === 0) {
-          for (const phone of phoneCandidates) {
-            nextResult = await callRead(phone);
-            if (extractRecords(nextResult).length > 0) break;
-          }
-        }
+        const nextResult = options.bindSearch
+          ? await ConnectedSystemsService.searchRecord(
+              vaultOwnerToken || "",
+              payload,
+            )
+          : await ConnectedSystemsService.readRecord(
+              vaultOwnerToken || "",
+              payload,
+            );
         if (completedReadKey) setReadResolvedKey(completedReadKey);
         return nextResult;
       },
@@ -1108,54 +872,38 @@ export function ConnectedSystemsPanel({
     }
     if (!bindingResolved) return;
     if (!agentInstruction.actionId.startsWith("connected_system.crm.")) return;
+    if (!schemaReady || visibleProfileFields.length === 0) return;
 
     const instructionKey = JSON.stringify(agentInstruction);
     if (consumedAgentInstructionRef.current === instructionKey) return;
     consumedAgentInstructionRef.current = instructionKey;
 
-    const slots = agentInstruction.slots || {};
-    const lookupEmail = cleanFieldValue(slots.email) || registeredEmail;
-    const lookupPhone = cleanFieldValue(slots.phone) || registeredPhone;
-    const recordId = cleanFieldValue(
-      slots.id || slots.recordId || slots.record_id,
-    );
     const proposedFields = agentInstructionFields(agentInstruction);
-
-    const applyProposedFields = () => {
-      if (Object.keys(proposedFields).length === 0) return;
-      setCrmFieldValues((current) => ({
-        ...current,
-        ...proposedFields,
-        Email: lookupEmail || registeredEmail || current.Email,
-        Phone: lookupPhone || registeredPhone || current.Phone,
-      }));
-    };
-
-    if (recordId) {
-      setUpdateId(recordId);
-      setDeleteId(recordId);
+    const declaredFields = new Map<string, CrmProfileField>();
+    for (const field of visibleProfileFields) {
+      declaredFields.set(field.key.toLowerCase(), field);
+      declaredFields.set((field.rawName || field.key).toLowerCase(), field);
     }
-
-    void (async () => {
-      if (lookupEmail && lookupPhone) {
-        await readRecord({
-          silent: false,
-          bindSearch: true,
-          email: lookupEmail,
-          phone: lookupPhone,
-        });
-      }
-      applyProposedFields();
-    })();
-    // readRecord is intentionally captured for this one-shot agent instruction.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const stagedFields = Object.entries(proposedFields).flatMap(
+      ([candidate, value]) => {
+        const field = declaredFields.get(candidate.toLowerCase());
+        return field ? [[field.key, value] as const] : [];
+      },
+    );
+    if (stagedFields.length === 0) return;
+    setCrmFieldValues((current) => {
+      const next = { ...current };
+      for (const [fieldKey, value] of stagedFields) next[fieldKey] = value;
+      return next;
+    });
+    toast.info("CRM proposal staged. Review it before linking or updating the record.");
   }, [
     agentInstruction,
     bindingResolved,
     mode,
-    registeredEmail,
-    registeredPhone,
+    schemaReady,
     selectedSystem,
+    visibleProfileFields,
     vaultOwnerToken,
   ]);
 
@@ -1172,6 +920,8 @@ export function ConnectedSystemsPanel({
       mode !== "detail" ||
       !activeBinding ||
       !currentRecordId ||
+      !schemaReady ||
+      !supportsAction("read") ||
       !hasLookup ||
       readResultHasCurrentRecord
     ) {
@@ -1187,55 +937,18 @@ export function ConnectedSystemsPanel({
     mode,
     readResultHasCurrentRecord,
     vaultOwnerToken,
-  ]);
-
-  useEffect(() => {
-    if (
-      !vaultOwnerToken ||
-      !selectedSystem ||
-      mode !== "detail" ||
-      !bindingResolved ||
-      activeBinding ||
-      currentRecordId ||
-      !hasRegisteredLookup
-    ) {
-      return;
-    }
-    const attemptKey = autoLinkKey;
-    if (autoLinkAttemptKeyRef.current === attemptKey) return;
-    autoLinkAttemptKeyRef.current = attemptKey;
-    void (async () => {
-      await readRecord({
-        silent: true,
-        bindSearch: true,
-        email: registeredEmail,
-        phone: registeredPhone,
-      });
-      setAutoLinkResolvedKey(attemptKey);
-    })();
-    // readRecord is intentionally keyed by the lookup identity and route state.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    activeBinding,
-    autoLinkKey,
-    bindingResolved,
-    currentRecordId,
-    hasRegisteredLookup,
-    mode,
-    registeredEmail,
-    registeredPhone,
-    selectedSystem,
-    vaultOwnerToken,
+    schemaReady,
   ]);
 
   const updateCrmFieldValue = (field: CrmProfileField, value: string) => {
-    if ((hasBoundRecord && field.identityField) || field.writable !== true || field.immutable) return;
+    if (!schemaReady || field.updateable !== true || field.identityField || field.immutable) return;
     setCrmFieldValues((current) => ({ ...current, [field.key]: value }));
   };
 
   const createRecordFromSchema = async () => {
     const recordFields = Object.fromEntries(
       visibleProfileFields
+        .filter((field) => field.createable === true && !field.immutable)
         .map((field) => [field.rawName || field.key, cleanFieldValue(crmFieldValues[field.key])])
         .filter(([, value]) => Boolean(value)),
     );
@@ -1273,23 +986,32 @@ export function ConnectedSystemsPanel({
    * first.
    */
   const linkThisSystem = async () => {
-    if (!hasLookup) {
+    const canRead = supportsAction("read");
+    const canCreate = supportsAction("create");
+    if (canRead && !hasLookup) {
       toast.error(
         "Complete the CRM identity fields before linking this system.",
       );
       return;
     }
-    const found = await readRecord({
-      silent: true,
-      bindSearch: true,
-    });
-    if (found?.binding?.status === "active") {
-      toast.success(`Found your existing ${customerName} record and linked it.`);
-      return;
+    if (canRead) {
+      const found = await readRecord({
+        silent: true,
+        bindSearch: true,
+      });
+      if (found?.binding?.status === "active") {
+        toast.success(`Found your existing ${customerName} record and linked it.`);
+        return;
+      }
+      if (!canCreate) {
+        toast.info(`No matching ${customerName} record was found.`);
+        return;
+      }
     }
+    if (!canCreate) return;
     if (visibleProfileFields.some((field) => field.required && !cleanFieldValue(crmFieldValues[field.key]))) {
       toast.error(
-        "No existing record was found. Complete the required fields, then link again to create one.",
+        "Complete the required fields before creating this CRM record.",
       );
       return;
     }
@@ -1417,7 +1139,10 @@ export function ConnectedSystemsPanel({
   ) => {
     const pendingChanges = Object.keys(changedProfileFields).length;
     const parts = [
-      schema ? "Fields discovered" : "Using Contact defaults",
+      schema ? `${visibleProfileFields.length} fields discovered` : "Waiting for CRM schema",
+      schema?.schemaStatus === "capability_metadata_missing"
+        ? "Configuration update required"
+        : null,
       primaryCrmRecord
         ? `${crmRecords.length} record${crmRecords.length === 1 ? "" : "s"} loaded`
         : hasReadback && currentRecordId
@@ -1434,49 +1159,91 @@ export function ConnectedSystemsPanel({
     return <p className="text-xs text-muted-foreground">{parts.join(" / ")}</p>;
   };
 
-  const renderCrmFieldGrid = () => (
-    <div className="grid gap-3 sm:grid-cols-2">
-      {visibleProfileFields.map((field) => {
-        const identityField = field.identityField === true;
-        const identityValue =
-          isLegacyMacys && field.key === "Email"
-            ? registeredEmail
-            : isLegacyMacys && field.key === "Phone"
-              ? registeredPhone
-              : "";
-        const value = identityField
-          ? identityValue || crmFieldValues[field.key]
-          : crmFieldValues[field.key] || "";
+  const crmFieldRows: CrmFieldTableRow[] = visibleProfileFields.map((field) => {
+    const access = [
+      field.readable ? "read" : null,
+      field.createable ? "create" : null,
+      field.updateable ? "update" : null,
+      field.immutable ? "immutable" : null,
+      field.identityField ? "identity" : null,
+    ].filter(Boolean).join(" · ") || "not declared";
+    return {
+      key: field.key,
+      label: field.label,
+      dataType: field.dataType || "string",
+      access,
+      required: field.required ? "Required" : "Optional",
+      currentValue: displayRecordValue(crmFieldValues[field.key]),
+      field,
+    };
+  });
+
+  const crmFieldColumns: ColumnDef<CrmFieldTableRow>[] = [
+    { accessorKey: "label", header: "Field" },
+    { accessorKey: "dataType", header: "Type" },
+    {
+      accessorKey: "access",
+      header: "Access",
+      cell: ({ row }) => <span className="text-xs text-muted-foreground">{row.original.access}</span>,
+    },
+    { accessorKey: "required", header: "Required" },
+    {
+      accessorKey: "currentValue",
+      header: "Current value",
+      cell: ({ row }) => <span className="block max-w-56 truncate">{row.original.currentValue}</span>,
+    },
+    {
+      id: "actions",
+      header: "",
+      cell: ({ row }) => {
+        const field = row.original.field;
+        if (
+          !schemaReady ||
+          !supportsAction("update") ||
+          field.updateable !== true ||
+          field.identityField ||
+          field.immutable
+        ) {
+          return <span className="text-xs text-muted-foreground">—</span>;
+        }
         return (
-          <label key={field.key} className="space-y-1.5">
-            <span className="flex items-center justify-between gap-2 text-[12px] font-medium text-muted-foreground">
-              <span>{field.label}</span>
-              {identityField && isLegacyMacys ? (
-                <span>From One profile</span>
-              ) : field.required ? (
-                <span>Required</span>
-              ) : field.key in changedProfileFields ? (
-                <span>Changed</span>
-              ) : null}
-            </span>
-            <Input
-              type={field.inputType || "text"}
-              value={value}
-              disabled={(hasBoundRecord && identityField) || field.writable !== true || field.immutable}
-              onChange={(event) =>
-                updateCrmFieldValue(field, event.target.value)
-              }
-              placeholder={field.placeholder}
-              autoComplete="off"
-            />
-            {crmBaselineValues[field.key] && !identityField ? (
-              <span className="block truncate text-[11px] text-muted-foreground">
-                Current: {displayRecordValue(crmBaselineValues[field.key])}
-              </span>
-            ) : null}
-          </label>
+          <Button
+            type="button"
+            variant="none"
+            effect="fade"
+            size="sm"
+            disabled={busy !== null}
+            onClick={() => {
+              setEditingField(field);
+              setEditingValue(cleanFieldValue(crmFieldValues[field.key]));
+            }}
+          >
+            Edit
+          </Button>
         );
-      })}
+      },
+    },
+  ];
+
+  const renderCrmFieldTable = (configurationMessage?: string | null) => (
+    <div className="space-y-2">
+      <DataTable
+        columns={crmFieldColumns}
+        data={crmFieldRows}
+        globalSearchKeys={["label", "dataType", "access", "required", "currentValue"]}
+        searchPlaceholder="Search fields"
+        initialPageSize={16}
+        pageSizeOptions={[16, 32, 64]}
+        density="compact"
+        stickyHeader
+        tableContainerClassName="max-w-full"
+        tableClassName="min-w-[920px]"
+      />
+      {configurationMessage ? (
+        <SurfaceInset className="px-3 py-2.5 text-xs leading-relaxed text-muted-foreground">
+          {configurationMessage}
+        </SurfaceInset>
+      ) : null}
     </div>
   );
 
@@ -1604,7 +1371,7 @@ export function ConnectedSystemsPanel({
               </h2>
               <p className="text-sm text-muted-foreground">
                 {systemLabel || selectedSystem?.displayName || "CRM"} /{" "}
-                {selectedSystem?.objectTypeDefault || "Contact"}.
+                {primaryObjectLabel}.
               </p>
             </div>
           </div>
@@ -1632,6 +1399,48 @@ export function ConnectedSystemsPanel({
             }
             stackTrailingOnMobile
           />
+        </SettingsGroup>
+      ) : null}
+
+      {showCatalogueOnly ? (
+        <SettingsGroup title={`${customerName} field catalogue`}>
+          <div className="space-y-3 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              {renderSchemaStatus()}
+              <div className="flex flex-wrap gap-2">
+                {schemaReady && hasBoundRecord && supportsAction("read") ? (
+                  <Button
+                    type="button"
+                    variant="none"
+                    effect="fade"
+                    size="sm"
+                    disabled={busy !== null || !hasLookup}
+                    onClick={() => void readRecord()}
+                  >
+                    <Icon icon={RefreshCw} size="sm" className="mr-2" />
+                    Refresh record
+                  </Button>
+                ) : null}
+                <Button
+                  type="button"
+                  variant="none"
+                  effect="fade"
+                  size="sm"
+                  disabled={busy !== null}
+                  onClick={() => void loadSchema()}
+                >
+                  <Icon icon={ListChecks} size="sm" className="mr-2" />
+                  Refresh fields
+                </Button>
+              </div>
+            </div>
+            {renderCrmFieldTable(
+              !schemaReady
+                ? schema?.configurationMessage ||
+                    "This is a discovered field catalogue. The CRM must publish explicit field access metadata before records can be read or changed."
+                : "This CRM does not currently have a complete registered record-operation contract. Fields are shown for configuration review only.",
+            )}
+          </div>
         </SettingsGroup>
       ) : null}
 
@@ -1664,40 +1473,25 @@ export function ConnectedSystemsPanel({
                 </Button>
               </div>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {[
-                ["Registered email", registeredEmail || "Not registered"],
-                ["Registered phone", registeredPhone || "Not registered"],
-              ].map(([label, value]) => (
-                <div
-                  key={label}
-                  className="rounded-lg border border-border/60 bg-background/70 px-3 py-2.5"
-                >
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                    {label}
-                  </div>
-                  <div className="mt-1 truncate text-sm font-medium text-foreground">
-                    {value}
-                  </div>
-                </div>
-              ))}
-            </div>
-            {!hasRegisteredLookup ? (
+            {!hasLookup ? (
               <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2.5 text-xs text-amber-700 dark:text-amber-300">
-                Add a verified email and phone number to your One profile
-                before linking a Macy's record.
+                Fill each field marked as an identity field before linking this
+                CRM record.
               </div>
             ) : null}
-            {renderCrmFieldGrid()}
+            {renderCrmFieldTable()}
             <p className="text-xs leading-relaxed text-muted-foreground">
-              We&apos;ll look for your existing record first, and only create
-              a new one if nothing matches.
+              {supportsAction("read") && supportsAction("create")
+                ? "We’ll look for your existing record first, and only create a new one if nothing matches."
+                : supportsAction("read")
+                  ? "We’ll look only for an existing CRM record."
+                  : "This CRM allows a new record to be prepared for review."}
             </p>
             <div className="flex justify-end">
               <Button
                 type="button"
                 size="sm"
-                disabled={busy !== null || !hasRegisteredLookup}
+                disabled={busy !== null || (supportsAction("read") && !hasLookup)}
                 onClick={() => void linkThisSystem()}
               >
                 <Icon
@@ -1713,7 +1507,11 @@ export function ConnectedSystemsPanel({
                   ? "Looking for your record..."
                   : busy === "create"
                     ? "Creating your record..."
-                    : "Link this system"}
+                    : supportsAction("read") && supportsAction("create")
+                      ? "Link this system"
+                      : supportsAction("read")
+                        ? "Find record"
+                        : "Create record"}
               </Button>
             </div>
           </div>
@@ -1760,7 +1558,7 @@ export function ConnectedSystemsPanel({
                 </Button>
               </div>
             </div>
-            {renderCrmFieldGrid()}
+            {renderCrmFieldTable()}
             {renderPendingUpdatePreview()}
             <div className="flex flex-wrap items-center justify-between gap-2">
               <Button
@@ -1789,7 +1587,7 @@ export function ConnectedSystemsPanel({
         <SettingsGroup title="Delete record">
           <SettingsRow
             icon={Trash2}
-            title={`Delete ${selectedSystem?.objectTypeDefault || "record"}`}
+            title={`Delete ${primaryObjectLabel}`}
             description={`Remove record ${currentRecordId} from ${customerName}.`}
             trailing={
               <div className="flex flex-wrap items-center justify-start gap-2 sm:justify-end">
@@ -1812,7 +1610,7 @@ export function ConnectedSystemsPanel({
                         Delete this CRM record?
                       </AlertDialogTitle>
                       <AlertDialogDescription>
-                        This deletes the {selectedSystem?.objectTypeDefault || "record"} in {customerName}. The One
+                        This deletes the {primaryObjectLabel} in {customerName}. The One
                         binding will be cleared after the MCP confirms deletion.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
@@ -1842,6 +1640,56 @@ export function ConnectedSystemsPanel({
           {statusBadge(String(deleteResult.resultClass || "completed"))}.
         </SurfaceInset>
       ) : null}
+      <SettingsDetailPanel
+        open={Boolean(editingField)}
+        onOpenChange={(open) => {
+          if (!open) setEditingField(null);
+        }}
+        title={editingField ? `Edit ${editingField.label}` : "Edit CRM field"}
+        description="This change is staged locally and will be reviewed before the CRM is updated."
+        desktopMaxWidthClassName="sm:!max-w-[520px]"
+      >
+        {editingField ? (
+          <div className="space-y-4 p-4 sm:p-5">
+            {Array.isArray(editingField.constraints?.allowedValues) ? (
+              <select
+                value={editingValue}
+                onChange={(event) => setEditingValue(event.target.value)}
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="">Not set</option>
+                {editingField.constraints?.allowedValues
+                  ?.filter((value): value is string => typeof value === "string")
+                  .map((value) => <option key={value} value={value}>{value}</option>)}
+              </select>
+            ) : (
+              <Input
+                type={editingField.inputType || "text"}
+                value={editingValue}
+                maxLength={typeof editingField.constraints?.maxLength === "number" ? editingField.constraints.maxLength : undefined}
+                onChange={(event) => setEditingValue(event.target.value)}
+                placeholder={editingField.placeholder}
+                autoComplete="off"
+              />
+            )}
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="none" effect="fade" size="sm" onClick={() => setEditingField(null)}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => {
+                  updateCrmFieldValue(editingField, editingValue);
+                  setEditingField(null);
+                }}
+              >
+                Stage change
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </SettingsDetailPanel>
       <AlertDialog
         open={Boolean(pendingIntent)}
         onOpenChange={(open) => {
@@ -1855,7 +1703,7 @@ export function ConnectedSystemsPanel({
             </AlertDialogTitle>
             <AlertDialogDescription>
               {pendingIntent
-                ? `${customerName} · ${pendingIntent.objectType || selectedSystem?.objectTypeDefault || "record"}${pendingIntent.recordId ? ` · record ${pendingIntent.recordId}` : ""}`
+                ? `${customerName} · ${pendingIntent.objectType || primaryObjectLabel}${pendingIntent.recordId ? ` · record ${pendingIntent.recordId}` : ""}`
                 : ""}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -668,7 +668,7 @@
         "vault_owner_token_required": true,
         "write_actions_require_explicit_intent_approval": true,
         "terminal_payload_storage": "field names, record id, result class, and sanitized summaries only",
-        "external_plaintext_boundary": "Salesforce CRM MCP transport is outside the ZK boundary until private VPC proxy replaces Customer 0 CloudHub endpoint."
+        "external_plaintext_boundary": "Salesforce CRM MCP transport is outside the ZK boundary. Hussh reaches MuleSoft Managed Omni Gateway over Streamable HTTP; MuleSoft Private Space owns the downstream CRM network boundary."
       }
     },
     {

--- a/hushh-webapp/lib/agent/__tests__/connected-system-directive-runtime.test.ts
+++ b/hushh-webapp/lib/agent/__tests__/connected-system-directive-runtime.test.ts
@@ -6,451 +6,88 @@ import { ConnectedSystemsService } from "@/lib/services/connected-systems-servic
 vi.mock("@/lib/services/connected-systems-service", () => ({
   ConnectedSystemsService: {
     listSystems: vi.fn(),
-    readRecord: vi.fn(),
+    getSchema: vi.fn(),
     getRecordBinding: vi.fn(),
     searchRecord: vi.fn(),
+    readRecord: vi.fn(),
+    createRecordIntent: vi.fn(),
     updateRecordIntent: vi.fn(),
+    createDeleteIntent: vi.fn(),
     approveIntent: vi.fn(),
   },
 }));
+
+function expectNoCrmTransport() {
+  expect(ConnectedSystemsService.listSystems).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.getSchema).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.getRecordBinding).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.searchRecord).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.readRecord).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.createRecordIntent).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.createDeleteIntent).not.toHaveBeenCalled();
+  expect(ConnectedSystemsService.approveIntent).not.toHaveBeenCalled();
+}
 
 describe("runConnectedSystemDirective", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("reads a CRM record inline with profile email and phone", async () => {
-    vi.mocked(ConnectedSystemsService.readRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: "003READ",
-      binding: {
-        systemId: "salesforce-fsc-customer0",
-        objectType: "Contact",
-        recordId: "003READ",
-        status: "active",
-      },
-      mcp: {
-        isError: false,
-        payload: {
-          Contact: [
-            {
-              Id: "003READ",
-              FirstName: "Kushal",
-              LastName: "Shah",
-              Email: "profile@example.com",
-              Phone: "+14155551212",
-              MailingCity: "Las Vegas",
-            },
-          ],
-        },
-      },
-    });
-
+  it("returns a reviewable lookup proposal without reading a CRM", async () => {
     const result = await runConnectedSystemDirective(
       {
         kind: "action",
         payload: {
           id: "call_read",
           type: "connected_system.crm.read",
-          slots: {
-            systemId: "salesforce-fsc-customer0",
-            objectType: "Contact",
-          },
+          slots: { systemId: "brand-one", objectType: "Person" },
         },
       },
       "HCT:test",
-      { email: "profile@example.com", phone: "+14155551212" }
+      { email: "profile@example.com", phone: "+14155551212" },
     );
 
-    expect(ConnectedSystemsService.readRecord).toHaveBeenCalledWith(
-      "HCT:test",
-      expect.objectContaining({
-        systemId: "salesforce-fsc-customer0",
-        objectType: "Contact",
-        email: "profile@example.com",
-        phone: "+14155551212",
-      })
-    );
     expect(result).toEqual(
       expect.objectContaining({
         delegate_agent_id: "agent_connected_systems",
         status: "completed",
-      })
+        detail: "No CRM record was read by the private agent.",
+      }),
     );
-    expect(result.display).toContain("CRM record found:");
-    expect(result.display).toContain("- Name: Kushal Shah");
-    expect(result.display).toContain("- City: Las Vegas");
+    expect(result.display).toContain("Review the proposed lookup");
+    expect(result.display).toContain("brand-one");
+    expectNoCrmTransport();
   });
 
-  it("lists CRM records across connected brands", async () => {
-    vi.mocked(ConnectedSystemsService.listSystems).mockResolvedValueOnce([
-      {
-        systemId: "brand-one",
-        displayName: "Brand One",
-        customerDisplayName: "Brand One",
-        status: "connected",
-        target: "One",
-        objectTypeDefault: "Contact",
-        transport: "external_crm_streamable_mcp",
-        supportedActions: { read: true },
-      },
-      {
-        systemId: "brand-two",
-        displayName: "Brand Two",
-        customerDisplayName: "Brand Two",
-        status: "connected",
-        target: "Two",
-        objectTypeDefault: "Contact",
-        transport: "external_crm_streamable_mcp",
-        supportedActions: { read: true },
-      },
-    ]);
-    vi.mocked(ConnectedSystemsService.readRecord)
-      .mockResolvedValueOnce({
-        systemId: "brand-one",
-        target: "One",
-        objectType: "Contact",
-        resultClass: "succeeded",
-        recordId: "003ONE",
-        mcp: {
-          isError: false,
-          payload: {
-            Contact: [
-              {
-                Id: "003ONE",
-                FirstName: "Abdul",
-                LastName: "Zalil",
-                Email: "abdul.zalil@gmail.com",
-                Phone: "4084690396",
-                MailingCity: "Las Vegas",
-              },
-            ],
-          },
-        },
-      })
-      .mockResolvedValueOnce({
-        systemId: "brand-two",
-        target: "Two",
-        objectType: "Contact",
-        resultClass: "succeeded",
-        recordId: "003TWO",
-        mcp: {
-          isError: false,
-          payload: {
-            Contact: [
-              {
-                Id: "003TWO",
-                FirstName: "Abdul",
-                LastName: "Zalil",
-                Email: "abdul.zalil@gmail.com",
-                Phone: "4084690396",
-                MailingCity: "Chicago",
-              },
-            ],
-          },
-        },
-      });
-
+  it("returns a field-diff proposal without creating or approving an intent", async () => {
     const result = await runConnectedSystemDirective(
       {
         kind: "action",
         payload: {
-          id: "call_read_all",
-          type: "connected_system.crm.read",
-          slots: {
-            scope: "all_connected_crm_systems",
-            objectType: "Contact",
-          },
-        },
-      },
-      "HCT:test",
-      { email: "abdul.zalil@gmail.com", phone: "4084690396" }
-    );
-
-    expect(ConnectedSystemsService.listSystems).toHaveBeenCalledWith("HCT:test");
-    expect(ConnectedSystemsService.readRecord).toHaveBeenCalledTimes(2);
-    expect(ConnectedSystemsService.readRecord).toHaveBeenNthCalledWith(
-      1,
-      "HCT:test",
-      expect.objectContaining({ systemId: "brand-one" })
-    );
-    expect(ConnectedSystemsService.readRecord).toHaveBeenNthCalledWith(
-      2,
-      "HCT:test",
-      expect.objectContaining({ systemId: "brand-two" })
-    );
-    expect(result.status).toBe("completed");
-    expect(result.display).toContain("Found records in 2 of 2 connected CRM brands.");
-    expect(result.display).toContain("**Brand One**");
-    expect(result.display).toContain("- Name: Abdul Zalil");
-    expect(result.display).toContain("- City: Las Vegas");
-    expect(result.display).toContain("**Brand Two**");
-    expect(result.display).toContain("- City: Chicago");
-  });
-
-  it("returns a reviewable CRM update proposal without looking up or approving a record", async () => {
-    vi.mocked(ConnectedSystemsService.getRecordBinding).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      status: "unbound",
-      binding: null,
-    });
-    vi.mocked(ConnectedSystemsService.searchRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: null,
-      binding: {
-        systemId: "salesforce-fsc-customer0",
-        objectType: "Contact",
-        recordId: "003ABC",
-        status: "active",
-      },
-      mcp: { isError: false, payload: { Contact: [] } },
-    });
-    vi.mocked(ConnectedSystemsService.updateRecordIntent).mockResolvedValueOnce({
-      intentId: "intent_123",
-      systemId: "salesforce-fsc-customer0",
-      action: "update",
-      status: "pending",
-      fieldNames: ["MailingCity"],
-    });
-    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
-      intentId: "intent_123",
-      systemId: "salesforce-fsc-customer0",
-      action: "update",
-      status: "succeeded",
-      fieldNames: ["MailingCity"],
-      recordId: "003ABC",
-    });
-
-    const result = await runConnectedSystemDirective(
-      {
-        kind: "action",
-        payload: {
-          id: "call_1",
+          id: "call_update",
           type: "connected_system.crm.update.propose",
           slots: {
-            systemId: "salesforce-fsc-customer0",
-            objectType: "Contact",
-            email: "kushal@example.com",
-            phone: "415-555-1212",
-            additionalFieldsJson: JSON.stringify({ MailingCity: "New York" }),
+            systemId: "brand-two",
+            additionalFieldsJson: JSON.stringify({ city: "New York" }),
           },
         },
       },
-      "HCT:test"
+      "HCT:test",
     );
 
-    expect(ConnectedSystemsService.searchRecord).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.approveIntent).not.toHaveBeenCalled();
     expect(result).toEqual(
       expect.objectContaining({
-        delegate_agent_id: "agent_connected_systems",
         status: "completed",
-      })
+        detail: "No CRM record was changed by the private agent.",
+      }),
     );
-    expect(result.display).toContain("Review the proposed 1 field change");
-    expect(result.detail).toBe("No CRM record was changed by the private agent.");
+    expect(result.display).toContain("proposed 1 field change");
+    expect(result.display).toContain("brand-two");
+    expectNoCrmTransport();
   });
 
-  it("does not use profile identity to execute a proposed update", async () => {
-    vi.mocked(ConnectedSystemsService.getRecordBinding).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      status: "unbound",
-      binding: null,
-    });
-    vi.mocked(ConnectedSystemsService.searchRecord).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: "003PROFILE",
-      mcp: { isError: false, payload: { Contact: [] } },
-    });
-    vi.mocked(ConnectedSystemsService.updateRecordIntent).mockResolvedValueOnce({
-      intentId: "intent_profile",
-      systemId: "salesforce-fsc-customer0",
-      action: "update",
-      status: "pending",
-      fieldNames: ["MailingCity"],
-    });
-    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
-      intentId: "intent_profile",
-      systemId: "salesforce-fsc-customer0",
-      action: "update",
-      status: "succeeded",
-      fieldNames: ["MailingCity"],
-      recordId: "003PROFILE",
-    });
-
-    const result = await runConnectedSystemDirective(
-      {
-        kind: "action",
-        payload: {
-          id: "call_profile",
-          type: "connected_system.crm.update.propose",
-          slots: {
-            systemId: "salesforce-fsc-customer0",
-            objectType: "Contact",
-            additionalFieldsJson: JSON.stringify({ MailingCity: "New York" }),
-          },
-        },
-      },
-      "HCT:test",
-      { email: "profile@example.com", phone: "+14155551212" }
-    );
-
-    expect(ConnectedSystemsService.getRecordBinding).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.searchRecord).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
-    expect(result.detail).toBe("No CRM record was changed by the private agent.");
-  });
-
-  it("does not inspect a saved CRM binding for a private-agent proposal", async () => {
-    vi.mocked(ConnectedSystemsService.getRecordBinding).mockResolvedValueOnce({
-      systemId: "salesforce-fsc-customer0",
-      target: "Macys",
-      objectType: "Contact",
-      status: "active",
-      binding: {
-        systemId: "salesforce-fsc-customer0",
-        objectType: "Contact",
-        recordId: "003BOUND",
-        status: "active",
-      },
-    });
-    vi.mocked(ConnectedSystemsService.updateRecordIntent).mockResolvedValueOnce({
-      intentId: "intent_bound",
-      systemId: "salesforce-fsc-customer0",
-      action: "update",
-      status: "pending",
-      fieldNames: ["MailingCity"],
-    });
-    vi.mocked(ConnectedSystemsService.approveIntent).mockResolvedValueOnce({
-      intentId: "intent_bound",
-      systemId: "salesforce-fsc-customer0",
-      action: "update",
-      status: "succeeded",
-      fieldNames: ["MailingCity"],
-      recordId: "003BOUND",
-    });
-
-    await runConnectedSystemDirective(
-      {
-        kind: "action",
-        payload: {
-          id: "call_bound",
-          type: "connected_system.crm.update.propose",
-          slots: {
-            systemId: "salesforce-fsc-customer0",
-            objectType: "Contact",
-            additionalFieldsJson: JSON.stringify({ MailingCity: "New York" }),
-          },
-        },
-      },
-      "HCT:test",
-      { email: "profile@example.com", phone: "+14155551212" }
-    );
-
-    expect(ConnectedSystemsService.getRecordBinding).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.searchRecord).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.approveIntent).not.toHaveBeenCalled();
-  });
-
-  it("never fans a private-agent proposal out to every connected CRM", async () => {
-    vi.mocked(ConnectedSystemsService.listSystems).mockResolvedValueOnce([
-      {
-        systemId: "brand-bound",
-        displayName: "Bound Brand",
-        customerDisplayName: "Bound Brand",
-        status: "connected",
-        target: "Bound",
-        objectTypeDefault: "Contact",
-        transport: "external_crm_streamable_mcp",
-        supportedActions: { update: true },
-      },
-      {
-        systemId: "brand-search",
-        displayName: "Search Brand",
-        customerDisplayName: "Search Brand",
-        status: "connected",
-        target: "Search",
-        objectTypeDefault: "Contact",
-        transport: "external_crm_streamable_mcp",
-        supportedActions: { update: true },
-      },
-    ]);
-    vi.mocked(ConnectedSystemsService.getRecordBinding)
-      .mockResolvedValueOnce({
-        systemId: "brand-bound",
-        target: "Bound",
-        objectType: "Contact",
-        status: "active",
-        binding: {
-          systemId: "brand-bound",
-          objectType: "Contact",
-          recordId: "003BOUND",
-          status: "active",
-        },
-      })
-      .mockResolvedValueOnce({
-        systemId: "brand-search",
-        target: "Search",
-        objectType: "Contact",
-        status: "unbound",
-        binding: null,
-      });
-    vi.mocked(ConnectedSystemsService.searchRecord).mockResolvedValueOnce({
-      systemId: "brand-search",
-      target: "Search",
-      objectType: "Contact",
-      resultClass: "succeeded",
-      recordId: "003SEARCH",
-      mcp: { isError: false, payload: { Contact: [] } },
-    });
-    vi.mocked(ConnectedSystemsService.updateRecordIntent)
-      .mockResolvedValueOnce({
-        intentId: "intent_bound",
-        systemId: "brand-bound",
-        action: "update",
-        status: "pending",
-        fieldNames: ["MailingCity"],
-      })
-      .mockResolvedValueOnce({
-        intentId: "intent_search",
-        systemId: "brand-search",
-        action: "update",
-        status: "pending",
-        fieldNames: ["MailingCity"],
-      });
-    vi.mocked(ConnectedSystemsService.approveIntent)
-      .mockResolvedValueOnce({
-        intentId: "intent_bound",
-        systemId: "brand-bound",
-        action: "update",
-        status: "succeeded",
-        fieldNames: ["MailingCity"],
-        recordId: "003BOUND",
-      })
-      .mockResolvedValueOnce({
-        intentId: "intent_search",
-        systemId: "brand-search",
-        action: "update",
-        status: "succeeded",
-        fieldNames: ["MailingCity"],
-        recordId: "003SEARCH",
-      });
-
+  it("never fans a proposal out when an all-systems scope is requested", async () => {
     const result = await runConnectedSystemDirective(
       {
         kind: "action",
@@ -459,22 +96,33 @@ describe("runConnectedSystemDirective", () => {
           type: "connected_system.crm.update.propose",
           slots: {
             scope: "all_connected_crm_systems",
-            objectType: "Contact",
-            additionalFieldsJson: JSON.stringify({ MailingCity: "New York" }),
+            additionalFieldsJson: JSON.stringify({ city: "New York" }),
           },
         },
       },
       "HCT:test",
-      { email: "profile@example.com", phone: "+14155551212" }
     );
 
-    expect(ConnectedSystemsService.listSystems).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.getRecordBinding).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.searchRecord).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.updateRecordIntent).not.toHaveBeenCalled();
-    expect(ConnectedSystemsService.approveIntent).not.toHaveBeenCalled();
     expect(result.status).toBe("completed");
-    expect(result.display).toContain("before anything is sent to a CRM");
-    expect(result.detail).toBe("No CRM record was changed by the private agent.");
+    expect(result.display).toContain("the selected CRM");
+    expectNoCrmTransport();
+  });
+
+  it("rejects an empty update proposal without calling a CRM", async () => {
+    const result = await runConnectedSystemDirective(
+      {
+        kind: "action",
+        payload: {
+          id: "call_empty",
+          type: "connected_system.crm.update.propose",
+          slots: { additionalFieldsJson: "{}" },
+        },
+      },
+      "HCT:test",
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.detail).toContain("at least one CRM field change");
+    expectNoCrmTransport();
   });
 });

--- a/hushh-webapp/lib/agent/agent-action-runtime.ts
+++ b/hushh-webapp/lib/agent/agent-action-runtime.ts
@@ -387,7 +387,18 @@ function executeConnectedSystemAgentAction(
   }
 
   const slots = input.slots || {};
-  const systemId = readString(slots.systemId) || "salesforce-fsc-customer0";
+  const systemId = readString(slots.systemId);
+  if (!systemId) {
+    return buildResult({
+      status: "blocked",
+      actionId: input.actionId,
+      label: "Select CRM",
+      routeBefore: routeBefore.pathname,
+      screenBefore: routeBefore.screen,
+      resultSummary: "Select a connected CRM before preparing this action.",
+      reason: "connected_system_selection_required",
+    });
+  }
   const instructionId = storeConnectedSystemInstruction(input.actionId, slots);
   const target = instructionId
     ? `${buildConnectedSystemRoute(systemId)}?agentActionId=${encodeURIComponent(instructionId)}`

--- a/hushh-webapp/lib/agent/connected-system-directive-runtime.ts
+++ b/hushh-webapp/lib/agent/connected-system-directive-runtime.ts
@@ -1,28 +1,15 @@
-import {
-  ConnectedSystemsService,
-  type ConnectedSystemMcpResponse,
-  type ConnectedSystemSummary,
-} from "@/lib/services/connected-systems-service";
-import type { DelegateResult, SpecialistDirective } from "@/lib/agent/specialist-directive-runtime";
+import type {
+  DelegateResult,
+  SpecialistDirective,
+} from "@/lib/agent/specialist-directive-runtime";
 
 const ALL_CONNECTED_CRM_SYSTEMS_SCOPE = "all_connected_crm_systems";
-const DEFAULT_RETURN_FIELDS = [
-  "Email",
-  "Phone",
-  "MobilePhone",
-  "LastName",
-  "MailingCity",
-  "MailingStreet",
-  "Title",
-  "Department",
-  "LeadSource",
-];
 
 function readString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function parseAdditionalFields(value: unknown): Record<string, unknown> {
+function parseProposedFields(value: unknown): Record<string, unknown> {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     return value as Record<string, unknown>;
   }
@@ -37,423 +24,44 @@ function parseAdditionalFields(value: unknown): Record<string, unknown> {
   }
 }
 
-function collectRecords(value: unknown, depth = 0): Record<string, unknown>[] {
-  if (!value || depth > 4) return [];
-  if (Array.isArray(value)) {
-    const direct = value.filter(
-      (item): item is Record<string, unknown> =>
-        Boolean(item) && typeof item === "object" && !Array.isArray(item)
-    );
-    if (direct.length > 0) return direct;
-    return value.flatMap((item) => collectRecords(item, depth + 1));
-  }
-  if (typeof value !== "object") return [];
-  const record = value as Record<string, unknown>;
-  for (const key of ["records", "Contact", "contacts", "data", "payload", "result", "records_"]) {
-    const nested = collectRecords(record[key], depth + 1);
-    if (nested.length > 0) return nested;
-  }
-  return [];
-}
-
-function recordIdFromSearch(result: ConnectedSystemMcpResponse): string {
-  const bindingId = readString(result.binding?.recordId);
-  if (bindingId) return bindingId;
-  const resultId = readString(result.recordId);
-  if (resultId) return resultId;
-  const firstRecord = collectRecords(result.mcp)[0];
-  return readString(firstRecord?.Id) || readString(firstRecord?.id);
-}
-
-function displayValue(record: Record<string, unknown>, key: string): string {
-  const value = record[key];
-  if (typeof value === "string") return value.trim();
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  return "";
-}
-
-function formatFieldLine(label: string, value: string): string {
-  return value ? `  - ${label}: ${value}` : "";
-}
-
-function readResultLines(result: ConnectedSystemMcpResponse): string[] {
-  const record = collectRecords(result.mcp)[0] || {};
-  const id = recordIdFromSearch(result);
-  const lines = [
-    displayValue(record, "FirstName") || displayValue(record, "LastName")
-      ? formatFieldLine(
-          "Name",
-          [displayValue(record, "FirstName"), displayValue(record, "LastName")]
-            .filter(Boolean)
-            .join(" ")
-        )
-      : "",
-    formatFieldLine("Email", displayValue(record, "Email")),
-    formatFieldLine("Phone", displayValue(record, "Phone")),
-    formatFieldLine("Mobile", displayValue(record, "MobilePhone")),
-    formatFieldLine("City", displayValue(record, "MailingCity")),
-    formatFieldLine("Title", displayValue(record, "Title")),
-    formatFieldLine("Department", displayValue(record, "Department")),
-    formatFieldLine("Lead source", displayValue(record, "LeadSource")),
-  ].filter(Boolean);
-  return lines.length > 0 ? lines : [id ? `  - Record id: ${id}` : "  - Record found"];
-}
-
-function summarizeReadResult(result: ConnectedSystemMcpResponse): string {
-  const lines = readResultLines(result);
-  if (lines.length === 0) {
-    return "CRM record found.";
-  }
-  return `CRM record found:\n${lines.join("\n")}`;
-}
-
-function brandLabel(system: ConnectedSystemSummary): string {
-  return (
-    readString(system.customerDisplayName) ||
-    readString(system.displayName) ||
-    readString(system.target) ||
-    readString(system.systemId) ||
-    "CRM brand"
-  );
-}
-
-function isUpdatableSystem(system: ConnectedSystemSummary): boolean {
-  return system.supportedActions?.update === true && system.status === "connected";
-}
-
-function isReadableSystem(system: ConnectedSystemSummary): boolean {
-  return system.supportedActions?.read === true && system.status === "connected";
-}
-
-async function findRecordIdForSystem(input: {
-  vaultOwnerToken: string;
-  systemId: string;
-  objectType: string;
-  email: string;
-  phone: string;
-}): Promise<string> {
-  const bindingResult = await ConnectedSystemsService.getRecordBinding({
-    vaultOwnerToken: input.vaultOwnerToken,
-    systemId: input.systemId,
-    objectType: input.objectType,
-  }).catch(() => null);
-  if (bindingResult?.binding?.status === "active") {
-    const bindingRecordId = readString(bindingResult.binding.recordId);
-    if (bindingRecordId) return bindingRecordId;
-  }
-
-  if (!input.email || !input.phone) return "";
-  const searchResult = await ConnectedSystemsService.searchRecord(input.vaultOwnerToken, {
-    systemId: input.systemId,
-    objectType: input.objectType,
-    email: input.email,
-    phone: input.phone,
-    returnFields: DEFAULT_RETURN_FIELDS,
-  });
-  return recordIdFromSearch(searchResult);
-}
-
-async function updateOneSystem(input: {
-  vaultOwnerToken: string;
-  system: ConnectedSystemSummary;
-  objectType: string;
-  email: string;
-  phone: string;
-  additionalFields: Record<string, unknown>;
-}): Promise<{ label: string; status: "updated" | "skipped" | "failed"; detail: string }> {
-  const label = brandLabel(input.system);
-  try {
-    const recordId = await findRecordIdForSystem({
-      vaultOwnerToken: input.vaultOwnerToken,
-      systemId: input.system.systemId,
-      objectType: input.objectType,
-      email: input.email,
-      phone: input.phone,
-    });
-    if (!recordId) {
-      return {
-        label,
-        status: "skipped",
-        detail: input.email && input.phone ? "No matching record found." : "No binding or lookup identity.",
-      };
-    }
-    const pendingIntent = await ConnectedSystemsService.updateRecordIntent(input.vaultOwnerToken, {
-      systemId: input.system.systemId,
-      objectType: input.objectType,
-      id: recordId,
-      additionalFields: input.additionalFields,
-      readbackLocator:
-        input.email && input.phone ? { email: input.email, phone: input.phone } : undefined,
-    });
-    const approved = await ConnectedSystemsService.approveIntent({
-      vaultOwnerToken: input.vaultOwnerToken,
-      systemId: pendingIntent.systemId,
-      intentId: pendingIntent.intentId,
-    });
-    if (approved.status === "failed") {
-      return {
-        label,
-        status: "failed",
-        detail: approved.errorMessage || "Update failed.",
-      };
-    }
-    return { label, status: "updated", detail: "Updated." };
-  } catch (error) {
-    return {
-      label,
-      status: "failed",
-      detail: error instanceof Error ? error.message : "Update failed.",
-    };
-  }
-}
-
-async function _runAllConnectedCrmUpdate(input: {
-  id: string;
-  type: string;
-  vaultOwnerToken: string;
-  objectType: string;
-  email: string;
-  phone: string;
-  additionalFields: Record<string, unknown>;
-}): Promise<DelegateResult> {
-  const systems = (await ConnectedSystemsService.listSystems(input.vaultOwnerToken)).filter(
-    isUpdatableSystem
-  );
-  if (systems.length === 0) {
-    return {
-      delegate_agent_id: "agent_connected_systems",
-      kind: "action",
-      id: input.id,
-      type: input.type,
-      status: "failed",
-      detail: "I could not find any connected CRM brands to update.",
-    };
-  }
-
-  const results = [];
-  for (const system of systems) {
-    results.push(
-      await updateOneSystem({
-        vaultOwnerToken: input.vaultOwnerToken,
-        system,
-        objectType: input.objectType,
-        email: input.email,
-        phone: input.phone,
-        additionalFields: input.additionalFields,
-      })
-    );
-  }
-
-  const updated = results.filter((result) => result.status === "updated");
-  const failed = results.filter((result) => result.status === "failed");
-  const skipped = results.filter((result) => result.status === "skipped");
-  const lines = [
-    `Updated ${updated.length} of ${results.length} connected CRM brand${
-      results.length === 1 ? "" : "s"
-    }.`,
-    ...results.map((result) => `- ${result.label}: ${result.detail}`),
-  ];
-  return {
-    delegate_agent_id: "agent_connected_systems",
-    kind: "action",
-    id: input.id,
-    type: input.type,
-    status: failed.length > 0 && updated.length === 0 ? "failed" : "completed",
-    display: lines.join("\n"),
-    detail:
-      failed.length || skipped.length
-        ? `${failed.length} failed, ${skipped.length} skipped.`
-        : undefined,
-  };
-}
-
-async function runCrmRead(input: {
-  id: string;
-  type: string;
-  vaultOwnerToken: string;
-  systemId: string;
-  objectType: string;
-  email: string;
-  phone: string;
-}): Promise<DelegateResult> {
-  if (!input.email || !input.phone) {
-    return {
-      delegate_agent_id: "agent_connected_systems",
-      kind: "action",
-      id: input.id,
-      type: input.type,
-      status: "failed",
-      detail: "I need the email and phone number before I can read the CRM record.",
-    };
-  }
-
-  const result = await ConnectedSystemsService.readRecord(input.vaultOwnerToken, {
-    systemId: input.systemId,
-    objectType: input.objectType,
-    email: input.email,
-    phone: input.phone,
-    returnFields: DEFAULT_RETURN_FIELDS,
-  });
-  const recordId = recordIdFromSearch(result);
-  const records = collectRecords(result.mcp);
-  if (!recordId && records.length === 0) {
-    return {
-      delegate_agent_id: "agent_connected_systems",
-      kind: "action",
-      id: input.id,
-      type: input.type,
-      status: "failed",
-      detail: "No matching CRM record found.",
-    };
-  }
-
-  return {
-    delegate_agent_id: "agent_connected_systems",
-    kind: "action",
-    id: input.id,
-    type: input.type,
-    status: "completed",
-    display: summarizeReadResult(result),
-  };
-}
-
-async function readOneSystem(input: {
-  vaultOwnerToken: string;
-  system: ConnectedSystemSummary;
-  objectType: string;
-  email: string;
-  phone: string;
-}): Promise<{ label: string; status: "found" | "skipped" | "failed"; detail: string }> {
-  const label = brandLabel(input.system);
-  if (!input.email || !input.phone) {
-    return { label, status: "skipped", detail: "No lookup identity." };
-  }
-  try {
-    const result = await ConnectedSystemsService.readRecord(input.vaultOwnerToken, {
-      systemId: input.system.systemId,
-      objectType: input.objectType,
-      email: input.email,
-      phone: input.phone,
-      returnFields: DEFAULT_RETURN_FIELDS,
-    });
-    const recordId = recordIdFromSearch(result);
-    const records = collectRecords(result.mcp);
-    if (!recordId && records.length === 0) {
-      return { label, status: "skipped", detail: "No matching record found." };
-    }
-    return {
-      label,
-      status: "found",
-      detail: readResultLines(result).join("\n"),
-    };
-  } catch (error) {
-    return {
-      label,
-      status: "failed",
-      detail: error instanceof Error ? error.message : "Read failed.",
-    };
-  }
-}
-
-async function runAllConnectedCrmRead(input: {
-  id: string;
-  type: string;
-  vaultOwnerToken: string;
-  objectType: string;
-  email: string;
-  phone: string;
-}): Promise<DelegateResult> {
-  const systems = (await ConnectedSystemsService.listSystems(input.vaultOwnerToken)).filter(
-    isReadableSystem
-  );
-  if (systems.length === 0) {
-    return {
-      delegate_agent_id: "agent_connected_systems",
-      kind: "action",
-      id: input.id,
-      type: input.type,
-      status: "failed",
-      detail: "I could not find any connected CRM brands to read.",
-    };
-  }
-
-  const results = [];
-  for (const system of systems) {
-    results.push(
-      await readOneSystem({
-        vaultOwnerToken: input.vaultOwnerToken,
-        system,
-        objectType: input.objectType,
-        email: input.email,
-        phone: input.phone,
-      })
-    );
-  }
-
-  const found = results.filter((result) => result.status === "found");
-  const failed = results.filter((result) => result.status === "failed");
-  const skipped = results.filter((result) => result.status === "skipped");
-  return {
-    delegate_agent_id: "agent_connected_systems",
-    kind: "action",
-    id: input.id,
-    type: input.type,
-    status: failed.length > 0 && found.length === 0 ? "failed" : "completed",
-    display: [
-      `Found records in ${found.length} of ${results.length} connected CRM brand${
-        results.length === 1 ? "" : "s"
-      }.`,
-      "",
-      ...results.flatMap((result) => [`**${result.label}**`, result.detail, ""]),
-    ]
-      .join("\n")
-      .trim(),
-    detail:
-      failed.length || skipped.length
-        ? `${failed.length} failed, ${skipped.length} skipped.`
-        : undefined,
-  };
-}
-
+/**
+ * Produces an in-app CRM proposal only.
+ *
+ * This deliberately has no ConnectedSystemsService dependency: the private
+ * agent does not receive CRM credentials, inspect bindings, select MCP tools,
+ * read records, create intents, or approve mutations. The Connected Systems
+ * screen revalidates the selected system's public schema/capabilities and
+ * requires the person's explicit review before it calls the backend.
+ */
 export async function runConnectedSystemDirective(
   directive: SpecialistDirective,
-  vaultOwnerToken: string,
-  profileLookup: { email?: string | null; phone?: string | null } = {}
+  _vaultOwnerToken: string,
+  _profileLookup: { email?: string | null; phone?: string | null } = {},
 ): Promise<DelegateResult> {
   const payload = directive.payload;
   const id = readString(payload.id);
   const type = readString(payload.type || payload.actionId);
   const slots =
-    payload.slots && typeof payload.slots === "object" && !Array.isArray(payload.slots)
+    payload.slots &&
+    typeof payload.slots === "object" &&
+    !Array.isArray(payload.slots)
       ? (payload.slots as Record<string, unknown>)
       : {};
-  const systemId = readString(slots.systemId) || "salesforce-fsc-customer0";
-  const objectType = readString(slots.objectType) || "Contact";
+  const systemId = readString(slots.systemId) || "the selected CRM";
   const scope = readString(slots.scope);
-
-  const email = readString(slots.email) || readString(profileLookup.email);
-  const phone = readString(slots.phone) || readString(profileLookup.phone);
+  const target =
+    scope === ALL_CONNECTED_CRM_SYSTEMS_SCOPE ? "the selected CRM" : systemId;
 
   if (type === "connected_system.crm.read") {
-    if (scope === ALL_CONNECTED_CRM_SYSTEMS_SCOPE) {
-      return runAllConnectedCrmRead({
-        id,
-        type,
-        vaultOwnerToken,
-        objectType,
-        email,
-        phone,
-      });
-    }
-    return runCrmRead({
+    return {
+      delegate_agent_id: "agent_connected_systems",
+      kind: "action",
       id,
       type,
-      vaultOwnerToken,
-      systemId,
-      objectType,
-      email,
-      phone,
-    });
+      status: "completed",
+      display: `Review the proposed lookup in Connected Systems for ${target}.`,
+      detail: "No CRM record was read by the private agent.",
+    };
   }
 
   if (type !== "connected_system.crm.update.propose") {
@@ -467,32 +75,28 @@ export async function runConnectedSystemDirective(
     };
   }
 
-  const additionalFields = parseAdditionalFields(slots.additionalFieldsJson);
-  if (Object.keys(additionalFields).length === 0) {
+  const proposedFields = parseProposedFields(slots.additionalFieldsJson);
+  const fieldCount = Object.keys(proposedFields).length;
+  if (fieldCount === 0) {
     return {
       delegate_agent_id: "agent_connected_systems",
       kind: "action",
       id,
       type,
       status: "failed",
-      detail: "I need at least one CRM field change before updating the record.",
+      detail: "I need at least one CRM field change before preparing a proposal.",
     };
   }
 
-  // The private agent may describe a proposal, but the Connected Systems
-  // screen owns intent creation, capability/schema validation, and approval.
-  // It must never fan a mutation out to every connected CRM.
   return {
     delegate_agent_id: "agent_connected_systems",
     kind: "action",
     id,
     type,
     status: "completed",
-    display: `Review the proposed ${Object.keys(additionalFields).length} field change${
-      Object.keys(additionalFields).length === 1 ? "" : "s"
-    } in Connected Systems before anything is sent to ${
-      scope === ALL_CONNECTED_CRM_SYSTEMS_SCOPE ? "a CRM" : systemId
-    }.`,
+    display: `Review the proposed ${fieldCount} field change${
+      fieldCount === 1 ? "" : "s"
+    } in Connected Systems before anything is sent to ${target}.`,
     detail: "No CRM record was changed by the private agent.",
   };
 }

--- a/hushh-webapp/lib/developers/content.ts
+++ b/hushh-webapp/lib/developers/content.ts
@@ -188,7 +188,7 @@ export const CONSENT_FLOW_STEPS: ConsentFlowStep[] = [
   {
     title: "Read",
     detail:
-      "Use grant_ref with get_encrypted_scoped_export. Hosted MCP returns a ResourceLink for connector-side decryption; local stdio returns only bounded approved information.",
+      "Use grant_ref with get_encrypted_scoped_export. Hosted MCP returns an encrypted-inline envelope and ciphertext for connector-side decryption; local stdio returns only bounded approved information.",
   },
 ];
 

--- a/hushh-webapp/lib/navigation/app-bottom-nav.ts
+++ b/hushh-webapp/lib/navigation/app-bottom-nav.ts
@@ -275,10 +275,16 @@ export function resolveBottomNavContextKey(
 
 export function resolveBottomNavOptionKeys(
   _pathname: string | null | undefined,
-  _scope: AppBottomNavScope,
+  scope: AppBottomNavScope,
   _context?: AppBottomNavContext,
 ): AppBottomNavKey[] {
-  return ["dashboard", "finance", "portfolio", "analysis", "connect", "search"];
+  if (scope === "investor") {
+    return ["dashboard", "finance", "portfolio", "analysis", "connect", "search"];
+  }
+  if (scope === "ria") {
+    return ["dashboard", "ria-home", "clients", "picks", "connect", "search"];
+  }
+  return ["dashboard", "connect", "search"];
 }
 
 /** Contextual workspace tabs render beside the stable primary navigation. */

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -612,6 +612,7 @@ export function resolveTopShellBreadcrumb(
       backHref: ROUTES.ONE_HOME,
       width: "profile",
       align: "center",
+      hideBack: true,
       items: [
         { label: "One", href: ROUTES.ONE_HOME },
         { label: "Connect" },

--- a/hushh-webapp/lib/services/connected-systems-service.ts
+++ b/hushh-webapp/lib/services/connected-systems-service.ts
@@ -1,7 +1,5 @@
 import { ApiService } from "@/lib/services/api-service";
 
-export const SALESFORCE_CRM_SYSTEM_ID = "salesforce-fsc-customer0";
-
 export type ConnectedSystemStatus = "connected" | "needs_configuration" | string;
 
 export type ConnectedSystemSummary = {
@@ -41,6 +39,10 @@ export type ConnectedSystemSchemaResponse = {
   systemId: string;
   target: string;
   objectType: string;
+  objectMetadata?: {
+    name: string;
+    label: string;
+  };
   supportedFields: string[];
   fields?: Array<{
     key: string;
@@ -50,12 +52,28 @@ export type ConnectedSystemSchemaResponse = {
     required?: boolean;
     identityField?: boolean;
     readable?: boolean;
+    createable?: boolean;
+    updateable?: boolean;
     writable?: boolean;
     immutable?: boolean;
+    permissionsDeclared?: boolean;
     constraints?: Record<string, unknown>;
     source?: string;
   }>;
-  mcp: Record<string, unknown>;
+  schemaStatus?: "ready" | "capability_metadata_missing" | string;
+  effectiveActions?: {
+    schema?: boolean;
+    read?: boolean;
+    create?: boolean;
+    update?: boolean;
+    delete?: boolean;
+  };
+  configurationMessage?: string | null;
+};
+
+export type ConnectedSystemRecord = {
+  recordId?: string | null;
+  fields: Record<string, string | number | boolean | null>;
 };
 
 export type ConnectedSystemMcpResponse = {
@@ -64,7 +82,7 @@ export type ConnectedSystemMcpResponse = {
   objectType: string;
   recordId?: string | null;
   resultClass: "succeeded" | "failed" | string;
-  mcp: Record<string, unknown>;
+  records?: ConnectedSystemRecord[];
   bindingStatus?: "active" | "unbound" | string;
   binding?: ConnectedSystemRecordBinding | null;
 };
@@ -178,7 +196,11 @@ async function readJsonOrThrow<T>(response: Response): Promise<T> {
 }
 
 function systemPath(systemId?: string): string {
-  return encodeURIComponent(systemId || SALESFORCE_CRM_SYSTEM_ID);
+  const selectedSystemId = String(systemId || "").trim();
+  if (!selectedSystemId) {
+    throw new Error("Select a connected CRM before making a record request.");
+  }
+  return encodeURIComponent(selectedSystemId);
 }
 
 export class ConnectedSystemsService {

--- a/hushh-webapp/scripts/architecture/generate-surface-map.mjs
+++ b/hushh-webapp/scripts/architecture/generate-surface-map.mjs
@@ -162,7 +162,7 @@ const routeOverrides = {
       terminal_payload_storage:
         "field names, record id, result class, and sanitized summaries only",
       external_plaintext_boundary:
-        "Salesforce CRM MCP transport is outside the ZK boundary until private VPC proxy replaces Customer 0 CloudHub endpoint.",
+        "Salesforce CRM MCP transport is outside the ZK boundary. Hussh reaches MuleSoft Managed Omni Gateway over Streamable HTTP; MuleSoft Private Space owns the downstream CRM network boundary.",
     },
   },
   "/gmail": {

--- a/scripts/env/bootstrap_profiles.sh
+++ b/scripts/env/bootstrap_profiles.sh
@@ -873,6 +873,11 @@ hydrate_backend_cloud_reference() {
   set_mapped_secret_key_or_cached "$file" "$profile" "$project" "GMAIL_OAUTH_TOKEN_KEY" "false" "$cache_file" GMAIL_OAUTH_TOKEN_KEY GMAIL_TOKEN_ENCRYPTION_KEY
   set_secret_key_or_cached "$file" "$profile" "$project" "OPENAI_API_KEY" "false" "$cache_file"
   set_secret_key_or_cached "$file" "$profile" "$project" "VOICE_RUNTIME_CONFIG_JSON" "false" "$cache_file"
+  # Managed Omni Gateway credentials are only materialized into the ignored,
+  # mode-600 local backend runtime file. They are never emitted by doctor or
+  # copied into frontend profiles.
+  set_secret_key_or_cached "$file" "$profile" "$project" "OMNIGATEWAY_CLIENT_ID" "false" "$cache_file"
+  set_secret_key_or_cached "$file" "$profile" "$project" "OMNIGATEWAY_CLIENT_SECRET" "false" "$cache_file"
   remove_env_keys "$file" FINRA_VERIFY_BASE_URL FINRA_VERIFY_API_KEY FINRA_VERIFY_TIMEOUT_SECONDS
 
   for key in PLAID_ENV PLAID_CLIENT_NAME PLAID_COUNTRY_CODES PLAID_WEBHOOK_URL PLAID_REDIRECT_PATH PLAID_REDIRECT_URI PLAID_TX_HISTORY_DAYS; do

--- a/scripts/env/doctor.sh
+++ b/scripts/env/doctor.sh
@@ -195,6 +195,8 @@ BACKEND_ONE_EMAIL_WATCH_RENEW_TOKEN="$(read_env_value "$BACKEND_SOURCE" "ONE_EMA
 BACKEND_ONE_EMAIL_KYC_DEFAULT_SCOPE="$(read_env_value "$BACKEND_SOURCE" "ONE_EMAIL_KYC_DEFAULT_SCOPE")"
 BACKEND_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED="$(read_env_value "$BACKEND_SOURCE" "ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED")"
 BACKEND_OPENAI_API_KEY="$(read_env_value "$BACKEND_SOURCE" "OPENAI_API_KEY")"
+BACKEND_OMNIGATEWAY_CLIENT_ID="$(read_env_value "$BACKEND_SOURCE" "OMNIGATEWAY_CLIENT_ID")"
+BACKEND_OMNIGATEWAY_CLIENT_SECRET="$(read_env_value "$BACKEND_SOURCE" "OMNIGATEWAY_CLIENT_SECRET")"
 BACKEND_VOICE_REALTIME_ENABLED="$(read_json_env_field "$BACKEND_SOURCE" "VOICE_RUNTIME_CONFIG_JSON" "realtime_enabled")"
 BACKEND_VOICE_V1_ENABLED="$(read_json_env_field "$BACKEND_SOURCE" "VOICE_RUNTIME_CONFIG_JSON" "hosted_voice_enabled")"
 BACKEND_FORCE_REALTIME_VOICE="$(read_json_env_field "$BACKEND_SOURCE" "VOICE_RUNTIME_CONFIG_JSON" "force_realtime")"
@@ -342,6 +344,15 @@ case "$PROFILE" in
       add_check "voice_runtime_readiness" "pass" "Voice backend runtime keys are present"
     else
       add_check "voice_runtime_readiness" "warn" "Missing voice backend keys: ${missing_voice_keys[*]}. Run: bash scripts/env/bootstrap_profiles.sh"
+    fi
+
+    missing_connected_systems_keys=()
+    if is_placeholder "$BACKEND_OMNIGATEWAY_CLIENT_ID"; then missing_connected_systems_keys+=("OMNIGATEWAY_CLIENT_ID"); fi
+    if is_placeholder "$BACKEND_OMNIGATEWAY_CLIENT_SECRET"; then missing_connected_systems_keys+=("OMNIGATEWAY_CLIENT_SECRET"); fi
+    if [ "${#missing_connected_systems_keys[@]}" -eq 0 ]; then
+      add_check "connected_systems_runtime_readiness" "pass" "Managed Omni Gateway credentials are present for Connected Systems"
+    else
+      add_check "connected_systems_runtime_readiness" "warn" "Missing Connected Systems gateway credentials: ${missing_connected_systems_keys[*]}. Run: ./bin/hushh env bootstrap"
     fi
     ;;
   uat)


### PR DESCRIPTION
## Summary
- make per-operation CRM response contracts authoritative and fail closed when access metadata or result mappings are absent
- render dynamic CRM fields through capability-safe DataTable and preserve intent confirmation for mutations
- hydrate Omni Gateway local credentials safely, add readiness diagnostics, and document the direct MCP transport/schema v1 contract

## Verification
- ./bin/hushh codex pre-pr
- ./scripts/ci/verify-main-branch-protection.sh
- python3 scripts/ci/verify-deployment-environment-governance.py
- focused backend/frontend contract tests and PDF/docs checks

## Rollout
The active partner schemas remain catalogue-only until MuleSoft supplies explicit access flags and read/mutation response mappings; no CRM write is enabled by this change alone.