### PR TITLE
feat(crm): complete bound lifecycle and Morphy partner formatter

### DIFF
--- a/.codex/skills/founder-brief-curation/references/pdf-artifact-generation.md
+++ b/.codex/skills/founder-brief-curation/references/pdf-artifact-generation.md
@@ -42,6 +42,40 @@ Use this reference for generic Markdown/HTML/PDF report artifacts when no narrow
 4. Mark current, future-state, and partner-confirmation-needed claims visibly in the source before rendering.
 5. For Mermaid diagrams, accept the renderer's fallback view unless the user specifically asks for pixel-rendered diagrams. Pixel-rendered Mermaid needs separate rendered-image verification.
 
+## Information Architecture And Density
+
+1. Before rendering, turn wrapped source lines into semantic paragraphs; a
+   source line-wrap must never become artificial vertical whitespace in the PDF.
+2. Choose the smallest clear structure for each idea: ordered steps for a
+   lifecycle, a table for repeated comparisons, and a code block only for
+   copyable protocol material. Do not use one-line paragraphs as a substitute
+   for structure.
+3. During rendered-page review, check paragraph grouping, page-width use,
+   heading continuity, table fit, and unexplained empty space. Rework source
+   structure or renderer semantics before accepting a sparse page.
+4. Preserve reading rhythm: group context with the action it explains, avoid
+   duplicated caveats, and keep current-state, future-state, and
+   partner-confirmation-needed claims visibly distinct.
+
+## Formatter Ownership And Brand Variants
+
+1. The Markdown-to-PDF script is a generator, not a visual fork. It must use
+   `hushh-webapp/lib/morphy-ux/pdf-document-formatter.mjs` for portable-document
+   visual tokens and audience profiles.
+2. Select a formatter profile for the reader: `technical` for internal
+   implementation references, `partner` for integration guides, or `founder`
+   for an editorial brief. Profiles may change density and hierarchy, never the
+   Hussh brand grammar or the truth boundary.
+3. Select `light`, `dark`, or explicit `molten-gold` theme. Light and dark must
+   take `hu` ink and the `ssh` foil gradient from the app's Foundation tokens;
+   only the explicit gold theme may use the Molten Gold variant.
+4. Copyable code always uses the Sublime Text Monokai code surface: `#272822`
+   background, `#f8f8f2` foreground, and the established pink/yellow/purple
+   syntax tokens. Do not replace it with prose-card styling.
+5. Rendered review remains mandatory for every profile. Verify wordmark
+   contrast, usable page width, semantic paragraph/list grouping, code legibility,
+   table fit, and page breaks before publishing.
+
 ## Verification
 
 1. Confirm the PDF exists and is non-empty.

--- a/.codex/skills/planning-board/scripts/board_ops.py
+++ b/.codex/skills/planning-board/scripts/board_ops.py
@@ -191,8 +191,54 @@ def get_issue_node_id(repo: str, issue_number: int) -> str:
     return node_id["id"]
 
 
+import os
+import time
+
+CACHE_FILE = os.path.expanduser("~/.hermes/scripts/.board_issue_cache.json")
 _issue_json_cache = {}
+_cache_loaded = False
+
+
+def _load_cache():
+    global _issue_json_cache, _cache_loaded
+    if _cache_loaded:
+        return
+    _cache_loaded = True
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            now = time.time()
+            for k, v in data.items():
+                cached_at = v.get("cached_at", 0)
+                is_closed = v.get("payload", {}).get("state") == "CLOSED"
+                if is_closed or (now - cached_at < 43200):
+                    parts = k.split("|", 1)
+                    if len(parts) == 2:
+                        _issue_json_cache[(parts[0], int(parts[1]))] = v["payload"]
+        except Exception:
+            pass
+
+
+def _save_cache():
+    try:
+        os.makedirs(os.path.dirname(CACHE_FILE), exist_ok=True)
+        data = {}
+        now = time.time()
+        for k, v in _issue_json_cache.items():
+            key_str = f"{k[0]}|{k[1]}"
+            data[key_str] = {
+                "cached_at": now,
+                "payload": v
+            }
+        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except Exception:
+        pass
+
+
 def get_issue_json(repo: str, issue_number: int) -> Any:
+    _load_cache()
     key = (repo, issue_number)
     if key in _issue_json_cache:
         return _issue_json_cache[key]
@@ -226,6 +272,7 @@ def get_issue_json(repo: str, issue_number: int) -> Any:
     payload["displayTitle"] = f'#{payload["number"]} {payload["title"]}'
     payload["labelNames"] = [label["name"] for label in payload.get("labels", [])]
     _issue_json_cache[key] = payload
+    _save_cache()
     return payload
 
 

--- a/.codex/skills/planning-board/scripts/board_ops.py
+++ b/.codex/skills/planning-board/scripts/board_ops.py
@@ -191,7 +191,11 @@ def get_issue_node_id(repo: str, issue_number: int) -> str:
     return node_id["id"]
 
 
+_issue_json_cache = {}
 def get_issue_json(repo: str, issue_number: int) -> Any:
+    key = (repo, issue_number)
+    if key in _issue_json_cache:
+        return _issue_json_cache[key]
     try:
         payload = run_gh_json(
             [
@@ -221,6 +225,7 @@ def get_issue_json(repo: str, issue_number: int) -> Any:
             raise
     payload["displayTitle"] = f'#{payload["number"]} {payload["title"]}'
     payload["labelNames"] = [label["name"] for label in payload.get("labels", [])]
+    _issue_json_cache[key] = payload
     return payload
 
 

--- a/.codex/skills/planning-board/scripts/board_sync_cycle.py
+++ b/.codex/skills/planning-board/scripts/board_sync_cycle.py
@@ -520,6 +520,27 @@ def sync_board_cycle(dry_run: bool = False) -> tuple[str, bool]:
         refs = set(extract_referenced_issues(pr.get("body", "")))
         refs.update(extract_referenced_issues(pr.get("headRefName", "")))
         r = pr["repo"]
+
+        # Unlinked-merge guard (Hussh Research SOP gap, 2026-07-09): a merged/
+        # closed owned PR with ZERO issue references cannot drive any board
+        # item to Done -- the completion is invisible to this sync. Flag it in
+        # the report instead of silently reporting a clean "no changes" run,
+        # so the operator notices and backfills issues/Closes-# links rather
+        # than the board silently drifting behind real shipped work.
+        unlinked_key = f"{r}-pr#{pr['number']}-unlinked"
+        if not refs:
+            if prev_state.get(unlinked_key) != "flagged":
+                pr_title = pr.get("title", "")
+                out.append(
+                    f"- \u26a0\ufe0f **{r}#{pr['number']}** ({pr_title!r}) merged/closed with "
+                    f"NO issue references -- board not updated. Add `Closes #NNNN` to the PR body "
+                    f"and re-run sync, or backfill an issue for this work."
+                )
+                has_changes = True
+            cur_state[unlinked_key] = "flagged"
+        else:
+            cur_state[unlinked_key] = "linked"
+
         for num in refs:
             try:
                 details = board_ops.get_issue_json(r, num)

--- a/.codex/workflows/generic-pdf-artifact-generation/PLAYBOOK.md
+++ b/.codex/workflows/generic-pdf-artifact-generation/PLAYBOOK.md
@@ -18,3 +18,4 @@ Produce a shareable PDF-style artifact that follows the docs-home, founder-langu
 1. local paths in public artifacts
 2. future-state claims presented as implementation truth
 3. diagram or PDF output accepted without rendered verification
+4. hard-wrapped Markdown emitted as individual paragraphs or detached list continuations

--- a/consent-protocol/api/routes/connected_systems.py
+++ b/consent-protocol/api/routes/connected_systems.py
@@ -9,8 +9,14 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from api.middleware import require_firebase_auth, require_vault_owner_token
 from hushh_mcp.services.connected_systems_service import (
+    ConnectedSystemConfigurationError,
     ConnectedSystemsError,
+    ConnectedSystemValidationError,
     get_connected_systems_service,
+)
+from hushh_mcp.services.crm_schema_mapping_service import (
+    CrmSchemaMappingError,
+    get_crm_schema_mapping_service,
 )
 
 router = APIRouter(prefix="/api/connected-systems", tags=["Connected Systems"])
@@ -27,13 +33,6 @@ class CrmReadRequest(BaseModel):
         default=None,
         validation_alias=AliasChoices("objectType", "object_type"),
         max_length=80,
-    )
-    # Macy's compatibility aliases. Generic clients supply searchFields.
-    email: str | None = Field(default=None, min_length=1, max_length=320)
-    phone: str | None = Field(default=None, min_length=1, max_length=80)
-    search_fields: dict[str, Any] | None = Field(
-        default=None,
-        validation_alias=AliasChoices("searchFields", "search_fields"),
     )
     return_fields: list[str] | None = Field(
         default=None,
@@ -61,28 +60,6 @@ class CrmCreateIntentRequest(BaseModel):
         validation_alias=AliasChoices("objectType", "object_type"),
         max_length=80,
     )
-    email: str | None = Field(default=None, min_length=1, max_length=320)
-    phone: str | None = Field(default=None, min_length=1, max_length=80)
-    first_name: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("firstName", "first_name"),
-        max_length=80,
-    )
-    last_name: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("lastName", "last_name"),
-        min_length=1,
-        max_length=80,
-    )
-    additional_fields: dict[str, Any] | None = Field(
-        default=None,
-        validation_alias=AliasChoices("additionalFields", "additional_fields"),
-    )
-    record_fields: dict[str, Any] | None = Field(
-        default=None,
-        validation_alias=AliasChoices("recordFields", "record_fields"),
-        description="Schema-driven create fields. Legacy aliases remain supported during migration.",
-    )
 
 
 class CrmUpdateIntentRequest(BaseModel):
@@ -93,12 +70,6 @@ class CrmUpdateIntentRequest(BaseModel):
         validation_alias=AliasChoices("objectType", "object_type"),
         max_length=80,
     )
-    record_id: str = Field(
-        ...,
-        validation_alias=AliasChoices("id", "recordId", "record_id"),
-        min_length=1,
-        max_length=128,
-    )
     additional_fields: dict[str, Any] | None = Field(
         default=None,
         validation_alias=AliasChoices("additionalFields", "additional_fields"),
@@ -107,10 +78,6 @@ class CrmUpdateIntentRequest(BaseModel):
         default=None,
         validation_alias=AliasChoices("recordFields", "record_fields"),
         description="Schema-driven update field diff. Legacy additionalFields remains supported.",
-    )
-    readback_locator: dict[str, Any] | None = Field(
-        default=None,
-        validation_alias=AliasChoices("readbackLocator", "readback_locator"),
     )
 
 
@@ -121,11 +88,6 @@ class CrmDeleteRequest(BaseModel):
         default=None,
         validation_alias=AliasChoices("objectType", "object_type"),
         max_length=80,
-    )
-    record_id: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("id", "recordId", "record_id"),
-        max_length=128,
     )
 
 
@@ -140,17 +102,62 @@ def _user_id(token_data: dict) -> str:
     return str(token_data.get("user_id") or "")
 
 
-def _legacy_create_aliases_to_record_fields(body: CrmCreateIntentRequest) -> dict[str, Any]:
-    """Keep Macy's wire aliases behind the schema-driven mutation boundary."""
-    fields = dict(body.additional_fields or {})
-    aliases = {
-        "Email": body.email,
-        "Phone": body.phone,
-        "FirstName": body.first_name,
-        "LastName": body.last_name,
+async def _resolve_schema_mapping(
+    *,
+    service: Any,
+    system_id: str,
+    object_type: str | None,
+    force_refresh: bool = False,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Fetch public schema then resolve its private-agent mapping.
+
+    The mapper receives the normalized schema only. It never receives the
+    authenticated user, their verified values, a CRM record, or credentials.
+    """
+    schema = await service.get_schema(system_id=system_id, object_type=object_type)
+    resolved = await get_crm_schema_mapping_service().resolve(
+        crm_id=system_id,
+        schema=schema,
+        force_refresh=force_refresh,
+    )
+    return schema, resolved.mapping
+
+
+def _schema_catalogue_only(schema: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **schema,
+        "profileFieldMappings": {},
+        "schemaMappingStatus": "unavailable",
+        "effectiveActions": {
+            "schema": True,
+            "read": False,
+            "create": False,
+            "update": False,
+            "delete": False,
+        },
+        "configurationMessage": (
+            "This CRM field catalogue is available, but its onboarding field mapping "
+            "is temporarily unavailable. Record actions stay disabled until it refreshes."
+        ),
     }
-    fields.update({key: value for key, value in aliases.items() if value not in (None, "")})
-    return fields
+
+
+async def _require_schema_mapping(
+    *, service: Any, system_id: str, object_type: str | None, force_refresh: bool = False
+) -> dict[str, str]:
+    try:
+        _schema, mapping = await _resolve_schema_mapping(
+            service=service,
+            system_id=system_id,
+            object_type=object_type,
+            force_refresh=force_refresh,
+        )
+        return mapping
+    except CrmSchemaMappingError as error:
+        raise ConnectedSystemConfigurationError(
+            "This CRM needs a verified field mapping before record actions can run.",
+            code=error.code,
+        ) from error
 
 
 async def _require_signed_in_lister(
@@ -205,7 +212,20 @@ async def get_connected_system_schema(
     _ = _user_id(token_data)
     service = get_connected_systems_service()
     try:
-        return await service.get_schema(system_id=system_id, object_type=object_type)
+        try:
+            schema, mapping = await _resolve_schema_mapping(
+                service=service,
+                system_id=system_id,
+                object_type=object_type,
+            )
+        except CrmSchemaMappingError:
+            schema = await service.get_schema(system_id=system_id, object_type=object_type)
+            return _schema_catalogue_only(schema)
+        return {
+            **schema,
+            "profileFieldMappings": mapping,
+            "schemaMappingStatus": "ready",
+        }
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
 
@@ -218,13 +238,16 @@ async def read_connected_system_record(
 ):
     service = get_connected_systems_service()
     try:
-        return await service.read_record(
+        await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
+        # A direct record read is binding-only. Browser lookup fields are not
+        # forwarded, so an authenticated user cannot turn this endpoint into an
+        # arbitrary CRM record probe.
+        return await service.read_bound_record(
             user_id=_user_id(token_data),
             system_id=system_id,
             object_type=body.object_type,
-            email=body.email,
-            phone=body.phone,
-            search_fields=body.search_fields,
             return_fields=body.return_fields,
         )
     except ConnectedSystemsError as error:
@@ -260,13 +283,16 @@ async def search_connected_system_record(
 ):
     service = get_connected_systems_service()
     try:
-        return await service.search_record(
+        await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
+        # Lookup is strictly derived from the authenticated user's server-side
+        # verified email and phone claim. The public request contains no
+        # lookup values, so this route cannot become a CRM record probe.
+        return await service.search_verified_record(
             user_id=_user_id(token_data),
             system_id=system_id,
             object_type=body.object_type,
-            email=body.email,
-            phone=body.phone,
-            search_fields=body.search_fields,
             return_fields=body.return_fields,
             force_refresh=body.force_refresh,
         )
@@ -282,16 +308,48 @@ async def create_connected_system_record_intent(
 ):
     service = get_connected_systems_service()
     try:
-        return await service.create_record_intent_from_fields(
-            user_id=_user_id(token_data),
-            system_id=system_id,
-            object_type=body.object_type,
-            record_fields=(
-                body.record_fields
-                if body.record_fields is not None
-                else _legacy_create_aliases_to_record_fields(body)
-            ),
+        mapping = await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
         )
+        # Initial records contain only server-side verified identity values
+        # mapped to this CRM's active schema. Client supplied values cannot
+        # create a record for another person.
+        try:
+            return await service.create_record_intent_for_verified_user(
+                user_id=_user_id(token_data),
+                system_id=system_id,
+                object_type=body.object_type,
+                profile_field_mappings=mapping,
+            )
+        except ConnectedSystemValidationError as error:
+            # A stale schema/model mapping gets exactly one forced refresh. The
+            # user still reviews the normal pending intent; this does not retry
+            # a CRM write or create an approval automatically.
+            if error.code not in {
+                "CONNECTED_SYSTEM_SCHEMA_FIELD_UNAVAILABLE",
+                "CONNECTED_SYSTEM_SCHEMA_FIELD_READ_ONLY",
+                "CONNECTED_SYSTEM_SCHEMA_REQUIRED_FIELDS",
+            }:
+                raise
+            configured_object_type = str(
+                body.object_type or service.get_system(system_id).object_type_default
+            )
+            get_crm_schema_mapping_service().invalidate(
+                crm_id=system_id,
+                object_type=configured_object_type,
+            )
+            mapping = await _require_schema_mapping(
+                service=service,
+                system_id=system_id,
+                object_type=body.object_type,
+                force_refresh=True,
+            )
+            return await service.create_record_intent_for_verified_user(
+                user_id=_user_id(token_data),
+                system_id=system_id,
+                object_type=body.object_type,
+                profile_field_mappings=mapping,
+            )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
 
@@ -304,17 +362,22 @@ async def update_connected_system_record_intent(
 ):
     service = get_connected_systems_service()
     try:
+        await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
         return await service.update_record_intent_from_fields(
             user_id=_user_id(token_data),
             system_id=system_id,
             object_type=body.object_type,
-            record_id=body.record_id,
+            # The route never selects a CRM id. The service resolves the
+            # authenticated owner's active binding and rejects any mismatch.
+            record_id=None,
             record_fields=(
                 body.record_fields
                 if body.record_fields is not None
                 else dict(body.additional_fields or {})
             ),
-            readback_locator=body.readback_locator,
+            readback_locator=None,
         )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
@@ -328,13 +391,16 @@ async def delete_connected_system_record(
 ):
     service = get_connected_systems_service()
     try:
+        await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
         # Compatibility route: delete is now a pending intent. Keeping this
         # URL prevents older clients from issuing an immediate destructive call.
         return service.create_delete_intent(
             user_id=_user_id(token_data),
             system_id=system_id,
             object_type=body.object_type,
-            record_id=body.record_id,
+            record_id=None,
         )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
@@ -348,11 +414,14 @@ async def create_connected_system_delete_intent(
 ):
     service = get_connected_systems_service()
     try:
+        await _require_schema_mapping(
+            service=service, system_id=system_id, object_type=body.object_type
+        )
         return service.create_delete_intent(
             user_id=_user_id(token_data),
             system_id=system_id,
             object_type=body.object_type,
-            record_id=body.record_id,
+            record_id=None,
         )
     except ConnectedSystemsError as error:
         _raise_connected_system_error(error)
@@ -366,6 +435,7 @@ async def approve_connected_system_intent(
 ):
     service = get_connected_systems_service()
     try:
+        await _require_schema_mapping(service=service, system_id=system_id, object_type=None)
         return await service.approve_intent(
             user_id=_user_id(token_data),
             system_id=system_id,

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 102,
+  "expected_migration_version": 104,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -793,6 +793,17 @@
       "description",
       "mcp_endpoint",
       "response_contract"
+    ],
+    "crm_schema_mapping_cache": [
+      "crm_id",
+      "object_type",
+      "schema_fingerprint",
+      "model_name",
+      "status",
+      "mapping_json",
+      "failure_code",
+      "refreshed_at",
+      "expires_at"
     ],
     "trusted_connections": [
       "id",

--- a/consent-protocol/db/migrations/103_demo_crm_response_contracts.sql
+++ b/consent-protocol/db/migrations/103_demo_crm_response_contracts.sql
@@ -1,0 +1,53 @@
+-- Verified operation response contracts for the two active demo CRM rows.
+--
+-- Captured against the registered Streamable HTTP MCP tools using an isolated
+-- synthetic lifecycle on 2026-07-17:
+-- create -> ID read -> update/readback -> delete -> absent ID read.
+--
+-- Update and delete intentionally produce an empty successful MCP tool result.
+-- Their explicit success policy is therefore `mcp_is_error_false`, followed by
+-- a registered state readback; this is not an inference from Salesforce names
+-- or a non-empty response body.
+
+BEGIN;
+
+UPDATE crm_operation_endpoints
+SET response_contract = jsonb_build_object(
+  'version', 'crm-record-collection.v1',
+  'recordsPath', jsonb_build_array('payload', 'records'),
+  'recordIdPath', jsonb_build_array('Id'),
+  'requestStyle', 'id_or_verified_identity.v1'
+)
+WHERE crm_id IN ('crm_002', 'salesforce-fsc-customer0')
+  AND operation = 'read';
+
+UPDATE crm_operation_endpoints
+SET response_contract = jsonb_build_object(
+  'version', 'crm-mutation-result.v1',
+  'successPath', jsonb_build_array('payload', 'success'),
+  'successValue', true,
+  'recordIdPath', jsonb_build_array('payload', 'id'),
+  'requestStyle', 'basic_identity_fields.v1'
+)
+WHERE crm_id IN ('crm_002', 'salesforce-fsc-customer0')
+  AND operation = 'create';
+
+UPDATE crm_operation_endpoints
+SET response_contract = jsonb_build_object(
+  'version', 'crm-mutation-result.v1',
+  'successPolicy', 'mcp_is_error_false',
+  'requestStyle', 'id_additional_fields.v1'
+)
+WHERE crm_id IN ('crm_002', 'salesforce-fsc-customer0')
+  AND operation = 'update';
+
+UPDATE crm_operation_endpoints
+SET response_contract = jsonb_build_object(
+  'version', 'crm-mutation-result.v1',
+  'successPolicy', 'mcp_is_error_false',
+  'requestStyle', 'id_only.v1'
+)
+WHERE crm_id IN ('crm_002', 'salesforce-fsc-customer0')
+  AND operation = 'delete';
+
+COMMIT;

--- a/consent-protocol/db/migrations/104_crm_schema_mapping_cache.sql
+++ b/consent-protocol/db/migrations/104_crm_schema_mapping_cache.sql
@@ -1,0 +1,25 @@
+-- Public-schema mapping cache for the manifest-owned Connected Systems child.
+-- It stores schema metadata decisions only: never CRM records, verified profile
+-- values, record IDs, credentials, consent material, prompts, or model output.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS crm_schema_mapping_cache (
+  crm_id TEXT NOT NULL REFERENCES enterprise_crm_registry(crm_id) ON DELETE CASCADE,
+  object_type TEXT NOT NULL,
+  schema_fingerprint TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('ready', 'invalidated', 'failed')),
+  mapping_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  failure_code TEXT,
+  refreshed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (crm_id, object_type, schema_fingerprint, model_name),
+  CONSTRAINT crm_schema_mapping_cache_mapping_object
+    CHECK (jsonb_typeof(mapping_json) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS idx_crm_schema_mapping_cache_lookup
+  ON crm_schema_mapping_cache (crm_id, object_type, model_name, status, expires_at DESC);
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -80,7 +80,9 @@
     "099_developer_oauth_pkce.sql",
     "100_connected_system_capability_contract.sql",
     "101_backfill_crm_operation_endpoints.sql",
-    "102_crm_operation_response_contract.sql"
+    "102_crm_operation_response_contract.sql",
+    "103_demo_crm_response_contracts.sql",
+    "104_crm_schema_mapping_cache.sql"
   ],
   "groups": {
     "iam": [
@@ -125,7 +127,9 @@
       "095_one_kyc_needs_confirm_status.sql",
       "100_connected_system_capability_contract.sql",
       "101_backfill_crm_operation_endpoints.sql",
-      "102_crm_operation_response_contract.sql"
+      "102_crm_operation_response_contract.sql",
+      "103_demo_crm_response_contracts.sql",
+      "104_crm_schema_mapping_cache.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/docs/reference/developer-api.md
+++ b/consent-protocol/docs/reference/developer-api.md
@@ -288,10 +288,48 @@ const scopedExport = await fetch("/api/v1/scoped-export", {
 const ciphertext = base64ToBytes(scopedExport.encrypted_data);
 ```
 
-Then unwrap and decrypt locally:
+For the hosted MCP equivalent, the envelope is nested in the MCP tool result.
+Prefer `structuredContent`; `content[0].text` is its JSON-string mirror for
+MCP clients that do not expose structured content. Hosted MCP uses
+`ciphertext`, where the raw HTTP API uses `encrypted_data`:
 
 ```js
-async function decryptScopedExport(scopedExport, ciphertext, connectorPrivateKey) {
+const scopedExport = toolResult.structuredContent ?? JSON.parse(
+  toolResult.content.find((item) => item.type === "text")?.text ?? "{}"
+);
+const ciphertext = base64ToBytes(scopedExport.ciphertext);
+```
+
+Then unwrap and decrypt locally. Consent export envelope v2 authenticates both
+AES-GCM operations. Do not omit `additionalData`, stringify the envelope
+exactly as shown, or substitute a new key pair after requesting consent.
+
+```js
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, stableValue(item)])
+    );
+  }
+  return value;
+}
+
+const canonicalJson = (value) => JSON.stringify(stableValue(value));
+
+async function decryptScopedExport(
+  scopedExport,
+  ciphertext,
+  connectorPrivateKey,
+  connectorKeyId
+) {
+  const envelope = scopedExport.export_envelope;
+  if (envelope?.version !== 2) throw new Error("Expected consent export envelope v2.");
+  if (scopedExport.wrapped_key_bundle.connector_key_id !== connectorKeyId) {
+    throw new Error("This export was wrapped for a different connector key.");
+  }
   const senderPublicKey = await crypto.subtle.importKey(
     "raw",
     base64ToBytes(scopedExport.wrapped_key_bundle.sender_public_key),
@@ -323,6 +361,7 @@ async function decryptScopedExport(scopedExport, ciphertext, connectorPrivateKey
     {
       name: "AES-GCM",
       iv: base64ToBytes(scopedExport.wrapped_key_bundle.wrapped_key_iv),
+      additionalData: new TextEncoder().encode(canonicalJson(envelope)),
     },
     wrappingKey,
     wrappedKeyCiphertext
@@ -340,13 +379,23 @@ async function decryptScopedExport(scopedExport, ciphertext, connectorPrivateKey
     base64ToBytes(scopedExport.tag)
   );
   const plaintext = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv: base64ToBytes(scopedExport.iv) },
+    {
+      name: "AES-GCM",
+      iv: base64ToBytes(scopedExport.iv),
+      additionalData: new TextEncoder().encode(canonicalJson(envelope.aad)),
+    },
     exportKey,
     encryptedPayload
   );
   return JSON.parse(new TextDecoder().decode(plaintext));
 }
 ```
+
+The connector private key must correspond to the exact public key and
+`connector_key_id` supplied in the approved consent request. If that private
+key is unavailable, create and securely retain a new connector key pair, then
+request fresh consent and fetch a new export. Never send a connector private
+key in a request, chat, log, or support ticket.
 
 If `granted_scope` is broader than `expected_scope`, narrow the decrypted JSON locally to the requested subtree before using it.
 

--- a/consent-protocol/hushh_mcp/adk_bridge/connected_systems_agent.py
+++ b/consent-protocol/hushh_mcp/adk_bridge/connected_systems_agent.py
@@ -7,9 +7,6 @@ frontend action plan that the central chat planner already supports.
 
 from __future__ import annotations
 
-import json
-import re
-from dataclasses import replace
 from typing import Any, cast
 from uuid import uuid4
 
@@ -28,15 +25,6 @@ from hushh_mcp.services.agent_chat_service import (
 DELEGATED_MODEL = "one+connected-systems"
 CONNECTED_SYSTEMS_A2A_AGENT_ID = "agent_connected_systems"
 ALL_CONNECTED_CRM_SYSTEMS_SCOPE = "all_connected_crm_systems"
-_FIELD_UPDATE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"\bmailing\s+city\s+(?:to|=|as)\s+(?P<value>[^,.]+)", re.I), "MailingCity"),
-    (re.compile(r"\bcity\s+(?:to|=|as)\s+(?P<value>[^,.]+)", re.I), "MailingCity"),
-    (re.compile(r"\btitle\s+(?:to|=|as)\s+(?P<value>[^,.]+)", re.I), "Title"),
-    (re.compile(r"\bphone\s+(?:to|=|as)\s+(?P<value>[^,.]+)", re.I), "Phone"),
-    (re.compile(r"\bemail\s+(?:to|=|as)\s+(?P<value>[^,\s]+)", re.I), "Email"),
-    (re.compile(r"\bfirst\s+name\s+(?:to|=|as)\s+(?P<value>[^,.]+)", re.I), "FirstName"),
-    (re.compile(r"\blast\s+name\s+(?:to|=|as)\s+(?P<value>[^,.]+)", re.I), "LastName"),
-)
 
 
 class ConnectedSystemsAgentA2A:
@@ -110,76 +98,16 @@ def _result(
 
 
 def _enrich_crm_plan(plan: AgentChatActionPlan, message: str) -> AgentChatActionPlan:
-    slots = dict(plan.slots)
-    email = _email_from_message(message)
-    phone = _phone_from_message(message)
-    if email and not slots.get("email"):
-        slots["email"] = email
-    if phone and not slots.get("phone"):
-        slots["phone"] = phone
-
-    if plan.action_id != "connected_system.crm.update.propose":
-        return replace(plan, slots=slots) if slots != plan.slots else plan
-
-    record_id = _record_id_from_message(message)
-    if record_id and not slots.get("id"):
-        slots["id"] = record_id
-
-    fields = _field_updates_from_message(message)
-    if fields and not slots.get("additionalFieldsJson"):
-        slots["additionalFieldsJson"] = json.dumps(fields, sort_keys=True)
-
-    if slots == plan.slots:
-        return plan
-    return replace(plan, slots=slots)
+    _ = message
+    # CRM IDs and verified lookup values are server-resolved, never harvested
+    # from chat. Schema-specific field edits are staged through the dynamic UI
+    # after the private agent's public-schema mapping has been validated.
+    return plan
 
 
 def _clarification_prompt(plan: AgentChatActionPlan, message: str) -> A2ADirective | None:
-    if plan.action_id != "connected_system.crm.update.propose":
-        return None
-    slots = dict(plan.slots)
-    if slots.get("additionalFieldsJson"):
-        return None
-    text = message.lower()
-    if "city" not in text:
-        scope_label = "across your connected CRM brands" if _is_all_crm_scope(slots) else ""
-        return A2ADirective(
-            kind="prompt",
-            payload={
-                "id": plan.call_id or f"crm_{uuid4().hex[:10]}",
-                "kind": "free_text",
-                "purpose": "crm_update_missing_change",
-                "type": plan.action_id,
-                "question": (
-                    f"What CRM field and value should I update {scope_label}?"
-                    if scope_label
-                    else "What CRM field and value should I update?"
-                ),
-                "placeholder": "Example: city to New York",
-                "confirmLabel": "Continue",
-                "cancelLabel": "Cancel",
-                "slots": slots,
-            },
-        )
-    return A2ADirective(
-        kind="prompt",
-        payload={
-            "id": plan.call_id or f"crm_{uuid4().hex[:10]}",
-            "kind": "free_text",
-            "purpose": "crm_update_missing_city",
-            "type": plan.action_id,
-            "question": (
-                "Yes. What city should I set across your connected CRM brands?"
-                if _is_all_crm_scope(slots)
-                else "Yes. What city should I set for your Macy's CRM record?"
-            ),
-            "placeholder": "New York",
-            "confirmLabel": "Use this city",
-            "cancelLabel": "Cancel",
-            "fieldName": "MailingCity",
-            "slots": slots,
-        },
-    )
+    _ = (plan, message)
+    return None
 
 
 def _directive_payload(plan: AgentChatActionPlan) -> dict[str, Any]:
@@ -236,45 +164,12 @@ def _delegate_result(task: A2ATask) -> SpecialistTurnResult:
 
 
 def _answered_prompt_result(task: A2ATask, result: dict[str, Any]) -> SpecialistTurnResult | None:
-    selected = result.get("selected")
-    selected_ref = selected[0] if isinstance(selected, list) and selected else {}
-    if not isinstance(selected_ref, dict):
-        selected_ref = {}
-    slots = selected_ref.get("slots") if isinstance(selected_ref.get("slots"), dict) else {}
-    slots = dict(slots or {})
-    free_text = str(result.get("freeText") or "").strip()
-    field_name = str(selected_ref.get("fieldName") or "").strip()
-    if field_name and free_text:
-        slots["additionalFieldsJson"] = json.dumps({field_name: free_text}, sort_keys=True)
-    elif free_text:
-        fields = _field_updates_from_message(free_text)
-        if fields:
-            slots["additionalFieldsJson"] = json.dumps(fields, sort_keys=True)
-    if not slots.get("additionalFieldsJson"):
-        return _result(
-            task,
-            text="I still need the CRM field value before I can prepare the update.",
-            directive=None,
-            is_complete=True,
-        )
-    action_type = str(result.get("type") or "connected_system.crm.update.propose")
-    plan = AgentChatActionPlan(
-        call_id=str(result.get("id") or f"crm_{uuid4().hex[:10]}"),
-        action_id=action_type,
-        label="Propose CRM Update",
-        execution="frontend",
-        slots=slots,
-        message=(
-            "Got it. Review and confirm the CRM update across your connected brands."
-            if _is_all_crm_scope(slots)
-            else "Got it. Review and confirm the CRM update before I apply it."
-        ),
-    )
+    _ = result
     return _result(
         task,
-        text=plan.message,
-        directive=A2ADirective(kind="action", payload=_directive_payload(plan)),
-        is_complete=False,
+        text="Open the CRM field table, stage the field change, then review it before approval.",
+        directive=None,
+        is_complete=True,
     )
 
 
@@ -303,61 +198,8 @@ def _plan_from_task(task: A2ATask) -> AgentChatActionPlan | None:
     )
 
 
-def _email_from_message(message: str) -> str | None:
-    match = re.search(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", message, flags=re.I)
-    return match.group(0).strip() if match else None
-
-
 def _is_all_crm_scope(slots: dict[str, Any]) -> bool:
     return str(slots.get("scope") or "") == ALL_CONNECTED_CRM_SYSTEMS_SCOPE
-
-
-def _phone_from_message(message: str) -> str | None:
-    match = re.search(
-        r"(?:\+?\d[\d\s().-]{7,}\d)",
-        message,
-    )
-    if not match:
-        return None
-    phone = match.group(0).strip()
-    digits = re.sub(r"\D", "", phone)
-    return phone if len(digits) >= 8 else None
-
-
-def _record_id_from_message(message: str) -> str | None:
-    match = re.search(
-        r"\b(?:record\s+id|record|id)\s*(?:is|to|=|:)?\s*(?P<id>[A-Za-z0-9_-]{8,32})",
-        message,
-        flags=re.I,
-    )
-    if not match:
-        return None
-    candidate = match.group("id").strip()
-    if candidate.lower() in {"city", "title", "phone", "email", "first", "last"}:
-        return None
-    return candidate
-
-
-def _field_updates_from_message(message: str) -> dict[str, Any]:
-    fields: dict[str, Any] = {}
-    for pattern, field_name in _FIELD_UPDATE_PATTERNS:
-        match = pattern.search(message)
-        if not match:
-            continue
-        value = _clean_field_value(match.group("value"))
-        if value:
-            fields[field_name] = value
-    return fields
-
-
-def _clean_field_value(value: str) -> str:
-    cleaned = re.split(
-        r"\b(?:for|on|in|across|at|and then|then|please)\b",
-        str(value or "").strip(),
-        maxsplit=1,
-        flags=re.I,
-    )[0]
-    return cleaned.strip(" .,'\"")
 
 
 _singleton: ConnectedSystemsAgentA2A | None = None

--- a/consent-protocol/hushh_mcp/agents/connected_systems/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/connected_systems/agent.yaml
@@ -1,7 +1,7 @@
 manifest_version: 2
 id: agent_connected_systems
 name: Connected Systems Agent
-version: 1.0.0
+version: 1.1.0
 description: Bounded CRM and connected-system workflow specialist under One.
 model: gemini-3.5-flash
 system_instruction: |
@@ -18,3 +18,56 @@ surfaces:
   web: true
   not_applicable_reason: Voice, remote A2A, MCP, and native exposure are not currently shipped.
 telemetry_namespace: agent.connected_systems
+subagents:
+  - id: crm_schema_mapper
+    name: CRM Schema Mapper
+    description: Maps a CRM's public field catalogue to the verified-profile semantics needed for safe onboarding.
+    model:
+      provider: gemini
+      name: gemini-3.5-flash
+      mode: hushh_managed_vertex
+    runtime:
+      kind: adk
+      adk_mode: single_turn
+      transport:
+        - in_process
+    system_instruction: |
+      You are the CRM Schema Mapper, an internal child of the Connected Systems
+      private-agent specialist. Map only the supplied public CRM schema metadata
+      to these semantic slots: email, phone, firstName, lastName, fullName, and
+      address. Return JSON matching the supplied response schema.
+
+      Select only exact field keys present in the supplied schema. Never invent
+      a field, a value, an identifier, a CRM tool, a capability, or a permission.
+      Email and phone are required. Select either firstName and lastName together,
+      or fullName. Address is optional. Use null when no safe match exists.
+
+      You never receive or request CRM records, verified profile values, record
+      identifiers, credentials, consent material, or vault material. You only
+      classify schema metadata and cannot execute a CRM action.
+    inputs:
+      - name: crm_schema
+        type: object
+        description: Normalized public object metadata and field descriptors only.
+    outputs:
+      - name: mapping
+        type: object
+        description: Typed semantic-to-schema-key mapping with confidence and reason per slot.
+    privacy:
+      context_allowlist:
+        - crm.object.name
+        - crm.object.label
+        - crm.schema.fields.key
+        - crm.schema.fields.label
+        - crm.schema.fields.type
+        - crm.schema.fields.required
+        - crm.schema.fields.constraints
+      plaintext_telemetry: false
+    telemetry_namespace: agent.connected_systems.crm_schema_mapper
+    performance:
+      latency_p95_ms: 10000
+      max_output_tokens: 1200
+    rollout:
+      kill_switch: CONNECTED_SYSTEMS_SCHEMA_MAPPER_ENABLED
+      strategy: canary
+      rollback: Disable the schema mapper; keep the CRM in catalogue-only mode until its mapping is available.

--- a/consent-protocol/hushh_mcp/hushh_adk/manifest.py
+++ b/consent-protocol/hushh_mcp/hushh_adk/manifest.py
@@ -106,6 +106,29 @@ class RolloutContract(StrictManifestModel):
     rollback: str
 
 
+class AgentSubagentConfig(StrictManifestModel):
+    """Manifest-owned internal ADK specialist.
+
+    A child is a bounded implementation detail of its parent, not another
+    top-level routing authority. Keeping its instruction and I/O contract in
+    the parent manifest makes the generated registry auditable and prevents a
+    parallel Python prompt from drifting away from the authored contract.
+    """
+
+    id: str
+    name: str
+    description: str
+    model: AgentModelConfig = Field(default_factory=AgentModelConfig)
+    runtime: RuntimeContract = Field(default_factory=RuntimeContract)
+    system_instruction: str
+    inputs: list[AgentInputConfig] = Field(default_factory=list)
+    outputs: list[AgentOutputConfig] = Field(default_factory=list)
+    privacy: PrivacyContract = Field(default_factory=PrivacyContract)
+    telemetry_namespace: str
+    performance: PerformanceContract = Field(default_factory=PerformanceContract)
+    rollout: RolloutContract
+
+
 class AgentManifestV2(StrictManifestModel):
     manifest_version: Literal[2] = 2
     id: str
@@ -143,6 +166,7 @@ class AgentManifestV2(StrictManifestModel):
             rollback="Disable the agent and restore the prior manifest.",
         )
     )
+    subagents: list[AgentSubagentConfig] = Field(default_factory=list)
     capabilities: dict[str, Any] = Field(default_factory=dict)
     ui_type: str | None = "chat"
     icon: str | None = None
@@ -152,6 +176,16 @@ class AgentManifestV2(StrictManifestModel):
     def reject_duplicates(cls, values: list[str]) -> list[str]:
         if len(values) != len(set(values)):
             raise ValueError("duplicate values are not allowed")
+        return values
+
+    @field_validator("subagents")
+    @classmethod
+    def reject_duplicate_subagent_ids(
+        cls, values: list[AgentSubagentConfig]
+    ) -> list[AgentSubagentConfig]:
+        identifiers = [value.id for value in values]
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError("duplicate subagent ids are not allowed")
         return values
 
     def tool_py_funcs(self) -> list[str]:

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -43,11 +43,13 @@ EXTERNAL_CRM_TOOL_CATALOG = (
         "name": "create-crm-record",
         "operation": "create",
         "description": "Create a Contact record from approved user fields.",
+        "responseContract": {"requestStyle": "basic_identity_fields.v1"},
     },
     {
         "name": "update-crm-record",
         "operation": "update",
         "description": "Update allowlisted Contact fields for the bound record.",
+        "responseContract": {"requestStyle": "id_additional_fields.v1"},
     },
     {
         "name": "delete-crm-record",
@@ -239,6 +241,13 @@ def _operation_response_contract(
     return _response_contract((system.operation(operation) or {}).get("responseContract"))
 
 
+def _operation_request_style(system: "ConnectedSystemDefinition", operation: str) -> str:
+    """Read the registered request-shape selector without making it executable."""
+    return _clean_text(
+        _operation_response_contract(system, operation).get("requestStyle"), max_length=80
+    )
+
+
 def _has_contract_path(contract: dict[str, Any], key: str) -> bool:
     return _contract_path(contract, key) is not None
 
@@ -256,7 +265,6 @@ def _valid_operation_response_contract(operation: str, contract: dict[str, Any])
             version == "crm-primary-object-schema.v1"
             and _has_contract_path(contract, "fieldsPath")
             and _has_contract_path(contract, "objectPath")
-            and isinstance(contract.get("requireFieldAccess"), bool)
         )
     if operation == "read":
         return (
@@ -265,11 +273,20 @@ def _valid_operation_response_contract(operation: str, contract: dict[str, Any])
             and _has_contract_path(contract, "recordIdPath")
         )
     if operation in {"create", "update", "delete"}:
+        success_policy = _clean_text(contract.get("successPolicy"), max_length=80)
         return (
             version == "crm-mutation-result.v1"
-            and _has_contract_path(contract, "successPath")
-            and _has_contract_path(contract, "recordIdPath")
-            and isinstance(contract.get("successValue"), bool)
+            and (
+                success_policy == "mcp_is_error_false"
+                or (
+                    _has_contract_path(contract, "successPath")
+                    and isinstance(contract.get("successValue"), (bool, str, int, float))
+                )
+            )
+            # A create must return the newly-created identifier. Updates and
+            # deletes operate on a previously owner-bound identifier, so their
+            # response need only confirm success.
+            and (operation != "create" or _has_contract_path(contract, "recordIdPath"))
         )
     return False
 
@@ -291,6 +308,11 @@ def _mutation_succeeded(
     if result.get("isError"):
         return False
     contract = _response_contract(response_contract)
+    if _clean_text(contract.get("successPolicy"), max_length=80) == "mcp_is_error_false":
+        # The registered MCP tool has an intentionally empty success payload.
+        # This is explicit registry policy; update/delete still require an
+        # independently verified state readback before becoming terminal.
+        return True
     path = _contract_path(contract, "successPath")
     if path:
         return _value_at_contract_path(result, path) is contract.get("successValue")
@@ -563,7 +585,6 @@ def _schema_fields_from_schema_result(
     result: dict[str, Any], *, response_contract: dict[str, Any] | None = None
 ) -> list[dict[str, Any]]:
     contract = _response_contract(response_contract)
-    strict_access = bool(contract.get("requireFieldAccess"))
     required_fields = {
         canonical
         for candidate in _collect_schema_required_candidates(result, response_contract=contract)
@@ -590,30 +611,26 @@ def _schema_fields_from_schema_result(
         createable = _descriptor_bool(descriptor, "createable", "isCreateable")
         updateable = _descriptor_bool(descriptor, "updateable", "isUpdateable")
         descriptor_required = _descriptor_bool(descriptor, "required", "isRequired")
+        # CRM schemas often expose a catalogue before they expose field-level
+        # access metadata. Keep that metadata optional: an omitted access bit
+        # means "not declared", not an inferred deny or allow. Operation tool
+        # mappings and the owner-bound record id remain the execution boundary.
+        # We can safely recognize a record id descriptor without asking a
+        # partner to add our redundant `identityField` extension.
+        type_value = (_schema_type_from_descriptor(descriptor) or "").lower()
+        raw_name_value = str(raw_name or canonical).strip().lower()
+        if identity is None and (
+            type_value == "id" or raw_name_value in {"id", "recordid", "record_id"}
+        ):
+            identity = True
         permissions_declared = all(
             value is not None for value in (identity, immutable, readable, createable, updateable)
         )
-        if strict_access:
-            # Missing field permissions are unknown, never an allow. In
-            # particular, writable is *derived* from the two operation-specific
-            # declarations; an upstream `writable` convenience bit cannot
-            # expand create or update authority.
-            identity = bool(identity)
-            immutable = bool(immutable)
-            readable = bool(readable)
-            createable = bool(createable)
-            updateable = bool(updateable)
-            writable = bool(createable or updateable)
-        else:
-            # Deterministic in-code fixtures predate the database registry.
-            # They remain wire-compatible only; all registry rows set
-            # requireFieldAccess and take the fail-closed branch above.
-            immutable = bool(immutable)
-            identity = bool(identity)
-            readable = True if readable is None else readable
-            createable = (not immutable) if createable is None else createable
-            updateable = (not immutable) if updateable is None else updateable
-            writable = bool(createable or updateable)
+        writable = (
+            bool(createable is True or updateable is True)
+            if createable is not None or updateable is not None
+            else None
+        )
         fields.append(
             {
                 "key": canonical,
@@ -621,12 +638,12 @@ def _schema_fields_from_schema_result(
                 "label": _schema_label_from_descriptor(descriptor) or canonical,
                 "dataType": _schema_type_from_descriptor(descriptor) or "string",
                 "required": bool(descriptor_required) or canonical in required_fields,
-                "identityField": bool(identity),
-                "readable": bool(readable),
-                "createable": bool(createable),
-                "updateable": bool(updateable),
-                "writable": bool(writable),
-                "immutable": bool(immutable),
+                "identityField": identity,
+                "readable": readable,
+                "createable": createable,
+                "updateable": updateable,
+                "writable": writable,
+                "immutable": immutable,
                 "permissionsDeclared": permissions_declared,
                 "constraints": _schema_constraints_from_descriptor(descriptor),
                 "source": source,
@@ -941,14 +958,16 @@ class ConnectedSystemDefinition:
         # configured with an absolute per-operation URL.
         if configured.startswith(("https://", "http://", "registry://")):
             return configured
-        return (
-            str(
-                (self.delete_transport_endpoint if operation == "delete" else None)
-                or self.transport_endpoint
-                or ""
-            ).strip()
-            or None
-        )
+        delete_override = str(self.delete_transport_endpoint or "").strip()
+        # `crm_delete_endpoint` was historically populated with a path on some
+        # rows. A path cannot be a Streamable HTTP MCP target by itself; use it
+        # only when it is an actual absolute endpoint and otherwise keep the
+        # registered base MCP transport.
+        if operation == "delete" and delete_override.startswith(
+            ("https://", "http://", "registry://")
+        ):
+            return delete_override
+        return str(self.transport_endpoint or "").strip() or None
 
     def supports(self, operation: str) -> bool:
         # A schema is mandatory for executable record actions so an untyped
@@ -1314,7 +1333,7 @@ class ConnectedSystemIntentStore:
         user_id: str,
         system_id: str,
         object_type: str,
-        record_id: str,
+        record_id: str | None,
         last_intent_id: str | None = None,
     ) -> dict[str, Any] | None:
         raise NotImplementedError
@@ -1775,12 +1794,14 @@ class ConnectedSystemsService:
         store: ConnectedSystemIntentStore | None = None,
         delete_enabled: bool | None = None,
         registry: tuple[ConnectedSystemDefinition, ...] | None = None,
+        identity_service: Any | None = None,
     ):
         self._registry_explicit = registry is not None
         self.registry = registry or self._load_registry()
         self.adapter = adapter
         self.store = store or DatabaseConnectedSystemIntentStore()
         self.delete_enabled = True if delete_enabled is None else delete_enabled
+        self.identity_service = identity_service
 
     def _load_registry(self) -> tuple[ConnectedSystemDefinition, ...]:
         from hushh_mcp.services import crm_registry_repo
@@ -1913,6 +1934,135 @@ class ConnectedSystemsService:
         except DatabaseExecutionError as error:
             raise _connected_systems_storage_error(error) from error
 
+    @staticmethod
+    def _profile_field_mappings(fields: list[dict[str, Any]]) -> dict[str, str]:
+        """Derive a mapping for explicit in-code test registries only.
+
+        Enterprise CRM rows must use the manifest-owned schema mapper/cache.
+        This narrow fixture helper preserves legacy deterministic test adapters
+        without silently making alias decisions for a partner schema.
+        """
+        aliases = {
+            "email": ("email", "emailaddress", "email_address"),
+            "phone": ("phone", "telephone", "phone_number", "mobilephone", "mobile_phone"),
+            "firstName": ("firstname", "first_name", "givenname", "given_name"),
+            "lastName": ("lastname", "last_name", "surname", "familyname", "family_name"),
+            "fullName": ("name", "fullname", "full_name", "displayname", "display_name"),
+            "address": ("mailingstreet", "street", "address", "addressline1", "address_line_1"),
+        }
+
+        normalized: list[tuple[dict[str, Any], str]] = []
+        for field in fields:
+            name = re.sub(
+                r"[^a-z0-9]", "", str(field.get("name") or field.get("key") or "").lower()
+            )
+            label = re.sub(r"[^a-z0-9]", "", str(field.get("label") or "").lower())
+            if name:
+                normalized.append((field, name))
+            elif label:
+                normalized.append((field, label))
+
+        mapping: dict[str, str] = {}
+        for semantic, candidates in aliases.items():
+            exact = next(
+                (
+                    field
+                    for field, token in normalized
+                    if token in candidates and field.get("identityField") is not True
+                ),
+                None,
+            )
+            # `Name` is a tempting substring of FirstName/LastName. A full
+            # name fallback must only bind to an exact full-name descriptor,
+            # otherwise it can overwrite a valid split last-name mapping.
+            partial = exact or (
+                None
+                if semantic == "fullName"
+                else next(
+                    (
+                        field
+                        for field, token in normalized
+                        if any(candidate in token for candidate in candidates)
+                        and field.get("identityField") is not True
+                    ),
+                    None,
+                )
+            )
+            if partial:
+                mapping[semantic] = str(partial["name"])
+        return mapping
+
+    async def _verified_user_crm_profile(self, *, user_id: str) -> dict[str, str]:
+        """Load the actor's server-side verified identity for CRM onboarding.
+
+        Browser-request fields are deliberately not accepted here: the lookup
+        and the initial CRM record use only the authenticated actor's verified
+        email and verified phone claim.
+        """
+        provider = self.identity_service
+        if provider is None:
+            from hushh_mcp.services.actor_identity_service import ActorIdentityService
+
+            provider = ActorIdentityService()
+        try:
+            identities = await provider.get_many([user_id])
+        except Exception as error:  # never surface identity-provider details
+            logger.warning("connected_systems.identity_lookup_failed user=%s", user_id)
+            raise ConnectedSystemConfigurationError(
+                "Verified account information is temporarily unavailable.",
+                code="CONNECTED_SYSTEM_VERIFIED_IDENTITY_UNAVAILABLE",
+            ) from error
+        identity = _ensure_dict((identities or {}).get(user_id))
+        email = _clean_text(identity.get("email"), max_length=320).lower()
+        phone = _normalize_crm_phone_for_mcp(identity.get("phone_number"))
+        if not identity.get("email_verified") or not email:
+            raise ConnectedSystemBlockedError(
+                "Verify your email before linking this CRM.",
+                code="CONNECTED_SYSTEM_EMAIL_VERIFICATION_REQUIRED",
+            )
+        if not identity.get("phone_verified") or not phone:
+            raise ConnectedSystemBlockedError(
+                "Verify your phone before linking this CRM.",
+                code="CONNECTED_SYSTEM_PHONE_VERIFICATION_REQUIRED",
+            )
+        display_name = _clean_text(identity.get("display_name"), max_length=160)
+        parts = display_name.split()
+        return {
+            "email": email,
+            "phone": phone,
+            "displayName": display_name,
+            "firstName": parts[0] if parts else "",
+            "lastName": " ".join(parts[1:]) if len(parts) > 1 else (parts[0] if parts else ""),
+        }
+
+    def _require_bound_record_id(
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        object_type: str,
+        supplied_record_id: str | None = None,
+    ) -> str:
+        binding = self._store_call(
+            self.store.get_binding,
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type,
+        )
+        bound_record_id = _clean_text((binding or {}).get("record_id"), max_length=128)
+        if not binding or not bound_record_id or binding.get("status") != "active":
+            raise ConnectedSystemBlockedError(
+                "Link your CRM record before reading or changing it.",
+                code="CONNECTED_SYSTEM_RECORD_BINDING_REQUIRED",
+            )
+        requested = _clean_text(supplied_record_id, max_length=128)
+        if requested and requested != bound_record_id:
+            raise ConnectedSystemBlockedError(
+                "This CRM record is not linked to your account.",
+                code="CONNECTED_SYSTEM_RECORD_BINDING_MISMATCH",
+            )
+        return bound_record_id
+
     async def get_schema(self, *, system_id: str, object_type: str | None = None) -> dict[str, Any]:
         system = self.get_system(system_id)
         self._require_operation(system, "schema")
@@ -1944,33 +2094,16 @@ class ConnectedSystemsService:
             response_contract=response_contract,
             default_object_type=payload["objectType"],
         )
-        permissions_complete = (
-            all(field.get("permissionsDeclared") for field in schema_fields)
-            if response_contract.get("requireFieldAccess") is True
-            else True
-        )
-        has_readable_identity = (
-            any(field.get("readable") and field.get("identityField") for field in schema_fields)
-            or response_contract.get("requireFieldAccess") is not True
-        )
+        permissions_complete = all(field.get("permissionsDeclared") for field in schema_fields)
         effective_actions = {
             "schema": True,
-            "read": bool(
-                permissions_complete and has_readable_identity and system.supports("read")
-            ),
-            "create": bool(
-                permissions_complete
-                and any(field.get("createable") for field in schema_fields)
-                and system.supports("create")
-            ),
-            "update": bool(
-                permissions_complete
-                and any(field.get("updateable") for field in schema_fields)
-                and system.supports("update")
-            ),
-            "delete": bool(
-                permissions_complete and system.supports("delete") and self.delete_enabled
-            ),
+            # The registered operation mapping, not invented per-field flags,
+            # controls whether the tool may run. Individual explicit `false`
+            # flags are still honoured during field validation below.
+            "read": bool(system.supports("read")),
+            "create": bool(system.supports("create")),
+            "update": bool(system.supports("update")),
+            "delete": bool(system.supports("delete") and self.delete_enabled),
         }
         return {
             "systemId": system.system_id,
@@ -1979,12 +2112,19 @@ class ConnectedSystemsService:
             "objectMetadata": object_metadata,
             "supportedFields": [field["key"] for field in schema_fields],
             "fields": schema_fields,
-            "schemaStatus": "ready" if permissions_complete else "capability_metadata_missing",
+            "profileFieldMappings": (
+                self._profile_field_mappings(schema_fields)
+                if system.registry_source != "enterprise_crm_registry"
+                else {}
+            ),
+            "schemaMappingStatus": "pending",
+            "schemaStatus": "ready",
+            "accessMetadata": "declared" if permissions_complete else "partial",
             "effectiveActions": effective_actions,
             "configurationMessage": (
                 None
                 if permissions_complete
-                else "This connected system needs an update before its fields can be used."
+                else "Some field-level access metadata is not declared. Registered CRM operations remain available and explicit field restrictions are still enforced."
             ),
         }
 
@@ -2016,16 +2156,16 @@ class ConnectedSystemsService:
                     code="CONNECTED_SYSTEM_SCHEMA_FIELD_UNAVAILABLE",
                 )
             if action == "update" and (
-                field.get("immutable")
-                or field.get("identityField")
-                or field.get("updateable") is not True
+                field.get("immutable") is True
+                or field.get("identityField") is True
+                or field.get("updateable") is False
             ):
                 raise ConnectedSystemValidationError(
                     f"Field cannot be updated: {key}",
                     code="CONNECTED_SYSTEM_SCHEMA_FIELD_READ_ONLY",
                 )
             if action == "create" and (
-                field.get("immutable") or field.get("createable") is not True
+                field.get("immutable") is True or field.get("createable") is False
             ):
                 raise ConnectedSystemValidationError(
                     f"Field cannot be written: {key}",
@@ -2037,7 +2177,11 @@ class ConnectedSystemsService:
             missing = [
                 field["label"]
                 for field in fields.values()
-                if field.get("required") and str(field["name"]).lower() not in supplied
+                if (
+                    field.get("required")
+                    and field.get("identityField") is not True
+                    and str(field["name"]).lower() not in supplied
+                )
             ]
             if missing:
                 raise ConnectedSystemValidationError(
@@ -2054,6 +2198,7 @@ class ConnectedSystemsService:
         object_type: str | None,
         record_fields: dict[str, Any],
         readback_locator: dict[str, Any] | None = None,
+        profile_field_mappings: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
         self._require_operation(system, "create")
@@ -2069,17 +2214,29 @@ class ConnectedSystemsService:
             "objectType": object_type_value,
             "recordFields": normalized,
         }
-        # The currently deployed Macy's tool predates recordFields. This is an
-        # explicit wire-compatibility adapter, not a generic CRM assumption.
-        if system.system_id == CONNECTED_SYSTEM_SALESFORCE_ID:
+        # A registered request style keeps the current Salesforce-family MCP
+        # wire shape out of the generic CRM validation path. Future systems
+        # remain on the typed `recordFields` default unless their own operation
+        # contract declares a different request style.
+        if _operation_request_style(system, "create") == "basic_identity_fields.v1":
+            mappings = dict(profile_field_mappings or {})
+            if not mappings and system.registry_source != "enterprise_crm_registry":
+                mappings = self._profile_field_mappings(list(fields.values()))
+            if not mappings:
+                raise ConnectedSystemConfigurationError(
+                    "This CRM needs a verified profile-field mapping before a record can be created.",
+                    code="CONNECTED_SYSTEM_PROFILE_FIELD_MAPPING_UNAVAILABLE",
+                )
             legacy = {str(key): value for key, value in normalized.items()}
             payload = {
                 "target": system.target,
                 "objectType": object_type_value,
-                "email": legacy.pop("Email", ""),
-                "phone": _normalize_crm_phone_for_mcp(legacy.pop("Phone", "")),
-                "lastName": legacy.pop("LastName", ""),
-                "firstName": legacy.pop("FirstName", "") or None,
+                "email": legacy.pop(str(mappings.get("email") or ""), ""),
+                "phone": _normalize_crm_phone_for_mcp(
+                    legacy.pop(str(mappings.get("phone") or ""), "")
+                ),
+                "lastName": legacy.pop(str(mappings.get("lastName") or ""), ""),
+                "firstName": legacy.pop(str(mappings.get("firstName") or ""), "") or None,
                 "additionalFields": legacy,
             }
         return self._create_intent(
@@ -2101,21 +2258,77 @@ class ConnectedSystemsService:
             record_id=None,
         )
 
+    async def create_record_intent_for_verified_user(
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        object_type: str | None,
+        profile_field_mappings: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Prepare a basic CRM create using server-side verified account data.
+
+        This intentionally has no browser-supplied field values. The initial
+        record is limited to the current user's verified email/phone and their
+        signed-in display name mapped against the active CRM schema.
+        """
+        profile = await self._verified_user_crm_profile(user_id=user_id)
+        schema = await self.get_schema(system_id=system_id, object_type=object_type)
+        system = self.get_system(system_id)
+        mappings = dict(profile_field_mappings or {})
+        if not mappings and system.registry_source != "enterprise_crm_registry":
+            mappings = _ensure_dict(schema.get("profileFieldMappings"))
+        fields: dict[str, Any] = {}
+        for semantic, profile_key in (
+            ("email", "email"),
+            ("phone", "phone"),
+            ("firstName", "firstName"),
+            ("lastName", "lastName"),
+        ):
+            field_name = _clean_text(mappings.get(semantic), max_length=80)
+            value = _clean_text(profile.get(profile_key), max_length=320)
+            if field_name and value:
+                fields[field_name] = value
+        # Salesforce-style `Name` fields are frequently derived and cannot be
+        # written alongside FirstName/LastName. Use a full-name field only for
+        # schemas that do not expose the split name pair.
+        if not (mappings.get("firstName") and mappings.get("lastName")):
+            full_name_field = _clean_text(mappings.get("fullName"), max_length=80)
+            full_name = _clean_text(profile.get("displayName"), max_length=160)
+            if full_name_field and full_name:
+                fields[full_name_field] = full_name
+        if "email" not in mappings or "phone" not in mappings:
+            raise ConnectedSystemConfigurationError(
+                "This CRM schema does not expose fields for verified email and phone.",
+                code="CONNECTED_SYSTEM_PROFILE_FIELD_MAPPING_UNAVAILABLE",
+            )
+        return await self.create_record_intent_from_fields(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type,
+            record_fields=fields,
+            profile_field_mappings=mappings,
+        )
+
     async def update_record_intent_from_fields(
         self,
         *,
         user_id: str,
         system_id: str,
         object_type: str | None,
-        record_id: str,
+        record_id: str | None,
         record_fields: dict[str, Any],
         readback_locator: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
         self._require_operation(system, "update")
-        record_id_value = _clean_text(record_id, max_length=128)
-        if not record_id_value:
-            raise ConnectedSystemValidationError("id is required for update.")
+        object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
+        record_id_value = self._require_bound_record_id(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type_value,
+            supplied_record_id=record_id,
+        )
         schema = await self.get_schema(system_id=system_id, object_type=object_type)
         self._require_schema_action(schema, "update")
         fields = {str(field["key"]): field for field in schema["fields"]}
@@ -2127,7 +2340,7 @@ class ConnectedSystemsService:
             "id": record_id_value,
             "recordFields": normalized,
         }
-        if system.system_id == CONNECTED_SYSTEM_SALESFORCE_ID:
+        if _operation_request_style(system, "update") == "id_additional_fields.v1":
             payload["additionalFields"] = normalized
             payload.pop("recordFields")
         return self._create_intent(
@@ -2169,12 +2382,20 @@ class ConnectedSystemsService:
         }
         if not search_fields:
             return {}
-        if system.system_id == CONNECTED_SYSTEM_SALESFORCE_ID:
+        # A registered request style, rather than a CRM name, preserves the
+        # email/phone lookup wire shape where a connector requires it. New
+        # CRM rows otherwise receive the generic typed search shape.
+        if (
+            _operation_request_style(system, "read") == "id_or_verified_identity.v1"
+            and locator
+            and locator.get("email")
+            and locator.get("phone")
+        ):
             return self._build_read_payload(
                 system_id=system.system_id,
                 object_type=object_type,
-                email=str(search_fields.get("Email") or ""),
-                phone=str(search_fields.get("Phone") or ""),
+                email=str(locator["email"]),
+                phone=str(locator["phone"]),
                 search_fields=None,
                 return_fields=list(record_fields),
             )
@@ -2195,6 +2416,7 @@ class ConnectedSystemsService:
         phone: str | None,
         search_fields: dict[str, Any] | None = None,
         return_fields: list[str] | None = None,
+        record_id: str | None = None,
     ) -> dict[str, Any]:
         payload = await self._build_schema_read_payload(
             system_id=system_id,
@@ -2203,6 +2425,7 @@ class ConnectedSystemsService:
             phone=phone,
             search_fields=search_fields,
             return_fields=return_fields,
+            record_id=record_id,
         )
         system = self.get_system(system_id)
         read_contract = _operation_response_contract(system, "read")
@@ -2254,30 +2477,58 @@ class ConnectedSystemsService:
         phone: str | None,
         search_fields: dict[str, Any] | None,
         return_fields: list[str] | None,
+        record_id: str | None = None,
     ) -> dict[str, Any]:
         system = self.get_system(system_id)
         schema = await self.get_schema(system_id=system_id, object_type=object_type)
         self._require_schema_action(schema, "read")
         fields = {
-            str(field["key"]): field for field in schema["fields"] if field.get("readable") is True
+            str(field["key"]): field
+            for field in schema["fields"]
+            if field.get("readable") is not False
         }
         by_name = {str(field["name"]): field for field in fields.values()}
-        # Macy's aliases remain a compatibility input only. They cannot make a
-        # future CRM look up arbitrary fields without a schema descriptor.
-        if email is not None or phone is not None:
-            if system.system_id != CONNECTED_SYSTEM_SALESFORCE_ID:
+        normalized_return: list[str] = []
+        for raw_name in return_fields or []:
+            field = fields.get(str(raw_name)) or by_name.get(str(raw_name))
+            if not field:
+                if system.registry_source != "enterprise_crm_registry":
+                    # Compatibility-only in-code fixtures predate typed
+                    # schema projection. Runtime registry connectors never
+                    # take this branch.
+                    normalized_return.append(str(raw_name))
+                    continue
                 raise ConnectedSystemValidationError(
-                    "Use searchFields for this CRM.",
-                    code="CONNECTED_SYSTEM_GENERIC_LOOKUP_REQUIRED",
+                    f"Return field is not available in this CRM schema: {raw_name}",
+                    code="CONNECTED_SYSTEM_SCHEMA_FIELD_UNAVAILABLE",
                 )
-            return self._build_read_payload(
-                system_id=system_id,
-                object_type=object_type,
-                email=email or "",
-                phone=phone or "",
-                search_fields=search_fields,
-                return_fields=return_fields,
-            )
+            normalized_return.append(str(field["name"]))
+        record_id_value = _clean_text(record_id, max_length=128)
+        if record_id_value:
+            return {
+                "target": system.target,
+                "objectType": str(schema["objectType"]),
+                "id": record_id_value,
+                "returnFields": list(dict.fromkeys(normalized_return)),
+            }
+        # Identity lookup is used only by the server-side verified-account
+        # onboarding flow. It is deliberately not a public arbitrary-field
+        # search path.
+        if email is not None or phone is not None:
+            email_value = _clean_text(email, max_length=320).lower()
+            phone_value = _normalize_crm_phone_for_mcp(phone)
+            if not email_value or not phone_value:
+                raise ConnectedSystemValidationError(
+                    "Verified email and phone are required for CRM lookup.",
+                    code="CONNECTED_SYSTEM_VERIFIED_LOOKUP_REQUIRED",
+                )
+            return {
+                "target": system.target,
+                "objectType": str(schema["objectType"]),
+                "email": email_value,
+                "phone": phone_value,
+                "returnFields": list(dict.fromkeys(normalized_return)),
+            }
         if not isinstance(search_fields, dict) or not search_fields:
             raise ConnectedSystemValidationError("searchFields is required for this CRM.")
         normalized_search: dict[str, Any] = {}
@@ -2289,21 +2540,59 @@ class ConnectedSystemsService:
                     code="CONNECTED_SYSTEM_SCHEMA_FIELD_UNAVAILABLE",
                 )
             normalized_search[str(field["name"])] = value
-        normalized_return: list[str] = []
-        for raw_name in return_fields or []:
-            field = fields.get(str(raw_name)) or by_name.get(str(raw_name))
-            if not field:
-                raise ConnectedSystemValidationError(
-                    f"Return field is not available in this CRM schema: {raw_name}",
-                    code="CONNECTED_SYSTEM_SCHEMA_FIELD_UNAVAILABLE",
-                )
-            normalized_return.append(str(field["name"]))
         return {
             "target": system.target,
             "objectType": str(schema["objectType"]),
             "searchFields": normalized_search,
             "returnFields": list(dict.fromkeys(normalized_return)),
         }
+
+    async def read_bound_record(
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        object_type: str | None,
+        return_fields: list[str] | None = None,
+    ) -> dict[str, Any]:
+        system = self.get_system(system_id)
+        object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
+        record_id = self._require_bound_record_id(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type_value,
+        )
+        return await self.read_record(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type_value,
+            email=None,
+            phone=None,
+            return_fields=return_fields,
+            record_id=record_id,
+        )
+
+    async def search_verified_record(
+        self,
+        *,
+        user_id: str,
+        system_id: str,
+        object_type: str | None,
+        return_fields: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> dict[str, Any]:
+        """Find a record using only the authenticated owner's verified identity."""
+        profile = await self._verified_user_crm_profile(user_id=user_id)
+        return await self.search_record(
+            user_id=user_id,
+            system_id=system_id,
+            object_type=object_type,
+            email=profile["email"],
+            phone=profile["phone"],
+            search_fields=None,
+            return_fields=return_fields,
+            force_refresh=force_refresh,
+        )
 
     def get_record_binding(
         self,
@@ -2548,15 +2837,12 @@ class ConnectedSystemsService:
         system = self.get_system(system_id)
         self._require_operation(system, "delete")
         object_type_value = _normalize_object_type(object_type, default=system.object_type_default)
-        binding = self._store_call(
-            self.store.get_binding,
+        record_id_value = self._require_bound_record_id(
             user_id=user_id,
             system_id=system_id,
             object_type=object_type_value,
+            supplied_record_id=record_id,
         )
-        record_id_value = _clean_text(record_id or (binding or {}).get("record_id"), max_length=128)
-        if not record_id_value:
-            raise ConnectedSystemValidationError("id is required for delete.")
         return self._create_intent(
             user_id=user_id,
             system=system,
@@ -2567,7 +2853,15 @@ class ConnectedSystemsService:
                 "objectType": object_type_value,
                 "id": record_id_value,
             },
-            readback_payload={},
+            # An empty successful MCP result is insufficient proof for delete.
+            # The registered read tool must confirm the owner-bound ID is gone
+            # before the binding transitions to deleted.
+            readback_payload={
+                "target": system.target,
+                "objectType": object_type_value,
+                "id": record_id_value,
+                "returnFields": [],
+            },
             field_names=[],
             record_id=record_id_value,
         )
@@ -2599,6 +2893,15 @@ class ConnectedSystemsService:
         if intent.get("approval_id") != approval:
             return self._public_intent(intent)
         try:
+            if intent["action"] in {"update", "delete"}:
+                # Re-check at execution time: a stale UI request cannot mutate
+                # a record after its binding was removed or replaced.
+                self._require_bound_record_id(
+                    user_id=user_id,
+                    system_id=system_id,
+                    object_type=str(intent["object_type"]),
+                    supplied_record_id=str(intent.get("record_id") or ""),
+                )
             if system.registry_source == "enterprise_crm_registry":
                 schema = await self.get_schema(
                     system_id=system_id, object_type=intent.get("object_type")
@@ -2625,11 +2928,7 @@ class ConnectedSystemsService:
             record_id = intent.get("record_id") or _record_id_from_result(
                 result, response_contract=response_contract
             )
-            readback = (
-                {"resultClass": "succeeded", "reason": "delete_confirmed"}
-                if intent["action"] == "delete" and mutation_succeeded
-                else await self._readback(intent, system=system)
-            )
+            readback = await self._readback(intent, system=system, record_id=record_id)
             if not record_id:
                 record_id = _clean_text(readback.get("recordId"), max_length=128)
             readback_class = self._classify_readback(intent, readback)
@@ -2834,9 +3133,26 @@ class ConnectedSystemsService:
         return intent
 
     async def _readback(
-        self, intent: dict[str, Any], *, system: ConnectedSystemDefinition
+        self,
+        intent: dict[str, Any],
+        *,
+        system: ConnectedSystemDefinition,
+        record_id: str | None,
     ) -> dict[str, Any]:
-        readback_payload = intent.get("readback_payload") or {}
+        readback_payload = _ensure_dict(intent.get("readback_payload"))
+        record_id_value = _clean_text(record_id, max_length=128)
+        if record_id_value:
+            # A CRM mutation response or owner binding is the only authority
+            # for this ID. Verify all mutations by that ID, never through a
+            # broader identity lookup.
+            readback_payload = {
+                "target": system.target,
+                "objectType": str(intent.get("object_type") or system.object_type_default),
+                "id": record_id_value,
+                "returnFields": []
+                if intent.get("action") == "delete"
+                else [str(field) for field in intent.get("field_names") or []],
+            }
         if not readback_payload:
             return {
                 "resultClass": "partial",
@@ -2870,6 +3186,8 @@ class ConnectedSystemsService:
         if readback.get("resultClass") != "succeeded":
             return "partial"
         records = _records_from_readback(readback)
+        if intent.get("action") == "delete":
+            return "succeeded" if not records else "partial"
         expected = _expected_readback_fields(intent)
         if not expected:
             return "succeeded" if records else "partial"

--- a/consent-protocol/hushh_mcp/services/crm_schema_mapping_service.py
+++ b/consent-protocol/hushh_mcp/services/crm_schema_mapping_service.py
@@ -1,0 +1,470 @@
+"""Cached, manifest-owned CRM schema mapping for Connected Systems.
+
+The model sees public CRM schema metadata only. It has no CRM transport,
+record, identity, consent, vault, or persistence authority. Persistence stays
+behind this repository so the current Postgres implementation can later move
+to Redis without changing the mapping contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+from db.db_client import DatabaseExecutionError, get_db
+from hushh_mcp.hushh_adk.manifest import AgentSubagentConfig, ManifestLoader
+from hushh_mcp.runtime_providers import build_managed_runtime_client
+
+logger = logging.getLogger(__name__)
+
+CRM_SCHEMA_MAPPER_ID = "crm_schema_mapper"
+CRM_SCHEMA_MAPPER_ENABLED_ENV = "CONNECTED_SYSTEMS_SCHEMA_MAPPER_ENABLED"
+CRM_SCHEMA_MAPPING_TTL = timedelta(hours=24)
+_SEMANTICS = ("email", "phone", "firstName", "lastName", "fullName", "address")
+_REQUIRED_SEMANTICS = ("email", "phone")
+
+
+class CrmSchemaMappingError(RuntimeError):
+    """Safe failure state for public-schema mapping only."""
+
+    code = "CONNECTED_SYSTEM_SCHEMA_MAPPING_UNAVAILABLE"
+
+
+@dataclass(frozen=True)
+class CrmSchemaMapping:
+    mapping: dict[str, str]
+    schema_fingerprint: str
+    model_name: str
+    source: str
+
+
+class CrmSchemaMappingStore(Protocol):
+    def get(
+        self, *, crm_id: str, object_type: str, schema_fingerprint: str, model_name: str
+    ) -> CrmSchemaMapping | None: ...
+
+    def put(
+        self,
+        *,
+        crm_id: str,
+        object_type: str,
+        schema_fingerprint: str,
+        model_name: str,
+        mapping: dict[str, str],
+    ) -> None: ...
+
+    def invalidate(self, *, crm_id: str, object_type: str) -> None: ...
+
+
+class InMemoryCrmSchemaMappingStore:
+    """Test-only cache. Production uses Postgres through the same seam."""
+
+    def __init__(self) -> None:
+        self.entries: dict[tuple[str, str, str, str], CrmSchemaMapping] = {}
+
+    def get(
+        self, *, crm_id: str, object_type: str, schema_fingerprint: str, model_name: str
+    ) -> CrmSchemaMapping | None:
+        cached = self.entries.get((crm_id, object_type, schema_fingerprint, model_name))
+        if cached is None:
+            return None
+        return CrmSchemaMapping(
+            mapping=dict(cached.mapping),
+            schema_fingerprint=cached.schema_fingerprint,
+            model_name=cached.model_name,
+            source="cache",
+        )
+
+    def put(
+        self,
+        *,
+        crm_id: str,
+        object_type: str,
+        schema_fingerprint: str,
+        model_name: str,
+        mapping: dict[str, str],
+    ) -> None:
+        self.entries[(crm_id, object_type, schema_fingerprint, model_name)] = CrmSchemaMapping(
+            mapping=dict(mapping),
+            schema_fingerprint=schema_fingerprint,
+            model_name=model_name,
+            source="fresh",
+        )
+
+    def invalidate(self, *, crm_id: str, object_type: str) -> None:
+        self.entries = {
+            key: value for key, value in self.entries.items() if key[:2] != (crm_id, object_type)
+        }
+
+
+class DatabaseCrmSchemaMappingStore:
+    """Postgres cache repository; no record values or model prompts are stored.
+
+    Redis/Memorystore can replace this implementation later without changing
+    ``CrmSchemaMappingStore`` or the API contract.
+    """
+
+    def __init__(self, db: Any | None = None) -> None:
+        self._db = db
+
+    @property
+    def db(self) -> Any:
+        if self._db is None:
+            self._db = get_db()
+        return self._db
+
+    def get(
+        self, *, crm_id: str, object_type: str, schema_fingerprint: str, model_name: str
+    ) -> CrmSchemaMapping | None:
+        try:
+            rows = self.db.execute_raw(
+                """
+                SELECT mapping_json
+                FROM crm_schema_mapping_cache
+                WHERE crm_id = :crm_id
+                  AND object_type = :object_type
+                  AND schema_fingerprint = :schema_fingerprint
+                  AND model_name = :model_name
+                  AND status = 'ready'
+                  AND expires_at > NOW()
+                LIMIT 1
+                """,
+                {
+                    "crm_id": crm_id,
+                    "object_type": object_type,
+                    "schema_fingerprint": schema_fingerprint,
+                    "model_name": model_name,
+                },
+            ).data
+        except DatabaseExecutionError as error:
+            raise CrmSchemaMappingError("CRM schema mapping storage is unavailable.") from error
+        if not rows:
+            return None
+        raw_mapping = rows[0].get("mapping_json") if isinstance(rows[0], dict) else {}
+        mapping = raw_mapping if isinstance(raw_mapping, dict) else {}
+        normalized = {
+            semantic: str(value)
+            for semantic, value in mapping.items()
+            if semantic in _SEMANTICS and isinstance(value, str) and value.strip()
+        }
+        return CrmSchemaMapping(
+            mapping=normalized,
+            schema_fingerprint=schema_fingerprint,
+            model_name=model_name,
+            source="cache",
+        )
+
+    def put(
+        self,
+        *,
+        crm_id: str,
+        object_type: str,
+        schema_fingerprint: str,
+        model_name: str,
+        mapping: dict[str, str],
+    ) -> None:
+        expires_at = datetime.now(timezone.utc) + CRM_SCHEMA_MAPPING_TTL
+        try:
+            self.db.execute_raw(
+                """
+                INSERT INTO crm_schema_mapping_cache (
+                  crm_id, object_type, schema_fingerprint, model_name,
+                  status, mapping_json, expires_at, refreshed_at
+                ) VALUES (
+                  :crm_id, :object_type, :schema_fingerprint, :model_name,
+                  'ready', CAST(:mapping_json AS jsonb), :expires_at, NOW()
+                )
+                ON CONFLICT (crm_id, object_type, schema_fingerprint, model_name)
+                DO UPDATE SET
+                  status = 'ready',
+                  mapping_json = EXCLUDED.mapping_json,
+                  expires_at = EXCLUDED.expires_at,
+                  refreshed_at = NOW(),
+                  failure_code = NULL
+                """,
+                {
+                    "crm_id": crm_id,
+                    "object_type": object_type,
+                    "schema_fingerprint": schema_fingerprint,
+                    "model_name": model_name,
+                    "mapping_json": json.dumps(mapping, sort_keys=True),
+                    "expires_at": expires_at,
+                },
+            )
+        except DatabaseExecutionError as error:
+            raise CrmSchemaMappingError("CRM schema mapping storage is unavailable.") from error
+
+    def invalidate(self, *, crm_id: str, object_type: str) -> None:
+        try:
+            self.db.execute_raw(
+                """
+                UPDATE crm_schema_mapping_cache
+                SET status = 'invalidated', expires_at = NOW(), refreshed_at = NOW()
+                WHERE crm_id = :crm_id AND object_type = :object_type AND status = 'ready'
+                """,
+                {"crm_id": crm_id, "object_type": object_type},
+            )
+        except DatabaseExecutionError as error:
+            raise CrmSchemaMappingError("CRM schema mapping storage is unavailable.") from error
+
+
+class CrmSchemaMapper(Protocol):
+    @property
+    def model_name(self) -> str: ...
+
+    async def map_schema(self, schema_projection: dict[str, Any]) -> dict[str, Any] | None: ...
+
+
+def _manifest_child() -> AgentSubagentConfig:
+    manifest_path = (
+        Path(__file__).resolve().parents[1] / "agents" / "connected_systems" / "agent.yaml"
+    )
+    manifest = ManifestLoader.load(str(manifest_path))
+    child = next((item for item in manifest.subagents if item.id == CRM_SCHEMA_MAPPER_ID), None)
+    if child is None:
+        raise CrmSchemaMappingError("CRM schema mapper is not declared in the agent manifest.")
+    if child.runtime.adk_mode != "single_turn" or child.runtime.transport != ["in_process"]:
+        raise CrmSchemaMappingError("CRM schema mapper manifest has an invalid runtime boundary.")
+    if child.privacy.plaintext_telemetry:
+        raise CrmSchemaMappingError(
+            "CRM schema mapper manifest does not permit plaintext telemetry."
+        )
+    return child
+
+
+class GeminiCrmSchemaMapper:
+    """One manifest-owned, tool-less Gemini call over schema metadata only."""
+
+    def __init__(self, *, client_factory=build_managed_runtime_client) -> None:
+        self._child = _manifest_child()
+        self._client_factory = client_factory
+        self._client: Any | None = None
+
+    @property
+    def model_name(self) -> str:
+        return self._child.model.name
+
+    def _client_for_call(self) -> Any:
+        if self._client is None:
+            self._client = self._client_factory(self._child.model.provider)
+        return self._client
+
+    async def map_schema(self, schema_projection: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            from google.genai import types
+        except ImportError as error:  # pragma: no cover - environment guard
+            raise CrmSchemaMappingError(
+                "CRM schema mapper is unavailable in this environment."
+            ) from error
+
+        allowed_keys = [field["key"] for field in schema_projection["fields"]]
+        slot_schema = {
+            "type": "OBJECT",
+            "nullable": True,
+            "properties": {
+                "fieldKey": {"type": "STRING", "enum": allowed_keys, "nullable": True},
+                "confidence": {"type": "NUMBER"},
+                "reason": {"type": "STRING"},
+            },
+            "required": ["fieldKey", "confidence", "reason"],
+        }
+        response_schema = {
+            "type": "OBJECT",
+            "properties": {
+                "mappings": {
+                    "type": "OBJECT",
+                    "properties": {semantic: slot_schema for semantic in _SEMANTICS},
+                    "required": list(_SEMANTICS),
+                }
+            },
+            "required": ["mappings"],
+        }
+        prompt = (
+            f"{self._child.system_instruction}\n\n"
+            "Public CRM schema metadata follows. Return JSON only.\n"
+            f"{json.dumps(schema_projection, sort_keys=True, separators=(',', ':'))}"
+        )
+        config = types.GenerateContentConfig(
+            temperature=0,
+            max_output_tokens=self._child.performance.max_output_tokens,
+            response_mime_type="application/json",
+            response_schema=response_schema,
+            automatic_function_calling=types.AutomaticFunctionCallingConfig(disable=True),
+        )
+        try:
+            response = await asyncio.wait_for(
+                self._client_for_call().aio.models.generate_content(
+                    model=self.model_name,
+                    contents=prompt,
+                    config=config,
+                ),
+                timeout=self._child.performance.latency_p95_ms / 1000,
+            )
+        except Exception as error:  # never surface provider internals or prompt content
+            logger.warning(
+                "agent.connected_systems.crm_schema_mapper.failed error=%s", type(error).__name__
+            )
+            return None
+        parsed = getattr(response, "parsed", None)
+        if isinstance(parsed, dict):
+            return parsed
+        try:
+            candidate = json.loads(str(getattr(response, "text", "") or ""))
+        except json.JSONDecodeError:
+            return None
+        return candidate if isinstance(candidate, dict) else None
+
+
+def _schema_projection(schema: dict[str, Any]) -> dict[str, Any]:
+    fields: list[dict[str, Any]] = []
+    for raw in schema.get("fields") or []:
+        if not isinstance(raw, dict):
+            continue
+        key = str(raw.get("key") or "").strip()
+        if not key:
+            continue
+        fields.append(
+            {
+                "key": key,
+                "label": str(raw.get("label") or key),
+                "type": str(raw.get("dataType") or "string"),
+                "required": raw.get("required") is True,
+                "constraints": raw.get("constraints")
+                if isinstance(raw.get("constraints"), dict)
+                else {},
+                # Explicit denies are relevant to validating a safe create
+                # map. Omitted access metadata remains unknown, never assumed.
+                "createable": raw.get("createable"),
+                "immutable": raw.get("immutable"),
+            }
+        )
+    return {
+        "object": {
+            "name": str(schema.get("objectType") or ""),
+            "label": str((schema.get("objectMetadata") or {}).get("label") or ""),
+        },
+        "fields": fields,
+    }
+
+
+def _fingerprint(projection: dict[str, Any]) -> str:
+    serialized = json.dumps(projection, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _validate_mapping(raw: dict[str, Any] | None, fields: list[dict[str, Any]]) -> dict[str, str]:
+    if not isinstance(raw, dict) or not isinstance(raw.get("mappings"), dict):
+        raise CrmSchemaMappingError("CRM schema mapper returned no usable mapping.")
+    allowed = {str(field["key"]): field for field in fields}
+    mapping: dict[str, str] = {}
+    for semantic in _SEMANTICS:
+        candidate = raw["mappings"].get(semantic)
+        if candidate is None:
+            continue
+        if not isinstance(candidate, dict):
+            raise CrmSchemaMappingError("CRM schema mapper returned an invalid mapping.")
+        key = str(candidate.get("fieldKey") or "").strip()
+        confidence = candidate.get("confidence")
+        reason = str(candidate.get("reason") or "").strip()
+        if not key:
+            continue
+        if (
+            key not in allowed
+            or not isinstance(confidence, (int, float))
+            or not 0 <= confidence <= 1
+        ):
+            raise CrmSchemaMappingError("CRM schema mapper proposed an invalid field.")
+        if not reason or len(reason) > 240:
+            raise CrmSchemaMappingError("CRM schema mapper returned an invalid mapping reason.")
+        field = allowed[key]
+        if field.get("immutable") is True or field.get("createable") is False:
+            raise CrmSchemaMappingError(
+                "CRM schema mapper selected a field unavailable for onboarding."
+            )
+        mapping[semantic] = key
+    if any(semantic not in mapping for semantic in _REQUIRED_SEMANTICS):
+        raise CrmSchemaMappingError(
+            "This CRM schema could not map verified email and phone fields."
+        )
+    if not ((mapping.get("firstName") and mapping.get("lastName")) or mapping.get("fullName")):
+        raise CrmSchemaMappingError("This CRM schema could not map a usable name field.")
+    return mapping
+
+
+class CrmSchemaMappingService:
+    def __init__(
+        self,
+        *,
+        store: CrmSchemaMappingStore | None = None,
+        mapper: CrmSchemaMapper | None = None,
+    ) -> None:
+        self.store = store or DatabaseCrmSchemaMappingStore()
+        self.mapper = mapper or GeminiCrmSchemaMapper()
+
+    async def resolve(
+        self, *, crm_id: str, schema: dict[str, Any], force_refresh: bool = False
+    ) -> CrmSchemaMapping:
+        if os.getenv(CRM_SCHEMA_MAPPER_ENABLED_ENV, "true").strip().lower() in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }:
+            raise CrmSchemaMappingError("CRM schema mapping is temporarily unavailable.")
+        object_type = str(schema.get("objectType") or "").strip()
+        projection = _schema_projection(schema)
+        if not object_type or not projection["fields"]:
+            raise CrmSchemaMappingError(
+                "The connected system did not return a usable primary-object schema."
+            )
+        schema_fingerprint = _fingerprint(projection)
+        if not force_refresh:
+            cached = self.store.get(
+                crm_id=crm_id,
+                object_type=object_type,
+                schema_fingerprint=schema_fingerprint,
+                model_name=self.mapper.model_name,
+            )
+            if cached is not None:
+                return cached
+        raw = await self.mapper.map_schema(projection)
+        mapping = _validate_mapping(raw, projection["fields"])
+        self.store.put(
+            crm_id=crm_id,
+            object_type=object_type,
+            schema_fingerprint=schema_fingerprint,
+            model_name=self.mapper.model_name,
+            mapping=mapping,
+        )
+        logger.info(
+            "agent.connected_systems.crm_schema_mapper.completed crm_id=%s object_type=%s cache=%s",
+            crm_id,
+            object_type,
+            False,
+        )
+        return CrmSchemaMapping(
+            mapping=mapping,
+            schema_fingerprint=schema_fingerprint,
+            model_name=self.mapper.model_name,
+            source="fresh",
+        )
+
+    def invalidate(self, *, crm_id: str, object_type: str) -> None:
+        self.store.invalidate(crm_id=crm_id, object_type=object_type)
+
+
+_service: CrmSchemaMappingService | None = None
+
+
+def get_crm_schema_mapping_service() -> CrmSchemaMappingService:
+    global _service
+    if _service is None:
+        _service = CrmSchemaMappingService()
+    return _service

--- a/consent-protocol/tests/test_agent_manifests.py
+++ b/consent-protocol/tests/test_agent_manifests.py
@@ -62,3 +62,15 @@ def test_kyc_owns_strict_zero_knowledge_formatter_contract() -> None:
     assert formatter["contract_id"] == "agent_kyc.approved_disclosure_formatter.v1"
     assert formatter["strict_client_zk"] is True
     assert formatter["backend_plaintext_allowed"] is False
+
+
+def test_connected_systems_schema_mapper_is_manifest_owned_and_toolless() -> None:
+    manifest = load("connected_systems")
+    mapper = next(child for child in manifest.subagents if child.id == "crm_schema_mapper")
+    assert mapper.model.name == "gemini-3.5-flash"
+    assert mapper.runtime.adk_mode == "single_turn"
+    assert mapper.runtime.transport == ["in_process"]
+    assert mapper.privacy.plaintext_telemetry is False
+    assert mapper.rollout.kill_switch == "CONNECTED_SYSTEMS_SCHEMA_MAPPER_ENABLED"
+    assert "credential" in mapper.system_instruction.lower()
+    assert "record" in mapper.system_instruction.lower()

--- a/consent-protocol/tests/test_connected_systems_migration.py
+++ b/consent-protocol/tests/test_connected_systems_migration.py
@@ -59,7 +59,11 @@ def test_response_contract_migration_is_registered_and_fail_closed_by_default():
     )
 
     assert migration.exists()
-    assert manifest["ordered_migrations"][-1] == "102_crm_operation_response_contract.sql"
+    assert manifest["ordered_migrations"][-3:] == [
+        "102_crm_operation_response_contract.sql",
+        "103_demo_crm_response_contracts.sql",
+        "104_crm_schema_mapping_cache.sql",
+    ]
     assert "102_crm_operation_response_contract.sql" in manifest["groups"]["iam"]
     assert "response_contract JSONB NOT NULL DEFAULT '{}'::jsonb" in migration.read_text()
     migration_text = migration.read_text()
@@ -67,4 +71,28 @@ def test_response_contract_migration_is_registered_and_fail_closed_by_default():
     assert "'objectPath'" in migration_text
     assert "'requireFieldAccess', true" in migration_text
     assert "response_contract" in uat_contract["required_tables"]["crm_operation_endpoints"]
-    assert uat_contract["expected_migration_version"] == 102
+    assert uat_contract["expected_migration_version"] == 104
+
+
+def test_demo_crm_response_mappings_and_schema_mapper_cache_are_release_registered():
+    response_migration = ROOT / "db" / "migrations" / "103_demo_crm_response_contracts.sql"
+    cache_migration = ROOT / "db" / "migrations" / "104_crm_schema_mapping_cache.sql"
+    manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text())
+    uat_contract = json.loads(
+        (ROOT / "db" / "contracts" / "uat_integrated_schema.json").read_text()
+    )
+
+    assert response_migration.exists()
+    assert cache_migration.exists()
+    assert "103_demo_crm_response_contracts.sql" in manifest["groups"]["iam"]
+    assert "104_crm_schema_mapping_cache.sql" in manifest["groups"]["iam"]
+    assert "mcp_is_error_false" in response_migration.read_text()
+    assert "CREATE TABLE IF NOT EXISTS crm_schema_mapping_cache" in cache_migration.read_text()
+    assert {
+        "crm_id",
+        "object_type",
+        "schema_fingerprint",
+        "model_name",
+        "mapping_json",
+        "expires_at",
+    } <= set(uat_contract["required_tables"]["crm_schema_mapping_cache"])

--- a/consent-protocol/tests/test_connected_systems_routes.py
+++ b/consent-protocol/tests/test_connected_systems_routes.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -35,7 +38,15 @@ class FakeConnectedSystemsService:
             }
         ]
 
-    async def create_record_intent_from_fields(self, **kwargs):
+    async def get_schema(self, **kwargs):
+        return {
+            "systemId": kwargs["system_id"],
+            "objectType": kwargs.get("object_type") or "Contact",
+            "fields": [],
+            "effectiveActions": {"schema": True},
+        }
+
+    async def create_record_intent_for_verified_user(self, **kwargs):
         self.created_payload = kwargs
         return {
             "intentId": "csi_test",
@@ -45,7 +56,7 @@ class FakeConnectedSystemsService:
             "fieldNames": ["Email", "Phone", "LastName"],
         }
 
-    async def read_record(self, **kwargs):
+    async def read_bound_record(self, **kwargs):
         self.read_payload = kwargs
         return {
             "systemId": kwargs["system_id"],
@@ -65,7 +76,7 @@ class FakeConnectedSystemsService:
             "binding": None,
         }
 
-    async def search_record(self, **kwargs):
+    async def search_verified_record(self, **kwargs):
         self.search_payload = kwargs
         return {
             "systemId": kwargs["system_id"],
@@ -137,6 +148,30 @@ def _build_app() -> FastAPI:
     return app
 
 
+class FakeSchemaMappingService:
+    async def resolve(self, **_kwargs):
+        return SimpleNamespace(
+            mapping={
+                "email": "Email",
+                "phone": "Phone",
+                "firstName": "FirstName",
+                "lastName": "LastName",
+            }
+        )
+
+    def invalidate(self, **_kwargs):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def schema_mapping_service(monkeypatch):
+    monkeypatch.setattr(
+        connected_systems,
+        "get_crm_schema_mapping_service",
+        lambda: FakeSchemaMappingService(),
+    )
+
+
 def test_list_connected_systems_route_returns_salesforce_registry_entry(monkeypatch):
     service = FakeConnectedSystemsService()
     monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
@@ -175,7 +210,7 @@ def test_list_connected_systems_returns_typed_registry_unavailable_error(monkeyp
     }
 
 
-def test_create_intent_route_accepts_live_mcp_camel_case_shape(monkeypatch):
+def test_create_intent_route_accepts_no_browser_identity_fields(monkeypatch):
     service = FakeConnectedSystemsService()
     monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
     client = TestClient(_build_app())
@@ -183,14 +218,7 @@ def test_create_intent_route_accepts_live_mcp_camel_case_shape(monkeypatch):
     response = client.post(
         "/api/connected-systems/salesforce-fsc-customer0/records/create-intents",
         headers={"Authorization": "Bearer HCT:test"},
-        json={
-            "objectType": "Contact",
-            "email": "doe.john@abc.com",
-            "phone": "1234567899",
-            "firstName": "John",
-            "lastName": "Doe",
-            "additionalFields": {"Title": "VP Sales"},
-        },
+        json={"objectType": "Contact"},
     )
 
     assert response.status_code == 200
@@ -199,17 +227,16 @@ def test_create_intent_route_accepts_live_mcp_camel_case_shape(monkeypatch):
         "user_id": "user_123",
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
-        "record_fields": {
-            "Email": "doe.john@abc.com",
-            "Phone": "1234567899",
-            "FirstName": "John",
-            "LastName": "Doe",
-            "Title": "VP Sales",
+        "profile_field_mappings": {
+            "email": "Email",
+            "phone": "Phone",
+            "firstName": "FirstName",
+            "lastName": "LastName",
         },
     }
 
 
-def test_read_route_accepts_updated_mcp_search_and_return_fields(monkeypatch):
+def test_read_route_uses_bound_record(monkeypatch):
     service = FakeConnectedSystemsService()
     monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
     client = TestClient(_build_app())
@@ -217,13 +244,7 @@ def test_read_route_accepts_updated_mcp_search_and_return_fields(monkeypatch):
     response = client.post(
         "/api/connected-systems/salesforce-fsc-customer0/records/read",
         headers={"Authorization": "Bearer HCT:test"},
-        json={
-            "objectType": "Contact",
-            "email": "doe.john@abc.com",
-            "phone": "1234567899",
-            "searchFields": {"Title": "VP Sales"},
-            "returnFields": ["LeadSource", "MailingCity"],
-        },
+        json={"objectType": "Contact", "returnFields": ["LeadSource", "MailingCity"]},
     )
 
     assert response.status_code == 200
@@ -232,9 +253,6 @@ def test_read_route_accepts_updated_mcp_search_and_return_fields(monkeypatch):
         "user_id": "user_123",
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
-        "email": "doe.john@abc.com",
-        "phone": "1234567899",
-        "search_fields": {"Title": "VP Sales"},
         "return_fields": ["LeadSource", "MailingCity"],
     }
 
@@ -258,7 +276,7 @@ def test_record_binding_route_returns_authenticated_user_binding(monkeypatch):
     }
 
 
-def test_search_route_binds_matching_crm_record(monkeypatch):
+def test_search_route_uses_verified_owner_identity(monkeypatch):
     service = FakeConnectedSystemsService()
     monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
     client = TestClient(_build_app())
@@ -266,12 +284,7 @@ def test_search_route_binds_matching_crm_record(monkeypatch):
     response = client.post(
         "/api/connected-systems/salesforce-fsc-customer0/records/search",
         headers={"Authorization": "Bearer HCT:test"},
-        json={
-            "objectType": "Contact",
-            "email": "doe.john@abc.com",
-            "phone": "1234567899",
-            "returnFields": ["LeadSource", "MailingCity"],
-        },
+        json={"objectType": "Contact", "returnFields": ["LeadSource", "MailingCity"]},
     )
 
     assert response.status_code == 200
@@ -280,15 +293,12 @@ def test_search_route_binds_matching_crm_record(monkeypatch):
         "user_id": "user_123",
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
-        "email": "doe.john@abc.com",
-        "phone": "1234567899",
-        "search_fields": None,
         "return_fields": ["LeadSource", "MailingCity"],
         "force_refresh": False,
     }
 
 
-def test_update_intent_route_accepts_updated_mcp_id_and_additional_fields(monkeypatch):
+def test_update_intent_route_resolves_bound_record_id(monkeypatch):
     service = FakeConnectedSystemsService()
     monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
     client = TestClient(_build_app())
@@ -298,7 +308,6 @@ def test_update_intent_route_accepts_updated_mcp_id_and_additional_fields(monkey
         headers={"Authorization": "Bearer HCT:test"},
         json={
             "objectType": "Contact",
-            "id": "003gK00000m36zhQAA",
             "additionalFields": {"MailingCity": "New York"},
         },
     )
@@ -309,13 +318,13 @@ def test_update_intent_route_accepts_updated_mcp_id_and_additional_fields(monkey
         "user_id": "user_123",
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
-        "record_id": "003gK00000m36zhQAA",
+        "record_id": None,
         "record_fields": {"MailingCity": "New York"},
         "readback_locator": None,
     }
 
 
-def test_delete_route_accepts_updated_mcp_id_shape(monkeypatch):
+def test_delete_route_resolves_bound_record_id(monkeypatch):
     service = FakeConnectedSystemsService()
     monkeypatch.setattr(connected_systems, "get_connected_systems_service", lambda: service)
     client = TestClient(_build_app())
@@ -323,10 +332,7 @@ def test_delete_route_accepts_updated_mcp_id_shape(monkeypatch):
     response = client.post(
         "/api/connected-systems/salesforce-fsc-customer0/records/delete",
         headers={"Authorization": "Bearer HCT:test"},
-        json={
-            "objectType": "Contact",
-            "id": "003gK00000m36zhQAA",
-        },
+        json={"objectType": "Contact"},
     )
 
     assert response.status_code == 200
@@ -336,7 +342,7 @@ def test_delete_route_accepts_updated_mcp_id_shape(monkeypatch):
         "user_id": "user_123",
         "system_id": "salesforce-fsc-customer0",
         "object_type": "Contact",
-        "record_id": "003gK00000m36zhQAA",
+        "record_id": None,
     }
 
 
@@ -348,10 +354,7 @@ def test_delete_route_returns_403_when_service_blocks_delete(monkeypatch):
     response = client.post(
         "/api/connected-systems/salesforce-fsc-customer0/records/delete",
         headers={"Authorization": "Bearer HCT:test"},
-        json={
-            "objectType": "Contact",
-            "id": "003gK00000m36zhQAA",
-        },
+        json={"objectType": "Contact"},
     )
 
     assert response.status_code == 403

--- a/consent-protocol/tests/test_connected_systems_service.py
+++ b/consent-protocol/tests/test_connected_systems_service.py
@@ -67,6 +67,7 @@ class FakeExternalCrmAdapter:
 
     async def delete_record(self, payload: dict) -> dict:
         self.calls.append(("delete-crm-record", payload))
+        self.readback_records = []
         return {"isError": False, "payload": {"deleted": True}}
 
 
@@ -358,24 +359,12 @@ async def test_registry_contracts_keep_two_crms_isolated_and_sanitize_read_recor
     )
 
     greenhouse_schema = await service.get_schema(system_id=greenhouse.system_id)
-    assert greenhouse_schema["schemaStatus"] == "capability_metadata_missing"
-    before = len(adapter.calls)
-    with pytest.raises(ConnectedSystemBlockedError):
-        await service.read_record(
-            user_id="user-1",
-            system_id=greenhouse.system_id,
-            object_type=None,
-            email=None,
-            phone=None,
-            search_fields={"candidateId": "candidate-42"},
-            return_fields=["candidateId"],
-        )
-    assert len(adapter.calls) == before + 1  # schema refresh, never a read MCP call
-    assert adapter.calls[-1][0] == "schema"
+    assert greenhouse_schema["schemaStatus"] == "ready"
+    assert greenhouse_schema["accessMetadata"] == "partial"
 
 
 @pytest.mark.asyncio
-async def test_registry_schema_catalogue_without_access_metadata_blocks_record_tools():
+async def test_registry_schema_catalogue_without_access_metadata_keeps_mapped_tools_available():
     class MetadataOnlyAdapter:
         def __init__(self) -> None:
             self.calls: list[str] = []
@@ -439,9 +428,10 @@ async def test_registry_schema_catalogue_without_access_metadata_blocks_record_t
     )
 
     schema = await service.get_schema(system_id=definition.system_id)
-    assert schema["schemaStatus"] == "capability_metadata_missing"
+    assert schema["schemaStatus"] == "ready"
+    assert schema["accessMetadata"] == "partial"
     assert schema["objectMetadata"] == {"name": "Person", "label": "Person"}
-    assert schema["fields"][0]["readable"] is False
+    assert schema["fields"][0]["readable"] is None
     assert schema["effectiveActions"] == {
         "schema": True,
         "read": False,
@@ -449,18 +439,7 @@ async def test_registry_schema_catalogue_without_access_metadata_blocks_record_t
         "update": False,
         "delete": False,
     }
-
-    with pytest.raises(ConnectedSystemBlockedError):
-        await service.read_record(
-            user_id="user-1",
-            system_id=definition.system_id,
-            object_type=None,
-            email=None,
-            phone=None,
-            search_fields={"Email": "person@example.test"},
-            return_fields=["Email"],
-        )
-    assert adapter.calls == ["schema", "schema"]
+    assert adapter.calls == ["schema"]
 
 
 @pytest.mark.asyncio
@@ -681,6 +660,83 @@ async def test_bound_read_skips_redundant_mcp_search():
 
 
 @pytest.mark.asyncio
+async def test_verified_profile_create_uses_server_identity_and_never_writes_derived_full_name():
+    class VerifiedIdentityService:
+        async def get_many(self, _user_ids):
+            return {
+                "user_123": {
+                    "display_name": "John Doe",
+                    "email": "john@example.test",
+                    "email_verified": True,
+                    "phone_number": "+1 (415) 555-0100",
+                    "phone_verified": True,
+                }
+            }
+
+    service, _adapter = build_service()
+    service.identity_service = VerifiedIdentityService()
+
+    intent = await service.create_record_intent_for_verified_user(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+    )
+
+    stored = service.store.intents[intent["intentId"]]["request_payload"]
+    assert stored["email"] == "john@example.test"
+    assert stored["phone"] == "4155550100"
+    assert stored["lastName"] == "Doe"
+    assert "Name" not in stored
+    assert "firstName" not in stored
+
+
+@pytest.mark.asyncio
+async def test_bound_mutations_reject_other_record_ids_and_recheck_binding_on_approval():
+    service, adapter = build_service()
+    service.store.upsert_binding(
+        {
+            "binding_id": "binding-owner",
+            "user_id": "user_123",
+            "system_id": CONNECTED_SYSTEM_SALESFORCE_ID,
+            "target": "Macys",
+            "object_type": "Contact",
+            "record_id": "003gK00000ownedQAA",
+        }
+    )
+
+    with pytest.raises(ConnectedSystemBlockedError, match="not linked"):
+        await service.update_record_intent_from_fields(
+            user_id="user_123",
+            system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+            object_type=None,
+            record_id="003gK00000otherQAA",
+            record_fields={"MailingCity": "Dallas"},
+        )
+
+    intent = await service.update_record_intent_from_fields(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        record_id=None,
+        record_fields={"MailingCity": "Dallas"},
+    )
+    service.store.mark_binding_deleted(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type="Contact",
+        record_id="003gK00000ownedQAA",
+    )
+
+    with pytest.raises(ConnectedSystemBlockedError, match="Link your CRM record"):
+        await service.approve_intent(
+            user_id="user_123",
+            system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+            intent_id=intent["intentId"],
+        )
+    assert not any(name == "update-crm-record" for name, _payload in adapter.calls)
+
+
+@pytest.mark.asyncio
 async def test_force_refresh_bypasses_binding_and_researches():
     """force_refresh=True re-runs the MCP search even when a binding exists."""
     service, adapter = build_service()
@@ -726,9 +782,9 @@ async def test_schema_read_and_create_payloads_match_live_mcp_contract():
         "LastName",
     ]
     fields = {field["key"]: field for field in schema["fields"]}
-    assert fields["Unsupported__c"]["writable"] is True
+    assert fields["Unsupported__c"]["writable"] is None
     assert fields["LastName"]["required"] is True
-    assert fields["Email"]["readable"] is True
+    assert fields["Email"]["readable"] is None
     assert adapter.calls[-1] == (
         "object-schema",
         {"target": "Macys", "objectType": "Contact"},
@@ -750,7 +806,6 @@ async def test_schema_read_and_create_payloads_match_live_mcp_contract():
             "objectType": "Contact",
             "email": "doe.john@abc.com",
             "phone": "1234567899",
-            "searchFields": {"Title": "VP Sales"},
             "returnFields": ["LeadSource", "MailingCity"],
         },
     )
@@ -771,7 +826,6 @@ async def test_schema_read_and_create_payloads_match_live_mcp_contract():
             "objectType": "Contact",
             "email": "doe.john@abc.com",
             "phone": "1234567899",
-            "searchFields": {"Id": "003gK00000demoQAA"},
             "returnFields": ["MailingCity"],
         },
     )
@@ -982,6 +1036,16 @@ async def test_rejected_intent_never_calls_mcp():
 @pytest.mark.asyncio
 async def test_update_uses_additional_fields_and_marks_readback_mismatch_partial():
     service, adapter = build_service()
+    service.store.upsert_binding(
+        {
+            "binding_id": "binding-test",
+            "user_id": "user_123",
+            "system_id": CONNECTED_SYSTEM_SALESFORCE_ID,
+            "target": "Macys",
+            "object_type": "Contact",
+            "record_id": "003gK00000demoQAA",
+        }
+    )
     adapter.readback_records = [
         {
             "Id": "003gK00000demoQAA",
@@ -1015,10 +1079,50 @@ async def test_update_uses_additional_fields_and_marks_readback_mismatch_partial
             "additionalFields": {"MailingCity": "New York"},
         },
     ) in adapter.calls
+    read_calls = [payload for name, payload in adapter.calls if name == "read-crm-record"]
+    assert read_calls[-1]["id"] == "003gK00000demoQAA"
+    assert "email" not in read_calls[-1]
+    assert "phone" not in read_calls[-1]
     assert all("body" not in payload for _name, payload in adapter.calls)
     assert approved["status"] == "partial"
     assert approved["binding"]["status"] == "active"
     assert approved["binding"]["recordId"] == "003gK00000demoQAA"
+
+
+@pytest.mark.asyncio
+async def test_delete_readback_uses_bound_id_and_clears_binding_only_after_absence():
+    service, adapter = build_service(delete_enabled=True)
+    service.store.upsert_binding(
+        {
+            "binding_id": "binding-delete-test",
+            "user_id": "user_123",
+            "system_id": CONNECTED_SYSTEM_SALESFORCE_ID,
+            "target": "Macys",
+            "object_type": "Contact",
+            "record_id": "003gK00000demoQAA",
+        }
+    )
+
+    intent = service.create_delete_intent(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type="Contact",
+    )
+    approved = await service.approve_intent(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        intent_id=intent["intentId"],
+    )
+
+    assert approved["status"] == "succeeded"
+    assert approved["binding"]["status"] == "deleted"
+    read_calls = [payload for name, payload in adapter.calls if name == "read-crm-record"]
+    assert read_calls[-1] == {
+        "target": "Macys",
+        "objectType": "Contact",
+        "id": "003gK00000demoQAA",
+        "returnFields": [],
+    }
 
 
 @pytest.mark.asyncio

--- a/consent-protocol/tests/test_crm_schema_mapping_service.py
+++ b/consent-protocol/tests/test_crm_schema_mapping_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from hushh_mcp.services.crm_schema_mapping_service import (
+    CrmSchemaMappingError,
+    CrmSchemaMappingService,
+    InMemoryCrmSchemaMappingStore,
+)
+
+
+class FakeMapper:
+    model_name = "gemini-3.5-flash"
+
+    def __init__(self, response: dict | None):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def map_schema(self, schema_projection: dict):
+        self.calls.append(schema_projection)
+        return self.response
+
+
+def schema(*, additional_field: bool = False) -> dict:
+    fields = [
+        {"key": "Email", "label": "Email", "dataType": "email", "required": True},
+        {"key": "Phone", "label": "Phone", "dataType": "phone", "required": True},
+        {"key": "FirstName", "label": "First name", "dataType": "string"},
+        {"key": "LastName", "label": "Last name", "dataType": "string", "required": True},
+    ]
+    if additional_field:
+        fields.append({"key": "MailingStreet", "label": "Address", "dataType": "string"})
+    return {
+        "systemId": "crm_demo",
+        "objectType": "Contact",
+        "objectMetadata": {"name": "Contact", "label": "Contact"},
+        "fields": fields,
+    }
+
+
+def mapping(*, email: str = "Email") -> dict:
+    return {
+        "mappings": {
+            "email": {"fieldKey": email, "confidence": 0.99, "reason": "email field"},
+            "phone": {"fieldKey": "Phone", "confidence": 0.99, "reason": "phone field"},
+            "firstName": {"fieldKey": "FirstName", "confidence": 0.96, "reason": "given name"},
+            "lastName": {"fieldKey": "LastName", "confidence": 0.96, "reason": "family name"},
+            "fullName": None,
+            "address": None,
+        }
+    }
+
+
+def test_schema_mapping_cache_hits_and_fingerprint_refreshes() -> None:
+    store = InMemoryCrmSchemaMappingStore()
+    mapper = FakeMapper(mapping())
+    service = CrmSchemaMappingService(store=store, mapper=mapper)
+
+    first = asyncio.run(service.resolve(crm_id="crm_demo", schema=schema()))
+    second = asyncio.run(service.resolve(crm_id="crm_demo", schema=schema()))
+    refreshed = asyncio.run(
+        service.resolve(crm_id="crm_demo", schema=schema(additional_field=True))
+    )
+
+    assert first.mapping["email"] == "Email"
+    assert second.source == "cache"
+    assert refreshed.schema_fingerprint != first.schema_fingerprint
+    assert len(mapper.calls) == 2
+
+
+def test_schema_mapper_receives_only_public_schema_metadata() -> None:
+    mapper = FakeMapper(mapping())
+    service = CrmSchemaMappingService(store=InMemoryCrmSchemaMappingStore(), mapper=mapper)
+
+    asyncio.run(service.resolve(crm_id="crm_demo", schema=schema()))
+
+    sent = json.dumps(mapper.calls[0], sort_keys=True)
+    assert "user" not in sent.lower()
+    assert "record" not in sent.lower()
+    assert "credential" not in sent.lower()
+    assert "consent" not in sent.lower()
+    assert "vault" not in sent.lower()
+    assert {"key", "label", "type", "required", "constraints"} <= set(mapper.calls[0]["fields"][0])
+
+
+def test_hallucinated_or_incomplete_mapping_fails_closed() -> None:
+    mapper = FakeMapper(mapping(email="NotARealField"))
+    service = CrmSchemaMappingService(store=InMemoryCrmSchemaMappingStore(), mapper=mapper)
+
+    with pytest.raises(CrmSchemaMappingError):
+        asyncio.run(service.resolve(crm_id="crm_demo", schema=schema()))
+
+
+def test_model_failure_keeps_the_crm_unavailable() -> None:
+    mapper = FakeMapper(None)
+    service = CrmSchemaMappingService(store=InMemoryCrmSchemaMappingStore(), mapper=mapper)
+
+    with pytest.raises(CrmSchemaMappingError):
+        asyncio.run(service.resolve(crm_id="crm_demo", schema=schema()))
+    assert len(mapper.calls) == 1
+
+
+def test_explicitly_unwriteable_onboarding_field_is_rejected() -> None:
+    candidate = schema()
+    candidate["fields"][0]["createable"] = False
+    mapper = FakeMapper(mapping())
+    service = CrmSchemaMappingService(store=InMemoryCrmSchemaMappingStore(), mapper=mapper)
+
+    with pytest.raises(CrmSchemaMappingError):
+        asyncio.run(service.resolve(crm_id="crm_demo", schema=candidate))

--- a/contracts/agents/product-agent-registry.v2.json
+++ b/contracts/agents/product-agent-registry.v2.json
@@ -63,6 +63,64 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [
+        {
+          "description": "Maps a CRM's public field catalogue to the verified-profile semantics needed for safe onboarding.",
+          "id": "crm_schema_mapper",
+          "inputs": [
+            {
+              "description": "Normalized public object metadata and field descriptors only.",
+              "name": "crm_schema",
+              "type": "object"
+            }
+          ],
+          "model": {
+            "credential_ref": null,
+            "mode": "hushh_managed_vertex",
+            "name": "gemini-3.5-flash",
+            "provider": "gemini"
+          },
+          "name": "CRM Schema Mapper",
+          "outputs": [
+            {
+              "description": "Typed semantic-to-schema-key mapping with confidence and reason per slot.",
+              "name": "mapping",
+              "type": "object"
+            }
+          ],
+          "performance": {
+            "latency_p95_ms": 10000,
+            "max_output_tokens": 1200
+          },
+          "privacy": {
+            "context_allowlist": [
+              "crm.object.name",
+              "crm.object.label",
+              "crm.schema.fields.key",
+              "crm.schema.fields.label",
+              "crm.schema.fields.type",
+              "crm.schema.fields.required",
+              "crm.schema.fields.constraints"
+            ],
+            "plaintext_telemetry": false
+          },
+          "rollout": {
+            "kill_switch": "CONNECTED_SYSTEMS_SCHEMA_MAPPER_ENABLED",
+            "rollback": "Disable the schema mapper; keep the CRM in catalogue-only mode until its mapping is available.",
+            "strategy": "canary"
+          },
+          "runtime": {
+            "adk_mode": "single_turn",
+            "factory": null,
+            "kind": "adk",
+            "transport": [
+              "in_process"
+            ]
+          },
+          "system_instruction": "You are the CRM Schema Mapper, an internal child of the Connected Systems\nprivate-agent specialist. Map only the supplied public CRM schema metadata\nto these semantic slots: email, phone, firstName, lastName, fullName, and\naddress. Return JSON matching the supplied response schema.\n\nSelect only exact field keys present in the supplied schema. Never invent\na field, a value, an identifier, a CRM tool, a capability, or a permission.\nEmail and phone are required. Select either firstName and lastName together,\nor fullName. Address is optional. Use null when no safe match exists.\n\nYou never receive or request CRM records, verified profile values, record\nidentifiers, credentials, consent material, or vault material. You only\nclassify schema metadata and cannot execute a CRM action.\n",
+          "telemetry_namespace": "agent.connected_systems.crm_schema_mapper"
+        }
+      ],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -77,7 +135,7 @@
       "telemetry_namespace": "agent.connected_systems",
       "tools": [],
       "ui_type": "chat",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "action_ids": [],
@@ -144,6 +202,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -223,6 +282,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -317,6 +377,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -396,6 +457,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -501,6 +563,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -613,6 +676,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -695,6 +759,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -970,6 +1035,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1112,6 +1178,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1214,6 +1281,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1291,6 +1359,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1406,6 +1475,7 @@
       },
       "side_effects": [],
       "status": "active",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1491,6 +1561,7 @@
       },
       "side_effects": [],
       "status": "active",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1570,6 +1641,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1744,6 +1816,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1864,6 +1937,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,
@@ -1981,6 +2055,7 @@
       },
       "side_effects": [],
       "status": "experimental",
+      "subagents": [],
       "surfaces": {
         "a2a": false,
         "android": false,

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -499,6 +499,21 @@
       "expected_row_growth": "low_reference"
     },
     {
+      "id": "crm_schema_mapping_cache",
+      "owner": "backend-agents-operons",
+      "data_class": "provider_cache",
+      "lifecycle_status": "customer0",
+      "exact_tables": [
+        "crm_schema_mapping_cache"
+      ],
+      "primary_access_path": "Connected Systems schema-mapper cache for a CRM object schema fingerprint and the tool-less field-role proposal used by verified-identity lookup and create-field selection.",
+      "retention_policy": "Retain only a ready mapping for its 24-hour TTL; invalidate it immediately when the CRM schema changes or a schema-validation retry fails. The cache is rebuilt from the active registry schema and is never durable user memory.",
+      "deletion_behavior": "Not user-delete scoped. Rows cascade-delete with the provisioned CRM registry row and can be invalidated without affecting CRM records or user bindings.",
+      "trust_boundary": "Public CRM schema metadata and normalized field-role keys only. Never store CRM records, verified profile values, record IDs, credentials, consent/vault material, prompts, telemetry plaintext, or unvalidated model output.",
+      "plaintext_posture": "public_schema_metadata_and_normalized_field_keys_only",
+      "expected_row_growth": "low_ttl_cache"
+    },
+    {
       "id": "developer_access",
       "owner": "mcp-developer-surface",
       "data_class": "audit_regulated",

--- a/docs/reference/operations/hussh-mcp-partner-integration-guide.md
+++ b/docs/reference/operations/hussh-mcp-partner-integration-guide.md
@@ -75,6 +75,46 @@ server-held connector private key is part of the MCP contract. A ciphertext
 result that exceeds the bounded MCP response limit fails closed; request a
 narrower discovered scope.
 
+## Decrypting an encrypted-inline export
+
+Use `structuredContent` as the canonical tool result. The text item in
+`content[0].text` is only its JSON-string mirror for MCP clients that do not
+surface structured content. The connector private key and `connector_key_id`
+must be the exact pair supplied when consent was requested.
+
+The protocol is standard X25519 plus AES-256-GCM; there is no proprietary KDF:
+
+```text
+shared_secret = X25519(connector_private_key, wrapped_key_bundle.sender_public_key)
+wrapping_key  = SHA-256(shared_secret)
+
+export_key = AES-256-GCM.decrypt(
+  key=wrapping_key,
+  ciphertext=wrapped_export_key || wrapped_key_tag,
+  iv=wrapped_key_iv,
+  aad=canonical_json(export_envelope)
+)
+
+plaintext = AES-256-GCM.decrypt(
+  key=export_key,
+  ciphertext=ciphertext || tag,
+  iv=iv,
+  aad=canonical_json(export_envelope.aad)
+)
+```
+
+`canonical_json` means recursively lexicographically key-sorted JSON, compact
+separators (no whitespace), UTF-8 encoded. Both AES-GCM steps authenticate
+their AAD; `aad_sha256` is an integrity diagnostic, not the AAD value. Do not
+use the full MCP response as AAD, omit AAD, derive a replacement key pair, or
+try alternate KDFs.
+
+The complete browser reference is in the
+[Developer API decryption guide](https://github.com/hushh-labs/hushh-research/blob/main/consent-protocol/docs/reference/developer-api.md#decrypt-an-encrypted-export-locally).
+If a private key is exposed or lost, rotate the key pair and request a fresh
+encrypted export for the replacement public key; never put a private key in a
+request, ticket, chat, log, or support attachment.
+
 ## Connected CRM systems
 
 Hussh calls MuleSoft-backed CRM systems directly over registered Streamable HTTP
@@ -89,21 +129,73 @@ CRM records hold only narrow CRM-native workflow fields. Hussh PKM, vault keys,
 KYC documents, email bodies, and broad personal memory are not CRM replication
 payloads.
 
-### CRM schema contract v1
+### CRM lifecycle and owner binding
+
+The CRM lifecycle is bounded per person and primary object:
+
+```text
+registered CRM list
+  -> verified email + phone lookup
+  -> create only when no record is found
+  -> persist one active user–CRM record ID binding
+  -> bound-ID read / update / delete
+  -> post-delete ID read confirms absence, then clears the binding
+```
+
+- Lookup and initial create use only the authenticated person's server-verified
+  email, phone, and display name. Browser input and chat text cannot select a
+  different person.
+- Read, update, delete, and approval-time rechecks resolve the binding on the
+  server. A client-supplied CRM record ID is not an authority.
+- Every create, update, and delete is an idempotent intent with an audit event,
+  explicit review, confirmation, and readback. Delete clears the binding only
+  after the registered read tool no longer returns the ID.
+
+### CRM schema mapping and field UI
+
+Hussh sends only normalized public schema metadata—object name plus field key,
+label, type, required state, and constraints—to the manifest-owned
+`crm_schema_mapper` child of the Connected Systems private agent. It uses
+Hussh-managed Vertex `gemini-3.5-flash` to map `email`, `phone`, split or full
+name, and optional address fields. It never receives CRM records, verified
+profile values, record IDs, credentials, consent material, or vault material;
+it has no tools and cannot execute a CRM operation.
+
+The mapping is validated against the exact current schema and cached in
+Postgres by CRM, object, schema fingerprint, and model version for at most 24
+hours. A schema change or one field-validation failure forces one schema
+refetch and remap. If that still fails, Hussh shows the searchable catalogue
+only and keeps CRM record actions unavailable. There is no field-name alias or
+deterministic mapping fallback for a partner CRM.
+
+The interface starts with the mapped Basic fields and offers an All fields
+selector. All fields render in a paginated, searchable table with Field, Type,
+Access, Required, and Current value columns. Only non-identity, non-immutable,
+not-explicitly-update-disabled fields can be staged for the existing review and
+confirmation lifecycle.
+
+### CRM operation contracts
 
 CRM integration is a separate backend-to-MuleSoft plane. Each active operation
 has a registry-owned response contract; a missing or invalid mapping is
 unavailable before Hussh opens an MCP call. The current schema tool response
 maps its primary object metadata from `details[0]` and field catalogue from
-`details[0].fields`. That shape is display-only until every
-field carries explicit `readable`, `identityField`, `immutable`, `createable`,
-and `updateable` booleans, plus normalized constraints where applicable such
-as `allowedValues` and `maxLength`.
+`details[0].fields`. Each descriptor supplies `name`, `label`, `type`, and
+`required`; normalized constraints such as `allowedValues` and `maxLength` are
+recommended. `readable`, `identityField`, `immutable`, `createable`, and
+`updateable` are optional refinements. Explicit `false` is enforced; an absent
+field flag is never treated as a new permission decision.
 
-Hussh derives `writable` only from `createable` or `updateable`. It never
-interprets an omitted permission as allowed. Until MuleSoft publishes this
-schema v1 contract, the Connected Systems interface shows a searchable field
-catalogue and exposes no CRM read, create, update, or delete action.
+For the verified demo CRM tools, the registry maps create success and returned
+ID from `success` and `id`; it maps reads from `records[]` and `Id`. Update and
+delete intentionally return an empty successful MCP tool result, so their
+registered success policy is `isError: false` plus a post-mutation state read.
+This is a declared transport contract, not a Salesforce-specific heuristic.
+
+Adding a future CRM requires only its registry row, schema contract, operation
+tool names/endpoints, request style, and response paths. Its field catalogue
+may be visible first, but no action is enabled until the complete contract and
+isolated lifecycle check pass.
 
 ## Partner checklist
 
@@ -111,4 +203,4 @@ catalogue and exposes no CRM read, create, update, or delete action.
 - Discover a narrow scope before requesting consent; do not guess scope names.
 - Store `request_ref` while polling and use `grant_ref` only after approval.
 - Expect encrypted-inline delivery with `resource: null`; do not implement a ResourceLink download step.
-- Treat CRM MCP operations as a private Hussh backend integration, not as additions to the public Consent MCP tool catalog.
+- Treat CRM MCP operations as a private Hussh backend integration, not as additions to the public Consent MCP tool catalog. MuleSoft Streamable HTTP is direct backend transport; Hussh Consent MCP is the separate encrypted information-exchange transport.

--- a/docs/reference/operations/mulesoft-crm-schema-contract-v1.json
+++ b/docs/reference/operations/mulesoft-crm-schema-contract-v1.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "MuleSoft CRM object-schema response v1",
-  "description": "Field access metadata required before Hussh enables CRM record operations.",
+  "description": "Primary-object field catalogue for CRM onboarding. Hussh maps public schema metadata through its manifest-owned private-agent child; access metadata is optional, and explicit false values are enforced.",
   "type": "object",
   "required": ["details"],
   "properties": {
@@ -18,17 +18,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "name",
-                "label",
-                "type",
-                "required",
-                "readable",
-                "identityField",
-                "immutable",
-                "createable",
-                "updateable"
-              ],
+              "required": ["name", "label", "type", "required"],
               "properties": {
                 "name": { "type": "string", "minLength": 1 },
                 "label": { "type": "string", "minLength": 1 },

--- a/docs/reference/operations/mulesoft-managed-omni-gateway-private-space.md
+++ b/docs/reference/operations/mulesoft-managed-omni-gateway-private-space.md
@@ -39,15 +39,30 @@ downstream CRM path is public.
 The `object-schema` tool must return an operation-contract-mapped primary
 object metadata node and field collection according to the checked-in
 `docs/reference/operations/mulesoft-crm-schema-contract-v1.json`. For the current rollout the collection is
-`details[0]` and `details[0].fields`. Every field must declare `readable`, `identityField`,
-`immutable`, `createable`, and `updateable`; it should also provide portable
-constraints such as picklist values and maximum length. Hussh derives
-`writable` from the create/update flags and never infers an omitted permission.
+`details[0]` and `details[0].fields`. Each descriptor supplies `name`,
+`label`, `type`, and `required`; portable constraints such as picklist values
+and maximum length are recommended. `readable`, `identityField`, `immutable`,
+`createable`, and `updateable` are optional refinements, not prerequisites for
+onboarding. When a partner supplies an explicit `false` value, Hussh enforces
+it; it does not invent a conflicting field permission.
 
-Until all descriptors validate, Hussh treats the result as a display-only
-catalogue. Read, create, update, and delete are unavailable before their MCP
-tool is called. Read and mutation result mappings are likewise registry-owned;
-they are not guessed from raw MuleSoft envelopes.
+Executable CRM operations are authorised by the registered tool and its
+response contract, then limited by the authenticated user's active
+user–CRM-record binding. A person can look up only their server-verified email
+and phone, and all later read/update/delete calls resolve the bound CRM record
+ID server-side. Read and mutation result mappings remain registry-owned; they
+are not guessed from raw MuleSoft envelopes. The two current demo rows map
+reads from `records[]` / `Id`, create from `success` / `id`, and their empty
+update/delete success result through an explicit `isError: false` transport
+policy plus a post-mutation readback.
+
+Hussh maps the public field catalogue with the manifest-owned
+`crm_schema_mapper` child using Hussh-managed Vertex `gemini-3.5-flash`. It
+receives only object and field metadata, not CRM records, verified profile
+values, identifiers, credentials, consent material, or vault material. Its
+validated result is cached by schema fingerprint for 24 hours. A mapping failure
+keeps the CRM catalogue-only and cannot bypass the registered operation,
+owner-binding, intent, confirmation, or readback controls.
 
 ## UAT verification boundary
 

--- a/docs/reference/quality/design-system.md
+++ b/docs/reference/quality/design-system.md
@@ -111,6 +111,13 @@ Forbidden:
 4. Shared shell and surface layout tokens live in `hushh-webapp/app/globals.css`.
 5. Color identity is the **Foundation** system with ONE switchable accent: the `--app-accent-*` family in `hushh-webapp/app/globals.css` (iOS Blue by default, Molten Gold under `html[data-accent="gold"]`, toggled in Profile → Preferences → Accent and persisted at `hushh.app.accent.v1` via `lib/theme/accent.ts`). Accent is emphasis ONLY; ink (`--primary`) carries primary, gray carries support. Legacy names (`--foundation-gold-*`, `--color-accent-*`, `--brand-*`, `--morphy-primary-*`, `--tone-blue*`) alias the accent family, so consumers written against them follow the preference automatically. Never hardcode an accent hex in component source; `npm run verify:accent-tokens` (part of `verify:design-system`) enforces this. RIA compatibility tokens must resolve through that same family; no persona may retint shared app chrome or bypass the active accent. The full Foundation Color Contract lives in [app-surface-design-system.md](./app-surface-design-system.md#foundation-color-contract).
 5a. Promotion path for feature design systems: when a route (e.g. One Location) proves out a surface grammar, promote its tokens to `lib/morphy-ux/tokens/surfaces.ts` and its primitives to `lib/morphy-ux/ui/surface-primitives.tsx`, leave a re-export shim at the feature path, and consume the `--app-accent-*` family for any accent usage so the promoted pieces stay accent-neutral.
+5b. Portable PDF artifacts use the Morphy-owned
+    `lib/morphy-ux/pdf-document-formatter.mjs`. The Markdown/PDF script is a
+    generator only: it reads Foundation tokens from `app/globals.css` and uses
+    a named `technical`, `partner`, or `founder` formatter profile. Light and
+    dark wordmarks use the same `hu` ink and `ssh` foil tokens as the app;
+    Molten Gold is explicit. Protocol code blocks retain the Sublime Monokai
+    surface in every profile.
 6. Use the container tokens below instead of ad hoc `max-w-*` route wrappers:
    - `--app-shell-reading`
    - `--app-shell-standard`

--- a/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
+++ b/hushh-webapp/__tests__/components/connected-systems-panel.test.tsx
@@ -139,13 +139,15 @@ describe("ConnectedSystemsPanel", () => {
     vi.mocked(ConnectedSystemsService.getSchema).mockResolvedValueOnce({
       ...readySchema,
       effectiveActions: { schema: true, read: false, create: false, update: false, delete: false },
+      configurationMessage: undefined,
     });
     render(<ConnectedSystemsPanel vaultOwnerToken="HCT:test" systemId={system.systemId} />);
 
     expect(await screen.findByText("Customer CRM field catalogue")).toBeTruthy();
     expect(
-      screen.getByText(/does not currently have a complete registered record-operation contract/i),
+      screen.getByText(/shown as a field catalogue until its verified onboarding mapping is available/i),
     ).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Field view"), { target: { value: "all" } });
     expect(screen.getByText("Preferred language")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
     expect(screen.queryByRole("button", { name: /Link this system/i })).toBeNull();
@@ -192,6 +194,7 @@ describe("ConnectedSystemsPanel", () => {
     );
 
     expect(await screen.findByText("Update my Customer CRM information")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Field view"), { target: { value: "all" } });
     expect(await screen.findByText("English")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     const editor = await screen.findByRole("combobox");
@@ -203,7 +206,6 @@ describe("ConnectedSystemsPanel", () => {
       expect(ConnectedSystemsService.updateRecordIntent).toHaveBeenCalledWith(
         "HCT:test",
         expect.objectContaining({
-          id: "person-42",
           recordFields: { PreferredLanguage: "French" },
         }),
       );

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -17,7 +17,7 @@ describe("Navbar bottom chrome contract", () => {
     expect(navbar).toContain("const BOTTOM_GAP_PX = 4;");
     expect(navbar).toContain("flex justify-center");
     expect(agentBar).toContain(
-      '"calc(var(--app-bottom-inset) + 0.12rem)",',
+      '"calc(var(--app-bottom-inset) + 0.58rem)",',
     );
     expect(agentBar).not.toContain(
       'calc(max(var(--app-bottom-inset), calc(var(--bottom-nav-offset) + var(--app-safe-area-bottom-effective) + var(--app-bottom-chrome-lift))) + 0.5rem)',

--- a/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
+++ b/hushh-webapp/__tests__/components/navbar-bottom-nav.test.tsx
@@ -54,16 +54,13 @@ describe("Navbar bottom utilities", () => {
     ROUTES.KAI_ANALYSIS,
     ROUTES.RIA_PICKS,
     ROUTES.PROFILE,
-  ])("keeps the shared workspace tabs grouped on %s", (pathname) => {
+  ])("keeps the primary bottom group stable on %s", (pathname) => {
     navigationMock.pathname = pathname;
     const { unmount } = render(<Navbar />);
     const routeNav = screen.getByRole("radiogroup", { name: "Route navigation" });
 
     expect(within(routeNav).getAllByRole("radio").map((radio) => radio.textContent?.trim())).toEqual([
       "One",
-      "Market",
-      "Portfolio",
-      "Analysis",
       "Connect",
       "Search",
     ]);
@@ -80,10 +77,21 @@ describe("Navbar bottom utilities", () => {
     expect(navigationMock.push).toHaveBeenLastCalledWith(ROUTES.ONE_HOME);
   });
 
-  it("uses six equal workspace bottom-nav slots", () => {
+  it("renders a compact specialist group beside the stable primary group", () => {
+    navigationMock.pathname = ROUTES.KAI_ANALYSIS;
     render(<Navbar />);
+    expect(
+      within(screen.getByRole("radiogroup", { name: "Route navigation" }))
+        .getAllByRole("radio")
+        .map((radio) => radio.textContent?.trim()),
+    ).toEqual(["One", "Connect", "Search"]);
+    expect(
+      within(screen.getByRole("radiogroup", { name: "Workspace navigation" }))
+        .getAllByRole("radio")
+        .map((radio) => radio.textContent?.trim()),
+    ).toEqual(["Market", "Portfolio", "Analysis"]);
     expect(screen.getByRole("radiogroup", { name: "Route navigation" }).getAttribute("style")).toContain(
-      "grid-template-columns: repeat(6, minmax(0, 1fr))",
+      "grid-template-columns: repeat(3, minmax(0, 1fr))",
     );
     expect(screen.getByTestId("app-bottom-nav-frame").className).toContain(
       "max-w-[min(calc(100vw-2rem),42rem)]",

--- a/hushh-webapp/__tests__/navigation/app-bottom-nav.test.ts
+++ b/hushh-webapp/__tests__/navigation/app-bottom-nav.test.ts
@@ -7,6 +7,7 @@ import {
   resolveBottomNavigationScope,
   resolveBottomNavHref,
   resolveBottomNavOptionKeys,
+  resolveBottomNavSpecialistOptionKeys,
   resolveInvestorActiveNav,
   resolveInvestorNavSlot,
   resolveOneActiveNav,
@@ -106,7 +107,7 @@ describe("app bottom navigation", () => {
     expect(resolveRiaActiveNav(ROUTES.RIA_HOME)).toBe("ria-home");
   });
 
-  it("keeps the shared workspace navigation available across route families", () => {
+  it("keeps the primary navigation stable across route families", () => {
     for (const [pathname, scope] of [
       [ROUTES.CONNECTED_SYSTEMS, "one"],
       [ROUTES.KAI_ANALYSIS, "investor"],
@@ -114,13 +115,24 @@ describe("app bottom navigation", () => {
     ] as const) {
       expect(resolveBottomNavOptionKeys(pathname, scope)).toEqual([
         "dashboard",
-        "finance",
-        "portfolio",
-        "analysis",
         "connect",
         "search",
       ]);
     }
+  });
+
+  it("exposes specialist workspace groups separately from primary navigation", () => {
+    expect(resolveBottomNavSpecialistOptionKeys("one")).toEqual([]);
+    expect(resolveBottomNavSpecialistOptionKeys("investor")).toEqual([
+      "finance",
+      "portfolio",
+      "analysis",
+    ]);
+    expect(resolveBottomNavSpecialistOptionKeys("ria")).toEqual([
+      "ria-home",
+      "clients",
+      "picks",
+    ]);
   });
 
   it("maps One context nav actions to the intended routes", () => {

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -3,15 +3,15 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { ArrowLeft, Users, Search as SearchIcon } from "lucide-react";
+import { Users, Search as SearchIcon } from "lucide-react";
 
 import {
   AppPageContentRegion,
   AppPageHeaderRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
-import { ROUTES } from "@/lib/navigation/routes";
 import { useRequireAuth } from "@/hooks/use-auth";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
@@ -164,42 +164,13 @@ export default function ConnectPageClient() {
       }}
     >
       <AppPageHeaderRegion>
-        <div className="relative w-full hidden sm:block h-6" /> {/* spacer below top bar */}
-        <div className="w-full flex justify-between items-center px-0.5 sm:px-1 mb-6">
-          <Button
-            type="button"
-            variant="none"
-            effect="fade"
-            size="sm"
-            onClick={() => router.push(ROUTES.ONE_HOME)}
-            className="h-10 w-10 p-0 rounded-full border border-border/60 bg-white/40 dark:bg-black/10 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-white/80 dark:hover:bg-white/10"
-            aria-label="Back to dashboard"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-          <div className="w-10 h-10" /> {/* Symmetry spacer */}
-        </div>
-
-        <header
-          className="flex w-full min-w-0 flex-col items-center gap-3 px-4 text-center sm:px-6"
-          data-slot="page-header"
-          data-page-primary="true"
-        >
-          {/* Centered Squinircle Glow Icon */}
-          <div className="relative inline-flex items-center justify-center h-16 w-16 rounded-[22px] bg-white/80 dark:bg-[rgba(30,30,45,0.7)] shadow-[0_12px_24px_rgba(0,0,0,0.12)] dark:shadow-[0_16px_32px_rgba(0,0,0,0.4)] ring-1 ring-white/60 dark:ring-white/10 animate-fade-in duration-300">
-            <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 h-[90%] w-[90%] blur-[14px] rounded-full opacity-35 dark:opacity-20 scale-90 bg-sky-400" aria-hidden />
-            <Users className="h-7 w-7 text-sky-500 relative z-10" />
-          </div>
-
-          <div className="min-w-0 max-w-full space-y-1.5">
-            <h1 className="text-[28px] font-medium leading-[1.08] tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[34px]">
-              Connect
-            </h1>
-            <p className="text-sm text-muted-foreground max-w-[280px] sm:max-w-md mx-auto leading-relaxed">
-              Find people on Hushh and send a connection request.
-            </p>
-          </div>
-        </header>
+        <PageHeader
+          eyebrow="One"
+          title="Connect"
+          description="Find people on Hussh and send a connection request."
+          icon={Users}
+          accent="neutral"
+        />
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -370,7 +370,7 @@ export function ConnectedSystemsPanel({
   mode = "detail",
   systemId,
   agentInstruction,
-  profile,
+  profile: _profile,
   onSetupReadinessChange,
   setupRouteBase,
 }: ConnectedSystemsPanelProps) {

--- a/hushh-webapp/components/profile/connected-systems-panel.tsx
+++ b/hushh-webapp/components/profile/connected-systems-panel.tsx
@@ -145,11 +145,11 @@ function crmFieldFromSchemaDescriptor(
     inputType: inputTypeFromSchema(descriptor.dataType),
     required: descriptor.required === true,
     identityField: descriptor.identityField === true,
-    readable: descriptor.readable === true,
-    createable: descriptor.createable === true,
-    updateable: descriptor.updateable === true,
-    writable: descriptor.updateable === true && descriptor.immutable !== true && descriptor.identityField !== true,
-    immutable: descriptor.immutable === true,
+    readable: descriptor.readable,
+    createable: descriptor.createable,
+    updateable: descriptor.updateable,
+    writable: descriptor.writable ?? descriptor.updateable,
+    immutable: descriptor.immutable,
     rawName: String(descriptor.name || key).trim() || key,
     source: String(descriptor.source || "mcp_schema").trim() || "mcp_schema",
     dataType: String(descriptor.dataType || "string"),
@@ -283,10 +283,6 @@ function agentInstructionFields(
       // ignored and the backend remains the schema-validation authority.
     }
   }
-  const email = agentInstructionSlot(instruction, "email");
-  const phone = agentInstructionSlot(instruction, "phone");
-  if (email) out.email = email;
-  if (phone) out.phone = phone;
   return out;
 }
 
@@ -360,7 +356,7 @@ function changedFieldsFromValues(
 ): Record<string, string> {
   const additionalFields: Record<string, string> = {};
   for (const field of fields) {
-    if (field.identityField || field.writable !== true || field.immutable) continue;
+    if (field.identityField || field.updateable === false || field.immutable === true) continue;
     const nextValue = (values[field.key] || "").trim();
     const previousValue = (baseline[field.key] || "").trim();
     if (nextValue !== previousValue) additionalFields[field.key] = nextValue;
@@ -406,6 +402,7 @@ export function ConnectedSystemsPanel({
   >(DEFAULT_CRM_PROFILE_VALUES);
   const [updateId, setUpdateId] = useState("");
   const [deleteId, setDeleteId] = useState("");
+  const [fieldView, setFieldView] = useState<"basic" | "all">("basic");
   const [bindingResolvedKey, setBindingResolvedKey] = useState<string | null>(
     null,
   );
@@ -458,6 +455,18 @@ export function ConnectedSystemsPanel({
     if (schemaDrivenProfileFields.length > 0) return schemaDrivenProfileFields;
     return [];
   }, [schemaDrivenProfileFields]);
+  const displayedProfileFields = useMemo(() => {
+    if (fieldView === "all") return visibleProfileFields;
+    const mappedFields = new Set(
+      Object.values(schema?.profileFieldMappings || {})
+        .map((value) => String(value || "").trim())
+        .filter(Boolean),
+    );
+    const basicFields = visibleProfileFields.filter(
+      (field) => mappedFields.has(field.rawName || field.key) || field.required,
+    );
+    return basicFields.length > 0 ? basicFields : visibleProfileFields;
+  }, [fieldView, schema?.profileFieldMappings, visibleProfileFields]);
   const changedProfileFields = useMemo(
     () =>
       changedFieldsFromValues(
@@ -473,19 +482,6 @@ export function ConnectedSystemsPanel({
     [boundRecordId, updateId],
   );
   const hasBoundRecord = Boolean(currentRecordId);
-  const lookupFields = useMemo(
-    () => visibleProfileFields.filter((field) => field.identityField),
-    [visibleProfileFields],
-  );
-  const schemaLookupValues = useMemo(
-    () => Object.fromEntries(
-      lookupFields
-        .map((field) => [field.rawName || field.key, cleanFieldValue(crmFieldValues[field.key])])
-        .filter(([, value]) => Boolean(value)),
-    ),
-    [crmFieldValues, lookupFields],
-  );
-  const hasLookup = lookupFields.length > 0 && Object.keys(schemaLookupValues).length === lookupFields.length;
   const currentReadRecord = useMemo(
     () => selectRecordForId(readResult, currentRecordId),
     [currentRecordId, readResult],
@@ -508,7 +504,6 @@ export function ConnectedSystemsPanel({
   );
   const boundRecordReadResolved =
     !hasBoundRecord ||
-    !hasLookup ||
     readResultHasCurrentRecord ||
     Boolean(crmRecordReadKey && readResolvedKey === crmRecordReadKey);
   const isBoundRecordHydrating =
@@ -516,7 +511,7 @@ export function ConnectedSystemsPanel({
     canUseBackend &&
     !error &&
     hasBoundRecord &&
-    schemaReady && supportsAction("read") && hasLookup &&
+    schemaReady && supportsAction("read") &&
     !boundRecordReadResolved;
   const isRecordStateLoading =
     mode === "detail" &&
@@ -538,30 +533,6 @@ export function ConnectedSystemsPanel({
       (!schemaReady ||
         (hasBoundRecord ? !canShowBoundRecordActions : !canShowUnboundRecordActions)),
   );
-
-  useEffect(() => {
-    const email = cleanFieldValue(profile?.email);
-    const phone = cleanFieldValue(profile?.phone);
-    if (visibleProfileFields.length === 0 || (!email && !phone)) return;
-    setCrmFieldValues((current) => {
-      const next = { ...current };
-      let changed = false;
-      for (const field of visibleProfileFields) {
-        if (!field.identityField || next[field.key]) continue;
-        const descriptor = `${field.key} ${field.rawName} ${field.label}`.toLowerCase();
-        const value = descriptor.includes("email")
-          ? email
-          : descriptor.includes("phone") || descriptor.includes("telephone") || descriptor.includes("mobile")
-            ? phone
-            : "";
-        if (value) {
-          next[field.key] = value;
-          changed = true;
-        }
-      }
-      return changed ? next : current;
-    });
-  }, [profile?.email, profile?.phone, visibleProfileFields]);
 
   useEffect(() => {
     if (mode !== "detail") return;
@@ -808,7 +779,7 @@ export function ConnectedSystemsPanel({
       "read",
       async () => {
         const returnFields = visibleProfileFields
-          .filter((field) => field.readable)
+          .filter((field) => field.readable !== false)
           .map((field) => field.rawName || field.key);
         const completedReadKey =
           !options.bindSearch && selectedSystem && currentRecordId
@@ -821,7 +792,6 @@ export function ConnectedSystemsPanel({
         const payload = {
           systemId: selectedSystem?.systemId,
           objectType: selectedSystem?.objectTypeDefault,
-          searchFields: schemaLookupValues,
           returnFields,
         };
         const nextResult = options.bindSearch
@@ -922,7 +892,6 @@ export function ConnectedSystemsPanel({
       !currentRecordId ||
       !schemaReady ||
       !supportsAction("read") ||
-      !hasLookup ||
       readResultHasCurrentRecord
     ) {
       return;
@@ -933,7 +902,6 @@ export function ConnectedSystemsPanel({
   }, [
     activeBinding,
     currentRecordId,
-    hasLookup,
     mode,
     readResultHasCurrentRecord,
     vaultOwnerToken,
@@ -941,24 +909,11 @@ export function ConnectedSystemsPanel({
   ]);
 
   const updateCrmFieldValue = (field: CrmProfileField, value: string) => {
-    if (!schemaReady || field.updateable !== true || field.identityField || field.immutable) return;
+    if (!schemaReady || field.updateable === false || field.identityField || field.immutable === true) return;
     setCrmFieldValues((current) => ({ ...current, [field.key]: value }));
   };
 
   const createRecordFromSchema = async () => {
-    const recordFields = Object.fromEntries(
-      visibleProfileFields
-        .filter((field) => field.createable === true && !field.immutable)
-        .map((field) => [field.rawName || field.key, cleanFieldValue(crmFieldValues[field.key])])
-        .filter(([, value]) => Boolean(value)),
-    );
-    const missingRequired = visibleProfileFields.filter(
-      (field) => field.required && !cleanFieldValue(crmFieldValues[field.key]),
-    );
-    if (missingRequired.length > 0) {
-      toast.error(`Complete required fields: ${missingRequired.map((field) => field.label).join(", ")}.`);
-      return;
-    }
     const result = await runMutation(
       "create",
       {
@@ -969,7 +924,6 @@ export function ConnectedSystemsPanel({
       () => ConnectedSystemsService.createRecordIntent(vaultOwnerToken || "", {
         systemId: selectedSystem?.systemId,
         objectType: selectedSystem?.objectTypeDefault,
-        recordFields,
       }),
     );
     if (result) {
@@ -988,12 +942,6 @@ export function ConnectedSystemsPanel({
   const linkThisSystem = async () => {
     const canRead = supportsAction("read");
     const canCreate = supportsAction("create");
-    if (canRead && !hasLookup) {
-      toast.error(
-        "Complete the CRM identity fields before linking this system.",
-      );
-      return;
-    }
     if (canRead) {
       const found = await readRecord({
         silent: true,
@@ -1009,12 +957,6 @@ export function ConnectedSystemsPanel({
       }
     }
     if (!canCreate) return;
-    if (visibleProfileFields.some((field) => field.required && !cleanFieldValue(crmFieldValues[field.key]))) {
-      toast.error(
-        "Complete the required fields before creating this CRM record.",
-      );
-      return;
-    }
     await createRecordFromSchema();
   };
 
@@ -1038,7 +980,6 @@ export function ConnectedSystemsPanel({
           {
             systemId: selectedSystem?.systemId,
             objectType: selectedSystem?.objectTypeDefault,
-            id: recordId,
             additionalFields: {},
             recordFields,
           },
@@ -1061,7 +1002,6 @@ export function ConnectedSystemsPanel({
         ConnectedSystemsService.createDeleteIntent(vaultOwnerToken || "", {
           systemId: selectedSystem?.systemId,
           objectType: selectedSystem?.objectTypeDefault || "Contact",
-          id: deleteId || currentRecordId,
         }),
     );
     if (result) {
@@ -1159,7 +1099,7 @@ export function ConnectedSystemsPanel({
     return <p className="text-xs text-muted-foreground">{parts.join(" / ")}</p>;
   };
 
-  const crmFieldRows: CrmFieldTableRow[] = visibleProfileFields.map((field) => {
+  const crmFieldRows: CrmFieldTableRow[] = displayedProfileFields.map((field) => {
     const access = [
       field.readable ? "read" : null,
       field.createable ? "create" : null,
@@ -1198,9 +1138,10 @@ export function ConnectedSystemsPanel({
       cell: ({ row }) => {
         const field = row.original.field;
         if (
+          !hasBoundRecord ||
           !schemaReady ||
           !supportsAction("update") ||
-          field.updateable !== true ||
+          field.updateable === false ||
           field.identityField ||
           field.immutable
         ) {
@@ -1227,6 +1168,20 @@ export function ConnectedSystemsPanel({
 
   const renderCrmFieldTable = (configurationMessage?: string | null) => (
     <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          {fieldView === "all" ? "All CRM fields" : "Basic profile fields"}
+        </p>
+        <select
+          aria-label="Field view"
+          className="h-8 rounded-md border border-border bg-background px-2 text-xs text-foreground"
+          value={fieldView}
+          onChange={(event) => setFieldView(event.target.value as "basic" | "all")}
+        >
+          <option value="basic">Basic fields</option>
+          <option value="all">All fields</option>
+        </select>
+      </div>
       <DataTable
         columns={crmFieldColumns}
         data={crmFieldRows}
@@ -1414,7 +1369,7 @@ export function ConnectedSystemsPanel({
                     variant="none"
                     effect="fade"
                     size="sm"
-                    disabled={busy !== null || !hasLookup}
+                    disabled={busy !== null}
                     onClick={() => void readRecord()}
                   >
                     <Icon icon={RefreshCw} size="sm" className="mr-2" />
@@ -1437,8 +1392,9 @@ export function ConnectedSystemsPanel({
             {renderCrmFieldTable(
               !schemaReady
                 ? schema?.configurationMessage ||
-                    "This is a discovered field catalogue. The CRM must publish explicit field access metadata before records can be read or changed."
-                : "This CRM does not currently have a complete registered record-operation contract. Fields are shown for configuration review only.",
+                    "This is a discovered field catalogue. Record actions are unavailable until its verified onboarding mapping refreshes."
+                : schema?.configurationMessage ||
+                    "This CRM is shown as a field catalogue until its verified onboarding mapping is available.",
             )}
           </div>
         </SettingsGroup>
@@ -1473,16 +1429,10 @@ export function ConnectedSystemsPanel({
                 </Button>
               </div>
             </div>
-            {!hasLookup ? (
-              <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2.5 text-xs text-amber-700 dark:text-amber-300">
-                Fill each field marked as an identity field before linking this
-                CRM record.
-              </div>
-            ) : null}
             {renderCrmFieldTable()}
             <p className="text-xs leading-relaxed text-muted-foreground">
               {supportsAction("read") && supportsAction("create")
-                ? "We’ll look for your existing record first, and only create a new one if nothing matches."
+                ? "We’ll look up only the verified email and phone on your Hussh account, then create a basic record only when no match exists."
                 : supportsAction("read")
                   ? "We’ll look only for an existing CRM record."
                   : "This CRM allows a new record to be prepared for review."}
@@ -1491,7 +1441,7 @@ export function ConnectedSystemsPanel({
               <Button
                 type="button"
                 size="sm"
-                disabled={busy !== null || (supportsAction("read") && !hasLookup)}
+                disabled={busy !== null}
                 onClick={() => void linkThisSystem()}
               >
                 <Icon
@@ -1550,7 +1500,7 @@ export function ConnectedSystemsPanel({
                   variant="none"
                   effect="fade"
                   size="sm"
-                  disabled={busy !== null || !hasLookup}
+                  disabled={busy !== null}
                   onClick={() => void readRecord()}
                 >
                   <Icon icon={RefreshCw} size="sm" className="mr-2" />
@@ -1611,7 +1561,8 @@ export function ConnectedSystemsPanel({
                       </AlertDialogTitle>
                       <AlertDialogDescription>
                         This deletes the {primaryObjectLabel} in {customerName}. The One
-                        binding will be cleared after the MCP confirms deletion.
+                        binding will be cleared only after the CRM no longer
+                        returns this record through its registered read tool.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/hushh-webapp/lib/morphy-ux/pdf-document-formatter.mjs
+++ b/hushh-webapp/lib/morphy-ux/pdf-document-formatter.mjs
@@ -1,0 +1,147 @@
+/**
+ * Portable-document formatter for Hussh artifacts.
+ *
+ * Morphy UX owns the visual contract. Report scripts provide validated
+ * Foundation tokens and content, then consume one of these audience profiles.
+ * This module intentionally has no browser or React dependency so the PDF
+ * renderer can use the same design grammar without creating a parallel theme.
+ */
+
+export const PDF_FORMATTER_PROFILES = Object.freeze({
+  technical: Object.freeze({
+    id: "technical",
+    bodySize: "11.5px",
+    lineHeight: "1.5",
+    titleSize: "29px",
+    sectionSize: "17px",
+    sectionGap: "24px",
+    codeSize: "9.6px",
+  }),
+  partner: Object.freeze({
+    id: "partner",
+    bodySize: "12px",
+    lineHeight: "1.52",
+    titleSize: "30px",
+    sectionSize: "18px",
+    sectionGap: "26px",
+    codeSize: "10px",
+  }),
+  founder: Object.freeze({
+    id: "founder",
+    bodySize: "12.5px",
+    lineHeight: "1.58",
+    titleSize: "32px",
+    sectionSize: "19px",
+    sectionGap: "30px",
+    codeSize: "10px",
+  }),
+});
+
+export const PDF_FORMATTER_THEMES = Object.freeze(["light", "dark", "molten-gold"]);
+
+const REQUIRED_FOUNDATION_TOKENS = [
+  "--foundation-off",
+  "--foundation-surface",
+  "--foundation-ink",
+  "--foundation-hairline",
+];
+
+const REQUIRED_ACCENT_TOKENS = [
+  "--app-accent-deep",
+  "--app-accent-bright",
+  "--app-accent-surface",
+  "--app-accent-border",
+  "--app-accent-hero-from",
+  "--app-accent-hero-mid",
+  "--app-accent-hero-to",
+];
+
+function requireTokens(tokens, names, source) {
+  const missing = names.filter((name) => !tokens[name]);
+  if (missing.length) {
+    throw new Error(`Missing ${source} token(s): ${missing.join(", ")}`);
+  }
+}
+
+export function resolvePdfFormatterProfile(profile = "technical") {
+  const formatter = PDF_FORMATTER_PROFILES[profile];
+  if (!formatter) {
+    throw new Error(
+      `Unsupported PDF formatter profile: ${profile}. Use ${Object.keys(PDF_FORMATTER_PROFILES).join(", ")}.`,
+    );
+  }
+  return formatter;
+}
+
+/**
+ * Print-safe twin of the app wordmark. Its colors remain CSS-token driven so
+ * `hu` and the `ssh` foil follow the selected Foundation theme.
+ */
+export function renderPdfHusshWordmark() {
+  return `<svg viewBox="73 8 460 146" role="img" aria-label="Hussh" preserveAspectRatio="xMinYMid meet">
+    <title>Hussh</title>
+    <defs>
+      <linearGradient id="hussh-pdf-wordmark-ssh" x1="0" y1="0" x2="1" y2="0">
+        <stop offset="0%" stop-color="var(--brand-hero-from)" />
+        <stop offset="50%" stop-color="var(--brand-hero-mid)" />
+        <stop offset="100%" stop-color="var(--brand-hero-to)" />
+      </linearGradient>
+    </defs>
+    <text x="300" y="135" text-anchor="middle" font-family='"SF Pro Display", "SF Pro", "Helvetica Neue", Inter, system-ui, sans-serif' font-weight="700" font-size="160" letter-spacing="-5.6">
+      <tspan fill="var(--brand-ink)">hu</tspan><tspan fill="url(#hussh-pdf-wordmark-ssh)">ssh</tspan>
+    </text>
+  </svg>`;
+}
+
+/**
+ * Produces the semantic CSS token bridge used by the Markdown-to-PDF renderer.
+ * The `ssh` wordmark foil always comes from the selected app accent tokens:
+ * default Foundation Blue in light/dark, or the explicit Molten Gold variant.
+ */
+export function createPdfDocumentFormatter({ theme, profile, foundation, accent }) {
+  if (!PDF_FORMATTER_THEMES.includes(theme)) {
+    throw new Error(`Unsupported PDF formatter theme: ${theme}.`);
+  }
+
+  requireTokens(foundation, REQUIRED_FOUNDATION_TOKENS, "Morphy Foundation");
+  requireTokens(accent, REQUIRED_ACCENT_TOKENS, "Morphy accent");
+  const selectedProfile = resolvePdfFormatterProfile(profile);
+  const dark = theme !== "light";
+
+  return {
+    id: selectedProfile.id,
+    chromeColor: dark ? "rgba(235,235,245,.62)" : "rgba(60,60,67,.62)",
+    css: `
+      color-scheme: ${dark ? "dark" : "light"};
+      --bg: ${foundation["--foundation-off"]};
+      --bg-secondary: ${foundation["--foundation-surface"]};
+      --bg-tertiary: ${foundation["--foundation-hairline"]};
+      --fg: ${foundation["--foundation-ink"]};
+      --fg-secondary: color-mix(in srgb, ${foundation["--foundation-ink"]} 78%, ${foundation["--foundation-off"]});
+      --fg-tertiary: color-mix(in srgb, ${foundation["--foundation-ink"]} 54%, ${foundation["--foundation-off"]});
+      --separator: ${foundation["--foundation-hairline"]};
+      --separator-strong: ${accent["--app-accent-border"]};
+      --accent: ${accent["--app-accent-deep"]};
+      --accent-soft: ${accent["--app-accent-surface"]};
+      --accent-surface: ${accent["--app-accent-surface"]};
+      --blue: ${accent["--app-accent-bright"]};
+      --diagram-bg: ${foundation["--foundation-surface"]};
+      --brand-ink: ${foundation["--foundation-ink"]};
+      --brand-hero-from: ${accent["--app-accent-hero-from"]};
+      --brand-hero-mid: ${accent["--app-accent-hero-mid"]};
+      --brand-hero-to: ${accent["--app-accent-hero-to"]};
+      --pdf-body-size: ${selectedProfile.bodySize};
+      --pdf-line-height: ${selectedProfile.lineHeight};
+      --pdf-title-size: ${selectedProfile.titleSize};
+      --pdf-section-size: ${selectedProfile.sectionSize};
+      --pdf-section-gap: ${selectedProfile.sectionGap};
+      --pdf-code-size: ${selectedProfile.codeSize};
+      /* Sublime Text Monokai: copyable protocol material is a code surface. */
+      --code-bg: #272822;
+      --code-border: #49483e;
+      --code-fg: #f8f8f2;
+      --code-key: #f92672;
+      --code-string: #e6db74;
+      --code-literal: #ae81ff;`,
+  };
+}

--- a/hushh-webapp/lib/navigation/app-bottom-nav.ts
+++ b/hushh-webapp/lib/navigation/app-bottom-nav.ts
@@ -275,22 +275,21 @@ export function resolveBottomNavContextKey(
 
 export function resolveBottomNavOptionKeys(
   _pathname: string | null | undefined,
-  scope: AppBottomNavScope,
+  _scope: AppBottomNavScope,
   _context?: AppBottomNavContext,
 ): AppBottomNavKey[] {
-  if (scope === "investor") {
-    return ["dashboard", "finance", "portfolio", "analysis", "connect", "search"];
-  }
-  if (scope === "ria") {
-    return ["dashboard", "ria-home", "clients", "picks", "connect", "search"];
-  }
+  // The primary group is stable on every signed-in route. Specialist tabs are
+  // deliberately rendered beside it on wide layouts, never folded into a
+  // six-slot global control.
   return ["dashboard", "connect", "search"];
 }
 
 /** Contextual workspace tabs render beside the stable primary navigation. */
 export function resolveBottomNavSpecialistOptionKeys(
-  _scope: AppBottomNavScope,
+  scope: AppBottomNavScope,
 ): AppBottomNavKey[] {
+  if (scope === "investor") return ["finance", "portfolio", "analysis"];
+  if (scope === "ria") return ["ria-home", "clients", "picks"];
   return [];
 }
 

--- a/hushh-webapp/lib/services/connected-systems-service.ts
+++ b/hushh-webapp/lib/services/connected-systems-service.ts
@@ -60,7 +60,18 @@ export type ConnectedSystemSchemaResponse = {
     constraints?: Record<string, unknown>;
     source?: string;
   }>;
+  /** Schema-derived mapping for basic onboarding fields, never user supplied. */
+  profileFieldMappings?: Partial<{
+    email: string;
+    phone: string;
+    firstName: string;
+    lastName: string;
+    fullName: string;
+    address: string;
+  }>;
+  schemaMappingStatus?: "ready" | "unavailable" | "pending" | string;
   schemaStatus?: "ready" | "capability_metadata_missing" | string;
+  accessMetadata?: "declared" | "partial" | string;
   effectiveActions?: {
     schema?: boolean;
     read?: boolean;
@@ -133,44 +144,25 @@ export type ConnectedSystemIntent = {
 export type ConnectedSystemReadInput = {
   systemId?: string;
   objectType?: string;
-  /** Macy's compatibility aliases. Generic callers should use searchFields. */
-  email?: string;
-  phone?: string;
-  searchFields?: Record<string, unknown>;
   returnFields?: string[];
 };
 
 export type ConnectedSystemCreateIntentInput = {
   systemId?: string;
   objectType?: string;
-  /** Macy's compatibility aliases. */
-  email?: string;
-  phone?: string;
-  firstName?: string;
-  lastName?: string;
-  /** Typed fields for schema-driven CRM forms. */
-  recordFields?: Record<string, unknown>;
-  additionalFields?: Record<string, unknown>;
 };
 
 export type ConnectedSystemUpdateIntentInput = {
   systemId?: string;
   objectType?: string;
-  id: string;
   additionalFields: Record<string, unknown>;
   /** Typed field diff for schema-driven CRM forms. */
   recordFields?: Record<string, unknown>;
-  readbackLocator?: {
-    email: string;
-    phone: string;
-    searchFields?: Record<string, unknown>;
-  };
 };
 
 export type ConnectedSystemDeleteInput = {
   systemId?: string;
   objectType?: string;
-  id?: string;
 };
 
 function authHeaders(vaultOwnerToken: string): HeadersInit {
@@ -248,9 +240,6 @@ export class ConnectedSystemsService {
         headers: authHeaders(vaultOwnerToken),
         body: JSON.stringify({
           objectType: input.objectType,
-          email: input.email,
-          phone: input.phone,
-          searchFields: input.searchFields,
           returnFields: input.returnFields,
         }),
       }
@@ -287,9 +276,6 @@ export class ConnectedSystemsService {
         headers: authHeaders(vaultOwnerToken),
         body: JSON.stringify({
           objectType: input.objectType,
-          email: input.email,
-          phone: input.phone,
-          searchFields: input.searchFields,
           returnFields: input.returnFields,
         }),
       }
@@ -308,12 +294,6 @@ export class ConnectedSystemsService {
         headers: authHeaders(vaultOwnerToken),
         body: JSON.stringify({
           objectType: input.objectType,
-          email: input.email,
-          phone: input.phone,
-          firstName: input.firstName,
-          lastName: input.lastName,
-          recordFields: input.recordFields,
-          additionalFields: input.additionalFields,
         }),
       }
     );
@@ -331,10 +311,8 @@ export class ConnectedSystemsService {
         headers: authHeaders(vaultOwnerToken),
         body: JSON.stringify({
           objectType: input.objectType,
-          id: input.id,
           additionalFields: input.additionalFields,
           recordFields: input.recordFields,
-          readbackLocator: input.readbackLocator,
         }),
       }
     );
@@ -387,7 +365,6 @@ export class ConnectedSystemsService {
         headers: authHeaders(vaultOwnerToken),
         body: JSON.stringify({
           objectType: input.objectType,
-          id: input.id,
         }),
       }
     );

--- a/hushh-webapp/scripts/reports/export-markdown-pdf.mjs
+++ b/hushh-webapp/scripts/reports/export-markdown-pdf.mjs
@@ -4,6 +4,12 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
+import {
+  createPdfDocumentFormatter,
+  PDF_FORMATTER_PROFILES,
+  PDF_FORMATTER_THEMES,
+  renderPdfHusshWordmark,
+} from "../../lib/morphy-ux/pdf-document-formatter.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../../..");
@@ -16,6 +22,7 @@ function parseArgs(argv) {
     title: "Hussh Report",
     subtitle: "",
     theme: "light",
+    profile: "technical",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -32,6 +39,8 @@ function parseArgs(argv) {
       args.subtitle = argv[++index];
     } else if (value === "--theme") {
       args.theme = argv[++index];
+    } else if (value === "--profile") {
+      args.profile = argv[++index];
     } else if (value === "--help" || value === "-h") {
       printHelp();
       process.exit(0);
@@ -45,8 +54,14 @@ function parseArgs(argv) {
     process.exit(1);
   }
 
-  if (!["light", "dark", "molten-gold"].includes(args.theme)) {
-    throw new Error(`Unsupported theme: ${args.theme}. Use light, dark, or molten-gold.`);
+  if (!PDF_FORMATTER_THEMES.includes(args.theme)) {
+    throw new Error(`Unsupported theme: ${args.theme}. Use ${PDF_FORMATTER_THEMES.join(", ")}.`);
+  }
+
+  if (!Object.hasOwn(PDF_FORMATTER_PROFILES, args.profile)) {
+    throw new Error(
+      `Unsupported profile: ${args.profile}. Use ${Object.keys(PDF_FORMATTER_PROFILES).join(", ")}.`,
+    );
   }
 
   return args;
@@ -77,7 +92,8 @@ Options:
   --html <path>       Optional HTML output path.
   --title <text>      Browser title and PDF header label.
   --subtitle <text>   Small header subtitle.
-  --theme <name>      Color theme: light (default), dark, or molten-gold.
+  --theme <name>      Foundation theme: light (default), dark, or molten-gold.
+  --profile <name>    Formatter profile: technical (default), partner, or founder.
 `);
 }
 
@@ -211,7 +227,16 @@ function renderMarkdown(markdown) {
   let tableRows = [];
   let codeFence = null;
   let codeLines = [];
+  let paragraphLines = [];
   let omitFromPdf = false;
+
+  const flushParagraph = () => {
+    if (!paragraphLines.length) {
+      return;
+    }
+    html.push(`<p>${renderInline(paragraphLines.join(" "))}</p>`);
+    paragraphLines = [];
+  };
 
   const closeLists = () => {
     if (unorderedOpen) {
@@ -259,6 +284,7 @@ function renderMarkdown(markdown) {
 
     const fence = /^```([A-Za-z0-9_-]+)?\s*$/.exec(line);
     if (fence) {
+      flushParagraph();
       if (codeFence) {
         flushCode();
       } else {
@@ -276,6 +302,7 @@ function renderMarkdown(markdown) {
     }
 
     if (line.trim().startsWith("|")) {
+      flushParagraph();
       closeLists();
       tableRows.push(line);
       continue;
@@ -284,12 +311,14 @@ function renderMarkdown(markdown) {
     flushTable();
 
     if (!line.trim()) {
+      flushParagraph();
       closeLists();
       continue;
     }
 
     const heading = /^(#{1,4})\s+(.+)$/.exec(line);
     if (heading) {
+      flushParagraph();
       closeLists();
       const level = heading[1].length;
       html.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
@@ -297,12 +326,28 @@ function renderMarkdown(markdown) {
     }
 
     if (line.startsWith("> ")) {
+      flushParagraph();
       closeLists();
       html.push(`<blockquote>${renderInline(line.slice(2))}</blockquote>`);
       continue;
     }
 
+    const listContinuation = /^\s{2,}(.+)$/.exec(line);
+    if (
+      listContinuation &&
+      (unorderedOpen || orderedOpen) &&
+      html.at(-1)?.startsWith("<li>")
+    ) {
+      const previousItem = html.at(-1);
+      html[html.length - 1] = previousItem.replace(
+        /<\/li>$/,
+        ` ${renderInline(listContinuation[1].trim())}</li>`,
+      );
+      continue;
+    }
+
     if (/^\s*-\s+/.test(line)) {
+      flushParagraph();
       if (!unorderedOpen) {
         closeLists();
         html.push("<ul>");
@@ -313,6 +358,7 @@ function renderMarkdown(markdown) {
     }
 
     if (/^\s*\d+\.\s+/.test(line)) {
+      flushParagraph();
       if (!orderedOpen) {
         closeLists();
         html.push("<ol>");
@@ -323,9 +369,10 @@ function renderMarkdown(markdown) {
     }
 
     closeLists();
-    html.push(`<p>${renderInline(line)}</p>`);
+    paragraphLines.push(line.trim());
   }
 
+  flushParagraph();
   flushTable();
   flushCode();
   closeLists();
@@ -359,120 +406,32 @@ function readCssCustomProperties(block) {
   );
 }
 
-function requireCssTokens(tokens, names, source) {
-  const missing = names.filter((name) => !tokens[name]);
-  if (missing.length) {
-    throw new Error(`Missing ${source} token(s): ${missing.join(", ")}`);
-  }
-}
-
 function visibleTitle(title) {
   const withoutBrand = title.replace(/^hussh\s+/i, "").trim();
   return withoutBrand || title;
 }
 
-async function moltenGoldPalette() {
+async function resolveFormatter(theme, profile) {
   const globals = await readFile(path.join(repoRoot, "hushh-webapp/app/globals.css"), "utf8");
-  const foundationStart = globals.lastIndexOf("\n.dark {");
-  const foundation = readCssCustomProperties(extractCssBlock(globals, ".dark", foundationStart));
-  const accent = readCssCustomProperties(
-    extractCssBlock(globals, 'html[data-accent="gold"].dark'),
-  );
+  const useDarkFoundation = theme !== "light";
+  const foundation = useDarkFoundation
+    ? {
+        ...readCssCustomProperties(
+          extractCssBlock(globals, ".dark", globals.indexOf("\n.dark {")),
+        ),
+        ...readCssCustomProperties(
+          extractCssBlock(globals, ".dark", globals.lastIndexOf("\n.dark {")),
+        ),
+      }
+    : readCssCustomProperties(extractCssBlock(globals, ":root"));
+  const accent = theme === "molten-gold"
+    ? readCssCustomProperties(extractCssBlock(globals, 'html[data-accent="gold"].dark'))
+    : foundation;
 
-  requireCssTokens(
-    foundation,
-    ["--foundation-off", "--foundation-surface", "--foundation-ink", "--foundation-hairline"],
-    "Morphy dark Foundation",
-  );
-  requireCssTokens(
-    accent,
-    [
-      "--app-accent-deep",
-      "--app-accent-bright",
-      "--app-accent-surface",
-      "--app-accent-border",
-      "--app-accent-hero-from",
-      "--app-accent-hero-mid",
-      "--app-accent-hero-to",
-    ],
-    "Morphy Molten Gold",
-  );
-
-  return {
-    chromeColor: `color-mix(in srgb, ${foundation["--foundation-ink"]} 62%, transparent)`,
-    css: `
-        color-scheme: dark;
-        --bg: ${foundation["--foundation-off"]};
-        --bg-secondary: ${foundation["--foundation-surface"]};
-        --bg-tertiary: ${foundation["--foundation-hairline"]};
-        --fg: ${foundation["--foundation-ink"]};
-        --fg-secondary: color-mix(in srgb, ${foundation["--foundation-ink"]} 78%, ${foundation["--foundation-off"]});
-        --fg-tertiary: color-mix(in srgb, ${foundation["--foundation-ink"]} 54%, ${foundation["--foundation-off"]});
-        --separator: ${foundation["--foundation-hairline"]};
-        --separator-strong: ${accent["--app-accent-border"]};
-        --accent: ${accent["--app-accent-deep"]};
-        --accent-soft: ${accent["--app-accent-surface"]};
-        --accent-surface: ${accent["--app-accent-surface"]};
-        --blue: ${accent["--app-accent-bright"]};
-        --diagram-bg: ${foundation["--foundation-surface"]};
-        --brand-ink: ${foundation["--foundation-ink"]};
-        --brand-hero-from: ${accent["--app-accent-hero-from"]};
-        --brand-hero-mid: ${accent["--app-accent-hero-mid"]};
-        --brand-hero-to: ${accent["--app-accent-hero-to"]};`,
-  };
+  return createPdfDocumentFormatter({ theme, profile, foundation, accent });
 }
 
-async function resolvePalette(theme) {
-  if (theme === "molten-gold") {
-    return moltenGoldPalette();
-  }
-
-  const darkTheme = theme === "dark";
-  return {
-    chromeColor: darkTheme ? "rgba(235,235,245,.62)" : "rgba(60,60,67,.62)",
-    css: darkTheme
-    ? `
-        color-scheme: dark;
-        --bg: #101114;
-        --bg-secondary: #1c1d21;
-        --bg-tertiary: #282a30;
-        --fg: #f2f2f7;
-        --fg-secondary: rgba(235, 235, 245, 0.78);
-        --fg-tertiary: rgba(235, 235, 245, 0.52);
-        --separator: rgba(235, 235, 245, 0.20);
-        --separator-strong: rgba(235, 235, 245, 0.38);
-        --accent: #e5c11c;
-        --accent-soft: #403612;
-        --accent-surface: #1c1d21;
-        --blue: #72adff;
-        --diagram-bg: #16171a;
-        --brand-ink: var(--fg);
-        --brand-hero-from: var(--accent);
-        --brand-hero-mid: var(--accent);
-        --brand-hero-to: var(--accent);`
-    : `
-        color-scheme: light;
-        --bg: #ffffff;
-        --bg-secondary: #f5f5f7;
-        --bg-tertiary: #ebebf0;
-        --fg: #1c1c1e;
-        --fg-secondary: rgba(60, 60, 67, 0.78);
-        --fg-tertiary: rgba(60, 60, 67, 0.52);
-        --separator: rgba(60, 60, 67, 0.18);
-        --separator-strong: rgba(60, 60, 67, 0.36);
-        --accent: #dbb90f;
-        --accent-soft: #fff3bf;
-        --accent-surface: #f5f5f7;
-        --blue: #007aff;
-        --diagram-bg: #ffffff;
-        --brand-ink: var(--fg);
-        --brand-hero-from: var(--accent);
-        --brand-hero-mid: var(--accent);
-        --brand-hero-to: var(--accent);`,
-  };
-}
-
-function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette }) {
+function buildHtml(markdown, { documentTitle, displayTitle, subtitle, formatter }) {
   const body = renderMarkdown(markdown);
   return `<!doctype html>
 <html lang="en">
@@ -482,13 +441,7 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
     <title>${escapeHtml(documentTitle)}</title>
     <style>
       :root {
-        ${palette.css}
-        --code-bg: #272822;
-        --code-border: #49483e;
-        --code-fg: #f8f8f2;
-        --code-key: #f92672;
-        --code-string: #e6db74;
-        --code-literal: #ae81ff;
+        ${formatter.css}
       }
 
       @page {
@@ -504,7 +457,7 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
       body {
         background: var(--bg);
         color: var(--fg);
-        font: 12px/1.52 -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro", "Helvetica Neue", system-ui, sans-serif;
+        font: var(--pdf-body-size)/var(--pdf-line-height) -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro", "Helvetica Neue", system-ui, sans-serif;
         margin: 0;
       }
 
@@ -541,7 +494,7 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
       h1 {
         break-after: avoid;
         font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro", "Helvetica Neue", system-ui, sans-serif;
-        font-size: 30px;
+        font-size: var(--pdf-title-size);
         letter-spacing: 0;
         line-height: 1.12;
         margin: 0 0 12px;
@@ -550,10 +503,10 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
       h2 {
         break-after: avoid;
         border-top: 1px solid var(--separator);
-        font-size: 18px;
+        font-size: var(--pdf-section-size);
         letter-spacing: 0;
         line-height: 1.2;
-        margin: 26px 0 8px;
+        margin: var(--pdf-section-gap) 0 8px;
         padding-top: 12px;
       }
 
@@ -617,7 +570,7 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
         border-radius: 14px;
         box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
         color: var(--code-fg);
-        font: 10px/1.45 "SF Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
+        font: var(--pdf-code-size)/1.45 "SF Mono", "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
         margin: 10px 0 14px;
         overflow: hidden;
         padding: 12px;
@@ -724,22 +677,10 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
     </style>
   </head>
   <body>
-    <main class="shell">
+    <main class="shell formatter-${formatter.id}">
       <header>
         <div class="brand">
-          <svg viewBox="73 8 460 146" role="img" aria-label="Hussh" preserveAspectRatio="xMinYMid meet">
-            <title>Hussh</title>
-            <defs>
-              <linearGradient id="hussh-pdf-wordmark-ssh" x1="0" y1="0" x2="1" y2="0">
-                <stop offset="0%" stop-color="var(--brand-hero-from)" />
-                <stop offset="50%" stop-color="var(--brand-hero-mid)" />
-                <stop offset="100%" stop-color="var(--brand-hero-to)" />
-              </linearGradient>
-            </defs>
-            <text x="300" y="135" text-anchor="middle" font-family='"SF Pro Display", "SF Pro", "Helvetica Neue", Inter, system-ui, sans-serif' font-weight="700" font-size="160" letter-spacing="-5.6">
-              <tspan fill="var(--brand-ink)">hu</tspan><tspan fill="url(#hussh-pdf-wordmark-ssh)">ssh</tspan>
-            </text>
-          </svg>
+          ${renderPdfHusshWordmark()}
         </div>
         <h1>${escapeHtml(displayTitle)}</h1>
         ${subtitle ? `<div class="subtitle">${escapeHtml(subtitle)}</div>` : ""}
@@ -750,11 +691,11 @@ function buildHtml(markdown, { documentTitle, displayTitle, subtitle, palette })
 </html>`;
 }
 
-async function renderPdf({ input, output, html: htmlOutput, title, subtitle, theme }) {
+async function renderPdf({ input, output, html: htmlOutput, title, subtitle, theme, profile }) {
   const markdown = rewriteShareableLinks(await readFile(input, "utf8"), input);
-  const palette = await resolvePalette(theme);
+  const formatter = await resolveFormatter(theme, profile);
   const displayTitle = visibleTitle(title);
-  const html = buildHtml(markdown, { documentTitle: title, displayTitle, subtitle, palette });
+  const html = buildHtml(markdown, { documentTitle: title, displayTitle, subtitle, formatter });
   if (htmlOutput) {
     await mkdir(path.dirname(htmlOutput), { recursive: true });
     await writeFile(htmlOutput, html, "utf8");
@@ -771,8 +712,8 @@ async function renderPdf({ input, output, html: htmlOutput, title, subtitle, the
       format: "A4",
       printBackground: true,
       displayHeaderFooter: true,
-      headerTemplate: `<div style="font: 8px -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif; color: ${palette.chromeColor}; width: 100%; padding: 0 14mm;">${escapeHtml(displayTitle)}</div>`,
-      footerTemplate: `<div style="font: 8px -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif; color: ${palette.chromeColor}; width: 100%; padding: 0 14mm; text-align: right;"><span class="pageNumber"></span> / <span class="totalPages"></span></div>`,
+      headerTemplate: `<div style="font: 8px -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif; color: ${formatter.chromeColor}; width: 100%; padding: 0 14mm;">${escapeHtml(displayTitle)}</div>`,
+      footerTemplate: `<div style="font: 8px -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif; color: ${formatter.chromeColor}; width: 100%; padding: 0 14mm; text-align: right;"><span class="pageNumber"></span> / <span class="totalPages"></span></div>`,
       margin: { top: "18mm", right: "14mm", bottom: "18mm", left: "14mm" },
     });
   } finally {


### PR DESCRIPTION
## Summary
- Complete bound CRM lifecycle and capability-safe dynamic connected-systems UI.
- Standardize the shell: centered One / Connect / Search primary navigation with contextual Finance/RIA workspace groups.
- Introduce a Morphy-owned PDF formatter with semantic layout, app-brand light/dark/Molten Gold variants, and Sublime Monokai code blocks.

## Verification
- `npm run test:ci` — 2,193 passed, 6 skipped
- `npm run verify:voice-gateway`
- `npm run verify:surface-map`
- `npm run verify:capacitor:static`
- `npm run build`
- `npm run lint`, `npm run typecheck`, `npm run verify:design-system`, docs and skill checks
- Rendered PDF review: 4 pages, black/Molten Gold partner variant; source hygiene check passed.