### PR TITLE
fix(uat): use canonical Finance reviewer route

### DIFF
--- a/.codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs
+++ b/.codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs
@@ -11,7 +11,7 @@ const appOrigin = String(
   process.env.REVIEWER_APP_ORIGIN || "https://uat.one.hushh.ai"
 ).replace(/\/$/, "");
 const timeoutMs = Number(process.env.REVIEWER_APP_TIMEOUT_MS || 360_000);
-const routes = String(process.env.REVIEWER_APP_ROUTES || "/agent,/one/kai/portfolio")
+const routes = String(process.env.REVIEWER_APP_ROUTES || "/agent,/one/kai?tab=portfolio")
   .split(",")
   .map((route) => route.trim())
   .filter(Boolean);
@@ -23,7 +23,7 @@ if (process.argv.includes("--help")) {
       "",
       "Optional:",
       "  REVIEWER_APP_ORIGIN=https://uat.one.hushh.ai",
-      "  REVIEWER_APP_ROUTES=/agent,/one/kai/portfolio",
+      "  REVIEWER_APP_ROUTES=/agent,/one/kai?tab=portfolio",
       "  PLAYWRIGHT_HEADLESS=0",
       "",
     ].join("\n")

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -656,7 +656,7 @@ jobs:
         shell: bash
         env:
           REVIEWER_APP_ORIGIN: ${{ env.APP_FRONTEND_ORIGIN }}
-          REVIEWER_APP_ROUTES: /agent,/one/kai/portfolio,/one/pkm
+          REVIEWER_APP_ROUTES: /agent,/one/kai?tab=portfolio,/one/pkm
         run: |
           set -euo pipefail
           node .codex/skills/reviewer-app-testing/scripts/verify-reviewer-byok-navigation.mjs \


### PR DESCRIPTION
Repairs the UAT reviewer BYOK release gate after the Finance route canonicalization. The harness now navigates to `/one/kai?tab=portfolio` instead of the compatibility redirect, preserving the same-session URL assertion.