### PR TITLE
fix(release): inspect Cloud Run candidate revisions

### DIFF
--- a/consent-protocol/tests/test_verify_env_secrets_parity.py
+++ b/consent-protocol/tests/test_verify_env_secrets_parity.py
@@ -22,8 +22,28 @@ def _revision(service: str) -> dict[str, object]:
     }
 
 
+def _cloud_run_revision(service: str) -> dict[str, object]:
+    return {
+        "metadata": {"labels": {"serving.knative.dev/service": service}},
+        "spec": {"containers": [{"env": [{"name": "DB_POOL_MAX_SIZE", "value": "8"}]}]},
+    }
+
+
 def test_candidate_revision_is_inspected_before_it_serves(monkeypatch) -> None:
     monkeypatch.setattr(parity, "_describe_run_revision", lambda *_args: _revision("backend"))
+
+    env, revisions = parity._selected_container_env_map(
+        "project", "region", "backend", {}, "backend-00001-candidate"
+    )
+
+    assert revisions == ["backend-00001-candidate"]
+    assert env["DB_POOL_MAX_SIZE"]["value"] == "8"
+
+
+def test_cloud_run_candidate_revision_shape_is_inspected_before_it_serves(monkeypatch) -> None:
+    monkeypatch.setattr(
+        parity, "_describe_run_revision", lambda *_args: _cloud_run_revision("backend")
+    )
 
     env, revisions = parity._selected_container_env_map(
         "project", "region", "backend", {}, "backend-00001-candidate"

--- a/scripts/ops/verify-env-secrets-parity.py
+++ b/scripts/ops/verify-env-secrets-parity.py
@@ -426,12 +426,18 @@ def _active_revision_names(service_json: dict[str, Any] | None) -> list[str]:
 def _container_env_map(service_json: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     if not isinstance(service_json, dict):
         return {}
+    # Cloud Run Service objects contain a revision template, while the
+    # Cloud Run Revision objects fetched for a no-traffic candidate put the
+    # container directly at ``spec.containers``. Candidate validation must
+    # inspect that second shape before traffic is promoted.
     containers = (
         service_json.get("spec", {})
         .get("template", {})
         .get("spec", {})
         .get("containers", [])
     )
+    if not containers:
+        containers = service_json.get("spec", {}).get("containers", [])
     if not containers or not isinstance(containers[0], dict):
         return {}
     env_entries = containers[0].get("env", [])


### PR DESCRIPTION
## Summary
- inspect Cloud Run Revision `spec.containers` when validating no-traffic candidates
- cover the revision payload shape in the parity regression test

## Verification
- `consent-protocol/.venv/bin/python -m pytest consent-protocol/tests/test_verify_env_secrets_parity.py -q`
- live production candidate inspection now isolates the four genuinely absent credentials without rendering any values

Production release remains fail-closed until the required Gmail and voice secrets are provisioned.