### PR TITLE
fix(release): align One Voice and Agentforce contracts

### DIFF
--- a/consent-protocol/docs/mcp-setup.md
+++ b/consent-protocol/docs/mcp-setup.md
@@ -199,10 +199,34 @@ python scripts/ops/provision_partner_developer_app.py \
   --display-name "Salesforce Agentforce UAT" \
   --contact-email partners@hushh.ai \
   --crm-id salesforce-agentforce-uat \
-  --schema-profile agentforce \
-  --enable-client-credentials \
+  --integration-target mulesoft-agentforce \
   --connector-key-id salesforce-agentforce-uat-2026-07 \
   --connector-public-key "$PARTNER_X25519_PUBLIC_KEY"
+```
+
+`--integration-target mulesoft-agentforce` is the default template for the
+dedicated MuleSoft → Agentforce partner app. It selects `agentforce`, enables
+app-bound OAuth client credentials, and leaves the global `standard` default
+unchanged for every other MCP client. It does **not** make the app an end-user
+identity or permit personalized Agentforce execution.
+
+MuleSoft must relay the exact generated catalog into Salesforce API Catalog:
+
+- Agentforce → MuleSoft and MuleSoft → Hussh are separate OAuth
+  client-credential hops. Neither hop represents a Hussh end user.
+- Preserve the four aliases and their flat input/output schemas exactly; do not
+  add resources, prompts, nested fields, or a wider tool allowlist.
+- Register and allowlist the server in API Catalog, then inspect the final
+  Agentforce Asset Library mappings. Salesforce's
+  [API Catalog guidance](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mulesoft_mcp_servers.htm&language=en_US&type=5)
+  still requires an authentication protocol supported by the Agentforce MCP
+  client.
+
+Print the versioned, non-secret relay handoff before configuring the Mule flow:
+
+```bash
+cd packages/hushh-mcp
+npm run print-mulesoft-agentforce-handoff
 ```
 
 This UAT catalog is generated from the runtime and has exactly four tools:

--- a/consent-protocol/mcp_modules/agentforce_contract.py
+++ b/consent-protocol/mcp_modules/agentforce_contract.py
@@ -22,6 +22,7 @@ AGENTFORCE_PROFILE = "agentforce"
 AGENTFORCE_MAX_TOOLS = 20
 AGENTFORCE_MAX_PROPERTY_CHARS = 255
 AGENTFORCE_MAX_REQUEST_SECONDS = 55.0
+MULESOFT_AGENTFORCE_INTEGRATION_TARGET = "mulesoft-agentforce"
 
 # Salesforce's current external-MCP documentation permits letters, numbers,
 # dots, slashes, and hyphens. Keep the existing canonical identifiers intact
@@ -47,6 +48,48 @@ def canonical_agentforce_tool_name(name: str) -> str | None:
     """Resolve one Agentforce alias to its canonical Hussh handler name."""
 
     return _CANONICAL_TOOL_NAMES.get(str(name or "").strip())
+
+
+def get_mulesoft_agentforce_handoff() -> dict[str, Any]:
+    """Return the non-secret relay contract for MuleSoft to Agentforce.
+
+    This is an integration handoff, not a deployable Mule configuration. It
+    deliberately captures the constraints MuleSoft must preserve when it
+    publishes Hussh into Salesforce API Catalog. MuleSoft changes discovery,
+    routing, and policy ownership; it does not relax Agentforce MCP-client
+    limits or turn its app credentials into an end-user identity.
+    """
+
+    tool_allowlist = list(get_agentforce_tool_names())
+    return {
+        "integrationTarget": MULESOFT_AGENTFORCE_INTEGRATION_TARGET,
+        "supportStatus": "schema-compatible-uat-only",
+        "upstream": {
+            "transport": "streamable-http",
+            "path": "/mcp/",
+            "authentication": "oauth2-client-credentials",
+            "requestTimeoutSeconds": AGENTFORCE_MAX_REQUEST_SECONDS,
+        },
+        "agentforce": {
+            "catalog": "salesforce-api-catalog",
+            "transport": "streamable-http",
+            "authentication": "oauth2-client-credentials",
+            "toolsOnly": True,
+            "toolAllowlist": tool_allowlist,
+        },
+        "relayRequirements": {
+            "preserveToolNames": True,
+            "preserveInputOutputSchemas": True,
+            "allowResources": False,
+            "allowPrompts": False,
+            "expandNestedFields": False,
+        },
+        "executionBoundary": {
+            "personalizedToolExecution": "unsupported",
+            "handlerCalls": "fail-closed",
+            "errorCode": "AGENTFORCE_PERSONALIZED_WORKFLOW_UNSUPPORTED",
+        },
+    }
 
 
 def _tool_annotations(canonical_name: str, title: str) -> dict[str, Any]:

--- a/consent-protocol/scripts/ops/provision_partner_developer_app.py
+++ b/consent-protocol/scripts/ops/provision_partner_developer_app.py
@@ -32,12 +32,39 @@ from __future__ import annotations
 
 import argparse
 import sys
+from pathlib import Path
 
-from hushh_mcp.services.developer_oauth_service import DeveloperOAuthService
-from hushh_mcp.services.developer_registry_service import DeveloperRegistryService
+CONSENT_PROTOCOL_ROOT = Path(__file__).resolve().parents[2]
+if str(CONSENT_PROTOCOL_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONSENT_PROTOCOL_ROOT))
+
+INTEGRATION_TARGET_GENERIC = "generic"
+INTEGRATION_TARGET_MULESOFT_AGENTFORCE = "mulesoft-agentforce"
+
+
+def _apply_integration_defaults(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """Apply a named partner integration without changing the global default.
+
+    Existing MCP applications keep the standard profile. The named MuleSoft →
+    Agentforce target always receives the narrow Agentforce UAT catalog and an
+    app-bound OAuth client credential. It never authorizes personalized tool
+    execution.
+    """
+
+    if args.integration_target != INTEGRATION_TARGET_MULESOFT_AGENTFORCE:
+        return
+    if args.schema_profile not in {"standard", "agentforce"}:
+        parser.error(
+            "--integration-target mulesoft-agentforce requires the agentforce schema profile"
+        )
+    args.schema_profile = "agentforce"
+    args.enable_client_credentials = True
 
 
 def main() -> int:
+    from hushh_mcp.services.developer_oauth_service import DeveloperOAuthService
+    from hushh_mcp.services.developer_registry_service import DeveloperRegistryService
+
     parser = argparse.ArgumentParser(
         description="Provision a partner-class developer app + token for one CRM system."
     )
@@ -64,9 +91,19 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--integration-target",
+        choices=(INTEGRATION_TARGET_GENERIC, INTEGRATION_TARGET_MULESOFT_AGENTFORCE),
+        default=INTEGRATION_TARGET_GENERIC,
+        help=(
+            "Named partner integration. mulesoft-agentforce selects the strict Agentforce "
+            "UAT catalog and app-bound OAuth client credentials; it does not enable "
+            "personalized Agentforce execution."
+        ),
+    )
+    parser.add_argument(
         "--enable-client-credentials",
         action="store_true",
-        help="Explicitly permit OAuth client_credentials for a flat-profile partner app.",
+        help="Explicitly permit OAuth client_credentials for a constrained-profile partner app.",
     )
     parser.add_argument(
         "--connector-public-key",
@@ -109,6 +146,8 @@ def main() -> int:
         help="Revoke all active tokens for the app and exit (no new token)",
     )
     args = parser.parse_args()
+
+    _apply_integration_defaults(parser, args)
 
     if args.enable_client_credentials and args.schema_profile not in {"flat", "agentforce"}:
         parser.error("--enable-client-credentials requires a constrained schema profile")
@@ -179,6 +218,7 @@ def main() -> int:
     print(f"kind:          {app.get('kind')}")
     print(f"crm_id:        {app.get('crm_id') or '(none)'}")
     print(f"tool_groups:   {app.get('allowed_tool_groups')}")
+    print(f"integration_target: {args.integration_target}")
     print(f"schema_profile:{app.get('schema_profile') or 'standard'}")
     print(f"client_credentials_enabled: {bool(app.get('oauth_client_credentials_enabled'))}")
     print(f"created_app:   {result['created_app']}")

--- a/consent-protocol/tests/test_mcp_flat_profile.py
+++ b/consent-protocol/tests/test_mcp_flat_profile.py
@@ -12,6 +12,7 @@ from mcp_modules.agentforce_contract import (
     agentforce_contract_errors,
     get_agentforce_contract,
     get_agentforce_tool_names,
+    get_mulesoft_agentforce_handoff,
 )
 from mcp_modules.developer_context import (
     reset_current_developer_principal,
@@ -86,6 +87,32 @@ def test_agentforce_uat_contract_is_strict_and_keeps_canonical_field_ids() -> No
         assert agentforce_tool["title"].strip()
         assert agentforce_tool["description"].strip()
         assert agentforce_tool["annotations"]["title"] == agentforce_tool["title"]
+
+
+def test_mulesoft_agentforce_handoff_preserves_the_narrow_catalog_and_boundary() -> None:
+    handoff = get_mulesoft_agentforce_handoff()
+
+    assert handoff["integrationTarget"] == "mulesoft-agentforce"
+    assert handoff["upstream"] == {
+        "transport": "streamable-http",
+        "path": "/mcp/",
+        "authentication": "oauth2-client-credentials",
+        "requestTimeoutSeconds": 55.0,
+    }
+    assert handoff["agentforce"]["toolsOnly"] is True
+    assert handoff["agentforce"]["toolAllowlist"] == list(get_agentforce_tool_names())
+    assert handoff["relayRequirements"] == {
+        "preserveToolNames": True,
+        "preserveInputOutputSchemas": True,
+        "allowResources": False,
+        "allowPrompts": False,
+        "expandNestedFields": False,
+    }
+    assert handoff["executionBoundary"] == {
+        "personalizedToolExecution": "unsupported",
+        "handlerCalls": "fail-closed",
+        "errorCode": "AGENTFORCE_PERSONALIZED_WORKFLOW_UNSUPPORTED",
+    }
 
 
 def test_flat_projection_preserves_lifecycle_references_and_export_envelope() -> None:

--- a/consent-protocol/tests/test_partner_developer_apps.py
+++ b/consent-protocol/tests/test_partner_developer_apps.py
@@ -8,6 +8,8 @@ the same registry lane as self-serve tokens.
 
 from __future__ import annotations
 
+import argparse
+import importlib.util
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -20,6 +22,15 @@ from hushh_mcp.services.developer_registry_service import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _partner_provisioning_module():
+    script_path = ROOT / "scripts" / "ops" / "provision_partner_developer_app.py"
+    spec = importlib.util.spec_from_file_location("partner_provisioning", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _result(rows):
@@ -179,6 +190,34 @@ class TestPartnerPrincipal:
         )
         assert principal.kind == "self_serve"
         assert principal.crm_id is None
+
+
+class TestMuleSoftAgentforceProvisioning:
+    def test_named_integration_selects_agentforce_uat_profile_and_client_credentials(self):
+        module = _partner_provisioning_module()
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            integration_target="mulesoft-agentforce",
+            schema_profile="standard",
+            enable_client_credentials=False,
+        )
+
+        module._apply_integration_defaults(parser, args)
+
+        assert args.schema_profile == "agentforce"
+        assert args.enable_client_credentials is True
+
+    def test_named_integration_rejects_an_incompatible_catalog(self):
+        module = _partner_provisioning_module()
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            integration_target="mulesoft-agentforce",
+            schema_profile="flat",
+            enable_client_credentials=False,
+        )
+
+        with pytest.raises(SystemExit):
+            module._apply_integration_defaults(parser, args)
 
 
 class TestPartnerMigrationContract:

--- a/consent-protocol/tests/test_verify_uat_release.py
+++ b/consent-protocol/tests/test_verify_uat_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -35,3 +36,71 @@ def test_http_probe_returns_structured_failure_on_transport_error(monkeypatch) -
         "ok": False,
         "error": "TLS handshake failed",
     }
+
+
+def test_semantic_verifier_probes_the_canonical_one_adk_relay(monkeypatch, tmp_path) -> None:
+    verifier = _load_verifier()
+    request_paths: list[str] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _Smoke:
+        user_id = "uat-user"
+
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def authenticate(self) -> None:
+            pass
+
+        def _firebase_auth_headers(self) -> dict[str, str]:
+            return {"Authorization": "Bearer test-token"}
+
+        def _request(self, method: str, path: str, **_kwargs) -> _Response:
+            request_paths.append(f"{method} {path}")
+            if path == "/api/kai/gmail/status/uat-user":
+                return _Response({"configured": True, "connected": False})
+            if path == "/api/one/adk/relay-session":
+                return _Response(
+                    {
+                        "relay_ticket": "opaque-ticket",
+                        "expires_at": 1,
+                        "model": "adk",
+                        "tier": "full",
+                    }
+                )
+            if path == "/api/ria/onboarding/verify-name":
+                return _Response({"status": "verified", "crd_number": "5838118"})
+            raise AssertionError(f"Unexpected UAT verifier request: {method} {path}")
+
+    monkeypatch.setattr(verifier, "UatKaiSmoke", _Smoke)
+    monkeypatch.setattr(
+        verifier,
+        "_http_probe",
+        lambda url: {"url": url, "status_code": 200, "ok": True},
+    )
+    report_path = tmp_path / "uat-release.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_uat_release.py",
+            "--backend-url",
+            "https://backend.example",
+            "--frontend-url",
+            "https://frontend.example",
+            "--report-path",
+            str(report_path),
+        ],
+    )
+
+    assert verifier.main() == 0
+    assert "POST /api/one/adk/relay-session" in request_paths
+    assert all("/api/kai/voice/" not in path for path in request_paths)
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert {check["name"] for check in report["checks"]} >= {"voice_relay_session"}

--- a/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
+++ b/hushh-webapp/__tests__/components/navbar-agent-trigger.contract.test.ts
@@ -94,6 +94,8 @@ describe("Navbar bottom chrome contract", () => {
     expect(bottomShell).not.toContain("AmbientChromeController");
     expect(bottomShell).toContain('<AmbientChromeMask\n          edge="bottom"');
     expect(bottomShell).toContain("useKaiBottomChromeElementTranslation");
+    expect(bottomShell).toContain("snapKaiBottomChromeVisible");
+    expect(bottomShell).toContain("onPointerDownCapture");
     expect(bottomShell).toContain("BOTTOM_SCROLL_TRANSFORM");
     expect(bottomShell).toContain("data-app-bottom-shell");
     expect(bottomShell).toContain('<Navbar shellNavigationHidden={model.navigationHidden} layout="slot"');

--- a/hushh-webapp/__tests__/lib/kai-bottom-chrome-visibility.test.ts
+++ b/hushh-webapp/__tests__/lib/kai-bottom-chrome-visibility.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onScroll,
   resetKaiBottomChromeVisibility,
+  snapKaiBottomChromeVisible,
   syncKaiBottomChromeVisibilityToScroll,
   useKaiBottomChromeElementTranslation,
   useKaiBottomChromeVisibility,
@@ -69,6 +70,18 @@ describe("kai bottom chrome visibility singleton", () => {
     act(() => onScroll(40));
     flushAnimation();
     expect(result.current.progress).toBeLessThan(0.1);
+  });
+
+  it("snaps a moving bottom shell visible before an interaction can move its target", () => {
+    const { result } = renderHook(() => useKaiBottomChromeVisibility(true));
+
+    act(() => onScroll(0));
+    act(() => onScroll(120));
+    flushAnimation();
+    expect(result.current.progress).toBeGreaterThan(0.9);
+
+    act(() => snapKaiBottomChromeVisible());
+    expect(result.current.progress).toBe(0);
   });
 
   it("settles a fixed sibling into the bottom-nav slot through shared CSS motion", () => {

--- a/hushh-webapp/__tests__/lib/morphy-ux/material-ripple.test.tsx
+++ b/hushh-webapp/__tests__/lib/morphy-ux/material-ripple.test.tsx
@@ -1,5 +1,5 @@
-import { render, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 
@@ -39,11 +39,33 @@ describe("MaterialRipple", () => {
     disabledSpy = vi.fn();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("attaches the Material ripple controller to the actionable parent", async () => {
     const { container } = render(
       <button type="button">
         Open
         <MaterialRipple variant="link" effect="glass" />
+      </button>,
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+
+    await waitFor(() => {
+      expect(attachSpy).toHaveBeenCalledWith(button);
+    });
+  });
+
+  it("attaches through a visual wrapper to the enclosing actionable", async () => {
+    const { container } = render(
+      <button type="button">
+        Open
+        <span aria-hidden className="pointer-events-none">
+          <MaterialRipple variant="link" effect="glass" />
+        </span>
       </button>,
     );
 
@@ -79,5 +101,58 @@ describe("MaterialRipple", () => {
       expect(disabledSpy).toHaveBeenLastCalledWith(false);
     });
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("settles a touch press when WebKit omits the synthesized click", async () => {
+    const { container } = render(
+      <button type="button">
+        Open
+        <MaterialRipple variant="link" effect="glass" />
+      </button>,
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+
+    await waitFor(() => {
+      expect(attachSpy).toHaveBeenCalledWith(button);
+    });
+    disabledSpy.mockClear();
+    vi.useFakeTimers();
+
+    act(() => {
+      button?.dispatchEvent(new Event("pointerup", { bubbles: true }));
+      vi.advanceTimersByTime(700);
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(disabledSpy).toHaveBeenCalledWith(true);
+    expect(disabledSpy).toHaveBeenLastCalledWith(false);
+  });
+
+  it("keeps the normal ripple release when a click follows touch-up", async () => {
+    const { container } = render(
+      <button type="button">
+        Open
+        <MaterialRipple variant="link" effect="glass" />
+      </button>,
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+
+    await waitFor(() => {
+      expect(attachSpy).toHaveBeenCalledWith(button);
+    });
+    disabledSpy.mockClear();
+    vi.useFakeTimers();
+
+    act(() => {
+      button?.dispatchEvent(new Event("pointerup", { bubbles: true }));
+      button?.dispatchEvent(new Event("click", { bubbles: true }));
+      vi.advanceTimersByTime(700);
+    });
+
+    expect(disabledSpy).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/lib/morphy-ux/material-ripple.test.tsx
+++ b/hushh-webapp/__tests__/lib/morphy-ux/material-ripple.test.tsx
@@ -10,12 +10,23 @@ type RipplePrototype = HTMLElement & {
 
 describe("MaterialRipple", () => {
   let attachSpy: ReturnType<typeof vi.spyOn>;
+  let disabledSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     const RippleElement =
       customElements.get("md-ripple") ||
       class TestRippleElement extends HTMLElement {
-        disabled = false;
+        private isDisabled = false;
+
+        get disabled() {
+          return this.isDisabled;
+        }
+
+        set disabled(value: boolean) {
+          this.isDisabled = value;
+          disabledSpy(value);
+        }
+
         attach(_control: HTMLElement) {}
         detach() {}
       };
@@ -25,6 +36,7 @@ describe("MaterialRipple", () => {
     }
 
     attachSpy = vi.spyOn(RippleElement.prototype as RipplePrototype, "attach");
+    disabledSpy = vi.fn();
   });
 
   it("attaches the Material ripple controller to the actionable parent", async () => {
@@ -41,5 +53,31 @@ describe("MaterialRipple", () => {
     await waitFor(() => {
       expect(attachSpy).toHaveBeenCalledWith(button);
     });
+  });
+
+  it("clears an iOS touchcancel without taking ownership of the button tap", async () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <button type="button" onClick={onClick}>
+        Open
+        <MaterialRipple variant="link" effect="glass" />
+      </button>,
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+
+    await waitFor(() => {
+      expect(attachSpy).toHaveBeenCalledWith(button);
+    });
+    disabledSpy.mockClear();
+
+    button?.dispatchEvent(new Event("touchcancel", { bubbles: true }));
+
+    await waitFor(() => {
+      expect(disabledSpy).toHaveBeenCalledWith(true);
+      expect(disabledSpy).toHaveBeenLastCalledWith(false);
+    });
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/components/app-ui/app-bottom-shell.tsx
+++ b/hushh-webapp/components/app-ui/app-bottom-shell.tsx
@@ -5,7 +5,10 @@ import { useLayoutEffect, useRef, type CSSProperties } from "react";
 import { AgentBar } from "@/components/agent/agent-bar";
 import { Navbar } from "@/components/navbar";
 import { AmbientChromeMask } from "@/components/app-ui/ambient-chrome-mask";
-import { useKaiBottomChromeElementTranslation } from "@/lib/navigation/kai-bottom-chrome-visibility";
+import {
+  snapKaiBottomChromeVisible,
+  useKaiBottomChromeElementTranslation,
+} from "@/lib/navigation/kai-bottom-chrome-visibility";
 
 export type BottomShellModel = {
   ambientEnabled: boolean;
@@ -64,6 +67,11 @@ export function AppBottomShell({ model }: { model: BottomShellModel }) {
           model.navigationHidden || undefined
         }
         data-ambient-chrome-ignore
+        onPointerDownCapture={
+          model.ambientEnabled && !model.navigationHidden
+            ? snapKaiBottomChromeVisible
+            : undefined
+        }
         className="fixed inset-x-0 bottom-0 z-[118] flex flex-col items-center gap-1.5 px-3 pb-[max(0.75rem,var(--app-safe-area-bottom-effective))] transform-gpu"
       >
         <AgentBar layout="slot" />

--- a/hushh-webapp/lib/morphy-ux/material-ripple.tsx
+++ b/hushh-webapp/lib/morphy-ux/material-ripple.tsx
@@ -218,6 +218,51 @@ export const MaterialRipple = ({
   }, [disabled]);
 
   useEffect(() => {
+    const control = containerRef.current?.parentElement;
+    if (!isRippleReady || !control) return;
+
+    let resetFrame: number | undefined;
+    const clearInterruptedPress = () => {
+      const ripple = rippleRef.current;
+      if (!ripple || disabled) return;
+
+      // Material Web listens for pointercancel, but iOS WKWebView may surface
+      // an interrupted long press as touchcancel only. Toggle disabled across
+      // frames so Lit commits `pressed = false` without intercepting the
+      // control's tap or shortening a normal pointerup/click ripple.
+      ripple.disabled = true;
+      if (resetFrame !== undefined) {
+        window.cancelAnimationFrame(resetFrame);
+      }
+      resetFrame = window.requestAnimationFrame(() => {
+        if (rippleRef.current === ripple && !disabled) {
+          ripple.disabled = false;
+        }
+      });
+    };
+    const clearWhenHidden = () => {
+      if (document.visibilityState !== "visible") {
+        clearInterruptedPress();
+      }
+    };
+
+    control.addEventListener("pointercancel", clearInterruptedPress, true);
+    control.addEventListener("touchcancel", clearInterruptedPress, true);
+    window.addEventListener("blur", clearInterruptedPress);
+    document.addEventListener("visibilitychange", clearWhenHidden);
+
+    return () => {
+      control.removeEventListener("pointercancel", clearInterruptedPress, true);
+      control.removeEventListener("touchcancel", clearInterruptedPress, true);
+      window.removeEventListener("blur", clearInterruptedPress);
+      document.removeEventListener("visibilitychange", clearWhenHidden);
+      if (resetFrame !== undefined) {
+        window.cancelAnimationFrame(resetFrame);
+      }
+    };
+  }, [disabled, isRippleReady]);
+
+  useEffect(() => {
     // Check for dark mode
     const isDarkMode = document.documentElement.classList.contains("dark");
 

--- a/hushh-webapp/lib/morphy-ux/material-ripple.tsx
+++ b/hushh-webapp/lib/morphy-ux/material-ripple.tsx
@@ -26,6 +26,35 @@ interface MdRipple extends HTMLElement {
   detach?: () => void;
 }
 
+const INTERACTIVE_CONTROL_SELECTOR = [
+  "button",
+  "a[href]",
+  "input[type='button']",
+  "input[type='submit']",
+  "input[type='reset']",
+  "[role='button']",
+  "[role='tab']",
+  "[role='menuitem']",
+  "[role='option']",
+  "[role='radio']",
+  "[role='switch']",
+  "[role='checkbox']",
+].join(", ");
+
+// Material Web releases a touch press on `click`, rather than `pointerup`.
+// Safari/WKWebView can suppress that click if a fixed ancestor moved during the
+// gesture. This is deliberately longer than a normal synthesized click, so the
+// regular Material 3 release animation remains untouched.
+const MISSING_TOUCH_CLICK_RESET_MS = 700;
+
+function resolveRippleControl(container: HTMLDivElement): HTMLElement {
+  return (
+    container.closest<HTMLElement>(INTERACTIVE_CONTROL_SELECTOR) ??
+    container.parentElement ??
+    container
+  );
+}
+
 // ============================================================================
 // COLOR MAPPING - Morphy Variants to Material 3 Tokens
 // ============================================================================
@@ -197,9 +226,7 @@ export const MaterialRipple = ({
     rippleElement.className = "morphy-md-ripple";
     rippleElement.disabled = disabled;
     containerRef.current.appendChild(rippleElement);
-    rippleElement.attach?.(
-      containerRef.current.parentElement || containerRef.current,
-    );
+    rippleElement.attach?.(resolveRippleControl(containerRef.current));
     rippleRef.current = rippleElement;
 
     return () => {
@@ -218,10 +245,12 @@ export const MaterialRipple = ({
   }, [disabled]);
 
   useEffect(() => {
-    const control = containerRef.current?.parentElement;
-    if (!isRippleReady || !control) return;
+    const container = containerRef.current;
+    if (!isRippleReady || !container) return;
+    const control = resolveRippleControl(container);
 
     let resetFrame: number | undefined;
+    let missingClickTimer: number | undefined;
     const clearInterruptedPress = () => {
       const ripple = rippleRef.current;
       if (!ripple || disabled) return;
@@ -240,6 +269,28 @@ export const MaterialRipple = ({
         }
       });
     };
+    const clearMissingClickReset = () => {
+      if (missingClickTimer === undefined) return;
+      window.clearTimeout(missingClickTimer);
+      missingClickTimer = undefined;
+    };
+    const scheduleMissingClickReset = (event: Event) => {
+      // Mouse and pen input reliably produces a click. Keep their normal
+      // Material release path intact; this is a WebKit touch fallback only.
+      if (
+        event.type === "pointerup" &&
+        "pointerType" in event &&
+        (event as PointerEvent).pointerType !== "touch"
+      ) {
+        return;
+      }
+
+      clearMissingClickReset();
+      missingClickTimer = window.setTimeout(() => {
+        missingClickTimer = undefined;
+        clearInterruptedPress();
+      }, MISSING_TOUCH_CLICK_RESET_MS);
+    };
     const clearWhenHidden = () => {
       if (document.visibilityState !== "visible") {
         clearInterruptedPress();
@@ -248,14 +299,21 @@ export const MaterialRipple = ({
 
     control.addEventListener("pointercancel", clearInterruptedPress, true);
     control.addEventListener("touchcancel", clearInterruptedPress, true);
+    control.addEventListener("pointerup", scheduleMissingClickReset, true);
+    control.addEventListener("touchend", scheduleMissingClickReset, true);
+    control.addEventListener("click", clearMissingClickReset, true);
     window.addEventListener("blur", clearInterruptedPress);
     document.addEventListener("visibilitychange", clearWhenHidden);
 
     return () => {
       control.removeEventListener("pointercancel", clearInterruptedPress, true);
       control.removeEventListener("touchcancel", clearInterruptedPress, true);
+      control.removeEventListener("pointerup", scheduleMissingClickReset, true);
+      control.removeEventListener("touchend", scheduleMissingClickReset, true);
+      control.removeEventListener("click", clearMissingClickReset, true);
       window.removeEventListener("blur", clearInterruptedPress);
       document.removeEventListener("visibilitychange", clearWhenHidden);
+      clearMissingClickReset();
       if (resetFrame !== undefined) {
         window.cancelAnimationFrame(resetFrame);
       }

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -26,7 +26,7 @@ import { Kai, PORTFOLIO_STREAM_EVENT, KAI_STREAM_EVENT } from "@/lib/capacitor/k
 import type { PortfolioSharePayload } from "@/lib/portfolio-share/contract";
 import { isKaiStreamEnvelope, type KaiStreamEnvelope } from "@/lib/streaming/kai-stream-types";
 import { AuthService } from "@/lib/services/auth-service";
-import type { AppRuntimeState, VoiceCapabilityResponse } from "@/lib/voice/voice-types";
+import type { AppRuntimeState } from "@/lib/voice/voice-types";
 import {
   toDurationBucket,
   trackApiRequestCompleted,
@@ -1370,124 +1370,6 @@ export class ApiService {
       }),
       signal: data.signal,
     });
-  }
-
-  static async synthesizeKaiVoice(data: {
-    userId: string;
-    vaultOwnerToken: string;
-    text: string;
-    voice?: string;
-    voiceTurnId?: string;
-    signal?: AbortSignal;
-  }): Promise<Response> {
-    return voiceFetch("/api/kai/voice/tts", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${data.vaultOwnerToken}`,
-        ...(data.voiceTurnId ? { "X-Voice-Turn-Id": data.voiceTurnId } : {}),
-      },
-      body: JSON.stringify({
-        user_id: data.userId,
-        text: data.text,
-        voice: data.voice,
-      }),
-      signal: data.signal,
-    });
-  }
-
-  static async createKaiRealtimeSession(data: {
-    userId: string;
-    vaultOwnerToken: string;
-    voice?: string;
-    voiceTurnId?: string;
-    signal?: AbortSignal;
-  }): Promise<Response> {
-    return voiceFetch("/api/kai/voice/realtime/session", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${data.vaultOwnerToken}`,
-        ...(data.voiceTurnId ? { "X-Voice-Turn-Id": data.voiceTurnId } : {}),
-      },
-      body: JSON.stringify({
-        user_id: data.userId,
-        voice: data.voice,
-      }),
-      signal: data.signal,
-    });
-  }
-
-  static async createOneVoiceSession(data: {
-    userId: string;
-    vaultOwnerToken: string;
-    voice?: string;
-    voiceTurnId?: string;
-    signal?: AbortSignal;
-  }): Promise<Response> {
-    return voiceFetch("/api/one/voice/session", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${data.vaultOwnerToken}`,
-        ...(data.voiceTurnId ? { "X-Voice-Turn-Id": data.voiceTurnId } : {}),
-      },
-      body: JSON.stringify({
-        user_id: data.userId,
-        voice: data.voice,
-      }),
-      signal: data.signal,
-    });
-  }
-
-  static async getKaiVoiceCapability(data: {
-    userId: string;
-    vaultOwnerToken: string;
-    voiceTurnId?: string;
-    signal?: AbortSignal;
-  }): Promise<Response> {
-    return voiceFetch("/api/kai/voice/capability", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${data.vaultOwnerToken}`,
-        ...(data.voiceTurnId ? { "X-Voice-Turn-Id": data.voiceTurnId } : {}),
-      },
-      body: JSON.stringify({
-        user_id: data.userId,
-      }),
-      signal: data.signal,
-    });
-  }
-
-  static async getKaiVoiceCapabilityJson(data: {
-    userId: string;
-    vaultOwnerToken: string;
-    voiceTurnId?: string;
-    signal?: AbortSignal;
-  }): Promise<VoiceCapabilityResponse> {
-    const response = await ApiService.getKaiVoiceCapability(data);
-    const payload = (await response.json().catch(() => ({}))) as Partial<VoiceCapabilityResponse>;
-    if (!response.ok) {
-      const detail =
-        typeof (payload as Record<string, unknown>).detail === "string"
-          ? String((payload as Record<string, unknown>).detail)
-          : `VOICE_CAPABILITY_HTTP_${response.status}`;
-      throw new Error(detail);
-    }
-    const enabled =
-      typeof payload.enabled === "boolean"
-        ? payload.enabled
-        : typeof payload.realtime_enabled === "boolean"
-          ? payload.realtime_enabled
-          : payload.voice_enabled === true;
-    const reason =
-      typeof payload.reason === "string"
-        ? payload.reason
-        : typeof payload.rollout_reason === "string"
-          ? payload.rollout_reason
-          : null;
-    return {
-      ...payload,
-      enabled,
-      reason,
-    };
   }
 
   // ==================== App Config ====================

--- a/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
+++ b/hushh-webapp/scripts/testing/verify-signed-in-routes.mjs
@@ -101,9 +101,7 @@ const TRANSIENT_BACKGROUND_FETCH_ERRORS = [
   "[KaiHistory] Failed to get history: TypeError: Failed to fetch",
   "Failed to load profile manager data: TypeError: Failed to fetch",
 ];
-const TRANSIENT_BACKGROUND_REQUEST_FAILURES = [
-  "/api/kai/voice/capability :: net::ERR_FAILED",
-];
+const TRANSIENT_BACKGROUND_REQUEST_FAILURES = [];
 const TRANSIENT_BACKGROUND_RESPONSE_FAILURES = [
   "/api/connected-systems/salesforce-fsc-customer0/schema?objectType=Contact",
   "/api/connected-systems/salesforce-fsc-customer0/records/search",
@@ -1181,12 +1179,6 @@ function assertNoIssues(route, viewport, issues) {
       return false;
     }
     if (TRANSIENT_BACKGROUND_FETCH_ERRORS.some((pattern) => value.includes(pattern))) {
-      return false;
-    }
-    if (
-      value.includes("/api/kai/voice/capability") &&
-      value.includes("has been blocked by CORS policy")
-    ) {
       return false;
     }
     if (value.includes("Failed to load resource: the server responded with a status of 409")) {

--- a/packages/hushh-mcp/CHANGELOG.md
+++ b/packages/hushh-mcp/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added an explicit fail-closed production boundary for personalized Agentforce
   calls while Salesforce documents that user-level authentication and
   personalized MCP responses are unsupported.
+- Added a versioned, non-secret `mulesoft-agentforce` relay handoff that
+  locks API Catalog allowlisting, flat schema preservation, tools-only
+  capabilities, client-credential hops, and the UAT-only execution boundary.
 
 ## 0.3.0 - 2026-07-15
 

--- a/packages/hushh-mcp/README.md
+++ b/packages/hushh-mcp/README.md
@@ -63,6 +63,8 @@ OAuth client credentials are issued only to explicitly provisioned constrained p
 
 Use `hushh-mcp --print-agentforce-manifest` to inspect the exact four-tool UAT catalog. It is generated from the same runtime contract that authenticated `agentforce` apps receive from `tools/list`; it is a preflight artifact, not a replacement endpoint or a deployable Salesforce registration.
 
+For the dedicated MuleSoft → Agentforce partner app, use the generated `hushh-mcp --print-mulesoft-agentforce-handoff` baseline. It requires two distinct app-bound OAuth client-credential hops (Agentforce → MuleSoft and MuleSoft → Hussh), an API Catalog allowlist matching exactly the four generated aliases, tools only, and exact preservation of the published flat schemas. It is an implementation handoff, not a deployable Mule flow and does not turn either app credential into a Hussh user identity.
+
 Each tool includes a semantic machine name, client-facing title and description, strictly typed flat input fields, explicit `required` entries, and a complete `outputSchema`. Preserve the published machine field names. Salesforce currently has a Builder label-rendering defect for some data types, so an administrator must verify and, if necessary, replace input/output display labels in the Asset Library after registration. JSON Schema titles improve inspection metadata but do not claim to fix that Salesforce UI defect.
 
 The current UAT boundary is intentionally narrow:
@@ -72,7 +74,7 @@ The current UAT boundary is intentionally narrow:
 - verify names, descriptions, field counts, labels, and output mappings from `tools/list`;
 - do not invoke the personalized consent/export lifecycle from Agentforce. The server returns a documented fail-closed error instead.
 
-Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5) and [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&language=en_US&type=5).
+Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5), [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&language=en_US&type=5), and [MuleSoft MCP servers in API Catalog](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mulesoft_mcp_servers.htm&language=en_US&type=5).
 
 Minimal env for stdio hosts:
 

--- a/packages/hushh-mcp/bin-config.test.ts
+++ b/packages/hushh-mcp/bin-config.test.ts
@@ -94,6 +94,26 @@ describe("hushh-mcp CLI config output", () => {
       prompts: false,
       logging: false,
     });
+    expect(manifest.mulesoftAgentforceHandoff).toMatchObject({
+      integrationTarget: "mulesoft-agentforce",
+      supportStatus: "schema-compatible-uat-only",
+      upstream: {
+        transport: "streamable-http",
+        authentication: "oauth2-client-credentials",
+        requestTimeoutSeconds: 55,
+      },
+      agentforce: {
+        catalog: "salesforce-api-catalog",
+        toolsOnly: true,
+      },
+      executionBoundary: {
+        personalizedToolExecution: "unsupported",
+        handlerCalls: "fail-closed",
+      },
+    });
+    expect(manifest.mulesoftAgentforceHandoff.agentforce.toolAllowlist).toEqual(
+      manifest.tools.map((tool: { name: string }) => tool.name),
+    );
     expect(manifest.tools.map((tool: { name: string }) => tool.name)).toEqual([
       "search-user-scopes",
       "request-consent",
@@ -116,5 +136,27 @@ describe("hushh-mcp CLI config output", () => {
         expect(field.description).toEqual(expect.any(String));
       }
     }
+  });
+
+  it("prints the non-secret MuleSoft to Agentforce handoff without widening the UAT boundary", async () => {
+    const { stdout, stderr } = await execAsync(
+      `node ${packageJson.bin["hushh-mcp"]} --print-mulesoft-agentforce-handoff`,
+      { cwd: process.cwd() },
+    );
+
+    expect(stderr).toBe("");
+    const handoff = JSON.parse(stdout);
+    expect(handoff.integrationTarget).toBe("mulesoft-agentforce");
+    expect(handoff.agentforce.toolAllowlist).toHaveLength(4);
+    expect(handoff.relayRequirements).toEqual({
+      preserveToolNames: true,
+      preserveInputOutputSchemas: true,
+      allowResources: false,
+      allowPrompts: false,
+      expandNestedFields: false,
+    });
+    expect(handoff.executionBoundary.personalizedToolExecution).toBe("unsupported");
+    expect(stdout).not.toContain("client_secret");
+    expect(stdout).not.toContain("developer-token");
   });
 });

--- a/packages/hushh-mcp/bin/hushh-mcp.js
+++ b/packages/hushh-mcp/bin/hushh-mcp.js
@@ -33,6 +33,7 @@ function printUsage() {
   console.log("  hushh-mcp --print-remote-config");
   console.log("  hushh-mcp --print-gateway-manifest");
   console.log("  hushh-mcp --print-agentforce-manifest");
+  console.log("  hushh-mcp --print-mulesoft-agentforce-handoff");
   console.log("");
   console.log("Environment:");
   console.log("  HUSHH_MCP_ENV_FILE      Optional path to a consent-protocol style .env file");
@@ -374,6 +375,23 @@ if (args.includes("--print-gateway-manifest")) {
 
 if (args.includes("--print-agentforce-manifest")) {
   printGatewayManifest("hushh-agentforce-mcp-manifest.json");
+  process.exit(0);
+}
+
+if (args.includes("--print-mulesoft-agentforce-handoff")) {
+  const manifestPath = path.join(
+    packageDir,
+    "gateway",
+    "hushh-agentforce-mcp-manifest.json",
+  );
+  if (!fs.existsSync(manifestPath)) {
+    fatal("The packaged Agentforce MCP manifest is unavailable.");
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (!manifest.mulesoftAgentforceHandoff) {
+    fatal("The packaged MuleSoft Agentforce handoff is unavailable.");
+  }
+  process.stdout.write(`${JSON.stringify(manifest.mulesoftAgentforceHandoff, null, 2)}\n`);
   process.exit(0);
 }
 

--- a/packages/hushh-mcp/gateway/hushh-agentforce-mcp-manifest.json
+++ b/packages/hushh-mcp/gateway/hushh-agentforce-mcp-manifest.json
@@ -12,6 +12,40 @@
     "prompts": false,
     "logging": false
   },
+  "mulesoftAgentforceHandoff": {
+    "integrationTarget": "mulesoft-agentforce",
+    "supportStatus": "schema-compatible-uat-only",
+    "upstream": {
+      "transport": "streamable-http",
+      "path": "/mcp/",
+      "authentication": "oauth2-client-credentials",
+      "requestTimeoutSeconds": 55
+    },
+    "agentforce": {
+      "catalog": "salesforce-api-catalog",
+      "transport": "streamable-http",
+      "authentication": "oauth2-client-credentials",
+      "toolsOnly": true,
+      "toolAllowlist": [
+        "search-user-scopes",
+        "request-consent",
+        "check-consent-status",
+        "get-encrypted-scoped-export"
+      ]
+    },
+    "relayRequirements": {
+      "preserveToolNames": true,
+      "preserveInputOutputSchemas": true,
+      "allowResources": false,
+      "allowPrompts": false,
+      "expandNestedFields": false
+    },
+    "executionBoundary": {
+      "personalizedToolExecution": "unsupported",
+      "handlerCalls": "fail-closed",
+      "errorCode": "AGENTFORCE_PERSONALIZED_WORKFLOW_UNSUPPORTED"
+    }
+  },
   "tools": [
     {
       "name": "search-user-scopes",

--- a/packages/hushh-mcp/package.json
+++ b/packages/hushh-mcp/package.json
@@ -39,7 +39,8 @@
     "print-codex-toml": "node ./bin/hushh-mcp.js --print-codex-toml",
     "print-remote-config": "node ./bin/hushh-mcp.js --print-remote-config",
     "print-gateway-manifest": "node ./bin/hushh-mcp.js --print-gateway-manifest",
-    "print-agentforce-manifest": "node ./bin/hushh-mcp.js --print-agentforce-manifest"
+    "print-agentforce-manifest": "node ./bin/hushh-mcp.js --print-agentforce-manifest",
+    "print-mulesoft-agentforce-handoff": "node ./bin/hushh-mcp.js --print-mulesoft-agentforce-handoff"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/hushh-mcp/scripts/generate-gateway-manifest.mjs
+++ b/packages/hushh-mcp/scripts/generate-gateway-manifest.mjs
@@ -72,11 +72,11 @@ function loadAgentforceContract() {
       "-c",
       [
         "import json",
-        "from mcp_modules.agentforce_contract import agentforce_contract_errors, get_agentforce_contract",
+        "from mcp_modules.agentforce_contract import agentforce_contract_errors, get_agentforce_contract, get_mulesoft_agentforce_handoff",
         "errors = agentforce_contract_errors()",
         "if errors:",
         "    raise SystemExit('; '.join(errors))",
-        "print(json.dumps(get_agentforce_contract(), separators=(',', ':')))"
+        "print(json.dumps({'contract': get_agentforce_contract(), 'mulesoftAgentforceHandoff': get_mulesoft_agentforce_handoff()}, separators=(',', ':')))"
       ].join("\n"),
     ],
     {
@@ -96,7 +96,8 @@ function loadAgentforceContract() {
   return JSON.parse(result.stdout);
 }
 
-const agentforceContract = loadAgentforceContract();
+const agentforceProjection = loadAgentforceContract();
+const agentforceContract = agentforceProjection.contract;
 const agentforceManifest = {
   profile: "agentforce-uat",
   supportStatus: "schema-compatible-uat-only",
@@ -108,6 +109,7 @@ const agentforceManifest = {
     prompts: false,
     logging: false,
   },
+  mulesoftAgentforceHandoff: agentforceProjection.mulesoftAgentforceHandoff,
   tools: agentforceContract.tools.map(
     ({ name, title, description, inputSchema, outputSchema, annotations }) => ({
       name,

--- a/packages/hushh-mcp/scripts/render-readme.mjs
+++ b/packages/hushh-mcp/scripts/render-readme.mjs
@@ -131,6 +131,8 @@ OAuth client credentials are issued only to explicitly provisioned constrained p
 
 Use \`hushh-mcp --print-agentforce-manifest\` to inspect the exact four-tool UAT catalog. It is generated from the same runtime contract that authenticated \`agentforce\` apps receive from \`tools/list\`; it is a preflight artifact, not a replacement endpoint or a deployable Salesforce registration.
 
+For the dedicated MuleSoft → Agentforce partner app, use the generated \`hushh-mcp --print-mulesoft-agentforce-handoff\` baseline. It requires two distinct app-bound OAuth client-credential hops (Agentforce → MuleSoft and MuleSoft → Hussh), an API Catalog allowlist matching exactly the four generated aliases, tools only, and exact preservation of the published flat schemas. It is an implementation handoff, not a deployable Mule flow and does not turn either app credential into a Hussh user identity.
+
 Each tool includes a semantic machine name, client-facing title and description, strictly typed flat input fields, explicit \`required\` entries, and a complete \`outputSchema\`. Preserve the published machine field names. Salesforce currently has a Builder label-rendering defect for some data types, so an administrator must verify and, if necessary, replace input/output display labels in the Asset Library after registration. JSON Schema titles improve inspection metadata but do not claim to fix that Salesforce UI defect.
 
 The current UAT boundary is intentionally narrow:
@@ -140,7 +142,7 @@ The current UAT boundary is intentionally narrow:
 - verify names, descriptions, field counts, labels, and output mappings from \`tools/list\`;
 - do not invoke the personalized consent/export lifecycle from Agentforce. The server returns a documented fail-closed error instead.
 
-Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5) and [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&language=en_US&type=5).
+Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5), [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&language=en_US&type=5), and [MuleSoft MCP servers in API Catalog](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mulesoft_mcp_servers.htm&language=en_US&type=5).
 
 Minimal env for stdio hosts:
 

--- a/scripts/ops/verify_uat_release.py
+++ b/scripts/ops/verify_uat_release.py
@@ -164,29 +164,30 @@ def main() -> int:
             _record_exception(report, failures, name="gmail_status", exc=exc)
 
         try:
-            voice_capability = smoke._request(  # noqa: SLF001
+            relay_session = smoke._request(  # noqa: SLF001
                 "POST",
-                "/api/kai/voice/capability",
-                headers=smoke._vault_headers(),  # noqa: SLF001
-                json_body={"user_id": smoke.user_id},
+                "/api/one/adk/relay-session",
+                headers=smoke._firebase_auth_headers(),  # noqa: SLF001
                 expected=200,
             ).json()
-            voice_capability_ok = bool(
-                voice_capability.get("voice_enabled") and voice_capability.get("realtime_enabled")
+            relay_session_ok = bool(
+                isinstance(relay_session.get("relay_ticket"), str)
+                and relay_session.get("relay_ticket")
+                and isinstance(relay_session.get("expires_at"), int)
+                and relay_session.get("expires_at") > 0
             )
             report["checks"].append(
                 {
-                    "name": "voice_capability",
-                    "ok": voice_capability_ok,
-                    "voice_enabled": bool(voice_capability.get("voice_enabled")),
-                    "execution_allowed": bool(voice_capability.get("execution_allowed")),
-                    "realtime_enabled": bool(voice_capability.get("realtime_enabled")),
+                    "name": "voice_relay_session",
+                    "ok": relay_session_ok,
+                    "model": relay_session.get("model"),
+                    "tier": relay_session.get("tier"),
                 }
             )
-            if not voice_capability_ok:
-                failures.append("voice_capability")
+            if not relay_session_ok:
+                failures.append("voice_relay_session")
         except Exception as exc:  # pragma: no cover - exercised in live verification
-            _record_exception(report, failures, name="voice_capability", exc=exc)
+            _record_exception(report, failures, name="voice_relay_session", exc=exc)
 
         try:
             ria_stage1 = smoke._request(  # noqa: SLF001
@@ -218,30 +219,6 @@ def main() -> int:
                 failures.append("ria_stage1_query_only")
         except Exception as exc:  # pragma: no cover - exercised in live verification
             _record_exception(report, failures, name="ria_stage1_query_only", exc=exc)
-
-        try:
-            realtime_session = smoke._request(  # noqa: SLF001
-                "POST",
-                "/api/kai/voice/realtime/session",
-                headers=smoke._vault_headers(),  # noqa: SLF001
-                json_body={"user_id": smoke.user_id, "voice": "alloy"},
-                expected=200,
-            ).json()
-            realtime_ok = bool(realtime_session.get("client_secret")) and bool(
-                realtime_session.get("session_id")
-            )
-            report["checks"].append(
-                {
-                    "name": "voice_realtime_session",
-                    "ok": realtime_ok,
-                    "model": realtime_session.get("model"),
-                    "voice": realtime_session.get("voice"),
-                }
-            )
-            if not realtime_ok:
-                failures.append("voice_realtime_session")
-        except Exception as exc:  # pragma: no cover - exercised in live verification
-            _record_exception(report, failures, name="voice_realtime_session", exc=exc)
 
     if args.include_signed_in_routes:
         route_results = []


### PR DESCRIPTION
## Summary
- verify UAT One Voice through the canonical ADK relay-ticket endpoint
- remove unreachable legacy Kai voice client helpers
- publish a generated MuleSoft to Agentforce UAT handoff contract
- clear interrupted iOS ripple presses without intercepting taps

## Verification
- `uv run pytest tests/test_mcp_flat_profile.py tests/test_partner_developer_apps.py tests/test_verify_uat_release.py tests/test_one_adk_live_protocol.py -q`
- `npm run verify:package` in `packages/hushh-mcp`
- `npm run typecheck` and targeted MaterialRipple test in `hushh-webapp`
- `./bin/hushh docs verify`
- `./bin/hushh codex pre-pr`