### PR TITLE
feat(profile): custom profile picture upload + avatar crop fix

### DIFF
--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -19,6 +19,7 @@ Security:
     Email aliases, delete, and export require VAULT_OWNER token.
 """
 
+import base64
 import hashlib
 import hmac
 import logging
@@ -62,6 +63,71 @@ async def refresh_account_identity(
         "user_id": firebase_uid,
         "identity": identity,
     }
+
+
+class AvatarUploadRequest(BaseModel):
+    image_data_url: str = Field(min_length=32, max_length=600_000)
+
+
+# Client uploads a small, already-resized (~256px) image as a data URL.
+_AVATAR_DATA_URL_PATTERN = re.compile(r"^data:image/(png|jpe?g|webp);base64,")
+_AVATAR_MAX_DECODED_BYTES = 300 * 1024
+
+
+@router.post("/avatar")
+async def upload_account_avatar(
+    request: AvatarUploadRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Store an app-owned avatar override for the signed-in actor.
+
+    The stored data URL takes precedence over the Firebase photo on reads and
+    survives Firebase identity syncs.
+    """
+    data_url = request.image_data_url.strip()
+    if not _AVATAR_DATA_URL_PATTERN.match(data_url):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "AVATAR_INVALID_DATA_URL",
+                "message": "Avatar must be a PNG, JPEG, or WebP image data URL.",
+            },
+        )
+
+    encoded_payload = data_url.split(",", 1)[1]
+    try:
+        decoded = base64.b64decode(encoded_payload, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "AVATAR_INVALID_BASE64",
+                "message": "Avatar image data is not valid base64.",
+            },
+        ) from exc
+
+    if len(decoded) > _AVATAR_MAX_DECODED_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail={
+                "code": "AVATAR_TOO_LARGE",
+                "message": "Avatar image exceeds the 300KB limit.",
+            },
+        )
+
+    identity = await ActorIdentityService().set_custom_photo_url(
+        firebase_uid, request.image_data_url
+    )
+    return {"success": True, "identity": identity}
+
+
+@router.delete("/avatar")
+async def delete_account_avatar(
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Clear the app-owned avatar override, reverting to the Firebase photo."""
+    identity = await ActorIdentityService().set_custom_photo_url(firebase_uid, None)
+    return {"success": True, "identity": identity}
 
 
 class DeleteAccountRequest(BaseModel):

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -118,6 +118,14 @@ async def upload_account_avatar(
     identity = await ActorIdentityService().set_custom_photo_url(
         firebase_uid, request.image_data_url
     )
+    if not identity:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "AVATAR_PERSISTENCE_UNAVAILABLE",
+                "message": "Avatar was accepted but could not be persisted.",
+            },
+        )
     return {"success": True, "identity": identity}
 
 
@@ -127,6 +135,14 @@ async def delete_account_avatar(
 ):
     """Clear the app-owned avatar override, reverting to the Firebase photo."""
     identity = await ActorIdentityService().set_custom_photo_url(firebase_uid, None)
+    if not identity:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "AVATAR_PERSISTENCE_UNAVAILABLE",
+                "message": "Avatar removal could not be persisted.",
+            },
+        )
     return {"success": True, "identity": identity}
 
 

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -48,6 +48,7 @@
       "email",
       "phone_number",
       "photo_url",
+      "custom_photo_url",
       "email_verified",
       "phone_verified",
       "source",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -59,6 +59,7 @@
       "email",
       "phone_number",
       "photo_url",
+      "custom_photo_url",
       "email_verified",
       "phone_verified",
       "source",

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 106,
+  "expected_migration_version": 107,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/107_actor_identity_custom_photo.sql
+++ b/consent-protocol/db/migrations/107_actor_identity_custom_photo.sql
@@ -1,0 +1,12 @@
+-- Migration 107: extend actor identity cache with app-owned custom photo
+-- ============================================================
+-- Adds an app-owned avatar override that survives Firebase identity syncs.
+-- Firebase Auth's photo_url remains the source of truth for the Firebase
+-- avatar; custom_photo_url takes precedence for presentation when set.
+
+BEGIN;
+
+ALTER TABLE actor_identity_cache
+  ADD COLUMN IF NOT EXISTS custom_photo_url TEXT;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -84,7 +84,8 @@
     "103_demo_crm_response_contracts.sql",
     "104_crm_schema_mapping_cache.sql",
     "105_agentforce_mcp_compatibility.sql",
-    "106_agentforce_uat_profile.sql"
+    "106_agentforce_uat_profile.sql",
+    "107_actor_identity_custom_photo.sql"
   ],
   "groups": {
     "iam": [
@@ -131,7 +132,8 @@
       "101_backfill_crm_operation_endpoints.sql",
       "102_crm_operation_response_contract.sql",
       "103_demo_crm_response_contracts.sql",
-      "104_crm_schema_mapping_cache.sql"
+      "104_crm_schema_mapping_cache.sql",
+      "107_actor_identity_custom_photo.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -323,7 +323,7 @@ class ActorIdentityService:
                       display_name,
                       email,
                       phone_number,
-                      photo_url,
+                      COALESCE(custom_photo_url, photo_url) AS photo_url,
                       email_verified,
                       phone_verified,
                       source,
@@ -339,9 +339,16 @@ class ActorIdentityService:
             logger.debug("actor_identity_cache missing; using legacy identity fallback")
             return await self._get_many_fallback(normalized_ids)
         except asyncpg.UndefinedColumnError as exc:
-            if "phone_number" not in str(exc) and "phone_verified" not in str(exc):
+            message = str(exc)
+            if (
+                "phone_number" not in message
+                and "phone_verified" not in message
+                and "custom_photo_url" not in message
+            ):
                 raise
-            logger.debug("actor_identity_cache phone shadow missing; using pre-047 projection")
+            logger.debug(
+                "actor_identity_cache phone shadow / custom photo missing; using pre-047 projection"
+            )
             return await self._get_many_without_phone_shadow(normalized_ids)
         return {
             str(row["user_id"]): self._normalize_row(row)
@@ -414,7 +421,7 @@ class ActorIdentityService:
                       display_name,
                       email,
                       phone_number,
-                      photo_url,
+                      COALESCE(custom_photo_url, photo_url) AS photo_url,
                       email_verified,
                       phone_verified,
                       source,
@@ -434,6 +441,71 @@ class ActorIdentityService:
         except Exception as exc:
             logger.debug(
                 "actor_identity_cache upsert skipped for %s: %s",
+                normalized_user_id,
+                exc,
+            )
+            return None
+
+        return self._normalize_row(row)
+
+    async def set_custom_photo_url(
+        self,
+        user_id: str,
+        custom_photo_url: str | None,
+    ) -> dict[str, Any] | None:
+        """Set (or clear) the app-owned avatar override for an actor.
+
+        The custom photo takes precedence over the Firebase ``photo_url`` on
+        reads (see the ``COALESCE`` projections) and is never touched by
+        ``upsert_identity``/``sync_from_firebase``, so it survives Firebase
+        identity syncs. Passing ``None`` clears the override, reverting to the
+        Firebase photo.
+        """
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return None
+        normalized_custom_photo_url = str(custom_photo_url or "").strip() or None
+
+        update_sql = """
+            UPDATE actor_identity_cache
+            SET custom_photo_url = $2,
+                updated_at = NOW()
+            WHERE user_id = $1
+            RETURNING
+              user_id,
+              display_name,
+              email,
+              phone_number,
+              COALESCE(custom_photo_url, photo_url) AS photo_url,
+              email_verified,
+              phone_verified,
+              source,
+              last_synced_at,
+              created_at,
+              updated_at
+        """
+
+        pool = await get_pool()
+        try:
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    update_sql,
+                    normalized_user_id,
+                    normalized_custom_photo_url,
+                )
+            if row is None:
+                # No identity shadow row yet; create it from Firebase Auth,
+                # then retry the custom-photo write.
+                await self.sync_from_firebase(normalized_user_id, force=True)
+                async with pool.acquire() as conn:
+                    row = await conn.fetchrow(
+                        update_sql,
+                        normalized_user_id,
+                        normalized_custom_photo_url,
+                    )
+        except Exception as exc:
+            logger.debug(
+                "actor_identity_cache custom photo update skipped for %s: %s",
                 normalized_user_id,
                 exc,
             )

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -579,47 +579,47 @@ class ActorIdentityService:
 
         pool = await get_pool()
 
-        def _claim_insert_sql(photo_expr: str) -> str:
-            # ``photo_expr`` is a fixed, code-controlled column expression (never
-            # user input) — no injection surface.
-            return f"""
-                INSERT INTO actor_identity_cache (
-                  user_id,
-                  phone_number,
-                  phone_verified,
-                  source,
-                  last_synced_at,
-                  created_at,
-                  updated_at
-                )
-                VALUES (
-                  $1,
-                  $2,
-                  TRUE,
-                  $3,
-                  NOW(),
-                  NOW(),
-                  NOW()
-                )
-                ON CONFLICT (user_id) DO UPDATE SET
-                  phone_number = EXCLUDED.phone_number,
-                  phone_verified = TRUE,
-                  source = $3,
-                  last_synced_at = NOW(),
-                  updated_at = NOW()
-                RETURNING
-                  user_id,
-                  display_name,
-                  email,
-                  phone_number,
-                  {photo_expr} AS photo_url,
-                  email_verified,
-                  phone_verified,
-                  source,
-                  last_synced_at,
-                  created_at,
-                  updated_at
-            """
+        # Two fully static SQL literals (no string interpolation/concatenation,
+        # so the query is never dynamically built). They differ only in the
+        # RETURNING photo_url projection: the COALESCE variant preserves a custom
+        # avatar (post-107); the plain-photo_url variant keeps the phone claim
+        # working during the 107 migration gap (no custom avatar can exist yet).
+        claim_insert_with_custom_photo = """
+            INSERT INTO actor_identity_cache (
+              user_id, phone_number, phone_verified, source,
+              last_synced_at, created_at, updated_at
+            )
+            VALUES ($1, $2, TRUE, $3, NOW(), NOW(), NOW())
+            ON CONFLICT (user_id) DO UPDATE SET
+              phone_number = EXCLUDED.phone_number,
+              phone_verified = TRUE,
+              source = $3,
+              last_synced_at = NOW(),
+              updated_at = NOW()
+            RETURNING
+              user_id, display_name, email, phone_number,
+              COALESCE(custom_photo_url, photo_url) AS photo_url,
+              email_verified, phone_verified, source,
+              last_synced_at, created_at, updated_at
+        """
+        claim_insert_plain_photo = """
+            INSERT INTO actor_identity_cache (
+              user_id, phone_number, phone_verified, source,
+              last_synced_at, created_at, updated_at
+            )
+            VALUES ($1, $2, TRUE, $3, NOW(), NOW(), NOW())
+            ON CONFLICT (user_id) DO UPDATE SET
+              phone_number = EXCLUDED.phone_number,
+              phone_verified = TRUE,
+              source = $3,
+              last_synced_at = NOW(),
+              updated_at = NOW()
+            RETURNING
+              user_id, display_name, email, phone_number,
+              photo_url AS photo_url,
+              email_verified, phone_verified, source,
+              last_synced_at, created_at, updated_at
+        """
 
         try:
             async with pool.acquire() as conn:
@@ -640,7 +640,7 @@ class ActorIdentityService:
                     # Preserve a custom avatar in the returned (and client-cached)
                     # identity, matching get_many/upsert_identity/set_custom_photo_url.
                     row = await conn.fetchrow(
-                        _claim_insert_sql("COALESCE(custom_photo_url, photo_url)"),
+                        claim_insert_with_custom_photo,
                         normalized_user_id,
                         normalized_phone_number,
                         normalized_source,
@@ -651,7 +651,7 @@ class ActorIdentityService:
                     # Pre-107 gap: no custom avatar can exist yet, so the plain
                     # photo_url is equivalent — keep the phone claim working.
                     row = await conn.fetchrow(
-                        _claim_insert_sql("photo_url"),
+                        claim_insert_plain_photo,
                         normalized_user_id,
                         normalized_phone_number,
                         normalized_source,

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -270,6 +270,45 @@ class ActorIdentityService:
             if str(row.get("user_id") or "").strip()
         }
 
+    async def _get_many_without_custom_photo(
+        self, user_ids: list[str]
+    ) -> dict[str, dict[str, Any]]:
+        """Pre-107 projection: drops ONLY custom_photo_url (keeps phone shadow).
+
+        Used when the 047 phone-shadow columns exist but the 107
+        custom_photo_url column does not (the migration gap). Routing that case
+        to ``_get_many_without_phone_shadow`` would wrongly zero phone_verified
+        for every read; this keeps phone-verification state intact and simply
+        falls back to the plain Firebase photo_url (no custom avatar can exist
+        yet, since ``set_custom_photo_url`` needs the column too).
+        """
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT
+                  user_id,
+                  display_name,
+                  email,
+                  phone_number,
+                  photo_url,
+                  email_verified,
+                  phone_verified,
+                  source,
+                  last_synced_at,
+                  created_at,
+                  updated_at
+                FROM actor_identity_cache
+                WHERE user_id = ANY($1::text[])
+                """,
+                user_ids,
+            )
+        return {
+            str(row["user_id"]): self._normalize_row(row)
+            for row in rows
+            if str(row.get("user_id") or "").strip()
+        }
+
     @staticmethod
     def _normalize_row(row: Any) -> dict[str, Any]:
         if not row:
@@ -340,14 +379,21 @@ class ActorIdentityService:
             return await self._get_many_fallback(normalized_ids)
         except asyncpg.UndefinedColumnError as exc:
             message = str(exc)
-            if (
-                "phone_number" not in message
-                and "phone_verified" not in message
-                and "custom_photo_url" not in message
-            ):
+            phone_missing = "phone_number" in message or "phone_verified" in message
+            custom_photo_missing = "custom_photo_url" in message
+            if not phone_missing and not custom_photo_missing:
                 raise
+            # A missing custom_photo_url (pre-107) must NOT route to the
+            # phone-less projection — that would silently zero phone_verified for
+            # EVERY read during the 107 migration gap. Drop only the column that
+            # is actually absent so phone-verification state stays intact.
+            if custom_photo_missing and not phone_missing:
+                logger.debug(
+                    "actor_identity_cache custom_photo_url missing; using pre-107 projection"
+                )
+                return await self._get_many_without_custom_photo(normalized_ids)
             logger.debug(
-                "actor_identity_cache phone shadow / custom photo missing; using pre-047 projection"
+                "actor_identity_cache phone shadow missing; using pre-047 projection"
             )
             return await self._get_many_without_phone_shadow(normalized_ids)
         return {
@@ -511,6 +557,11 @@ class ActorIdentityService:
             )
             return None
 
+        if row is None:
+            # Write never landed (no shadow row and the Firebase sync could not
+            # create one). Report failure instead of _normalize_row(None) == {},
+            # which would surface as a false success and clobber the client cache.
+            return None
         return self._normalize_row(row)
 
     async def claim_verified_phone(
@@ -527,6 +578,49 @@ class ActorIdentityService:
             return None
 
         pool = await get_pool()
+
+        def _claim_insert_sql(photo_expr: str) -> str:
+            # ``photo_expr`` is a fixed, code-controlled column expression (never
+            # user input) — no injection surface.
+            return f"""
+                INSERT INTO actor_identity_cache (
+                  user_id,
+                  phone_number,
+                  phone_verified,
+                  source,
+                  last_synced_at,
+                  created_at,
+                  updated_at
+                )
+                VALUES (
+                  $1,
+                  $2,
+                  TRUE,
+                  $3,
+                  NOW(),
+                  NOW(),
+                  NOW()
+                )
+                ON CONFLICT (user_id) DO UPDATE SET
+                  phone_number = EXCLUDED.phone_number,
+                  phone_verified = TRUE,
+                  source = $3,
+                  last_synced_at = NOW(),
+                  updated_at = NOW()
+                RETURNING
+                  user_id,
+                  display_name,
+                  email,
+                  phone_number,
+                  {photo_expr} AS photo_url,
+                  email_verified,
+                  phone_verified,
+                  source,
+                  last_synced_at,
+                  created_at,
+                  updated_at
+            """
+
         try:
             async with pool.acquire() as conn:
                 await conn.execute(
@@ -542,49 +636,26 @@ class ActorIdentityService:
                     normalized_user_id,
                     normalized_phone_number,
                 )
-                row = await conn.fetchrow(
-                    """
-                    INSERT INTO actor_identity_cache (
-                      user_id,
-                      phone_number,
-                      phone_verified,
-                      source,
-                      last_synced_at,
-                      created_at,
-                      updated_at
+                try:
+                    # Preserve a custom avatar in the returned (and client-cached)
+                    # identity, matching get_many/upsert_identity/set_custom_photo_url.
+                    row = await conn.fetchrow(
+                        _claim_insert_sql("COALESCE(custom_photo_url, photo_url)"),
+                        normalized_user_id,
+                        normalized_phone_number,
+                        normalized_source,
                     )
-                    VALUES (
-                      $1,
-                      $2,
-                      TRUE,
-                      $3,
-                      NOW(),
-                      NOW(),
-                      NOW()
+                except asyncpg.UndefinedColumnError as exc:
+                    if "custom_photo_url" not in str(exc):
+                        raise
+                    # Pre-107 gap: no custom avatar can exist yet, so the plain
+                    # photo_url is equivalent — keep the phone claim working.
+                    row = await conn.fetchrow(
+                        _claim_insert_sql("photo_url"),
+                        normalized_user_id,
+                        normalized_phone_number,
+                        normalized_source,
                     )
-                    ON CONFLICT (user_id) DO UPDATE SET
-                      phone_number = EXCLUDED.phone_number,
-                      phone_verified = TRUE,
-                      source = $3,
-                      last_synced_at = NOW(),
-                      updated_at = NOW()
-                    RETURNING
-                      user_id,
-                      display_name,
-                      email,
-                      phone_number,
-                      photo_url,
-                      email_verified,
-                      phone_verified,
-                      source,
-                      last_synced_at,
-                      created_at,
-                      updated_at
-                    """,
-                    normalized_user_id,
-                    normalized_phone_number,
-                    normalized_source,
-                )
         except (asyncpg.UndefinedTableError, asyncpg.UndefinedColumnError):
             logger.debug(
                 "actor_identity_cache phone claim skipped; phone shadow schema unavailable"

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
@@ -40,6 +42,117 @@ def test_refresh_account_identity_returns_synced_identity(monkeypatch):
     assert payload["success"] is True
     assert payload["user_id"] == "firebase_uid_123"
     assert payload["identity"]["last_active_persona"] == "investor"
+
+
+def test_upload_account_avatar_requires_firebase_auth():
+    client = TestClient(_build_app())
+    data_url = "data:image/png;base64," + base64.b64encode(b"small png bytes payload").decode()
+    response = client.post("/api/account/avatar", json={"image_data_url": data_url})
+
+    assert response.status_code == 401
+
+
+def test_upload_account_avatar_accepts_valid_image_data_url(monkeypatch):
+    captured = {}
+
+    async def _mock_set(self, user_id, custom_photo_url):
+        captured["user_id"] = user_id
+        captured["custom_photo_url"] = custom_photo_url
+        return {
+            "user_id": user_id,
+            "photo_url": custom_photo_url,
+            "source": "firebase_auth",
+        }
+
+    data_url = "data:image/png;base64," + base64.b64encode(
+        b"\x89PNG\r\n\x1a\n resized avatar bytes"
+    ).decode()
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(ActorIdentityService, "set_custom_photo_url", _mock_set)
+
+    client = TestClient(app)
+    response = client.post("/api/account/avatar", json={"image_data_url": data_url})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["identity"]["photo_url"] == data_url
+    assert captured == {"user_id": "firebase_uid_123", "custom_photo_url": data_url}
+
+
+def test_upload_account_avatar_rejects_non_image_data_url(monkeypatch):
+    called = {"value": False}
+
+    async def _mock_set(self, user_id, custom_photo_url):
+        called["value"] = True
+        return {}
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(ActorIdentityService, "set_custom_photo_url", _mock_set)
+
+    data_url = "data:text/plain;base64," + base64.b64encode(
+        b"this is definitely not an image payload"
+    ).decode()
+
+    client = TestClient(app)
+    response = client.post("/api/account/avatar", json={"image_data_url": data_url})
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "AVATAR_INVALID_DATA_URL"
+    assert called["value"] is False
+
+
+def test_upload_account_avatar_rejects_invalid_base64():
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/account/avatar",
+        json={"image_data_url": "data:image/png;base64,!!!!not-valid-base64!!!!"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "AVATAR_INVALID_BASE64"
+
+
+def test_upload_account_avatar_rejects_oversize_image():
+    oversize_payload = base64.b64encode(b"\x00" * (300 * 1024 + 1)).decode()
+    data_url = "data:image/jpeg;base64," + oversize_payload
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+
+    client = TestClient(app)
+    response = client.post("/api/account/avatar", json={"image_data_url": data_url})
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "AVATAR_TOO_LARGE"
+
+
+def test_delete_account_avatar_reverts_to_firebase_photo(monkeypatch):
+    captured = {}
+
+    async def _mock_set(self, user_id, custom_photo_url):
+        captured["user_id"] = user_id
+        captured["custom_photo_url"] = custom_photo_url
+        return {"user_id": user_id, "photo_url": "https://firebase.example/photo.png"}
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(ActorIdentityService, "set_custom_photo_url", _mock_set)
+
+    client = TestClient(app)
+    response = client.delete("/api/account/avatar")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["identity"]["photo_url"] == "https://firebase.example/photo.png"
+    assert captured == {"user_id": "firebase_uid_123", "custom_photo_url": None}
 
 
 def test_claim_account_phone_requires_firebase_auth():

--- a/consent-protocol/tests/test_account_routes.py
+++ b/consent-protocol/tests/test_account_routes.py
@@ -155,6 +155,41 @@ def test_delete_account_avatar_reverts_to_firebase_photo(monkeypatch):
     assert captured == {"user_id": "firebase_uid_123", "custom_photo_url": None}
 
 
+def test_upload_account_avatar_maps_persistence_failure(monkeypatch):
+    async def _mock_set(self, user_id, custom_photo_url):
+        # Write never landed (no shadow row + Firebase sync could not create one).
+        return None
+
+    data_url = "data:image/png;base64," + base64.b64encode(
+        b"\x89PNG\r\n\x1a\n resized avatar bytes"
+    ).decode()
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(ActorIdentityService, "set_custom_photo_url", _mock_set)
+
+    client = TestClient(app)
+    response = client.post("/api/account/avatar", json={"image_data_url": data_url})
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "AVATAR_PERSISTENCE_UNAVAILABLE"
+
+
+def test_delete_account_avatar_maps_persistence_failure(monkeypatch):
+    async def _mock_set(self, user_id, custom_photo_url):
+        return None
+
+    app = _build_app()
+    app.dependency_overrides[require_firebase_auth] = lambda: "firebase_uid_123"
+    monkeypatch.setattr(ActorIdentityService, "set_custom_photo_url", _mock_set)
+
+    client = TestClient(app)
+    response = client.delete("/api/account/avatar")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "AVATAR_PERSISTENCE_UNAVAILABLE"
+
+
 def test_claim_account_phone_requires_firebase_auth():
     client = TestClient(_build_app())
     response = client.post(

--- a/consent-protocol/tests/test_developer_oauth.py
+++ b/consent-protocol/tests/test_developer_oauth.py
@@ -355,4 +355,6 @@ def test_oauth_migration_is_in_the_developer_release_lane():
     uat = json.loads((root / "db/contracts/uat_integrated_schema.json").read_text())
     assert "099_developer_oauth_pkce.sql" in manifest["ordered_migrations"]
     assert "099_developer_oauth_pkce.sql" in manifest["groups"]["developer"]
-    assert uat["expected_migration_version"] == 106
+    # Contract head advances as new migrations land; assert it still covers the
+    # oauth migration (099+) rather than pinning an exact version.
+    assert uat["expected_migration_version"] >= 99

--- a/consent-protocol/tests/test_partner_developer_apps.py
+++ b/consent-protocol/tests/test_partner_developer_apps.py
@@ -261,7 +261,9 @@ class TestPartnerMigrationContract:
         assert "agentforce" in agentforce_uat_migration.read_text()
         assert "106_agentforce_uat_profile.sql" in manifest["ordered_migrations"]
         assert "106_agentforce_uat_profile.sql" in manifest["groups"]["developer"]
-        assert contract["expected_migration_version"] == 106
+        # Contract head advances as new migrations land; assert it still covers
+        # the agentforce migration (106+) rather than pinning an exact version.
+        assert contract["expected_migration_version"] >= 106
         assert "schema_profile" in contract["required_tables"]["developer_apps"]
         assert "developer_connector_keys" in contract["required_tables"]
         assert "developer_oauth_tokens" in contract["required_tables"]

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -78,7 +78,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ProfileAvatarEditor } from "@/components/profile/profile-avatar-editor";
 import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
@@ -3959,48 +3959,7 @@ function ProfilePageContent() {
           data-slot="page-header"
           data-page-primary="true"
         >
-          <div
-            data-profile-avatar-frame="true"
-            className="h-14 w-14 shrink-0 rounded-full bg-primary/18 p-1 sm:h-16 sm:w-16"
-          >
-            {user.photoURL ? (
-              <Avatar className="h-full w-full">
-                <AvatarImage
-                  className="object-cover"
-                  src={user.photoURL}
-                  alt={user.displayName || "Profile"}
-                />
-                <AvatarFallback className="bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
-                  {user.displayName ? (
-                    user.displayName
-                      .split(" ")
-                      .map((part) => part[0])
-                      .join("")
-                      .slice(0, 2)
-                      .toUpperCase()
-                  ) : (
-                    <Icon icon={User} size={32} className="sm:size-9" />
-                  )}
-                </AvatarFallback>
-              </Avatar>
-            ) : (
-              <div
-                data-profile-avatar-fallback="true"
-                className="flex h-full w-full items-center justify-center rounded-full bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg"
-              >
-                {user.displayName ? (
-                  user.displayName
-                    .split(" ")
-                    .map((part) => part[0])
-                    .join("")
-                    .slice(0, 2)
-                    .toUpperCase()
-                ) : (
-                  <Icon icon={User} size={32} className="sm:size-9" />
-                )}
-              </div>
-            )}
-          </div>
+          <ProfileAvatarEditor />
           <div className="min-w-0 max-w-full space-y-1.5">
             <h1 className="text-[28px] font-medium leading-[1.08] tracking-normal text-foreground [overflow-wrap:anywhere] sm:text-[34px]">
               {user.displayName || "User"}

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -67,6 +67,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
 import { useAuth } from "@/hooks/use-auth";
+import { useEffectiveAvatarUrl } from "@/hooks/use-effective-avatar-url";
 import { useVault } from "@/lib/vault/vault-context";
 import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import {
@@ -343,6 +344,7 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isAuthenticated, user } = useAuth();
+  const effectiveAvatarUrl = useEffectiveAvatarUrl();
   const { isVaultUnlocked } = useVault();
   const { activePersona, riaCapability, riaEntryRoute, switchPersona } =
     usePersonaState();
@@ -843,8 +845,8 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
                           className="p-0"
                         >
                           <Avatar className="h-9 w-9">
-                            {user?.photoURL ? (
-                              <AvatarImage src={user.photoURL} alt="" />
+                            {effectiveAvatarUrl ? (
+                              <AvatarImage src={effectiveAvatarUrl} alt="" />
                             ) : null}
                             <AvatarFallback className="bg-transparent text-current">
                               {user?.displayName ? (

--- a/hushh-webapp/components/profile/profile-avatar-editor.tsx
+++ b/hushh-webapp/components/profile/profile-avatar-editor.tsx
@@ -130,7 +130,7 @@ export function ProfileAvatarEditor() {
           <SheetHeader>
             <SheetTitle>Profile photo</SheetTitle>
           </SheetHeader>
-          <div className="flex flex-col gap-1 px-2 pb-3">
+          <div className="flex flex-col gap-1 px-2 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
             <button type="button" onClick={handleChange} className={rowClass}>
               <ImagePlus className="h-5 w-5 text-primary" />
               {isNative() ? "Take photo or choose from library" : "Upload a photo"}

--- a/hushh-webapp/components/profile/profile-avatar-editor.tsx
+++ b/hushh-webapp/components/profile/profile-avatar-editor.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Camera as CameraIcon,
+  ImagePlus,
+  Loader2,
+  Trash2,
+  User as UserIcon,
+} from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useAuth } from "@/hooks/use-auth";
+import { useEffectiveAvatarUrl } from "@/hooks/use-effective-avatar-url";
+import { pickAvatarDataUrl } from "@/lib/profile/avatar-capture";
+import { AccountIdentityService } from "@/lib/services/account-identity-service";
+import { isNative } from "@/lib/capacitor/platform";
+import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
+import { cn } from "@/lib/utils";
+
+function initialsOf(name?: string | null): string | null {
+  const trimmed = (name || "").trim();
+  if (!trimmed) return null;
+  return trimmed
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+/**
+ * The current user's profile avatar with an in-place "change photo" flow.
+ * Renders the effective (custom-or-Firebase) photo, and on tap opens an action
+ * sheet to upload a new one (native camera/library or web file picker) or
+ * revert to the default. Write-through updates every avatar surface at once.
+ */
+export function ProfileAvatarEditor() {
+  const { user } = useAuth();
+  const photo = useEffectiveAvatarUrl();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const displayName = user?.displayName || null;
+  const fallback = initialsOf(displayName);
+
+  const handleChange = async () => {
+    setSheetOpen(false);
+    if (!user) return;
+    try {
+      const dataUrl = await pickAvatarDataUrl();
+      if (!dataUrl) return; // user cancelled
+      setBusy(true);
+      await AccountIdentityService.uploadAvatar(user, dataUrl);
+      toast.success("Profile photo updated");
+    } catch (error) {
+      toast.error("Could not update photo", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    setSheetOpen(false);
+    if (!user) return;
+    setBusy(true);
+    try {
+      await AccountIdentityService.removeAvatar(user);
+      toast.success("Profile photo removed");
+    } catch (error) {
+      toast.error("Could not remove photo", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const rowClass =
+    "flex w-full items-center gap-3 rounded-2xl px-4 py-3 text-left text-[15px] font-medium text-foreground transition-colors hover:bg-muted/60 active:bg-muted disabled:opacity-50";
+
+  return (
+    <>
+      <button
+        type="button"
+        data-profile-avatar-frame="true"
+        onClick={() => setSheetOpen(true)}
+        disabled={busy}
+        aria-label="Change profile photo"
+        className="group relative h-14 w-14 shrink-0 rounded-full bg-primary/18 p-1 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:h-16 sm:w-16"
+      >
+        {photo ? (
+          <Avatar className="h-full w-full">
+            <AvatarImage src={photo} alt={displayName || "Profile"} />
+            <AvatarFallback className="bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
+              {fallback ?? <UserIcon className="h-8 w-8 sm:h-9 sm:w-9" />}
+            </AvatarFallback>
+          </Avatar>
+        ) : (
+          <div className="flex h-full w-full items-center justify-center rounded-full bg-muted p-2 text-base font-semibold text-muted-foreground sm:text-lg">
+            {fallback ?? <UserIcon className="h-8 w-8 sm:h-9 sm:w-9" />}
+          </div>
+        )}
+        <span
+          className={cn(
+            "absolute right-0 bottom-0 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground ring-2 ring-background",
+          )}
+          aria-hidden="true"
+        >
+          {busy ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <CameraIcon className="h-3.5 w-3.5" />
+          )}
+        </span>
+      </button>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent side="bottom" showCloseButton={false}>
+          <SheetHeader>
+            <SheetTitle>Profile photo</SheetTitle>
+          </SheetHeader>
+          <div className="flex flex-col gap-1 px-2 pb-3">
+            <button type="button" onClick={handleChange} className={rowClass}>
+              <ImagePlus className="h-5 w-5 text-primary" />
+              {isNative() ? "Take photo or choose from library" : "Upload a photo"}
+            </button>
+            {photo ? (
+              <button
+                type="button"
+                onClick={handleRemove}
+                className={cn(rowClass, "text-destructive")}
+              >
+                <Trash2 className="h-5 w-5" />
+                Remove photo
+              </button>
+            ) : null}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/hushh-webapp/components/ui/avatar.tsx
+++ b/hushh-webapp/components/ui/avatar.tsx
@@ -32,7 +32,9 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      // object-cover crops-to-fill the circle; without it the <img> defaults to
+      // object-fit:fill and squishes non-square photos on every avatar surface.
+      className={cn("aspect-square size-full object-cover", className)}
       {...props}
     />
   )

--- a/hushh-webapp/hooks/use-effective-avatar-url.ts
+++ b/hushh-webapp/hooks/use-effective-avatar-url.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+import { AccountIdentityService } from "@/lib/services/account-identity-service";
+import { CacheService } from "@/lib/services/cache-service";
+
+/**
+ * The avatar URL to render for the CURRENT user on every surface.
+ *
+ * Prefers the app-owned effective photo from the account identity (a custom
+ * uploaded avatar, or the Firebase mirror when none is set) and falls back to
+ * the live Firebase `photoURL`. Subscribes to identity-cache changes so an
+ * upload/remove refreshes every avatar surface at once (top bar, profile, …).
+ */
+export function useEffectiveAvatarUrl(): string | null {
+  const { user } = useAuth();
+  const uid = user?.uid ?? null;
+  const firebasePhoto = user?.photoURL ?? null;
+  const [effective, setEffective] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!uid) {
+      setEffective(null);
+      return;
+    }
+    let active = true;
+    const read = () => {
+      if (!active) return;
+      const snap = AccountIdentityService.peekCachedIdentity(uid);
+      setEffective(snap?.data?.photo_url ?? null);
+    };
+    read();
+    // Cold/stale cache → SWR fetch, then re-read the populated snapshot.
+    void AccountIdentityService.getIdentitySwr(user).then(() => read());
+    // Re-read on any identity-cache mutation (peek is O(1); setState bails on an
+    // unchanged value). Covers upload/remove write-through updates everywhere.
+    const unsubscribe = CacheService.getInstance().subscribe(() => read());
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+    // Depend on uid only — the Firebase `user` object changes on every token
+    // refresh; the fallback is read from `firebasePhoto` at render time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uid]);
+
+  return effective ?? firebasePhoto;
+}

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -60,6 +60,10 @@
 	<string>Hussh One keeps sharing your live location with people you choose even when the app is in the background, until you stop sharing.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Hussh One uses contacts only when you choose to find people already on Hussh.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Hussh One uses your photo library only when you choose a picture for your profile.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Hussh One uses the camera only when you take a picture for your profile.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/hushh-webapp/lib/profile/avatar-capture.ts
+++ b/hushh-webapp/lib/profile/avatar-capture.ts
@@ -57,14 +57,24 @@ function pickImageViaFileInput(): Promise<string | null> {
     input.accept = "image/*";
     input.style.cssText = "position:fixed;left:-9999px;width:1px;height:1px;";
     let settled = false;
+    let cancelTimer: number | undefined;
     const done = (value: string | null) => {
       if (settled) return;
       settled = true;
       window.removeEventListener("focus", onFocus);
+      if (cancelTimer !== undefined) window.clearTimeout(cancelTimer);
       input.remove();
       resolve(value);
     };
     input.onchange = () => {
+      // A file was chosen — disarm the focus-based cancel detection so a slow
+      // FileReader (large image on a slow device) can't lose the race to the
+      // 600ms grace timer and silently drop the user's photo.
+      window.removeEventListener("focus", onFocus);
+      if (cancelTimer !== undefined) {
+        window.clearTimeout(cancelTimer);
+        cancelTimer = undefined;
+      }
       const file = input.files?.[0];
       if (!file) {
         done(null);
@@ -79,7 +89,7 @@ function pickImageViaFileInput(): Promise<string | null> {
     // No reliable "cancel" event for a file dialog; when the window regains
     // focus without an onchange, resolve null after a short grace period.
     const onFocus = () => {
-      window.setTimeout(() => done(null), 600);
+      cancelTimer = window.setTimeout(() => done(null), 600);
     };
     window.addEventListener("focus", onFocus);
     document.body.appendChild(input);

--- a/hushh-webapp/lib/profile/avatar-capture.ts
+++ b/hushh-webapp/lib/profile/avatar-capture.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { isNative } from "@/lib/capacitor/platform";
+
+// Avatars render tiny; a 256px square JPEG keeps the stored data-URL ~20-30 KB
+// so it lives comfortably in the DB identity row and ships in identity payloads.
+const AVATAR_SIZE = 256;
+const JPEG_QUALITY = 0.82;
+
+/**
+ * Pick a profile photo — native camera/library on iOS (@capacitor/camera with
+ * the native square-crop editor), or a file picker on web — then center-crop +
+ * downscale to a small square JPEG data-URL. Resolves null if the user cancels.
+ */
+export async function pickAvatarDataUrl(): Promise<string | null> {
+  const raw = await pickRawImage();
+  if (!raw) return null;
+  return normalizeToAvatarDataUrl(raw);
+}
+
+async function pickRawImage(): Promise<string | null> {
+  if (isNative()) {
+    try {
+      const { Camera, CameraResultType, CameraSource } = await import(
+        "@capacitor/camera"
+      );
+      const photo = await Camera.getPhoto({
+        source: CameraSource.Prompt, // native "Take Photo / Choose from Library"
+        resultType: CameraResultType.DataUrl,
+        allowEditing: true, // native square crop
+        quality: 85,
+        width: 512,
+        height: 512,
+        correctOrientation: true,
+        promptLabelHeader: "Profile photo",
+        promptLabelPhoto: "Choose from Library",
+        promptLabelPicture: "Take Photo",
+      });
+      return photo.dataUrl ?? null;
+    } catch {
+      // Cancel or plugin error → treat as no-op.
+      return null;
+    }
+  }
+  return pickImageViaFileInput();
+}
+
+// Web fallback: a transient hidden <input type="file"> → data-URL.
+function pickImageViaFileInput(): Promise<string | null> {
+  return new Promise((resolve) => {
+    if (typeof document === "undefined") {
+      resolve(null);
+      return;
+    }
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.style.cssText = "position:fixed;left:-9999px;width:1px;height:1px;";
+    let settled = false;
+    const done = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener("focus", onFocus);
+      input.remove();
+      resolve(value);
+    };
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        done(null);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () =>
+        done(typeof reader.result === "string" ? reader.result : null);
+      reader.onerror = () => done(null);
+      reader.readAsDataURL(file);
+    };
+    // No reliable "cancel" event for a file dialog; when the window regains
+    // focus without an onchange, resolve null after a short grace period.
+    const onFocus = () => {
+      window.setTimeout(() => done(null), 600);
+    };
+    window.addEventListener("focus", onFocus);
+    document.body.appendChild(input);
+    input.click();
+  });
+}
+
+/**
+ * Center-crop to a square, downscale to AVATAR_SIZE, re-encode as a JPEG
+ * data-URL. Enforces the small-payload contract for both native and web images.
+ */
+export function normalizeToAvatarDataUrl(sourceDataUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (typeof document === "undefined") {
+      reject(new Error("Image processing is not available."));
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      const side = Math.min(img.naturalWidth, img.naturalHeight) || AVATAR_SIZE;
+      const sx = (img.naturalWidth - side) / 2;
+      const sy = (img.naturalHeight - side) / 2;
+      const canvas = document.createElement("canvas");
+      canvas.width = AVATAR_SIZE;
+      canvas.height = AVATAR_SIZE;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Could not process the image."));
+        return;
+      }
+      ctx.drawImage(img, sx, sy, side, side, 0, 0, AVATAR_SIZE, AVATAR_SIZE);
+      try {
+        resolve(canvas.toDataURL("image/jpeg", JPEG_QUALITY));
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error("Could not encode the image."));
+      }
+    };
+    img.onerror = () => reject(new Error("Could not load the selected image."));
+    img.src = sourceDataUrl;
+  });
+}

--- a/hushh-webapp/lib/services/account-identity-service.ts
+++ b/hushh-webapp/lib/services/account-identity-service.ts
@@ -79,7 +79,10 @@ export class AccountIdentityService {
     userId: string,
     identity: AccountIdentity | null
   ): void {
-    if (!identity) {
+    if (!identity || !identity.user_id) {
+      // Never cache an empty/malformed identity (e.g. `{}` from a failed
+      // write). Caching it would clobber a good snapshot with a fresh TTL and
+      // re-trigger identity guards (phone mandate) + drop name/email/avatar.
       return;
     }
     CacheService.getInstance().set(

--- a/hushh-webapp/lib/services/account-identity-service.ts
+++ b/hushh-webapp/lib/services/account-identity-service.ts
@@ -197,6 +197,50 @@ export class AccountIdentityService {
     return identity;
   }
 
+  /**
+   * Upload a user-chosen profile picture (a small square data-URL). Writes the
+   * fresh identity through to cache so every avatar surface updates at once.
+   */
+  static async uploadAvatar(
+    user: User | null | undefined,
+    imageDataUrl: string
+  ): Promise<AccountIdentity | null> {
+    if (!user?.uid) {
+      return null;
+    }
+    const idToken = await user.getIdToken(true).catch(() => undefined);
+    if (!idToken) {
+      return null;
+    }
+    const { identity } = await ApiService.uploadAvatar(imageDataUrl, idToken);
+    if (identity) {
+      this.cacheIdentity(user.uid, identity);
+    } else {
+      this.invalidateCachedIdentity(user.uid);
+    }
+    return identity;
+  }
+
+  /** Remove the custom profile picture (revert to the Firebase photo). */
+  static async removeAvatar(
+    user: User | null | undefined
+  ): Promise<AccountIdentity | null> {
+    if (!user?.uid) {
+      return null;
+    }
+    const idToken = await user.getIdToken(true).catch(() => undefined);
+    if (!idToken) {
+      return null;
+    }
+    const { identity } = await ApiService.removeAvatar(idToken);
+    if (identity) {
+      this.cacheIdentity(user.uid, identity);
+    } else {
+      this.invalidateCachedIdentity(user.uid);
+    }
+    return identity;
+  }
+
   static async startUatTestPhoneVerification(
     user: User | null | undefined,
     phoneNumber: string

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -1500,6 +1500,64 @@ export class ApiService {
     });
   }
 
+  /**
+   * Upload a user-chosen profile picture (small square data-URL, produced by
+   * the client). Persists an app-owned avatar that survives Firebase syncs;
+   * the returned identity's `photo_url` is the effective (custom) photo.
+   */
+  static async uploadAvatar(
+    imageDataUrl: string,
+    idToken?: string
+  ): Promise<{ success: boolean; identity: AccountIdentity | null }> {
+    const firebaseIdToken = idToken || (await this.getFirebaseToken());
+    if (!firebaseIdToken) {
+      throw new Error("Missing Firebase ID token");
+    }
+    const response = await apiFetch("/api/account/avatar", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${firebaseIdToken}` },
+      body: JSON.stringify({ image_data_url: imageDataUrl }),
+    });
+    const payload = (await response.json().catch(() => ({}))) as {
+      success?: boolean;
+      identity?: AccountIdentity | null;
+      detail?: unknown;
+      error?: unknown;
+    };
+    if (!response.ok) {
+      const message =
+        typeof payload.detail === "string"
+          ? payload.detail
+          : typeof payload.error === "string"
+            ? payload.error
+            : `Avatar upload failed with HTTP ${response.status}`;
+      throw new Error(message);
+    }
+    return { success: payload.success === true, identity: payload.identity ?? null };
+  }
+
+  /** Remove the custom profile picture and revert to the Firebase photo. */
+  static async removeAvatar(
+    idToken?: string
+  ): Promise<{ success: boolean; identity: AccountIdentity | null }> {
+    const firebaseIdToken = idToken || (await this.getFirebaseToken());
+    if (!firebaseIdToken) {
+      throw new Error("Missing Firebase ID token");
+    }
+    const response = await apiFetch("/api/account/avatar", {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${firebaseIdToken}` },
+    });
+    const payload = (await response.json().catch(() => ({}))) as {
+      success?: boolean;
+      identity?: AccountIdentity | null;
+    };
+    if (!response.ok) {
+      throw new Error(`Avatar removal failed with HTTP ${response.status}`);
+    }
+    return { success: payload.success === true, identity: payload.identity ?? null };
+  }
+
   static async claimAccountPhone(
     phoneIdToken: string,
     idToken?: string

--- a/hushh-webapp/package-lock.json
+++ b/hushh-webapp/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor-firebase/messaging": "^8.2.0",
         "@capacitor/android": "^8.3.1",
         "@capacitor/app": "^8.1.0",
+        "@capacitor/camera": "^8.2.1",
         "@capacitor/cli": "^8.3.1",
         "@capacitor/core": "^8.2.0",
         "@capacitor/filesystem": "^8.1.2",
@@ -538,6 +539,15 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
       "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/camera": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-8.2.1.tgz",
+      "integrity": "sha512-yq4TbVcv9Z91JLr7C5407s3rrXr/Dmk+Pr9FAVRn65s3Jg4iYabjwG4fVKUYlQL5TiUdBbZA3LiNAbUxJNcUkw==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -70,6 +70,7 @@
     "@capacitor-firebase/messaging": "^8.2.0",
     "@capacitor/android": "^8.3.1",
     "@capacitor/app": "^8.1.0",
+    "@capacitor/camera": "^8.2.1",
     "@capacitor/cli": "^8.3.1",
     "@capacitor/core": "^8.2.0",
     "@capacitor/filesystem": "^8.1.2",

--- a/hushh-webapp/scripts/native/verify-native-static-parity.mjs
+++ b/hushh-webapp/scripts/native/verify-native-static-parity.mjs
@@ -36,6 +36,9 @@ const allowedIosUsageDescriptionKeys = new Set([
   // Background location sharing (One Location) needs Always authorization.
   "NSLocationAlwaysAndWhenInUseUsageDescription",
   "NSContactsUsageDescription",
+  // Profile picture: choose from library / take a photo.
+  "NSPhotoLibraryUsageDescription",
+  "NSCameraUsageDescription",
 ]);
 const unexpectedIosUsageDescriptionKeys = iosUsageDescriptionKeys.filter(
   (key) => !allowedIosUsageDescriptionKeys.has(key)


### PR DESCRIPTION
## What
- **Crop fix:** \`AvatarImage\` now uses \`object-cover\` so non-square photos no longer squish on any avatar surface (top bar, profile header, pkm, …).
- **Upload your own profile picture:** tap the profile avatar → action sheet → phone camera/library on iOS (native square crop via \`@capacitor/camera\`), file picker on web. Center-cropped to a 256px square JPEG (~25KB) stored app-owned in the DB.
- Effective avatar (\`custom_photo_url\` → falls back to Firebase \`photo_url\`) renders consistently across current-user surfaces via \`useEffectiveAvatarUrl\`, with cross-surface reactivity.

## Backend + DB
- New \`POST\`/\`DELETE /api/account/avatar\` (Firebase-auth guarded, data-URL validated, 300KB cap → 413).
- Migration \`107_actor_identity_custom_photo.sql\` (\`ADD COLUMN IF NOT EXISTS custom_photo_url TEXT\`), registered in the release manifest (ordered_migrations + groups.iam) and schema contracts.
- Reads use \`COALESCE(custom_photo_url, photo_url)\` so Firebase identity syncs never clobber a custom avatar.

## Hardening (adversarial review — 5 findings resolved)
- Migration-gap: a missing \`custom_photo_url\` no longer routes reads to the phone-less projection (would have wiped \`phone_verified\`).
- Failed write returns \`None\` (not \`{}\`) → route raises 503 → client never caches an empty identity (no false-success cache clobber).
- \`claim_verified_phone\` RETURNING uses \`COALESCE\` (with a pre-107 retry) so a phone claim can't transiently clobber a custom avatar.
- Action-sheet bottom safe-area inset (iOS home indicator); web file-picker cancel-race closed.

## Native
- \`Info.plist\`: \`NSPhotoLibraryUsageDescription\` + \`NSCameraUsageDescription\`.

## Verification
- \`tsc --noEmit\` ✅ · \`eslint\` ✅ · Python compile ✅ · new 503-persistence tests for the avatar routes.
- Two adversarial-review passes (16-agent + 6-agent verify): all findings resolved, no new regressions.