### PR TITLE
chore(ops): add emergency production dispatcher

### DIFF
--- a/.codex/skills/repo-operations/references/operations-surface.md
+++ b/.codex/skills/repo-operations/references/operations-surface.md
@@ -51,4 +51,4 @@ Use this reference to orient DevOps work in `hushh-research`.
 3. A bypass-listed actor may still waive the review gate when the live branch protection allows it.
 4. The sanctioned `main` owner-bypass cohort is intentional policy, not a finding, when it exactly matches `config/ci-governance.json` and includes `kushaltrivedi5`.
 5. Merge-queue rules remain separate from review bypass and are satisfied through the dedicated `main-bypass-queue` owner team.
-6. The privileged `main` bypass cohort may dispatch UAT manually; only `kushaltrivedi5` may dispatch Production.
+6. The privileged `main` bypass cohort may dispatch UAT manually; only `production.manual_dispatch_users` may dispatch Production.

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Report production deploy lane
         run: |
-          echo "Owner-only production deploy: using production environment."
+          echo "Governed production deploy: using production environment."
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -119,7 +119,8 @@
   "production": {
     "required_post_merge_check": "Main Post-Merge Smoke Gate",
     "manual_dispatch_users": [
-      "kushaltrivedi5"
+      "kushaltrivedi5",
+      "ankitkumarsingh1702"
     ],
     "owner_environment": "production"
   }

--- a/docs/reference/architecture/architecture-view-catalog.md
+++ b/docs/reference/architecture/architecture-view-catalog.md
@@ -446,7 +446,7 @@ flowchart TB
     main["main"]
     smoke["Main Post-Merge Smoke Gate"]
     uatWorkflow["Deploy to UAT<br/>manual exact green main SHA"]
-    prodWorkflow["Deploy to Production<br/>owner-only exact green main SHA"]
+    prodWorkflow["Deploy to Production<br/>governed exact green main SHA"]
   end
 
   subgraph uat["UAT hosted runtime"]

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -131,7 +131,7 @@ Before deleting a local backup branch, classify its unique commits as:
 2. Production deploys only through a manual workflow dispatch with an explicit green `main` SHA.
 3. The workflow validates that the SHA is reachable from `origin/main`.
 4. The workflow also validates that `Main Post-Merge Smoke Gate` succeeded for that SHA before deployment starts.
-5. Only `kushaltrivedi5` may dispatch the production workflow after the SHA preflight passes.
+5. Only actors listed in `production.manual_dispatch_users` may dispatch the production workflow after the SHA preflight passes.
 6. The canonical GitHub deployment environment for this lane is `production`.
 
 ## Protected Surfaces & Trust Model
@@ -179,15 +179,16 @@ outside it, and the boundaries are enforced, not informal:
 |---|---|---|---|
 | Merge cohort | `allowed-maintainers-to-approve` team | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
 | UAT deploy cohort | same as merge cohort | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
-| Production deploy cohort | `kushaltrivedi5` only | dispatch production deploy | `production.manual_dispatch_users` |
+| Production deploy cohort | `kushaltrivedi5`, `ankitkumarsingh1702` | dispatch production deploy | `production.manual_dispatch_users` |
 
 Invariants enforced in CI by `verify-deployment-environment-governance.py`:
 
 - **UAT == merge cohort.** Anyone trusted to land code on `main` may validate it
   in the UAT sandbox — no more, no less. The two lists are held equal and any
   independent drift fails the check.
-- **Production == owner only.** `production.manual_dispatch_users` must be exactly
-  `["kushaltrivedi5"]`; any widening fails the check.
+- **Production == approved dispatch cohort.** `production.manual_dispatch_users`
+  must be exactly `["kushaltrivedi5", "ankitkumarsingh1702"]`; any independent
+  widening or narrowing fails the check.
 
 ### Rule: deploy-actor lists are governance, not routine config
 
@@ -208,7 +209,7 @@ cannot actually approve on `main`).
 #      main.review_bypass_users
 #      main.merge_queue_bypass_users
 #      uat.manual_dispatch_users        (held equal to the merge cohort)
-#    Leave production.manual_dispatch_users = ["kushaltrivedi5"] unless the owner says otherwise.
+#    Leave production.manual_dispatch_users unchanged unless the owner says otherwise.
 
 # 2. Push intent to GitHub (idempotent). Dry-run first, then apply:
 python3 scripts/ci/apply-governance.py
@@ -299,7 +300,7 @@ The production workflow uses one active GitHub environment name:
 
 | Environment | Intended use |
 |---|---|
-| `production` | Owner-only production deploy lane for `kushaltrivedi5` |
+| `production` | Governed production deploy lane for `kushaltrivedi5` and `ankitkumarsingh1702` |
 
 The UAT workflow uses one active GitHub environment name:
 
@@ -309,8 +310,8 @@ The UAT workflow uses one active GitHub environment name:
 
 Operational rules:
 
-1. Only `kushaltrivedi5` may dispatch the production workflow.
-2. Other developers may still merge to `main` through PR flow, but production dispatch remains owner-only.
+1. Only actors listed in `production.manual_dispatch_users` may dispatch the production workflow.
+2. Other developers may still merge to `main` through PR flow, but production dispatch remains restricted to the production dispatch cohort.
 3. `production` should not require reviewers and should not allow admin bypass.
 4. Verify the live setup with `../../../scripts/ci/verify-production-environment-governance.sh`.
 5. Verify both deploy lanes together with `../../../scripts/ci/verify-deployment-environment-governance.py`.

--- a/docs/reference/operations/ci.md
+++ b/docs/reference/operations/ci.md
@@ -339,7 +339,7 @@ Practical maintainer rule:
 2. A successful `Main Post-Merge Smoke` run produces the only deployable source of truth: the green `main` SHA.
 3. UAT deploys only by an explicit manual dispatch of that green `main` SHA through `.github/workflows/deploy-uat.yml`.
 4. Manual UAT dispatch is limited to `kushaltrivedi5`, `Akash-292`, `RGlodAkshat`, and `ankitkumarsingh1702`.
-5. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only `kushaltrivedi5` may trigger it.
+5. Production deploys only through a manual SHA dispatch in `.github/workflows/deploy-production.yml`, and only actors listed in `production.manual_dispatch_users` may trigger it.
 6. Manual UAT or production redeploys must use a SHA that is reachable from `origin/main` and already green in post-merge smoke.
 7. Feature or hotfix branches never deploy directly; they merge through `main`.
 

--- a/scripts/ci/verify-deployment-environment-governance.py
+++ b/scripts/ci/verify-deployment-environment-governance.py
@@ -14,6 +14,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = REPO_ROOT / "config" / "ci-governance.json"
 DEFAULT_REPO = "hushh-labs/hushh-research"
+PRODUCTION_MANUAL_DISPATCH_USERS = ["kushaltrivedi5", "ankitkumarsingh1702"]
 
 
 def _gh_json(*args: str) -> dict:
@@ -58,9 +59,10 @@ def _assert_surface(surface: str, repo: str, policy: dict) -> list[str]:
         errors.append(f"{env_name} should not use custom branch policies")
 
     allowed_users = surface_policy.get("manual_dispatch_users") or []
-    if surface == "production" and allowed_users != ["kushaltrivedi5"]:
+    if surface == "production" and allowed_users != PRODUCTION_MANUAL_DISPATCH_USERS:
         errors.append(
-            f"production manual dispatch policy drifted: expected ['kushaltrivedi5'], got {allowed_users}"
+            "production manual dispatch policy drifted: "
+            f"expected {PRODUCTION_MANUAL_DISPATCH_USERS}, got {allowed_users}"
         )
 
     # UAT dispatch authority must equal the merge cohort (main.review_bypass_users).


### PR DESCRIPTION
## Summary
- add ankitkumarsingh1702 to the governed production manual dispatch cohort
- update production governance verifier expectation and docs wording
- keep deploy-production.yml workflow authority intact; only the governed actor list changes

## Verification
- python3 scripts/ci/assert-governed-actor.py --surface production --actor ankitkumarsingh1702
- python3 scripts/ci/verify-deployment-environment-governance.py --surface production
- ./scripts/ci/verify-production-environment-governance.sh
- python3 -m py_compile scripts/ci/assert-governed-actor.py scripts/ci/verify-deployment-environment-governance.py
- bash scripts/ci/secret-scan.sh
- ./scripts/ci/verify-main-branch-protection.sh
- bash scripts/ci/check-dco-signoff.sh origin/main HEAD