### PR TITLE
Fix Plaid Finance setup re-entry

### DIFF
--- a/hushh-webapp/__tests__/onboarding/setup-warm-transition.contract.test.ts
+++ b/hushh-webapp/__tests__/onboarding/setup-warm-transition.contract.test.ts
@@ -120,6 +120,28 @@ describe("setup warm-transition contract", () => {
     expect(coordinator).toContain("setCallbackReadiness(true)");
   });
 
+  it("lets resolved Finance re-entry start Plaid without setup callback writes", () => {
+    const flow = read("components/kai/kai-flow.tsx");
+    const plaidConnect = flow.slice(
+      flow.indexOf("const handleConnectPlaid"),
+      flow.indexOf("useEffect(() => {\n    if (!resumePlaidAfterVault)"),
+    );
+
+    expect(flow).toContain("function isActiveFinanceSetupJourney");
+    expect(plaidConnect).toContain("let shouldSettleSetupSource = false;");
+    expect(plaidConnect).toContain("if (isActiveFinanceSetupJourney(journey))");
+    expect(plaidConnect).toContain(
+      "} else if (!PreVaultUserStateService.isSetupResolved(journey))",
+    );
+    expect(plaidConnect).toContain(
+      "Resolved-root re-entry is explicit user intent",
+    );
+    expect(plaidConnect).toContain("returnPath: shouldSettleSetupSource");
+    expect(plaidConnect).toContain(
+      "if (onSetupSourceSettled && !shouldSettleSetupSource)",
+    );
+  });
+
   it("does not send an unconfirmed Finance source choice to Kai", () => {
     const flow = read("components/kai/kai-flow.tsx");
     const settlement = flow.slice(

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -43,7 +43,10 @@ import {
   buildKaiAnalysisPreviewRoute,
   ROUTES,
 } from "@/lib/navigation/routes";
-import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
+import {
+  PreVaultUserStateService,
+  type PreVaultUserState,
+} from "@/lib/services/pre-vault-user-state-service";
 import { useScrollReset } from "@/lib/navigation/use-scroll-reset";
 import { KAI_PORTFOLIO_IMPORT_IDLE_TIMEOUT_MS } from "@/lib/services/kai-import-stream-config";
 import type { LiveHoldingPreview } from "@/lib/kai/import/live-holdings-preview";
@@ -149,6 +152,16 @@ interface QualityReport {
   diagnostics?: Record<string, unknown>;
   dropped_reasons?: Record<string, number>;
   quality_gate?: Record<string, unknown>;
+}
+
+function isActiveFinanceSetupJourney(
+  journey: PreVaultUserState | null | undefined,
+): journey is PreVaultUserState {
+  return Boolean(
+    journey &&
+      !PreVaultUserStateService.isSetupResolved(journey) &&
+      journey.onboardingActiveCapability === "finance",
+  );
 }
 
 // Streaming state
@@ -693,11 +706,7 @@ export function KaiFlow({
     const journey = await PreVaultUserStateService.bootstrapState(userId, {
       force: true,
     }).catch(() => null);
-    if (
-      !journey ||
-      PreVaultUserStateService.isSetupResolved(journey) ||
-      journey.onboardingActiveCapability !== "finance"
-    ) {
+    if (!isActiveFinanceSetupJourney(journey)) {
       return false;
     }
     setOnboardingFlowActiveCookie(false);
@@ -2969,6 +2978,7 @@ export function KaiFlow({
     }
     setIsConnectingPlaid(true);
     try {
+      let shouldSettleSetupSource = false;
       const redirectUri = resolvePlaidRedirectUri();
       const linkToken = await PlaidPortfolioService.createLinkToken({
         userId,
@@ -2988,35 +2998,37 @@ export function KaiFlow({
         const journey = await PreVaultUserStateService.bootstrapState(userId, {
           force: true,
         });
-        if (
-          journey.onboardingActiveCapability !== "finance" ||
-          PreVaultUserStateService.isSetupResolved(journey)
-        ) {
+        if (isActiveFinanceSetupJourney(journey)) {
+          shouldSettleSetupSource = true;
+          onboardingAttemptId =
+            typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+              ? crypto.randomUUID()
+              : `plaid_${Date.now().toString(36)}`;
+          await PreVaultUserStateService.syncOnboardingJourney({
+            userId,
+            phase: "external_connector",
+            activeCapability: "finance",
+            callbackState: "pending",
+            callbackAttemptId: onboardingAttemptId,
+            expectedJourneyUpdatedAt: journey.onboardingJourneyUpdatedAt,
+          });
+        } else if (!PreVaultUserStateService.isSetupResolved(journey)) {
           throw new Error("Finance setup is no longer active. Return to setup and try again.");
+        } else {
+          // Resolved-root re-entry is explicit user intent from the Finance
+          // workspace. Do not mutate setup journey state, but do allow Plaid.
         }
-        onboardingAttemptId =
-          typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-            ? crypto.randomUUID()
-            : `plaid_${Date.now().toString(36)}`;
-        await PreVaultUserStateService.syncOnboardingJourney({
-          userId,
-          phase: "external_connector",
-          activeCapability: "finance",
-          callbackState: "pending",
-          callbackAttemptId: onboardingAttemptId,
-          expectedJourneyUpdatedAt: journey.onboardingJourneyUpdatedAt,
-        });
       }
       if (linkToken.resume_session_id) {
         savePlaidOAuthResumeSession({
           version: 1,
           userId,
           resumeSessionId: linkToken.resume_session_id,
-          returnPath: onSetupSourceSettled
+          returnPath: shouldSettleSetupSource
             ? ROUTES.ONE_SETUP_FINANCE_IMPORT
             : ROUTES.KAI_DASHBOARD,
           startedAt: new Date().toISOString(),
-          onboardingAttemptId,
+          ...(onboardingAttemptId ? { onboardingAttemptId } : {}),
         });
       }
 
@@ -3063,11 +3075,16 @@ export function KaiFlow({
                   setVaultDialogOpen(true);
                   toast.info("Set up or open your private vault to save Plaid details.");
                 } else if (mode === "import") {
-                  void finishFinanceSetupIfActive("plaid", onboardingAttemptId).then((handled) => {
-                    if (handled) return;
+                  if (onSetupSourceSettled && !shouldSettleSetupSource) {
                     setOnboardingFlowActiveCookie(false);
                     router.push(ROUTES.KAI_DASHBOARD);
-                  });
+                  } else {
+                    void finishFinanceSetupIfActive("plaid", onboardingAttemptId).then((handled) => {
+                      if (handled) return;
+                      setOnboardingFlowActiveCookie(false);
+                      router.push(ROUTES.KAI_DASHBOARD);
+                    });
+                  }
                 } else {
                   setState("dashboard");
                 }


### PR DESCRIPTION
## Summary
- allow resolved-root Finance setup re-entry to start Plaid without rewriting onboarding journey state
- keep active Finance setup attempts governed by the existing external_connector callback attempt guard
- route resolved re-entry Plaid OAuth returns back to Kai dashboard instead of requiring setup callback settlement
- add a regression contract for the screenshot failure path

## RCA
After the Plaid dashboard redirect allowlist fix, production /link/token/create succeeds. The remaining failure was frontend-side: /one/setup/finance/import allows resolved-root re-entry, but KaiFlow's Plaid handler still threw "Finance setup is no longer active" whenever setupCompleted=true.

## Verification
- cd hushh-webapp && npm run test -- __tests__/onboarding/setup-warm-transition.contract.test.ts
- cd hushh-webapp && npm run typecheck
- cd hushh-webapp && npm run verify:docs