### PR TITLE
fix: use supported Vertex API preflight

### DIFF
--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -43,6 +43,14 @@ def test_backend_and_readiness_job_share_the_supported_text_model_regions() -> N
     assert "GOOGLE_CLOUD_LOCATION=asia-southeast1" not in backend_build
 
 
+def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None:
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+
+    assert "gcloud services list --enabled" in backend_build
+    assert "--filter='config.name=aiplatform.googleapis.com'" in backend_build
+    assert "gcloud services describe" not in backend_build
+
+
 def test_production_deploy_builds_candidates_without_serving_traffic() -> None:
     production_workflow = _read(".github/workflows/deploy-production.yml")
 

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -52,9 +52,11 @@ steps:
         fi
         gcloud iam service-accounts describe "${_RUNTIME_SERVICE_ACCOUNT}" \
           --project="$PROJECT_ID" >/dev/null
-        vertex_api_state="$(gcloud services describe aiplatform.googleapis.com \
-          --project="$PROJECT_ID" --format='value(state)')"
-        if [[ "${vertex_api_state}" != "ENABLED" ]]; then
+        vertex_api_name="$(gcloud services list --enabled \
+          --project="$PROJECT_ID" \
+          --filter='config.name=aiplatform.googleapis.com' \
+          --format='value(config.name)' | head -n 1)"
+        if [[ "${vertex_api_name}" != "aiplatform.googleapis.com" ]]; then
           echo "Vertex AI API must be enabled in ${PROJECT_ID}." >&2
           exit 1
         fi


### PR DESCRIPTION
## Summary
- replace the invalid `gcloud services describe` deploy preflight with the supported enabled-services query
- fail closed unless Vertex AI is enabled
- add a regression contract so the invalid command cannot return

## Verification
- `consent-protocol/.venv/bin/python -m pytest consent-protocol/tests/test_uat_deploy_no_traffic_contract.py -q`
- `scripts/ci/runtime-contract-check.sh`
- corrected command verified against the UAT project

## Deployment context
UAT run 29786387668 built the backend image successfully, then failed before candidate deployment or traffic promotion because the old preflight command does not exist.