### PR TITLE
fix: delimit readiness job environment

### DIFF
--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -39,7 +39,9 @@ def test_backend_and_readiness_job_share_the_supported_text_model_regions() -> N
     # candidate-image readiness job must prove the same configuration.
     assert backend_build.count("GOOGLE_CLOUD_LOCATION=global") == 2
     assert '"HUSHH_VERTEX_LOCATIONS=global,us,eu"' in backend_build
-    assert "HUSHH_VERTEX_LOCATIONS=global\\,us\\,eu" in backend_build
+    assert '--set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|' in backend_build
+    assert "|HUSHH_VERTEX_LOCATIONS=global,us,eu|" in backend_build
+    assert "HUSHH_VERTEX_LOCATIONS=global\\,us\\,eu" not in backend_build
     assert "GOOGLE_CLOUD_LOCATION=asia-southeast1" not in backend_build
 
 

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -256,7 +256,7 @@ steps:
           --service-account="${_RUNTIME_SERVICE_ACCOUNT}" \
           --command="python" \
           --args="scripts/verify_managed_vertex_runtime.py" \
-          --set-env-vars="HUSHH_GENAI_AUTH_MODE=vertex_adc,GOOGLE_GENAI_USE_VERTEXAI=true,GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GOOGLE_CLOUD_LOCATION=global,HUSHH_VERTEX_LOCATIONS=global\,us\,eu,AGENT_ONE_ADK_LOCATION=us-central1" \
+          --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=$PROJECT_ID|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
           --max-retries=0 \
           --task-timeout=30s \
           --quiet


### PR DESCRIPTION
## Summary
- use gcloud alternate-delimiter syntax for the candidate GenAI readiness job
- preserve the comma-separated Vertex location value as one environment value
- prevent the shell-consumed backslash form from returning

## Verification
- `consent-protocol/.venv/bin/python -m pytest consent-protocol/tests/test_uat_deploy_no_traffic_contract.py -q`
- `scripts/ci/runtime-contract-check.sh`
- Cloud Build YAML parse

## Deployment context
UAT run 29787137412 built and deployed the backend candidate at 0% traffic, then failed safely while parsing the readiness-job environment flag. Rollback preserved existing UAT traffic.