### PR TITLE
fix: make Vertex readiness probe standalone

### DIFF
--- a/consent-protocol/scripts/verify_managed_vertex_runtime.py
+++ b/consent-protocol/scripts/verify_managed_vertex_runtime.py
@@ -5,18 +5,23 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from pathlib import Path
 
-from google.adk.models.llm_request import LlmRequest
-from google.genai import types
+PROTOCOL_ROOT = Path(__file__).resolve().parents[1]
+if str(PROTOCOL_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROTOCOL_ROOT))
 
-from hushh_mcp.hushh_adk.manifest import ManifestLoader
-from hushh_mcp.runtime_providers import ManagedGeminiRuntimeBinding
+from google.adk.models.llm_request import LlmRequest  # noqa: E402
+from google.genai import types  # noqa: E402
+
+from hushh_mcp.hushh_adk.manifest import ManifestLoader  # noqa: E402
+from hushh_mcp.runtime_providers import ManagedGeminiRuntimeBinding  # noqa: E402
 
 
 def _managed_manifest_models() -> tuple[tuple[str, ...], str]:
     """Resolve probe targets from authored manifests, never a duplicate list."""
-    manifest_root = Path(__file__).resolve().parents[1] / "hushh_mcp" / "agents"
+    manifest_root = PROTOCOL_ROOT / "hushh_mcp" / "agents"
     text_models: set[str] = set()
     live_models: set[str] = set()
     for path in sorted(manifest_root.glob("*/agent.yaml")):
@@ -102,7 +107,7 @@ async def main() -> None:
     async def probe_live_setup() -> None:
         manager = live_client.aio.live.connect(
             model=live_model,
-            config=types.LiveConnectConfig(response_modalities=["AUDIO"]),
+            config=types.LiveConnectConfig(response_modalities=[types.Modality.AUDIO]),
         )
         await asyncio.wait_for(manager.__aenter__(), timeout=10)
         await manager.__aexit__(None, None, None)

--- a/consent-protocol/tests/test_managed_vertex_readiness_script.py
+++ b/consent-protocol/tests/test_managed_vertex_readiness_script.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROTOCOL_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROTOCOL_ROOT / "scripts" / "verify_managed_vertex_runtime.py"
+
+
+def test_readiness_script_imports_from_an_uninstalled_container_checkout() -> None:
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and local script path
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            (
+                "import runpy; "
+                f"runpy.run_path({str(SCRIPT_PATH)!r}, run_name='readiness_import_test')"
+            ),
+        ],
+        cwd=PROTOCOL_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- make the managed Vertex readiness script import backend packages from an uninstalled container checkout
- reuse the resolved protocol root for manifest discovery
- use the typed Live audio modality
- add an isolated-import regression matching `python scripts/...` inside the backend image

## Verification
- focused readiness/deploy tests: 8 passed
- Ruff passed
- strict mypy passed for the readiness script
- runtime contract check passed

## Deployment context
UAT run 29787797600 launched the candidate job correctly at 0% traffic, then the job failed on `ModuleNotFoundError: hushh_mcp`. The workflow rolled back without traffic promotion.