### PR TITLE
fix: bound PKM worker thinking latency

### DIFF
--- a/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_agent_lab_service.py
@@ -1406,6 +1406,14 @@ class PKMAgentLabService:
 
         config = genai_types.GenerateContentConfig(
             temperature=0.0,
+            # These calls are deterministic schema workers inside a bounded,
+            # sequential PKM graph. Gemini's default thinking can consume the
+            # shared preview deadline before the final structure contract runs.
+            # Minimal thinking preserves Gemini 3.5 Flash semantics while
+            # keeping the user-facing chain within its existing latency budget.
+            thinking_config=genai_types.ThinkingConfig(
+                thinking_level=genai_types.ThinkingLevel.MINIMAL,
+            ),
             response_mime_type="application/json",
             automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(disable=True),
             response_schema=response_schema,

--- a/consent-protocol/tests/services/test_pkm_agent_lab_service.py
+++ b/consent-protocol/tests/services/test_pkm_agent_lab_service.py
@@ -134,6 +134,27 @@ async def test_agent_contract_retries_one_timeout_within_preview_budget(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_agent_contract_uses_minimal_thinking_for_schema_workers():
+    service = PKMAgentLabService()
+    generate_content = AsyncMock(return_value=SimpleNamespace(parsed={"status": "ok"}, text=""))
+    service._client = SimpleNamespace(
+        aio=SimpleNamespace(models=SimpleNamespace(generate_content=generate_content))
+    )
+
+    result = await service._run_agent_contract(
+        manifest=SimpleNamespace(id="agent_test", model="gemini-3.5-flash"),
+        prompt="Return a valid structured response.",
+        response_schema={"type": "OBJECT"},
+        timeout_seconds=3.0,
+    )
+
+    assert result == {"status": "ok"}
+    config = generate_content.await_args.kwargs["config"]
+    assert config.thinking_config is not None
+    assert config.thinking_config.thinking_level == "MINIMAL"
+
+
+@pytest.mark.asyncio
 async def test_agent_contract_retries_transient_resource_exhausted(monkeypatch):
     class ResourceExhaustedError(Exception):
         status_code = 429


### PR DESCRIPTION
## Summary
- keep Gemini 3.5 Flash for PKM schema workers
- request minimal thinking for deterministic JSON contracts
- preserve the existing 35-second preview deadline and fail-closed evaluator

## RCA
Two no-traffic UAT candidate evaluations exhausted the shared preview budget before the final structure worker. The second run left only 6.867 seconds for that worker after earlier sequential stages.

## Impact Map
- Routes/API/schema/database/cache/mobile: unchanged
- PKM: execution latency only; authored contracts and persistence unchanged
- Trust boundary: unchanged; synthetic evaluation remains no-write
- Rollback: revert this commit; candidate deploy remains no-traffic until gates pass

## Verification
- 60 focused PKM service/evaluator tests passed
- 91 agent tests passed
- 8 ADK foundation tests passed
- ruff check/format passed
- agent hierarchy verification passed
- live synthetic Vertex case passed on gemini-3.5-flash in 9.95s with zero inner timeouts
- direct strict mypy still reports 22 pre-existing annotations in pkm_agent_lab_service.py; no new mypy finding was introduced