### PR TITLE
fix(ria): stop onboarding wizard flashing before the profile redirect

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -353,6 +353,8 @@ describe("RiaOnboardingPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("step-welcome")).toBeTruthy();
     });
+    // A fresh (setup) advisor reaches the branded wizard, not just the loader.
+    expect(screen.getByTestId("onboarding-shell")).toBeTruthy();
     expect(screen.getByTestId("shell-eyebrow").textContent).toBe("Welcome");
     expect(screen.getByTestId("welcome-type").textContent).toBe("individual");
     expect(
@@ -1059,6 +1061,32 @@ describe("RiaOnboardingPage", () => {
     await waitFor(() => {
       expect(mocks.routerReplace).toHaveBeenCalledWith("/one/profile/regulatory");
     });
+
+    // The wizard must NEVER paint for an already-onboarded advisor — the whole
+    // point of the entry guard. Regression guard for the onboarding→profile flash.
+    expect(screen.queryByTestId("onboarding-shell")).toBeNull();
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
+  });
+
+  it("holds a neutral loader (no wizard chrome) while persona state is still resolving", async () => {
+    mocks.usePersonaState.mockReturnValue({
+      refresh: mocks.refreshPersonaState,
+      riaCapability: "disabled",
+      loading: true,
+      refreshing: true,
+      riaOnboardingStatus: null,
+    });
+
+    render(<RiaOnboardingPage />);
+
+    // Until persona resolves we cannot know if the advisor is onboarded, so the
+    // branded wizard must not paint — only the neutral loader.
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("onboarding-shell")).toBeNull();
+    expect(screen.queryByTestId("step-welcome")).toBeNull();
+    expect(mocks.routerReplace).not.toHaveBeenCalled();
   });
 
   it("keeps a switch advisor in the wizard when re-verifying via ?edit=license", async () => {
@@ -1080,6 +1108,8 @@ describe("RiaOnboardingPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("step-license")).toBeTruthy();
     });
+    // Established advisor with an explicit edit intent stays in the wizard.
+    expect(screen.getByTestId("onboarding-shell")).toBeTruthy();
     expect(mocks.routerReplace).not.toHaveBeenCalled();
   });
 

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -12,7 +12,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
 import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
-import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
+import {
+  NativeTestBeacon,
+  type NativeTestDataState,
+} from "@/components/app-ui/native-test-beacon";
 import { OnboardingShell } from "@/components/ria/onboarding/onboarding-shell";
 import { OnboardingStepWelcome } from "@/components/ria/onboarding/onboarding-step-welcome";
 import { OnboardingStepLicense } from "@/components/ria/onboarding/onboarding-step-license";
@@ -216,6 +219,11 @@ export default function RiaOnboardingPage({
     normalizeRiaOnboardingDraft(undefined),
   );
   const [loading, setLoading] = useState(true);
+  // Gates the branded onboarding shell until the one-shot entry decision (below)
+  // has been made, so an already-established advisor never sees the wizard flash
+  // before the redirect to their profile. Set true once we've decided the user
+  // belongs in the wizard.
+  const [entryResolved, setEntryResolved] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [iamUnavailable, setIamUnavailable] = useState(false);
@@ -408,14 +416,24 @@ export default function RiaOnboardingPage({
   // not hijacked out of the review step. Skipped for an explicit edit intent
   // (e.g. re-verifying a licence from the profile).
   useEffect(() => {
+    // Undecided while persona state is still resolving — keep the neutral loader
+    // (in the render below) up rather than painting the branded wizard.
     if (personaLoading || personaRefreshing) return;
     if (onboardingEntryHandledRef.current) return;
     onboardingEntryHandledRef.current = true;
-    if (setupMode) return;
-    if (hasEditIntent) return;
-    if (riaCapability === "switch") {
+    // An established advisor (outside the embedded setup hub, with no explicit
+    // edit intent) belongs in their profile — redirect and DON'T reveal the
+    // wizard, so the loader stays up through the navigation and the welcome step
+    // never paints for a frame.
+    if (!setupMode && !hasEditIntent && riaCapability === "switch") {
       router.replace(buildProfileRoute({ panel: "regulatory" }));
+      return;
     }
+    // Setup / edit-intent / setup-hub / IAM-unavailable / signed-out → this user
+    // belongs in the wizard. One-shot: because onboardingEntryHandledRef is now
+    // set, a post-submit capability flip to "switch" cannot re-hide the review
+    // step.
+    setEntryResolved(true);
   }, [hasEditIntent, personaLoading, personaRefreshing, riaCapability, router, setupMode]);
 
   useEffect(() => {
@@ -965,6 +983,18 @@ export default function RiaOnboardingPage({
           ? "error"
           : "loaded";
 
+  // Hold the branded onboarding shell until BOTH the entry decision is made and
+  // the initial data fetch has settled — otherwise the welcome branding paints
+  // around renderStep's inner spinner (a second, subtler flash). `loading` is a
+  // one-time initial fetch that never re-enters true, so this can't re-hide the
+  // page after entry.
+  const bootResolved = entryResolved && !loading;
+  const beaconDataState: NativeTestDataState = bootResolved
+    ? nativeTestDataState
+    : !setupMode && !hasEditIntent && riaCapability === "switch"
+      ? "redirect-valid"
+      : "loading";
+
   function renderStep() {
     if (loading) {
       return (
@@ -1104,7 +1134,7 @@ export default function RiaOnboardingPage({
         routeId="/ria/onboarding"
         marker="native-route-ria-onboarding"
         authState={user ? "authenticated" : "anonymous"}
-        dataState={nativeTestDataState}
+        dataState={beaconDataState}
         errorCode={error ? "ria_onboarding" : null}
         errorMessage={error}
       />
@@ -1118,32 +1148,43 @@ export default function RiaOnboardingPage({
           } as CSSProperties
         }
       >
-        <OnboardingShell
-          currentStepIndex={currentStepIndex}
-          totalSteps={steps.length}
-          eyebrow={currentStep.eyebrow}
-          title={currentStep.title}
-          description={currentStep.description}
-          canContinue={canContinue}
-          saving={saving}
-          isFirstStep={currentStepIndex === 0}
-          isLastStep={currentStep.id === "review"}
-          advisoryAccessReady={advisoryAccessReady}
-          hideTerminal={setupMode && advisoryAccessReady}
-          onSkip={setupMode && !advisoryAccessReady ? onSetupSkip : undefined}
-          allowInvalidPress={currentStep.id === "services"}
-          heroImage={RIA_ONBOARDING_STEP_IMAGES[currentStep.id]}
-          onBack={handleBack}
-          onContinue={handleContinue}
-        >
-          {renderStep()}
+        {bootResolved ? (
+          <OnboardingShell
+            currentStepIndex={currentStepIndex}
+            totalSteps={steps.length}
+            eyebrow={currentStep.eyebrow}
+            title={currentStep.title}
+            description={currentStep.description}
+            canContinue={canContinue}
+            saving={saving}
+            isFirstStep={currentStepIndex === 0}
+            isLastStep={currentStep.id === "review"}
+            advisoryAccessReady={advisoryAccessReady}
+            hideTerminal={setupMode && advisoryAccessReady}
+            onSkip={setupMode && !advisoryAccessReady ? onSetupSkip : undefined}
+            allowInvalidPress={currentStep.id === "services"}
+            heroImage={RIA_ONBOARDING_STEP_IMAGES[currentStep.id]}
+            onBack={handleBack}
+            onContinue={handleContinue}
+          >
+            {renderStep()}
 
-          {error ? (
-            <div className="mt-4 rounded-[24px] border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/20 dark:text-red-400">
-              {error}
-            </div>
-          ) : null}
-        </OnboardingShell>
+            {error ? (
+              <div className="mt-4 rounded-[24px] border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/20 dark:text-red-400">
+                {error}
+              </div>
+            ) : null}
+          </OnboardingShell>
+        ) : (
+          <div
+            role="status"
+            aria-label="Loading"
+            className="flex min-h-[60dvh] items-center justify-center gap-2 text-sm text-muted-foreground"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading…
+          </div>
+        )}
       </FullscreenFlowShell>
     </>
   );

--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -17,6 +17,10 @@ import { RiaService, type RiaHomeResponse } from "@/lib/services/ria-service";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { ROUTES } from "@/lib/navigation/routes";
 import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
+import {
+  NativeTestBeacon,
+  type NativeTestDataState,
+} from "@/components/app-ui/native-test-beacon";
 import { RIA_TONE_BADGE, RIA_TONE_SURFACE } from "@/lib/ria/ria-tone";
 import { RIA_COPY } from "@/lib/ria/ria-screen-copy";
 import { cn } from "@/lib/utils";
@@ -242,6 +246,36 @@ export default function RiaHomePage() {
     ]
   );
   usePublishVoiceSurfaceMetadata(voiceSurfaceMetadata);
+
+  // Hold a neutral loader instead of painting the RIA home hero while we're about
+  // to redirect a not-onboarded user (or while persona state is still resolving),
+  // so the home chrome never flashes before landing on onboarding. Mirrors the
+  // onboarding page's entry guard. A "disabled"/IAM advisor is NOT held here
+  // (handled via homeResource.error / RiaCompatibilityState below), so an
+  // established advisor is never trapped in the loader.
+  const redirectingToOnboarding =
+    riaCapability === "setup" || riaOnboardingStatus?.exists === false;
+  if (personaLoading || personaRefreshing || redirectingToOnboarding) {
+    const holdDataState: NativeTestDataState = redirectingToOnboarding
+      ? "redirect-valid"
+      : "loading";
+    return (
+      <>
+        <NativeTestBeacon
+          routeId="/ria"
+          marker="native-route-ria-home"
+          authState={user ? "authenticated" : "pending"}
+          dataState={holdDataState}
+          errorCode={null}
+          errorMessage={null}
+        />
+        <InlineLoadingState
+          label="Loading…"
+          className="min-h-[60dvh] justify-center"
+        />
+      </>
+    );
+  }
 
   return (
     <RiaPageShell


### PR DESCRIPTION
## Problem

An already-established RIA advisor (`riaCapability === "switch"`) who lands on `/ria/onboarding` briefly sees the onboarding **welcome step flash** for ~1 frame before being redirected to their profile (`/one/profile`, regulatory panel). Reported as "first I see onboarding, then the profile screen."

## Root cause

The "established advisor → profile" decision is a **post-paint `useEffect`** gated on `!personaLoading && !personaRefreshing`. But the render path painted the branded `OnboardingShell` (welcome eyebrow/title/hero) **unconditionally** — `renderStep()` only gated on the local data-fetch `loading` flag, never on persona state. `riaCapability` starts `"disabled"` (persona `null`) and only becomes `"switch"` after an async `getPersonaState()` fetch, so the wizard paints in the gap between the local load resolving and the redirect firing. The redirect was correct — it just ran one render too late.

## Fix

Hold a **neutral loader** until the one-shot entry decision resolves, so the branded wizard never paints for a frame.

- **`app/ria/onboarding/page.tsx`** — new `entryResolved` state gates `OnboardingShell`. The entry effect now **redirects-or-reveals exactly once**:
  - established advisor (not in the embedded setup hub, no `?edit`/`?reinitiate`/`?step` intent) → `router.replace` to the profile and keep the loader up through navigation;
  - setup / edit-intent / setup-hub / IAM-unavailable / signed-out → reveal the wizard.
  - Tied to the existing one-shot `onboardingEntryHandledRef`, so a **post-submit capability flip to `"switch"` no longer re-hides the review step** (a naive capability-only guard would have regressed the rejected-submit path). The native test beacon reports `loading` / `redirect-valid` during the hold.
- **`app/ria/page.tsx`** — mirror guard: a not-onboarded user no longer flashes the RIA home hero before redirecting to onboarding. `disabled`/IAM advisors are not held (handled via the existing compatibility state), so nobody is trapped in the loader.

## Testing

- `npx vitest run __tests__/app/ria/onboarding-page.test.tsx` → **24/24 pass**, including new/strengthened assertions:
  - established (`switch`) advisor: the wizard chrome (`onboarding-shell` / `step-welcome`) **never paints** before the redirect;
  - a neutral loader is held while persona state is still resolving;
  - setup and `?edit=license` advisors still reach the wizard.
- `npm run typecheck` — clean.
- `npm run lint` (changed files, `--max-warnings=0`) — clean.

## Scope

Web/`main` only, by request. This file has diverged between `main` and the mobile/iOS branch, so the iOS build is unaffected by this PR and would need the fix applied there separately.
