### PR TITLE
fix(one): use the hushh quiet mark for the Set up One profile row

### DIFF
--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -32,7 +32,6 @@ import {
   SendHorizontal,
   ShieldCheck,
   SlidersHorizontal,
-  Sparkles,
   Trash2,
   User,
   UserRound,
@@ -3998,8 +3997,14 @@ function ProfilePageContent() {
           <div className="space-y-4 sm:space-y-5">
             <SettingsGroup title="Your settings" separatorInset>
               <SettingsRow
-                icon={Sparkles}
-                iconTone="accent"
+                leading={
+                  <span
+                    aria-hidden
+                    className="inline-flex h-8 w-8 items-center justify-center self-center rounded-[10px] bg-accent/12 text-[18px] leading-none sm:h-10 sm:w-10 sm:rounded-[12px] sm:text-[20px]"
+                  >
+                    🤫
+                  </span>
+                }
                 title={PROFILE_LABELS.setup}
                 chevron
                 density="compact"


### PR DESCRIPTION
Swaps the Set up One row's leading icon from the generic `Sparkles` lucide glyph to the hushh quiet mark (🤫), rendered in the same iOS-style icon well as the other rows. Removes the now-unused `Sparkles` import. Frontend only.