### PR TITLE
fix(one): send setup Skip/Finish home + reachable Skip on mobile

### DIFF
--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -21,6 +21,7 @@ import styles from "./one-setup-hub.module.css";
 import { useAuth } from "@/lib/firebase/auth-context";
 import { useVault } from "@/lib/vault/vault-context";
 import {
+  isOneSetupSurfaceRoute,
   normalizeInternalRouteHref,
   resolveCompletedSetupCapabilityTarget,
   ROUTES,
@@ -82,10 +83,16 @@ export function OneSetupHub() {
     runtimeChoiceSnapshot.userId === (user?.uid ?? null)
       ? runtimeChoiceSnapshot.state
       : "loading";
-  const returnTo = useMemo(
-    () => normalizeInternalRouteHref(searchParams.get("return_to")),
-    [searchParams],
-  );
+  const returnTo = useMemo(() => {
+    const raw = normalizeInternalRouteHref(searchParams.get("return_to"));
+    if (!raw) return null;
+    // Never send the master exit back onto a setup surface. A stray
+    // `?return_to=/one/setup` (e.g. from a capability/connector sub-flow that
+    // returns to the hub) would make Skip/Finish replace /one/setup with
+    // itself and look like a no-op. Fall through to home instead.
+    const path = raw.split(/[?#]/)[0] ?? raw;
+    return isOneSetupSurfaceRoute(path) ? null : raw;
+  }, [searchParams]);
   const completionTarget = returnTo || ROUTES.ONE_HOME;
 
   useEffect(() => {
@@ -308,12 +315,33 @@ export function OneSetupHub() {
       }}
     >
       <AppPageHeaderRegion>
-        <PageHeader
-          title={!hubStateLoading && allReady ? "You're all set" : "Finish setting up One"}
-          description={summary}
-          accent="neutral"
-          className={styles.setupHeader}
-        />
+        <div className="relative">
+          <PageHeader
+            title={!hubStateLoading && allReady ? "You're all set" : "Finish setting up One"}
+            description={summary}
+            accent="neutral"
+            className={styles.setupHeader}
+          />
+          {/* Mobile surfaces the master Skip/Finish action top-right in the
+              header so it is always reachable and never hides behind the fixed
+              "Talk to One" agent bar. Desktop keeps the in-flow footer below. */}
+          {!hubStateLoading ? (
+            <button
+              type="button"
+              onClick={() => void handleMasterAck()}
+              disabled={dismissing || !runtimeChoiceComplete}
+              title={
+                !runtimeChoiceComplete
+                  ? "Choose a Connections option before continuing."
+                  : undefined
+              }
+              data-testid="one-setup-master-ack-mobile"
+              className="absolute right-0 top-1 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-semibold text-[var(--app-accent)] transition hover:bg-[var(--app-accent-tint)] disabled:pointer-events-none disabled:opacity-40 sm:hidden"
+            >
+              {masterActionLabel}
+            </button>
+          ) : null}
+        </div>
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
@@ -416,29 +444,34 @@ export function OneSetupHub() {
             </SettingsGroup>
           ) : null}
         </div>
-        <SetupCompletionFooter
-          label={masterActionLabel}
-          onComplete={() => void handleMasterAck()}
-          busy={dismissing}
-          disabled={!runtimeChoiceComplete}
-          controlId="one-setup-master-ack"
-          actionId="setup.hub_master_ack"
-          testId="one-setup-master-ack"
-          purpose={
-            masterSkipped
-              ? "Skip the remaining setup for now and go home."
-              : "Finish setup for now and go home."
-          }
-          supportingText={
-            !runtimeChoiceComplete
-              ? "Choose a Connections option before continuing."
-              : masterSkipped
-              ? "You can set up these capabilities any time."
-              : "Your completed setup stays in place. You can add more any time."
-          }
-          variant={masterSkipped ? "none" : "blue-gradient"}
-          effect={masterSkipped ? "fade" : "fill"}
-        />
+        {/* Desktop keeps the calm in-flow terminal action; mobile uses the
+            top-right header action instead (the fixed agent bar would cover a
+            bottom footer on phones). */}
+        <div className="hidden sm:block">
+          <SetupCompletionFooter
+            label={masterActionLabel}
+            onComplete={() => void handleMasterAck()}
+            busy={dismissing}
+            disabled={!runtimeChoiceComplete}
+            controlId="one-setup-master-ack"
+            actionId="setup.hub_master_ack"
+            testId="one-setup-master-ack"
+            purpose={
+              masterSkipped
+                ? "Skip the remaining setup for now and go home."
+                : "Finish setup for now and go home."
+            }
+            supportingText={
+              !runtimeChoiceComplete
+                ? "Choose a Connections option before continuing."
+                : masterSkipped
+                ? "You can set up these capabilities any time."
+                : "Your completed setup stays in place. You can add more any time."
+            }
+            variant={masterSkipped ? "none" : "blue-gradient"}
+            effect={masterSkipped ? "fade" : "fill"}
+          />
+        </div>
           </>
         )}
       </AppPageContentRegion>


### PR DESCRIPTION
## Two bugs on `/one/setup` (reported after #4629)

### 1. Skip/Finish still did nothing — `return_to=/one/setup` self-navigation
The hub URL was `…/one/setup?return_to=%2Fone%2Fsetup`. The hub computes `completionTarget = returnTo || ONE_HOME`, so `return_to=/one/setup` made Skip/Finish `router.replace('/one/setup')` — replacing the hub **with itself**. (#4629 made the navigation reliable, but the target was wrong.)

**Fix:** `returnTo` now ignores any setup-surface route (`isOneSetupSurfaceRoute`) and falls through to `/one`.

### 2. Skip unreachable on phones
On mobile the footer "Skip setup" sits behind the fixed "Talk to One" agent bar, so it can't be seen/tapped.

**Fix:** mobile renders the master Skip/Finish action **top-right in the header** (`sm:hidden`); desktop keeps the in-flow `SetupCompletionFooter` (`hidden sm:block`). No `actions={` prop, so the hub terminal-action contract stays intact.

## Verification (static)
- Contract + related suites pass (one-setup-hub-terminal-action, top-app-bar, onboarding-guard, post-auth, pre-vault) — 72 tests
- typecheck + lint clean on the changed file
- Mobile visual placement to be confirmed on UAT after deploy