### PR TITLE
fix(one): stop /one/setup re-appearing after onboarding (guard + back-nav)

### DIFF
--- a/hushh-webapp/__tests__/services/pre-vault-user-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/pre-vault-user-state-service.test.ts
@@ -136,12 +136,18 @@ describe("PreVaultUserStateService.bootstrapState", () => {
     expect(OneSetupCompletionHintService.isResolved(userId)).toBe(true);
   });
 
-  it("clears the positive latch only for explicit incomplete state", async () => {
+  it("keeps the sticky completion latch on a stale incomplete or unknown read", async () => {
     const incompleteUserId = "bootstrap-explicit-incomplete-user";
     const unknownUserId = "bootstrap-unknown-setup-user";
     getIdTokenMock.mockResolvedValue("firebase-token");
     OneSetupCompletionHintService.markResolved(incompleteUserId);
     OneSetupCompletionHintService.markResolved(unknownUserId);
+    // Any extra (self-heal) write resolves cleanly so the fire-and-forget
+    // re-push never rejects during the test.
+    apiJsonMock.mockResolvedValue({
+      userId: incompleteUserId,
+      setupCompleted: true,
+    });
     apiJsonMock
       .mockResolvedValueOnce({
         userId: incompleteUserId,
@@ -155,10 +161,33 @@ describe("PreVaultUserStateService.bootstrapState", () => {
     await PreVaultUserStateService.bootstrapState(incompleteUserId);
     await PreVaultUserStateService.bootstrapState(unknownUserId);
 
-    expect(
-      OneSetupCompletionHintService.isResolved(incompleteUserId),
-    ).toBe(false);
+    // The latch is a sticky, monotonic "onboarding dismissed" signal: a routine
+    // or racing `false`/null read must NOT wipe it (that was the guard-bounce
+    // bug). It is cleared only by explicit sign-out / account reset.
+    expect(OneSetupCompletionHintService.isResolved(incompleteUserId)).toBe(true);
     expect(OneSetupCompletionHintService.isResolved(unknownUserId)).toBe(true);
+  });
+
+  it("self-heals the backend when the latch is set but setupCompleted is false", async () => {
+    const userId = "bootstrap-self-heal-user";
+    getIdTokenMock.mockResolvedValue("firebase-token");
+    OneSetupCompletionHintService.markResolved(userId);
+    apiJsonMock
+      .mockResolvedValueOnce({ userId, setupCompleted: false }) // bootstrap read
+      .mockResolvedValueOnce({ userId, setupCompleted: true }); // self-heal re-push
+
+    await PreVaultUserStateService.bootstrapState(userId);
+
+    // The fire-and-forget self-heal re-pushes setupCompleted=true so every
+    // device converges even if the dismissal-time write never landed.
+    await vi.waitFor(() => {
+      expect(apiJsonMock).toHaveBeenCalledTimes(2);
+    });
+    const healCall = apiJsonMock.mock.calls[1];
+    expect(String(healCall?.[0])).toContain("pre-vault-state");
+    expect(
+      JSON.parse(String((healCall?.[1] as RequestInit).body)),
+    ).toMatchObject({ userId, setupCompleted: true });
   });
 
   it("persists the explicit Connections choice without replacing capability markers", async () => {

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -150,6 +150,40 @@ describe("top shell breadcrumbs", () => {
     );
   });
 
+  it("routes agent back-nav to One home once onboarding is dismissed", () => {
+    const fromSetup = new URLSearchParams();
+    fromSetup.set("from", "/one/setup");
+
+    // First onboarding (not dismissed): retrace into the hub is preserved.
+    expect(resolveTopShellBreadcrumb("/one/kai", fromSetup)?.backHref).toBe(
+      "/one/setup",
+    );
+
+    // Dismissed: an agent surface never retraces into setup, even with a stale
+    // ?from=/one/setup marker — this is the "back from every sub-agent → setup"
+    // regression.
+    expect(
+      resolveTopShellBreadcrumb("/one/kai", fromSetup, { setupDismissed: true })
+        ?.backHref,
+    ).toBe("/one");
+
+    // Setup-internal pages keep their retrace to the hub (deliberate entries
+    // like Connections stay reachable and go back to the hub).
+    expect(
+      resolveTopShellBreadcrumb("/one/setup/connections", undefined, {
+        setupDismissed: true,
+      })?.backHref,
+    ).toBe("/one/setup");
+
+    // A non-setup ?from origin is unaffected by the dismissal rewrite.
+    const fromGmail = new URLSearchParams();
+    fromGmail.set("from", "/one/gmail");
+    expect(
+      resolveTopShellBreadcrumb("/one/kai", fromGmail, { setupDismissed: true })
+        ?.backHref,
+    ).toBe("/one/gmail");
+  });
+
   it("returns every base Finance tab to One", () => {
     for (const tab of ["market", "portfolio", "analysis"]) {
       const params = new URLSearchParams();

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -93,6 +93,8 @@ import {
   type TopShellBreadcrumbConfig,
 } from "@/lib/navigation/top-shell-breadcrumbs";
 import { navigateTopShellBack } from "@/lib/navigation/top-shell-back";
+import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import {
   ShellActionSurface,
   SHELL_ICON_BUTTON_CLASSNAME,
@@ -380,12 +382,22 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
   const lastAgentSectionId = useKaiSession((s) => s.lastAgentSectionId);
   const lastKaiPath = useKaiSession((s) => s.lastKaiPath);
   const lastRiaPath = useKaiSession((s) => s.lastRiaPath);
-  const topShellBreadcrumb = useMemo(
-    () =>
-      resolveTopShellBreadcrumb(normalizedPathname, searchParams) ??
-      resolveCommonRouteBreadcrumb(normalizedPathname, lastAgentSectionId),
-    [lastAgentSectionId, normalizedPathname, searchParams],
-  );
+  const topShellBreadcrumb = useMemo(() => {
+    // Once onboarding is dismissed, back-navigation from any product/agent
+    // surface must never retrace into the setup funnel. Re-read on every
+    // navigation (pathname change) so a freshly-resolved user is honored.
+    const setupDismissed = Boolean(
+      user?.uid &&
+        (OneSetupCompletionHintService.isResolved(user.uid) ||
+          PreVaultUserStateService.getCachedBootstrapState(user.uid)
+            ?.setupCompleted === true),
+    );
+    return (
+      resolveTopShellBreadcrumb(normalizedPathname, searchParams, {
+        setupDismissed,
+      }) ?? resolveCommonRouteBreadcrumb(normalizedPathname, lastAgentSectionId)
+    );
+  }, [lastAgentSectionId, normalizedPathname, searchParams, user?.uid]);
   const chromeState = useMemo(
     () => getKaiChromeState(normalizedPathname),
     [normalizedPathname],

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -1,6 +1,7 @@
 import {
   buildOneSetupCapabilityRoute,
   buildKaiMarketRoute,
+  isOneSetupSurfaceRoute,
   KAI_MARKET_PATH,
   normalizeInternalRouteHref,
   resolveOnboardingCapabilityForRoute,
@@ -118,7 +119,41 @@ function resolveCapabilitySetupBackHref(
     : ROUTES.ONE_SETUP;
 }
 
+export interface ResolveTopShellBreadcrumbOptions {
+  /**
+   * True once the user has dismissed onboarding (finished/skipped setup, or the
+   * backend/latch reports it). When set, a product/agent surface must never send
+   * BACK into the setup funnel — stale `?from=/one/setup` markers and hardcoded
+   * setup defaults are rewritten to ONE_HOME. Setup-internal pages keep their
+   * retrace to the hub so the first onboarding pass is unchanged.
+   */
+  setupDismissed?: boolean;
+}
+
 export function resolveTopShellBreadcrumb(
+  pathname: string,
+  searchParams?: URLSearchParams | { get(name: string): string | null } | null,
+  options?: ResolveTopShellBreadcrumbOptions,
+): TopShellBreadcrumbConfig | null {
+  const config = resolveTopShellBreadcrumbInner(pathname, searchParams);
+  if (!config || !options?.setupDismissed) return config;
+  // Once onboarding is dismissed, a product/agent surface must never send BACK
+  // into the setup funnel. Setup-internal pages (the hub, connections, a
+  // per-capability step) keep retracing to the hub; every other surface whose
+  // back target resolves to a setup route (stale `?from=/one/setup`, hardcoded
+  // defaults) is rerouted to home.
+  const here = normalizeBreadcrumbPathname(pathname);
+  if (isOneSetupSurfaceRoute(here)) return config;
+  const backPath = config.backHref
+    ? normalizeBreadcrumbPathname(config.backHref)
+    : null;
+  if (backPath && isOneSetupSurfaceRoute(backPath)) {
+    return { ...config, backHref: ROUTES.ONE_HOME };
+  }
+  return config;
+}
+
+function resolveTopShellBreadcrumbInner(
   pathname: string,
   searchParams?: URLSearchParams | { get(name: string): string | null } | null,
 ): TopShellBreadcrumbConfig | null {

--- a/hushh-webapp/lib/services/one-setup-exit-service.ts
+++ b/hushh-webapp/lib/services/one-setup-exit-service.ts
@@ -61,17 +61,47 @@ export function acknowledgeOneSetupExit(params: {
     completedAt,
   });
   return (async () => {
-    await PreVaultUserStateService.syncKaiSetupState({
-      userId: params.userId,
-      completed: true,
-      skipped: params.skipped,
-      completedAt,
-    });
-    await PreVaultUserStateService.syncOnboardingJourney({
-      userId: params.userId,
-      phase: "root_completion",
-    });
+    // Persist the account-wide, cross-device setupCompleted flag. Retry so it
+    // lands even on a flaky network: the sticky local latch already keeps THIS
+    // device out of setup meanwhile, and the bootstrap self-heal re-pushes on a
+    // future load if every attempt here still fails.
+    await persistWithRetry(() =>
+      PreVaultUserStateService.syncKaiSetupState({
+        userId: params.userId,
+        completed: true,
+        skipped: params.skipped,
+        completedAt,
+      }),
+    );
+    await persistWithRetry(() =>
+      PreVaultUserStateService.syncOnboardingJourney({
+        userId: params.userId,
+        phase: "root_completion",
+      }),
+    );
     // Root completion must not mutate the Finance profile. Finance has its own
     // terminal capability acknowledgement and setupCapabilityIds signal.
   })();
+}
+
+const SETUP_EXIT_RETRY_DELAYS_MS = [400, 1200];
+
+async function persistWithRetry(op: () => Promise<unknown>): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 0;
+    attempt <= SETUP_EXIT_RETRY_DELAYS_MS.length;
+    attempt++
+  ) {
+    try {
+      await op();
+      return;
+    } catch (error) {
+      lastError = error;
+      const wait = SETUP_EXIT_RETRY_DELAYS_MS[attempt];
+      if (wait === undefined) break;
+      await new Promise((resolve) => setTimeout(resolve, wait));
+    }
+  }
+  throw lastError;
 }

--- a/hushh-webapp/lib/services/pre-vault-user-state-service.ts
+++ b/hushh-webapp/lib/services/pre-vault-user-state-service.ts
@@ -158,11 +158,43 @@ function normalizeResponse(
 function syncSetupCompletionHint(state: PreVaultUserState): void {
   if (state.setupCompleted === true) {
     OneSetupCompletionHintService.markResolved(state.userId);
-    return;
   }
-  if (state.setupCompleted === false) {
-    OneSetupCompletionHintService.clear(state.userId);
-  }
+  // Do NOT clear the latch on a `false`/null read. The completion latch is a
+  // sticky, monotonic "onboarding dismissed" signal. Clearing it on routine or
+  // racing `setupCompleted === false` reads — which happen on every forced
+  // bootstrap a sub-agent makes before a slow/failed durable write has landed —
+  // is exactly what let the onboarding guard re-force `/one/setup` on
+  // back-navigation after onboarding. The latch is cleared ONLY by an explicit
+  // sign-out / account reset via UserLocalStateService.clearForUser.
+}
+
+// Cross-device durability self-heal. If this device holds the sticky "dismissed"
+// latch but the backend has not (yet) recorded setupCompleted=true — e.g. a
+// dismissal-time write failed offline — re-push it once so every device
+// converges. Account reset clears the latch, so this never fires post-reset.
+const setupCompletionHealInFlight = new Set<string>();
+
+function maybeHealSetupCompletion(state: PreVaultUserState): void {
+  // Only heal an EXPLICIT mismatch: the backend says setupCompleted === false
+  // while this device holds the sticky "dismissed" latch. A null/unknown
+  // backend is the legacy fail-open case and must not trigger a write.
+  if (state.setupCompleted !== false) return;
+  if (!state.userId) return;
+  if (!OneSetupCompletionHintService.isResolved(state.userId)) return;
+  if (setupCompletionHealInFlight.has(state.userId)) return;
+  setupCompletionHealInFlight.add(state.userId);
+  void PreVaultUserStateService.syncKaiSetupState({
+    userId: state.userId,
+    completed: true,
+    skipped: state.setupSkipped === true,
+  })
+    .catch(() => {
+      // Best-effort: the sticky latch keeps THIS device out of setup regardless;
+      // a later bootstrap will retry the heal.
+    })
+    .finally(() => {
+      setupCompletionHealInFlight.delete(state.userId);
+    });
 }
 
 function normalizeOnboardingPhase(
@@ -271,6 +303,7 @@ export class PreVaultUserStateService {
       );
       const normalized = normalizeResponse(userId, payload);
       syncSetupCompletionHint(normalized);
+      maybeHealSetupCompletion(normalized);
       // Pre-vault bootstrap state changes infrequently and is updated by this service,
       // so keeping it warm for the session reduces repeated heavy bootstrap requests.
       CacheService.getInstance().set(cacheKey, normalized, CACHE_TTL.SESSION);


### PR DESCRIPTION
## Symptom
After finishing/leaving onboarding, pressing **BACK** inside many sub-agents (finance/kai, gmail, location, kyc, ria, crm, marketplace, consent, pkm) bounced the user back to `/one/setup`. Setup should be a one-time onboarding step, reachable afterwards **only** via deliberate entries (Profile → "Set up One", home "Set up X" tiles).

## Root cause (verified in code, 19-agent trace)
Post-dismissal the onboarding guard admits a route only when `setupCompleted===true` **or** the positive completion latch is set. But `syncSetupCompletionHint` **wiped that latch** on any `setupCompleted===false` read ([pre-vault-user-state-service.ts:163](../blob/main/hushh-webapp/lib/services/pre-vault-user-state-service.ts)) — and every sub-agent forces a bootstrap that returns `false` before a slow/failed durable write has landed (the write was fire-and-forget from #4629). Latch wiped → guard `router.replace(/one/setup)`; every sub-agent's back target is `/one`, which is not admission-exempt.

## Fix (frontend-only)
- **Sticky latch:** `syncSetupCompletionHint` no longer clears on `false`/`null`. The latch is a monotonic "onboarding dismissed" signal, cleared only by explicit sign-out / account reset (`UserLocalStateService.clearForUser`, already wired).
- **Self-heal + reliable write (every device):** `acknowledgeOneSetupExit` retries the durable `setupCompleted=true` write with backoff; `bootstrapState` re-pushes it if the latch is set but the backend still reports `false`, so all devices converge — without a new backend field.
- **Dismissal-aware back-nav:** `resolveTopShellBreadcrumb` takes `setupDismissed`; once dismissed, an agent surface whose back target resolves to a setup route is rerouted to `/one`; setup-internal pages (hub, connections, per-capability step) keep retracing to the hub so the first onboarding pass is unchanged. `top-app-bar` computes `setupDismissed` and passes it (drives both the crumb and the actual back action via the shared breadcrumb).

Guard needs no change (it already admits via the now-sticky latch). Deliberate entries unchanged. Sign-out/reset still re-arm onboarding.

## Tests
- 2277 pass. Updated the pre-vault latch test (sticky, not cleared on false) + added self-heal test; added breadcrumb dismissed-vs-first-onboarding cases.
- typecheck + lint clean on changed files.
- (2 unrelated pre-existing failures on main: phone-verification interaction + marketplace SubtleCrypto/jsdom — not in this change's import graph.)

## Verify on UAT (manual)
Onboard → land on `/one` → open each sub-agent → BACK → must land on `/one` home, never `/one/setup`. Reload/new tab → still no setup. Profile "Set up One" + home tiles still open setup deliberately.