### PR TITLE
test(one): regression guards for one-time setup + skip reliability

### DIFF
--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -138,4 +138,29 @@ describe("One setup hub terminal action contract", () => {
     expect(coordinator).toContain("disabled={pending}");
     expect(coordinator).toContain("enabled: enabled && !settlementBlocked");
   });
+
+  it("never sends the master exit back onto a setup surface", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // completionTarget must drop a `return_to` that resolves to a setup route
+    // (e.g. ?return_to=/one/setup). Otherwise Skip/Finish replace()s the hub
+    // with itself and looks like a no-op (regression #4630).
+    expect(source).toContain("isOneSetupSurfaceRoute(path) ? null : raw");
+  });
+
+  it("surfaces the master action top-right on mobile and keeps the in-flow footer for desktop", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
+      "utf8",
+    );
+
+    // Mobile shows a reachable top-right Skip/Finish (the fixed agent bar would
+    // cover a bottom footer on phones); desktop keeps the in-flow footer.
+    expect(source).toContain('data-testid="one-setup-master-ack-mobile"');
+    expect(source).toContain("sm:hidden");
+    expect(source).toContain('<div className="hidden sm:block">');
+  });
 });

--- a/hushh-webapp/__tests__/services/one-setup-exit-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-setup-exit-service.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression guard for the setup EXIT (Skip / Finish) reliability contract:
+ *
+ *  1. The local "onboarding dismissed" latch is primed SYNCHRONOUSLY, before any
+ *     awaited backend write — so a slow/hung/offline network can never trap the
+ *     person on the setup hub (the original "skip nahi ho raha" bug).
+ *  2. The durable cross-device write is retried so it reliably lands.
+ *  3. Even if every write attempt fails, the sticky latch stays set (the
+ *     bootstrap self-heal re-pushes later); Skip is never a dead end.
+ *
+ * See hushh-research-setup-skip memory + PRs #4629 / #4632.
+ */
+
+const {
+  syncKaiSetupStateMock,
+  syncOnboardingJourneyMock,
+  primeSetupResolvedMock,
+  markSeenMock,
+  setRequiredCookieMock,
+  setFlowActiveCookieMock,
+} = vi.hoisted(() => ({
+  syncKaiSetupStateMock: vi.fn(),
+  syncOnboardingJourneyMock: vi.fn(),
+  primeSetupResolvedMock: vi.fn(),
+  markSeenMock: vi.fn(),
+  setRequiredCookieMock: vi.fn(),
+  setFlowActiveCookieMock: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    syncKaiSetupState: syncKaiSetupStateMock,
+    syncOnboardingJourney: syncOnboardingJourneyMock,
+    primeSetupResolved: primeSetupResolvedMock,
+  },
+}));
+
+vi.mock("@/lib/services/one-setup-gate-service", () => ({
+  OneSetupGateService: { markSeen: markSeenMock },
+}));
+
+vi.mock("@/lib/services/onboarding-route-cookie", () => ({
+  setOnboardingRequiredCookie: setRequiredCookieMock,
+  setOnboardingFlowActiveCookie: setFlowActiveCookieMock,
+}));
+
+import { acknowledgeOneSetupExit } from "@/lib/services/one-setup-exit-service";
+import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
+
+describe("acknowledgeOneSetupExit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    syncKaiSetupStateMock.mockResolvedValue(undefined);
+    syncOnboardingJourneyMock.mockResolvedValue(undefined);
+  });
+
+  it("primes the completion latch synchronously, before the durable writes settle", () => {
+    const userId = "exit-sync-user";
+    // The durable write never settles — the person must still reach home.
+    syncKaiSetupStateMock.mockReturnValue(new Promise<void>(() => {}));
+
+    void acknowledgeOneSetupExit({ userId, skipped: true });
+
+    // The onboarding guard admits /one off this latch, so it MUST be set before
+    // any await — otherwise a slow/hung network re-traps the person on the hub.
+    expect(OneSetupCompletionHintService.isResolved(userId)).toBe(true);
+  });
+
+  it("retries the durable setupCompleted write until it lands", async () => {
+    vi.useFakeTimers();
+    const userId = "exit-retry-user";
+    syncKaiSetupStateMock
+      .mockRejectedValueOnce(new Error("network"))
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce(undefined);
+
+    const settled = acknowledgeOneSetupExit({ userId, skipped: false }).then(
+      () => "ok",
+      () => "err",
+    );
+    await vi.runAllTimersAsync();
+
+    expect(await settled).toBe("ok");
+    expect(syncKaiSetupStateMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it("keeps the latch set even if every durable write attempt fails", async () => {
+    vi.useFakeTimers();
+    const userId = "exit-fail-user";
+    syncKaiSetupStateMock.mockRejectedValue(new Error("offline"));
+
+    const settled = acknowledgeOneSetupExit({ userId, skipped: true }).then(
+      () => "ok",
+      () => "err",
+    );
+    await vi.runAllTimersAsync();
+
+    expect(await settled).toBe("err");
+    // The sticky local latch persists → this device stays out of setup even
+    // though the backend write never landed (the bootstrap self-heal re-pushes
+    // later). Skip is never a dead end.
+    expect(OneSetupCompletionHintService.isResolved(userId)).toBe(true);
+    expect(syncKaiSetupStateMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+});

--- a/hushh-webapp/__tests__/services/pre-vault-user-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/pre-vault-user-state-service.test.ts
@@ -190,6 +190,24 @@ describe("PreVaultUserStateService.bootstrapState", () => {
     ).toMatchObject({ userId, setupCompleted: true });
   });
 
+  it("does not self-heal when the backend read is unknown (null)", async () => {
+    const userId = "bootstrap-null-no-heal-user";
+    getIdTokenMock.mockResolvedValue("firebase-token");
+    OneSetupCompletionHintService.markResolved(userId);
+    apiJsonMock.mockResolvedValueOnce({ userId, setupCompleted: null });
+
+    await PreVaultUserStateService.bootstrapState(userId);
+    // Let any (unexpected) fire-and-forget heal have a chance to run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // null = legacy/unknown fail-open state; it must NOT trigger a re-push
+    // (only an EXPLICIT setupCompleted===false mismatch self-heals). The sticky
+    // latch is still preserved.
+    expect(apiJsonMock).toHaveBeenCalledTimes(1);
+    expect(OneSetupCompletionHintService.isResolved(userId)).toBe(true);
+  });
+
   it("persists the explicit Connections choice without replacing capability markers", async () => {
     const userId = "bootstrap-runtime-choice-user";
     getIdTokenMock.mockResolvedValue("firebase-token");

--- a/hushh-webapp/__tests__/services/user-local-state-service.test.ts
+++ b/hushh-webapp/__tests__/services/user-local-state-service.test.ts
@@ -23,11 +23,17 @@ vi.mock("@/lib/services/vault-method-prompt-local-service", () => ({
   VaultMethodPromptLocalService: { clear: mocks.clearVaultMethodPrompt },
 }));
 
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+}));
+
 import { UserLocalStateService } from "@/lib/services/user-local-state-service";
+import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 
 describe("UserLocalStateService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     mocks.clearPreVault.mockResolvedValue(undefined);
     mocks.clearKaiNavTour.mockResolvedValue(undefined);
     mocks.clearRiaOnboardingDraft.mockResolvedValue(undefined);
@@ -41,5 +47,18 @@ describe("UserLocalStateService", () => {
     expect(mocks.clearKaiNavTour).toHaveBeenCalledWith("uid-1");
     expect(mocks.clearRiaOnboardingDraft).toHaveBeenCalledWith("uid-1");
     expect(mocks.clearVaultMethodPrompt).toHaveBeenCalledWith("uid-1");
+  });
+
+  it("clears the setup completion latch so onboarding can re-arm", async () => {
+    // The completion latch is a sticky "onboarding dismissed" signal that is
+    // NEVER cleared by a routine backend read — only by an explicit sign-out /
+    // account reset through here. If this regresses, a reset user is wrongly
+    // admitted and can never re-run onboarding on this device.
+    OneSetupCompletionHintService.markResolved("uid-rearm");
+    expect(OneSetupCompletionHintService.isResolved("uid-rearm")).toBe(true);
+
+    await UserLocalStateService.clearForUser("uid-rearm");
+
+    expect(OneSetupCompletionHintService.isResolved("uid-rearm")).toBe(false);
   });
 });


### PR DESCRIPTION
Test-only. Locks the invariants behind the setup-reappearance / skip saga (#4627/#4629/#4630/#4632) so they cannot silently regress. No runtime change → no UAT deploy needed.

## What's covered
**`one-setup-exit-service.test.ts` (new)** — Skip/Finish reliability:
- primes the dismissal latch **synchronously before** the awaited backend writes (so a slow/hung network never traps the user on the hub)
- retries the durable `setupCompleted=true` write until it lands
- keeps the latch set even if **every** write attempt fails (skip is never a dead end; bootstrap self-heal re-pushes later)

**`pre-vault-user-state-service.test.ts`** — self-heal precision: does NOT re-push on a `null`/unknown read (only an explicit `setupCompleted===false` mismatch). (Sticky-latch + self-heal-on-false already covered.)

**`user-local-state-service.test.ts`** — re-arm: `clearForUser` clears the completion latch so sign-out / account reset re-runs onboarding.

**`one-setup-hub-terminal-action.contract.test.ts`** — `completionTarget` never resolves to a setup surface (#4630 self-nav); mobile top-right Skip + desktop in-flow footer.

Already-merged coverage (in #4632): sticky latch not cleared on `false`, self-heal on `false`, dismissal-aware breadcrumb back-nav; plus the existing guard latch-admit / redirect-on-incomplete tests.

## Verification
58 targeted tests pass; typecheck + lint clean.