### PR TITLE
fix: allow managed Vertex readiness cold starts

### DIFF
--- a/consent-protocol/scripts/verify_managed_vertex_runtime.py
+++ b/consent-protocol/scripts/verify_managed_vertex_runtime.py
@@ -18,6 +18,8 @@ from google.genai import types  # noqa: E402
 from hushh_mcp.hushh_adk.manifest import ManifestLoader  # noqa: E402
 from hushh_mcp.runtime_providers import ManagedGeminiRuntimeBinding  # noqa: E402
 
+PROBE_TIMEOUT_SECONDS = 25
+
 
 def _managed_manifest_models() -> tuple[tuple[str, ...], str]:
     """Resolve probe targets from authored manifests, never a duplicate list."""
@@ -81,7 +83,7 @@ async def main() -> None:
                     automatic_function_calling=types.AutomaticFunctionCallingConfig(disable=True),
                 ),
             ),
-            timeout=10,
+            timeout=PROBE_TIMEOUT_SECONDS,
         )
 
     async def probe_adk_text(model: str, location: str) -> None:
@@ -102,14 +104,14 @@ async def main() -> None:
                 return
             raise RuntimeError("ADK managed Vertex probe returned no response")
 
-        await asyncio.wait_for(consume_first_response(), timeout=10)
+        await asyncio.wait_for(consume_first_response(), timeout=PROBE_TIMEOUT_SECONDS)
 
     async def probe_live_setup() -> None:
         manager = live_client.aio.live.connect(
             model=live_model,
             config=types.LiveConnectConfig(response_modalities=[types.Modality.AUDIO]),
         )
-        await asyncio.wait_for(manager.__aenter__(), timeout=10)
+        await asyncio.wait_for(manager.__aenter__(), timeout=PROBE_TIMEOUT_SECONDS)
         await manager.__aexit__(None, None, None)
 
     await asyncio.gather(

--- a/consent-protocol/tests/test_managed_vertex_readiness_script.py
+++ b/consent-protocol/tests/test_managed_vertex_readiness_script.py
@@ -26,3 +26,7 @@ def test_readiness_script_imports_from_an_uninstalled_container_checkout() -> No
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_readiness_probe_has_cold_response_headroom() -> None:
+    assert "PROBE_TIMEOUT_SECONDS = 25" in SCRIPT_PATH.read_text(encoding="utf-8")

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -258,7 +258,7 @@ steps:
           --args="scripts/verify_managed_vertex_runtime.py" \
           --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=$PROJECT_ID|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
           --max-retries=0 \
-          --task-timeout=30s \
+          --task-timeout=90s \
           --quiet
         gcloud run jobs execute "${job_name}" \
           --project="$PROJECT_ID" \


### PR DESCRIPTION
## Summary

- keep the managed Vertex and Live readiness checks mandatory while allowing a 25-second first response on cold starts
- extend the isolated Cloud Run readiness job to 90 seconds
- retain an explicit timeout contract test

## Verification

- `pytest -q consent-protocol/tests/test_managed_vertex_readiness_script.py`
- `ruff check consent-protocol`
- `git diff --check`

The prior UAT release attempt rolled back before traffic promotion because the 10-second ADK probe timed out. This change targets only that pre-traffic gate.