### PR TITLE
feat(one-location): add connection visibility and Friends Map

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -54,6 +54,14 @@ class CreateGrantRequest(_CamelModel):
     share_kind: str | None = Field(default=None, alias="shareKind", max_length=40)
 
 
+class UpdateConnectionVisibilityRequest(_CamelModel):
+    enabled: bool
+    precision: str = Field(default="precise", pattern="^(precise|approximate)$")
+    excluded_user_ids: list[str] = Field(
+        default_factory=list, alias="excludedUserIds", max_length=100
+    )
+
+
 class StoreEnvelopeRequest(_CamelModel):
     envelope: dict[str, Any]
 
@@ -184,6 +192,37 @@ def _require_retention_auth(request: Request) -> None:
 def get_location_state(token_data: dict = Depends(require_vault_owner_token)):
     try:
         return _service().list_state(user_id=_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.patch("/location/visibility")
+async def update_location_visibility(
+    payload: UpdateConnectionVisibilityRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return _service().set_connection_visibility(
+            owner_user_id=_user_id(token_data),
+            enabled=payload.enabled,
+            precision=payload.precision,
+            excluded_user_ids=payload.excluded_user_ids,
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.get("/location/publish-targets")
+async def get_location_publish_targets(
+    limit: int = Query(default=500, ge=1, le=500),
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "targets": _service().list_publish_targets(
+                owner_user_id=_user_id(token_data), limit=limit
+            )
+        }
     except Exception as exc:
         raise _handle_error(exc) from exc
 

--- a/consent-protocol/api/utils/fcm_messages.py
+++ b/consent-protocol/api/utils/fcm_messages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 CONSENT_NOTIFICATION_CATEGORY = "CONSENT_REQUEST"
 CONSENT_NOTIFICATION_ACTION_REVIEW = "CONSENT_REVIEW"
@@ -26,6 +27,12 @@ def build_push_message(
 
     webpush = None
     if show_alert and normalized_platform == "web":
+        parsed_request_url = urlparse(request_url)
+        webpush_fcm_options = (
+            messaging.WebpushFCMOptions(link=request_url)
+            if parsed_request_url.scheme == "https"
+            else None
+        )
         webpush = messaging.WebpushConfig(
             headers={"Urgency": "high"},
             notification=messaging.WebpushNotification(
@@ -35,7 +42,7 @@ def build_push_message(
                 require_interaction=True,
                 data={"url": request_url},
             ),
-            fcm_options=messaging.WebpushFCMOptions(link=request_url),
+            fcm_options=webpush_fcm_options,
         )
 
     apns = None

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 114,
+  "expected_migration_version": 115,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",
@@ -898,6 +898,28 @@
       "active_source",
       "created_at",
       "updated_at"
+    ],
+    "one_location_share_grants": [
+      "id",
+      "owner_user_id",
+      "recipient_user_id",
+      "status",
+      "access_origin"
+    ],
+    "one_location_visibility_preferences": [
+      "owner_user_id",
+      "audience",
+      "precision",
+      "enabled_at",
+      "disabled_at",
+      "updated_at",
+      "metadata"
+    ],
+    "one_location_visibility_exclusions": [
+      "owner_user_id",
+      "excluded_user_id",
+      "source",
+      "created_at"
     ]
   }
 }

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 114,
+  "expected_migration_version": 115,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",
@@ -143,6 +143,28 @@
       "active_source",
       "created_at",
       "updated_at"
+    ],
+    "one_location_share_grants": [
+      "id",
+      "owner_user_id",
+      "recipient_user_id",
+      "status",
+      "access_origin"
+    ],
+    "one_location_visibility_preferences": [
+      "owner_user_id",
+      "audience",
+      "precision",
+      "enabled_at",
+      "disabled_at",
+      "updated_at",
+      "metadata"
+    ],
+    "one_location_visibility_exclusions": [
+      "owner_user_id",
+      "excluded_user_id",
+      "source",
+      "created_at"
     ]
   }
 }

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 114,
+  "expected_migration_version": 115,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1004,6 +1004,28 @@
       "active_source",
       "created_at",
       "updated_at"
+    ],
+    "one_location_share_grants": [
+      "id",
+      "owner_user_id",
+      "recipient_user_id",
+      "status",
+      "access_origin"
+    ],
+    "one_location_visibility_preferences": [
+      "owner_user_id",
+      "audience",
+      "precision",
+      "enabled_at",
+      "disabled_at",
+      "updated_at",
+      "metadata"
+    ],
+    "one_location_visibility_exclusions": [
+      "owner_user_id",
+      "excluded_user_id",
+      "source",
+      "created_at"
     ]
   }
 }

--- a/consent-protocol/db/migrations/115_one_location_connection_visibility.sql
+++ b/consent-protocol/db/migrations/115_one_location_connection_visibility.sql
@@ -1,0 +1,74 @@
+BEGIN;
+
+ALTER TABLE one_location_share_grants
+  ADD COLUMN IF NOT EXISTS access_origin TEXT NOT NULL DEFAULT 'direct';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'one_location_share_grants_access_origin_check'
+  ) THEN
+    ALTER TABLE one_location_share_grants
+      ADD CONSTRAINT one_location_share_grants_access_origin_check
+      CHECK (access_origin IN ('direct', 'request_approved', 'connections_visibility'));
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS one_location_visibility_preferences (
+  owner_user_id TEXT PRIMARY KEY,
+  audience TEXT NOT NULL DEFAULT 'private'
+    CHECK (audience IN ('private', 'connections')),
+  precision TEXT NOT NULL DEFAULT 'precise'
+    CHECK (precision IN ('precise', 'approximate')),
+  enabled_at TIMESTAMPTZ,
+  disabled_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS one_location_visibility_exclusions (
+  owner_user_id TEXT NOT NULL,
+  excluded_user_id TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'owner',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (owner_user_id, excluded_user_id),
+  CONSTRAINT one_location_visibility_exclusions_not_self
+    CHECK (owner_user_id <> excluded_user_id)
+);
+
+ALTER TABLE one_location_visibility_exclusions
+  ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'owner';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'one_location_visibility_exclusions_source_check'
+  ) THEN
+    ALTER TABLE one_location_visibility_exclusions
+      ADD CONSTRAINT one_location_visibility_exclusions_source_check
+      CHECK (source IN ('owner', 'recipient'));
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_location_visibility_active_pair
+  ON one_location_share_grants (owner_user_id, recipient_user_id)
+  WHERE status = 'active' AND access_origin = 'connections_visibility';
+
+CREATE INDEX IF NOT EXISTS idx_one_location_visibility_preferences_audience
+  ON one_location_visibility_preferences (audience, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_visibility_exclusions_owner
+  ON one_location_visibility_exclusions (owner_user_id, excluded_user_id);
+
+COMMENT ON COLUMN one_location_share_grants.access_origin IS
+  'Coordinate-free grant purpose. Managed connection visibility must not replace direct or request-approved access.';
+COMMENT ON TABLE one_location_visibility_preferences IS
+  'Owner-controlled metadata-only audience policy for encrypted One Location visibility.';
+COMMENT ON TABLE one_location_visibility_exclusions IS
+  'Per-owner connection exclusions. This table must never contain coordinates or map information.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -92,7 +92,8 @@
     "111_macys_crm_response_contracts.sql",
     "112_dynamic_crm_registry_cache.sql",
     "113_kai_plaid_portfolio_tables.sql",
-    "114_one_action_directive_ledger.sql"
+    "114_one_action_directive_ledger.sql",
+    "115_one_location_connection_visibility.sql"
   ],
   "groups": {
     "iam": [
@@ -144,7 +145,8 @@
       "110_one_email_kyc_preferences.sql",
       "111_macys_crm_response_contracts.sql",
       "112_dynamic_crm_registry_cache.sql",
-      "114_one_action_directive_ledger.sql"
+      "114_one_action_directive_ledger.sql",
+      "115_one_location_connection_visibility.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -217,6 +217,16 @@ class AccountService:
                    OR recipient_user_id = :user_id
                 """
             ),
+            "one_location_visibility_exclusions": text(
+                """
+                DELETE FROM one_location_visibility_exclusions
+                WHERE owner_user_id = :user_id
+                   OR excluded_user_id = :user_id
+                """
+            ),
+            "one_location_visibility_preferences": text(
+                "DELETE FROM one_location_visibility_preferences WHERE owner_user_id = :user_id"
+            ),
             "runtime_persona_state": text(
                 "DELETE FROM runtime_persona_state WHERE user_id = :user_id"
             ),
@@ -662,6 +672,8 @@ class AccountService:
         for table_name in (
             "one_location_events",
             "one_location_referrals",
+            "one_location_visibility_exclusions",
+            "one_location_visibility_preferences",
             "one_location_public_invite_submissions",
             "one_location_public_invites",
             "one_location_circle_invites",
@@ -841,6 +853,8 @@ class AccountService:
             "trusted_connections": False,
             "one_location_share_grants": False,
             "one_location_recipient_keys": False,
+            "one_location_visibility_exclusions": False,
+            "one_location_visibility_preferences": False,
             "runtime_persona_state": False,
             "vault_key_wrappers": False,
             "vault_keys": False,
@@ -1052,6 +1066,8 @@ class AccountService:
                 for table_name in (
                     "one_location_events",
                     "one_location_referrals",
+                    "one_location_visibility_exclusions",
+                    "one_location_visibility_preferences",
                     "one_location_public_invite_submissions",
                     "one_location_public_invites",
                     "one_location_circle_invites",

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -246,6 +246,24 @@ class ConnectionsService:
             """,
             {"id": req.get("id")},
         )
+        # An owner who selected all connections also selected future mutual
+        # connections. Reconcile both audiences best-effort after acceptance;
+        # keyless users remain unavailable until One Location provisions them.
+        try:
+            from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+
+            location_service = OneLocationAgentService()
+            for owner in (requester, user_id):
+                visibility = location_service.get_connection_visibility(owner_user_id=owner)
+                if visibility.get("enabled"):
+                    location_service.set_connection_visibility(
+                        owner_user_id=owner,
+                        enabled=True,
+                        precision=str(visibility.get("precision") or "precise"),
+                        excluded_user_ids=list(visibility.get("excludedUserIds") or []),
+                    )
+        except Exception as exc:  # noqa: BLE001 - connection acceptance remains authoritative
+            logger.warning("connections.location_visibility_reconcile_failed error=%s", exc)
         return {
             "status": "accepted",
             "requestId": req.get("id"),
@@ -523,5 +541,21 @@ class ConnectionsService:
             RETURNING id
             """,
             {"id": (connection_id or "").strip()},
+        )
+        # Read and publish authorization also re-check the graph. This cleanup
+        # keeps Access Manager state accurate even after either user disconnects.
+        self._execute_many(
+            """
+            UPDATE one_location_share_grants
+            SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
+            WHERE status = 'active'
+              AND access_origin = 'connections_visibility'
+              AND (
+                (owner_user_id = :a AND recipient_user_id = :b)
+                OR (owner_user_id = :b AND recipient_user_id = :a)
+              )
+            RETURNING id
+            """,
+            {"a": user_a, "b": user_b},
         )
         return {"removed": 1 if conn else 0}

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -16,6 +16,7 @@ from hushh_mcp.consent.token import issue_token, validate_token
 from hushh_mcp.constants import ConsentScope
 from hushh_mcp.operons.location.policy import (
     LOCATION_CAPABILITY_SCOPES,
+    MAX_LOCATION_SHARE_HOURS,
     normalize_duration_hours,
     normalize_source_platform,
 )
@@ -184,7 +185,8 @@ def _redact_location_metadata(value: Any) -> Any:
 
 
 def _json_param(value: dict[str, Any] | list[Any] | None) -> str:
-    return json.dumps(_redact_location_metadata(value or {}), separators=(",", ":"))
+    normalized = {} if value is None else value
+    return json.dumps(_redact_location_metadata(normalized), separators=(",", ":"))
 
 
 def _json_param_with_public_location(value: dict[str, Any] | None) -> str:
@@ -682,16 +684,18 @@ class OneLocationAgentService:
         display_name = str(row.get("display_name") or "").strip()
         masked_phone = _mask_phone(row.get("phone_number"))
         user_id = str(row.get("user_id") or "")
+        public_key_jwk = _loads_json(row.get("public_key_jwk"))
+        phone_verified = bool(row.get("phone_verified"))
         return {
             "userId": user_id,
             "displayName": display_name or masked_phone or "Verified user",
             "maskedPhone": masked_phone,
-            "phoneVerified": bool(row.get("phone_verified")),
+            "phoneVerified": phone_verified,
             "keyId": str(row.get("key_id") or "") or None,
-            "publicKeyJwk": _loads_json(row.get("public_key_jwk")),
+            "publicKeyJwk": public_key_jwk,
             "keyAlgorithm": str(row.get("algorithm") or "ECDH-P256-AES256-GCM"),
             "keyRegisteredAt": _iso(row.get("key_created_at") or row.get("created_at")),
-            "canReceiveLocation": bool(row.get("key_id")),
+            "canReceiveLocation": bool(phone_verified and row.get("key_id") and public_key_jwk),
         }
 
     def _optional_signal_rows(
@@ -1544,6 +1548,7 @@ class OneLocationAgentService:
             "updatedAt": _iso(row.get("updated_at")),
             "revokedAt": _iso(row.get("revoked_at")),
             "latestEnvelopeId": str(row.get("latest_envelope_id") or "") or None,
+            "accessOrigin": str(row.get("access_origin") or "direct"),
             "shareKind": share_kind,
             "shareMessage": share_message,
         }
@@ -2063,6 +2068,7 @@ class OneLocationAgentService:
               FROM one_location_share_grants
               WHERE status = 'active'
                 AND expires_at <= NOW()
+                AND access_origin <> 'connections_visibility'
                 AND (
                   :user_id IS NULL
                   OR owner_user_id = :user_id
@@ -2072,11 +2078,16 @@ class OneLocationAgentService:
               LIMIT 500
               FOR UPDATE SKIP LOCKED
             )
-            UPDATE one_location_share_grants grant
+            UPDATE one_location_share_grants share_grant
             SET status = 'expired', updated_at = NOW()
             FROM stale
-            WHERE grant.id = stale.id
-            RETURNING grant.id, grant.owner_user_id, grant.recipient_user_id, grant.expires_at
+            WHERE share_grant.id = stale.id
+            RETURNING
+              share_grant.id,
+              share_grant.owner_user_id,
+              share_grant.recipient_user_id,
+              share_grant.expires_at,
+              share_grant.access_origin
             """,
             {"user_id": user_id},
         )
@@ -2448,6 +2459,44 @@ class OneLocationAgentService:
             event_type="location_recipient_key_registered",
             metadata={"key_id": normalized_key_id, "algorithm": algorithm},
         )
+        try:
+            waiting_owners = self._execute_many(
+                """
+                SELECT preference.owner_user_id, preference.precision
+                FROM one_location_visibility_preferences preference
+                JOIN connections connection
+                  ON connection.status = 'active'
+                 AND (
+                   (connection.user_a_id = preference.owner_user_id AND connection.user_b_id = :user_id)
+                   OR
+                   (connection.user_b_id = preference.owner_user_id AND connection.user_a_id = :user_id)
+                 )
+                WHERE preference.audience = 'connections'
+                  AND preference.owner_user_id <> :user_id
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM one_location_visibility_exclusions exclusion
+                    WHERE exclusion.owner_user_id = preference.owner_user_id
+                      AND exclusion.excluded_user_id = :user_id
+                  )
+                """,
+                {"user_id": user_id},
+            )
+            for owner in waiting_owners:
+                owner_user_id = str(owner.get("owner_user_id") or "")
+                exclusions = self._visibility_excluded_user_ids(owner_user_id=owner_user_id)
+                self.set_connection_visibility(
+                    owner_user_id=owner_user_id,
+                    enabled=True,
+                    precision=str(owner.get("precision") or "precise"),
+                    excluded_user_ids=sorted(exclusions),
+                )
+        except Exception as exc:  # noqa: BLE001 - key registration remains authoritative
+            logger.warning(
+                "one_location.visibility_key_reconcile_failed user=%s error=%s",
+                redact_log_field("user_id", user_id),
+                exc,
+            )
         return self._recipient_payload(row) or {}
 
     def list_verified_recipients(
@@ -2488,6 +2537,36 @@ class OneLocationAgentService:
             owner_user_id=owner_user_id,
             recipients=recipients,
         )
+
+    def _list_connection_visibility_recipients(self, *, owner_user_id: str) -> list[dict[str, Any]]:
+        """Return the complete accepted-connection audience without UI pagination."""
+        rows = self._execute_many(
+            """
+            SELECT
+              a.user_id, a.display_name, a.phone_number, a.phone_verified,
+              k.key_id, k.public_key_jwk, k.algorithm, k.created_at AS key_created_at
+            FROM connections c
+            JOIN actor_identity_cache a
+              ON a.user_id = CASE
+                   WHEN c.user_a_id = :owner_user_id THEN c.user_b_id
+                   ELSE c.user_a_id
+                 END
+            LEFT JOIN LATERAL (
+              SELECT key_id, public_key_jwk, algorithm, created_at
+              FROM one_location_recipient_keys
+              WHERE user_id = a.user_id
+                AND status = 'active'
+              ORDER BY created_at DESC
+              LIMIT 1
+            ) k ON TRUE
+            WHERE c.status = 'active'
+              AND (c.user_a_id = :owner_user_id OR c.user_b_id = :owner_user_id)
+              AND a.user_id <> :owner_user_id
+            ORDER BY COALESCE(a.display_name, a.phone_number, a.user_id), a.user_id
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        return [payload for row in rows if (payload := self._recipient_payload(row))]
 
     def list_directory_candidates(
         self, *, owner_user_id: str, limit: int = 50
@@ -2677,6 +2756,399 @@ class OneLocationAgentService:
         )
         return row is not None
 
+    def _visibility_preference_row(self, *, owner_user_id: str) -> dict[str, Any] | None:
+        return self._execute_one(
+            """
+            SELECT *
+            FROM one_location_visibility_preferences
+            WHERE owner_user_id = :owner_user_id
+            LIMIT 1
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+
+    def _visibility_excluded_user_ids(self, *, owner_user_id: str) -> set[str]:
+        rows = self._execute_many(
+            """
+            SELECT excluded_user_id
+            FROM one_location_visibility_exclusions
+            WHERE owner_user_id = :owner_user_id
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        return {
+            str(row.get("excluded_user_id") or "") for row in rows if row.get("excluded_user_id")
+        }
+
+    @staticmethod
+    def _visibility_payload(
+        row: dict[str, Any] | None,
+        *,
+        excluded_user_ids: set[str] | None = None,
+        eligible_connection_count: int = 0,
+        ready_connection_count: int = 0,
+    ) -> dict[str, Any]:
+        audience = str((row or {}).get("audience") or "private")
+        return {
+            "enabled": audience == "connections",
+            "audience": audience,
+            "precision": str((row or {}).get("precision") or "precise"),
+            "enabledAt": _iso((row or {}).get("enabled_at")),
+            "disabledAt": _iso((row or {}).get("disabled_at")),
+            "updatedAt": _iso((row or {}).get("updated_at")),
+            "excludedUserIds": sorted(excluded_user_ids or set()),
+            "eligibleConnectionCount": eligible_connection_count,
+            "readyConnectionCount": ready_connection_count,
+            "unavailableConnectionCount": max(
+                0, eligible_connection_count - ready_connection_count
+            ),
+        }
+
+    def _managed_visibility_authorized(self, *, owner_user_id: str, recipient_user_id: str) -> bool:
+        row = self._execute_one(
+            """
+            SELECT 1
+            FROM one_location_visibility_preferences preference
+            JOIN connections connection
+              ON connection.status = 'active'
+             AND (
+               (connection.user_a_id = :owner_user_id AND connection.user_b_id = :recipient_user_id)
+               OR
+               (connection.user_a_id = :recipient_user_id AND connection.user_b_id = :owner_user_id)
+             )
+            WHERE preference.owner_user_id = :owner_user_id
+              AND preference.audience = 'connections'
+              AND NOT EXISTS (
+                SELECT 1
+                FROM one_location_visibility_exclusions exclusion
+                WHERE exclusion.owner_user_id = :owner_user_id
+                  AND exclusion.excluded_user_id = :recipient_user_id
+              )
+            LIMIT 1
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "recipient_user_id": recipient_user_id,
+            },
+        )
+        return row is not None
+
+    def _renew_managed_visibility_grant(self, row: dict[str, Any]) -> dict[str, Any]:
+        if str(row.get("access_origin") or "direct") != "connections_visibility":
+            return row
+        owner_user_id = str(row.get("owner_user_id") or "")
+        recipient_user_id = str(row.get("recipient_user_id") or "")
+        if not self._managed_visibility_authorized(
+            owner_user_id=owner_user_id,
+            recipient_user_id=recipient_user_id,
+        ):
+            raise OneLocationAgentError(
+                "LOCATION_VISIBILITY_NOT_AUTHORIZED",
+                "Connection visibility is no longer authorized.",
+                status_code=403,
+            )
+        expires_at = _parse_datetime(row.get("expires_at"), field_name="expires_at")
+        if str(row.get("status") or "") == "active" and expires_at > _utcnow() + timedelta(hours=6):
+            return row
+        capability = self._mint_grant_capability_token(
+            owner_user_id=owner_user_id,
+            recipient_user_id=recipient_user_id,
+            duration_hours=MAX_LOCATION_SHARE_HOURS,
+        )
+        metadata = _loads_json(row.get("metadata")) or {}
+        metadata.update(
+            {
+                "reason": "connections_visibility",
+                "share_kind": "connections_visibility",
+                "access_origin": "connections_visibility",
+                "capability_token": capability["token"],
+                "capability_scope": LOCATION_GRANT_CONSENT_SCOPE,
+            }
+        )
+        renewed = self._execute_one(
+            """
+            UPDATE one_location_share_grants
+            SET status = 'active',
+                duration_hours = :duration_hours,
+                expires_at = :expires_at,
+                revoked_at = NULL,
+                updated_at = NOW(),
+                metadata = CAST(:metadata_json AS JSONB)
+            WHERE id = CAST(:grant_id AS UUID)
+            RETURNING *
+            """,
+            {
+                "grant_id": str(row.get("id") or ""),
+                "duration_hours": MAX_LOCATION_SHARE_HOURS,
+                "expires_at": _utcnow() + timedelta(hours=MAX_LOCATION_SHARE_HOURS),
+                "metadata_json": _json_param(metadata),
+            },
+        )
+        return renewed or row
+
+    def _revoke_managed_visibility_grants(
+        self, *, owner_user_id: str, keep_recipient_ids: set[str] | None = None
+    ) -> list[dict[str, Any]]:
+        rows = self._execute_many(
+            """
+            SELECT *
+            FROM one_location_share_grants
+            WHERE owner_user_id = :owner_user_id
+              AND access_origin = 'connections_visibility'
+              AND status = 'active'
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        revoked: list[dict[str, Any]] = []
+        keep = keep_recipient_ids or set()
+        for row in rows:
+            recipient_user_id = str(row.get("recipient_user_id") or "")
+            if recipient_user_id in keep:
+                continue
+            updated = self._execute_one(
+                """
+                UPDATE one_location_share_grants
+                SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
+                WHERE id = CAST(:grant_id AS UUID)
+                  AND status = 'active'
+                RETURNING *
+                """,
+                {"grant_id": str(row.get("id") or "")},
+            )
+            if updated:
+                revoked.append(updated)
+        return revoked
+
+    def set_connection_visibility(
+        self,
+        *,
+        owner_user_id: str,
+        enabled: bool,
+        precision: str = "precise",
+        excluded_user_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        if precision not in {"precise", "approximate"}:
+            raise OneLocationAgentError(
+                "LOCATION_VISIBILITY_PRECISION_INVALID",
+                "Choose precise or approximate location visibility.",
+                status_code=422,
+            )
+        normalized_exclusions = {
+            str(user_id).strip()
+            for user_id in (excluded_user_ids or [])
+            if str(user_id).strip() and str(user_id).strip() != owner_user_id
+        }
+        if len(normalized_exclusions) > 500:
+            raise OneLocationAgentError(
+                "LOCATION_VISIBILITY_EXCLUSIONS_LIMIT",
+                "Too many visibility exclusions were selected.",
+                status_code=422,
+            )
+        audience = "connections" if enabled else "private"
+        row = self._execute_one(
+            """
+            WITH preference AS (
+              INSERT INTO one_location_visibility_preferences (
+                owner_user_id, audience, precision, enabled_at, disabled_at, updated_at, metadata
+              )
+              VALUES (
+                :owner_user_id, :audience, :precision,
+                CASE WHEN :enabled THEN NOW() ELSE NULL END,
+                CASE WHEN :enabled THEN NULL ELSE NOW() END,
+                NOW(), '{}'::jsonb
+              )
+              ON CONFLICT (owner_user_id) DO UPDATE SET
+                audience = EXCLUDED.audience,
+                precision = EXCLUDED.precision,
+                enabled_at = CASE
+                  WHEN EXCLUDED.audience = 'connections'
+                    THEN COALESCE(one_location_visibility_preferences.enabled_at, NOW())
+                  ELSE one_location_visibility_preferences.enabled_at
+                END,
+                disabled_at = CASE
+                  WHEN EXCLUDED.audience = 'private' THEN NOW()
+                  ELSE NULL
+                END,
+                updated_at = NOW()
+              RETURNING *
+            ), deleted_owner_exclusions AS (
+              DELETE FROM one_location_visibility_exclusions
+              WHERE owner_user_id = :owner_user_id
+                AND source = 'owner'
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements_text(
+                    CAST(:excluded_user_ids_json AS JSONB)
+                  ) desired(value)
+                  WHERE desired.value = excluded_user_id
+                )
+            ), inserted_owner_exclusions AS (
+              INSERT INTO one_location_visibility_exclusions (
+                owner_user_id, excluded_user_id, source, created_at
+              )
+              SELECT :owner_user_id, value, 'owner', NOW()
+              FROM jsonb_array_elements_text(CAST(:excluded_user_ids_json AS JSONB)) AS value
+              ON CONFLICT (owner_user_id, excluded_user_id) DO NOTHING
+            )
+            SELECT * FROM preference
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "audience": audience,
+                "precision": precision,
+                "enabled": enabled,
+                "excluded_user_ids_json": _json_param(sorted(normalized_exclusions)),
+            },
+        )
+
+        effective_exclusions = self._visibility_excluded_user_ids(owner_user_id=owner_user_id)
+        recipients = self._list_connection_visibility_recipients(owner_user_id=owner_user_id)
+        eligible = [
+            recipient
+            for recipient in recipients
+            if str(recipient.get("userId") or "") not in effective_exclusions
+        ]
+        ready = [recipient for recipient in eligible if recipient.get("canReceiveLocation")]
+        grants: list[dict[str, Any]] = []
+        keep_recipient_ids: set[str] = set()
+        if enabled:
+            for recipient in ready:
+                recipient_user_id = str(recipient.get("userId") or "")
+                keep_recipient_ids.add(recipient_user_id)
+                existing = self._execute_one(
+                    """
+                    SELECT *
+                    FROM one_location_share_grants
+                    WHERE owner_user_id = :owner_user_id
+                      AND recipient_user_id = :recipient_user_id
+                      AND access_origin = 'connections_visibility'
+                      AND status = 'active'
+                    LIMIT 1
+                    """,
+                    {
+                        "owner_user_id": owner_user_id,
+                        "recipient_user_id": recipient_user_id,
+                    },
+                )
+                if existing:
+                    grants.append(
+                        self._grant_payload(self._renew_managed_visibility_grant(existing)) or {}
+                    )
+                    continue
+                grants.append(
+                    self.create_grant(
+                        owner_user_id=owner_user_id,
+                        recipient_user_id=recipient_user_id,
+                        recipient_key_id=str(recipient.get("keyId") or ""),
+                        duration_hours=MAX_LOCATION_SHARE_HOURS,
+                        reason="connections_visibility",
+                        share_kind="connections_visibility",
+                        access_origin="connections_visibility",
+                        enforce_connection=True,
+                    )
+                )
+        self._revoke_managed_visibility_grants(
+            owner_user_id=owner_user_id,
+            keep_recipient_ids=keep_recipient_ids,
+        )
+        return {
+            "visibility": self._visibility_payload(
+                row,
+                excluded_user_ids=effective_exclusions,
+                eligible_connection_count=len(eligible),
+                ready_connection_count=len(ready),
+            ),
+            "grants": grants,
+        }
+
+    def get_connection_visibility(self, *, owner_user_id: str) -> dict[str, Any]:
+        row = self._visibility_preference_row(owner_user_id=owner_user_id)
+        exclusions = self._visibility_excluded_user_ids(owner_user_id=owner_user_id)
+        recipients = self._list_connection_visibility_recipients(owner_user_id=owner_user_id)
+        eligible = [
+            recipient
+            for recipient in recipients
+            if str(recipient.get("userId") or "") not in exclusions
+        ]
+        ready = [recipient for recipient in eligible if recipient.get("canReceiveLocation")]
+        return self._visibility_payload(
+            row,
+            excluded_user_ids=exclusions,
+            eligible_connection_count=len(eligible),
+            ready_connection_count=len(ready),
+        )
+
+    def list_publish_targets(self, *, owner_user_id: str, limit: int = 500) -> list[dict[str, Any]]:
+        visibility = self._visibility_preference_row(owner_user_id=owner_user_id)
+        visibility_precision = str((visibility or {}).get("precision") or "precise")
+        rows = self._execute_many(
+            """
+            SELECT
+              share_grant.*,
+              recipient.display_name AS recipient_display_name,
+              recipient.phone_number AS recipient_phone_number,
+              recipient.phone_verified AS recipient_phone_verified,
+              recipient_key.public_key_jwk AS recipient_public_key_jwk,
+              recipient_key.algorithm AS recipient_key_algorithm,
+              recipient_key.created_at AS recipient_key_created_at
+            FROM one_location_share_grants share_grant
+            JOIN one_location_recipient_keys recipient_key
+              ON recipient_key.user_id = share_grant.recipient_user_id
+             AND recipient_key.key_id = share_grant.recipient_key_id
+             AND recipient_key.status = 'active'
+            LEFT JOIN actor_identity_cache recipient
+              ON recipient.user_id = share_grant.recipient_user_id
+            WHERE share_grant.owner_user_id = :owner_user_id
+              AND share_grant.status = 'active'
+              AND share_grant.expires_at > NOW()
+            ORDER BY share_grant.created_at DESC
+            LIMIT :limit
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "limit": max(1, min(int(limit), 500)),
+            },
+        )
+        targets: list[dict[str, Any]] = []
+        for row in rows:
+            recipient_user_id = str(row.get("recipient_user_id") or "")
+            if str(row.get("access_origin") or "direct") == "connections_visibility":
+                if not self._is_active_connection(
+                    owner_user_id=owner_user_id,
+                    other_user_id=recipient_user_id,
+                ):
+                    continue
+                row = self._renew_managed_visibility_grant(row)
+            grant = self._grant_payload(row)
+            if not grant:
+                continue
+            targets.append(
+                {
+                    "grant": grant,
+                    "precision": (
+                        visibility_precision
+                        if str(row.get("access_origin") or "direct") == "connections_visibility"
+                        else "precise"
+                    ),
+                    "recipient": {
+                        "userId": recipient_user_id,
+                        "displayName": str(row.get("recipient_display_name") or "")
+                        or _mask_phone(row.get("recipient_phone_number"))
+                        or "Connection",
+                        "maskedPhone": _mask_phone(row.get("recipient_phone_number")),
+                        "phoneVerified": bool(row.get("recipient_phone_verified")),
+                        "keyId": str(row.get("recipient_key_id") or "") or None,
+                        "publicKeyJwk": _loads_json(row.get("recipient_public_key_jwk")),
+                        "keyAlgorithm": str(
+                            row.get("recipient_key_algorithm") or "ECDH-P256-AES256-GCM"
+                        ),
+                        "keyRegisteredAt": _iso(row.get("recipient_key_created_at")),
+                        "canReceiveLocation": bool(row.get("recipient_key_id")),
+                    },
+                }
+            )
+        return targets
+
     def create_grant(
         self,
         *,
@@ -2686,8 +3158,10 @@ class OneLocationAgentService:
         duration_hours: float,
         reason: str | None = None,
         share_kind: str | None = None,
+        access_origin: str = "direct",
         require_recipient_phone_verified: bool = True,
         enforce_connection: bool = False,
+        send_notification: bool = True,
     ) -> dict[str, Any]:
         if owner_user_id == recipient_user_id:
             raise OneLocationAgentError(
@@ -2702,6 +3176,12 @@ class OneLocationAgentService:
                 "LOCATION_RECIPIENT_NOT_CONNECTED",
                 "You can only share your live location with your connections.",
                 status_code=403,
+            )
+        if access_origin not in {"direct", "request_approved", "connections_visibility"}:
+            raise OneLocationAgentError(
+                "LOCATION_ACCESS_ORIGIN_INVALID",
+                "Location access origin is invalid.",
+                status_code=422,
             )
         try:
             duration = normalize_duration_hours(duration_hours)
@@ -2726,33 +3206,62 @@ class OneLocationAgentService:
             recipient_user_id=recipient_user_id,
             duration_hours=duration,
         )
-        self._execute_many(
-            """
-            UPDATE one_location_share_grants
-            SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
-            WHERE owner_user_id = :owner_user_id
-              AND recipient_user_id = :recipient_user_id
-              AND status = 'active'
-            RETURNING id
-            """,
-            {"owner_user_id": owner_user_id, "recipient_user_id": recipient_user_id},
-        )
-        row = self._execute_one(
-            """
+        is_managed_visibility = access_origin == "connections_visibility"
+        if not is_managed_visibility:
+            self._execute_many(
+                """
+                UPDATE one_location_share_grants
+                SET status = 'revoked', revoked_at = NOW(), updated_at = NOW()
+                WHERE owner_user_id = :owner_user_id
+                  AND recipient_user_id = :recipient_user_id
+                  AND access_origin = :access_origin
+                  AND status = 'active'
+                RETURNING id
+                """,
+                {
+                    "owner_user_id": owner_user_id,
+                    "recipient_user_id": recipient_user_id,
+                    "access_origin": access_origin,
+                },
+            )
+        insert_sql = """
             INSERT INTO one_location_share_grants (
               owner_user_id, recipient_user_id, recipient_key_id, status,
               consent_scope, capability_scopes, duration_hours, expires_at,
-              created_at, updated_at, metadata
+              created_at, updated_at, metadata, access_origin
             )
             VALUES (
               :owner_user_id, :recipient_user_id, :recipient_key_id, 'active',
               'cap.location.live.view', CAST(:capability_scopes AS JSONB),
-              :duration_hours, :expires_at, NOW(), NOW(), CAST(:metadata_json AS JSONB)
+              :duration_hours, :expires_at, NOW(), NOW(), CAST(:metadata_json AS JSONB),
+              :access_origin
             )
+        """
+        if is_managed_visibility:
+            insert_sql += """
+            ON CONFLICT (owner_user_id, recipient_user_id)
+              WHERE status = 'active' AND access_origin = 'connections_visibility'
+            DO UPDATE SET
+              recipient_key_id = EXCLUDED.recipient_key_id,
+              consent_scope = EXCLUDED.consent_scope,
+              capability_scopes = EXCLUDED.capability_scopes,
+              duration_hours = EXCLUDED.duration_hours,
+              expires_at = EXCLUDED.expires_at,
+              revoked_at = NULL,
+              updated_at = NOW(),
+              metadata = EXCLUDED.metadata
+            RETURNING *, (xmax = 0) AS was_inserted,
+              :recipient_display_name AS recipient_display_name,
+              :recipient_phone_number AS recipient_phone_number
+            """
+        else:
+            insert_sql += """
             RETURNING *,
               :recipient_display_name AS recipient_display_name,
               :recipient_phone_number AS recipient_phone_number
-            """,
+            """
+        row = self._execute_one(
+            insert_sql,
             {
                 "owner_user_id": owner_user_id,
                 "recipient_user_id": recipient_user_id,
@@ -2764,10 +3273,12 @@ class OneLocationAgentService:
                     {
                         "reason": reason or "owner_approved",
                         "share_kind": resolved_kind,
+                        "access_origin": access_origin,
                         "capability_token": capability["token"],
                         "capability_scope": LOCATION_GRANT_CONSENT_SCOPE,
                     }
                 ),
+                "access_origin": access_origin,
                 "recipient_display_name": recipient.get("display_name"),
                 "recipient_phone_number": recipient.get("phone_number"),
             },
@@ -2779,14 +3290,16 @@ class OneLocationAgentService:
                 "Could not create the location share.",
                 status_code=500,
             )
-        self._insert_event(
-            owner_user_id=owner_user_id,
-            actor_user_id=owner_user_id,
-            recipient_user_id=recipient_user_id,
-            grant_id=grant["id"],
-            event_type="location_share_created",
-            metadata={"duration_hours": duration},
-        )
+        was_inserted = not is_managed_visibility or bool((row or {}).get("was_inserted"))
+        if was_inserted:
+            self._insert_event(
+                owner_user_id=owner_user_id,
+                actor_user_id=owner_user_id,
+                recipient_user_id=recipient_user_id,
+                grant_id=grant["id"],
+                event_type="location_share_created",
+                metadata={"duration_hours": duration},
+            )
         # Kind-aware notification copy so the recipient instantly knows WHAT this
         # is (emergency SOS vs friendly Check-In vs plain share) and WHY. The
         # share kind comes from the grant "reason" marker; a Check-In note is
@@ -2795,7 +3308,10 @@ class OneLocationAgentService:
         # ("owner_approved" / "request_approved" / "sos_panic") are never shown
         # as a raw message.
         share_message = _visible_share_message(reason)
-        if resolved_kind == "sos":
+        if resolved_kind == "connections_visibility":
+            notification_title = "Visible on Friends Map"
+            notification_body = f"{owner_label} is sharing live location with connections."
+        elif resolved_kind == "sos":
             notification_title = "SOS alert"
             notification_body = (
                 f"{owner_label} triggered an SOS and is sharing live location with you."
@@ -2827,7 +3343,7 @@ class OneLocationAgentService:
         # this call. Sending share-created as well produces two alerts for one
         # user action, so direct/SOS/check-in/drive shares use this notification
         # while approvals use only location_access_approved.
-        if reason != "request_approved":
+        if was_inserted and send_notification and reason != "request_approved":
             self._send_metadata_notification(
                 user_id=recipient_user_id,
                 notification_type="location_share_created",
@@ -2885,6 +3401,19 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_GRANT_NOT_FOUND", "Location share was not found.", status_code=404
             )
+        if str(grant_row.get("access_origin") or "direct") == "connections_visibility":
+            grant_owner_user_id = str(grant_row.get("owner_user_id") or "")
+            grant_recipient_user_id = str(grant_row.get("recipient_user_id") or "")
+            if not self._is_active_connection(
+                owner_user_id=grant_owner_user_id,
+                other_user_id=grant_recipient_user_id,
+            ):
+                raise OneLocationAgentError(
+                    "LOCATION_RECIPIENT_NOT_CONNECTED",
+                    "Location access ended because this connection is no longer active.",
+                    status_code=403,
+                )
+            grant_row = self._renew_managed_visibility_grant(grant_row)
         if str(grant_row.get("status") or "") != "active":
             raise OneLocationAgentError(
                 "LOCATION_GRANT_NOT_ACTIVE", "Location share is not active.", status_code=409
@@ -2988,6 +3517,18 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_GRANT_NOT_FOUND", "No approved location share was found.", status_code=404
             )
+        if str(grant_row.get("access_origin") or "direct") == "connections_visibility":
+            grant_owner_user_id = str(grant_row.get("owner_user_id") or "")
+            if not self._is_active_connection(
+                owner_user_id=grant_owner_user_id,
+                other_user_id=recipient_user_id,
+            ):
+                raise OneLocationAgentError(
+                    "LOCATION_RECIPIENT_NOT_CONNECTED",
+                    "Location access ended because this connection is no longer active.",
+                    status_code=403,
+                )
+            grant_row = self._renew_managed_visibility_grant(grant_row)
         if str(grant_row.get("status") or "") != "active":
             raise OneLocationAgentError(
                 "LOCATION_GRANT_NOT_ACTIVE", "Location share is not active.", status_code=410
@@ -3712,7 +4253,7 @@ class OneLocationAgentService:
                     exc,
                 )
         try:
-            recipients = self.list_verified_recipients(owner_user_id=user_id)
+            recipients = self.list_verified_recipients(owner_user_id=user_id, limit=100)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "one_location.list_state.recipients_failed user=%s error=%s",
@@ -3720,6 +4261,37 @@ class OneLocationAgentService:
                 exc,
             )
             recipients = []
+        visibility = self._visibility_payload(None)
+        try:
+            preference_row = self._visibility_preference_row(owner_user_id=user_id)
+            exclusions = self._visibility_excluded_user_ids(owner_user_id=user_id)
+            if str((preference_row or {}).get("audience") or "private") == "connections":
+                visibility = self.set_connection_visibility(
+                    owner_user_id=user_id,
+                    enabled=True,
+                    precision=str((preference_row or {}).get("precision") or "precise"),
+                    excluded_user_ids=sorted(exclusions),
+                )["visibility"]
+            else:
+                eligible = [
+                    recipient
+                    for recipient in recipients
+                    if str(recipient.get("userId") or "") not in exclusions
+                ]
+                visibility = self._visibility_payload(
+                    preference_row,
+                    excluded_user_ids=exclusions,
+                    eligible_connection_count=len(eligible),
+                    ready_connection_count=sum(
+                        1 for recipient in eligible if recipient.get("canReceiveLocation")
+                    ),
+                )
+        except Exception as exc:  # noqa: BLE001 - migration drift must not 500 state
+            logger.warning(
+                "one_location.list_state.visibility_failed user=%s error=%s",
+                user_id,
+                exc,
+            )
         owner_grants = _safe_many(
             "owner_grants",
             """
@@ -3731,7 +4303,7 @@ class OneLocationAgentService:
             LEFT JOIN actor_identity_cache r ON r.user_id = g.recipient_user_id
             WHERE g.owner_user_id = :user_id
             ORDER BY g.created_at DESC
-            LIMIT 50
+            LIMIT 100
             """,
             {"user_id": user_id},
         )
@@ -3746,7 +4318,7 @@ class OneLocationAgentService:
             LEFT JOIN actor_identity_cache o ON o.user_id = g.owner_user_id
             WHERE g.recipient_user_id = :user_id
             ORDER BY g.created_at DESC
-            LIMIT 50
+            LIMIT 100
             """,
             {"user_id": user_id},
         )
@@ -3858,6 +4430,7 @@ class OneLocationAgentService:
 
         return {
             "recipients": recipients,
+            "visibility": visibility,
             "myRecipientKey": my_recipient_key,
             "ownerGrants": [
                 payload
@@ -3944,6 +4517,27 @@ class OneLocationAgentService:
             )
         actor_is_owner = str(row.get("owner_user_id") or "") == owner_user_id
         recipient_user_id = str(row.get("recipient_user_id") or "") or None
+        if str(row.get("access_origin") or "direct") == "connections_visibility":
+            self._execute_one(
+                """
+                INSERT INTO one_location_visibility_exclusions (
+                  owner_user_id, excluded_user_id, source, created_at
+                )
+                VALUES (:owner_user_id, :excluded_user_id, :source, NOW())
+                ON CONFLICT (owner_user_id, excluded_user_id) DO UPDATE SET
+                  source = CASE
+                    WHEN one_location_visibility_exclusions.source = 'recipient'
+                      THEN 'recipient'
+                    ELSE EXCLUDED.source
+                  END
+                RETURNING owner_user_id
+                """,
+                {
+                    "owner_user_id": str(row.get("owner_user_id") or ""),
+                    "excluded_user_id": str(row.get("recipient_user_id") or ""),
+                    "source": "owner" if actor_is_owner else "recipient",
+                },
+            )
         self._insert_event(
             owner_user_id=str(row.get("owner_user_id") or owner_user_id),
             actor_user_id=owner_user_id,
@@ -4117,6 +4711,7 @@ class OneLocationAgentService:
             recipient_key_id=None,
             duration_hours=duration_hours,
             reason="request_approved",
+            access_origin="request_approved",
             require_recipient_phone_verified=False,
         )
         resolved = self._execute_one(

--- a/consent-protocol/hushh_mcp/services/one_location_center_contributor.py
+++ b/consent-protocol/hushh_mcp/services/one_location_center_contributor.py
@@ -48,11 +48,13 @@ _SHARE_KIND_LABEL = {
     "sos": "SOS",
     "check_in": "Check-In",
     "share": "Share",
+    "connections_visibility": "Friends Map",
 }
 _SHARE_KIND_SCOPE_DESCRIPTION = {
     "sos": "SOS emergency live location",
     "check_in": "Check-in live location",
     "share": "Live location sharing",
+    "connections_visibility": "Friends Map location visibility",
 }
 
 
@@ -275,10 +277,11 @@ class OneLocationCenterContributor:
         # Distinguish an emergency SOS share from a friendly Check-In from a plain
         # location share so the Consent Manager can tag + describe each row
         # accurately (instead of every location grant reading the same). The share
-        # kind + optional human message are already coordinate-free on the grant
-        # payload (see OneLocationAgentService._grant_payload).
+        # kind is coordinate-free on the grant payload (see
+        # OneLocationAgentService._grant_payload). Free-form share text is
+        # intentionally excluded because it can contain an address or coordinates.
         share_kind = _safe_str(grant.get("shareKind")) or "share"
-        share_message = _safe_str(grant.get("shareMessage"))
+        access_origin = _safe_str(grant.get("accessOrigin")) or "direct"
         scope_description = _SHARE_KIND_SCOPE_DESCRIPTION.get(
             share_kind, _SHARE_KIND_SCOPE_DESCRIPTION["share"]
         )
@@ -289,8 +292,8 @@ class OneLocationCenterContributor:
                 "grant_id": grant_id,
                 "requester_label": counterpart_label,
                 "share_kind": share_kind,
+                "access_origin": access_origin,
                 "share_kind_label": _SHARE_KIND_LABEL.get(share_kind, _SHARE_KIND_LABEL["share"]),
-                **({"share_message": share_message} if share_message else {}),
                 **({"duration_label": _duration_label(duration_hours)} if duration_hours else {}),
             }
         )

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -101,6 +101,8 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
         "DELETE FROM one_kyc_workflows",
         "DELETE FROM one_location_events",
         "DELETE FROM one_location_referrals",
+        "DELETE FROM one_location_visibility_exclusions",
+        "DELETE FROM one_location_visibility_preferences",
         "DELETE FROM one_location_public_invite_submissions",
         "DELETE FROM one_location_public_invites",
         "DELETE FROM one_location_circle_invites",
@@ -143,6 +145,9 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
     assert executed_sql.index("DELETE FROM one_location_events") < executed_sql.index(
         "DELETE FROM one_location_share_grants"
     )
+    assert executed_sql.index(
+        "DELETE FROM one_location_visibility_exclusions"
+    ) < executed_sql.index("DELETE FROM actor_identity_cache")
     assert executed_sql.index("DELETE FROM one_location_share_grants") < executed_sql.index(
         "DELETE FROM actor_identity_cache"
     )
@@ -209,6 +214,8 @@ async def test_reset_account_clears_data_but_keeps_account_spine(monkeypatch):
         "DELETE FROM consent_audit",
         "DELETE FROM one_kyc_workflows",
         "DELETE FROM one_location_events",
+        "DELETE FROM one_location_visibility_exclusions",
+        "DELETE FROM one_location_visibility_preferences",
     ]
     for fragment in cleared_fragments:
         assert fragment in executed_sql

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -259,6 +259,9 @@ def test_remove_connection_revokes_connection_and_trusted_edges():
     conn_update_indices = [i for i, (sql, _) in enumerate(db.calls) if "UPDATE connections" in sql]
     assert len(trusted_update_indices) >= 1, "UPDATE trusted_connections was not called"
     assert len(conn_update_indices) >= 1, "UPDATE connections was not called"
+    location_updates = [sql for sql, _ in db.calls if "UPDATE one_location_share_grants" in sql]
+    assert len(location_updates) == 1
+    assert "access_origin = 'connections_visibility'" in location_updates[0]
     # Trusted-edge revoke must happen BEFORE the connection revoke.
     assert trusted_update_indices[0] < conn_update_indices[0], (
         "UPDATE trusted_connections must precede UPDATE connections"

--- a/consent-protocol/tests/test_fcm_messages.py
+++ b/consent-protocol/tests/test_fcm_messages.py
@@ -176,8 +176,27 @@ def test_location_notification_name_only_body_reaches_every_platform() -> None:
     assert android.notification.body == body
     assert web.notification.body == body
     assert web.webpush.notification.body == body
+    assert web.webpush.fcm_options is None
     assert ios.notification.body == body
     assert ios.apns.payload.aps.alert.body == body
+
+
+def test_build_push_message_for_local_web_omits_https_only_fcm_link() -> None:
+    device_token = "web-device-id"
+    message = build_push_message(
+        _MessagingStub,
+        token=device_token,
+        platform="web",
+        data={"type": "location_share_created"},
+        title="Location shared",
+        body="A connection is visible on Friends Map.",
+        request_url="http://127.0.0.1:3000/one/location",
+        notification_tag="one-location-share:test",
+        show_alert=True,
+    )
+
+    assert message.webpush.fcm_options is None
+    assert message.webpush.notification.data == {"url": "http://127.0.0.1:3000/one/location"}
 
 
 def test_build_push_message_without_alert_is_data_only():

--- a/consent-protocol/tests/test_one_action_directive_ledger_migration.py
+++ b/consent-protocol/tests/test_one_action_directive_ledger_migration.py
@@ -11,9 +11,12 @@ def test_action_directive_ledger_is_in_release_and_schema_contracts():
     uat = json.loads((ROOT / "db/contracts/uat_integrated_schema.json").read_text())
     dev = json.loads((ROOT / "db/contracts/dev_minimum_schema.json").read_text())
 
-    assert manifest["ordered_migrations"][-1] == "114_one_action_directive_ledger.sql"
-    assert uat["expected_migration_version"] == 114
-    assert dev["expected_migration_version"] == 114
+    ordered = manifest["ordered_migrations"]
+    assert ordered.index("114_one_action_directive_ledger.sql") < ordered.index(
+        "115_one_location_connection_visibility.sql"
+    )
+    assert uat["expected_migration_version"] == 115
+    assert dev["expected_migration_version"] == 115
     assert "one_action_directive_ledger" in uat["required_tables"]
     assert "one_action_directive_ledger" in dev["required_tables"]
 

--- a/consent-protocol/tests/test_one_location_center_contributor.py
+++ b/consent-protocol/tests/test_one_location_center_contributor.py
@@ -51,6 +51,32 @@ def test_active_owner_grant_maps_to_active_access():
     assert entry["metadata"]["section"] == "people"
 
 
+def test_connection_visibility_grant_is_labeled_and_coordinate_free():
+    state = {
+        "ownerGrants": [
+            {
+                "id": "grant_friends_map",
+                "status": "active",
+                "recipientUserId": "user_b",
+                "recipientDisplayName": "Bob",
+                "shareKind": "connections_visibility",
+                "accessOrigin": "connections_visibility",
+                "shareMessage": "Meet at 12.9716, 77.5946 near Main Street",
+                "durationHours": 24,
+            }
+        ]
+    }
+    entry = _contributor(state).collect("user_a")["active_grants"][0]
+    assert entry["scope_description"] == "Friends Map location visibility"
+    assert entry["metadata"]["share_kind_label"] == "Friends Map"
+    assert entry["metadata"]["access_origin"] == "connections_visibility"
+    assert "share_message" not in entry["metadata"]
+    assert "12.9716" not in str(entry)
+    assert "main street" not in str(entry).lower()
+    assert "latitude" not in str(entry).lower()
+    assert "longitude" not in str(entry).lower()
+
+
 def test_pending_owner_request_maps_to_requests():
     state = {
         "requests": [

--- a/consent-protocol/tests/test_one_location_connection_visibility.py
+++ b/consent-protocol/tests/test_one_location_connection_visibility.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from hushh_mcp.services.one_location_agent_service import OneLocationAgentService
+
+
+class _VisibilityMemoryService(OneLocationAgentService):
+    def __init__(self) -> None:
+        self.preference: dict | None = None
+        self.preference_sql = ""
+        self.exclusions: dict[str, str] = {}
+        self.grants: list[dict] = []
+        self.recipients = [
+            {
+                "userId": "user_b",
+                "displayName": "Bob",
+                "keyId": "key-user-b",
+                "canReceiveLocation": True,
+            },
+            {
+                "userId": "user_c",
+                "displayName": "Carol",
+                "keyId": "key-user-c",
+                "canReceiveLocation": True,
+            },
+            {
+                "userId": "user_d",
+                "displayName": "Dev",
+                "keyId": None,
+                "canReceiveLocation": False,
+            },
+        ]
+
+    def list_verified_recipients(self, *, owner_user_id: str, limit: int = 50):  # noqa: ARG002
+        return self.recipients[:limit]
+
+    def _list_connection_visibility_recipients(self, *, owner_user_id: str):  # noqa: ARG002
+        return self.recipients
+
+    def _execute_many(self, sql: str, params=None):
+        if "FROM one_location_visibility_exclusions" in sql:
+            return [
+                {"excluded_user_id": user_id, "source": source}
+                for user_id, source in self.exclusions.items()
+            ]
+        if "FROM one_location_share_grants" in sql and "connections_visibility" in sql:
+            return [grant.copy() for grant in self.grants if grant["status"] == "active"]
+        raise AssertionError(f"unexpected execute_many SQL: {sql}")
+
+    def _execute_one(self, sql: str, params=None):
+        params = params or {}
+        if "INSERT INTO one_location_visibility_preferences" in sql:
+            self.preference_sql = sql
+            now = datetime.now(timezone.utc)
+            encoded_exclusions = json.loads(params["excluded_user_ids_json"])
+            assert isinstance(encoded_exclusions, list)
+            owner_exclusions = set(encoded_exclusions)
+            self.exclusions = {
+                user_id: source
+                for user_id, source in self.exclusions.items()
+                if source == "recipient"
+            }
+            self.exclusions.update({user_id: "owner" for user_id in owner_exclusions})
+            self.preference = {
+                "owner_user_id": params["owner_user_id"],
+                "audience": params["audience"],
+                "precision": params["precision"],
+                "enabled_at": now if params["enabled"] else None,
+                "disabled_at": None if params["enabled"] else now,
+                "updated_at": now,
+            }
+            return self.preference.copy()
+        if sql.strip().startswith("DELETE FROM one_location_visibility_exclusions"):
+            self.exclusions = {
+                user_id: source for user_id, source in self.exclusions.items() if source != "owner"
+            }
+            return None
+        if "INSERT INTO one_location_visibility_exclusions" in sql:
+            self.exclusions.setdefault(params["excluded_user_id"], "owner")
+            return {"owner_user_id": params["owner_user_id"]}
+        if "FROM one_location_share_grants" in sql and "recipient_user_id" in sql:
+            return next(
+                (
+                    grant.copy()
+                    for grant in self.grants
+                    if grant["recipient_user_id"] == params["recipient_user_id"]
+                    and grant["status"] == "active"
+                ),
+                None,
+            )
+        if "UPDATE one_location_share_grants" in sql and "status = 'revoked'" in sql:
+            for grant in self.grants:
+                if grant["id"] == params["grant_id"] and grant["status"] == "active":
+                    grant["status"] = "revoked"
+                    return grant.copy()
+            return None
+        raise AssertionError(f"unexpected execute_one SQL: {sql}")
+
+    def create_grant(self, **kwargs):
+        now = datetime.now(timezone.utc)
+        row = {
+            "id": f"grant-{len(self.grants) + 1}",
+            "owner_user_id": kwargs["owner_user_id"],
+            "recipient_user_id": kwargs["recipient_user_id"],
+            "recipient_key_id": kwargs["recipient_key_id"],
+            "status": "active",
+            "consent_scope": "cap.location.live.view",
+            "capability_scopes": [],
+            "duration_hours": kwargs["duration_hours"],
+            "expires_at": now + timedelta(hours=24),
+            "created_at": now,
+            "updated_at": now,
+            "metadata": {
+                "share_kind": "connections_visibility",
+                "access_origin": "connections_visibility",
+            },
+            "access_origin": "connections_visibility",
+        }
+        self.grants.append(row)
+        return self._grant_payload(row)
+
+    def _renew_managed_visibility_grant(self, row):
+        return row
+
+
+class _PublishTargetQueryService(OneLocationAgentService):
+    def __init__(self) -> None:
+        self.query = ""
+
+    def _visibility_preference_row(self, *, owner_user_id: str):  # noqa: ARG002
+        return None
+
+    def _execute_many(self, sql: str, params=None):  # noqa: ARG002
+        self.query = sql
+        return []
+
+
+def test_connection_visibility_is_idempotent_and_respects_readiness_and_exclusions():
+    service = _VisibilityMemoryService()
+
+    enabled = service.set_connection_visibility(
+        owner_user_id="user_a",
+        enabled=True,
+        precision="approximate",
+        excluded_user_ids=["user_b"],
+    )
+    assert enabled["visibility"]["enabled"] is True
+    assert enabled["visibility"]["precision"] == "approximate"
+    assert enabled["visibility"]["eligibleConnectionCount"] == 2
+    assert enabled["visibility"]["readyConnectionCount"] == 1
+    assert [grant["recipientUserId"] for grant in enabled["grants"]] == ["user_c"]
+    assert "AND NOT EXISTS" in service.preference_sql
+
+    repeated = service.set_connection_visibility(
+        owner_user_id="user_a",
+        enabled=True,
+        precision="approximate",
+        excluded_user_ids=["user_b"],
+    )
+    assert len(service.grants) == 1
+    assert repeated["grants"][0]["id"] == enabled["grants"][0]["id"]
+
+    disabled = service.set_connection_visibility(
+        owner_user_id="user_a",
+        enabled=False,
+        precision="approximate",
+        excluded_user_ids=[],
+    )
+    assert disabled["visibility"]["enabled"] is False
+    assert service.grants[0]["status"] == "revoked"
+
+
+def test_publish_targets_query_uses_a_non_reserved_grant_alias():
+    service = _PublishTargetQueryService()
+
+    assert service.list_publish_targets(owner_user_id="user_a") == []
+    assert "FROM one_location_share_grants share_grant" in service.query
+    assert "FROM one_location_share_grants grant" not in service.query
+
+
+def test_recipient_readiness_matches_grant_phone_and_key_requirements():
+    ready = OneLocationAgentService._recipient_payload(
+        {
+            "user_id": "user_b",
+            "phone_verified": True,
+            "key_id": "key-b",
+            "public_key_jwk": {"kty": "EC", "crv": "P-256", "x": "x", "y": "y"},
+        }
+    )
+    unverified = OneLocationAgentService._recipient_payload(
+        {
+            "user_id": "user_c",
+            "phone_verified": False,
+            "key_id": "key-c",
+            "public_key_jwk": {"kty": "EC"},
+        }
+    )
+    missing_key = OneLocationAgentService._recipient_payload(
+        {"user_id": "user_d", "phone_verified": True, "key_id": "key-d"}
+    )
+
+    assert ready and ready["canReceiveLocation"] is True
+    assert unverified and unverified["canReceiveLocation"] is False
+    assert missing_key and missing_key["canReceiveLocation"] is False

--- a/consent-protocol/tests/test_one_location_connection_visibility_migration.py
+++ b/consent-protocol/tests/test_one_location_connection_visibility_migration.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = "115_one_location_connection_visibility.sql"
+
+
+def test_connection_visibility_migration_is_in_release_and_schema_contracts() -> None:
+    manifest = json.loads((ROOT / "db/release_migration_manifest.json").read_text())
+    ordered = manifest["ordered_migrations"]
+
+    assert ordered[-1] == MIGRATION
+    assert MIGRATION in manifest["groups"]["iam"]
+    assert (ROOT / "db/migrations" / MIGRATION).exists()
+
+    for contract_name in (
+        "uat_integrated_schema.json",
+        "dev_minimum_schema.json",
+        "prod_core_schema.json",
+    ):
+        contract = json.loads((ROOT / "db/contracts" / contract_name).read_text())
+        required = contract["required_tables"]
+        assert contract["expected_migration_version"] == 115
+        assert "access_origin" in required["one_location_share_grants"]
+        assert "one_location_visibility_preferences" in required
+        assert "one_location_visibility_exclusions" in required
+
+
+def test_connection_visibility_migration_is_coordinate_free_and_pair_unique() -> None:
+    sql = (ROOT / "db/migrations" / MIGRATION).read_text().lower()
+
+    assert "idx_one_location_visibility_active_pair" in sql
+    assert "connections_visibility" in sql
+    for prohibited in ("latitude", "longitude", "address", "map_payload"):
+        assert prohibited not in sql

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -855,12 +855,14 @@
         "one_location_public_invites",
         "one_location_recipient_keys",
         "one_location_referrals",
-        "one_location_share_grants"
+        "one_location_share_grants",
+        "one_location_visibility_exclusions",
+        "one_location_visibility_preferences"
       ],
       "id": "one_location_agent",
       "lifecycle_status": "current",
       "owner": "iam-consent-governance",
-      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit"
+      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, connection-visibility preferences and exclusions, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit"
     },
     {
       "data_class": "personal_projection",
@@ -4080,7 +4082,7 @@
     "action_gateway": "3f982e6ed3859a48f1f7fd61b9de7119f233d9cc8dad073a8f40b3a537d14a73",
     "agent_registry": "277e07bfd16d70760bd47c197521a6844239e76eb454e0e91633f71310307c86",
     "cache_manifest": "b7584a0c98febbdd104b0aa20ace6a4889da27f8867da423a6175a60de85deb7",
-    "data_plane": "a1a2a500c7103122d25c811f94a7d4faa82615c659a7e9de2c4ea917c1e8bd02",
+    "data_plane": "ed5b561098f4134d18bcfa03f921477bade454661682c7c5ae8d5c4b89ebf5ed",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
     "route_index": "f09909abd11c55ceae914d2bf53f0b2c80acbd96f9ca1287943aaa42465434ba",

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -2,7 +2,7 @@
 
 Status: v1 implementation contract
 Owner: One + IAM/consent governance
-Last updated: 2026-06-18
+Last updated: 2026-07-21
 
 ## Visual Map
 
@@ -110,6 +110,34 @@ owner/link metadata plus the attached public location snapshot.
   permission.
 - Consent/audit records are metadata-only.
 
+## Connection Visibility Contract
+
+`Visible to connections` is a private Friends Map audience, not a public link.
+It is off by default and includes accepted mutual `connections` only. Pending
+requests, directional trusted edges, directory matches, and public-link users
+are never members of this audience.
+
+- The owner preference and per-person exclusions are coordinate-free metadata.
+- Every eligible recipient still receives an independent E2EE grant and
+  ciphertext envelope. The backend never encrypts or fans out plaintext.
+- Managed grants use `access_origin = connections_visibility`; direct,
+  request-approved, SOS, check-in, drive, and pickup access remain independent.
+- A recipient without a current One Location key remains unavailable until key
+  provisioning completes.
+- Future accepted connections join an enabled audience automatically unless
+  excluded. Recipient opt-outs remain sticky.
+- Disconnect, exclusion, or disabling visibility blocks reads immediately and
+  revokes managed grants.
+- Managed grants are bounded 24-hour authorization leases that renew silently
+  while the owner preference, connection, and encrypted publishing remain
+  active. The user-facing setting stays on until the owner turns it off.
+- Native publishers refresh their authorized recipient/key list every five
+  minutes, so newly accepted connections join without persisting vault
+  credentials or waiting for the owner to reopen One Location.
+- Approximate mode reduces coordinate precision on the client before E2EE.
+- Consent notifications route to the shield and Access Manager, never the
+  general bell. Location updates themselves do not create notifications.
+
 Capability scopes:
 
 - `cap.location.live.share`
@@ -202,17 +230,22 @@ retention boundary.
 
 ## Native Contract
 
-v1 is foreground-only.
+Web, iOS, and Android share the typed `HushhLocation` Capacitor contract.
 
-- iOS uses `NSLocationWhenInUseUsageDescription` and the `HushhLocation`
-  Capacitor plugin.
-- Android uses fine/coarse location permissions and the `HushhLocation`
-  Capacitor plugin.
-- No iOS background location mode is added.
-- No Android background location permission is added.
-
-Denied, unavailable, approximate, and foreground-only states must be visible in
-the web control surface.
+- Web publishes only while the page is active. A previously encrypted point is
+  still governed by the live audience policy and is labeled stale by its
+  capture time; it is never presented as a current background update.
+- iOS requests `Always` authorization only after the user enables connection
+  visibility, then publishes recipient-specific ciphertext through the native
+  background publisher.
+- Android requests background location only after the same explicit opt-in and
+  uses a visible location foreground service. Session credentials remain in
+  process memory and the service is not restarted after process death.
+- Foreground publishing remains available when background permission is not
+  granted; the UI must say `Updates while One is open` rather than promising
+  continuous visibility.
+- Denied, unavailable, approximate, foreground-only, and background-authorized
+  states remain visible in Settings.
 
 ## Migration From KAI Prototype
 

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -366,12 +366,14 @@
         "one_location_public_invites",
         "one_location_recipient_keys",
         "one_location_referrals",
-        "one_location_share_grants"
+        "one_location_share_grants",
+        "one_location_visibility_exclusions",
+        "one_location_visibility_preferences"
       ],
-      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit",
-      "retention_policy": "Active grants and ciphertext envelopes are short-lived by scoped duration; expired or terminal workflow rows are retained only for bounded operational review before compaction.",
-      "deletion_behavior": "Delete rows where the deleting account is owner, recipient, requester, referrer, referred user, or key owner; revoke active grants before deletion where possible.",
-      "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, public invite token hashes, Invite to One token hashes, One Network connection metadata, request metadata, hashed public-intake throttling metadata, and audit metadata; it must not store latitude, longitude, addresses, map previews, movement trails, or raw public tokens. Public invite links can request access or reveal only an explicit public snapshot; Invite to One links create metadata-only network readiness and never reveal private grants, ciphertext, or owner identity beyond a safe label.",
+      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, connection-visibility preferences and exclusions, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit",
+      "retention_policy": "Active grants and ciphertext envelopes are short-lived by scoped duration; an owner's coordinate-free visibility preference and exclusions persist until changed or the account is deleted; expired or terminal workflow rows are retained only for bounded operational review before compaction.",
+      "deletion_behavior": "Delete rows where the deleting account is owner, recipient, requester, referrer, referred user, key owner, visibility owner, or excluded connection; revoke active grants before deletion where possible.",
+      "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, coordinate-free connection-visibility preferences and exclusions, public invite token hashes, Invite to One token hashes, One Network connection metadata, request metadata, hashed public-intake throttling metadata, and audit metadata; it must not store latitude, longitude, addresses, map previews, movement trails, or raw public tokens. Public invite links can request access or reveal only an explicit public snapshot; Invite to One links create metadata-only network readiness and never reveal private grants, ciphertext, or owner identity beyond a safe label.",
       "plaintext_posture": "ciphertext_coordinates_and_metadata_only",
       "expected_row_growth": "medium_per_user_share"
     },

--- a/docs/reference/mobile/capacitor-parity-audit.md
+++ b/docs/reference/mobile/capacitor-parity-audit.md
@@ -179,12 +179,16 @@ Native parity for authenticated flows now includes the verified phone mandate af
 - `/register-phone` is a contract route even though it bypasses the standard shell.
 - One Voice/Kai compatibility surfaces require native microphone permission metadata:
   `NSMicrophoneUsageDescription` on iOS and `android.permission.RECORD_AUDIO` on Android.
-- One Location Agent requires foreground-only location parity:
-  `NSLocationWhenInUseUsageDescription` on iOS,
-  `android.permission.ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` on
-  Android, and the `HushhLocation` plugin on web, iOS, and Android.
-- One Location Agent v1 must not add iOS background location mode or Android
-  background location permission.
+- One Location requires foreground location parity on every platform. Web
+  publishes only while the page is active. Android and iOS may additionally
+  publish in the background only after the user explicitly enables Friends Map
+  visibility and grants the OS-level background permission.
+- iOS declares `NSLocationWhenInUseUsageDescription`,
+  `NSLocationAlwaysAndWhenInUseUsageDescription`, and the `location` background
+  mode. Android declares fine/coarse/background location plus a location-typed
+  foreground service. These declarations do not authorize capture by
+  themselves; the setting remains off by default and native publishing stops
+  when visibility is disabled, access disappears, or authentication expires.
 - `/one/kai/funding-trade` is part of the native route inventory because voice/action parity can
   land users on the funding trade surface.
 - `/one/location` is part of the native route inventory because live location is

--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -92,7 +92,10 @@ import {
   ConsentNotificationProvider,
   useConsentNotificationState,
 } from "@/components/consent/notification-provider";
-import { markOneLocationGrantUnwatched } from "@/lib/one-location/notifications";
+import {
+  hasSeenOneLocationNotification,
+  markOneLocationGrantUnwatched,
+} from "@/lib/one-location/notifications";
 
 const EMPTY_LOCATION_STATE = {
   recipients: [],
@@ -192,7 +195,7 @@ describe("global One Location notification provider", () => {
     );
   });
 
-  it("shows one popup and records one bell item for duplicate live pushes on a non-Location route", async () => {
+  it("shows one popup, refreshes consent state, and keeps the general bell clean", async () => {
     renderProvider();
     await waitFor(() => expect(mocks.initializeFCM).toHaveBeenCalledOnce());
 
@@ -212,13 +215,7 @@ describe("global One Location notification provider", () => {
     });
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
-    expect(mocks.startTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: "one_location_share:grant-live-1",
-        routeHref: expect.stringContaining("section=shared"),
-      }),
-    );
+    expect(mocks.startTask).not.toHaveBeenCalled();
   });
 
   it("queues a foreground push received during auth hydration and drains it once for the matching user", async () => {
@@ -249,7 +246,7 @@ describe("global One Location notification provider", () => {
     );
 
     await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
+    expect(mocks.startTask).not.toHaveBeenCalled();
   });
 
   it("recovers globally and still presents only once when push registration is blocked", async () => {
@@ -279,7 +276,7 @@ describe("global One Location notification provider", () => {
 
     await waitFor(() => expect(mocks.getState).toHaveBeenCalled());
     await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
+    expect(mocks.startTask).not.toHaveBeenCalled();
 
     act(() => {
       window.dispatchEvent(
@@ -296,7 +293,7 @@ describe("global One Location notification provider", () => {
     });
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
+    expect(mocks.startTask).not.toHaveBeenCalled();
   });
 
   it("presents a push-active reconciliation once and deduplicates a later live push", async () => {
@@ -316,7 +313,8 @@ describe("global One Location notification provider", () => {
     renderProvider();
     await waitFor(() => expect(mocks.getState).toHaveBeenCalled());
     await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(mocks.startTask).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
+    expect(mocks.startTask).not.toHaveBeenCalled();
 
     act(() => {
       window.dispatchEvent(
@@ -333,7 +331,7 @@ describe("global One Location notification provider", () => {
     });
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
+    expect(mocks.startTask).not.toHaveBeenCalled();
   });
 
   it("presents a reconciliation once after a fetch finishes while the page is hidden", async () => {
@@ -369,8 +367,16 @@ describe("global One Location notification provider", () => {
     await act(async () => {
       resolveFirstState(locationState);
     });
-    await waitFor(() => expect(mocks.startTask).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(
+        hasSeenOneLocationNotification(
+          "recipient-user",
+          "location_access_request:request-visibility-race-1",
+        ),
+      ).toBe(true),
+    );
     expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.startTask).not.toHaveBeenCalled();
 
     visibilityState.mockReturnValue("visible");
     act(() => {
@@ -379,12 +385,12 @@ describe("global One Location notification provider", () => {
 
     await waitFor(() => expect(mocks.getState).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(mocks.toast).toHaveBeenCalledTimes(1));
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
+    expect(mocks.startTask).not.toHaveBeenCalled();
 
     visibilityState.mockRestore();
   });
 
-  it("keeps approval copy and the backend deep link without creating a second share entry", async () => {
+  it("keeps approval copy and the backend deep link without creating a bell entry", async () => {
     renderProvider();
     await waitFor(() => expect(mocks.initializeFCM).toHaveBeenCalledOnce());
 
@@ -409,16 +415,13 @@ describe("global One Location notification provider", () => {
     });
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
-    expect(mocks.startTask).toHaveBeenCalledTimes(1);
-    expect(mocks.startTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId:
-          "one_location_workflow:location_access_approved:grant-approved-1",
-        title: "Location request approved",
-        description: "Alex approved your location request.",
-        routeHref: detail.data.request_url,
-      }),
-    );
+    expect(mocks.startTask).not.toHaveBeenCalled();
+    const popup = mocks.toast.mock.calls[0]?.[0] as ReactNode;
+    render(<>{popup}</>);
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(mocks.routerPush).toHaveBeenCalledWith(detail.data.request_url, {
+      scroll: false,
+    });
   });
 
   it("does not surface live terminal notifications for an explicitly unwatched grant", async () => {

--- a/hushh-webapp/__tests__/one-location-notifications.test.ts
+++ b/hushh-webapp/__tests__/one-location-notifications.test.ts
@@ -29,7 +29,6 @@ vi.mock("@/lib/services/app-background-task-service", () => ({
   },
 }));
 
-
 import {
   buildOneLocationWorkflowHref,
   hasSeenOneLocationNotification,
@@ -45,7 +44,6 @@ import {
   resolveOneLocationNotificationHref,
 } from "@/lib/one-location/notifications";
 
-
 const USER = "user_recipient_1";
 const GRANT = "grant_abc";
 
@@ -60,7 +58,9 @@ afterEach(() => {
 
 describe("One-Location notification privacy", () => {
   it("uses the exact name-only copy for a plain location share", () => {
-    expect(locationShareNotificationCopy({ ownerLabel: "hushh Social" })).toEqual({
+    expect(
+      locationShareNotificationCopy({ ownerLabel: "hushh Social" }),
+    ).toEqual({
       title: "Location shared",
       description: "hushh Social shared location access with you.",
     });
@@ -129,10 +129,10 @@ describe("One-Location persistent notification de-dup", () => {
   });
 });
 
-describe("One-Location notification surfaces (bell + consent)", () => {
+describe("One-Location notification surfaces (consent only)", () => {
   const CONSENT_EVENT = "consent-state-changed";
 
-  it("creates a bell task with a 'shared' deep-link AND a consent refresh for a share", () => {
+  it("refreshes the consent surface without creating a general-bell task for a share", () => {
     const events: string[] = [];
     const handler = () => events.push("consent");
     window.addEventListener(CONSENT_EVENT, handler);
@@ -143,22 +143,14 @@ describe("One-Location notification surfaces (bell + consent)", () => {
         ownerLabel: "Alex",
       });
       expect(created).toBe(true);
-      // Routed to the consent surface (shield icon + consent manager)...
       expect(events.length).toBe(1);
-      // ...AND surfaced in the bell with an "Open" deep-link into the
-      // recipient's "Shared with me" section so it is reachable from the bell.
-      expect(tasks.size).toBe(1);
-      const task = tasks.get("one_location_share:grant_routing_1");
-      expect(task).toBeTruthy();
-      expect(task?.routeHref).toContain("/one/location");
-      expect(task?.routeHref).toContain("grantId=grant_routing_1");
-      expect(task?.routeHref).toContain("section=shared");
+      expect(tasks.size).toBe(0);
     } finally {
       window.removeEventListener(CONSENT_EVENT, handler);
     }
   });
 
-  it("creates a bell task AND a consent refresh for a workflow (approve/deny/request) event", () => {
+  it("refreshes the consent surface without creating a general-bell task for a workflow event", () => {
     const events: string[] = [];
     const handler = () => events.push("consent");
     window.addEventListener(CONSENT_EVENT, handler);
@@ -173,20 +165,12 @@ describe("One-Location notification surfaces (bell + consent)", () => {
       });
       expect(created).toBe(true);
       expect(events.length).toBe(1);
-      expect(tasks.size).toBe(1);
-      const task = tasks.get(
-        "one_location_workflow:location_access_request:req_routing_1",
-      );
-      expect(task).toBeTruthy();
-      expect(task?.routeHref).toBe(
-        "/one/location?requestId=req_routing_1&section=approvals",
-      );
+      expect(tasks.size).toBe(0);
     } finally {
       window.removeEventListener(CONSENT_EVENT, handler);
     }
   });
 });
-
 
 describe("One-Location workflow deep-link sections", () => {
   it("routes an access request to the focused Needs my review detail", () => {
@@ -205,10 +189,22 @@ describe("One-Location workflow deep-link sections", () => {
   });
 
   it("maps each workflow type to its owning section", () => {
-    expect(oneLocationSectionForWorkflowNotificationType("location_access_approved")).toBe("shared");
-    expect(oneLocationSectionForWorkflowNotificationType("location_access_denied")).toBe("my_requests");
-    expect(oneLocationSectionForWorkflowNotificationType("location_public_invite_submitted")).toBe("public_responses");
-    expect(oneLocationSectionForWorkflowNotificationType("location_one_network_joined")).toBe("people");
+    expect(
+      oneLocationSectionForWorkflowNotificationType("location_access_approved"),
+    ).toBe("shared");
+    expect(
+      oneLocationSectionForWorkflowNotificationType("location_access_denied"),
+    ).toBe("my_requests");
+    expect(
+      oneLocationSectionForWorkflowNotificationType(
+        "location_public_invite_submitted",
+      ),
+    ).toBe("public_responses");
+    expect(
+      oneLocationSectionForWorkflowNotificationType(
+        "location_one_network_joined",
+      ),
+    ).toBe("people");
   });
 });
 
@@ -219,9 +215,7 @@ describe("One-Location native notification routing", () => {
         request_url:
           "/one/location?grantId=grant_1&section=shared&notification=open",
       }),
-    ).toBe(
-      "/one/location?grantId=grant_1&section=shared&notification=open",
-    );
+    ).toBe("/one/location?grantId=grant_1&section=shared&notification=open");
   });
 
   it("normalizes an absolute app URL into an internal native route", () => {
@@ -239,9 +233,7 @@ describe("One-Location native notification routing", () => {
         request_url: "https://example.com/account",
         deep_link: "/one/location?submissionId=sub_1&section=public_responses",
       }),
-    ).toBe(
-      "/one/location?submissionId=sub_1&section=public_responses",
-    );
+    ).toBe("/one/location?submissionId=sub_1&section=public_responses");
   });
 
   it("uses the Location hub for malformed or unsafe payload URLs", () => {
@@ -269,7 +261,6 @@ describe("One-Location share notification copy", () => {
 });
 
 describe("One-Location unwatch", () => {
-
   it("hides a grant and suppresses its share notification", () => {
     expect(isOneLocationGrantUnwatched(USER, GRANT)).toBe(false);
     markOneLocationGrantUnwatched(USER, GRANT);

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -4,6 +4,7 @@ const {
   mockAuth,
   mockFirebaseAuthentication,
   mockHushhAuth,
+  mockHushhLocation,
   mockCapacitor,
   mockPhoneAuthProvider,
   mockUpdatePhoneNumber,
@@ -53,6 +54,9 @@ const {
     getIdToken: vi.fn(),
     signOut: vi.fn(),
     signInWithApple: vi.fn(),
+  },
+  mockHushhLocation: {
+    stopBackgroundShare: vi.fn(),
   },
   mockCapacitor: {
     isNativePlatform: vi.fn(() => true),
@@ -133,6 +137,7 @@ vi.mock("@capacitor-firebase/authentication", () => ({
 
 vi.mock("@/lib/capacitor", () => ({
   HushhAuth: mockHushhAuth,
+  HushhLocation: mockHushhLocation,
 }));
 
 import { FirebaseAuthentication } from "@capacitor-firebase/authentication";
@@ -145,7 +150,7 @@ import {
   signOut as firebaseSignOut,
   updatePhoneNumber,
 } from "firebase/auth";
-import { HushhAuth } from "@/lib/capacitor";
+import { HushhAuth, HushhLocation } from "@/lib/capacitor";
 import { AuthService } from "@/lib/services/auth-service";
 
 function createIdToken(expiresInSeconds: number): string {
@@ -181,6 +186,7 @@ function enableLocalDevPhoneTest() {
 describe("AuthService.signOut", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(HushhLocation.stopBackgroundShare).mockResolvedValue();
     vi.mocked(HushhAuth.signOut).mockResolvedValue(undefined);
     vi.mocked(firebaseSignOut).mockResolvedValue(undefined);
   });
@@ -189,6 +195,7 @@ describe("AuthService.signOut", () => {
     await expect(AuthService.signOut()).resolves.toBeUndefined();
 
     expect(HushhAuth.signOut).toHaveBeenCalledTimes(1);
+    expect(HushhLocation.stopBackgroundShare).toHaveBeenCalledTimes(1);
     expect(firebaseSignOut).toHaveBeenCalledWith(mockAuth);
   });
 

--- a/hushh-webapp/android/app/src/main/AndroidManifest.xml
+++ b/hushh-webapp/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,11 @@
             android:grantUriPermissions="true">
             <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
         </provider>
+
+        <service
+            android:name=".plugins.HushhLocation.BackgroundLocationService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
     </application>
 
     <!-- Permissions -->
@@ -53,5 +58,9 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
 </manifest>

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/MainActivity.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : BridgeActivity() {
         registerPlugin(KaiPlugin::class.java) // Agent Kai plugin
         registerPlugin(PersonalKnowledgeModelPlugin::class.java) // PKM plugin
         registerPlugin(HushhAccountPlugin::class.java) // Account management (deletion)
-        registerPlugin(HushhLocationPlugin::class.java) // Foreground location capture
+        registerPlugin(HushhLocationPlugin::class.java) // Foreground capture + opted-in background sharing
         registerPlugin(HushhContactsPlugin::class.java) // Contact matching
         
         Log.d("MainActivity", "All 12 plugins registered successfully")

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/BackgroundLocationService.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/BackgroundLocationService.kt
@@ -1,0 +1,372 @@
+package com.hushh.app.plugins.HushhLocation
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import com.hushh.app.MainActivity
+import com.hushh.app.R
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONObject
+import java.io.IOException
+import kotlin.math.cos
+import kotlin.math.max
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Foreground service that keeps recipient-specific encrypted location updates
+ * flowing while the Capacitor WebView is backgrounded. Session credentials stay
+ * in process memory and the service is intentionally START_NOT_STICKY.
+ */
+class BackgroundLocationService : Service(), LocationListener {
+    private data class Grant(
+        val id: String,
+        val recipientKeyId: String,
+        val recipientPublicKeyJwk: JSONObject,
+        val precision: String
+    )
+
+    private data class Session(
+        val vaultOwnerToken: String,
+        val backendBaseUrl: String,
+        val grants: List<Grant>,
+        val minMoveMeters: Double,
+        val minIntervalMs: Long
+    )
+
+    private val client = OkHttpClient()
+    @Volatile
+    private var session: Session? = null
+    private var lastPublishedAt = 0L
+    private var lastTargetsRefreshAt = 0L
+    private var lastLocation: Location? = null
+    private lateinit var locationManager: LocationManager
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val refreshTargetsRunnable = object : Runnable {
+        override fun run() {
+            val activeSession = session ?: return
+            refreshTargetsIfNeeded(activeSession, System.currentTimeMillis())
+            if (session != null) {
+                mainHandler.postDelayed(this, TARGET_REFRESH_INTERVAL_MS)
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        locationManager = getSystemService(LOCATION_SERVICE) as LocationManager
+        createNotificationChannel()
+        val launchIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Friends Map is updating")
+            .setContentText("Your encrypted location is visible to connections.")
+            .setOngoing(true)
+            .setContentIntent(pendingIntent)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            } else {
+                0
+            }
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            stopPublishing()
+            return START_NOT_STICKY
+        }
+        val rawSession = takePendingSession()
+        if (rawSession.isNullOrBlank()) {
+            stopPublishing()
+            return START_NOT_STICKY
+        }
+        session = parseSession(JSONObject(rawSession))
+        lastPublishedAt = 0L
+        lastTargetsRefreshAt = 0L
+        lastLocation = null
+        startLocationUpdates()
+        mainHandler.removeCallbacks(refreshTargetsRunnable)
+        mainHandler.post(refreshTargetsRunnable)
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        mainHandler.removeCallbacks(refreshTargetsRunnable)
+        locationManager.removeUpdates(this)
+        session = null
+        super.onDestroy()
+    }
+
+    override fun onLocationChanged(location: Location) {
+        val activeSession = session ?: return
+        val now = System.currentTimeMillis()
+        val moved = lastLocation?.distanceTo(location)?.toDouble() ?: Double.POSITIVE_INFINITY
+        if (moved < activeSession.minMoveMeters && now - lastPublishedAt < activeSession.minIntervalMs) {
+            return
+        }
+        lastLocation = location
+        lastPublishedAt = now
+        val capturedAt = isoTimestamp(location.time)
+        activeSession.grants.forEach { grant ->
+            runCatching {
+                val point = protectedPoint(location, grant.precision)
+                val pointJson = JSONObject()
+                    .put("latitude", point.first)
+                    .put("longitude", point.second)
+                    .put("accuracyM", point.third)
+                    .put("capturedAt", capturedAt)
+                    .put("sourcePlatform", "android")
+                val envelope = LocationEnvelopeCrypto.encrypt(
+                    pointJson.toString().toByteArray(Charsets.UTF_8),
+                    grant.recipientPublicKeyJwk,
+                    grant.recipientKeyId,
+                    capturedAt
+                )
+                postEnvelope(activeSession, grant.id, envelope)
+            }
+        }
+    }
+
+    private fun startLocationUpdates() {
+        val fine = ActivityCompat.checkSelfPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+        val coarse = ActivityCompat.checkSelfPermission(
+            this,
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!fine && !coarse) {
+            stopPublishing()
+            return
+        }
+        locationManager.removeUpdates(this)
+        val activeSession = session ?: return
+        val minTime = activeSession.minIntervalMs.coerceAtLeast(5_000L)
+        val minDistance = activeSession.minMoveMeters.toFloat().coerceAtLeast(10f)
+        val providers = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+            .filter(locationManager::isProviderEnabled)
+        if (providers.isEmpty()) {
+            stopPublishing()
+            return
+        }
+        providers.forEach { provider ->
+            locationManager.requestLocationUpdates(provider, minTime, minDistance, this)
+        }
+    }
+
+    private fun postEnvelope(activeSession: Session, grantId: String, envelope: JSONObject) {
+        val base = activeSession.backendBaseUrl.trimEnd('/')
+        val body = JSONObject().put("envelope", envelope).toString()
+            .toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url("$base/api/one/location/grants/$grantId/envelopes")
+            .header("Authorization", "Bearer ${activeSession.vaultOwnerToken}")
+            .post(body)
+            .build()
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, error: IOException) = Unit
+
+            override fun onResponse(call: Call, response: Response) {
+                response.use {
+                    when (it.code) {
+                        401 -> mainHandler.post { stopPublishing() }
+                        403, 404, 410 -> mainHandler.post { removeGrant(grantId) }
+                    }
+                }
+            }
+        })
+    }
+
+    private fun refreshTargetsIfNeeded(activeSession: Session, now: Long) {
+        if (now - lastTargetsRefreshAt < TARGET_REFRESH_INTERVAL_MS) return
+        lastTargetsRefreshAt = now
+        val base = activeSession.backendBaseUrl.trimEnd('/')
+        val request = Request.Builder()
+            .url("$base/api/one/location/publish-targets?limit=500")
+            .header("Authorization", "Bearer ${activeSession.vaultOwnerToken}")
+            .get()
+            .build()
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, error: IOException) = Unit
+
+            override fun onResponse(call: Call, response: Response) {
+                response.use {
+                    if (it.code == 401) {
+                        mainHandler.post { stopPublishing() }
+                        return
+                    }
+                    if (!it.isSuccessful) return
+                    val payload = it.body?.string()?.let(::JSONObject) ?: return
+                    val refreshed = parseTargets(payload)
+                    mainHandler.post {
+                        val current = session ?: return@post
+                        if (
+                            current.vaultOwnerToken != activeSession.vaultOwnerToken ||
+                            current.backendBaseUrl != activeSession.backendBaseUrl
+                        ) return@post
+                        session = current.copy(grants = refreshed)
+                        if (refreshed.isEmpty()) stopPublishing()
+                    }
+                }
+            }
+        })
+    }
+
+    private fun removeGrant(grantId: String) {
+        val current = session ?: return
+        val remaining = current.grants.filterNot { it.id == grantId }
+        if (remaining.size == current.grants.size) return
+        session = current.copy(grants = remaining)
+        if (remaining.isEmpty()) stopPublishing()
+    }
+
+    private fun parseTargets(payload: JSONObject): List<Grant> {
+        val targets = payload.optJSONArray("targets") ?: return emptyList()
+        return buildList {
+            for (index in 0 until targets.length()) {
+                val target = targets.optJSONObject(index) ?: continue
+                val grant = target.optJSONObject("grant") ?: continue
+                val recipient = target.optJSONObject("recipient") ?: continue
+                val grantId = grant.optString("id")
+                val keyId = recipient.optString("keyId")
+                val jwk = recipient.optJSONObject("publicKeyJwk")
+                if (grantId.isBlank() || keyId.isBlank() || jwk == null) continue
+                add(
+                    Grant(
+                        id = grantId,
+                        recipientKeyId = keyId,
+                        recipientPublicKeyJwk = jwk,
+                        precision = target.optString("precision", "precise")
+                    )
+                )
+            }
+        }
+    }
+
+    private fun parseSession(json: JSONObject): Session {
+        val rawGrants = json.getJSONArray("grants")
+        val grants = buildList {
+            for (index in 0 until rawGrants.length()) {
+                val grant = rawGrants.getJSONObject(index)
+                add(
+                    Grant(
+                        id = grant.getString("grantId"),
+                        recipientKeyId = grant.getString("recipientKeyId"),
+                        recipientPublicKeyJwk = grant.getJSONObject("recipientPublicKeyJwk"),
+                        precision = grant.optString("precision", "precise")
+                    )
+                )
+            }
+        }
+        return Session(
+            vaultOwnerToken = json.getString("vaultOwnerToken"),
+            backendBaseUrl = json.getString("backendBaseUrl"),
+            grants = grants,
+            minMoveMeters = json.optDouble("minMoveMeters", 25.0),
+            minIntervalMs = json.optLong("minIntervalMs", 8_000L)
+        )
+    }
+
+    private fun protectedPoint(location: Location, precision: String): Triple<Double, Double, Double> {
+        val accuracy = max(0.0, location.accuracy.toDouble())
+        if (precision != "approximate") {
+            return Triple(location.latitude, location.longitude, accuracy)
+        }
+        val gridMeters = 1_000.0
+        val metersPerDegree = 111_320.0
+        val latitudeStep = gridMeters / metersPerDegree
+        val longitudeScale = max(0.2, cos(Math.toRadians(location.latitude)))
+        val longitudeStep = gridMeters / (metersPerDegree * longitudeScale)
+        return Triple(
+            Math.round(location.latitude / latitudeStep) * latitudeStep,
+            Math.round(location.longitude / longitudeStep) * longitudeStep,
+            max(accuracy, gridMeters)
+        )
+    }
+
+    private fun isoTimestamp(timestampMs: Long): String =
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }.format(Date(timestampMs))
+
+    private fun stopPublishing() {
+        mainHandler.removeCallbacks(refreshTargetsRunnable)
+        locationManager.removeUpdates(this)
+        session = null
+        clearPendingSession()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            "Friends Map location",
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "Shown while One updates encrypted background location."
+        }
+        getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val ACTION_START = "com.hushh.app.location.START_BACKGROUND_SHARE"
+        const val ACTION_STOP = "com.hushh.app.location.STOP_BACKGROUND_SHARE"
+        private const val CHANNEL_ID = "one_location_background"
+        private const val NOTIFICATION_ID = 4107
+        private const val TARGET_REFRESH_INTERVAL_MS = 5 * 60 * 1000L
+
+        @Volatile
+        private var pendingSession: String? = null
+
+        fun prepareSession(rawSession: String) {
+            pendingSession = rawSession
+        }
+
+        private fun takePendingSession(): String? = pendingSession.also { pendingSession = null }
+
+        fun clearPendingSession() {
+            pendingSession = null
+        }
+    }
+}

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/HushhLocationPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/HushhLocationPlugin.kt
@@ -4,12 +4,14 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
 import android.net.Uri
 import android.os.Bundle
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
@@ -28,10 +30,8 @@ import java.util.Locale
 import java.util.TimeZone
 
 /**
- * Foreground-only location capture for One Location Agent.
- *
- * Coordinates are returned only to the local web layer. The web layer encrypts
- * before calling the backend.
+ * Foreground capture plus explicitly authorized native background publishing.
+ * Coordinates are encrypted locally before any background network request.
  */
 @CapacitorPlugin(
     name = "HushhLocation",
@@ -42,6 +42,10 @@ import java.util.TimeZone
                 Manifest.permission.ACCESS_FINE_LOCATION,
                 Manifest.permission.ACCESS_COARSE_LOCATION
             ]
+        ),
+        Permission(
+            alias = "backgroundLocation",
+            strings = [Manifest.permission.ACCESS_BACKGROUND_LOCATION]
         )
     ]
 )
@@ -130,24 +134,81 @@ class HushhLocationPlugin : Plugin() {
 
     @PluginMethod
     fun requestAlwaysAuthorization(call: PluginCall) {
-        // Android background publishing is not implemented yet. Return the
-        // truthful foreground state so the web layer can keep the opt-in off.
-        call.resolve(permissionPayload())
-    }
-
-    @PluginMethod
-    fun startBackgroundShare(call: PluginCall) {
-        call.resolve(
-            JSObject()
-                .put("started", false)
-                .put("reason", "android_background_share_unavailable")
+        if (!hasLocationPermission()) {
+            call.resolve(permissionPayload())
+            return
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || hasBackgroundLocationPermission()) {
+            call.resolve(permissionPayload())
+            return
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            try {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                context.startActivity(intent)
+                call.resolve(permissionPayload().put("settingsOpened", true))
+            } catch (error: Exception) {
+                call.reject("Could not open app settings: ${error.message}")
+            }
+            return
+        }
+        requestPermissionForAlias(
+            "backgroundLocation",
+            call,
+            "backgroundLocationPermissionCallback"
         )
     }
 
     @PluginMethod
+    fun startBackgroundShare(call: PluginCall) {
+        if (!hasBackgroundLocationPermission()) {
+            call.resolve(
+                JSObject()
+                    .put("started", false)
+                    .put("reason", "always-permission-required")
+            )
+            return
+        }
+        val grants = call.getArray("grants")
+        if (grants == null || grants.length() == 0) {
+            call.resolve(JSObject().put("started", false).put("reason", "no-grants"))
+            return
+        }
+        val backendBaseUrl = call.getString("backendBaseUrl")
+        if (backendBaseUrl.isNullOrBlank() || !isAllowedBackendBaseUrl(backendBaseUrl)) {
+            call.resolve(JSObject().put("started", false).put("reason", "backend-origin-not-allowed"))
+            return
+        }
+        BackgroundLocationService.prepareSession(call.data.toString())
+        val intent = Intent(context, BackgroundLocationService::class.java).apply {
+            action = BackgroundLocationService.ACTION_START
+        }
+        try {
+            ContextCompat.startForegroundService(context, intent)
+            call.resolve(JSObject().put("started", true))
+        } catch (error: Exception) {
+            BackgroundLocationService.clearPendingSession()
+            call.resolve(
+                JSObject()
+                    .put("started", false)
+                    .put("reason", "background-service-unavailable")
+            )
+        }
+    }
+
+    @PluginMethod
     fun stopBackgroundShare(call: PluginCall) {
-        // Safe idempotent no-op while Android background publishing is absent.
+        BackgroundLocationService.clearPendingSession()
+        context.stopService(Intent(context, BackgroundLocationService::class.java))
         call.resolve()
+    }
+
+    @PermissionCallback
+    private fun backgroundLocationPermissionCallback(call: PluginCall) {
+        call.resolve(permissionPayload())
     }
 
     @PermissionCallback
@@ -187,7 +248,10 @@ class HushhLocationPlugin : Plugin() {
         return JSObject()
             .put("state", state)
             .put("precise", fineGranted)
-            .put("background", "foreground-only")
+            .put(
+                "background",
+                if (hasBackgroundLocationPermission()) "available" else "foreground-only"
+            )
             .put("locationServicesEnabled", locationServicesEnabled)
     }
 
@@ -200,10 +264,33 @@ class HushhLocationPlugin : Plugin() {
             hasAndroidPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
     }
 
+    private fun hasBackgroundLocationPermission(): Boolean {
+        if (!hasLocationPermission()) return false
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.Q ||
+            hasAndroidPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+    }
+
     private fun locationServicesEnabled(): Boolean {
         val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
         return listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
             .any { provider -> locationManager.isProviderEnabled(provider) }
+    }
+
+    private fun isAllowedBackendBaseUrl(value: String): Boolean {
+        val uri = runCatching { Uri.parse(value) }.getOrNull() ?: return false
+        val host = uri.host?.lowercase(Locale.US) ?: return false
+        val cleanPath = uri.path.isNullOrEmpty() || uri.path == "/"
+        if (!cleanPath || uri.userInfo != null || uri.query != null || uri.fragment != null) return false
+        val hosted = uri.scheme == "https" && uri.port == -1 && host in setOf(
+            "api.hushh.ai",
+            "api.uat.hushh.ai",
+            "api.uat.one.hushh.ai"
+        )
+        if (hosted) return true
+        val isDebuggable = context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+        return isDebuggable &&
+            uri.scheme in setOf("http", "https") &&
+            host in setOf("127.0.0.1", "localhost", "10.0.2.2")
     }
 
     @SuppressLint("MissingPermission")

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/LocationEnvelopeCrypto.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhLocation/LocationEnvelopeCrypto.kt
@@ -1,0 +1,88 @@
+package com.hushh.app.plugins.HushhLocation
+
+import android.util.Base64
+import org.json.JSONObject
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.SecureRandom
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+import javax.crypto.Cipher
+import javax.crypto.KeyAgreement
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/** Matches the Web Crypto and iOS ECDH-P256 + AES-256-GCM envelope. */
+internal object LocationEnvelopeCrypto {
+    private val random = SecureRandom()
+
+    fun encrypt(
+        pointJson: ByteArray,
+        recipientPublicKeyJwk: JSONObject,
+        recipientKeyId: String,
+        capturedAt: String
+    ): JSONObject {
+        val parameters = AlgorithmParameters.getInstance("EC").apply {
+            init(ECGenParameterSpec("secp256r1"))
+        }
+        val ecSpec = parameters.getParameterSpec(java.security.spec.ECParameterSpec::class.java)
+        val recipientKey = KeyFactory.getInstance("EC").generatePublic(
+            ECPublicKeySpec(
+                ECPoint(
+                    BigInteger(1, decode(recipientPublicKeyJwk.getString("x"))),
+                    BigInteger(1, decode(recipientPublicKeyJwk.getString("y")))
+                ),
+                ecSpec
+            )
+        )
+        val ephemeral = KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"), random)
+        }.generateKeyPair()
+        val agreement = KeyAgreement.getInstance("ECDH").apply {
+            init(ephemeral.private)
+            doPhase(recipientKey, true)
+        }
+        val sharedSecret = agreement.generateSecret()
+        val aesKey = SecretKeySpec(sharedSecret.copyOf(32), "AES")
+        val iv = ByteArray(12).also(random::nextBytes)
+        val ciphertextWithTag = Cipher.getInstance("AES/GCM/NoPadding").run {
+            init(Cipher.ENCRYPT_MODE, aesKey, GCMParameterSpec(128, iv))
+            doFinal(pointJson)
+        }
+        val ephemeralPublic = ephemeral.public as ECPublicKey
+        val ephemeralJwk = JSONObject()
+            .put("kty", "EC")
+            .put("crv", "P-256")
+            .put("x", encode(toFixed32(ephemeralPublic.w.affineX)))
+            .put("y", encode(toFixed32(ephemeralPublic.w.affineY)))
+
+        return JSONObject()
+            .put("algorithm", "ECDH-P256-AES256-GCM")
+            .put("recipientKeyId", recipientKeyId)
+            .put("ciphertext", encode(ciphertextWithTag))
+            .put("iv", encode(iv))
+            .put("senderEphemeralPublicKeyJwk", ephemeralJwk)
+            .put("capturedAt", capturedAt)
+            .put("sourcePlatform", "android")
+            .put(
+                "metadata",
+                JSONObject().put("payload", "coordinate_envelope").put("plaintext", false)
+            )
+    }
+
+    private fun decode(value: String): ByteArray =
+        Base64.decode(value, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+
+    private fun encode(value: ByteArray): String =
+        Base64.encodeToString(value, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+
+    private fun toFixed32(value: BigInteger): ByteArray {
+        val raw = value.toByteArray()
+        val unsigned = if (raw.size > 32) raw.copyOfRange(raw.size - 32, raw.size) else raw
+        return ByteArray(32 - unsigned.size) + unsigned
+    }
+}

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -131,6 +131,7 @@ import {
 import { driveEtaText } from "@/app/one/location/drive-eta";
 import { publicInviteUrlLabel } from "@/lib/one-location/public-invite-url";
 import { OneLocationService } from "@/lib/one-location/service";
+import { pointForConnectionVisibility } from "@/lib/one-location/location-privacy";
 import {
   syncOneLocationContactSignals,
   type OneLocationContactSignalResult,
@@ -269,6 +270,7 @@ type BusyState =
   | "refer"
   | "revoke"
   | "sos"
+  | "visibility"
   | "locationSettings"
   | "selfLocation"
   | "driveTo"
@@ -1632,6 +1634,12 @@ export function OneLocationAgentPageContent({
   const [revokingGrantId, setRevokingGrantId] = useState<string | null>(null);
   // Opt-in: keep publishing location while the app is backgrounded (native only).
   const [backgroundShareEnabled, setBackgroundShareEnabled] = useState(false);
+  useEffect(() => {
+    setBackgroundShareEnabled(
+      Boolean(state?.visibility?.enabled) &&
+        permission?.background === "available",
+    );
+  }, [permission?.background, state?.visibility?.enabled]);
   // Monotonic counter bumped each time a share completes successfully, so the
   // redesign hub can close the 3-step share flow and return to the main screen.
   const [shareCompletedTick, setShareCompletedTick] = useState(0);
@@ -2145,60 +2153,61 @@ export function OneLocationAgentPageContent({
     );
   }, [pendingCircleInviteToken, router, vaultOwnerToken]);
 
-  const refresh = useCallback(async (options?: { background?: boolean }) => {
-    if (!auth.userId) {
-      setBusy(null);
-      setLoadError("Sign in before loading location sharing.");
-      return;
-    }
-    if (!vaultOwnerToken) {
-      setBusy(null);
-      // `/one/location` is already protected by OneAuthGate -> VaultLockGuard.
-      // A missing owner token means that canonical hard gate is taking over;
-      // do not flash a second route-local unlock/error presentation first.
-      setLoadError(null);
-      return;
-    }
-    if (refreshInFlightRef.current) {
-      return refreshInFlightRef.current;
-    }
-    const activeUserId = auth.userId;
-    const activeUser = auth.user;
-    const activeVaultOwnerToken = vaultOwnerToken;
-    const hasUsableState = stateEntry?.userId === activeUserId;
-    // A memory snapshot is safe only for this unlocked session. Keep it visible
-    // while the network reconciles instead of replacing a usable Location page
-    // with the same foreground loader on every focus, push, or route re-entry.
-    const showForegroundLoad = !options?.background && !hasUsableState;
-    if (showForegroundLoad) {
-      setBusy((current) => current ?? "load");
-    }
-    const task = (async () => {
-      setLoadError(null);
-      try {
-        if (!activeUser) {
-          throw new Error(
-            "Refresh your session before loading location sharing.",
-          );
-        }
-        if (workspaceBootstrapUserRef.current !== activeUserId) {
-          await AccountIdentityService.syncCurrentUser(activeUser).catch(
-            (error) => {
-              console.warn(
-                "[OneLocation] Failed to sync account identity:",
-                error,
-              );
-            },
-          );
-          const key = await ensureLocationRecipientKey(activeUserId);
-          await OneLocationService.registerRecipientKey({
-            vaultOwnerToken: activeVaultOwnerToken,
-            keyId: key.keyId,
-            publicKeyJwk: key.publicKeyJwk,
-            algorithm: key.algorithm,
-          });
-          workspaceBootstrapUserRef.current = activeUserId;
-        }
+  const refresh = useCallback(
+    async (options?: { background?: boolean }) => {
+      if (!auth.userId) {
+        setBusy(null);
+        setLoadError("Sign in before loading location sharing.");
+        return;
+      }
+      if (!vaultOwnerToken) {
+        setBusy(null);
+        // `/one/location` is already protected by OneAuthGate -> VaultLockGuard.
+        // A missing owner token means that canonical hard gate is taking over;
+        // do not flash a second route-local unlock/error presentation first.
+        setLoadError(null);
+        return;
+      }
+      if (refreshInFlightRef.current) {
+        return refreshInFlightRef.current;
+      }
+      const activeUserId = auth.userId;
+      const activeUser = auth.user;
+      const activeVaultOwnerToken = vaultOwnerToken;
+      const hasUsableState = stateEntry?.userId === activeUserId;
+      // A memory snapshot is safe only for this unlocked session. Keep it visible
+      // while the network reconciles instead of replacing a usable Location page
+      // with the same foreground loader on every focus, push, or route re-entry.
+      const showForegroundLoad = !options?.background && !hasUsableState;
+      if (showForegroundLoad) {
+        setBusy((current) => current ?? "load");
+      }
+      const task = (async () => {
+        setLoadError(null);
+        try {
+          if (!activeUser) {
+            throw new Error(
+              "Refresh your session before loading location sharing.",
+            );
+          }
+          if (workspaceBootstrapUserRef.current !== activeUserId) {
+            await AccountIdentityService.syncCurrentUser(activeUser).catch(
+              (error) => {
+                console.warn(
+                  "[OneLocation] Failed to sync account identity:",
+                  error,
+                );
+              },
+            );
+            const key = await ensureLocationRecipientKey(activeUserId);
+            await OneLocationService.registerRecipientKey({
+              vaultOwnerToken: activeVaultOwnerToken,
+              keyId: key.keyId,
+              publicKeyJwk: key.publicKeyJwk,
+              algorithm: key.algorithm,
+            });
+            workspaceBootstrapUserRef.current = activeUserId;
+          }
         const [nextPermission, nextState] = await Promise.all([
           OneLocationService.getPermissionState().catch(() => ({
             state: "unavailable" as const,
@@ -2249,29 +2258,34 @@ export function OneLocationAgentPageContent({
         );
         suppressAutoRecipientSelectionRef.current = false;
       } catch (error) {
-        suppressAutoRecipientSelectionRef.current = false;
-        // ApiService handles rejected VAULT_OWNER tokens for web and native by
-        // locking the vault. Do not briefly render the backend auth message
-        // while VaultLockGuard switches to the standard re-unlock flow.
-        if (!isVaultOwnerAuthError(error)) {
-          setLoadError(
-            oneLocationErrorMessage(error, "Could not load location sharing."),
-          );
+          suppressAutoRecipientSelectionRef.current = false;
+          // ApiService handles rejected VAULT_OWNER tokens for web and native by
+          // locking the vault. Do not briefly render the backend auth message
+          // while VaultLockGuard switches to the standard re-unlock flow.
+          if (!isVaultOwnerAuthError(error)) {
+            setLoadError(
+              oneLocationErrorMessage(
+                error,
+                "Could not load location sharing.",
+              ),
+            );
+          }
+        } finally {
+          refreshInFlightRef.current = null;
+          if (showForegroundLoad) setBusy(null);
         }
-      } finally {
-        refreshInFlightRef.current = null;
-        if (showForegroundLoad) setBusy(null);
-      }
-    })();
-    refreshInFlightRef.current = task;
-    return task;
-  }, [
-    auth.user,
-    auth.userId,
-    contactMatchedUserIds,
-    stateEntry?.userId,
-    vaultOwnerToken,
-  ]);
+      })();
+      refreshInFlightRef.current = task;
+      return task;
+    },
+    [
+      auth.user,
+      auth.userId,
+      contactMatchedUserIds,
+      stateEntry?.userId,
+      vaultOwnerToken,
+    ],
+  );
 
   const refreshLocationPermission = useCallback(async () => {
     const nextPermission = await OneLocationService.getPermissionState().catch(
@@ -2300,6 +2314,25 @@ export function OneLocationAgentPageContent({
         error instanceof Error
           ? error.message
           : "Could not open location settings.",
+      );
+    } finally {
+      setBusy(null);
+      window.setTimeout(() => void refreshLocationPermission(), 1200);
+    }
+  }, [refreshLocationPermission]);
+
+  const handleOpenAppSettings = useCallback(async () => {
+    setBusy("locationSettings");
+    try {
+      const result = await OneLocationService.openAppSettings();
+      toast.info(
+        result.opened
+          ? 'Set Location to "Allow all the time", then return to One.'
+          : "Open this app's system settings and allow background location.",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not open app settings.",
       );
     } finally {
       setBusy(null);
@@ -2684,8 +2717,15 @@ export function OneLocationAgentPageContent({
       }
       const point =
         pointOverride ?? (await OneLocationService.captureCurrentPosition());
+      const protectedPoint =
+        grant.accessOrigin === "connections_visibility"
+          ? pointForConnectionVisibility(
+              point,
+              state?.visibility?.precision ?? "precise",
+            )
+          : point;
       const envelope = await encryptLocationForRecipient({
-        point,
+        point: protectedPoint,
         recipientPublicKeyJwk: recipient.publicKeyJwk,
         recipientKeyId: recipient.keyId,
       });
@@ -2695,7 +2735,7 @@ export function OneLocationAgentPageContent({
         envelope,
       });
     },
-    [vaultOwnerToken],
+    [state?.visibility?.precision, vaultOwnerToken],
   );
 
   const publishEnvelopeWithRetry = useCallback(
@@ -3481,12 +3521,16 @@ export function OneLocationAgentPageContent({
       backendBaseUrl: getApiBaseUrl(),
       minMoveMeters: LIVE_LOCATION_MIN_MOVE_METERS,
       minIntervalMs: LIVE_LOCATION_MIN_PUBLISH_INTERVAL_MS,
+      visibilityPrecision: state?.visibility?.precision ?? "precise",
     });
     void syncBackgroundShare({ enabled: backgroundShareEnabled, session });
-    return () => {
-      void OneLocationService.stopBackgroundShare();
-    };
-  }, [backgroundShareEnabled, activeOwnerGrants, recipients, vaultOwnerToken]);
+  }, [
+    backgroundShareEnabled,
+    activeOwnerGrants,
+    recipients,
+    state?.visibility?.precision,
+    vaultOwnerToken,
+  ]);
 
   const handleRevoke = useCallback(
     async (grantId: string) => {
@@ -3507,6 +3551,68 @@ export function OneLocationAgentPageContent({
       }
     },
     [refresh, vaultOwnerToken],
+  );
+
+  const handleUpdateConnectionVisibility = useCallback(
+    async (params: {
+      enabled: boolean;
+      precision: "precise" | "approximate";
+      excludedUserIds: string[];
+    }) => {
+      if (!vaultOwnerToken) {
+        toast.error("Unlock your vault before changing location visibility.");
+        return false;
+      }
+      setBusy("visibility");
+      try {
+        const isEnabling = params.enabled && !state?.visibility?.enabled;
+        let nextPermission = await OneLocationService.getPermissionState();
+        if (isEnabling && nextPermission.state !== "granted") {
+          nextPermission = await OneLocationService.requestLocationPermission();
+        }
+        if (isEnabling && nextPermission.state !== "granted") {
+          toast.error(
+            "Allow location permission before becoming visible to connections.",
+          );
+          setPermission(nextPermission);
+          return false;
+        }
+        if (isEnabling) {
+          nextPermission =
+            await OneLocationService.requestAlwaysAuthorization().catch(
+              () => nextPermission,
+            );
+        }
+        setPermission(nextPermission);
+        const result = await OneLocationService.updateConnectionVisibility({
+          vaultOwnerToken,
+          ...params,
+        });
+        setBackgroundShareEnabled(
+          params.enabled && nextPermission.background === "available",
+        );
+        toast.success(
+          params.enabled
+            ? nextPermission.background === "available"
+              ? `Visible to ${result.visibility.readyConnectionCount} connections until you turn it off.`
+              : `Visible to ${result.visibility.readyConnectionCount} connections while One is open.`
+            : "Your location is private now.",
+        );
+        await refresh({ background: true });
+        return true;
+      } catch (error) {
+        toast.error(
+          oneLocationErrorMessage(
+            error,
+            "Could not update connection visibility.",
+          ),
+        );
+        return false;
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refresh, state?.visibility?.enabled, vaultOwnerToken],
   );
 
   const handleStopSos = useCallback(async () => {
@@ -5223,6 +5329,16 @@ export function OneLocationAgentPageContent({
     permissionIsPrompt: permission?.state === "prompt",
     myLocationPoint,
     myLocationError,
+    locationPermission: permission,
+    visibility: state?.visibility ?? {
+      enabled: false,
+      audience: "private",
+      precision: "precise",
+      excludedUserIds: [],
+      eligibleConnectionCount: 0,
+      readyConnectionCount: 0,
+      unavailableConnectionCount: 0,
+    },
     recipients: rankedRecipients,
     visibleRecipients,
     activeOwnerGrants,
@@ -5238,6 +5354,18 @@ export function OneLocationAgentPageContent({
       title: event.title,
       detail: event.detail,
     })),
+    friendsMapEntries: activeReceivedGrants.flatMap((grant) => {
+      if (grant.accessOrigin !== "connections_visibility") return [];
+      const point = decryptedPoints[grant.id];
+      if (!point) return [];
+      return [
+        {
+          id: grant.id,
+          name: receivedGrantOwnerLabel(grant),
+          point,
+        },
+      ];
+    }),
     recipientSearch,
     selectedRecipientIds,
     selectedRequestOwnerIds,
@@ -5257,6 +5385,8 @@ export function OneLocationAgentPageContent({
     onHideMyLocation: () => handleHideMyLiveLocation(),
     onRequestPermission: () => void handleRequestLocationPermission(),
     onOpenLocationSettings: () => void handleOpenLocationSettings(),
+    onOpenAppSettings: () => void handleOpenAppSettings(),
+    onUpdateConnectionVisibility: handleUpdateConnectionVisibility,
     onSyncContacts: () => void handleSyncContactSignal(),
     onShareToContacts: () => void handleShareContactInvite(),
     onOpenShareReview: () => void handleOpenShareReview(),
@@ -5370,7 +5500,10 @@ export function OneLocationAgentPageContent({
               className="h-9 rounded-full px-3"
             >
               {busy === "load" ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                <Loader2
+                  className="mr-2 h-4 w-4 animate-spin"
+                  aria-hidden="true"
+                />
               ) : (
                 <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
               )}

--- a/hushh-webapp/components/one-location/redesign/__tests__/friends-map.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/friends-map.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("@/lib/one-location/use-google-maps", () => ({
+  useGoogleMaps: () => ({ status: "loading" }),
+}));
+
+import { FriendsMap } from "@/components/one-location/redesign/friends-map";
+
+describe("FriendsMap", () => {
+  it("shows a useful empty state before a connection shares", () => {
+    render(<FriendsMap entries={[]} />);
+
+    expect(
+      screen.getByText("No connections are sharing right now"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps sharing entries usable when the map provider is unavailable", () => {
+    render(
+      <FriendsMap
+        entries={[
+          {
+            id: "friend-1",
+            name: "Neelesh Meena",
+            point: {
+              latitude: 28.6139,
+              longitude: 77.209,
+              capturedAt: new Date().toISOString(),
+              sourcePlatform: "web",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Map unavailable. Live connections remain available below.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Neelesh Meena/i }),
+    ).toHaveTextContent("Live -");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/friends-map.tsx
+++ b/hushh-webapp/components/one-location/redesign/friends-map.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { MapPin } from "lucide-react";
+
+import { liveFreshness } from "@/lib/one-location/freshness";
+import { useGoogleMaps } from "@/lib/one-location/use-google-maps";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+import { cn } from "@/lib/utils";
+
+const LIVE_THRESHOLD_MS = 90_000;
+
+export type FriendsMapEntry = {
+  id: string;
+  name: string;
+  point: PlainLocationPoint;
+};
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return "?";
+  return `${parts[0]?.[0] ?? ""}${parts.at(-1)?.[0] ?? ""}`.toUpperCase();
+}
+
+export function FriendsMap({ entries }: { entries: FriendsMapEntry[] }) {
+  const { status } = useGoogleMaps();
+  const { resolvedTheme } = useTheme();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const markersRef = useRef<google.maps.Marker[]>([]);
+  const [selectedId, setSelectedId] = useState(entries[0]?.id ?? "");
+  const colorScheme = resolvedTheme === "dark" ? "DARK" : "LIGHT";
+
+  useEffect(() => {
+    if (!entries.some((entry) => entry.id === selectedId)) {
+      setSelectedId(entries[0]?.id ?? "");
+    }
+  }, [entries, selectedId]);
+
+  useEffect(() => {
+    if (status !== "ready" || !containerRef.current) return;
+    const map = new google.maps.Map(containerRef.current, {
+      center: { lat: 0, lng: 0 },
+      zoom: 2,
+      disableDefaultUI: true,
+      clickableIcons: false,
+      colorScheme,
+    });
+    mapRef.current = map;
+    return () => {
+      markersRef.current.forEach((marker) => marker.setMap(null));
+      markersRef.current = [];
+      mapRef.current = null;
+    };
+  }, [colorScheme, status]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (status !== "ready" || !map || !entries.length) return;
+    markersRef.current.forEach((marker) => marker.setMap(null));
+    const bounds = new google.maps.LatLngBounds();
+    const accentColor = getComputedStyle(document.documentElement)
+      .getPropertyValue("--app-accent")
+      .trim();
+    markersRef.current = entries.map((entry) => {
+      const position = {
+        lat: entry.point.latitude,
+        lng: entry.point.longitude,
+      };
+      bounds.extend(position);
+      const marker = new google.maps.Marker({
+        map,
+        position,
+        title: entry.name,
+        label: {
+          text: initials(entry.name),
+          color: "#ffffff",
+          fontSize: "11px",
+          fontWeight: "700",
+        },
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          fillColor: entry.id === selectedId ? accentColor : "#5b6472",
+          fillOpacity: 1,
+          strokeColor: "#ffffff",
+          strokeWeight: 3,
+          scale: entry.id === selectedId ? 20 : 17,
+        },
+      });
+      marker.addListener("click", () => setSelectedId(entry.id));
+      return marker;
+    });
+    if (entries.length === 1) {
+      map.setCenter(bounds.getCenter());
+      map.setZoom(15);
+    } else {
+      map.fitBounds(bounds, 44);
+    }
+  }, [entries, selectedId, status]);
+
+  const selected = useMemo(
+    () => entries.find((entry) => entry.id === selectedId) ?? entries[0],
+    [entries, selectedId],
+  );
+
+  if (!entries.length) {
+    return (
+      <div className="flex aspect-[4/3] items-center justify-center bg-black/[0.035] px-8 text-center dark:bg-white/[0.04]">
+        <div>
+          <MapPin className="mx-auto h-6 w-6 text-muted-foreground" />
+          <p className="mt-3 text-[15px] font-semibold text-foreground">
+            No connections are sharing right now
+          </p>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            Friends appear here automatically when they become visible to
+            connections.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const freshness = selected
+    ? liveFreshness(selected.point.capturedAt, Date.now(), LIVE_THRESHOLD_MS)
+    : null;
+
+  return (
+    <div>
+      <div className="relative aspect-[4/3] overflow-hidden bg-[#e8edf2] dark:bg-[#15171a]">
+        {status === "ready" ? (
+          <div key={colorScheme} ref={containerRef} className="h-full w-full" />
+        ) : (
+          <div className="flex h-full items-center justify-center px-8 text-center">
+            <p className="text-[13px] font-medium text-muted-foreground">
+              Map unavailable. Live connections remain available below.
+            </p>
+          </div>
+        )}
+      </div>
+      <div className="flex gap-2 overflow-x-auto p-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {entries.map((entry) => {
+          const active = entry.id === selected?.id;
+          const entryFreshness = liveFreshness(
+            entry.point.capturedAt,
+            Date.now(),
+            LIVE_THRESHOLD_MS,
+          );
+          return (
+            <button
+              key={entry.id}
+              type="button"
+              onClick={() => setSelectedId(entry.id)}
+              className={cn(
+                "flex min-w-[150px] items-center gap-2 rounded-xl border px-3 py-2 text-left",
+                active
+                  ? "border-[color:var(--app-accent)] bg-[color:var(--app-accent)]/[0.06]"
+                  : "border-border/70",
+              )}
+            >
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--app-accent)] text-[11px] font-bold text-[color:var(--app-accent-fg)]">
+                {initials(entry.name)}
+              </span>
+              <span className="min-w-0">
+                <span className="block truncate text-[13px] font-semibold text-foreground">
+                  {entry.name}
+                </span>
+                <span
+                  className={cn(
+                    "block text-[11px]",
+                    entryFreshness.state === "live"
+                      ? "text-emerald-600"
+                      : "text-amber-600",
+                  )}
+                >
+                  {entryFreshness.state === "live"
+                    ? `Live - ${entryFreshness.agoLabel}`
+                    : `Last seen ${entryFreshness.agoLabel}`}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {freshness?.state === "paused" ? (
+        <p className="px-3 pb-3 text-[12px] text-amber-600">
+          This is a last known location, not a live position.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -29,7 +29,9 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import {
+  Check,
   ChevronRight,
+  EyeOff,
   Link as LinkIcon,
   Lock,
   Map,
@@ -55,6 +57,7 @@ import type {
   OneLocationGrant,
   OneLocationPublicInvite,
   OneLocationRecipient,
+  OneLocationVisibility,
   PlainLocationPoint,
 } from "@/lib/one-location/types";
 
@@ -88,6 +91,7 @@ import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { ROUTES } from "@/lib/navigation/routes";
 import { LocalEmergencyDialerRow } from "./local-emergency-dialer-row";
+import { FriendsMap, type FriendsMapEntry } from "./friends-map";
 
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
 
@@ -130,6 +134,12 @@ export type LocationHubViewModel = {
   permissionIsPrompt: boolean;
   myLocationPoint: PlainLocationPoint | null;
   myLocationError: string | null;
+  locationPermission: {
+    state: string;
+    background: string;
+    precise: boolean | null;
+  } | null;
+  visibility: OneLocationVisibility;
 
   /* data lists */
   recipients: OneLocationRecipient[];
@@ -141,6 +151,7 @@ export type LocationHubViewModel = {
   latestActivePublicInvite: OneLocationPublicInvite | null;
   latestActiveCircleInvite: OneLocationCircleInvite | null;
   activityReceipts: { id: string; title: string; detail: string }[];
+  friendsMapEntries: FriendsMapEntry[];
 
   /* composer state */
   recipientSearch: string;
@@ -168,6 +179,12 @@ export type LocationHubViewModel = {
   onHideMyLocation: () => void;
   onRequestPermission: () => void;
   onOpenLocationSettings: () => void;
+  onOpenAppSettings: () => void;
+  onUpdateConnectionVisibility: (params: {
+    enabled: boolean;
+    precision: "precise" | "approximate";
+    excludedUserIds: string[];
+  }) => Promise<boolean>;
   onSyncContacts: () => void;
   onShareToContacts: () => void;
   onOpenShareReview: () => void;
@@ -527,7 +544,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         ) : flow === "invite" ? (
           <InviteFlow vm={vm} onClose={closeFlow} />
         ) : flow === "privacy" ? (
-          <PrivacyFlow onManageSharing={() => closeFlow("people")} />
+          <PrivacyFlow vm={vm} onManageSharing={() => closeFlow("people")} />
         ) : (
           <TemporaryLinkFlow
             vm={vm}
@@ -862,10 +879,12 @@ function LocationToggle({
   checked,
   onChange,
   label,
+  disabled = false,
 }: {
   checked: boolean;
   onChange: (next: boolean) => void;
   label: string;
+  disabled?: boolean;
 }) {
   return (
     <button
@@ -873,9 +892,11 @@ function LocationToggle({
       role="switch"
       aria-checked={checked}
       aria-label={label}
+      disabled={disabled}
       onClick={() => onChange(!checked)}
       className={cn(
         "relative h-[31px] w-[51px] shrink-0 rounded-full transition-colors duration-200",
+        disabled && "cursor-not-allowed opacity-60",
         checked ? "bg-[#34c759]" : "bg-black/15 dark:bg-white/20",
       )}
     >
@@ -889,17 +910,58 @@ function LocationToggle({
   );
 }
 
-function PrivacyFlow({ onManageSharing }: { onManageSharing: () => void }) {
-  // Inert local state for now — real auto-share / pause wiring comes later.
-  const [autoShare, setAutoShare] = useState(false);
-  const [paused, setPaused] = useState(false);
+function PrivacyFlow({
+  vm,
+  onManageSharing,
+}: {
+  vm: LocationHubViewModel;
+  onManageSharing: () => void;
+}) {
+  const [showSetup, setShowSetup] = useState(false);
+  const [draftPrecision, setDraftPrecision] = useState<
+    "precise" | "approximate"
+  >(vm.visibility.precision);
+  const [draftExclusions, setDraftExclusions] = useState<string[]>(
+    vm.visibility.excludedUserIds,
+  );
+
+  useEffect(() => {
+    setDraftPrecision(vm.visibility.precision);
+    setDraftExclusions(vm.visibility.excludedUserIds);
+  }, [vm.visibility.excludedUserIds, vm.visibility.precision]);
+
+  const readyConnections = vm.recipients.filter(
+    (recipient) => recipient.canReceiveLocation,
+  );
+  const effectiveCount = readyConnections.filter(
+    (recipient) => !draftExclusions.includes(recipient.userId),
+  ).length;
+  const backgroundAvailable = vm.locationPermission?.background === "available";
+
+  const updateVisibility = async (
+    enabled: boolean,
+    precision = draftPrecision,
+    excludedUserIds = draftExclusions,
+  ) =>
+    vm.onUpdateConnectionVisibility({ enabled, precision, excludedUserIds });
+
+  const toggleConnection = async (userId: string) => {
+    if (vm.busy === "visibility") return;
+    const previous = draftExclusions;
+    const next = draftExclusions.includes(userId)
+      ? draftExclusions.filter((candidate) => candidate !== userId)
+      : [...draftExclusions, userId];
+    setDraftExclusions(next);
+    const updated = await updateVisibility(true, draftPrecision, next);
+    if (!updated) setDraftExclusions(previous);
+  };
 
   return (
     <div>
       <TaskFlowHeader
         eyebrow="Location"
-        title="Privacy"
-        description="You control who sees your location and when. Change this anytime."
+        title="Settings"
+        description="Control who can see you on Friends Map and how your location updates."
       />
 
       <p className="mt-6 px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
@@ -909,46 +971,192 @@ function PrivacyFlow({ onManageSharing }: { onManageSharing: () => void }) {
         <div className="flex items-center gap-3.5 border-b border-black/[0.06] py-4 dark:border-white/10">
           <div className="flex-1">
             <p className="text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
-              Auto-share my location
+              Visible to connections
             </p>
             <p className="mt-0.5 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
-              On — your circle sees you live, no approval needed. Off — every
-              request needs your approval first.
+              {vm.visibility.enabled
+                ? `${vm.visibility.readyConnectionCount} connections can see you on Friends Map.`
+                : "Off by default. Only accepted mutual connections can be included."}
             </p>
           </div>
           <LocationToggle
-            checked={autoShare}
-            onChange={setAutoShare}
-            label="Auto-share my location"
+            checked={vm.visibility.enabled}
+            onChange={(next) => {
+              if (next) setShowSetup(true);
+              else void updateVisibility(false);
+            }}
+            label="Visible to connections"
+            disabled={vm.busy === "visibility"}
           />
         </div>
-        <div className="flex items-center gap-3.5 py-4">
-          <div className="flex-1">
-            <p className="text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
-              Pause my location
-            </p>
-            <p className="mt-0.5 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
-              Go invisible to everyone until you turn this off.
-            </p>
-          </div>
-          <LocationToggle
-            checked={paused}
-            onChange={setPaused}
-            label="Pause my location"
-          />
+        <div className="py-4">
+          <p className="text-[14px] font-semibold text-[#1c1c2e] dark:text-foreground">
+            {backgroundAvailable
+              ? "Always updating"
+              : "Updates while One is open"}
+          </p>
+          <p className="mt-1 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
+            {backgroundAvailable
+              ? "Background location is allowed. Sharing continues until you turn it off."
+              : "Allow Always location in system settings for background updates. Sharing remains on and resumes whenever One is open."}
+          </p>
+          {!backgroundAvailable && vm.visibility.enabled ? (
+            <Button
+              variant="outline"
+              onClick={vm.onOpenAppSettings}
+              isLoading={vm.busy === "locationSettings"}
+              className="mt-3 h-9 rounded-full px-4 text-[13px]"
+            >
+              Open app settings
+            </Button>
+          ) : null}
         </div>
       </div>
+
+      {vm.visibility.enabled ? (
+        <div className="mt-4">
+          <p className="px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
+            Location precision
+          </p>
+          <div className="mt-2 grid grid-cols-2 rounded-xl bg-black/[0.05] p-1 dark:bg-white/[0.07]">
+            {(["precise", "approximate"] as const).map((precision) => (
+              <button
+                key={precision}
+                type="button"
+                disabled={vm.busy === "visibility"}
+                onClick={() => {
+                  setDraftPrecision(precision);
+                  void updateVisibility(true, precision);
+                }}
+                className={cn(
+                  "h-10 rounded-lg text-sm font-semibold capitalize",
+                  vm.busy === "visibility" && "cursor-not-allowed opacity-60",
+                  draftPrecision === precision
+                    ? "bg-white text-foreground shadow-sm dark:bg-white/15"
+                    : "text-muted-foreground",
+                )}
+              >
+                {precision}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {showSetup && !vm.visibility.enabled ? (
+        <div className="mt-4 space-y-4 rounded-2xl border border-[color:var(--app-accent)]/20 bg-white p-4 shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+          <div>
+            <p className="text-[16px] font-semibold text-foreground">
+              {effectiveCount
+                ? `Share with ${effectiveCount} connections?`
+                : "Turn on Friends Map visibility?"}
+            </p>
+            <p className="mt-1 text-[13px] leading-[1.5] text-muted-foreground">
+              Current and future accepted connections are included unless you
+              exclude them. One notification is sent when a person first
+              receives access.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 rounded-xl bg-black/[0.05] p-1 dark:bg-white/[0.07]">
+            {(["precise", "approximate"] as const).map((precision) => (
+              <button
+                key={precision}
+                type="button"
+                disabled={vm.busy === "visibility"}
+                onClick={() => setDraftPrecision(precision)}
+                className={cn(
+                  "h-10 rounded-lg text-sm font-semibold capitalize",
+                  vm.busy === "visibility" && "cursor-not-allowed opacity-60",
+                  draftPrecision === precision
+                    ? "bg-white text-foreground shadow-sm dark:bg-white/15"
+                    : "text-muted-foreground",
+                )}
+              >
+                {precision}
+              </button>
+            ))}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setShowSetup(false)}
+              disabled={vm.busy === "visibility"}
+              className="h-11 rounded-full"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={async () => {
+                const updated = await updateVisibility(true);
+                if (updated) setShowSetup(false);
+              }}
+              isLoading={vm.busy === "visibility"}
+              className="h-11 rounded-full"
+            >
+              Turn on
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       <div className="mt-4 flex items-start gap-2.5 px-1">
         <Shield className="mt-0.5 h-[15px] w-[15px] shrink-0 text-[color:var(--app-accent)]" />
         <p className="text-[13px] leading-[1.5] text-black/50 dark:text-muted-foreground">
-          Your location is never shared outside your circle. You can revoke
-          access to anyone at any time.
+          Coordinates remain encrypted separately for each connection. Turning
+          this off or removing a connection ends access immediately.
         </p>
       </div>
 
+      {vm.visibility.enabled && readyConnections.length ? (
+        <div className="mt-6">
+          <div className="flex items-center justify-between px-1">
+            <p className="text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
+              Friends Map audience
+            </p>
+            <span className="text-[12px] font-semibold text-[color:var(--app-accent)]">
+              {vm.visibility.readyConnectionCount} visible
+            </span>
+          </div>
+          <div className="mt-2.5 overflow-hidden rounded-2xl bg-white px-4 shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+            {readyConnections.map((recipient, index) => {
+              const excluded = draftExclusions.includes(recipient.userId);
+              return (
+                <button
+                  key={recipient.userId}
+                  type="button"
+                  disabled={vm.busy === "visibility"}
+                  onClick={() => void toggleConnection(recipient.userId)}
+                  className={cn(
+                    "flex w-full items-center gap-3 py-3.5 text-left",
+                    index > 0 &&
+                      "border-t border-black/[0.06] dark:border-white/10",
+                  )}
+                >
+                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[color:var(--app-accent)]/10 text-sm font-bold text-[color:var(--app-accent)]">
+                    {personInitials(vm.recipientLabel(recipient))}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[15px] font-semibold text-foreground">
+                      {vm.recipientLabel(recipient)}
+                    </span>
+                    <span className="block text-[12px] text-muted-foreground">
+                      {excluded ? "Excluded" : "Can see your location"}
+                    </span>
+                  </span>
+                  {excluded ? (
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <Check className="h-4 w-4 text-emerald-600" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+
       <p className="mt-7 px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
-        Who can see you
+        Temporary sharing
       </p>
       <button
         type="button"
@@ -957,10 +1165,10 @@ function PrivacyFlow({ onManageSharing }: { onManageSharing: () => void }) {
       >
         <div className="min-w-0 flex-1">
           <p className="text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
-            Manage sharing
+            Manage direct shares
           </p>
           <p className="mt-0.5 text-[13px] text-black/50 dark:text-muted-foreground">
-            See and change who has your live location
+            See temporary shares and stop individual access
           </p>
         </div>
         <ChevronRight className="h-4 w-4 shrink-0 text-black/30 dark:text-muted-foreground" />
@@ -1063,6 +1271,15 @@ function PeopleHub({
   if (!showPeopleList) {
     return (
       <div className="space-y-5">
+        <section className="overflow-hidden rounded-[20px] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+          <div className="px-4 pb-3 pt-4">
+            <p className="text-[17px] font-bold text-foreground">Friends Map</p>
+            <p className="mt-0.5 text-[13px] text-muted-foreground">
+              Live locations shared by your connections
+            </p>
+          </div>
+          <FriendsMap entries={vm.friendsMapEntries} />
+        </section>
         <SectionCard
           title="Trusted Circle"
           description="Only your connections can receive private live location."
@@ -1106,6 +1323,15 @@ function PeopleHub({
 
   return (
     <div className="space-y-4">
+      <section className="overflow-hidden rounded-[20px] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+        <div className="px-4 pb-3 pt-4">
+          <p className="text-[17px] font-bold text-foreground">Friends Map</p>
+          <p className="mt-0.5 text-[13px] text-muted-foreground">
+            Live locations shared by your connections
+          </p>
+        </div>
+        <FriendsMap entries={vm.friendsMapEntries} />
+      </section>
       <PersonSearchInput
         value={vm.recipientSearch}
         onChange={vm.setRecipientSearch}
@@ -1146,7 +1372,9 @@ function PeopleHub({
         <div className="overflow-hidden rounded-[20px] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
           {filtered.map((r, i) => {
             const grant = vm.activeOwnerGrants.find(
-              (g) => g.recipientUserId === r.userId,
+              (g) =>
+                g.recipientUserId === r.userId &&
+                g.accessOrigin !== "connections_visibility",
             );
             const sharing = Boolean(grant);
             const receiving = vm.receivedGrants.some(
@@ -1495,7 +1723,6 @@ function SosFlow({ vm }: { vm: LocationHubViewModel }) {
           <LocalEmergencyDialerRow />
         </div>
       </div>
-
     </div>
   );
 }

--- a/hushh-webapp/ios/App/App/Plugins/BackgroundLocationPublisher.swift
+++ b/hushh-webapp/ios/App/App/Plugins/BackgroundLocationPublisher.swift
@@ -5,6 +5,7 @@ struct BackgroundShareGrantNative {
     let grantId: String
     let recipientKeyId: String
     let recipientPublicKeyJwk: [String: Any]
+    let precision: String
 }
 
 struct BackgroundShareSessionNative {
@@ -22,7 +23,10 @@ final class BackgroundLocationPublisher {
 
     private var session: BackgroundShareSessionNative?
     private var lastPublishedAt: Date?
+    private var lastTargetsRefreshAt: Date?
     private var lastPoint: CLLocation?
+    private var generation = 0
+    private var refreshTimer: DispatchSourceTimer?
     private let urlSession = URLSession(configuration: .default)
     private let iso = ISO8601DateFormatter()
 
@@ -30,16 +34,24 @@ final class BackgroundLocationPublisher {
     private var pending: [QueuedPost] = []
     private let maxPending = 50
     private(set) var needsReauth = false
+    var onPublishingStopped: (() -> Void)?
 
     func start(session: BackgroundShareSessionNative) {
+        generation += 1
         self.session = session
         self.lastPublishedAt = nil
+        self.lastTargetsRefreshAt = nil
         self.lastPoint = nil
         self.needsReauth = false
         self.pending.removeAll()
+        scheduleTargetRefresh()
+        refreshTargetsIfNeeded(session: session, now: Date())
     }
 
     func stop() {
+        generation += 1
+        refreshTimer?.cancel()
+        refreshTimer = nil
         self.session = nil
         self.pending.removeAll()
     }
@@ -61,16 +73,16 @@ final class BackgroundLocationPublisher {
         lastPublishedAt = now
 
         let capturedAt = iso.string(from: location.timestamp)
-        let pointDict: [String: Any] = [
-            "latitude": location.coordinate.latitude,
-            "longitude": location.coordinate.longitude,
-            "accuracyM": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : NSNull(),
-            "capturedAt": capturedAt,
-            "sourcePlatform": "ios"
-        ]
-        guard let pointJSON = try? JSONSerialization.data(withJSONObject: pointDict) else { return }
-
         for grant in session.grants {
+            let point = protectedPoint(location: location, precision: grant.precision)
+            let pointDict: [String: Any] = [
+                "latitude": point.latitude,
+                "longitude": point.longitude,
+                "accuracyM": point.accuracy,
+                "capturedAt": capturedAt,
+                "sourcePlatform": "ios"
+            ]
+            guard let pointJSON = try? JSONSerialization.data(withJSONObject: pointDict) else { continue }
             guard let envelope = try? LocationEnvelopeCrypto.encrypt(
                 pointJSON: pointJSON,
                 recipientPublicKeyJwk: grant.recipientPublicKeyJwk,
@@ -82,7 +94,28 @@ final class BackgroundLocationPublisher {
         }
     }
 
+    private func protectedPoint(
+        location: CLLocation,
+        precision: String
+    ) -> (latitude: Double, longitude: Double, accuracy: Double) {
+        let accuracy = location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : 0
+        guard precision == "approximate" else {
+            return (location.coordinate.latitude, location.coordinate.longitude, accuracy)
+        }
+        let gridMeters = 1_000.0
+        let metersPerDegree = 111_320.0
+        let latitudeStep = gridMeters / metersPerDegree
+        let longitudeScale = max(0.2, cos(location.coordinate.latitude * .pi / 180))
+        let longitudeStep = gridMeters / (metersPerDegree * longitudeScale)
+        return (
+            (location.coordinate.latitude / latitudeStep).rounded() * latitudeStep,
+            (location.coordinate.longitude / longitudeStep).rounded() * longitudeStep,
+            max(accuracy, gridMeters)
+        )
+    }
+
     private func post(envelope: [String: Any], grantId: String, session: BackgroundShareSessionNative) {
+        let requestGeneration = generation
         let base = session.backendBaseUrl.hasSuffix("/")
             ? String(session.backendBaseUrl.dropLast())
             : session.backendBaseUrl
@@ -101,18 +134,118 @@ final class BackgroundLocationPublisher {
         urlSession.dataTask(with: request) { [weak self] _, response, error in
             guard let self = self else { return }
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-            if error != nil || status == 0 {
-                self.enqueue(QueuedPost(grantId: grantId, envelope: envelope))
-                return
-            }
-            if status == 401 {
-                self.needsReauth = true
-                return
-            }
-            if (200...299).contains(status) {
-                self.drainPending(session: session)
+            DispatchQueue.main.async {
+                guard self.generation == requestGeneration, self.session != nil else { return }
+                if error != nil || status == 0 {
+                    self.enqueue(QueuedPost(grantId: grantId, envelope: envelope))
+                    return
+                }
+                if status == 401 {
+                    self.needsReauth = true
+                    self.stop()
+                    self.onPublishingStopped?()
+                    return
+                }
+                if [403, 404, 410].contains(status) {
+                    self.removeGrant(grantId)
+                    return
+                }
+                if (200...299).contains(status), let activeSession = self.session {
+                    self.drainPending(session: activeSession)
+                }
             }
         }.resume()
+    }
+
+    private func refreshTargetsIfNeeded(session: BackgroundShareSessionNative, now: Date) {
+        if let last = lastTargetsRefreshAt, now.timeIntervalSince(last) < 300 { return }
+        lastTargetsRefreshAt = now
+        let requestGeneration = generation
+        let base = session.backendBaseUrl.hasSuffix("/")
+            ? String(session.backendBaseUrl.dropLast())
+            : session.backendBaseUrl
+        guard let url = URL(string: "\(base)/api/one/location/publish-targets?limit=500") else {
+            return
+        }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(session.vaultOwnerToken)", forHTTPHeaderField: "Authorization")
+        urlSession.dataTask(with: request) { [weak self] data, response, _ in
+            guard let self = self else { return }
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            DispatchQueue.main.async {
+                guard self.generation == requestGeneration, self.session != nil else { return }
+                if status == 401 {
+                    self.needsReauth = true
+                    self.stop()
+                    self.onPublishingStopped?()
+                    return
+                }
+                guard
+                    (200...299).contains(status),
+                    let data = data,
+                    let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    let targets = payload["targets"] as? [[String: Any]]
+                else { return }
+                let grants = targets.compactMap(self.parseTarget)
+                self.session = BackgroundShareSessionNative(
+                    vaultOwnerToken: session.vaultOwnerToken,
+                    backendBaseUrl: session.backendBaseUrl,
+                    grants: grants,
+                    minMoveMeters: session.minMoveMeters,
+                    minIntervalMs: session.minIntervalMs
+                )
+                if grants.isEmpty {
+                    self.stop()
+                    self.onPublishingStopped?()
+                }
+            }
+        }.resume()
+    }
+
+    private func scheduleTargetRefresh() {
+        refreshTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 300, repeating: 300)
+        timer.setEventHandler { [weak self] in
+            guard let self = self, let activeSession = self.session else { return }
+            self.refreshTargetsIfNeeded(session: activeSession, now: Date())
+        }
+        refreshTimer = timer
+        timer.resume()
+    }
+
+    private func removeGrant(_ grantId: String) {
+        guard let current = session else { return }
+        let remaining = current.grants.filter { $0.grantId != grantId }
+        guard remaining.count != current.grants.count else { return }
+        pending.removeAll { $0.grantId == grantId }
+        session = BackgroundShareSessionNative(
+            vaultOwnerToken: current.vaultOwnerToken,
+            backendBaseUrl: current.backendBaseUrl,
+            grants: remaining,
+            minMoveMeters: current.minMoveMeters,
+            minIntervalMs: current.minIntervalMs
+        )
+        if remaining.isEmpty {
+            stop()
+            onPublishingStopped?()
+        }
+    }
+
+    private func parseTarget(_ target: [String: Any]) -> BackgroundShareGrantNative? {
+        guard
+            let grant = target["grant"] as? [String: Any],
+            let recipient = target["recipient"] as? [String: Any],
+            let grantId = grant["id"] as? String,
+            let keyId = recipient["keyId"] as? String,
+            let jwk = recipient["publicKeyJwk"] as? [String: Any]
+        else { return nil }
+        return BackgroundShareGrantNative(
+            grantId: grantId,
+            recipientKeyId: keyId,
+            recipientPublicKeyJwk: jwk,
+            precision: target["precision"] as? String ?? "precise"
+        )
     }
 
     private func enqueue(_ item: QueuedPost) {

--- a/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/HushhLocationPlugin.swift
@@ -4,10 +4,11 @@ import CoreLocation
 import UIKit
 
 /**
- * HushhLocationPlugin - foreground-only one-shot location capture.
+ * HushhLocationPlugin - foreground capture plus explicitly authorized
+ * background publishing for encrypted One Location shares.
  *
- * One Location Agent v1 does not request background location. Coordinates are
- * returned only to the local web layer so it can encrypt before persistence.
+ * Background publishing runs only with Always authorization and encrypts every
+ * recipient envelope locally before transport.
  */
 @objc(HushhLocationPlugin)
 public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManagerDelegate {
@@ -42,6 +43,12 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         manager.desiredAccuracy = kCLLocationAccuracyBest
         manager.allowsBackgroundLocationUpdates = true
         manager.pausesLocationUpdatesAutomatically = false
+        backgroundPublisher.onPublishingStopped = { [weak self] in
+            DispatchQueue.main.async {
+                guard let self = self, self.watchCalls.isEmpty else { return }
+                self.manager.stopUpdatingLocation()
+            }
+        }
     }
 
     @objc func getPermissionState(_ call: CAPPluginCall) {
@@ -160,7 +167,7 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
         if let watchCall = watchCalls.removeValue(forKey: id) {
             bridge?.releaseCall(watchCall)
         }
-        if watchCalls.isEmpty {
+        if watchCalls.isEmpty && !backgroundPublisher.isActive {
             DispatchQueue.main.async { self.manager.stopUpdatingLocation() }
         }
         call.resolve()
@@ -179,13 +186,22 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
             call.resolve(["started": false, "reason": "invalid-session"])
             return
         }
+        guard isAllowedBackendBaseUrl(base) else {
+            call.resolve(["started": false, "reason": "backend-origin-not-allowed"])
+            return
+        }
         let grants: [BackgroundShareGrantNative] = rawGrants.compactMap { g in
             guard
                 let grantId = g["grantId"] as? String,
                 let keyId = g["recipientKeyId"] as? String,
                 let jwk = g["recipientPublicKeyJwk"] as? [String: Any]
             else { return nil }
-            return BackgroundShareGrantNative(grantId: grantId, recipientKeyId: keyId, recipientPublicKeyJwk: jwk)
+            return BackgroundShareGrantNative(
+                grantId: grantId,
+                recipientKeyId: keyId,
+                recipientPublicKeyJwk: jwk,
+                precision: g["precision"] as? String ?? "precise"
+            )
         }
         guard !grants.isEmpty else {
             call.resolve(["started": false, "reason": "no-grants"])
@@ -236,7 +252,34 @@ public class HushhLocationPlugin: CAPPlugin, CAPBridgedPlugin, CLLocationManager
             bridge?.releaseCall(watchCall)
             watchCalls.removeValue(forKey: id)
         }
-        DispatchQueue.main.async { self.manager.stopUpdatingLocation() }
+        if !backgroundPublisher.isActive {
+            DispatchQueue.main.async { self.manager.stopUpdatingLocation() }
+        }
+    }
+
+    private func isAllowedBackendBaseUrl(_ value: String) -> Bool {
+        guard
+            let components = URLComponents(string: value),
+            let scheme = components.scheme?.lowercased(),
+            let host = components.host?.lowercased(),
+            components.user == nil,
+            components.password == nil,
+            components.query == nil,
+            components.fragment == nil,
+            components.path.isEmpty || components.path == "/"
+        else { return false }
+
+        let hosted = scheme == "https" && components.port == nil && [
+            "api.hushh.ai",
+            "api.uat.hushh.ai",
+            "api.uat.one.hushh.ai"
+        ].contains(host)
+        if hosted { return true }
+#if DEBUG
+        return ["http", "https"].contains(scheme) && ["127.0.0.1", "localhost"].contains(host)
+#else
+        return false
+#endif
     }
 
     private func permissionPayload() -> [String: Any] {

--- a/hushh-webapp/lib/capacitor/index.ts
+++ b/hushh-webapp/lib/capacitor/index.ts
@@ -777,6 +777,7 @@ export type BackgroundShareGrant = {
   grantId: string;
   recipientKeyId: string;
   recipientPublicKeyJwk: JsonWebKey;
+  precision?: "precise" | "approximate";
 };
 
 export type BackgroundShareSession = {
@@ -790,7 +791,7 @@ export type BackgroundShareSession = {
 export interface HushhLocationPlugin {
   getPermissionState(): Promise<HushhLocationPermissionState>;
   requestLocationPermission(): Promise<HushhLocationPermissionState>;
-  /** iOS: prompt for the "Always Allow" upgrade. No-op elsewhere. */
+  /** Prompt for background location where the platform supports it. */
   requestAlwaysAuthorization(): Promise<HushhLocationPermissionState>;
   openAppSettings(): Promise<{
     opened: boolean;
@@ -835,10 +836,8 @@ export interface HushhLocationPlugin {
   /** Stop a `watchPosition` subscription started with the returned id. */
   clearWatch(options: { id: string }): Promise<void>;
   /**
-   * Start native background publishing for the given share session. iOS only:
-   * requires Always authorization. Returns { started:false, reason } when
-   * unavailable (web, missing permission). Foreground JS keeps publishing too;
-   * native takes over while the app is backgrounded.
+   * Start native background publishing for the given share session. iOS and
+   * Android require background authorization; web remains foreground-only.
    */
   startBackgroundShare(
     session: BackgroundShareSession,
@@ -847,10 +846,13 @@ export interface HushhLocationPlugin {
   stopBackgroundShare(): Promise<void>;
 }
 
-
-export const HushhLocation = registerPlugin<HushhLocationPlugin>("HushhLocation", {
-  web: () => import("./plugins/location-web").then((m) => new m.HushhLocationWeb()),
-});
+export const HushhLocation = registerPlugin<HushhLocationPlugin>(
+  "HushhLocation",
+  {
+    web: () =>
+      import("./plugins/location-web").then((m) => new m.HushhLocationWeb()),
+  },
+);
 
 // ==================== HushhContactsPlugin ====================
 // Contact-book permission and read-only contact lookup for Connect matching.
@@ -874,9 +876,13 @@ export interface HushhContactsPlugin {
   }>;
 }
 
-export const HushhContacts = registerPlugin<HushhContactsPlugin>("HushhContacts", {
-  web: () => import("./plugins/contacts-web").then((m) => new m.HushhContactsWeb()),
-});
+export const HushhContacts = registerPlugin<HushhContactsPlugin>(
+  "HushhContacts",
+  {
+    web: () =>
+      import("./plugins/contacts-web").then((m) => new m.HushhContactsWeb()),
+  },
+);
 
 // ==================== HushhPersonalKnowledgeModelPlugin ====================
 // PKM operations for dynamic domain/attribute management

--- a/hushh-webapp/lib/consent/location-consent.ts
+++ b/hushh-webapp/lib/consent/location-consent.ts
@@ -14,7 +14,6 @@ import { buildOneLocationWorkflowHref } from "@/lib/one-location/notifications";
 
 type MetadataLike = Record<string, unknown> | null | undefined;
 
-
 function readString(metadata: MetadataLike, key: string): string {
   const value = metadata?.[key];
   return typeof value === "string" ? value.trim() : "";
@@ -30,7 +29,9 @@ export function isLocationConsent(
 ): boolean {
   const requestSource = readString(metadata, "request_source");
   if (requestSource.startsWith("one_location")) return true;
-  const normalizedScope = String(scope || "").trim().toLowerCase();
+  const normalizedScope = String(scope || "")
+    .trim()
+    .toLowerCase();
   return (
     normalizedScope.startsWith("cap.location.") ||
     normalizedScope.startsWith("attr.location.")
@@ -42,6 +43,9 @@ export function isLocationConsent(
  * relevant section (mirrors the in-app notification deep links).
  */
 export function locationConsentWorkflowHref(metadata: MetadataLike): string {
+  if (readString(metadata, "access_origin") === "connections_visibility") {
+    return "/one/location?action=privacy";
+  }
   const section = readString(metadata, "section");
   const grantId = readString(metadata, "grant_id");
   const requestId = readString(metadata, "request_id");
@@ -66,7 +70,6 @@ export function locationConsentWorkflowHref(metadata: MetadataLike): string {
   });
 }
 
-
 /**
  * Short human tag for a location consent row's share kind (SOS / Check-In /
  * Share). Returns "" for rows that carry no share_kind (e.g. access requests,
@@ -77,6 +80,7 @@ export function locationConsentShareKindLabel(metadata: MetadataLike): string {
   if (kind === "sos") return "SOS";
   if (kind === "check_in" || kind === "checkin") return "Check-In";
   if (kind === "share") return "Share";
+  if (kind === "connections_visibility") return "Friends Map";
   return "";
 }
 
@@ -105,6 +109,9 @@ export function locationConsentSummary(metadata: MetadataLike): string {
   }
   if (shareKind === "share") {
     return `${who} is sharing their location with you${durationSuffix}.`;
+  }
+  if (shareKind === "connections_visibility") {
+    return `${who} is sharing their location with connections on Friends Map.`;
   }
   if (durationLabel) {
     return `${who} wants to see your location for ${durationLabel}.`;
@@ -175,7 +182,6 @@ export function parseLocationConsentEntry(
     _LOCATION_SOURCE_KINDS[readString(entry.metadata, "request_source")] ??
     "unknown";
 
-
   const metadataGrantId = readString(entry.metadata, "grant_id");
   const metadataRequestId =
     readString(entry.metadata, "request_id") ||
@@ -196,4 +202,3 @@ export function parseLocationConsentEntry(
 
   return { kind, id, requestId };
 }
-

--- a/hushh-webapp/lib/one-location/__tests__/background-share.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/background-share.test.ts
@@ -39,6 +39,7 @@ describe("buildBackgroundShareSession", () => {
           grantId: "g1",
           recipientKeyId: "k1",
           recipientPublicKeyJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" },
+          precision: "precise",
         },
       ],
     });

--- a/hushh-webapp/lib/one-location/__tests__/location-privacy.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-privacy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  approximateLocationPoint,
+  pointForConnectionVisibility,
+} from "@/lib/one-location/location-privacy";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+const point: PlainLocationPoint = {
+  latitude: 28.613939,
+  longitude: 77.209021,
+  accuracyM: 12,
+  capturedAt: "2026-07-21T12:00:00.000Z",
+  sourcePlatform: "android",
+};
+
+describe("connection visibility precision", () => {
+  it("leaves precise points unchanged", () => {
+    expect(pointForConnectionVisibility(point, "precise")).toBe(point);
+  });
+
+  it("coarsens coordinates before encryption and reports the privacy radius", () => {
+    const approximate = approximateLocationPoint(point, 1_000);
+    expect(approximate).not.toBe(point);
+    expect(approximate.latitude).not.toBe(point.latitude);
+    expect(approximate.longitude).not.toBe(point.longitude);
+    expect(approximate.accuracyM).toBe(1_000);
+    expect(approximate.capturedAt).toBe(point.capturedAt);
+    expect(approximate.sourcePlatform).toBe("android");
+  });
+
+  it("bounds an invalid grid size to the supported privacy range", () => {
+    expect(approximateLocationPoint(point, 1).accuracyM).toBe(250);
+    expect(approximateLocationPoint(point, 50_000).accuracyM).toBe(5_000);
+  });
+});

--- a/hushh-webapp/lib/one-location/background-share.ts
+++ b/hushh-webapp/lib/one-location/background-share.ts
@@ -22,6 +22,7 @@ export function buildBackgroundShareSession(params: {
   backendBaseUrl: string;
   minMoveMeters: number;
   minIntervalMs: number;
+  visibilityPrecision?: "precise" | "approximate";
 }): BackgroundShareSession {
   const grants: BackgroundShareGrant[] = [];
   for (const grant of params.activeGrants) {
@@ -36,6 +37,10 @@ export function buildBackgroundShareSession(params: {
       grantId: grant.id,
       recipientKeyId: recipient.keyId,
       recipientPublicKeyJwk: recipient.publicKeyJwk,
+      precision:
+        grant.accessOrigin === "connections_visibility"
+          ? (params.visibilityPrecision ?? "precise")
+          : "precise",
     });
   }
   return {

--- a/hushh-webapp/lib/one-location/location-privacy.ts
+++ b/hushh-webapp/lib/one-location/location-privacy.ts
@@ -1,0 +1,40 @@
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+
+const METERS_PER_LATITUDE_DEGREE = 111_320;
+const MIN_LONGITUDE_SCALE = 0.2;
+
+/**
+ * Reduce coordinate precision before encryption. The backend still receives
+ * ciphertext only, while recipients see an intentionally coarse point.
+ */
+export function approximateLocationPoint(
+  point: PlainLocationPoint,
+  gridMeters = 1_000,
+): PlainLocationPoint {
+  const boundedGridMeters = Math.max(250, Math.min(gridMeters, 5_000));
+  const latitudeStep = boundedGridMeters / METERS_PER_LATITUDE_DEGREE;
+  const longitudeScale = Math.max(
+    MIN_LONGITUDE_SCALE,
+    Math.cos((point.latitude * Math.PI) / 180),
+  );
+  const longitudeStep =
+    boundedGridMeters / (METERS_PER_LATITUDE_DEGREE * longitudeScale);
+
+  return {
+    ...point,
+    latitude: Number(
+      (Math.round(point.latitude / latitudeStep) * latitudeStep).toFixed(6),
+    ),
+    longitude: Number(
+      (Math.round(point.longitude / longitudeStep) * longitudeStep).toFixed(6),
+    ),
+    accuracyM: Math.max(point.accuracyM ?? 0, boundedGridMeters),
+  };
+}
+
+export function pointForConnectionVisibility(
+  point: PlainLocationPoint,
+  precision: "precise" | "approximate",
+): PlainLocationPoint {
+  return precision === "approximate" ? approximateLocationPoint(point) : point;
+}

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -3,7 +3,8 @@
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 
-export const ONE_LOCATION_GRANT_OPENED_EVENT = "hushh:one-location-grant-opened";
+export const ONE_LOCATION_GRANT_OPENED_EVENT =
+  "hushh:one-location-grant-opened";
 export const ONE_LOCATION_NOTIFICATION_OPEN_PARAM = "locationNotification";
 export const ONE_LOCATION_NOTIFICATION_OPEN_VALUE = "opened";
 export const ONE_LOCATION_GRANT_ID_PARAM = "grantId";
@@ -79,11 +80,13 @@ const WORKFLOW_COPY: Record<
   },
   location_referral_invite: {
     title: "Location referral pending",
-    fallbackDescription: "A trusted person referred you into a location request flow.",
+    fallbackDescription:
+      "A trusted person referred you into a location request flow.",
   },
   location_public_invite_submitted: {
     title: "Public location request",
-    fallbackDescription: "Someone requested location access from your public link.",
+    fallbackDescription:
+      "Someone requested location access from your public link.",
   },
   location_one_network_joined: {
     title: "Connected on One",
@@ -136,13 +139,19 @@ function writeOpenedGrantIds(userId: string, grantIds: string[]): void {
   }
 }
 
-export function isOneLocationGrantOpened(userId: string | null | undefined, grantId: string): boolean {
+export function isOneLocationGrantOpened(
+  userId: string | null | undefined,
+  grantId: string,
+): boolean {
   const normalizedGrantId = String(grantId || "").trim();
   if (!userId || !normalizedGrantId) return false;
   return readOpenedGrantIds(userId).includes(normalizedGrantId);
 }
 
-export function markOneLocationGrantOpened(userId: string | null | undefined, grantId: string): void {
+export function markOneLocationGrantOpened(
+  userId: string | null | undefined,
+  grantId: string,
+): void {
   const normalizedUserId = String(userId || "").trim();
   const normalizedGrantId = String(grantId || "").trim();
   if (!normalizedUserId || !normalizedGrantId) return;
@@ -181,9 +190,7 @@ function readSeenNotificationIds(userId: string): Set<string> {
     if (!raw) return new Set();
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed)
-      ? new Set(
-          parsed.map((item) => String(item || "").trim()).filter(Boolean),
-        )
+      ? new Set(parsed.map((item) => String(item || "").trim()).filter(Boolean))
       : new Set();
   } catch {
     return new Set();
@@ -199,7 +206,8 @@ function writeSeenNotificationIds(userId: string, ids: Set<string>): void {
     // Cap the stored history so it can never grow unbounded.
     const MAX_SEEN = 500;
     const all = Array.from(ids).filter(Boolean);
-    const trimmed = all.length > MAX_SEEN ? all.slice(all.length - MAX_SEEN) : all;
+    const trimmed =
+      all.length > MAX_SEEN ? all.slice(all.length - MAX_SEEN) : all;
     storage.setItem(
       seenNotificationsStorageKey(normalizedUserId),
       JSON.stringify(trimmed),
@@ -312,7 +320,9 @@ export function oneLocationGrantTaskId(grantId: string): string {
 export function dismissOneLocationShareNotification(grantId: string): void {
   const normalizedGrantId = String(grantId || "").trim();
   if (!normalizedGrantId) return;
-  AppBackgroundTaskService.dismissTask(oneLocationGrantTaskId(normalizedGrantId));
+  AppBackgroundTaskService.dismissTask(
+    oneLocationGrantTaskId(normalizedGrantId),
+  );
 }
 
 export function oneLocationWorkflowTaskId(
@@ -325,7 +335,10 @@ export function oneLocationWorkflowTaskId(
 export function buildOneLocationNotificationHref(grantId: string): string {
   const params = new URLSearchParams();
   params.set(ONE_LOCATION_GRANT_ID_PARAM, grantId);
-  params.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
+  params.set(
+    ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
+    ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
+  );
   params.set(ONE_LOCATION_SECTION_PARAM, "shared");
   return `/one/location?${params.toString()}`;
 }
@@ -380,7 +393,10 @@ export function buildOneLocationWorkflowHref(params: {
   if (submissionId) query.set(ONE_LOCATION_SUBMISSION_ID_PARAM, submissionId);
   if (section) query.set(ONE_LOCATION_SECTION_PARAM, section);
   if (grantId && params.openGrant) {
-    query.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
+    query.set(
+      ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
+      ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
+    );
   }
   const suffix = query.toString();
   return suffix ? `/one/location?${suffix}` : "/one/location";
@@ -419,7 +435,8 @@ export function privacySafeOneLocationNotificationLabel(
   fallback = "A trusted person",
 ): string {
   const normalized = String(value || "").trim();
-  if (!normalized || MASKED_PHONE_ONLY_PATTERN.test(normalized)) return fallback;
+  if (!normalized || MASKED_PHONE_ONLY_PATTERN.test(normalized))
+    return fallback;
   return normalized.replace(MASKED_PHONE_SUFFIX_PATTERN, "").trim() || fallback;
 }
 
@@ -435,7 +452,9 @@ export function privacySafeOneLocationNotificationBody(
   return normalized.replace(MASKED_PHONE_BODY_PATTERN, "").trim() || fallback;
 }
 
-export function locationShareNotificationDescription(ownerLabel?: string | null): string {
+export function locationShareNotificationDescription(
+  ownerLabel?: string | null,
+): string {
   const label = privacySafeOneLocationNotificationLabel(ownerLabel);
   return `${label} shared location access with you.`;
 }
@@ -446,7 +465,9 @@ export type OneLocationShareKind = "sos" | "check_in" | "drive_to" | "share";
 export function normalizeOneLocationShareKind(
   value?: string | null,
 ): OneLocationShareKind {
-  const normalized = String(value || "").trim().toLowerCase();
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
   if (normalized === "sos") return "sos";
   if (normalized === "check_in" || normalized === "checkin") return "check_in";
   if (normalized === "drive_to" || normalized === "drive") return "drive_to";
@@ -507,7 +528,6 @@ export function locationShareNotificationCopy(params: {
   };
 }
 
-
 export function locationWorkflowNotificationCopy(params: {
   type: OneLocationWorkflowNotificationType;
   ownerLabel?: string | null;
@@ -522,9 +542,16 @@ export function locationWorkflowNotificationCopy(params: {
     params.requesterLabel,
     "Someone",
   );
-  const referringLabel = privacySafeOneLocationNotificationLabel(params.referringLabel);
-  const visitorLabel = privacySafeOneLocationNotificationLabel(params.visitorLabel, "Someone");
-  const networkLabel = privacySafeOneLocationNotificationLabel(params.networkLabel);
+  const referringLabel = privacySafeOneLocationNotificationLabel(
+    params.referringLabel,
+  );
+  const visitorLabel = privacySafeOneLocationNotificationLabel(
+    params.visitorLabel,
+    "Someone",
+  );
+  const networkLabel = privacySafeOneLocationNotificationLabel(
+    params.networkLabel,
+  );
 
   switch (params.type) {
     case "location_share_created":
@@ -616,7 +643,8 @@ export function recordOneLocationShareNotification(params: {
 }): boolean {
   const userId = String(params.userId || "").trim();
   const grantId = String(params.grantId || "").trim();
-  if (!userId || !grantId || isOneLocationGrantOpened(userId, grantId)) return false;
+  if (!userId || !grantId || isOneLocationGrantOpened(userId, grantId))
+    return false;
   // The recipient explicitly stopped watching this share - never re-notify.
   if (isOneLocationGrantUnwatched(userId, grantId)) return false;
 
@@ -626,45 +654,11 @@ export function recordOneLocationShareNotification(params: {
   if (hasSeenOneLocationNotification(userId, eventId)) return false;
   markOneLocationNotificationSeen(userId, eventId);
 
-  // Surface in the bell (DebateTaskCenter / AppBackgroundTaskService) with an
-  // "Open" deep-link into the recipient's "Shared with me" section, so the
-  // share is reachable from the bell - not only the transient toast. The copy is
-  // kind-aware so the bell entry reads "SOS alert" / "Check-in shared" (with the
-  // note) / "Location shared" instead of one generic line for every share.
-  const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
-  const shareKind = normalizeOneLocationShareKind(params.shareKind);
-  const { title, description } = locationShareNotificationCopy({
-    ownerLabel,
-    shareKind: params.shareKind,
-    shareMessage: params.shareMessage,
-  });
-  const taskId = oneLocationGrantTaskId(grantId);
-  AppBackgroundTaskService.startTask({
-    taskId,
-    userId,
-    kind: LOCATION_SHARE_TASK_KIND,
-    title,
-    description,
-    routeHref: buildOneLocationNotificationHref(grantId),
-    visibility: "primary",
-    groupLabel: "Location",
-    autoClearAfterMs: 0,
-    metadata: {
-      grantId,
-      ownerLabel,
-      expiresAt: params.expiresAt || null,
-      durationHours: params.durationHours || null,
-      shareKind,
-      shareMessage: String(params.shareMessage || "").trim() || null,
-    },
-  });
-  AppBackgroundTaskService.completeTask(taskId, description);
-
-  // Also route to the consent surfaces (shield icon + consent manager).
+  // Location access belongs exclusively to the consent surfaces. The general
+  // bell intentionally receives no AppBackgroundTask entry.
   notifyConsentSurfaceRefresh("location_share_created", grantId);
   return true;
 }
-
 
 export function recordOneLocationWorkflowNotification(params: {
   userId: string;
@@ -686,39 +680,18 @@ export function recordOneLocationWorkflowNotification(params: {
   if (hasSeenOneLocationNotification(userId, eventId)) return false;
   markOneLocationNotificationSeen(userId, eventId);
 
-  // Surface in the bell (DebateTaskCenter / AppBackgroundTaskService) with an
-  // "Open" deep-link into the relevant One-Location section, so the workflow
-  // event is reachable from the bell - not only the transient toast.
-  const taskId = oneLocationWorkflowTaskId(params.notificationType, id);
-  AppBackgroundTaskService.startTask({
-    taskId,
-    userId,
-    kind: LOCATION_WORKFLOW_TASK_KIND,
-    title: params.title,
-    description: params.description,
-    routeHref: params.routeHref || "/one/location",
-    visibility: "primary",
-    groupLabel: "Location",
-    autoClearAfterMs: 0,
-    metadata: {
-      notificationType: params.notificationType,
-      id,
-      ...(params.metadata || {}),
-    },
-  });
-  AppBackgroundTaskService.completeTask(taskId, params.description);
-
-  // Also route to the consent surfaces (shield icon + consent manager).
+  // Workflow events are likewise consent-only; the shield and Access Manager
+  // own their durable presentation.
   notifyConsentSurfaceRefresh(params.notificationType, id);
   return true;
 }
-
 
 export function playOneLocationNotificationSound(): void {
   if (typeof window === "undefined") return;
   const audioContextConstructor =
     window.AudioContext ||
-    (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
   if (!audioContextConstructor) return;
 
   try {
@@ -727,7 +700,10 @@ export function playOneLocationNotificationSound(): void {
     const gain = context.createGain();
     oscillator.type = "sine";
     oscillator.frequency.setValueAtTime(880, context.currentTime);
-    oscillator.frequency.exponentialRampToValueAtTime(660, context.currentTime + 0.12);
+    oscillator.frequency.exponentialRampToValueAtTime(
+      660,
+      context.currentTime + 0.12,
+    );
     gain.gain.setValueAtTime(0.0001, context.currentTime);
     gain.gain.exponentialRampToValueAtTime(0.08, context.currentTime + 0.02);
     gain.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + 0.22);

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -14,9 +14,11 @@ import type {
   OneLocationNetworkConnection,
   OneLocationPublicInvite,
   OneLocationPublicInviteSubmission,
+  OneLocationPublishTarget,
   OneLocationRecipient,
   OneLocationReferral,
   OneLocationState,
+  OneLocationVisibility,
   PlainLocationPoint,
   DriveDestination,
   RouteEta,
@@ -133,7 +135,6 @@ export class OneLocationService {
     return HushhLocation.stopBackgroundShare();
   }
 
-
   static async registerRecipientKey(params: {
     vaultOwnerToken: string;
     keyId: string;
@@ -163,6 +164,39 @@ export class OneLocationService {
     return apiJsonWithRetry<OneLocationState>("/api/one/location/state", {
       headers: jsonAuthHeaders(vaultOwnerToken),
     });
+  }
+
+  static async updateConnectionVisibility(params: {
+    vaultOwnerToken: string;
+    enabled: boolean;
+    precision: "precise" | "approximate";
+    excludedUserIds?: string[];
+  }): Promise<{
+    visibility: OneLocationVisibility;
+    grants: OneLocationGrant[];
+  }> {
+    return apiJson("/api/one/location/visibility", {
+      method: "PATCH",
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({
+        enabled: params.enabled,
+        precision: params.precision,
+        excludedUserIds: params.excludedUserIds ?? [],
+      }),
+    });
+  }
+
+  static async getPublishTargets(params: {
+    vaultOwnerToken: string;
+    limit?: number;
+  }): Promise<OneLocationPublishTarget[]> {
+    const search = new URLSearchParams({ limit: String(params.limit ?? 500) });
+    const response = await apiJsonWithRetry<{
+      targets: OneLocationPublishTarget[];
+    }>(`/api/one/location/publish-targets?${search.toString()}`, {
+      headers: jsonAuthHeaders(params.vaultOwnerToken),
+    });
+    return response.targets;
   }
 
   static async chat(params: {
@@ -410,7 +444,6 @@ export class OneLocationService {
   }
 
   static async placesAutocomplete(params: {
-
     vaultOwnerToken: string;
     input: string;
     sessionToken?: string;

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -1,9 +1,5 @@
 export type LocationSourcePlatform =
-  | "web"
-  | "ios"
-  | "android"
-  | "native"
-  | "unknown";
+  "web" | "ios" | "android" | "native" | "unknown";
 
 export type OneLocationRecommendationTier =
   | "needs_action"
@@ -151,6 +147,8 @@ export type OneLocationGrant = {
   updatedAt?: string | null;
   revokedAt?: string | null;
   latestEnvelopeId?: string | null;
+  accessOrigin?:
+    "direct" | "request_approved" | "connections_visibility" | string;
   /**
    * Share intent surfaced by the backend so the recipient's notification, bell,
    * and Consent Manager can distinguish an emergency SOS from a friendly
@@ -162,6 +160,25 @@ export type OneLocationGrant = {
    * coordinate-free and bounded by the backend; shown verbatim to the recipient.
    */
   shareMessage?: string | null;
+};
+
+export type OneLocationVisibility = {
+  enabled: boolean;
+  audience: "private" | "connections";
+  precision: "precise" | "approximate";
+  enabledAt?: string | null;
+  disabledAt?: string | null;
+  updatedAt?: string | null;
+  excludedUserIds: string[];
+  eligibleConnectionCount: number;
+  readyConnectionCount: number;
+  unavailableConnectionCount: number;
+};
+
+export type OneLocationPublishTarget = {
+  grant: OneLocationGrant;
+  precision: "precise" | "approximate";
+  recipient: OneLocationRecipient;
 };
 
 export type OneLocationAccessRequest = {
@@ -278,6 +295,7 @@ export type OneLocationMyRecipientKey = {
 
 export type OneLocationState = {
   recipients: OneLocationRecipient[];
+  visibility?: OneLocationVisibility;
   myRecipientKey?: OneLocationMyRecipientKey | null;
   kaiCircleCandidates?: KaiCircleCandidate[];
   viewerCapabilities?: OneLocationViewerCapabilities;
@@ -398,7 +416,12 @@ export interface ShareTarget {
   label: string;
 }
 
-export type ClientActionType = "publish_share" | "view_envelope" | "create_public_link" | "sos_panic" | "check_in";
+export type ClientActionType =
+  | "publish_share"
+  | "view_envelope"
+  | "create_public_link"
+  | "sos_panic"
+  | "check_in";
 
 export interface ClientAction {
   id: string;

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -36,7 +36,7 @@ import {
   FirebaseAuthentication,
   ProviderId,
 } from "@capacitor-firebase/authentication";
-import { HushhAuth, type AuthUser } from "@/lib/capacitor";
+import { HushhAuth, HushhLocation, type AuthUser } from "@/lib/capacitor";
 import { toast } from "sonner";
 
 export interface AuthResult {
@@ -867,6 +867,7 @@ export class AuthService {
     // Capacitor WebView. Always attempt both; a failure in one must never
     // short-circuit cleanup of the other.
     const results = await Promise.allSettled([
+      HushhLocation.stopBackgroundShare(),
       HushhAuth.signOut(),
       firebaseSignOut(auth),
     ]);

--- a/hushh-webapp/scripts/architecture/generate-surface-map.mjs
+++ b/hushh-webapp/scripts/architecture/generate-surface-map.mjs
@@ -20,6 +20,10 @@ function readJson(filePath) {
   return JSON.parse(read(filePath));
 }
 
+function relativePosix(from, to) {
+  return path.relative(from, to).split(path.sep).join("/");
+}
+
 function routeValuesFromRoutesTs(source) {
   return [
     ...new Set(
@@ -32,10 +36,10 @@ function routeValuesFromRoutesTs(source) {
 
 function routeValuesFromAppPages() {
   return walkFiles(path.join(appRoot, "app"), (filePath) =>
-    filePath.endsWith("/page.tsx"),
+    path.basename(filePath) === "page.tsx",
   )
     .map((filePath) => {
-      const relative = path.relative(path.join(appRoot, "app"), filePath);
+      const relative = relativePosix(path.join(appRoot, "app"), filePath);
       const route = relative.replace(/(?:^|\/)page\.tsx$/, "");
       return route ? `/${route}` : "/";
     })
@@ -91,9 +95,9 @@ function routeToVoiceContractFile(route) {
 }
 
 function apiTemplateFromRouteFile(filePath) {
-  const relative = path.relative(path.join(appRoot, "app/api"), filePath);
+  const relative = relativePosix(path.join(appRoot, "app/api"), filePath);
   const withoutRoute = relative.replace(/\/route\.ts$/, "");
-  const parts = withoutRoute.split(path.sep).map((part) => {
+  const parts = withoutRoute.split("/").map((part) => {
     const catchAll = part.match(/^\[\.\.\.(.+)\]$/);
     if (catchAll) return `{${catchAll[1]}*}`;
     const dynamic = part.match(/^\[(.+)\]$/);
@@ -440,11 +444,11 @@ function buildSurfaceMap() {
     (inventory.routes || []).map((route) => [route.route, route]),
   );
   const apiRoutes = walkFiles(path.join(appRoot, "app/api"), (filePath) =>
-    filePath.endsWith("/route.ts"),
+    path.basename(filePath) === "route.ts",
   )
     .map((filePath) => ({
       template: apiTemplateFromRouteFile(filePath),
-      file: path.relative(appRoot, filePath),
+      file: relativePosix(appRoot, filePath),
     }))
     .sort((left, right) => left.template.localeCompare(right.template));
 

--- a/hushh-webapp/scripts/native/verify-native-static-parity.mjs
+++ b/hushh-webapp/scripts/native/verify-native-static-parity.mjs
@@ -64,6 +64,12 @@ const locationUsageMatch = infoPlist.match(
 if (!locationUsageMatch?.[1]?.trim()) {
   fail("iOS Info.plist must include non-empty NSLocationWhenInUseUsageDescription.");
 }
+const alwaysLocationUsageMatch = infoPlist.match(
+  /<key>NSLocationAlwaysAndWhenInUseUsageDescription<\/key>\s*<string>([^<]+)<\/string>/
+);
+if (!alwaysLocationUsageMatch?.[1]?.trim()) {
+  fail("iOS Info.plist must include non-empty NSLocationAlwaysAndWhenInUseUsageDescription.");
+}
 const contactsUsageMatch = infoPlist.match(
   /<key>NSContactsUsageDescription<\/key>\s*<string>([^<]+)<\/string>/
 );
@@ -81,6 +87,10 @@ const allowedAndroidPermissions = new Set([
   "android.permission.MODIFY_AUDIO_SETTINGS",
   "android.permission.ACCESS_FINE_LOCATION",
   "android.permission.ACCESS_COARSE_LOCATION",
+  "android.permission.ACCESS_BACKGROUND_LOCATION",
+  "android.permission.FOREGROUND_SERVICE",
+  "android.permission.FOREGROUND_SERVICE_LOCATION",
+  "android.permission.POST_NOTIFICATIONS",
   "android.permission.READ_CONTACTS",
 ]);
 const unexpectedAndroidPermissions = androidPermissions.filter(
@@ -106,8 +116,11 @@ if (!androidManifest.includes('android.permission.ACCESS_COARSE_LOCATION')) {
 if (!androidManifest.includes('android.permission.READ_CONTACTS')) {
   fail("AndroidManifest.xml must include android.permission.READ_CONTACTS.");
 }
-if (androidManifest.includes('android.permission.ACCESS_BACKGROUND_LOCATION')) {
-  fail("One Location Agent v1 must not request android.permission.ACCESS_BACKGROUND_LOCATION.");
+if (!androidManifest.includes('android.permission.ACCESS_BACKGROUND_LOCATION')) {
+  fail("Friends Map background sharing requires android.permission.ACCESS_BACKGROUND_LOCATION.");
+}
+if (!androidManifest.includes('android.permission.FOREGROUND_SERVICE_LOCATION')) {
+  fail("Friends Map background sharing requires android.permission.FOREGROUND_SERVICE_LOCATION.");
 }
 const androidMainActivity = androidManifest.match(
   /<activity\b(?=[^>]*android:name="\.MainActivity")[^>]*>/,


### PR DESCRIPTION
## Summary

- add opt-in **Visible to connections** settings with per-connection exclusions and precise/approximate visibility
- add **Friends Map** for accepted connections who have enabled location visibility
- publish encrypted per-recipient location envelopes across web, Android, and iOS/Capacitor flows
- surface connection visibility grants in One Location notifications and Access Manager without exposing coordinates
- add migration `115_one_location_connection_visibility.sql` plus lifecycle, account cleanup, and resilience coverage
- fix local FCM link handling, reserved SQL alias usage, JSON array decoding, and async location UI actions found during end-to-end testing

## Verification

- `48 passed` backend focused tests
- `60 passed` frontend focused tests
- `npm run typecheck`
- `npm run verify:surface-map`
- `npm run verify:capacitor:static`
- `npm run verify:capacitor:plugins`
- production `npm run build`
- runtime topology index and data-model audit current (`113/113` tables classified)
- DCO signoff passed
- gitleaks passed with no leaks

## Notes

- targets `main` through the governed maintainer direct-PR flow
- does not enable visibility by default; each user must explicitly turn it on
- consent and Access Manager projections remain coordinate-free
