### PR TITLE
feat(mcp): add Salesforce AgentExchange connector boundary

### DIFF
--- a/consent-protocol/docs/README.md
+++ b/consent-protocol/docs/README.md
@@ -62,7 +62,7 @@ It does not own:
 | Understand the consent token model | [reference/consent-protocol.md](./reference/consent-protocol.md) |
 | FCM push notification architecture | [reference/fcm-notifications.md](./reference/fcm-notifications.md) |
 | Understand MCP runtime and contributor-local setup | [mcp-setup.md](./mcp-setup.md) |
-| Implement the MuleSoft and Agentforce secure relay | [reference/mulesoft-agentforce-secure-relay.md](./reference/mulesoft-agentforce-secure-relay.md) |
+| Implement the Salesforce AgentExchange trusted connector | [reference/mulesoft-agentforce-secure-relay.md](./reference/mulesoft-agentforce-secure-relay.md) |
 | Integrate into a host monorepo (subtree) | [monorepo-integration.md](./monorepo-integration.md) |
 | Read the Hussh philosophy | [manifesto.md](./manifesto.md) |
 

--- a/consent-protocol/docs/mcp-setup.md
+++ b/consent-protocol/docs/mcp-setup.md
@@ -175,17 +175,19 @@ the bearer header. Do not work around either path with stdio, `?token=`, or an
 unauthenticated endpoint. OAuth authenticates the connector only; each read
 still follows the scoped consent lifecycle and encryption rules above.
 
-### MuleSoft and Agentforce handoff
+### Salesforce AgentExchange trusted connector
 
-> **Important current boundary.** The Exchange registration preserves the
-> canonical five-tool Hussh catalog. Direct Agentforce identities are
-> catalog-only in Hussh because Salesforce does not support user-level
-> authentication or personalized MCP responses. MuleSoft uses a separate,
-> operations-provisioned Hussh execute application upstream; that does not
-> remove Salesforce's host-product limitation. The canonical implementation
-> guide is [MuleSoft and Agentforce secure relay](./reference/mulesoft-agentforce-secure-relay.md).
+> **Important current boundary.** Hussh preserves one canonical five-tool
+> catalog. A direct Agentforce MCP profile is catalog-only. Personalized
+> consent calls run only in customer-installed Salesforce/AgentExchange package
+> code using a separate, operations-provisioned Hussh execute app. Its client
+> credential is never a user identity. The canonical guide is
+> [Salesforce AgentExchange trusted connector](./reference/mulesoft-agentforce-secure-relay.md).
 
-MuleSoft Exchange cannot attach Hussh OAuth credentials while it fetches an
+#### Legacy MuleSoft Exchange registration (not selected)
+
+This retained compatibility path is not part of the Salesforce AgentExchange
+implementation. MuleSoft Exchange cannot attach Hussh OAuth credentials while it fetches an
 MCP URL for publication. Use **Upload MCP file**, not Fetch MCP URL, and upload
 the generated registration projection:
 
@@ -206,30 +208,27 @@ npm run gateway:generate
 npm run print-mulesoft-exchange-manifest
 ```
 
-Configure a dedicated Hussh execute application's OAuth client ID and secret
-**separately** in MuleSoft's authenticated upstream connection to
-`https://api.uat.hushh.ai/mcp/`. MuleSoft publishes its own endpoint to
-Agentforce. Agentforce does not receive or store the Hussh secret; it
-authenticates to MuleSoft.
+Configure the package's per-org Hussh execute application's OAuth client ID and
+secret only in its protected connector runtime. Agentforce does not receive or
+store the Hussh secret.
 
 The generated `hushh-agentforce-mcp-manifest.json` remains a diagnostic
-handoff/reference artifact, not the file to upload to Exchange. Give the
-MuleSoft team its `mulesoftAgentforceHandoff` object unchanged only when they
-need relay configuration guidance.
+handoff/reference artifact, not the file to upload to Exchange. New Salesforce
+package integrations consume its `salesforceAgentExchangeHandoff` object.
+`mulesoftAgentforceHandoff` is legacy compatibility output and not part of this
+selected integration.
 
-- MuleSoft calls Hussh at `https://api.uat.hushh.ai/mcp/` over Streamable HTTP,
-  using either a provisioned **bearer credential** or OAuth client credentials
-  for its Hussh execute application. Bearer is first-class and is not a legacy
-  path. Direct Agentforce profiles do not execute personalized tools.
-- Agentforce authenticates to MuleSoft with MuleSoft-owned OAuth client
-  credentials. Do not give the Hussh Technologies client secret to Agentforce.
+- A trusted connector calls Hussh at `https://api.uat.hushh.ai/mcp/` over
+  Streamable HTTP with a provisioned **bearer credential** or OAuth client
+  credentials for its Hussh execute application. Bearer is first-class.
+- The AgentExchange package is not a key store. After installation, its trusted
+  connector code generates/imports the per-org X25519 key pair, retains the
+  private key outside Agentforce, and sends only the public bundle to Hussh.
 - API Catalog registration is tools-only and uses the exact five generated
-  hyphenated definitions. At the Agentforce-facing MuleSoft edge, use MCP
-  Global Access to hide and block `get-encrypted-scoped-export`; that tool is
-  a secure Mule connector subflow, not an LLM action. Map
-  `structuredContent` as the canonical successful result. `content[0].text`
-  is a compatibility mirror and must not be passed to the Agentforce planner
-  as a second result.
+  hyphenated definitions. Tool 5, `get-encrypted-scoped-export`, stays inside
+  trusted connector code and is blocked from the Agentforce planner. Map
+  `structuredContent` as the canonical successful result; `content[0].text`
+  is a compatibility mirror and not a second planner result.
 - Client credentials do not represent a Hussh user. The supplied identifier
   selects the consent subject; explicit approval and the scoped grant remain
   mandatory before encrypted information is returned.
@@ -265,7 +264,7 @@ local process. There is one endpoint and one consent lifecycle.
   telemetry stay per-system. The operator stores the one-time raw bearer token
   or OAuth client secret only in the partner's secret manager. Hussh stores the
   public X25519 key and fingerprint only, never the partner private key.
-### Salesforce Agentforce: catalog registration and secure Mule UAT
+### Salesforce Agentforce: package connector UAT
 
 Salesforce supports Streamable HTTP and OAuth client credentials for MCP, but
 its current [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5)
@@ -274,31 +273,23 @@ user IDs or personalized responses. Hussh therefore treats the direct
 Agentforce profile as catalog-only. It rejects personalized tool calls with
 `REQUIRES_SECURE_CONSENT_FLOW`; that protection must not be relaxed.
 
-MuleSoft uses a separate Hussh execute application in its secured upstream
-flow. This permits MuleSoft-to-Hussh UAT of the consent lifecycle but does not
-remove Salesforce's documented Agentforce limitation. Production use requires
-Salesforce confirmation of the exact branded host boundary. The implementation
-and UAT checklist are in [MuleSoft and Agentforce secure relay](./reference/mulesoft-agentforce-secure-relay.md).
+An installed Salesforce package uses its own per-org Hussh execute app and
+connector key. It may supply the complete public key bundle with each consent
+request in compatibility/UAT mode, but production should register one active
+public key per app/org and omit that bundle from routine calls. The private key
+must stay in a customer-controlled KMS/HSM or reviewed connector crypto
+runtime, never in Agentforce or the package artifact.
 
-MuleSoft must relay the exact generated catalog into Salesforce API Catalog:
+Production use requires Salesforce confirmation of the exact branded host
+boundary. The implementation and UAT checklist are in [Salesforce AgentExchange
+trusted connector](./reference/mulesoft-agentforce-secure-relay.md).
 
-- Agentforce → MuleSoft and MuleSoft → Hussh are separate OAuth
-  client-credential hops. Neither hop represents a Hussh end user.
-- Preserve the five names and their flat input/output schemas exactly in the
-  Exchange registration; do not add resources, prompts, nested fields, or a
-  wider catalog. Use MuleSoft MCP Global Access to hide and reject tool 5 at
-  the Agentforce-facing edge.
-- Register and allowlist the server in API Catalog, then inspect the final
-  Agentforce Asset Library mappings. Salesforce's
-  [API Catalog guidance](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mulesoft_mcp_servers.htm&language=en_US&type=5)
-  still requires an authentication protocol supported by the Agentforce MCP
-  client.
-
-Print the versioned, non-secret relay handoff before configuring the Mule flow:
+Print the versioned, non-secret Salesforce handoff before configuring an
+installed package:
 
 ```bash
 cd packages/hushh-mcp
-npm run print-mulesoft-agentforce-handoff
+npx hushh-mcp --print-salesforce-agentexchange-handoff
 ```
 
 This catalog is generated from the runtime and has exactly five tools:
@@ -313,11 +304,9 @@ They have client-facing names/descriptions, primitive or string-array fields,
 explicit required inputs, bounded field metadata, and complete output schemas.
 The server exposes no resources or prompts to Agentforce and caps the request
 timeout at 55 seconds so it settles before Agentforce's 60-second MCP timeout.
-Salesforce still documents that Agentforce MCP has no user-level
-authentication and does not support use cases requiring individualized
-responses. Do not treat any client credential as a Salesforce or Hussh user
-identity, and do not enable a personalized Agentforce action until Salesforce
-confirms the exact host boundary.
+Do not treat any client credential as a Salesforce or Hussh user identity, and
+do not enable a personalized Agentforce action until the target-org UAT proves
+the exact package boundary.
 
 Before every Agentforce registration or schema change, print and review the
 generated catalog:
@@ -327,11 +316,11 @@ cd packages/hushh-mcp
 npm run print-agentforce-manifest
 ```
 
-In Agentforce Registry, register the MuleSoft Streamable HTTP endpoint and
-configure MuleSoft OAuth client credentials. The Exchange registration remains
-five tools; the MuleSoft Agentforce-facing policy controls the safe action
-subset. Then inspect the Asset Library action schemas: verify all input/output
-field counts and manually
+In Agentforce Registry/API Catalog, configure the installed package or external
+connector connection using its supported Named Credential path. The Hussh
+registration remains five tools; trusted connector policy controls the safe
+action subset. Then inspect the Asset Library action schemas: verify all
+input/output field counts and manually
 replace any display labels that Salesforce renders as `string`. Salesforce
 documents this as a current Builder issue; JSON Schema `title` is included for
 inspection but is not claimed as a platform UI fix. Record only safe metadata

--- a/consent-protocol/docs/reference/developer-api.md
+++ b/consent-protocol/docs/reference/developer-api.md
@@ -90,10 +90,12 @@ They authenticate only the partner application and never create a synthetic
 user subject. The supplied user identifier selects the consent subject;
 explicit approval and a valid scoped grant remain mandatory before encrypted
 information delivery. The direct Agentforce profile is catalog-only and returns
-`REQUIRES_SECURE_CONSENT_FLOW` for a personalized call. A MuleSoft execute
-application is a separate upstream principal, not a workaround for
-Salesforce's current lack of user-level MCP authentication and support for
-personalized responses. See [MuleSoft and Agentforce secure relay](./mulesoft-agentforce-secure-relay.md).
+`REQUIRES_SECURE_CONSENT_FLOW` for a personalized call. A Salesforce
+AgentExchange trusted connector is a separate upstream principal, not a
+workaround for direct-host limitations: it performs the consent lifecycle and
+decryption outside the Agentforce model with its own per-org app and connector
+key. See [Salesforce AgentExchange trusted
+connector](./mulesoft-agentforce-secure-relay.md).
 Register an exact
 HTTPS redirect URI for PKCE first; loopback HTTP is permitted solely for local
 development. Client secrets, authorization codes, access tokens, refresh
@@ -165,10 +167,11 @@ Authorization: Bearer <developer-token>
 ```
 
 For the raw HTTP developer API, the connector fields are required unless the
-developer app has an active registered connector bundle. Registered apps may
-omit the fields; any supplied legacy bundle must match the app's public key,
-key id, and wrapping algorithm exactly. This prevents one app from rebinding a
-grant to another connector key. Hussh never manages the connector private key.
+developer app has an active registered connector bundle. An unregistered
+standard/flat execute app supplies the complete bundle per request. Registered
+apps may omit it; any supplied bundle must match the app's public key, key ID,
+and wrapping algorithm exactly. This prevents one app from rebinding a grant to
+another connector key. Hussh never manages the connector private key.
 
 ### 3. Poll status
 
@@ -419,8 +422,11 @@ async function decryptScopedExport(
 The connector private key must correspond to the exact public key and
 `connector_key_id` supplied in the approved consent request. If that private
 key is unavailable, create and securely retain a new connector key pair, then
-request fresh consent and fetch a new export. Never send a connector private
-key in a request, chat, log, or support ticket.
+request fresh consent and fetch a new export. For a Salesforce AgentExchange
+connector, key generation/import happens after installation in that org's
+trusted connector runtime; the package, Agentforce model, and Hussh never
+receive the private key. Never send a connector private key in a request,
+chat, log, or support ticket.
 
 If `granted_scope` is broader than `expected_scope`, narrow the decrypted JSON locally to the requested subtree before using it.
 

--- a/consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md
+++ b/consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md
@@ -1,207 +1,142 @@
-# MuleSoft and Agentforce secure consent relay
+# Salesforce AgentExchange trusted connector
 
 ## Visual Context
 
 Canonical visual owner: [consent-protocol](../README.md).
 
+## Decision
+
+Hussh has one Streamable HTTP endpoint and one canonical five-tool consent
+contract. A Salesforce integration does not create a reduced Hussh endpoint,
+an Agentforce-specific consent lifecycle, or a different encryption protocol.
+
+An AgentExchange package is a distribution mechanism. The installed,
+customer-specific connector runtime is the trust boundary: it owns its own
+X25519 key pair, sends only the public key to Hussh, and performs decryption
+outside Agentforce's language-model context. MuleSoft is not part of the
+selected Salesforce integration.
+
 ```mermaid
 flowchart LR
-  af["Agentforce"] -->|"MuleSoft OAuth client"| mule["MuleSoft MCP edge"]
-  mule -->|"Hussh execute-app token"| hushh["Hussh Consent MCP"]
-  hushh -->|"ciphertext + envelope"| crypto["Mule secure crypto subflow"]
-  crypto -->|"approved fields"| partner["Brand partner system"]
-  person["Person"] -->|"reviews and approves"| hushh
+  person["Person"] -->|"reviews and approves"| hushh["Hussh Consent MCP"]
+  connector["Installed Salesforce trusted connector<br/>per Salesforce org"] -->|"execute-app credential + public key"| hushh
+  hushh -->|"ciphertext + authenticated envelope"| connector
+  connector -->|"validated approved fields"| action["Deterministic Salesforce action"]
+  action --> agentforce["Agentforce"]
 ```
 
-## Decision at a glance
+## Boundaries that do not change
 
-Hussh has one MCP endpoint and one canonical five-tool consent contract. Do
-not create a second Hussh endpoint, a reduced Hussh manifest, or a parallel
-consent lifecycle for Agentforce.
+1. Hussh publishes exactly these five tools:
+   `search-user-scopes`, `prepare-campaign-context`, `request-consent`,
+   `check-consent-status`, and `get-encrypted-scoped-export`.
+2. A direct Agentforce MCP profile remains catalog-only. It must not receive a
+   synthetic Hussh user identity or run personalized consent calls.
+3. `get-encrypted-scoped-export` is a trusted-connector operation, never an
+   Agentforce planner/LLM action. The model receives neither ciphertext, a
+   connector private key, nor a decrypted export.
+4. OAuth application authority, the person's consent authority, and the
+   encryption-recipient key are separate controls. A client credential does
+   not replace consent and a public key does not widen a scope.
+5. Hussh receives only the connector public key, key ID, algorithm, and
+   fingerprint. It does not receive a connector private key or readable scoped
+   information.
 
-The encrypted export is deliberately **not an Agentforce action**. It is a
-connector-only step inside MuleSoft after a grant has been approved. Agentforce
-does not receive a connector private key, ciphertext envelope, plaintext
-information, or a Hussh credential.
+Salesforce documents that external MCP tool support has host constraints. The
+package route therefore needs a Salesforce UAT rehearsal in the target org;
+the existence of an AgentExchange listing is not proof that a personalized
+consent workflow is permitted. See Salesforce's [MCP
+considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5)
+and [API Catalog guidance](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mcp_servers.htm&language=en_US&type=5).
 
-This is the required topology:
+## Per-org connector identity and key custody
 
-```text
-Agentforce
-  -- MuleSoft-owned OAuth client credentials --> MuleSoft MCP endpoint
-  -- Hussh execute-app OAuth credentials ----> Hussh /mcp/
-  -- approved grant + registered public key --> encrypted export
-  -- private key in MuleSoft KMS/HSM --------> decrypt in a Mule secure subflow
-  -- approved, purpose-bound delivery -------> brand partner system
+Each installed Salesforce org gets its own Hussh `partner_crm` execute app and
+its own connector key identity. The connector generates or imports an X25519
+key pair after installation in a customer-controlled KMS/HSM or reviewed
+connector crypto runtime. It retains the private key there.
+
+Only this public bundle reaches Hussh:
+
+```json
+{
+  "connector_public_key": "base64-x25519-public-key",
+  "connector_key_id": "salesforce-org-key-2026-07",
+  "connector_wrapping_alg": "X25519-AES256-GCM"
+}
 ```
 
-The two OAuth hops are intentionally different identities. The first protects
-the Salesforce-to-MuleSoft connection. The second identifies the provisioned
-partner application to Hussh. Neither credential is a person identity and
-neither replaces a person's consent.
+The current contract supports two safe modes:
 
-## Current Agentforce gate
-
-Salesforce documents that Agentforce MCP supports Streamable HTTP and OAuth
-2.0 client credentials, but does not support user-level authentication or use
-cases requiring an individual identifier or personalized response. That is a
-host-product limitation, not a Hussh authentication defect. See Salesforce's
-[MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5).
-
-Therefore:
-
-- Direct Agentforce identities are catalog-only in Hussh. A direct
-  personalized call returns `REQUIRES_SECURE_CONSENT_FLOW` and does not invoke
-  a consent handler.
-- A MuleSoft relay can authenticate to Hussh with its own operations-provisioned
-  execute application, but it does **not** turn an unsupported Agentforce
-  personalized-response use case into a supported one.
-- The production gate is written confirmation from Salesforce that the exact
-  Agentforce and MuleSoft topology is supported for the proposed branded
-  experience. Until that exists, test the personal lifecycle only as a
-  MuleSoft-to-Hussh UAT flow, not as an Agentforce production capability.
-
-This boundary is intentional. Do not weaken Hussh's catalog-only protection to
-work around an Agentforce host limitation.
-
-## What remains five tools, and what Agentforce sees
-
-Hussh always publishes these five tools, in this exact order:
-
-1. `search-user-scopes`
-2. `prepare-campaign-context`
-3. `request-consent`
-4. `check-consent-status`
-5. `get-encrypted-scoped-export`
-
-The generated Exchange file remains a five-tool **registration projection**.
-It is the only file uploaded to MuleSoft Exchange and is not hand-edited.
-
-MuleSoft must use its MCP Global Access policy at the Agentforce-facing edge:
-
-| Boundary | Tools exposed | Reason |
+| Mode | `request-consent` key fields | Intended use |
 | --- | --- | --- |
-| Hussh canonical endpoint | All five | One public contract and one complete consent lifecycle. |
-| MuleSoft internal Hussh client | All five | The secure connector needs the approved encrypted export. |
-| Agentforce action surface | No personalized lifecycle actions by default; if Salesforce approves the UAT topology, only tools 1–4 | Tool 5 is ciphertext delivery and cannot be interpreted or decrypted by an LLM. |
+| Registered key | Omit the fields; Hussh resolves the app's active registered key. If supplied, all three must exactly match it. | Production default: one active public key per partner/org app. |
+| Per-request key bundle | Supply all three fields on every request. | Compatibility/UAT for an unregistered standard/flat execute app. |
 
-The policy is an access projection, not a second manifest. MuleSoft's MCP
-Global Access policy filters both `tools/list` and blocked `tools/call`
-requests, which is exactly what is needed here. Its Tool Mapping policy may
-improve descriptions, but must not change the Hussh names, arguments, output
-meaning, or lifecycle semantics. See MuleSoft's [Global Access
-policy](https://docs.mulesoft.com/gateway/latest/policies-included-mcp-global-access)
-and [policy ordering](https://docs.mulesoft.com/gateway/latest/policies-mcp-access-control-together).
+Never put the private key in an MCP argument, AgentExchange package artifact,
+Custom Metadata/Custom Setting, SObject, Named Credential field, prompt,
+Flow variable, trace, DataWeave, log, ticket, or Hussh system. Do not ship a
+universal private key in a managed package.
 
-The four control-plane tools are not confusing when configured with these
-Agentforce instructions:
+Key rotation is explicit: retain the old key only long enough to complete or
+revoke exports bound to it, register the new public key with an explicit key
+ID, and create fresh consent/export bindings. Do not silently rebind a grant
+to a new key.
 
-- Use `search-user-scopes` before selecting a scope.
-- Use `prepare-campaign-context` only for an offer/context journey. Do not use
-  it and `request-consent` as two independent requests for the same purpose.
-- Use `request-consent` after a scope and purpose are selected.
-- Use `check-consent-status` only with the returned `request_ref` and at the
-  returned interval.
-- Never call, display, parse, or describe `get-encrypted-scoped-export` in an
-  Agentforce prompt. MuleSoft invokes it only in the secure connector subflow
-  after it has verified an approved grant.
+## Lifecycle implemented by the trusted connector
 
-## Sovereignty and information boundary
+The package's deterministic connector code, not an Agentforce prompt,
+performs this lifecycle:
 
-The correct sovereignty statement is precise:
+1. Authenticate as that org's Hussh execute application using its protected
+   bearer credential or short-lived OAuth client-credentials token.
+2. Call `search-user-scopes`, choose the narrowest returned scope, then call
+   `request-consent` with a clear purpose and the registered key (or complete
+   per-request public bundle).
+3. Treat `pending` as a valid state. Direct the person to the Hussh Consent
+   Center and poll only at `poll_after_seconds`.
+4. Once `check-consent-status` returns an approved `grant_ref`, call
+   `get-encrypted-scoped-export` inside the trusted connector only.
+5. Validate app binding, grant, exact expected scope, export revision, expiry,
+   recipient key ID/fingerprint, algorithm, envelope, and AAD before decrypting.
+6. Decrypt and scope-narrow deterministically outside every model context.
+   Validate and write only the approved fields required for the named CRM
+   action, then emit a metadata-only delivery receipt.
 
-- Hussh governs application identity, consent, scope, grant status, expiry,
-  revocation, audit references, and encrypted-export issuance.
-- Hussh receives and delivers **ciphertext** plus the public recipient-key
-  binding. Hussh does not receive the connector private key or readable export
-  information.
-- MuleSoft is not merely transport once it decrypts. It becomes a minimal
-  trusted connector delivery boundary and must meet the brand partner's key,
-  retention, access-control, and audit requirements.
-- A VPC/private network protects the route. It is not consent, key custody, or
-  authorization. Consent and cryptographic key separation remain mandatory
-  inside a VPC.
+The connector must be idempotent by Hussh request/grant reference. A retry
+cannot create a duplicate request, delivery, or CRM mutation.
 
-Do not state that no information may touch Hussh at all: consent metadata and
-ciphertext necessarily do. The enforceable boundary is that readable scoped
-information and the private key never enter Hussh or an LLM context.
+## Tool visibility is an integration policy, not a second contract
 
-## MuleSoft build requirements
+The trusted connector uses all five tools. Agentforce receives the connector's
+single deterministic action result, not individual personalized Hussh tools.
+Hussh does not publish a four-tool variant.
 
-### 1. Provision two app identities and one connector key
+Regardless of that policy, tool 5 stays internal to trusted connector code and
+is blocked from the Agentforce planner. Its response is an encrypted export
+package, not a CRM record and not model context.
 
-1. **Salesforce to MuleSoft**: create MuleSoft-owned OAuth client credentials
-   for the Agentforce connection. Store those only in Salesforce Named
-   Credential/connection configuration.
-2. **MuleSoft to Hussh**: Hussh provisions a separate `partner_crm` execute
-   developer application with OAuth `client_credentials`, consent entitlement,
-   and one registered X25519 public key. Store its client secret only in
-   Anypoint Secrets Manager or an approved external secret manager.
-3. **Connector key pair**: generate and retain the X25519 private key in the
-   approved MuleSoft/brand KMS, HSM, or reviewed external crypto service.
-   Register only its public key, key ID, and fingerprint with Hussh. Never put
-   the private key in a DataWeave file, Exchange asset, property file, log,
-   ticket, request argument, or Agentforce configuration.
+The generated `hushh-agentforce-mcp-manifest.json` is a diagnostic contract,
+not a package to upload. Its `salesforceAgentExchangeHandoff` object is the
+current non-secret integration guide. The older
+`mulesoftAgentforceHandoff` object is retained for existing Mule relay users.
 
-Use a distinct Hussh execute application per brand partner. Rotation,
-revocation, audit attribution, and a connector-key change then remain isolated
-to that partner.
+## Approved output to Salesforce and Agentforce
 
-### 2. Keep the app-exchange registration simple
+After decryption, connector code may produce an action-specific, flat,
+deterministically validated object for Salesforce. This is a separate action
+result, not a change to the encrypted export tool or its five-tool lifecycle.
+For example, the fixed financial-documents projection produces top-level
+`statements` and `holdings` arrays joined by `statement_ref`.
 
-1. In Exchange choose **Upload MCP file**, not Fetch MCP URL.
-2. Upload the generated
-   `packages/hushh-mcp/gateway/hushh-mulesoft-exchange-mcp-schema.json` file.
-   It intentionally contains only Exchange-supported MCP fields and the five
-   canonical definitions. Its `protocolVersion` is `2025-06-18` deliberately:
-   that is the Exchange/Mule policy-compatible registration revision. Hussh's
-   runtime also accepts that revision; it is not a second endpoint or lifecycle.
-   The file contains no URL, authentication block, or secret.
-3. Publish the brand partner's MuleSoft MCP endpoint to API Catalog.
-4. In Agentforce, create the connection to the **MuleSoft endpoint** using the
-   MuleSoft OAuth identity-provider URL, scope, client ID, and client secret.
-   Do not enter the Hussh client into Salesforce.
-5. Add only approved actions from the Asset Library. For the default
-   production-safe configuration, do not add the personal lifecycle actions.
-   For a Salesforce-approved UAT, allow tools 1–4 only. Tool 5 remains hidden
-   and rejected at the Agentforce-facing edge.
+The connector must not pass raw PKM, envelope metadata, credentials, or an
+arbitrary decrypted blob to an Agentforce prompt. Its action contract declares
+the minimal fields it returns. Agentforce compatibility is proven in the
+target-org UAT using that action schema and a synthetic approved export.
 
-The generated `hushh-agentforce-mcp-manifest.json` is a diagnostic artifact,
-not the Exchange upload file. The full `hushh-mcp-gateway.json` is the
-canonical partner contract, not a Salesforce configuration file.
+## Exact envelope cryptography
 
-### 3. Build a secure Mule consent workflow
-
-Implement this as a Mule orchestration flow, not as Agentforce prompt logic:
-
-1. Exchange the MuleSoft-to-Hussh client credentials for a short-lived access
-   token and cache it only until shortly before expiry.
-2. Call Hussh over Streamable HTTP with `Authorization: Bearer <access token>`.
-   Preserve JSON-RPC IDs and Hussh lifecycle references.
-3. For the proposed purpose, call either the normal
-   `search-user-scopes -> request-consent -> check-consent-status` path or the
-   distinct `prepare-campaign-context -> check-consent-status` offer path.
-   Do not use both request creators for one purpose.
-4. On `pending`, give the person the Hussh Consent Center route through the
-   approved experience and poll only at `poll_after_seconds`. A pending result
-   is a valid lifecycle outcome, not an error.
-5. On `granted`, verify the grant reference, expected scope, expiry, connector
-   key ID/fingerprint, and envelope binding before the delivery step.
-6. Invoke `get-encrypted-scoped-export` **inside MuleSoft only**. Do not
-   forward its output to Agentforce or a model.
-7. Decrypt, validate and scope-narrow inside the protected crypto runtime;
-   immediately send only the approved fields to the brand partner system.
-8. Emit a metadata-only delivery receipt. Respect expiry/revocation and the
-   brand partner's approved retention/deletion policy.
-
-The flow must be idempotent by Hussh request/grant reference. Retrying a
-network request must not create a duplicate consent request, duplicate
-delivery, or untracked persistence event.
-
-### 4. Implement the exact envelope cryptography
-
-The Hussh envelope is `X25519-AES256-GCM`. It is not an interchangeable
-password-based encryption pattern.
+The envelope is `X25519-AES256-GCM`:
 
 ```text
 shared_secret = X25519(connector_private_key, sender_public_key)
@@ -222,90 +157,30 @@ plaintext = AES-256-GCM.decrypt(
 )
 ```
 
-`canonical_json` is recursively key-sorted, compact UTF-8 JSON. Validate the
-envelope's application binding, grant, expected scope, revision, expiry,
-recipient key ID/fingerprint, and AAD digest before delivery. Do not replace
-this with PBKDF2, AES-CBC, a guessed HKDF, an AES key-wrap variant, or a custom
-AAD representation.
+`canonical_json` is recursively key-sorted compact UTF-8 JSON. Do not replace
+this with PBKDF2, AES-CBC, guessed HKDF, an AES key-wrap variant, or a new AAD
+representation. Reference code and response-field details are in the
+[Developer API decryption guide](./developer-api.md#decrypt-an-encrypted-export-locally).
 
-MuleSoft's standard Cryptography module must not be assumed to implement the
-required X25519 envelope procedure. The team must provide a reviewed Java
-crypto module or approved external crypto service with X25519 and AES-256-GCM
-support, key material held outside the Mule application, test vectors, and a
-security review. MuleSoft's [Cryptography module
-reference](https://docs.mulesoft.com/cryptography-module/latest/cryptography-module-reference)
-is the starting point for supported primitives, not proof of this complete
-protocol implementation.
+## Required UAT proof
 
-## Result and error handling
+Before enabling personal-information delivery in any installed Salesforce org:
 
-For a successful Hussh tool result, MuleSoft treats `structuredContent` as the
-one canonical result. `content[0].text` is the serialized compatibility mirror
-and must not be sent to Agentforce as a second answer.
+1. Prove the connector uses its own execute app and a unique public-key
+   fingerprint; Hussh has no private key.
+2. Run all five tools against a synthetic user through request, approval,
+   polling, encrypted retrieval, envelope validation, decrypt, deterministic
+   action output, CRM readback, expiry/revocation, and cleanup.
+3. Prove tool 5 is absent from Agentforce planner/model context and that no
+   prompt, log, or telemetry record contains ciphertext, plaintext, key
+   material, identifier, access token, or export envelope.
+4. Run negative cases: wrong app, wrong key ID/fingerprint, tampered
+   ciphertext/AAD, stale export revision, scope mismatch, revoked grant,
+   duplicate delivery, and key rotation.
+5. Verify the target Salesforce org's Agentforce/API Catalog/Named Credential
+   configuration supports the exact installed package boundary before production.
 
-After validating and decrypting a financial-documents export, the trusted
-connector can apply Hussh's fixed `financial_statement_bundle.v1` projection.
-It produces top-level `statements` and `holdings` arrays joined by
-`statement_ref`, omits unavailable optional values, and performs no LLM call or
-request-time schema mapping. The connector's separate Agentforce-facing action
-returns that normalized object as `structuredContent` and an exact compact JSON
-mirror in `content[0].text`. This projection is connector output; it does not
-change the encrypted `get-encrypted-scoped-export` result or the five-tool
-consent lifecycle.
-
-For a tool execution error, Hussh returns `isError: true` and one safe JSON
-text content item. It intentionally omits `structuredContent`: error fields
-such as `error_code` and `next_action` cannot conform to a tool's strict
-success output schema. Parse that text only in the Mule transport layer and
-map it to a safe, user-facing brand response. Never surface internal errors,
-credentials, connector-key details, supplied identifiers, ciphertext, or
-plaintext.
-
-## Required telemetry and audit boundary
-
-All parties use the same correlation reference but record only metadata:
-
-| Owner | Required record | Prohibited record |
-| --- | --- | --- |
-| Hussh | app identity, hashed lifecycle reference, scope, envelope/key fingerprint, result, correlation, timestamps | private key, plaintext information, raw supplied identifier |
-| MuleSoft | correlation, policy version, grant/scope validation outcome, key ID/fingerprint, delivery target alias, result, deletion/retention event | private key, ciphertext, plaintext, access token |
-| Brand partner | lawful purpose, approved destination, access, retention and deletion evidence | broader information than the approved scope |
-
-Redact request/response logs, DataWeave errors, traces, DLQs, prompt payloads,
-and analytics. The private key and decrypted payload must never be serialized.
-
-## UAT acceptance checklist
-
-Do not call the topology ready until all of the following independently pass:
-
-1. MuleSoft exchanges its Hussh execute-app credentials and `initialize` plus
-   `tools/list` show the exact five canonical names upstream.
-2. The Exchange upload validates and API Catalog registers the MuleSoft
-   endpoint with no Hussh-specific manifest fields.
-3. Agentforce authenticates only to MuleSoft and sees only its configured
-   action subset. Confirm tool 5 is absent and blocked at this edge.
-4. The direct Agentforce profile returns `REQUIRES_SECURE_CONSENT_FLOW` for a
-   personalized call; this proves the host boundary is not silently bypassed.
-5. MuleSoft-to-Hussh UAT completes the approved lifecycle against a synthetic
-   user: scope discovery, request, approval, status, encrypted retrieval,
-   envelope validation, decrypt, scoped delivery, readback, expiry/revocation
-   rejection, and cleanup.
-6. Negative tests cover wrong app, expired token, wrong key ID/fingerprint,
-   tampered ciphertext/AAD, scope mismatch, revoked grant, duplicate delivery,
-   and a blocked Agentforce `tools/call` to tool 5.
-7. Salesforce confirms in writing that the intended branded Agentforce
-   experience is permitted before any production personal-information path is
-   enabled.
-
-## Brand partner reuse model
-
-For each new brand partner, reuse this exact architecture. Only these inputs
-change: MuleSoft deployment identity, its separate Hussh execute application,
-registered connector public key, partner destination alias, purpose copy,
-retention/deletion policy, and allowed scope set. The Hussh endpoint, five
-tool definitions, consent semantics, error contract, and envelope algorithm
-do not change.
-
-This preserves a single governing Hussh protocol while allowing each brand
-partner to have isolated credentials, cryptographic key custody, audit, and
-delivery controls.
+The only variable pieces across Salesforce, HubSpot, Sierra, Oracle, and other
+connectors are the tenant app identity, connector public key, trusted runtime,
+destination action schema, purpose, retention, and allowed scopes. Hussh's
+endpoint, consent semantics, envelope, and five-tool catalog stay identical.

--- a/consent-protocol/mcp_modules/agentforce_contract.py
+++ b/consent-protocol/mcp_modules/agentforce_contract.py
@@ -1,14 +1,15 @@
-"""Agentforce lint and handoff for the canonical Hussh consent MCP catalog.
+"""Agentforce lint and trusted-connector handoff for Hussh Consent MCP.
 
 Agentforce receives the same five generated tools and schemas as every other
 host. This module verifies the Salesforce-safe subset and publishes a
-non-secret MuleSoft handoff; it does not define a second endpoint or catalog.
+non-secret Salesforce trusted-connector handoff; it does not define a second
+endpoint or catalog.
 
-The direct Agentforce profile is catalog-only because Salesforce does not
-provide user-level MCP authentication. A MuleSoft secure relay uses its own
-operations-provisioned ``execute`` principal upstream, while Hussh keeps the
-person-specific authority in explicit consent, scoped grants, and encrypted
-delivery. No client credential becomes a synthetic user identity.
+The direct Agentforce profile is catalog-only. The Salesforce-side
+AgentExchange trusted connector uses its own operations-provisioned ``execute``
+principal upstream. Hussh keeps person-specific authority in explicit consent,
+scoped grants, and encrypted delivery. No client credential becomes a synthetic
+user identity.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ AGENTFORCE_PROFILE = "agentforce"
 AGENTFORCE_MAX_TOOLS = 20
 AGENTFORCE_MAX_PROPERTY_CHARS = 255
 AGENTFORCE_MAX_REQUEST_SECONDS = 55.0
+SALESFORCE_AGENTEXCHANGE_INTEGRATION_TARGET = "salesforce-agentexchange"
 MULESOFT_AGENTFORCE_INTEGRATION_TARGET = "mulesoft-agentforce"
 
 # Salesforce's current external-MCP documentation permits letters, numbers,
@@ -46,20 +48,19 @@ def canonical_agentforce_tool_name(name: str) -> str | None:
     return canonical_tool_name(name)
 
 
-def get_mulesoft_agentforce_handoff() -> dict[str, Any]:
-    """Return the non-secret relay contract for MuleSoft to Agentforce.
+def get_salesforce_agentexchange_handoff() -> dict[str, Any]:
+    """Return the non-secret contract for a Salesforce trusted connector.
 
-    This is an integration handoff, not a deployable Mule configuration. It
-    deliberately captures the constraints MuleSoft must preserve when it
-    publishes Hussh into Salesforce API Catalog. MuleSoft changes discovery,
-    routing, and policy ownership; it does not relax Agentforce MCP-client
-    limits or turn its app credentials into an end-user identity.
+    This is implementation guidance, not a deployable Salesforce package,
+    Mule flow, credential, or key. The installed connector runtime is the
+    decryption boundary. AgentExchange distributes that runtime; it does not
+    hold a universal connector private key.
     """
 
     tool_allowlist = list(get_agentforce_tool_names())
     connector_delivery_tool = "get-encrypted-scoped-export"
     return {
-        "integrationTarget": MULESOFT_AGENTFORCE_INTEGRATION_TARGET,
+        "integrationTarget": SALESFORCE_AGENTEXCHANGE_INTEGRATION_TARGET,
         "supportStatus": "agentforce-catalog-compatible",
         "upstream": {
             "transport": "streamable-http",
@@ -77,13 +78,9 @@ def get_mulesoft_agentforce_handoff() -> dict[str, Any]:
                 "catalogOnly": True,
                 "directPersonalizedToolCalls": "blocked",
                 "directToolCallResult": "REQUIRES_SECURE_CONSENT_FLOW",
-                "muleControlPlaneTools": [
-                    tool for tool in tool_allowlist if tool != connector_delivery_tool
-                ],
                 "agentforceActionDefault": "no-personalized-consent-actions",
-                "salesforceApprovedUatActionAllowlist": [
-                    tool for tool in tool_allowlist if tool != connector_delivery_tool
-                ],
+                "plannerExposure": "no-personalized-hussh-tools",
+                "trustedConnectorTools": tool_allowlist,
                 "connectorOnlyTool": connector_delivery_tool,
                 "connectorOnlyReason": (
                     "The encrypted export is delivered to the registered connector and "
@@ -91,22 +88,38 @@ def get_mulesoft_agentforce_handoff() -> dict[str, Any]:
                 ),
             },
         },
-        "relayRequirements": {
+        "connectorRequirements": {
             "preserveToolNames": True,
             "preserveInputOutputSchemas": True,
             "allowResources": False,
             "allowPrompts": False,
             "expandNestedFields": False,
+            "keyCustody": "per-org-connector-runtime",
+            "privateKeyInAgentforceModel": False,
         },
         "executionBoundary": {
             "directAgentforceExecution": "catalog-only",
-            "mulesoftUpstreamExecution": "operations-provisioned-execute-principal",
+            "trustedConnectorExecution": "operations-provisioned-execute-principal",
             "agentforcePersonalizedExecution": "requires-salesforce-supported-host-boundary",
             "applicationAuthentication": "oauth2-client-credentials-per-hop",
             "userAuthority": "explicit-consent-and-scoped-grant",
             "informationDelivery": "encrypted-export-after-approval",
         },
     }
+
+
+def get_mulesoft_agentforce_handoff() -> dict[str, Any]:
+    """Return the retained MuleSoft implementation view of the generic handoff.
+
+    Kept for existing CLI consumers. New integrations should consume
+    :func:`get_salesforce_agentexchange_handoff` and select MuleSoft only when
+    it is their trusted connector runtime.
+    """
+
+    handoff = get_salesforce_agentexchange_handoff()
+    handoff["integrationTarget"] = MULESOFT_AGENTFORCE_INTEGRATION_TARGET
+    handoff["implementation"] = "mulesoft-secure-relay"
+    return handoff
 
 
 def get_agentforce_contract() -> dict[str, Any]:

--- a/consent-protocol/mcp_modules/flat_contract.py
+++ b/consent-protocol/mcp_modules/flat_contract.py
@@ -119,19 +119,19 @@ _PURPOSE_INPUT = _field(
 )
 _CONNECTOR_KEY_INPUT = _field(
     "string",
-    "Optional legacy connector X25519 public key. When supplied, it must exactly match this app's registered key.",
+    "Optional connector X25519 public key. An unregistered connector supplies the complete key bundle per request; a registered app may omit it or must supply the exact registered value.",
     minLength=40,
     maxLength=128,
 )
 _CONNECTOR_KEY_ID_INPUT = _field(
     "string",
-    "Optional legacy connector key identifier. When supplied, it must exactly match this app's registered key identifier.",
+    "Optional connector key identifier. Supply it with the public key and wrapping algorithm for an unregistered connector; a registered app may omit it or must supply the exact registered value.",
     minLength=1,
     maxLength=128,
 )
 _CONNECTOR_ALGORITHM_INPUT = _field(
     "string",
-    "Optional legacy wrapping algorithm. When supplied, it must be X25519-AES256-GCM and match this app's registered key.",
+    "Optional wrapping algorithm. It must be X25519-AES256-GCM and is supplied with an unregistered connector key bundle; a registered app may omit it or must supply the exact registered value.",
     enum=["X25519-AES256-GCM"],
 )
 
@@ -605,7 +605,7 @@ def get_flat_contract() -> dict[str, Any]:
                         ),
                         "delivery": _field(
                             "string",
-                            "Delivery mode. Hosted connectors, including MuleSoft and Agentforce relays, receive encrypted_inline; trusted local stdio may receive decrypted_local.",
+                            "Delivery mode. Trusted hosted connectors receive encrypted_inline; trusted local stdio may receive decrypted_local. Decrypt outside every language-model context.",
                         ),
                         "expected_scope": _field(
                             "string", "Scope requested for this export.", maxLength=200

--- a/consent-protocol/mcp_modules/tools/public_contract.json
+++ b/consent-protocol/mcp_modules/tools/public_contract.json
@@ -395,21 +395,21 @@
             "type": "integer"
           },
           "connector_key_id": {
-            "description": "Optional legacy connector key identifier. When supplied, it must exactly match this app's registered key identifier.",
+            "description": "Optional connector key identifier. Supply it with the public key and wrapping algorithm for an unregistered connector; a registered app may omit it or must supply the exact registered value.",
             "maxLength": 128,
             "minLength": 1,
             "title": "Connector key identifier",
             "type": "string"
           },
           "connector_public_key": {
-            "description": "Optional legacy connector X25519 public key. When supplied, it must exactly match this app's registered key.",
+            "description": "Optional connector X25519 public key. An unregistered connector supplies the complete key bundle per request; a registered app may omit it or must supply the exact registered value.",
             "maxLength": 128,
             "minLength": 40,
             "title": "Connector public key",
             "type": "string"
           },
           "connector_wrapping_alg": {
-            "description": "Optional legacy wrapping algorithm. When supplied, it must be X25519-AES256-GCM and match this app's registered key.",
+            "description": "Optional wrapping algorithm. It must be X25519-AES256-GCM and is supplied with an unregistered connector key bundle; a registered app may omit it or must supply the exact registered value.",
             "enum": [
               "X25519-AES256-GCM"
             ],
@@ -685,10 +685,10 @@
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false,
-        "readOnlyHint": false,
+        "readOnlyHint": true,
         "title": "Get encrypted scoped export"
       },
-      "description": "Retrieves ciphertext for an approved grant. Use only after check-consent-status returns a grant_ref. Decrypt outside the LLM with the partner-owned private key.",
+      "description": "Secure connector delivery only: retrieves ciphertext for an approved grant. Use only after check-consent-status returns a grant_ref. Never display, interpret, or decrypt this result in an LLM; the registered connector decrypts it outside the model.",
       "inputSchema": {
         "additionalProperties": false,
         "description": "A flat, capability-safe field set.",
@@ -733,7 +733,7 @@
             "type": "string"
           },
           "delivery": {
-            "description": "Delivery mode. Hosted connectors receive encrypted_inline; trusted local stdio may receive decrypted_local.",
+            "description": "Delivery mode. Trusted hosted connectors receive encrypted_inline; trusted local stdio may receive decrypted_local. Decrypt outside every language-model context.",
             "title": "Delivery mode",
             "type": "string"
           },
@@ -768,7 +768,7 @@
             "type": "string"
           },
           "information_json": {
-            "description": "Locally decrypted information JSON. Present only for a trusted local stdio connector; hosted responses return an empty string.",
+            "description": "Reserved for a trusted local stdio connector. Hosted responses, including MuleSoft and Agentforce relays, always return an empty string.",
             "maxLength": 120000,
             "title": "Locally decrypted information JSON",
             "type": "string"

--- a/consent-protocol/scripts/ops/provision_partner_developer_app.py
+++ b/consent-protocol/scripts/ops/provision_partner_developer_app.py
@@ -40,19 +40,23 @@ if str(CONSENT_PROTOCOL_ROOT) not in sys.path:
 
 INTEGRATION_TARGET_GENERIC = "generic"
 INTEGRATION_TARGET_MULESOFT_AGENTFORCE = "mulesoft-agentforce"
+INTEGRATION_TARGET_SALESFORCE_AGENTEXCHANGE = "salesforce-agentexchange"
 
 
 def _apply_integration_defaults(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     """Apply a named partner integration without changing the global default.
 
     Every application receives the same canonical five-tool catalog. The named
-    MuleSoft → Agentforce target issues an app-bound OAuth credential that can
+    Salesforce connector targets issue an app-bound OAuth credential that can
     execute the same consent lifecycle as bearer and PKCE. Client credentials
     authenticate the partner application; user approval and the scoped grant
     remain the authority for any information release.
     """
 
-    if args.integration_target != INTEGRATION_TARGET_MULESOFT_AGENTFORCE:
+    if args.integration_target not in {
+        INTEGRATION_TARGET_MULESOFT_AGENTFORCE,
+        INTEGRATION_TARGET_SALESFORCE_AGENTEXCHANGE,
+    }:
         return
     args.enable_client_credentials = True
     args.client_credentials_execution_mode = "execute"
@@ -88,11 +92,16 @@ def main() -> int:
     )
     parser.add_argument(
         "--integration-target",
-        choices=(INTEGRATION_TARGET_GENERIC, INTEGRATION_TARGET_MULESOFT_AGENTFORCE),
+        choices=(
+            INTEGRATION_TARGET_GENERIC,
+            INTEGRATION_TARGET_MULESOFT_AGENTFORCE,
+            INTEGRATION_TARGET_SALESFORCE_AGENTEXCHANGE,
+        ),
         default=INTEGRATION_TARGET_GENERIC,
         help=(
-            "Named partner integration. mulesoft-agentforce provisions an executable "
-            "client-credentials credential; consent approval still gates information release."
+            "Named partner integration. mulesoft-agentforce and salesforce-agentexchange "
+            "provision executable client-credentials credentials; consent approval still "
+            "gates information release."
         ),
     )
     parser.add_argument(

--- a/consent-protocol/tests/test_mcp_flat_profile.py
+++ b/consent-protocol/tests/test_mcp_flat_profile.py
@@ -13,6 +13,7 @@ from mcp_modules.agentforce_contract import (
     get_agentforce_contract,
     get_agentforce_tool_names,
     get_mulesoft_agentforce_handoff,
+    get_salesforce_agentexchange_handoff,
 )
 from mcp_modules.canonical_contract import get_published_tool_names
 from mcp_modules.developer_context import (
@@ -101,10 +102,10 @@ def test_agentforce_uat_contract_is_strict_and_keeps_canonical_field_ids() -> No
         assert agentforce_tool["outputSchema"]["title"] == f"{agentforce_tool['title']} output"
 
 
-def test_mulesoft_agentforce_handoff_preserves_the_narrow_catalog_and_boundary() -> None:
-    handoff = get_mulesoft_agentforce_handoff()
+def test_salesforce_agentexchange_handoff_preserves_the_catalog_and_boundary() -> None:
+    handoff = get_salesforce_agentexchange_handoff()
 
-    assert handoff["integrationTarget"] == "mulesoft-agentforce"
+    assert handoff["integrationTarget"] == "salesforce-agentexchange"
     assert handoff["upstream"] == {
         "transport": "streamable-http",
         "path": "/mcp/",
@@ -117,18 +118,14 @@ def test_mulesoft_agentforce_handoff_preserves_the_narrow_catalog_and_boundary()
         "catalogOnly": True,
         "directPersonalizedToolCalls": "blocked",
         "directToolCallResult": "REQUIRES_SECURE_CONSENT_FLOW",
-        "muleControlPlaneTools": [
-            "search-user-scopes",
-            "prepare-campaign-context",
-            "request-consent",
-            "check-consent-status",
-        ],
         "agentforceActionDefault": "no-personalized-consent-actions",
-        "salesforceApprovedUatActionAllowlist": [
+        "plannerExposure": "no-personalized-hussh-tools",
+        "trustedConnectorTools": [
             "search-user-scopes",
             "prepare-campaign-context",
             "request-consent",
             "check-consent-status",
+            "get-encrypted-scoped-export",
         ],
         "connectorOnlyTool": "get-encrypted-scoped-export",
         "connectorOnlyReason": (
@@ -136,21 +133,32 @@ def test_mulesoft_agentforce_handoff_preserves_the_narrow_catalog_and_boundary()
             "must be decrypted outside the Agentforce LLM."
         ),
     }
-    assert handoff["relayRequirements"] == {
+    assert handoff["connectorRequirements"] == {
         "preserveToolNames": True,
         "preserveInputOutputSchemas": True,
         "allowResources": False,
         "allowPrompts": False,
         "expandNestedFields": False,
+        "keyCustody": "per-org-connector-runtime",
+        "privateKeyInAgentforceModel": False,
     }
     assert handoff["executionBoundary"] == {
         "directAgentforceExecution": "catalog-only",
-        "mulesoftUpstreamExecution": "operations-provisioned-execute-principal",
+        "trustedConnectorExecution": "operations-provisioned-execute-principal",
         "agentforcePersonalizedExecution": "requires-salesforce-supported-host-boundary",
         "applicationAuthentication": "oauth2-client-credentials-per-hop",
         "userAuthority": "explicit-consent-and-scoped-grant",
         "informationDelivery": "encrypted-export-after-approval",
     }
+
+
+def test_mulesoft_handoff_remains_a_compatible_implementation_view() -> None:
+    handoff = get_mulesoft_agentforce_handoff()
+    assert handoff["integrationTarget"] == "mulesoft-agentforce"
+    assert handoff["implementation"] == "mulesoft-secure-relay"
+    assert handoff["agentforce"]["agentActionPolicy"]["connectorOnlyTool"] == (
+        "get-encrypted-scoped-export"
+    )
 
 
 def test_flat_projection_preserves_lifecycle_references_and_export_envelope() -> None:

--- a/consent-protocol/tests/test_partner_developer_apps.py
+++ b/consent-protocol/tests/test_partner_developer_apps.py
@@ -193,6 +193,21 @@ class TestPartnerPrincipal:
 
 
 class TestMuleSoftAgentforceProvisioning:
+    def test_agentexchange_integration_selects_executable_client_credentials(self):
+        module = _partner_provisioning_module()
+        parser = argparse.ArgumentParser()
+        args = argparse.Namespace(
+            integration_target="salesforce-agentexchange",
+            schema_profile="standard",
+            enable_client_credentials=False,
+            client_credentials_execution_mode="catalog_only",
+        )
+
+        module._apply_integration_defaults(parser, args)
+
+        assert args.enable_client_credentials is True
+        assert args.client_credentials_execution_mode == "execute"
+
     def test_named_integration_selects_executable_client_credentials(self):
         module = _partner_provisioning_module()
         parser = argparse.ArgumentParser()

--- a/docs/reference/operations/hussh-mcp-partner-integration-guide.md
+++ b/docs/reference/operations/hussh-mcp-partner-integration-guide.md
@@ -96,26 +96,24 @@ grant_type=client_credentials
 The returned access token belongs in `Authorization: Bearer <access-token>`.
 No refresh token is issued for the client-credentials grant.
 
-## Agentforce registration through MuleSoft
+## Agentforce registration through the Salesforce trusted connector
 
-The generated Exchange file always registers the same five-tool Hussh catalog.
-It does not mean every tool is appropriate as an Agentforce action. Tool 5 is
-secure connector delivery: it remains available to MuleSoft's internal Hussh
-client after approval, but is not an Agentforce action and is blocked at the
-Agentforce-facing MuleSoft edge.
+An installed Salesforce AgentExchange package uses its own per-org Hussh
+execute app and key bundle. It is the single decryption source. This does not
+change the five-tool catalog or make every tool an Agentforce action. Tool 5 is
+secure connector delivery: it remains available only to that trusted connector
+after approval and is blocked from the Agentforce planner.
 
-The two OAuth hops are separate: Agentforce authenticates to MuleSoft with a
-MuleSoft-owned client; MuleSoft authenticates to Hussh with an
-operations-provisioned Hussh execute application. Agentforce never receives a
-Hussh credential or connector private key.
+The trusted connector's OAuth application, the person's consent, and the
+connector key are separate authorities. The installed connector authenticates
+to Hussh using its per-org execute app. Agentforce never receives a Hussh
+credential or connector private key.
 
-Salesforce documents that Agentforce MCP does not support user-level
-authentication or personalized responses. Hussh therefore keeps its direct
-Agentforce profile catalog-only; personal tool calls return the safe terminal
-state `REQUIRES_SECURE_CONSENT_FLOW`. A MuleSoft relay does not remove that
-Salesforce limitation. The exact required design, key custody, tool policy,
-crypto procedure, UAT checks, and production gate are in the canonical
-[MuleSoft and Agentforce secure relay](../../../consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md)
+Hussh keeps its direct Agentforce profile catalog-only; personal tool calls
+return the safe terminal state `REQUIRES_SECURE_CONSENT_FLOW`. A trusted
+connector does not remove direct-host constraints. The exact key custody, tool
+policy, crypto procedure, UAT checks, and production gate are in the canonical
+[Salesforce AgentExchange trusted connector](../../../consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md)
 guide.
 
 ## Consent lifecycle
@@ -244,7 +242,7 @@ person-specific tool call.
 
 | What the host shows | Likely boundary | Correct next check |
 | --- | --- | --- |
-| No tools found | Catalog response was rejected or transformed. | Inspect the raw `tools/list` result and validate all five schemas without MuleSoft field expansion. |
+| No tools found | Catalog response was rejected or transformed. | Inspect the raw `tools/list` result and validate all five schemas without connector field expansion. |
 | `Invalid method: initialize` | The client and endpoint are not completing the MCP handshake. | Use Streamable HTTP at `/mcp/`, include the trailing slash, and negotiate revision `2025-11-25`. |
 | HTTP 401 or 403 | Credential exchange, expiry, revocation, or app entitlement. | Re-run the approved OAuth exchange or rotate the bearer credential; never move the secret into a URL. |
 | Generic `Tool execution failed` after tools load | The host hid the safe MCP error or the lifecycle handler rejected the call. | Inspect `content[0].text` for the safe error code and correlation reference, then backend metadata-only logs; do not infer failure from the host summary alone. |
@@ -254,4 +252,4 @@ person-specific tool call.
 | Decryption authentication fails | Wrong private key, wrong canonical AAD, changed envelope, or mixed ciphertext/tag ordering. | Verify the registered key ID and fingerprint, then follow the reference algorithm exactly. |
 | Manifest and live tools differ | Package/deployment drift. | Treat the live `tools/list` response as runtime evidence and stop registration until the intended v0.4 deployment is confirmed. |
 
-> **Acceptance gate.** Approve the MuleSoft-to-Hussh integration only after token exchange, protocol initialization, the exact five-tool catalog, and schema loading pass independently. Then test the MuleSoft execute application through consent, polling, encrypted retrieval, and partner-side decryption. Confirm that no secret, private key, supplied user identifier, plaintext information, or internal reference enters logs or planner context. Enable an Agentforce personalized experience only after Salesforce confirms that exact host boundary is supported.
+> **Acceptance gate.** Approve a trusted connector only after token exchange, protocol initialization, the exact five-tool catalog, and schema loading pass independently. Then test its per-org execute app through consent, polling, encrypted retrieval, and partner-side decryption. Confirm that no secret, private key, supplied user identifier, plaintext information, or internal reference enters logs or planner context. Enable an Agentforce personalized experience only after target-org UAT confirms that exact host boundary is supported.

--- a/packages/hushh-mcp/README.md
+++ b/packages/hushh-mcp/README.md
@@ -51,29 +51,21 @@ npx -y @hushh/mcp --help
 
 ### One canonical catalog and authentication
 
-The same `/mcp/` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, MuleSoft, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
+The same `/mcp/` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
 
 Every tool uses shallow, fully described JSON Schema. Successful calls return `structuredContent` as the canonical result and `content[0].text` as its compatibility mirror. Execution errors return `isError: true` with safe JSON text only, so a strict client never validates an error against a success output schema.
 
-### MuleSoft Exchange and Agentforce registration
+### Salesforce AgentExchange trusted connector
 
-When MuleSoft publishes Hussh into Agentforce, use **Upload MCP file** and upload the generated Exchange projection:
-
-```bash
-hushh-mcp --print-mulesoft-exchange-manifest
-```
-
-The saved artifact is `gateway/hushh-mulesoft-exchange-mcp-schema.json`. It contains only Exchange-supported MCP fields, the same five canonical tools, and an open object output schema. It deliberately has no endpoint URL, OAuth material, host metadata, or annotations because Exchange rejects those fields before it can authenticate to Hussh.
-
-Configure a dedicated Hussh execute application's OAuth client ID and secret separately in MuleSoft's upstream connection to `https://api.uat.hushh.ai/mcp/`. MuleSoft is then the registered Agentforce boundary. Agentforce does not receive the Hussh secret.
+An installed Salesforce package uses a dedicated Hussh execute app per Salesforce org. Its trusted connector runtime is the single decryption source: it generates/imports an X25519 key pair after installation, retains the private key outside Agentforce, and supplies or registers only the public key with Hussh. Agentforce does not receive the Hussh secret or a connector private key.
 
 `hushh-mcp --print-agentforce-manifest` remains a diagnostic preflight view of the canonical five-tool catalog. It is not the file to upload to Exchange.
 
-MuleSoft maps successful `structuredContent` into Agentforce actions and does not pass its text mirror as a second planner result. The Exchange registration keeps the five generated tools, while MuleSoft MCP Global Access hides and blocks `get-encrypted-scoped-export` at the Agentforce-facing edge; it is a secure Mule connector subflow, not an LLM action. The separate `hushh-mcp --print-mulesoft-agentforce-handoff` output is relay guidance, not a deployable Mule flow and not an application credential.
+The trusted connector uses all five tools internally. Agentforce receives the connector's single deterministic action result, not individual personalized Hussh tools; Hussh does not publish a four-tool variant. `get-encrypted-scoped-export` stays in the single trusted connector runtime and out of the Agentforce planner/LLM. Successful MCP calls use `structuredContent`; `content[0].text` is only its compatibility mirror. Use `hushh-mcp --print-salesforce-agentexchange-handoff` for the current package-boundary guidance.
 
-Direct Agentforce profiles are catalog-only because Salesforce documents no user-level authentication or personalized MCP responses. A MuleSoft upstream execute application does not remove that host-product limitation. Implement the exact two-hop OAuth, key custody, crypto, tool policy, and UAT gate in [MuleSoft and Agentforce secure relay](../../consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md).
+Direct Agentforce profiles are catalog-only. A trusted connector execute application does not remove direct-host limits; validate the installed package in the target org before enabling personal-information delivery. Implement key custody, crypto, tool policy, and the UAT gate in [Salesforce AgentExchange trusted connector](../../consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md).
 
-Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5), [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&language=en_US&type=5), and [MuleSoft MCP servers in API Catalog](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mulesoft_mcp_servers.htm&language=en_US&type=5).
+Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5), [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&type=5), and [API Catalog MCP servers](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mcp_servers.htm&language=en_US&type=5).
 
 Minimal env for stdio hosts:
 

--- a/packages/hushh-mcp/bin-config.test.ts
+++ b/packages/hushh-mcp/bin-config.test.ts
@@ -94,8 +94,8 @@ describe("hushh-mcp CLI config output", () => {
       prompts: false,
       logging: false,
     });
-    expect(manifest.mulesoftAgentforceHandoff).toMatchObject({
-      integrationTarget: "mulesoft-agentforce",
+    expect(manifest.salesforceAgentExchangeHandoff).toMatchObject({
+      integrationTarget: "salesforce-agentexchange",
       supportStatus: "agentforce-catalog-compatible",
       upstream: {
         transport: "streamable-http",
@@ -108,12 +108,12 @@ describe("hushh-mcp CLI config output", () => {
       },
       executionBoundary: {
         directAgentforceExecution: "catalog-only",
-        mulesoftUpstreamExecution: "operations-provisioned-execute-principal",
+        trustedConnectorExecution: "operations-provisioned-execute-principal",
         agentforcePersonalizedExecution: "requires-salesforce-supported-host-boundary",
         applicationAuthentication: "oauth2-client-credentials-per-hop",
       },
     });
-    expect(manifest.mulesoftAgentforceHandoff.agentforce.toolAllowlist).toEqual(
+    expect(manifest.salesforceAgentExchangeHandoff.agentforce.toolAllowlist).toEqual(
       manifest.tools.map((tool: { name: string }) => tool.name),
     );
     expect(manifest.tools.map((tool: { name: string }) => tool.name)).toEqual([
@@ -185,47 +185,45 @@ describe("hushh-mcp CLI config output", () => {
     expect(stdout).not.toContain("client_secret");
   });
 
-  it("prints the non-secret MuleSoft to Agentforce handoff without widening the UAT boundary", async () => {
+  it("prints the non-secret Salesforce AgentExchange handoff without widening the UAT boundary", async () => {
     const { stdout, stderr } = await execAsync(
-      `node ${packageJson.bin["hushh-mcp"]} --print-mulesoft-agentforce-handoff`,
+      `node ${packageJson.bin["hushh-mcp"]} --print-salesforce-agentexchange-handoff`,
       { cwd: process.cwd() },
     );
 
     expect(stderr).toBe("");
     const handoff = JSON.parse(stdout);
-    expect(handoff.integrationTarget).toBe("mulesoft-agentforce");
+    expect(handoff.integrationTarget).toBe("salesforce-agentexchange");
     expect(handoff.agentforce.toolAllowlist).toHaveLength(5);
     expect(handoff.agentforce.agentActionPolicy).toEqual({
       catalogOnly: true,
       directPersonalizedToolCalls: "blocked",
       directToolCallResult: "REQUIRES_SECURE_CONSENT_FLOW",
-      muleControlPlaneTools: [
-        "search-user-scopes",
-        "prepare-campaign-context",
-        "request-consent",
-        "check-consent-status",
-      ],
       agentforceActionDefault: "no-personalized-consent-actions",
-      salesforceApprovedUatActionAllowlist: [
+      plannerExposure: "no-personalized-hussh-tools",
+      trustedConnectorTools: [
         "search-user-scopes",
         "prepare-campaign-context",
         "request-consent",
         "check-consent-status",
+        "get-encrypted-scoped-export",
       ],
       connectorOnlyTool: "get-encrypted-scoped-export",
       connectorOnlyReason:
         "The encrypted export is delivered to the registered connector and must be decrypted outside the Agentforce LLM.",
     });
-    expect(handoff.relayRequirements).toEqual({
+    expect(handoff.connectorRequirements).toEqual({
       preserveToolNames: true,
       preserveInputOutputSchemas: true,
       allowResources: false,
       allowPrompts: false,
       expandNestedFields: false,
+      keyCustody: "per-org-connector-runtime",
+      privateKeyInAgentforceModel: false,
     });
     expect(handoff.executionBoundary).toMatchObject({
       directAgentforceExecution: "catalog-only",
-      mulesoftUpstreamExecution: "operations-provisioned-execute-principal",
+      trustedConnectorExecution: "operations-provisioned-execute-principal",
       agentforcePersonalizedExecution: "requires-salesforce-supported-host-boundary",
     });
     expect(stdout).not.toContain("client_secret");

--- a/packages/hushh-mcp/bin/hushh-mcp.js
+++ b/packages/hushh-mcp/bin/hushh-mcp.js
@@ -33,6 +33,7 @@ function printUsage() {
   console.log("  hushh-mcp --print-remote-config");
   console.log("  hushh-mcp --print-gateway-manifest");
   console.log("  hushh-mcp --print-agentforce-manifest");
+  console.log("  hushh-mcp --print-salesforce-agentexchange-handoff");
   console.log("  hushh-mcp --print-mulesoft-exchange-manifest");
   console.log("  hushh-mcp --print-mulesoft-agentforce-handoff");
   console.log("");
@@ -398,6 +399,23 @@ if (args.includes("--print-mulesoft-agentforce-handoff")) {
     fatal("The packaged MuleSoft Agentforce handoff is unavailable.");
   }
   process.stdout.write(`${JSON.stringify(manifest.mulesoftAgentforceHandoff, null, 2)}\n`);
+  process.exit(0);
+}
+
+if (args.includes("--print-salesforce-agentexchange-handoff")) {
+  const manifestPath = path.join(
+    packageDir,
+    "gateway",
+    "hushh-agentforce-mcp-manifest.json",
+  );
+  if (!fs.existsSync(manifestPath)) {
+    fatal("The packaged Salesforce AgentExchange handoff is unavailable.");
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (!manifest.salesforceAgentExchangeHandoff) {
+    fatal("The packaged Salesforce AgentExchange handoff is unavailable.");
+  }
+  process.stdout.write(`${JSON.stringify(manifest.salesforceAgentExchangeHandoff, null, 2)}\n`);
   process.exit(0);
 }
 

--- a/packages/hushh-mcp/gateway/hushh-agentforce-mcp-manifest.json
+++ b/packages/hushh-mcp/gateway/hushh-agentforce-mcp-manifest.json
@@ -12,6 +12,62 @@
     "prompts": false,
     "logging": false
   },
+  "salesforceAgentExchangeHandoff": {
+    "integrationTarget": "salesforce-agentexchange",
+    "supportStatus": "agentforce-catalog-compatible",
+    "upstream": {
+      "transport": "streamable-http",
+      "path": "/mcp/",
+      "authentication": "bearer-or-oauth2-client-credentials",
+      "requestTimeoutSeconds": 55
+    },
+    "agentforce": {
+      "catalog": "salesforce-api-catalog",
+      "transport": "streamable-http",
+      "authentication": "oauth2-client-credentials",
+      "toolsOnly": true,
+      "toolAllowlist": [
+        "search-user-scopes",
+        "prepare-campaign-context",
+        "request-consent",
+        "check-consent-status",
+        "get-encrypted-scoped-export"
+      ],
+      "agentActionPolicy": {
+        "catalogOnly": true,
+        "directPersonalizedToolCalls": "blocked",
+        "directToolCallResult": "REQUIRES_SECURE_CONSENT_FLOW",
+        "agentforceActionDefault": "no-personalized-consent-actions",
+        "plannerExposure": "no-personalized-hussh-tools",
+        "trustedConnectorTools": [
+          "search-user-scopes",
+          "prepare-campaign-context",
+          "request-consent",
+          "check-consent-status",
+          "get-encrypted-scoped-export"
+        ],
+        "connectorOnlyTool": "get-encrypted-scoped-export",
+        "connectorOnlyReason": "The encrypted export is delivered to the registered connector and must be decrypted outside the Agentforce LLM."
+      }
+    },
+    "connectorRequirements": {
+      "preserveToolNames": true,
+      "preserveInputOutputSchemas": true,
+      "allowResources": false,
+      "allowPrompts": false,
+      "expandNestedFields": false,
+      "keyCustody": "per-org-connector-runtime",
+      "privateKeyInAgentforceModel": false
+    },
+    "executionBoundary": {
+      "directAgentforceExecution": "catalog-only",
+      "trustedConnectorExecution": "operations-provisioned-execute-principal",
+      "agentforcePersonalizedExecution": "requires-salesforce-supported-host-boundary",
+      "applicationAuthentication": "oauth2-client-credentials-per-hop",
+      "userAuthority": "explicit-consent-and-scoped-grant",
+      "informationDelivery": "encrypted-export-after-approval"
+    }
+  },
   "mulesoftAgentforceHandoff": {
     "integrationTarget": "mulesoft-agentforce",
     "supportStatus": "agentforce-catalog-compatible",
@@ -37,38 +93,37 @@
         "catalogOnly": true,
         "directPersonalizedToolCalls": "blocked",
         "directToolCallResult": "REQUIRES_SECURE_CONSENT_FLOW",
-        "muleControlPlaneTools": [
-          "search-user-scopes",
-          "prepare-campaign-context",
-          "request-consent",
-          "check-consent-status"
-        ],
         "agentforceActionDefault": "no-personalized-consent-actions",
-        "salesforceApprovedUatActionAllowlist": [
+        "plannerExposure": "no-personalized-hussh-tools",
+        "trustedConnectorTools": [
           "search-user-scopes",
           "prepare-campaign-context",
           "request-consent",
-          "check-consent-status"
+          "check-consent-status",
+          "get-encrypted-scoped-export"
         ],
         "connectorOnlyTool": "get-encrypted-scoped-export",
         "connectorOnlyReason": "The encrypted export is delivered to the registered connector and must be decrypted outside the Agentforce LLM."
       }
     },
-    "relayRequirements": {
+    "connectorRequirements": {
       "preserveToolNames": true,
       "preserveInputOutputSchemas": true,
       "allowResources": false,
       "allowPrompts": false,
-      "expandNestedFields": false
+      "expandNestedFields": false,
+      "keyCustody": "per-org-connector-runtime",
+      "privateKeyInAgentforceModel": false
     },
     "executionBoundary": {
       "directAgentforceExecution": "catalog-only",
-      "mulesoftUpstreamExecution": "operations-provisioned-execute-principal",
+      "trustedConnectorExecution": "operations-provisioned-execute-principal",
       "agentforcePersonalizedExecution": "requires-salesforce-supported-host-boundary",
       "applicationAuthentication": "oauth2-client-credentials-per-hop",
       "userAuthority": "explicit-consent-and-scoped-grant",
       "informationDelivery": "encrypted-export-after-approval"
-    }
+    },
+    "implementation": "mulesoft-secure-relay"
   },
   "tools": [
     {
@@ -488,21 +543,21 @@
           "connector_public_key": {
             "title": "Connector public key",
             "type": "string",
-            "description": "Optional legacy connector X25519 public key. When supplied, it must exactly match this app's registered key.",
+            "description": "Optional connector X25519 public key. An unregistered connector supplies the complete key bundle per request; a registered app may omit it or must supply the exact registered value.",
             "minLength": 40,
             "maxLength": 128
           },
           "connector_key_id": {
             "title": "Connector key identifier",
             "type": "string",
-            "description": "Optional legacy connector key identifier. When supplied, it must exactly match this app's registered key identifier.",
+            "description": "Optional connector key identifier. Supply it with the public key and wrapping algorithm for an unregistered connector; a registered app may omit it or must supply the exact registered value.",
             "minLength": 1,
             "maxLength": 128
           },
           "connector_wrapping_alg": {
             "title": "Connector wrapping algorithm",
             "type": "string",
-            "description": "Optional legacy wrapping algorithm. When supplied, it must be X25519-AES256-GCM and match this app's registered key.",
+            "description": "Optional wrapping algorithm. It must be X25519-AES256-GCM and is supplied with an unregistered connector key bundle; a registered app may omit it or must supply the exact registered value.",
             "enum": [
               "X25519-AES256-GCM"
             ]
@@ -781,7 +836,7 @@
           "delivery": {
             "title": "Delivery mode",
             "type": "string",
-            "description": "Delivery mode. Hosted connectors, including MuleSoft and Agentforce relays, receive encrypted_inline; trusted local stdio may receive decrypted_local."
+            "description": "Delivery mode. Trusted hosted connectors receive encrypted_inline; trusted local stdio may receive decrypted_local. Decrypt outside every language-model context."
           },
           "expected_scope": {
             "title": "Expected scope",

--- a/packages/hushh-mcp/gateway/hushh-mcp-gateway.json
+++ b/packages/hushh-mcp/gateway/hushh-mcp-gateway.json
@@ -411,21 +411,21 @@
           "connector_public_key": {
             "title": "Connector public key",
             "type": "string",
-            "description": "Optional legacy connector X25519 public key. When supplied, it must exactly match this app's registered key.",
+            "description": "Optional connector X25519 public key. An unregistered connector supplies the complete key bundle per request; a registered app may omit it or must supply the exact registered value.",
             "minLength": 40,
             "maxLength": 128
           },
           "connector_key_id": {
             "title": "Connector key identifier",
             "type": "string",
-            "description": "Optional legacy connector key identifier. When supplied, it must exactly match this app's registered key identifier.",
+            "description": "Optional connector key identifier. Supply it with the public key and wrapping algorithm for an unregistered connector; a registered app may omit it or must supply the exact registered value.",
             "minLength": 1,
             "maxLength": 128
           },
           "connector_wrapping_alg": {
             "title": "Connector wrapping algorithm",
             "type": "string",
-            "description": "Optional legacy wrapping algorithm. When supplied, it must be X25519-AES256-GCM and match this app's registered key.",
+            "description": "Optional wrapping algorithm. It must be X25519-AES256-GCM and is supplied with an unregistered connector key bundle; a registered app may omit it or must supply the exact registered value.",
             "enum": [
               "X25519-AES256-GCM"
             ]
@@ -688,7 +688,7 @@
           "delivery": {
             "title": "Delivery mode",
             "type": "string",
-            "description": "Delivery mode. Hosted connectors, including MuleSoft and Agentforce relays, receive encrypted_inline; trusted local stdio may receive decrypted_local."
+            "description": "Delivery mode. Trusted hosted connectors receive encrypted_inline; trusted local stdio may receive decrypted_local. Decrypt outside every language-model context."
           },
           "expected_scope": {
             "title": "Expected scope",

--- a/packages/hushh-mcp/gateway/hushh-mulesoft-exchange-mcp-schema.json
+++ b/packages/hushh-mcp/gateway/hushh-mulesoft-exchange-mcp-schema.json
@@ -257,21 +257,21 @@
           "connector_public_key": {
             "title": "Connector public key",
             "type": "string",
-            "description": "Optional legacy connector X25519 public key. When supplied, it must exactly match this app's registered key.",
+            "description": "Optional connector X25519 public key. An unregistered connector supplies the complete key bundle per request; a registered app may omit it or must supply the exact registered value.",
             "minLength": 40,
             "maxLength": 128
           },
           "connector_key_id": {
             "title": "Connector key identifier",
             "type": "string",
-            "description": "Optional legacy connector key identifier. When supplied, it must exactly match this app's registered key identifier.",
+            "description": "Optional connector key identifier. Supply it with the public key and wrapping algorithm for an unregistered connector; a registered app may omit it or must supply the exact registered value.",
             "minLength": 1,
             "maxLength": 128
           },
           "connector_wrapping_alg": {
             "title": "Connector wrapping algorithm",
             "type": "string",
-            "description": "Optional legacy wrapping algorithm. When supplied, it must be X25519-AES256-GCM and match this app's registered key.",
+            "description": "Optional wrapping algorithm. It must be X25519-AES256-GCM and is supplied with an unregistered connector key bundle; a registered app may omit it or must supply the exact registered value.",
             "enum": [
               "X25519-AES256-GCM"
             ]

--- a/packages/hushh-mcp/scripts/generate-gateway-manifest.mjs
+++ b/packages/hushh-mcp/scripts/generate-gateway-manifest.mjs
@@ -106,11 +106,11 @@ function loadAgentforceContract() {
       "-c",
       [
         "import json",
-        "from mcp_modules.agentforce_contract import agentforce_contract_errors, get_agentforce_contract, get_mulesoft_agentforce_handoff",
+        "from mcp_modules.agentforce_contract import agentforce_contract_errors, get_agentforce_contract, get_mulesoft_agentforce_handoff, get_salesforce_agentexchange_handoff",
         "errors = agentforce_contract_errors()",
         "if errors:",
         "    raise SystemExit('; '.join(errors))",
-        "print(json.dumps({'contract': get_agentforce_contract(), 'mulesoftAgentforceHandoff': get_mulesoft_agentforce_handoff()}, separators=(',', ':')))"
+        "print(json.dumps({'contract': get_agentforce_contract(), 'salesforceAgentExchangeHandoff': get_salesforce_agentexchange_handoff(), 'mulesoftAgentforceHandoff': get_mulesoft_agentforce_handoff()}, separators=(',', ':')))"
       ].join("\n"),
     ],
     {
@@ -143,6 +143,8 @@ const agentforceManifest = {
     prompts: false,
     logging: false,
   },
+  salesforceAgentExchangeHandoff: agentforceProjection.salesforceAgentExchangeHandoff,
+  // Retained only for deployments already using the MuleSoft relay CLI output.
   mulesoftAgentforceHandoff: agentforceProjection.mulesoftAgentforceHandoff,
   tools: agentforceContract.tools.map(
     ({ name, title, description, inputSchema, outputSchema, annotations }) => ({

--- a/packages/hushh-mcp/scripts/render-readme.mjs
+++ b/packages/hushh-mcp/scripts/render-readme.mjs
@@ -119,29 +119,21 @@ npx -y ${contract.packageName} --help
 
 ### One canonical catalog and authentication
 
-The same \`/mcp/\` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, MuleSoft, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
+The same \`/mcp/\` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
 
 Every tool uses shallow, fully described JSON Schema. Successful calls return \`structuredContent\` as the canonical result and \`content[0].text\` as its compatibility mirror. Execution errors return \`isError: true\` with safe JSON text only, so a strict client never validates an error against a success output schema.
 
-### MuleSoft Exchange and Agentforce registration
+### Salesforce AgentExchange trusted connector
 
-When MuleSoft publishes Hussh into Agentforce, use **Upload MCP file** and upload the generated Exchange projection:
-
-\`\`\`bash
-hushh-mcp --print-mulesoft-exchange-manifest
-\`\`\`
-
-The saved artifact is \`gateway/hushh-mulesoft-exchange-mcp-schema.json\`. It contains only Exchange-supported MCP fields, the same five canonical tools, and an open object output schema. It deliberately has no endpoint URL, OAuth material, host metadata, or annotations because Exchange rejects those fields before it can authenticate to Hussh.
-
-Configure a dedicated Hussh execute application's OAuth client ID and secret separately in MuleSoft's upstream connection to \`${contract.promotedEnvironment.remoteUrlTemplate}\`. MuleSoft is then the registered Agentforce boundary. Agentforce does not receive the Hussh secret.
+An installed Salesforce package uses a dedicated Hussh execute app per Salesforce org. Its trusted connector runtime is the single decryption source: it generates/imports an X25519 key pair after installation, retains the private key outside Agentforce, and supplies or registers only the public key with Hussh. Agentforce does not receive the Hussh secret or a connector private key.
 
 \`hushh-mcp --print-agentforce-manifest\` remains a diagnostic preflight view of the canonical five-tool catalog. It is not the file to upload to Exchange.
 
-MuleSoft maps successful \`structuredContent\` into Agentforce actions and does not pass its text mirror as a second planner result. The Exchange registration keeps the five generated tools, while MuleSoft MCP Global Access hides and blocks \`get-encrypted-scoped-export\` at the Agentforce-facing edge; it is a secure Mule connector subflow, not an LLM action. The separate \`hushh-mcp --print-mulesoft-agentforce-handoff\` output is relay guidance, not a deployable Mule flow and not an application credential.
+The trusted connector uses all five tools internally. Agentforce receives the connector's single deterministic action result, not individual personalized Hussh tools; Hussh does not publish a four-tool variant. \`get-encrypted-scoped-export\` stays in the single trusted connector runtime and out of the Agentforce planner/LLM. Successful MCP calls use \`structuredContent\`; \`content[0].text\` is only its compatibility mirror. Use \`hushh-mcp --print-salesforce-agentexchange-handoff\` for the current package-boundary guidance.
 
-Direct Agentforce profiles are catalog-only because Salesforce documents no user-level authentication or personalized MCP responses. A MuleSoft upstream execute application does not remove that host-product limitation. Implement the exact two-hop OAuth, key custody, crypto, tool policy, and UAT gate in [MuleSoft and Agentforce secure relay](../../consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md).
+Direct Agentforce profiles are catalog-only. A trusted connector execute application does not remove direct-host limits; validate the installed package in the target org before enabling personal-information delivery. Implement key custody, crypto, tool policy, and the UAT gate in [Salesforce AgentExchange trusted connector](../../consent-protocol/docs/reference/mulesoft-agentforce-secure-relay.md).
 
-Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5), [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&language=en_US&type=5), and [MuleSoft MCP servers in API Catalog](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mulesoft_mcp_servers.htm&language=en_US&type=5).
+Salesforce references: [MCP considerations](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_considerations.htm&language=en_US&type=5), [MCP response schemas](https://help.salesforce.com/s/articleView?id=ai.agent_mcp_tool_action_design.htm&type=5), and [API Catalog MCP servers](https://help.salesforce.com/s/articleView?id=platform.api_catalog_manage_mcp_servers.htm&language=en_US&type=5).
 
 Minimal env for stdio hosts:
 


### PR DESCRIPTION
Summary: make the installed Salesforce AgentExchange connector the single decryption source per org; keep the canonical five Hussh MCP tools internal to that connector; and clarify public-key binding plus the Salesforce provisioning target. Verification: protocol test-ci (414 passed); hushh-mcp package tests, generated-doc check, and gateway check; docs verify; pre-pr; and DCO verification.