### PR TITLE
feat(one-location): add Connect shortcut to People

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1817,6 +1817,9 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     // The populated People tab exposes a compact "Sync contacts" circle action.
     fireEvent.click(screen.getByRole("button", { name: "People" }));
+    expect(
+      await screen.findByRole("button", { name: /Add Connections/i }),
+    ).toBeTruthy();
     fireEvent.click(
       await screen.findByRole("button", { name: /Sync contacts/i }),
     );
@@ -1942,8 +1945,11 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await switchLocationTab("People", "Trusted Circle");
-    // New empty-state: Trusted Circle SectionCard with invite/sync/share buttons
-    // + trust note. "Ask someone to share" is populated-state-only.
+    // Empty state keeps connection management, invite/sync/share actions, and
+    // the trust note visible. "Ask someone to share" is populated-state-only.
+    expect(
+      screen.getByRole("button", { name: /Add Connections/i }),
+    ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /Invite trusted person/i }),
     ).toBeTruthy();
@@ -1952,6 +1958,13 @@ describe("OneLocationAgentPage", () => {
       screen.getByRole("button", { name: /Share to contacts/i }),
     ).toBeTruthy();
     expect(screen.queryByText(/Ask someone to share/)).toBeNull();
+
+    mockRouterPush.mockClear();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Add Connections/i }),
+    );
+    expect(mockRouterPush).toHaveBeenCalledWith("/one/connect");
+
     fireEvent.click(screen.getByRole("button", { name: "Links" }));
     expect(
       await screen.findByRole("button", { name: /Create a new link/i }),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -592,6 +592,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           <LocationHubPanel>
             <PeopleHub
               vm={vm}
+              onAddConnections={() => router.push(ROUTES.CONNECT)}
               onInvite={() => openFlow("invite")}
               onStartShare={() => openFlow("share")}
               onAsk={() => openFlow("ask")}
@@ -1041,11 +1042,13 @@ function PersonRow({
 
 function PeopleHub({
   vm,
+  onAddConnections,
   onInvite,
   onStartShare,
   onAsk,
 }: {
   vm: LocationHubViewModel;
+  onAddConnections: () => void;
   onInvite: () => void;
   onStartShare: () => void;
   onAsk: () => void;
@@ -1069,8 +1072,16 @@ function PeopleHub({
         >
           <div className="grid grid-cols-1 gap-2">
             <Button
-              onClick={onInvite}
+              onClick={onAddConnections}
               className="h-11 rounded-full bg-[color:var(--app-accent)] text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+            >
+              <UsersRound className="mr-2 h-4 w-4" />
+              Add Connections
+            </Button>
+            <Button
+              variant="outline"
+              onClick={onInvite}
+              className="h-10 rounded-full text-sm font-semibold"
             >
               <UserPlus className="mr-2 h-4 w-4" />
               Invite trusted person
@@ -1114,6 +1125,13 @@ function PeopleHub({
       {/* Compact circle-management actions. Invite adds people; "Sync contacts"
           tags which existing connections are in your phone contacts. */}
       <div className="grid grid-cols-1 gap-2">
+        <Button
+          onClick={onAddConnections}
+          className="h-10 rounded-full bg-[color:var(--app-accent)] text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
+        >
+          <UsersRound className="mr-2 h-4 w-4" />
+          Add Connections
+        </Button>
         <Button
           variant="outline"
           onClick={onInvite}


### PR DESCRIPTION
## Summary

- add an **Add Connections** CTA to the One Location People tab
- show the CTA in both populated and empty People states
- route the CTA through the canonical `/one/connect` workspace
- cover visibility and navigation with the existing One Location page test

## User impact

People managing location sharing can now move directly from the People tab to the Connect workspace to create or manage mutual connections.

## Validation

- `npm test -- --run __tests__/components/one-location-agent-page.test.tsx` (36/36)
- `npm run typecheck`
- targeted ESLint
- `npm run verify:design-system`
- `npm run verify:capacitor:static`
- `npm run audit:ui-surfaces`
- `npm run verify:cache` (53/53)
- `npm run verify:docs`
- `npm run verify:service-boundary`
- `npm run build`
- local production smoke: `/one/location` 200, `/one/connect` 200

## Known local limitation

`npm run verify:routes` requires maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; local execution stopped at that identity gate without inspecting secrets. GitHub CI provides the authoritative route validation environment.
