### PR TITLE
fix(one): make setup one-time — unreachable via browser/OS back after onboarding

### DIFF
--- a/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
@@ -6,6 +6,10 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OnboardingJourneyGuard } from "@/components/onboarding/onboarding-journey-guard";
+import {
+  clearSetupIntent,
+  markSetupIntent,
+} from "@/lib/services/one-setup-intent";
 
 const {
   push,
@@ -53,7 +57,7 @@ vi.mock("@/lib/morphy-ux/button", () => ({
 }));
 
 vi.mock("@/lib/navigation/routes", () => ({
-  ROUTES: { ONE_SETUP: "/one/setup", PROFILE: "/one/profile" },
+  ROUTES: { ONE_SETUP: "/one/setup", ONE_HOME: "/one", PROFILE: "/one/profile" },
   buildOneSetupRoute: ({ returnTo }: { returnTo: string }) =>
     `/one/setup?return_to=${encodeURIComponent(returnTo)}`,
   isCapabilityOnboardingRoute: () => false,
@@ -116,6 +120,7 @@ describe("OnboardingJourneyGuard", () => {
     isPersistentSetupResolvedMock.mockReturnValue(false);
     pathnameValue = "/one/setup";
     window.history.replaceState(null, "", "/one/setup");
+    clearSetupIntent();
   });
 
   it("admits a cached setup route without a bootstrap request or checking churn", async () => {
@@ -167,6 +172,58 @@ describe("OnboardingJourneyGuard", () => {
       expect(replace).toHaveBeenCalledWith("/one/setup?return_to=%2Fone");
     });
     expect(screen.getByText("Returning to setup...")).toBeTruthy();
+  });
+
+  it("ejects a dismissed user who reaches a setup surface without a deliberate open", async () => {
+    // Post-onboarding, a setup surface reached via the browser/OS back button,
+    // a stale history entry, or a direct URL (no deliberate open) must send the
+    // user home — setup is one-time.
+    pathnameValue = "/one/setup";
+    isPersistentSetupResolvedMock.mockReturnValue(true); // dismissed
+    clearSetupIntent(); // not a deliberate open
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>hub</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/one");
+    });
+    expect(screen.queryByText("hub")).toBeNull();
+  });
+
+  it("admits a deliberate setup open (Profile → Set Up One) for a dismissed user", () => {
+    pathnameValue = "/one/setup";
+    isPersistentSetupResolvedMock.mockReturnValue(true); // dismissed
+    markSetupIntent(); // deliberate open
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>hub</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    expect(screen.getByText("hub")).toBeTruthy();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("admits a setup surface during first onboarding (not dismissed)", async () => {
+    pathnameValue = "/one/setup";
+    isPersistentSetupResolvedMock.mockReturnValue(false); // not dismissed
+    getCachedBootstrapStateMock.mockReturnValue(null);
+
+    render(
+      <OnboardingJourneyGuard>
+        <div>hub</div>
+      </OnboardingJourneyGuard>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("hub")).toBeTruthy();
+    });
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("admits completed Location without widening the unresolved setup gate", () => {

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { OneDashboardPage } from "@/components/dashboard/one-dashboard-page";
 import { buildOneSetupCapabilityRoute, ROUTES } from "@/lib/navigation/routes";
 import type { CapabilityStatus } from "@/lib/services/capability-setup-state-service";
+import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
 
 function status(
   id: string,
@@ -42,6 +43,28 @@ function countRosterMetrics(
 describe("OneDashboardPage", () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  it("routes home tiles to the product surface once onboarding is dismissed", () => {
+    const userId = "dashboard-dismissed-user";
+    OneSetupCompletionHintService.markResolved(userId); // dismissed
+
+    render(
+      <OneDashboardPage
+        displayName="Dismissed User"
+        userId={userId}
+        capabilityStatusById={buildStatusMap({
+          finance: { state: "not-started", requiresUnlock: true },
+        })}
+      />,
+    );
+
+    // Profile-only: a not-configured tile opens the capability's own screen,
+    // never /one/setup/* (which the guard would eject a dismissed user from).
+    const financeLink = screen.getByRole("link", { name: "Open Finance" });
+    const href = financeLink.getAttribute("href") ?? "";
+    expect(href).not.toBe(buildOneSetupCapabilityRoute("finance"));
+    expect(href.startsWith("/one/setup")).toBe(false);
   });
 
   it("renders the primary One agent modes with route targets", () => {

--- a/hushh-webapp/__tests__/services/one-setup-intent.test.ts
+++ b/hushh-webapp/__tests__/services/one-setup-intent.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearSetupIntent,
+  hasSetupIntent,
+  markSetupIntent,
+} from "@/lib/services/one-setup-intent";
+
+describe("one-setup-intent", () => {
+  beforeEach(() => {
+    clearSetupIntent();
+  });
+
+  it("defaults to no deliberate intent", () => {
+    expect(hasSetupIntent()).toBe(false);
+  });
+
+  it("records a deliberate setup open", () => {
+    markSetupIntent();
+    expect(hasSetupIntent()).toBe(true);
+  });
+
+  it("clears the intent (as the guard does when leaving the setup surface)", () => {
+    markSetupIntent();
+    clearSetupIntent();
+    expect(hasSetupIntent()).toBe(false);
+  });
+});

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -111,6 +111,7 @@ import {
   resolveDeleteAccountAuth,
 } from "@/lib/flows/delete-account";
 import { buildOneSetupRoute, ROUTES } from "@/lib/navigation/routes";
+import { markSetupIntent } from "@/lib/services/one-setup-intent";
 import {
   buildCanonicalProfileRouteFromLegacyQuery,
   buildProfileRoute,
@@ -4008,9 +4009,13 @@ function ProfilePageContent() {
                 title={PROFILE_LABELS.setup}
                 chevron
                 density="compact"
-                onClick={() =>
-                  router.push(buildOneSetupRoute({ returnTo: ROUTES.PROFILE }))
-                }
+                onClick={() => {
+                  // Mark this as a DELIBERATE setup open so the onboarding guard
+                  // admits the hub for an already-dismissed user (any other
+                  // arrival — back button / history — is ejected to home).
+                  markSetupIntent();
+                  router.push(buildOneSetupRoute({ returnTo: ROUTES.PROFILE }));
+                }}
               />
               {shouldShowRiaRegulatoryRow ? (
                 <SettingsRow

--- a/hushh-webapp/components/dashboard/one-agent-roster.tsx
+++ b/hushh-webapp/components/dashboard/one-agent-roster.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/lib/onboarding/capability-status-display";
 import { getCapabilitySetupCopy } from "@/lib/onboarding/capability-setup-copy";
 import { buildOneSetupCapabilityRoute } from "@/lib/navigation/routes";
+import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import type { OneLocationState } from "@/lib/one-location/types";
 import type { KaiHomeInsightsV2, KaiHomeMover } from "@/lib/services/api-service";
@@ -223,6 +225,7 @@ function useCachedAgentMetrics(
 function buildModes(
   statusById: Record<string, CapabilityStatus>,
   cachedMetrics: Record<string, AgentMetric>,
+  setupDismissed: boolean,
 ): OneAgentMode[] {
   return ONE_CAPABILITIES.filter(
     (capability) =>
@@ -262,8 +265,12 @@ function buildModes(
       id: capability.id,
       title: capability.title,
       description: capability.description,
+      // Once onboarding is dismissed, a home tile for a not-yet-configured
+      // capability opens the capability's OWN screen — never the setup hub.
+      // Setup is reachable only via Profile → "Set Up One" (post-onboarding),
+      // and routing a tile into a setup surface would be ejected by the guard.
       href:
-        setupCapability && isActionable
+        !setupDismissed && setupCapability && isActionable
           ? buildOneSetupCapabilityRoute(capability.id)
           : capability.href,
       icon: capability.icon,
@@ -503,7 +510,13 @@ export function OneAgentRoster({
   userId?: string | null;
 }) {
   const cachedMetrics = useCachedAgentMetrics(userId);
-  const modes = buildModes(capabilityStatusById, cachedMetrics);
+  const setupDismissed = Boolean(
+    userId &&
+      (OneSetupCompletionHintService.isResolved(userId) ||
+        PreVaultUserStateService.getCachedBootstrapState(userId)
+          ?.setupCompleted === true),
+  );
+  const modes = buildModes(capabilityStatusById, cachedMetrics, setupDismissed);
   const [view, setView] = useState<AgentRosterView>("grid");
   const [animateViewChange, setAnimateViewChange] = useState(false);
   const [query, setQuery] = useState("");

--- a/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
+++ b/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
@@ -21,6 +21,10 @@ import {
   type PreVaultUserState,
 } from "@/lib/services/pre-vault-user-state-service";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
+import {
+  clearSetupIntent,
+  hasSetupIntent,
+} from "@/lib/services/one-setup-intent";
 
 const SETUP_REDIRECT_RETRY_MS = 1200;
 const SETUP_REDIRECT_FAILURE_MS = 2400;
@@ -112,6 +116,18 @@ export function OnboardingJourneyGuard({
           setupSurface,
         })),
   );
+  // "Dismissed" = the user finished/skipped onboarding at least once. After
+  // that, a setup surface is reachable ONLY via a deliberate in-app open
+  // (Profile → "Set Up One", which calls markSetupIntent). Any other arrival —
+  // the browser/OS back button, a stale history entry, a direct URL — is ejected
+  // to home so setup is never re-shown post-onboarding.
+  const setupDismissed = Boolean(
+    persistentSetupResolved ||
+      (cachedState && PreVaultUserStateService.isSetupResolved(cachedState)),
+  );
+  const shouldEjectSetupSurface = Boolean(
+    setupSurface && setupDismissed && !hasSetupIntent(),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -127,11 +143,25 @@ export function OnboardingJourneyGuard({
 
     async function verifyAdmission() {
       if (authLoading) return;
-      if (
-        !userId ||
-        exempt ||
-        setupSurface
-      ) {
+      if (!userId || exempt) {
+        redirectTargetRef.current = null;
+        setError(null);
+        setChecking(false);
+        return;
+      }
+      if (setupSurface) {
+        // First onboarding and a deliberate open (Profile → "Set Up One") are
+        // admitted. A dismissed user who reached a setup surface WITHOUT a
+        // deliberate open (browser/OS back, history, direct URL) is ejected to
+        // home — this is the one place that catches every arrival path.
+        if (shouldEjectSetupSurface) {
+          if (redirectTargetRef.current !== ROUTES.ONE_HOME) {
+            redirectTargetRef.current = ROUTES.ONE_HOME;
+            setRedirecting(true);
+            router.replace(ROUTES.ONE_HOME);
+          }
+          return;
+        }
         redirectTargetRef.current = null;
         setError(null);
         setChecking(false);
@@ -280,16 +310,37 @@ export function OnboardingJourneyGuard({
     retryNonce,
     router,
     setupSurface,
+    shouldEjectSetupSurface,
     userId,
   ]);
 
+  // The deliberate-entry intent covers only the active setup visit. Clear it the
+  // moment the user is on any non-setup surface so a later back-navigation into
+  // setup is treated as non-deliberate and ejected.
+  useEffect(() => {
+    if (!isOneSetupSurfaceRoute(pathname)) {
+      clearSetupIntent();
+    }
+  }, [pathname]);
+
   if (exempt || (!authLoading && !userId)) return <>{children}</>;
   if (
+    shouldEjectSetupSurface ||
     (checking && !cachedAdmissionAllowsCurrentRoute) ||
     authLoading ||
     redirecting
   ) {
-    return <HushhLoader label={redirecting ? "Returning to setup..." : "Checking setup..."} />;
+    return (
+      <HushhLoader
+        label={
+          shouldEjectSetupSurface
+            ? "Opening One..."
+            : redirecting
+              ? "Returning to setup..."
+              : "Checking setup..."
+        }
+      />
+    );
   }
   if (error) {
     return (

--- a/hushh-webapp/lib/services/one-setup-intent.ts
+++ b/hushh-webapp/lib/services/one-setup-intent.ts
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * Deliberate-entry intent for the One setup surface.
+ *
+ * The onboarding guard forces the setup hub ONCE during first onboarding. After
+ * the user dismisses onboarding, `/one/setup` must be reachable ONLY by an
+ * explicit in-app action (Profile → "Set Up One"), never by the browser/OS back
+ * button, a stale history entry, or a direct URL.
+ *
+ * This flag records "the user just deliberately opened setup". It is:
+ *  - in-memory only (module scope) — a page reload or a fresh tab does NOT count
+ *    as deliberate, so history/back navigation can never satisfy it;
+ *  - set on the deliberate tap (Profile → "Set Up One");
+ *  - read by the onboarding guard to admit a dismissed user onto a setup surface;
+ *  - cleared by the guard the moment the user is on any non-setup surface, so it
+ *    only ever covers the active deliberate visit.
+ */
+let deliberateSetupEntry = false;
+
+/** Record that the user is deliberately opening the setup surface. */
+export function markSetupIntent(): void {
+  deliberateSetupEntry = true;
+}
+
+/** Forget any deliberate-entry intent (called when leaving the setup surface). */
+export function clearSetupIntent(): void {
+  deliberateSetupEntry = false;
+}
+
+/** Whether the current arrival at a setup surface is a deliberate in-app open. */
+export function hasSetupIntent(): boolean {
+  return deliberateSetupEntry;
+}


### PR DESCRIPTION
## Symptom
After onboarding, pressing the **Chrome/OS back button** re-showed `/one/setup`. The earlier fix (#4632) only covered the app's in-shell back button (breadcrumb), not the physical back button.

## Root cause (3 read-only agents)
- Nothing intercepts the browser/OS/hardware back button — it pops the real history stack; the breadcrumb `backHref` is used only by in-app controls.
- A `/one/setup` entry stays in history: hub→capability uses `router.push`; "Finish/Skip" uses `router.replace` (overwrites only the current entry). Net: `[…, /one/setup, /one]` → Chrome-back → `/one/setup`.
- The onboarding guard admits every setup surface unconditionally and the hub has no "already done → go home" redirect.

## Fix (frontend-only, Profile-only per product decision)
- **`lib/services/one-setup-intent.ts`** (new): in-memory "deliberate setup open" flag.
- **`onboarding-journey-guard.tsx`**: once dismissed, a setup surface reached **without** a deliberate open (Profile → "Set Up One") is ejected to `/one` home — the guard is the one place that catches *every* arrival (browser/OS/app back, history, direct URL). Intent is cleared whenever the user is on a non-setup surface. First onboarding and deliberate opens are admitted; sync render avoids a hub flash.
- **`profile-workspace-page.tsx`**: "Set Up One" calls `markSetupIntent()` before navigating.
- **`one-agent-roster.tsx`**: after dismissal, home "Set up X" tiles open the capability's own screen instead of the setup hub.

## Tests
- Guard: dismissed + no intent → `replace('/one')`; dismissed + intent → admit; first onboarding → admit.
- `one-setup-intent` mark/clear/has.
- Dashboard: dismissed user's tile href is not a `/one/setup/*` route.
- 2255 pass; typecheck + lint clean on changed files. (3 pre-existing env-only failures unrelated to this change: 2 location tests need `@capacitor/google-maps`, 1 marketplace test hits jsdom SubtleCrypto — not in this change's import graph.)

## Verify on UAT
Finish/skip onboarding → `/one` → press **Chrome back** repeatedly → stays in app, never `/one/setup`. New tab → app directly. Profile → "Set Up One" opens the hub; Finish → back on Profile; Chrome-back does not re-show setup. Home "Set up X" tile → opens the capability, not setup.