### PR TITLE
fix(auth): center login content

### DIFF
--- a/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
+++ b/hushh-webapp/__tests__/components/auth-step-layout.contract.test.ts
@@ -27,7 +27,7 @@ describe("AuthStep layout contract", () => {
     expect(source).not.toContain("isLocalReviewerSurface");
   });
 
-  it("sizes the page to exactly one viewport (minus the fixed Agent Bar's reserved clearance) so it never scrolls, and anchors content to the bottom for one-thumb reach", () => {
+  it("sizes the page to one viewport without scrolling and vertically centers the complete sign-in block", () => {
     const source = readFileSync(
       join(process.cwd(), "components/onboarding/AuthStep.tsx"),
       "utf8",
@@ -45,12 +45,11 @@ describe("AuthStep layout contract", () => {
       "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
     );
     expect(source).toContain("overflow-hidden");
-    expect(source).toContain("justify-end");
-    // The root hero+buttons column anchors to the bottom (justify-end), not
-    // vertically centered as a whole, for one-thumb reach on tall phones.
-    expect(source).not.toContain(
-      "flex flex-1 flex-col items-center justify-center px-6 pb-6 text-center",
+    expect(source).toContain("data-auth-content-block");
+    expect(source).toContain(
+      'className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center"',
     );
+    expect(source).not.toContain("justify-end");
     // The provider buttons sit directly on the shared hero background (no
     // frosted glass card/sheet), matching the welcome ("/") page's
     // direct-on-canvas CTA.

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1042,16 +1042,16 @@ export function AuthStep({
       </button>
 
       <div
-        className="relative mx-auto flex w-full max-w-[440px] flex-col"
+        className="relative mx-auto flex w-full max-w-[440px] flex-col justify-center"
         style={{
           height: "calc(100dvh - var(--app-scroll-bottom-pad, 0px))",
           minHeight: "calc(100svh - var(--app-scroll-bottom-pad, 0px))",
         }}
+        data-auth-content-block
       >
-        {/* Hero + buttons anchor to the bottom of the screen (justify-end),
-            not vertically centered, so the whole sign-in surface sits within
-            comfortable one-thumb reach on tall phones. */}
-        <div className="flex flex-1 flex-col items-center justify-end px-6 pb-2 text-center">
+        {/* Center the complete sign-in group as one visual block while the
+            fixed Back control remains independently anchored above it. */}
+        <div className="flex flex-none flex-col items-center px-6 pb-2 text-center">
           {/* Quiet mark: the bare 🤫 over a soft accent glow, no medallion
               chrome (badge circle removed by design). */}
           <div


### PR DESCRIPTION
## Summary
- vertically center the complete login/sign-in content block
- preserve the fixed Back control and existing Agent Bar viewport clearance
- update the layout contract test to prevent bottom anchoring from returning

## Verification
- `npm test -- --run __tests__/components/auth-step-layout.contract.test.ts` (3/3 passed)
- `npx eslint components/onboarding/AuthStep.tsx __tests__/components/auth-step-layout.contract.test.ts --max-warnings=0`
- `npm run build`
- browser-verified at 390x844, 430x932, and 1365x768 with a 0px center delta and no overlap

## Scope
Only the login layout component and its focused contract test are changed.