### PR TITLE
Match Location onboarding and add selected-contact SMS safety workflow

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# Non-secret key-algorithm labels from the SMS contacts test fixture in PR #4655.
+900247e8948d1a33d4d0d65f12fc60436b5b032f:hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx:generic-api-key:16
+900247e8948d1a33d4d0d65f12fc60436b5b032f:hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx:generic-api-key:26

--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -28,6 +28,7 @@ router = APIRouter(prefix="/api/one", tags=["One Location Agent"])
 _PublicToken = Annotated[str, Path(min_length=1, max_length=128)]
 _InviteId = Annotated[str, Path(min_length=1, max_length=128)]
 _GrantId = Annotated[str, Path(min_length=1, max_length=128)]
+_RecipientUserId = Annotated[str, Path(min_length=1, max_length=160)]
 
 
 class _CamelModel(BaseModel):
@@ -52,6 +53,10 @@ class CreateGrantRequest(_CamelModel):
     duration_hours: float = Field(alias="durationHours", gt=0, le=24)
     reason: str | None = Field(default=None, max_length=300)
     share_kind: str | None = Field(default=None, alias="shareKind", max_length=40)
+
+
+class AddSmsContactRequest(_CamelModel):
+    recipient_user_id: str = Field(alias="recipientUserId", min_length=1, max_length=160)
 
 
 class StoreEnvelopeRequest(_CamelModel):
@@ -191,6 +196,38 @@ def _require_retention_auth(request: Request) -> None:
 def get_location_state(token_data: dict = Depends(require_vault_owner_token)):
     try:
         return _service().list_state(user_id=_user_id(token_data))
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.post("/location/sms-contacts")
+def add_location_sms_contact(
+    payload: AddSmsContactRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "smsContactUserIds": _service().add_sms_contact(
+                owner_user_id=_user_id(token_data),
+                contact_user_id=payload.recipient_user_id,
+            )
+        }
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+
+
+@router.delete("/location/sms-contacts/{recipient_user_id}")
+def remove_location_sms_contact(
+    recipient_user_id: _RecipientUserId,
+    token_data: dict = Depends(require_vault_owner_token),
+):
+    try:
+        return {
+            "smsContactUserIds": _service().remove_sms_contact(
+                owner_user_id=_user_id(token_data),
+                contact_user_id=recipient_user_id,
+            )
+        }
     except Exception as exc:
         raise _handle_error(exc) from exc
 

--- a/consent-protocol/api/utils/fcm_messages.py
+++ b/consent-protocol/api/utils/fcm_messages.py
@@ -6,6 +6,20 @@ CONSENT_NOTIFICATION_CATEGORY = "CONSENT_REQUEST"
 CONSENT_NOTIFICATION_ACTION_REVIEW = "CONSENT_REVIEW"
 CONSENT_NOTIFICATION_ACTION_APPROVE = "CONSENT_APPROVE"
 CONSENT_NOTIFICATION_ACTION_DENY = "CONSENT_DENY"
+ONE_LOCATION_SMS_EMERGENCY_PROFILE = "one_location_sms_emergency"
+ONE_LOCATION_SMS_EMERGENCY_CATEGORY = "ONE_LOCATION_SMS_EMERGENCY"
+ONE_LOCATION_SMS_EMERGENCY_ANDROID_CHANNEL = "one_location_sms_emergency_v1"
+ONE_LOCATION_SMS_EMERGENCY_IOS_SOUND = "one_location_sms_alarm.wav"
+
+
+def _is_one_location_sms_emergency(data: dict[str, str]) -> bool:
+    profile = str(data.get("notification_profile") or "").strip().lower()
+    if profile == ONE_LOCATION_SMS_EMERGENCY_PROFILE:
+        return True
+    return (
+        str(data.get("type") or "").strip().lower() == "location_share_created"
+        and str(data.get("share_kind") or "").strip().lower() == "sos"
+    )
 
 
 def build_push_message(
@@ -22,6 +36,7 @@ def build_push_message(
 ):
     normalized_platform = str(platform or "").strip().lower()
     normalized_type = str(data.get("type") or "").strip().lower()
+    is_sms_emergency = _is_one_location_sms_emergency(data)
     notification = messaging.Notification(title=title, body=body) if show_alert else None
 
     webpush = None
@@ -34,8 +49,27 @@ def build_push_message(
                 tag=notification_tag,
                 require_interaction=True,
                 data={"url": request_url},
+                renotify=is_sms_emergency,
+                silent=False,
+                vibrate=[240, 120, 240, 120, 520] if is_sms_emergency else None,
             ),
             fcm_options=messaging.WebpushFCMOptions(link=request_url),
+        )
+
+    android = None
+    if normalized_platform == "android" and show_alert and is_sms_emergency:
+        android = messaging.AndroidConfig(
+            priority="high",
+            notification=messaging.AndroidNotification(
+                title=title,
+                body=body,
+                channel_id=ONE_LOCATION_SMS_EMERGENCY_ANDROID_CHANNEL,
+                tag=notification_tag,
+                ticker="Emergency SMS alert",
+                priority="max",
+                visibility="public",
+                vibrate_timings_millis=[0, 240, 120, 240, 120, 520],
+            ),
         )
 
     apns = None
@@ -48,12 +82,16 @@ def build_push_message(
             payload=messaging.APNSPayload(
                 aps=messaging.Aps(
                     alert=messaging.ApsAlert(title=title, body=body),
-                    sound="default",
+                    sound=(ONE_LOCATION_SMS_EMERGENCY_IOS_SOUND if is_sms_emergency else "default"),
                     badge=1,
                     category=(
-                        CONSENT_NOTIFICATION_CATEGORY
-                        if normalized_type == "consent_request"
-                        else None
+                        ONE_LOCATION_SMS_EMERGENCY_CATEGORY
+                        if is_sms_emergency
+                        else (
+                            CONSENT_NOTIFICATION_CATEGORY
+                            if normalized_type == "consent_request"
+                            else None
+                        )
                     ),
                     thread_id=notification_tag,
                 ),
@@ -81,4 +119,5 @@ def build_push_message(
         notification=notification,
         webpush=webpush,
         apns=apns,
+        android=android,
     )

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 115,
+  "expected_migration_version": 116,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -708,6 +708,12 @@
       "user_id",
       "presence_mode",
       "renderer_consent_version",
+      "created_at",
+      "updated_at"
+    ],
+    "one_location_sms_contacts": [
+      "owner_user_id",
+      "contact_user_id",
       "created_at",
       "updated_at"
     ],

--- a/consent-protocol/db/migrations/116_one_location_sms_contacts.sql
+++ b/consent-protocol/db/migrations/116_one_location_sms_contacts.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+-- Save My Soul recipients are an explicit owner-scoped subset of the existing
+-- connections graph. No rows are backfilled: an empty list must fail closed.
+CREATE TABLE IF NOT EXISTS one_location_sms_contacts (
+  owner_user_id TEXT NOT NULL
+    REFERENCES actor_profiles(user_id) ON DELETE CASCADE,
+  contact_user_id TEXT NOT NULL
+    REFERENCES actor_profiles(user_id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (owner_user_id, contact_user_id),
+  CONSTRAINT one_location_sms_contacts_not_self
+    CHECK (owner_user_id <> contact_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_one_location_sms_contacts_contact
+  ON one_location_sms_contacts (contact_user_id, owner_user_id);
+
+COMMENT ON TABLE one_location_sms_contacts IS
+  'Owner-selected Save My Soul recipients. Membership grants no location access by itself.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/116_one_location_sms_contacts_down.sql
+++ b/consent-protocol/db/migrations/rollback/116_one_location_sms_contacts_down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS one_location_sms_contacts;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -93,7 +93,8 @@
     "112_dynamic_crm_registry_cache.sql",
     "113_kai_plaid_portfolio_tables.sql",
     "114_one_action_directive_ledger.sql",
-    "115_one_location_map_presence.sql"
+    "115_one_location_map_presence.sql",
+    "116_one_location_sms_contacts.sql"
   ],
   "groups": {
     "iam": [
@@ -146,7 +147,8 @@
       "111_macys_crm_response_contracts.sql",
       "112_dynamic_crm_registry_cache.sql",
       "114_one_action_directive_ledger.sql",
-      "115_one_location_map_presence.sql"
+      "115_one_location_map_presence.sql",
+      "116_one_location_sms_contacts.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/docs/reference/fcm-notifications.md
+++ b/consent-protocol/docs/reference/fcm-notifications.md
@@ -1,7 +1,7 @@
 # FCM Notifications
 
 > **Status**: Production (Pure Push)
-> **Last Updated**: February 2026
+> **Last Updated**: July 2026
 > **Scope**: Web (FCM), iOS/Android (Capacitor Firebase Messaging)
 
 
@@ -27,6 +27,39 @@ Consent and connection requests are treated as **alert-class notifications** on 
 - Approve and Deny notification actions only open the app into a confirmation flow; they do not commit a decision directly from the notification
 
 This is stricter than the web lane. Web remains service-worker/browser-notification based, while native iOS is expected to surface a system-visible alert when the device allows it.
+
+### Emergency SMS alert policy
+
+One Location `SMS · Save my soul` sends are a separate emergency notification
+profile, identified by:
+
+```json
+{
+  "type": "location_share_created",
+  "share_kind": "sos",
+  "notification_profile": "one_location_sms_emergency",
+  "notification_category": "ONE_LOCATION_SMS_EMERGENCY"
+}
+```
+
+The explicit profile is canonical. Receivers also recognize
+`type=location_share_created` plus `share_kind=sos` so an older queued payload
+still receives emergency presentation.
+
+| Surface | Emergency behavior |
+| ------- | ------------------ |
+| Visible web app | Assertive red emergency card, three-pulse Web Audio alarm, supported-device vibration, and a 30-second presentation window |
+| Background web / PWA | Persistent browser notification with emergency vibration metadata and live-location routing |
+| Android | Dedicated `one_location_sms_emergency_v1` high-importance channel using the device alarm sound, red notification light, and emergency vibration pattern |
+| iOS background | `ONE_LOCATION_SMS_EMERGENCY` category, custom `one_location_sms_alarm.wav` sound generated in the app's `Library/Sounds`, badge, and an Open live location action |
+| iOS foreground | Shared red in-app emergency card and alarm; the native delegate keeps only the badge to prevent a duplicate banner and duplicate sound |
+
+This profile does **not** bypass Focus or Do Not Disturb. Android explicitly
+keeps channel DND bypass disabled. iOS Critical Alerts are not requested because
+that capability requires a separate Apple entitlement and review. Browser
+vendors and operating systems retain control over closed-tab notification
+sounds, so web background delivery cannot guarantee the custom three-pulse
+audio; the browser notification remains persistent and vibrates where supported.
 
 ### Reminder policy
 

--- a/consent-protocol/hushh_mcp/agents/location/agent.yaml
+++ b/consent-protocol/hushh_mcp/agents/location/agent.yaml
@@ -42,14 +42,14 @@ system_instruction: |
   request_confirmation before propose_public_link: the browser already shows
   an owner-confirmation card for the proposed link, so asking first makes the
   user confirm twice. Once the duration is known, call propose_public_link
-  directly. SOS is high-stakes: always call request_confirmation before
+  directly. Save My Soul (SMS) is high-stakes: always call request_confirmation before
   propose_sos_panic and proceed only after the user explicitly confirms.
 
   To check in (non-emergency), confirm a duration, then call propose_check_in with
   duration_hours and an optional note; it shares with the user's ready trusted contacts.
 
   Device location permission: if the user asks you to (re-)ask for location
-  permission, or a share/check-in/SOS action fails because permission is
+  permission, or a share/check-in/SMS action fails because permission is
   missing or was denied, call request_device_location_permission immediately —
   do not just explain how to enable it in settings, actually trigger the
   device prompt. Tell the user what to expect ("I'm asking your device for
@@ -122,7 +122,7 @@ tools:
     py_func: hushh_mcp.agents.location.tools.revoke_public_link
     required_scope: cap.location.live.share
   - name: propose_sos_panic
-    description: Propose an emergency SOS broadcast to all ready trusted contacts; the browser creates grants, encrypts, and publishes.
+    description: Propose a Save My Soul alert to the user's selected, ready SMS contacts; the browser creates grants, encrypts, and publishes.
     py_func: hushh_mcp.agents.location.tools.propose_sos_panic
     required_scope: cap.location.live.share
   - name: propose_check_in

--- a/consent-protocol/hushh_mcp/agents/location/tools.py
+++ b/consent-protocol/hushh_mcp/agents/location/tools.py
@@ -227,7 +227,7 @@ async def propose_public_link(duration_hours: float) -> dict[str, Any]:
 
 @hushh_tool(scope=ConsentScope.CAP_LOCATION_LIVE_SHARE, name="propose_sos_panic")
 async def propose_sos_panic() -> dict[str, Any]:
-    """Propose an emergency SOS broadcast to the user's ready trusted contacts.
+    """Propose a Save My Soul alert to the user's selected, ready SMS contacts.
     The browser creates 8h grants per recipient, encrypts, publishes, and records
     the incident. Coordinate-free."""
     _ctx()
@@ -265,7 +265,7 @@ async def request_device_location_permission() -> dict[str, Any]:
     """Ask the device to (re-)prompt the OS location permission dialog. Use this
     whenever an action needs the device's location and it is not currently
     available or was previously denied - e.g. the user asks to share, check in,
-    or send SOS and a prior attempt failed because permission was never granted
+    or send SMS and a prior attempt failed because permission was never granted
     or was denied. The server never receives a coordinate here; the OS prompt
     and outcome happen entirely client-side."""
     _ctx()

--- a/consent-protocol/hushh_mcp/one_adk/agent_tree.py
+++ b/consent-protocol/hushh_mcp/one_adk/agent_tree.py
@@ -823,7 +823,7 @@ async def ask_email_agent(request: str, tool_context: ToolContext) -> dict[str, 
 
 
 async def ask_location_agent(request: str, tool_context: ToolContext) -> dict[str, Any]:
-    """Ask the Location specialist about live location sharing with trusted people, check-ins, or SOS."""
+    """Ask the Location specialist about live location sharing, check-ins, or Save My Soul."""
     return await _specialist_turn("agent_location", request, tool_context)
 
 

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -175,6 +175,13 @@ class AccountService:
                    OR recipient_user_id = :user_id
                 """
             ),
+            "one_location_sms_contacts": text(
+                """
+                DELETE FROM one_location_sms_contacts
+                WHERE owner_user_id = :user_id
+                   OR contact_user_id = :user_id
+                """
+            ),
             "one_location_public_invite_submissions": text(
                 """
                 DELETE FROM one_location_public_invite_submissions
@@ -661,6 +668,7 @@ class AccountService:
         results["one_kyc_workflows"] = True
         for table_name in (
             "one_location_events",
+            "one_location_sms_contacts",
             "one_location_referrals",
             "one_location_public_invite_submissions",
             "one_location_public_invites",
@@ -832,6 +840,7 @@ class AccountService:
             "marketplace_profile": False,
             "one_kyc_workflows": False,
             "one_location_events": False,
+            "one_location_sms_contacts": False,
             "one_location_referrals": False,
             "one_location_access_requests": False,
             "one_location_envelopes": False,
@@ -1051,6 +1060,7 @@ class AccountService:
                 results["one_kyc_workflows"] = True
                 for table_name in (
                     "one_location_events",
+                    "one_location_sms_contacts",
                     "one_location_referrals",
                     "one_location_public_invite_submissions",
                     "one_location_public_invites",

--- a/consent-protocol/hushh_mcp/services/location_chat_service.py
+++ b/consent-protocol/hushh_mcp/services/location_chat_service.py
@@ -97,8 +97,8 @@ _ACTION_RESULT_TEMPLATES = {
     ("view_envelope", "completed"): "Here's the latest location I could open.",
     ("create_public_link", "completed"): "Your public location link is ready.",
     ("create_public_link", "cancelled"): "Okay — I didn't create a public link.",
-    ("sos_panic", "completed"): "SOS sent — your emergency contacts are being notified.",
-    ("sos_panic", "cancelled"): "Okay — I didn't send an SOS.",
+    ("sos_panic", "completed"): "SMS sent — your selected contacts are being notified.",
+    ("sos_panic", "cancelled"): "Okay — I didn't send SMS.",
     ("check_in", "completed"): "Done — your trusted contacts can see your check-in. ✓",
     ("check_in", "cancelled"): "Okay — I didn't check you in.",
     (
@@ -301,7 +301,7 @@ def _function_declarations_v2(types: Any) -> list:
                     "Ask the device to (re-)prompt the OS location permission dialog. "
                     "Call this whenever the user asks you to (re-)ask for location "
                     "permission, or an action needing the device's location (share, "
-                    "check-in, SOS) failed because permission is missing or was "
+                    "check-in, SMS) failed because permission is missing or was "
                     "previously denied. Coordinate-free; the prompt happens on-device."
                 ),
                 parameters=schema(type=kind.OBJECT, properties={}, required=[]),
@@ -376,7 +376,7 @@ def _function_declarations_v2(types: Any) -> list:
             types.FunctionDeclaration(
                 name="propose_sos_panic",
                 description=(
-                    "Propose an emergency SOS broadcast to all of the user's ready trusted "
+                    "Propose a Save My Soul alert to the user's selected, ready SMS "
                     "contacts. The browser creates 8h grants per recipient, encrypts, "
                     "publishes, and records the incident. Coordinate-free. Call "
                     "request_confirmation first before proposing this."
@@ -794,7 +794,7 @@ class LocationChatService:
             return {
                 "id": action_id,
                 "type": "sos_panic",
-                "summary": "Send an emergency SOS to all your trusted contacts",
+                "summary": "Send SMS to your selected emergency contacts",
             }
         check_in = next((d for d in directives if d.get("type") == "check_in"), None)
         if check_in:

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2678,6 +2678,184 @@ class OneLocationAgentService:
         )
         return row is not None
 
+    def _is_sms_contact(self, *, owner_user_id: str, contact_user_id: str) -> bool:
+        """Fail closed when the selected-contact table is unavailable.
+
+        Postgres is the authoritative membership store. A future Redis layer may
+        cache this lookup, but it must preserve the same owner-scoped contract
+        and fall back to Postgres without broadening the recipient set.
+        """
+        try:
+            row = self._execute_one(
+                """
+                SELECT 1
+                FROM one_location_sms_contacts
+                WHERE owner_user_id = :owner_user_id
+                  AND contact_user_id = :contact_user_id
+                LIMIT 1
+                """,
+                {
+                    "owner_user_id": owner_user_id,
+                    "contact_user_id": contact_user_id,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - safety path must fail closed
+            logger.warning(
+                "one_location.sms_contact_lookup_failed owner=%s contact=%s error=%s",
+                redact_log_field("owner_user_id", owner_user_id),
+                redact_log_field("contact_user_id", contact_user_id),
+                exc,
+            )
+            return False
+        return row is not None
+
+    def list_sms_contact_ids(self, *, owner_user_id: str) -> list[str]:
+        rows = self._execute_many(
+            """
+            SELECT sms.contact_user_id
+            FROM one_location_sms_contacts sms
+            WHERE sms.owner_user_id = :owner_user_id
+              AND EXISTS (
+                SELECT 1
+                FROM connections c
+                WHERE c.status = 'active'
+                  AND (
+                    (c.user_a_id = :owner_user_id AND c.user_b_id = sms.contact_user_id)
+                    OR
+                    (c.user_b_id = :owner_user_id AND c.user_a_id = sms.contact_user_id)
+                  )
+              )
+            ORDER BY sms.created_at, sms.contact_user_id
+            """,
+            {"owner_user_id": owner_user_id},
+        )
+        return [
+            str(row.get("contact_user_id") or "")
+            for row in rows
+            if str(row.get("contact_user_id") or "").strip()
+        ]
+
+    def add_sms_contact(self, *, owner_user_id: str, contact_user_id: str) -> list[str]:
+        if owner_user_id == contact_user_id:
+            raise OneLocationAgentError(
+                "LOCATION_SMS_CONTACT_SELF",
+                "Choose a different connection as an SMS contact.",
+                status_code=422,
+            )
+        if not self._is_active_connection(
+            owner_user_id=owner_user_id, other_user_id=contact_user_id
+        ):
+            raise OneLocationAgentError(
+                "LOCATION_SMS_CONTACT_NOT_CONNECTED",
+                "Only an active connection can be added as an SMS contact.",
+                status_code=403,
+            )
+        # Reject contacts that cannot actually decrypt a live-location envelope.
+        self._recipient_key_row(
+            recipient_user_id=contact_user_id,
+            require_phone_verified=True,
+            unavailable_message=(
+                "This connection must finish Location setup before they can be "
+                "added as an SMS contact."
+            ),
+        )
+        self._execute_one(
+            """
+            INSERT INTO one_location_sms_contacts (
+              owner_user_id, contact_user_id, created_at, updated_at
+            )
+            VALUES (:owner_user_id, :contact_user_id, NOW(), NOW())
+            ON CONFLICT (owner_user_id, contact_user_id) DO UPDATE
+            SET updated_at = one_location_sms_contacts.updated_at
+            RETURNING contact_user_id
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "contact_user_id": contact_user_id,
+            },
+        )
+        return self.list_sms_contact_ids(owner_user_id=owner_user_id)
+
+    def remove_sms_contact(self, *, owner_user_id: str, contact_user_id: str) -> list[str]:
+        self._execute_one(
+            """
+            DELETE FROM one_location_sms_contacts
+            WHERE owner_user_id = :owner_user_id
+              AND contact_user_id = :contact_user_id
+            RETURNING contact_user_id
+            """,
+            {
+                "owner_user_id": owner_user_id,
+                "contact_user_id": contact_user_id,
+            },
+        )
+        return self.list_sms_contact_ids(owner_user_id=owner_user_id)
+
+    def _send_location_share_created_notification(
+        self,
+        *,
+        grant: dict[str, Any],
+        owner_user_id: str,
+        recipient_user_id: str,
+        duration: float,
+        reason: str | None,
+        resolved_kind: str,
+    ) -> None:
+        owner_identity = self._identity_row(owner_user_id)
+        owner_label = _identity_notification_label(owner_identity)
+        share_message = _visible_share_message(reason)
+        if resolved_kind == "sos":
+            notification_title = "SMS · Save my soul"
+            notification_body = (
+                f"{owner_label}: {share_message}"
+                if share_message
+                else (f"{owner_label} sent a Save My Soul alert and shared live location with you.")
+            )
+        elif resolved_kind == "drive_to":
+            notification_title = "Drive shared"
+            notification_body = f"{owner_label} started sharing their drive and live ETA with you."
+        elif resolved_kind == "pick_me_up":
+            notification_title = "Pickup requested"
+            notification_body = (
+                f"{owner_label}: {share_message}"
+                if share_message
+                else f"{owner_label} is requesting a pickup."
+            )
+        elif resolved_kind == "pickup_enroute":
+            notification_title = "Drive shared"
+            notification_body = f"{owner_label} started sharing their drive and live ETA with you."
+        elif resolved_kind == "check_in":
+            notification_title = "Check-in shared"
+            notification_body = (
+                f"{owner_label}: {share_message}"
+                if share_message
+                else f"{owner_label} checked in and shared their location with you."
+            )
+        else:
+            notification_title = "Location shared"
+            notification_body = f"{owner_label} shared location access with you."
+        self._send_metadata_notification(
+            user_id=recipient_user_id,
+            notification_type="location_share_created",
+            title=notification_title,
+            body=notification_body,
+            notification_tag=f"one-location-share:{grant['id']}",
+            request_url=_one_location_url(
+                grantId=grant["id"],
+                locationNotification="opened",
+                section="shared",
+            ),
+            data={
+                "grant_id": grant["id"],
+                "owner_user_id": owner_user_id,
+                "owner_display_label": owner_label,
+                "duration_hours": str(duration),
+                "expires_at": grant.get("expiresAt"),
+                "share_kind": resolved_kind,
+                **({"share_message": share_message} if share_message else {}),
+            },
+        )
+
     def create_grant(
         self,
         *,
@@ -2712,14 +2890,20 @@ class OneLocationAgentService:
                 str(exc),
                 status_code=422,
             ) from exc
+        resolved_kind = share_kind or _classify_share_kind(reason)
+        if resolved_kind == "sos" and not self._is_sms_contact(
+            owner_user_id=owner_user_id, contact_user_id=recipient_user_id
+        ):
+            raise OneLocationAgentError(
+                "LOCATION_SMS_CONTACT_REQUIRED",
+                "This person is not in your SMS contacts.",
+                status_code=403,
+            )
         recipient = self._recipient_key_row(
             recipient_user_id=recipient_user_id,
             recipient_key_id=recipient_key_id,
             require_phone_verified=require_recipient_phone_verified,
         )
-        resolved_kind = share_kind or _classify_share_kind(reason)
-        owner_identity = self._identity_row(owner_user_id)
-        owner_label = _identity_notification_label(owner_identity)
         key_id = str(recipient.get("key_id") or "")
         expires_at = _utcnow() + timedelta(hours=duration)
         capability = self._mint_grant_capability_token(
@@ -2788,67 +2972,18 @@ class OneLocationAgentService:
             event_type="location_share_created",
             metadata={"duration_hours": duration},
         )
-        # Kind-aware notification copy so the recipient instantly knows WHAT this
-        # is (emergency SOS vs friendly Check-In vs plain share) and WHY. The
-        # share kind comes from the grant "reason" marker; a Check-In note is
-        # surfaced verbatim ("<Owner>: <message>"), SOS gets urgent dedicated
-        # copy, and a plain share keeps the neutral line. Internal markers
-        # ("owner_approved" / "request_approved" / "sos_panic") are never shown
-        # as a raw message.
-        share_message = _visible_share_message(reason)
-        if resolved_kind == "sos":
-            notification_title = "SOS alert"
-            notification_body = (
-                f"{owner_label} triggered an SOS and is sharing live location with you."
-            )
-        elif resolved_kind == "drive_to":
-            notification_title = "Drive shared"
-            notification_body = f"{owner_label} started sharing their drive and live ETA with you."
-        elif resolved_kind == "pick_me_up":
-            notification_title = "Pickup requested"
-            notification_body = (
-                f"{owner_label}: {share_message}"
-                if share_message
-                else f"{owner_label} is requesting a pickup."
-            )
-        elif resolved_kind == "pickup_enroute":
-            notification_title = "Drive shared"
-            notification_body = f"{owner_label} started sharing their drive and live ETA with you."
-        elif resolved_kind == "check_in":
-            notification_title = "Check-in shared"
-            notification_body = (
-                f"{owner_label}: {share_message}"
-                if share_message
-                else f"{owner_label} checked in and shared their location with you."
-            )
-        else:
-            notification_title = "Location shared"
-            notification_body = f"{owner_label} shared location access with you."
         # Request approval has its own richer notification immediately after
         # this call. Sending share-created as well produces two alerts for one
-        # user action, so direct/SOS/check-in/drive shares use this notification
-        # while approvals use only location_access_approved.
-        if reason != "request_approved":
-            self._send_metadata_notification(
-                user_id=recipient_user_id,
-                notification_type="location_share_created",
-                title=notification_title,
-                body=notification_body,
-                notification_tag=f"one-location-share:{grant['id']}",
-                request_url=_one_location_url(
-                    grantId=grant["id"],
-                    locationNotification="opened",
-                    section="shared",
-                ),
-                data={
-                    "grant_id": grant["id"],
-                    "owner_user_id": owner_user_id,
-                    "owner_display_label": owner_label,
-                    "duration_hours": str(duration),
-                    "expires_at": grant.get("expiresAt"),
-                    "share_kind": resolved_kind,
-                    **({"share_message": share_message} if share_message else {}),
-                },
+        # user action. SMS waits until its first encrypted envelope is durably
+        # stored so a recipient is never told a location is available too early.
+        if reason != "request_approved" and resolved_kind != "sos":
+            self._send_location_share_created_notification(
+                grant=grant,
+                owner_user_id=owner_user_id,
+                recipient_user_id=recipient_user_id,
+                duration=duration,
+                reason=reason,
+                resolved_kind=resolved_kind,
             )
         return grant
 
@@ -2890,6 +3025,7 @@ class OneLocationAgentService:
             raise OneLocationAgentError(
                 "LOCATION_GRANT_NOT_ACTIVE", "Location share is not active.", status_code=409
             )
+        is_first_envelope = not bool(grant_row.get("latest_envelope_id"))
         expires_at = _parse_datetime(grant_row.get("expires_at"), field_name="expires_at")
         if expires_at <= _utcnow():
             self._expire_stale_grants(owner_user_id)
@@ -2981,6 +3117,25 @@ class OneLocationAgentService:
                 "recipient_key_id": recipient_key_id,
             },
         )
+        grant_metadata = _loads_json(grant_row.get("metadata"))
+        if not isinstance(grant_metadata, dict):
+            grant_metadata = {}
+        stored_kind = str(grant_metadata.get("share_kind") or "")
+        if stored_kind == "sos" and is_first_envelope:
+            self._send_location_share_created_notification(
+                grant=self._grant_payload(
+                    {
+                        **grant_row,
+                        "latest_envelope_id": envelope_payload["id"],
+                    }
+                )
+                or {"id": grant_id, "expiresAt": _iso(grant_row.get("expires_at"))},
+                owner_user_id=owner_user_id,
+                recipient_user_id=str(grant_row.get("recipient_user_id") or ""),
+                duration=float(grant_row.get("duration_hours") or 8),
+                reason=str(grant_metadata.get("reason") or "") or None,
+                resolved_kind="sos",
+            )
         return envelope_payload
 
     def view_latest_envelope(self, *, recipient_user_id: str, grant_id: str) -> dict[str, Any]:
@@ -3972,6 +4127,26 @@ class OneLocationAgentService:
             """,
             {"user_id": user_id},
         )
+        sms_contacts = _safe_many(
+            "sms_contacts",
+            """
+            SELECT sms.contact_user_id
+            FROM one_location_sms_contacts sms
+            WHERE sms.owner_user_id = :user_id
+              AND EXISTS (
+                SELECT 1
+                FROM connections c
+                WHERE c.status = 'active'
+                  AND (
+                    (c.user_a_id = :user_id AND c.user_b_id = sms.contact_user_id)
+                    OR
+                    (c.user_b_id = :user_id AND c.user_a_id = sms.contact_user_id)
+                  )
+              )
+            ORDER BY sms.created_at, sms.contact_user_id
+            """,
+            {"user_id": user_id},
+        )
         public_submissions = _safe_many(
             "public_submissions",
             """
@@ -4064,6 +4239,11 @@ class OneLocationAgentService:
                 payload
                 for row in network_connections
                 if (payload := self._trusted_connection_as_network_payload(row))
+            ],
+            "smsContactUserIds": [
+                str(row.get("contact_user_id") or "")
+                for row in sms_contacts
+                if str(row.get("contact_user_id") or "").strip()
             ],
             "publicInviteSubmissions": [
                 payload

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2852,6 +2852,14 @@ class OneLocationAgentService:
                 "duration_hours": str(duration),
                 "expires_at": grant.get("expiresAt"),
                 "share_kind": resolved_kind,
+                **(
+                    {
+                        "notification_profile": "one_location_sms_emergency",
+                        "notification_category": "ONE_LOCATION_SMS_EMERGENCY",
+                    }
+                    if resolved_kind == "sos"
+                    else {}
+                ),
                 **({"share_message": share_message} if share_message else {}),
             },
         )

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -2073,11 +2073,15 @@ class OneLocationAgentService:
               LIMIT 500
               FOR UPDATE SKIP LOCKED
             )
-            UPDATE one_location_share_grants grant
+            UPDATE one_location_share_grants AS target_grant
             SET status = 'expired', updated_at = NOW()
             FROM stale
-            WHERE grant.id = stale.id
-            RETURNING grant.id, grant.owner_user_id, grant.recipient_user_id, grant.expires_at
+            WHERE target_grant.id = stale.id
+            RETURNING
+              target_grant.id,
+              target_grant.owner_user_id,
+              target_grant.recipient_user_id,
+              target_grant.expires_at
             """,
             {"user_id": user_id},
         )

--- a/consent-protocol/hushh_mcp/services/one_location_center_contributor.py
+++ b/consent-protocol/hushh_mcp/services/one_location_center_contributor.py
@@ -42,15 +42,15 @@ _ACTIVE_GRANT_STATUSES = {"active", "approved", "granted"}
 _PENDING_REQUEST_STATUSES = {"pending", "request_pending", "sent"}
 
 # Human-facing labels + scope descriptions per share kind so the Consent Manager
-# can render a "SOS" / "Check-In" / "Share" tag and an accurate one-line
+# can render an "SMS" / "Check-In" / "Share" tag and an accurate one-line
 # description instead of the same generic copy for every location grant.
 _SHARE_KIND_LABEL = {
-    "sos": "SOS",
+    "sos": "SMS",
     "check_in": "Check-In",
     "share": "Share",
 }
 _SHARE_KIND_SCOPE_DESCRIPTION = {
-    "sos": "SOS emergency live location",
+    "sos": "SMS · Save my soul live location",
     "check_in": "Check-in live location",
     "share": "Live location sharing",
 }

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -100,6 +100,7 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
         "DELETE FROM marketplace_public_profiles",
         "DELETE FROM one_kyc_workflows",
         "DELETE FROM one_location_events",
+        "DELETE FROM one_location_sms_contacts",
         "DELETE FROM one_location_referrals",
         "DELETE FROM one_location_public_invite_submissions",
         "DELETE FROM one_location_public_invites",
@@ -209,6 +210,7 @@ async def test_reset_account_clears_data_but_keeps_account_spine(monkeypatch):
         "DELETE FROM consent_audit",
         "DELETE FROM one_kyc_workflows",
         "DELETE FROM one_location_events",
+        "DELETE FROM one_location_sms_contacts",
     ]
     for fragment in cleared_fragments:
         assert fragment in executed_sql

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -2578,3 +2578,9 @@ def test_sms_grant_fails_closed_until_recipient_is_selected() -> None:
     assert len(service.notifications) == 1
     assert service.notifications[0]["title"] == "SMS · Save my soul"
     assert service.notifications[0]["body"] == "User A: Come get me"
+    assert service.notifications[0]["data"]["notification_profile"] == (
+        "one_location_sms_emergency"
+    )
+    assert service.notifications[0]["data"]["notification_category"] == (
+        "ONE_LOCATION_SMS_EMERGENCY"
+    )

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -217,11 +217,15 @@ class EnvelopeReadProbe(OneLocationAgentService):
 
 
 def test_view_latest_envelope_returns_ciphertext_only_payload() -> None:
-    response = EnvelopeReadProbe().view_latest_envelope(
+    service = EnvelopeReadProbe()
+    response = service.view_latest_envelope(
         recipient_user_id="user_b",
         grant_id="00000000-0000-0000-0000-000000000001",
     )
 
+    stale_cleanup_sql = next(sql for sql in service.calls if "WITH stale AS" in sql)
+    assert "UPDATE one_location_share_grants AS target_grant" in stale_cleanup_sql
+    assert "RETURNING\n              target_grant.id" in stale_cleanup_sql
     assert response["grant"]["recipientUserId"] == "user_b"
     assert response["envelope"]["ciphertext"] == "ciphertext-only"
     assert "latitude" not in json.dumps(response)

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -267,6 +267,7 @@ class FourUserMemoryService(OneLocationAgentService):
         self.network_connections: dict[str, dict] = {}
         self.trusted_connections: dict[str, dict] = {}
         self.connections: dict[str, dict] = {}
+        self.sms_contacts: set[tuple[str, str]] = set()
         self.events: dict[str, dict] = {}
         self.notifications: list[dict] = []
         self.professional_relationships: list[dict] = []
@@ -328,6 +329,23 @@ class FourUserMemoryService(OneLocationAgentService):
 
     def _execute_many(self, sql: str, params: dict | None = None) -> list[dict]:
         params = params or {}
+        if "FROM one_location_sms_contacts sms" in sql:
+            owner = params.get("owner_user_id") or params.get("user_id")
+            active_connected_ids = {
+                (
+                    connection["user_b_id"]
+                    if connection["user_a_id"] == owner
+                    else connection["user_a_id"]
+                )
+                for connection in self.connections.values()
+                if connection.get("status") == "active"
+                and owner in {connection.get("user_a_id"), connection.get("user_b_id")}
+            }
+            return [
+                {"contact_user_id": contact}
+                for selected_owner, contact in sorted(self.sms_contacts)
+                if selected_owner == owner and contact in active_connected_ids
+            ]
         if "UPDATE one_location_share_grants" in sql and "expires_at <= NOW()" in sql:
             return []
         if "FROM one_location_recipient_keys" in sql and "encrypted_private_key_jwk" in sql:
@@ -605,6 +623,18 @@ class FourUserMemoryService(OneLocationAgentService):
 
     def _execute_one(self, sql: str, params: dict | None = None) -> dict | None:
         params = params or {}
+        if "SELECT 1" in sql and "FROM one_location_sms_contacts" in sql:
+            pair = (params["owner_user_id"], params["contact_user_id"])
+            return {"exists": 1} if pair in self.sms_contacts else None
+        if "INSERT INTO one_location_sms_contacts" in sql:
+            pair = (params["owner_user_id"], params["contact_user_id"])
+            self.sms_contacts.add(pair)
+            return {"contact_user_id": params["contact_user_id"]}
+        if "DELETE FROM one_location_sms_contacts" in sql:
+            pair = (params["owner_user_id"], params["contact_user_id"])
+            existed = pair in self.sms_contacts
+            self.sms_contacts.discard(pair)
+            return {"contact_user_id": params["contact_user_id"]} if existed else None
         if "SELECT 1" in sql and "FROM connections" in sql and "status = 'active'" in sql:
             a = params.get("a")
             b = params.get("b")
@@ -2470,3 +2500,81 @@ def test_create_grant_without_enforce_allows_non_connection() -> None:
         duration_hours=1,
     )
     assert grant["recipientUserId"] == "user_b"
+
+
+def test_sms_contacts_are_owner_scoped_idempotent_and_do_not_change_connection() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+    service._seed_connection("user_a", "user_b")
+    before = dict(service.connections)
+
+    assert service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b") == ["user_b"]
+    assert service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b") == ["user_b"]
+    assert service.list_sms_contact_ids(owner_user_id="user_c") == []
+    assert service.connections == before
+
+    assert service.remove_sms_contact(owner_user_id="user_a", contact_user_id="user_b") == []
+    assert service.remove_sms_contact(owner_user_id="user_a", contact_user_id="user_b") == []
+    assert service.connections == before
+
+
+def test_sms_contact_rejects_non_connection() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+
+    with pytest.raises(OneLocationAgentError) as err:
+        service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b")
+    assert err.value.code == "LOCATION_SMS_CONTACT_NOT_CONNECTED"
+
+
+def test_sms_grant_fails_closed_until_recipient_is_selected() -> None:
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+    service._seed_connection("user_a", "user_b")
+
+    with pytest.raises(OneLocationAgentError) as err:
+        service.create_grant(
+            owner_user_id="user_a",
+            recipient_user_id="user_b",
+            recipient_key_id="key-user_b",
+            duration_hours=8,
+            reason="Come get me",
+            share_kind="sos",
+            enforce_connection=True,
+        )
+    assert err.value.code == "LOCATION_SMS_CONTACT_REQUIRED"
+
+    service.add_sms_contact(owner_user_id="user_a", contact_user_id="user_b")
+    grant = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=8,
+        reason="Come get me",
+        share_kind="sos",
+        enforce_connection=True,
+    )
+    assert grant["shareKind"] == "sos"
+    assert grant["shareMessage"] == "Come get me"
+    assert service.notifications == []
+
+    service.store_encrypted_envelope(
+        owner_user_id="user_a",
+        grant_id=grant["id"],
+        envelope=encrypted_envelope("key-user_b", "ciphertext"),
+    )
+    assert len(service.notifications) == 1
+    assert service.notifications[0]["title"] == "SMS · Save my soul"
+    assert service.notifications[0]["body"] == "User A: Come get me"

--- a/consent-protocol/tests/test_fcm_messages.py
+++ b/consent-protocol/tests/test_fcm_messages.py
@@ -8,12 +8,25 @@ class _MessagingStub:
             self.body = body
 
     class WebpushNotification:
-        def __init__(self, title=None, body=None, tag=None, require_interaction=None, data=None):
+        def __init__(
+            self,
+            title=None,
+            body=None,
+            tag=None,
+            require_interaction=None,
+            data=None,
+            renotify=None,
+            silent=None,
+            vibrate=None,
+        ):
             self.title = title
             self.body = body
             self.tag = tag
             self.require_interaction = require_interaction
             self.data = data
+            self.renotify = renotify
+            self.silent = silent
+            self.vibrate = vibrate
 
     class WebpushFCMOptions:
         def __init__(self, link=None):
@@ -57,13 +70,48 @@ class _MessagingStub:
             self.headers = headers
             self.payload = payload
 
+    class AndroidNotification:
+        def __init__(
+            self,
+            title=None,
+            body=None,
+            channel_id=None,
+            tag=None,
+            ticker=None,
+            priority=None,
+            visibility=None,
+            vibrate_timings_millis=None,
+        ):
+            self.title = title
+            self.body = body
+            self.channel_id = channel_id
+            self.tag = tag
+            self.ticker = ticker
+            self.priority = priority
+            self.visibility = visibility
+            self.vibrate_timings_millis = vibrate_timings_millis
+
+    class AndroidConfig:
+        def __init__(self, priority=None, notification=None):
+            self.priority = priority
+            self.notification = notification
+
     class Message:
-        def __init__(self, token=None, data=None, notification=None, webpush=None, apns=None):
+        def __init__(
+            self,
+            token=None,
+            data=None,
+            notification=None,
+            webpush=None,
+            apns=None,
+            android=None,
+        ):
             self.token = token
             self.data = data
             self.notification = notification
             self.webpush = webpush
             self.apns = apns
+            self.android = android
 
 
 def test_build_push_message_for_ios_uses_explicit_apns_alert():
@@ -178,6 +226,62 @@ def test_location_notification_name_only_body_reaches_every_platform() -> None:
     assert web.webpush.notification.body == body
     assert ios.notification.body == body
     assert ios.apns.payload.aps.alert.body == body
+
+
+def test_sms_emergency_uses_distinct_cross_platform_alert_profile() -> None:
+    android_delivery_target = "android-device-id"
+    ios_delivery_target = "ios-device-id"
+    web_delivery_target = "web-device-id"
+    data = {
+        "type": "location_share_created",
+        "share_kind": "sos",
+        "notification_profile": "one_location_sms_emergency",
+        "notification_category": "ONE_LOCATION_SMS_EMERGENCY",
+    }
+    common = {
+        "data": data,
+        "title": "SMS · Save my soul",
+        "body": "Alex: Come get me",
+        "request_url": "/one/location?section=shared",
+        "notification_tag": "one-location-share:sms-1",
+        "show_alert": True,
+    }
+
+    android = build_push_message(
+        _MessagingStub,
+        token=android_delivery_target,
+        platform="android",
+        **common,
+    )
+    ios = build_push_message(
+        _MessagingStub,
+        token=ios_delivery_target,
+        platform="ios",
+        **common,
+    )
+    web = build_push_message(
+        _MessagingStub,
+        token=web_delivery_target,
+        platform="web",
+        **common,
+    )
+
+    assert android.android.priority == "high"
+    assert android.android.notification.channel_id == "one_location_sms_emergency_v1"
+    assert android.android.notification.priority == "max"
+    assert android.android.notification.vibrate_timings_millis == [
+        0,
+        240,
+        120,
+        240,
+        120,
+        520,
+    ]
+    assert ios.apns.payload.aps.category == "ONE_LOCATION_SMS_EMERGENCY"
+    assert ios.apns.payload.aps.sound == "one_location_sms_alarm.wav"
+    assert web.webpush.notification.renotify is True
+    assert web.webpush.notification.silent is False
+    assert web.webpush.notification.vibrate == [240, 120, 240, 120, 520]
 
 
 def test_build_push_message_without_alert_is_data_only():

--- a/consent-protocol/tests/test_location_chat_sos_directive.py
+++ b/consent-protocol/tests/test_location_chat_sos_directive.py
@@ -231,8 +231,8 @@ def test_action_result_templates_contain_sos_panic_entries():
     assert ("sos_panic", "cancelled") in _ACTION_RESULT_TEMPLATES, (
         "_ACTION_RESULT_TEMPLATES must have a ('sos_panic', 'cancelled') entry"
     )
-    assert "SOS" in _ACTION_RESULT_TEMPLATES[("sos_panic", "completed")]
-    assert "SOS" in _ACTION_RESULT_TEMPLATES[("sos_panic", "cancelled")]
+    assert "SMS" in _ACTION_RESULT_TEMPLATES[("sos_panic", "completed")]
+    assert "SMS" in _ACTION_RESULT_TEMPLATES[("sos_panic", "cancelled")]
 
 
 # ---------------------------------------------------------------------------

--- a/consent-protocol/tests/test_one_location_list_state_resilience.py
+++ b/consent-protocol/tests/test_one_location_list_state_resilience.py
@@ -62,6 +62,7 @@ def test_list_state_degrades_when_one_section_fails():
         "publicInvites",
         "circleInvites",
         "networkConnections",
+        "smsContactUserIds",
         "publicInviteSubmissions",
         "capabilityScopes",
     ):

--- a/consent-protocol/tests/test_one_location_public_invite_migration.py
+++ b/consent-protocol/tests/test_one_location_public_invite_migration.py
@@ -95,3 +95,22 @@ def test_location_map_presence_migration_is_additive_and_private_by_default() ->
     assert "foreground_map_visible" in sql
     assert "DROP TABLE" not in sql
     assert "DELETE FROM" not in sql
+
+
+def test_sms_contact_migration_is_owner_scoped_and_fails_closed_by_default() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    schema_contract = json.loads(SCHEMA_CONTRACT_PATH.read_text(encoding="utf-8"))
+    migration_name = "116_one_location_sms_contacts.sql"
+    sql = (MIGRATIONS_DIR / migration_name).read_text(encoding="utf-8")
+    rollback = (MIGRATIONS_DIR / "rollback" / "116_one_location_sms_contacts_down.sql").read_text(
+        encoding="utf-8"
+    )
+
+    assert migration_name in manifest["ordered_migrations"]
+    assert migration_name in manifest["groups"]["iam"]
+    assert "one_location_sms_contacts" in schema_contract["required_tables"]
+    assert "PRIMARY KEY (owner_user_id, contact_user_id)" in sql
+    assert "CHECK (owner_user_id <> contact_user_id)" in sql
+    assert "REFERENCES actor_profiles(user_id) ON DELETE CASCADE" in sql
+    assert "INSERT INTO" not in sql
+    assert "DROP TABLE IF EXISTS one_location_sms_contacts" in rollback

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -47,6 +47,38 @@ def _register_key(client: TestClient, user: dict[str, str], user_id: str) -> Non
     assert response.status_code == 200
 
 
+def test_sms_contacts_api_is_owner_scoped_and_idempotent(monkeypatch) -> None:
+    service = FourUserMemoryService()
+    current_user = {"user_id": "user_a"}
+    client = _client(service, current_user, monkeypatch)
+    _register_key(client, current_user, "user_b")
+    service._seed_connection("user_a", "user_b")
+    current_user["user_id"] = "user_a"
+
+    first = client.post(
+        "/api/one/location/sms-contacts",
+        json={"recipientUserId": "user_b"},
+    )
+    second = client.post(
+        "/api/one/location/sms-contacts",
+        json={"recipientUserId": "user_b"},
+    )
+    assert first.status_code == 200
+    assert first.json()["smsContactUserIds"] == ["user_b"]
+    assert second.json()["smsContactUserIds"] == ["user_b"]
+
+    current_user["user_id"] = "user_c"
+    assert client.get("/api/one/location/state").json()["smsContactUserIds"] == []
+
+    current_user["user_id"] = "user_a"
+    removed = client.delete("/api/one/location/sms-contacts/user_b")
+    removed_again = client.delete("/api/one/location/sms-contacts/user_b")
+    assert removed.status_code == 200
+    assert removed.json()["smsContactUserIds"] == []
+    assert removed_again.json()["smsContactUserIds"] == []
+    assert service.connections
+
+
 def test_four_user_one_location_api_flow_is_authenticated_and_ciphertext_only(monkeypatch) -> None:
     service = FourUserMemoryService()
     current_user = {"user_id": "user_a"}

--- a/contracts/agents/product-agent-registry.v2.json
+++ b/contracts/agents/product-agent-registry.v2.json
@@ -25,7 +25,7 @@
       "id": "agent_connected_systems",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/connected_systems/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\connected_systems\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Connected Systems Agent",
@@ -162,7 +162,7 @@
       "id": "agent_connections",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/connections/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\connections\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Connections Agent",
@@ -244,7 +244,7 @@
       "id": "agent_email",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/email/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\email\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Email Agent",
@@ -331,7 +331,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/financial_guard/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\financial_guard\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Financial Guard Agent",
@@ -419,7 +419,7 @@
       "id": "agent_gmail",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/gmail/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\gmail\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Gmail Agent",
@@ -511,7 +511,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/kai/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\kai\\agent.yaml",
       "manifest_version": 2,
       "model": {
         "credential_ref": null,
@@ -729,7 +729,7 @@
       "id": "agent_kyc",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/kyc/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\kyc\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Agent KYC",
@@ -819,7 +819,7 @@
       "id": "agent_location",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/location/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\location\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Location Agent",
@@ -875,7 +875,7 @@
         "voice": false,
         "web": false
       },
-      "system_instruction_sha256": "f2e78483e77eb1cc699cebf011420de1e9ce32d01d28a93561d86050b0e33b99",
+      "system_instruction_sha256": "74316966e7e3c618945a9bb56d59d235c4ead0e159cb8cbed3405206b8a671da",
       "telemetry_namespace": "agent.unclassified",
       "tools": [
         {
@@ -957,7 +957,7 @@
           "required_scope": "cap.location.live.share"
         },
         {
-          "description": "Propose an emergency SOS broadcast to all ready trusted contacts; the browser creates grants, encrypts, and publishes.",
+          "description": "Propose a Save My Soul alert to the user's selected, ready SMS contacts; the browser creates grants, encrypts, and publishes.",
           "name": "propose_sos_panic",
           "py_func": "hushh_mcp.agents.location.tools.propose_sos_panic",
           "required_scope": "cap.location.live.share"
@@ -1056,7 +1056,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/memory_intent/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\memory_intent\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Memory Intent Agent",
@@ -1204,7 +1204,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/memory_merge/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\memory_merge\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Memory Merge Agent",
@@ -1332,7 +1332,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/memory_segmentation/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\memory_segmentation\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Memory Segmentation Agent",
@@ -1431,7 +1431,7 @@
       "id": "agent_nav",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/nav/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\nav\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Consent Center Agent",
@@ -1528,7 +1528,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/onboarding/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\onboarding\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Onboarding Specialist",
@@ -1647,7 +1647,7 @@
       "legacy_ids": [
         "agent_orchestrator"
       ],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/one/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\one\\agent.yaml",
       "manifest_version": 2,
       "model": {
         "credential_ref": null,
@@ -1736,7 +1736,7 @@
       "id": "agent_personal_information",
       "inputs": [],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/personal_information/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\personal_information\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Information Marketplace",
@@ -1889,7 +1889,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/pkm_structure/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\pkm_structure\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "PKM Structure Agent",
@@ -2012,7 +2012,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/portfolio_import/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\portfolio_import\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.6-flash",
       "name": "Portfolio Import Agent",
@@ -2148,7 +2148,7 @@
         }
       ],
       "legacy_ids": [],
-      "manifest_path": "consent-protocol/hushh_mcp/agents/summary_reducer/agent.yaml",
+      "manifest_path": "consent-protocol\\hushh_mcp\\agents\\summary_reducer\\agent.yaml",
       "manifest_version": 2,
       "model": "gemini-3.1-flash-lite",
       "name": "PKM Summary Reducer",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4188,7 +4188,7 @@
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "afac5b3a07a1ec2e6ab4f87231b37edb81a0d771daae2cf4900dd6fb9a35f049",
-    "agent_registry": "2f55a5b5d8751ddda35340826a575d32bccc37132e3812a27ae270d3dbcf966d",
+    "agent_registry": "7cd4e5facd8671943c46de4e91cfe306160f4322b9bdc020d305c4145e88145f",
     "cache_manifest": "2cdf307a25efe39a9635368fe20550614724dfa7e46f57b65119c02eb07ed9d8",
     "data_plane": "2450e780a874943549dfd6c5abb5c83eca1dee1222e70e26244e17b0bb1a83f2",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -856,12 +856,13 @@
         "one_location_public_invites",
         "one_location_recipient_keys",
         "one_location_referrals",
+        "one_location_sms_contacts",
         "one_location_share_grants"
       ],
       "id": "one_location_agent",
       "lifecycle_status": "current",
       "owner": "iam-consent-governance",
-      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit"
+      "primary_access_path": "One Location Agent verified-recipient directory, owner-selected Save My Soul contacts, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit"
     },
     {
       "data_class": "personal_projection",
@@ -4187,9 +4188,9 @@
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "afac5b3a07a1ec2e6ab4f87231b37edb81a0d771daae2cf4900dd6fb9a35f049",
-    "agent_registry": "709b9c535294795e9c742993f45eaf6e6d0bf6d60f9c8d0e88118c63aa811577",
+    "agent_registry": "2f55a5b5d8751ddda35340826a575d32bccc37132e3812a27ae270d3dbcf966d",
     "cache_manifest": "2cdf307a25efe39a9635368fe20550614724dfa7e46f57b65119c02eb07ed9d8",
-    "data_plane": "65c1849b0757a65887e6d0950a4045bc28dc4fbaae0bb3e053f268e838f8d299",
+    "data_plane": "2450e780a874943549dfd6c5abb5c83eca1dee1222e70e26244e17b0bb1a83f2",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
     "route_index": "136444f22def3c00a9e0baa323b42074072dd8b17802f1f1644fd00fc12e74d2",

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -188,6 +188,8 @@ not the product owner for live location.
 | Method | Path | Auth | Description |
 | ------ | ---- | ---- | ----------- |
 | GET | `/api/one/location/state` | VAULT_OWNER Bearer | List verified recipient directory, owner grants, received grants, pending requests, and referrals for the authenticated user |
+| POST | `/api/one/location/sms-contacts` | VAULT_OWNER Bearer | Idempotently add an active, location-ready connection to the authenticated owner's Save My Soul contacts |
+| DELETE | `/api/one/location/sms-contacts/{recipient_user_id}` | VAULT_OWNER Bearer | Idempotently remove one owner-scoped Save My Soul contact without changing the underlying connection |
 | GET | `/api/one/location/recipients` | VAULT_OWNER Bearer | List phone-verified users excluding self, with masked labels and active public key metadata only |
 | POST | `/api/one/location/recipient-keys` | VAULT_OWNER Bearer | Register the authenticated user's recipient public key; private key remains device-local |
 | POST | `/api/one/location/public-invites` | VAULT_OWNER Bearer | Create a duration-bounded public request link; the raw token is returned once and only its hash is stored |

--- a/docs/reference/architecture/api-contracts.md
+++ b/docs/reference/architecture/api-contracts.md
@@ -182,6 +182,17 @@ ciphertext, movement trails, raw owner identity, or reverse-geocoded enrichment.
 The maintained architecture reference is
 [One Location Agent](./one-location-agent.md).
 
+Save My Soul grants preserve the ordinary `location_share_created` notification
+contract and add emergency presentation metadata when `share_kind=sos`:
+`notification_profile=one_location_sms_emergency` and
+`notification_category=ONE_LOCATION_SMS_EMERGENCY`. Clients must recognize the
+explicit profile and retain `share_kind=sos` as a compatibility fallback.
+Presentation is intentionally platform-specific: the visible web/native shell
+uses the shared red alarm card, Android routes through the dedicated
+`one_location_sms_emergency_v1` high-importance channel, and iOS background
+delivery uses the matching category plus `one_location_sms_alarm.wav`. The
+profile does not authorize Do Not Disturb bypass or Apple Critical Alerts.
+
 The older KAI location route family is transitional prototype history and is
 not the product owner for live location.
 

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -367,11 +367,12 @@
         "one_location_public_invites",
         "one_location_recipient_keys",
         "one_location_referrals",
+        "one_location_sms_contacts",
         "one_location_share_grants"
       ],
-      "primary_access_path": "One Location Agent verified-recipient directory, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit",
+      "primary_access_path": "One Location Agent verified-recipient directory, owner-selected Save My Soul contacts, recipient public key registration, owner-approved grants, encrypted envelope writes, authenticated recipient ciphertext reads, public request invites, Invite to One network onboarding, referrals, revocation, expiry, and metadata-only audit",
       "retention_policy": "Active grants and ciphertext envelopes are short-lived by scoped duration; expired or terminal workflow rows are retained only for bounded operational review before compaction.",
-      "deletion_behavior": "Delete rows where the deleting account is owner, recipient, requester, referrer, referred user, or key owner; revoke active grants before deletion where possible.",
+      "deletion_behavior": "Delete rows where the deleting account is owner, SMS contact, recipient, requester, referrer, referred user, or key owner; revoke active grants before deletion where possible.",
       "trust_boundary": "Coordinates exist only on owner and recipient devices. Backend stores recipient public keys, grant metadata, ciphertext envelopes, public invite token hashes, Invite to One token hashes, One Network connection metadata, request metadata, hashed public-intake throttling metadata, and audit metadata; it must not store latitude, longitude, addresses, map previews, movement trails, or raw public tokens. Public invite links can request access or reveal only an explicit public snapshot; Invite to One links create metadata-only network readiness and never reveal private grants, ciphertext, or owner identity beyond a safe label.",
       "plaintext_posture": "ciphertext_coordinates_and_metadata_only",
       "expected_row_growth": "medium_per_user_share"

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -841,7 +841,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.getByTestId("one-location-onboarding-features")).toBeTruthy();
     await waitFor(() => expect(mockOpenAppSettings).toHaveBeenCalled());
     expect(
-      screen.getByRole("button", { name: "Allow location" }),
+      screen.getByRole("button", { name: "Continue" }),
     ).toBeEnabled();
     expect(onSetupComplete).not.toHaveBeenCalled();
   });

--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -125,9 +125,21 @@ describe("OneLocationOnboardingFlow", () => {
     ).firstElementChild;
     expect(featureSurface?.className).toContain("overflow-hidden");
     expect(featureSurface?.className).toContain("flex-col");
+    expect(featureSurface?.className).toContain("bg-[#f5f5f7]");
+    expect(featureSurface?.className).toContain("pl-6");
+    expect(featureSurface?.className).toContain("pr-5");
+    expect(featureSurface?.className).toContain(
+      "pt-[max(env(safe-area-inset-top,0px),55px)]",
+    );
     expect(
       document.querySelector("[data-one-feature-grid]")?.className,
     ).toContain("grid-rows-3");
+    expect(
+      document.querySelector("[data-one-feature-grid]")?.className,
+    ).toContain("mt-[18px]");
+    expect(
+      document.querySelector("[data-one-feature-cta] button")?.className,
+    ).toContain("h-[52px]");
     for (const card of document.querySelectorAll("[data-one-use-case-card]")) {
       expect(card.className).toContain("h-full");
       expect(card.className).toContain("min-h-0");
@@ -149,19 +161,21 @@ describe("OneLocationOnboardingFlow", () => {
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
-        name: "Need help, but can't call or speak?",
+        name: "Need help, but can’t call or speak?",
       }),
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
-        name: 'Still answering "Where are you?"',
+        name: "Still answering “Where are you?”",
       }),
     ).toBeTruthy();
     expect(
       screen.getByRole("heading", {
-        name: "Meeting up, but can't find each other?",
+        name: "Meeting up, but can’t find each other?",
       }),
     ).toBeTruthy();
+    expect(screen.getByText("SMS · Save my soul")).toBeTruthy();
+    expect(screen.getByText("Shared securely")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Go back" })).toBeTruthy();
     expect(
       screen
@@ -207,8 +221,8 @@ describe("OneLocationOnboardingFlow", () => {
     const props = renderFlow({ requireLocationToComplete: true });
 
     fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-    expect(screen.getByRole("button", { name: "Allow location" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Allow location" }));
+    expect(screen.getByRole("button", { name: "Continue" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
     expect(props.onRequestLocation).toHaveBeenCalledTimes(2);
     expect(screen.getByTestId("one-location-onboarding-features")).toBeTruthy();

--- a/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
@@ -13,17 +13,24 @@ const HUB_SOURCE = fs.readFileSync(
   ),
   "utf8",
 );
+const SMS_PANEL_SOURCE = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "../../components/one-location/redesign/sos-panel.tsx",
+  ),
+  "utf8",
+);
 
-describe("One Location SOS emergency actions", () => {
-  it("keeps one local emergency row that opens the device dialer", () => {
+describe("One Location SMS emergency actions", () => {
+  it("opens the US 911 dialer only after an explicit user tap", () => {
     render(<LocalEmergencyDialerRow />);
 
     expect(
-      screen.getByRole("link", { name: "Open local emergency dialer" }),
-    ).toHaveAttribute("href", "tel:");
-    expect(screen.getByText("Local Emergency")).toBeInTheDocument();
-    expect(screen.getByText("Open your phone dialer")).toBeInTheDocument();
-    expect(HUB_SOURCE.match(/<LocalEmergencyDialerRow \/>/g)).toHaveLength(1);
+      screen.getByRole("link", { name: "Call 911" }),
+    ).toHaveAttribute("href", "tel:911");
+    expect(screen.getByText("Emergency services")).toBeInTheDocument();
+    expect(screen.getByText("United States")).toBeInTheDocument();
+    expect(SMS_PANEL_SOURCE).toContain('href="tel:911"');
   });
 
   it("does not advertise unimplemented SOS support actions", () => {

--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -221,6 +221,56 @@ describe("global One Location notification provider", () => {
     );
   });
 
+  it("renders emergency SMS as a persistent alarm popup and keeps its alert metadata", async () => {
+    renderProvider();
+    await waitFor(() => expect(mocks.initializeFCM).toHaveBeenCalledOnce());
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("fcm-message", {
+          detail: {
+            notification: {
+              title: "SMS · Save my soul",
+              body: "Alex: Come get me",
+            },
+            data: {
+              type: "location_share_created",
+              grant_id: "grant-sms-emergency-1",
+              owner_display_label: "Alex",
+              share_kind: "sos",
+              share_message: "Come get me",
+              notification_profile: "one_location_sms_emergency",
+              notification_category: "ONE_LOCATION_SMS_EMERGENCY",
+            },
+          },
+        }),
+      );
+    });
+
+    expect(mocks.toast).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        duration: 30000,
+        className: expect.stringContaining("one-location-emergency-toast"),
+      }),
+    );
+    const popup = mocks.toast.mock.calls[0]?.[0] as ReactNode;
+    render(<>{popup}</>);
+    expect(screen.getByRole("alert")).toHaveAttribute(
+      "data-one-location-emergency-sms-alert",
+    );
+    expect(screen.getByText("Emergency SMS")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /open live location/i }),
+    ).toBeInTheDocument();
+    expect(mocks.startTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "one_location_share:grant-sms-emergency-1",
+        metadata: expect.objectContaining({ shareKind: "sos" }),
+      }),
+    );
+  });
+
   it("queues a foreground push received during auth hydration and drains it once for the matching user", async () => {
     mocks.auth.user = null;
     const view = renderProvider();

--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -212,6 +212,16 @@ describe("global One Location notification provider", () => {
     });
 
     expect(mocks.toast).toHaveBeenCalledTimes(1);
+    expect(mocks.toast.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        duration: 10000,
+        className: undefined,
+      }),
+    );
+    const popup = mocks.toast.mock.calls[0]?.[0] as ReactNode;
+    render(<>{popup}</>);
+    expect(screen.getByRole("button", { name: "Open" })).toBeInTheDocument();
+    expect(screen.queryByText("Emergency SMS")).not.toBeInTheDocument();
     expect(mocks.startTask).toHaveBeenCalledTimes(1);
     expect(mocks.startTask).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
+++ b/hushh-webapp/__tests__/consent-notification-provider-location.test.tsx
@@ -251,18 +251,21 @@ describe("global One Location notification provider", () => {
     expect(mocks.toast.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
         duration: 30000,
-        className: expect.stringContaining("one-location-emergency-toast"),
+        className: expect.stringMatching(
+          /one-location-emergency-toast.*!bg-red-600.*!text-white/,
+        ),
       }),
     );
     const popup = mocks.toast.mock.calls[0]?.[0] as ReactNode;
     render(<>{popup}</>);
-    expect(screen.getByRole("alert")).toHaveAttribute(
-      "data-one-location-emergency-sms-alert",
-    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveAttribute("data-one-location-emergency-sms-alert");
+    expect(alert).toHaveClass("text-white");
     expect(screen.getByText("Emergency SMS")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /open live location/i }),
-    ).toBeInTheDocument();
+    const viewLocationButton = screen.getByRole("button", {
+      name: /view live location/i,
+    });
+    expect(viewLocationButton).toHaveClass("bg-white", "text-red-700");
     expect(mocks.startTask).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: "one_location_share:grant-sms-emergency-1",

--- a/hushh-webapp/__tests__/firebase-messaging-service-worker.test.ts
+++ b/hushh-webapp/__tests__/firebase-messaging-service-worker.test.ts
@@ -11,7 +11,7 @@ type ServiceWorkerHandler = (event: {
 
 function createHarness(options: { acknowledgeVisibleDelivery: boolean }) {
   const handlers = new Map<string, ServiceWorkerHandler>();
-  const shown: string[] = [];
+  const shown: Array<{ title: string; options?: Record<string, unknown> }> = [];
   const serviceWorker = {
     __HUSHH_FCM_ACK_TIMEOUT_MS__: 5,
     clients: {
@@ -19,7 +19,8 @@ function createHarness(options: { acknowledgeVisibleDelivery: boolean }) {
         {
           visibilityState: "visible",
           postMessage: (payload: { delivery_id?: string }) => {
-            if (!options.acknowledgeVisibleDelivery || !payload.delivery_id) return;
+            if (!options.acknowledgeVisibleDelivery || !payload.delivery_id)
+              return;
             queueMicrotask(() => {
               handlers.get("message")?.({
                 data: {
@@ -34,8 +35,11 @@ function createHarness(options: { acknowledgeVisibleDelivery: boolean }) {
       openWindow: async () => undefined,
     },
     registration: {
-      showNotification: async (title: string) => {
-        shown.push(title);
+      showNotification: async (
+        title: string,
+        notificationOptions?: Record<string, unknown>,
+      ) => {
+        shown.push({ title, options: notificationOptions });
       },
     },
     addEventListener: (type: string, handler: ServiceWorkerHandler) => {
@@ -58,13 +62,13 @@ function createHarness(options: { acknowledgeVisibleDelivery: boolean }) {
 
   return {
     shown,
-    async push(type: string) {
+    async push(type: string, data: Record<string, string> = { type }) {
       let pending = Promise.resolve();
       handlers.get("push")?.({
         data: {
           json: () => ({
             notification: { title: type, body: "body" },
-            data: { type },
+            data,
           }),
         },
         waitUntil: (promise) => {
@@ -86,12 +90,35 @@ describe("Firebase messaging service-worker foreground ownership", () => {
   it("falls back to the system banner when the visible app does not acknowledge", async () => {
     const harness = createHarness({ acknowledgeVisibleDelivery: false });
     await harness.push("location_share_created");
-    expect(harness.shown).toEqual(["location_share_created"]);
+    expect(harness.shown.map((item) => item.title)).toEqual([
+      "location_share_created",
+    ]);
   });
 
   it("keeps system delivery for notification families not rendered by the provider", async () => {
     const harness = createHarness({ acknowledgeVisibleDelivery: true });
     await harness.push("kai_analysis_complete");
-    expect(harness.shown).toEqual(["kai_analysis_complete"]);
+    expect(harness.shown.map((item) => item.title)).toEqual([
+      "kai_analysis_complete",
+    ]);
+  });
+
+  it("uses a persistent vibrating system alert for background emergency SMS", async () => {
+    const harness = createHarness({ acknowledgeVisibleDelivery: false });
+    await harness.push("location_share_created", {
+      type: "location_share_created",
+      share_kind: "sos",
+      notification_profile: "one_location_sms_emergency",
+    });
+
+    expect(harness.shown[0]).toEqual({
+      title: "location_share_created",
+      options: expect.objectContaining({
+        requireInteraction: true,
+        renotify: true,
+        silent: false,
+        vibrate: [240, 120, 240, 120, 520],
+      }),
+    });
   });
 });

--- a/hushh-webapp/__tests__/lib/one-location-state-resource.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location-state-resource.test.ts
@@ -55,4 +55,35 @@ describe("OneLocationStateResource", () => {
     expect(OneLocationStateResource.peek(userId)?.data).toBe(snapshot);
     expect(OneLocationStateResource.peek("another-owner")).toBeNull();
   });
+
+  it("publishes SMS membership immediately and rejects an older in-flight snapshot", async () => {
+    const userId = "location-resource-owner";
+    const initial = {
+      recipients: [],
+      smsContactUserIds: ["selected"],
+    } as unknown as OneLocationState;
+    OneLocationStateResource.write(userId, initial);
+
+    let resolve!: (state: OneLocationState) => void;
+    const staleLoad = OneLocationStateResource.load(
+      userId,
+      () =>
+        new Promise<OneLocationState>((done) => {
+          resolve = done;
+        }),
+    );
+
+    expect(OneLocationStateResource.replaceSmsContactUserIds(userId, [])).toBe(
+      true,
+    );
+    expect(
+      OneLocationStateResource.peek(userId)?.data.smsContactUserIds,
+    ).toEqual([]);
+
+    resolve(initial);
+    await staleLoad;
+    expect(
+      OneLocationStateResource.peek(userId)?.data.smsContactUserIds,
+    ).toEqual([]);
+  });
 });

--- a/hushh-webapp/__tests__/navigation/home-shell-contract.test.ts
+++ b/hushh-webapp/__tests__/navigation/home-shell-contract.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { resolveTopShellMetrics } from "@/components/app-ui/top-shell-metrics";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
-import { resolveAppRouteLayout } from "@/lib/navigation/app-route-layout";
+import {
+  resolveAppRouteLayout,
+  shouldSuppressPersistentChromeForRouteState,
+} from "@/lib/navigation/app-route-layout";
 import { ROUTES } from "@/lib/navigation/routes";
 
 describe("home shell contract", () => {
@@ -28,6 +31,21 @@ describe("home shell contract", () => {
     expect(resolveTopShellMetrics(ROUTES.RIA_PICKS).hasTabs).toBe(true);
     expect(resolveTopShellMetrics(ROUTES.PROFILE).hasTabs).toBe(false);
     expect(resolveTopShellMetrics(ROUTES.CONNECT).hasTabs).toBe(false);
+  });
+
+  it("suppresses persistent chrome only for immersive SMS safety surfaces", () => {
+    expect(
+      shouldSuppressPersistentChromeForRouteState(ROUTES.ONE_LOCATION, "sos"),
+    ).toBe(true);
+    expect(
+      shouldSuppressPersistentChromeForRouteState(
+        ROUTES.ONE_LOCATION,
+        "sms-contacts",
+      ),
+    ).toBe(true);
+    expect(
+      shouldSuppressPersistentChromeForRouteState(ROUTES.ONE_LOCATION, "share"),
+    ).toBe(false);
   });
 
   it("keeps auth-only routes out of the shared command surface", () => {

--- a/hushh-webapp/__tests__/notifications/one-location-sms-emergency-native.contract.test.ts
+++ b/hushh-webapp/__tests__/notifications/one-location-sms-emergency-native.contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const androidPlugin = readFileSync(
+  join(
+    process.cwd(),
+    "android/app/src/main/java/com/hushh/app/plugins/HushhNotifications/HushhNotificationsPlugin.kt",
+  ),
+  "utf8",
+);
+const iosAppDelegate = readFileSync(
+  join(process.cwd(), "ios/App/App/AppDelegate.swift"),
+  "utf8",
+);
+
+describe("One Location emergency SMS native notification contract", () => {
+  it("keeps the Android alarm channel aligned with the backend payload", () => {
+    expect(androidPlugin).toContain(
+      'EMERGENCY_SMS_CHANNEL_ID = "one_location_sms_emergency_v1"',
+    );
+    expect(androidPlugin).toContain("NotificationManager.IMPORTANCE_HIGH");
+    expect(androidPlugin).toContain("AudioAttributes.USAGE_ALARM");
+    expect(androidPlugin).toContain("longArrayOf(0, 240, 120, 240, 120, 520)");
+    expect(androidPlugin).toContain("setBypassDnd(false)");
+  });
+
+  it("keeps the iOS category and custom alarm sound aligned with APNs", () => {
+    expect(iosAppDelegate).toContain(
+      'emergencySmsNotificationCategory = "ONE_LOCATION_SMS_EMERGENCY"',
+    );
+    expect(iosAppDelegate).toContain(
+      'emergencySmsProfile = "one_location_sms_emergency"',
+    );
+    expect(iosAppDelegate).toContain(
+      'emergencySmsSound = "one_location_sms_alarm.wav"',
+    );
+    expect(iosAppDelegate).toContain("prepareEmergencySmsSound()");
+    expect(iosAppDelegate).toContain("completionHandler([.badge])");
+  });
+});

--- a/hushh-webapp/__tests__/one-location-notification-reconciliation.test.ts
+++ b/hushh-webapp/__tests__/one-location-notification-reconciliation.test.ts
@@ -110,6 +110,39 @@ function stateFixture(): OneLocationState {
 }
 
 describe("One Location global notification reconciliation", () => {
+  it("waits for the first encrypted envelope before surfacing SMS", () => {
+    const state = stateFixture();
+    state.receivedGrants = [
+      {
+        ...state.receivedGrants[0],
+        id: "sms-pending-envelope",
+        shareKind: "sos",
+        shareMessage: "Come get me",
+        latestEnvelopeId: null,
+      },
+    ];
+
+    expect(
+      buildOneLocationNotificationPayloads(state, USER_ID).filter(
+        (payload) => payload.type === "location_share_created",
+      ),
+    ).toEqual([]);
+
+    state.receivedGrants[0]!.latestEnvelopeId = "envelope-1";
+    expect(
+      buildOneLocationNotificationPayloads(state, USER_ID).filter(
+        (payload) => payload.type === "location_share_created",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "location_share_created",
+        grant_id: "sms-pending-envelope",
+        share_kind: "sos",
+        share_message: "Come get me",
+      }),
+    ]);
+  });
+
   it("reconstructs every user-facing workflow without visiting the Location page", () => {
     const payloads = buildOneLocationNotificationPayloads(stateFixture(), USER_ID);
     expect(payloads.map((payload) => payload.type)).toEqual(

--- a/hushh-webapp/__tests__/one-location-notification-reconciliation.test.ts
+++ b/hushh-webapp/__tests__/one-location-notification-reconciliation.test.ts
@@ -139,12 +139,17 @@ describe("One Location global notification reconciliation", () => {
         grant_id: "sms-pending-envelope",
         share_kind: "sos",
         share_message: "Come get me",
+        notification_profile: "one_location_sms_emergency",
+        notification_category: "ONE_LOCATION_SMS_EMERGENCY",
       }),
     ]);
   });
 
   it("reconstructs every user-facing workflow without visiting the Location page", () => {
-    const payloads = buildOneLocationNotificationPayloads(stateFixture(), USER_ID);
+    const payloads = buildOneLocationNotificationPayloads(
+      stateFixture(),
+      USER_ID,
+    );
     expect(payloads.map((payload) => payload.type)).toEqual(
       expect.arrayContaining([
         "location_share_created",
@@ -165,7 +170,9 @@ describe("One Location global notification reconciliation", () => {
       share_message: "Reached safely",
     });
     expect(
-      payloads.find((payload) => payload.type === "location_one_network_joined"),
+      payloads.find(
+        (payload) => payload.type === "location_one_network_joined",
+      ),
     ).toMatchObject({
       connection_id: "connection-1",
       network_display_label: "Alex",
@@ -213,7 +220,9 @@ describe("One Location global notification reconciliation", () => {
           payload.grant_id === "grant-direct",
       ),
     ).toBe(false);
-    expect(payloads.some((payload) => payload.grant_id === "grant-old-revoked")).toBe(false);
+    expect(
+      payloads.some((payload) => payload.grant_id === "grant-old-revoked"),
+    ).toBe(false);
     expect(payloads).toContainEqual(
       expect.objectContaining({
         type: "location_share_expired",

--- a/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhNotifications/HushhNotificationsPlugin.kt
+++ b/hushh-webapp/android/app/src/main/java/com/hushh/app/plugins/HushhNotifications/HushhNotificationsPlugin.kt
@@ -1,11 +1,20 @@
 package com.hushh.app.plugins.HushhNotifications
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.graphics.Color
+import android.media.AudioAttributes
+import android.media.RingtoneManager
+import android.os.Build
 import android.util.Log
 import com.getcapacitor.JSObject
 import com.getcapacitor.Plugin
 import com.getcapacitor.PluginCall
 import com.getcapacitor.PluginMethod
 import com.getcapacitor.annotation.CapacitorPlugin
+import com.hushh.app.R
 import com.hushh.app.plugins.shared.BackendUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -31,11 +40,55 @@ class HushhNotificationsPlugin : Plugin() {
 
     private val TAG = "HushhNotifications"
 
+    override fun load() {
+        super.load()
+        ensureEmergencySmsChannel(context)
+    }
+
+    private fun ensureEmergencySmsChannel(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val manager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+                ?: return
+        if (manager.getNotificationChannel(EMERGENCY_SMS_CHANNEL_ID) != null) return
+
+        val alarmSound =
+            RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+                ?: RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val audioAttributes =
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_ALARM)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .build()
+        val channel =
+            NotificationChannel(
+                EMERGENCY_SMS_CHANNEL_ID,
+                context.getString(R.string.sms_emergency_channel_name),
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = context.getString(R.string.sms_emergency_channel_description)
+                enableVibration(true)
+                vibrationPattern = longArrayOf(0, 240, 120, 240, 120, 520)
+                enableLights(true)
+                lightColor = Color.RED
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                setBypassDnd(false)
+                setSound(alarmSound, audioAttributes)
+            }
+        manager.createNotificationChannel(channel)
+        Log.i(TAG, "Emergency SMS notification channel ready")
+    }
+
     private val httpClient = OkHttpClient.Builder()
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
         .writeTimeout(30, TimeUnit.SECONDS)
         .build()
+
+    companion object {
+        const val EMERGENCY_SMS_CHANNEL_ID = "one_location_sms_emergency_v1"
+    }
 
     private fun getBackendUrl(call: PluginCall? = null): String {
         return BackendUrl.resolve(bridge, call, "HushhNotifications")

--- a/hushh-webapp/android/app/src/main/res/values/strings.xml
+++ b/hushh-webapp/android/app/src/main/res/values/strings.xml
@@ -4,5 +4,7 @@
     <string name="title_activity_main">Hussh One</string>
     <string name="package_name">com.hushh.app</string>
     <string name="custom_url_scheme">com.hushh.app</string>
+    <string name="sms_emergency_channel_name">Emergency SMS alerts</string>
+    <string name="sms_emergency_channel_description">Urgent Save My Soul alerts from your selected contacts</string>
     <string name="asset_statements" translatable="false">[{\"include\":\"https://one.hushh.ai/.well-known/assetlinks.json\"}]</string>
 </resources>

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -159,6 +159,7 @@ import {
 import {
   isSosShareReadyRecipient,
   runSosPanic,
+  selectSmsRecipients,
   selectShareReadyRecipients,
   SosPanicError,
 } from "@/lib/one-location/sos-trigger";
@@ -279,6 +280,7 @@ type BusyState =
   | "publicRevoke"
   | "circleInvite"
   | "circleRevoke"
+  | `sms-contact:${string}`
   | null;
 
 type OneLocationSelectionSurface =
@@ -1991,6 +1993,14 @@ export function OneLocationAgentPageContent({
     () => selectShareReadyRecipients(rankedRecipients),
     [rankedRecipients],
   );
+  const smsContactUserIds = useMemo(
+    () => state?.smsContactUserIds ?? [],
+    [state?.smsContactUserIds],
+  );
+  const smsActionRecipients = useMemo(
+    () => selectSmsRecipients(sosActionRecipients, smsContactUserIds),
+    [smsContactUserIds, sosActionRecipients],
+  );
 
   // Ref kept in sync with the latest sosIncident value so the reconcile effect
   // can read it without adding it as a dependency (preventing infinite loops).
@@ -2983,16 +2993,20 @@ export function OneLocationAgentPageContent({
     vaultOwnerToken,
   ]);
 
-  const handleTriggerSos = useCallback(async () => {
+  const handleTriggerSos = useCallback(async (
+    note?: "Come get me" | "I'm not safe" | null,
+  ) => {
     if (sosIncident) return; // re-entry guard: never overwrite/orphan an active incident
     if (!vaultOwnerToken || locationPermissionBlocksSharing(permission)) return;
-    const readyRecipients = sosActionRecipients.filter(
+    const readyRecipients = smsActionRecipients.filter(
       isSosShareReadyRecipient,
     );
-    const totalTrusted = sosActionRecipients.length;
+    const totalSelected = smsActionRecipients.length;
     if (!readyRecipients.length) {
       toast.error(
-        "No trusted contacts are ready to receive your location yet.",
+        totalSelected
+          ? "Your SMS contacts are not ready to receive location yet."
+          : "Add at least one SMS contact before sending an alert.",
       );
       return;
     }
@@ -3004,7 +3018,7 @@ export function OneLocationAgentPageContent({
       });
       if (!readiness.ready || !readiness.point) {
         toast.error(
-          "Couldn't get your location — SOS not sent. Check location permissions.",
+          "Couldn't get your location — SMS not sent. Check location permissions.",
         );
         return;
       }
@@ -3013,15 +3027,16 @@ export function OneLocationAgentPageContent({
         vaultOwnerToken,
         recipients: readyRecipients,
         point,
+        note,
         publish: (grant, recipient, pt) =>
           publishEnvelopeWithRetry(grant, recipient, "manual", pt),
       });
       setSosIncident(incident);
-      const skipped = totalTrusted - readyRecipients.length;
+      const skipped = totalSelected - readyRecipients.length;
       toast.success(
         skipped > 0
-          ? `SOS sent. Alerted ${readyRecipients.length} of ${totalTrusted} contacts (${skipped} not ready).`
-          : `SOS sent. Alerting ${readyRecipients.length} trusted contact(s).`,
+          ? `SMS sent to ${readyRecipients.length} of ${totalSelected} contacts (${skipped} not ready).`
+          : `SMS sent to ${readyRecipients.length} contact(s).`,
       );
       await refresh();
     } catch (error) {
@@ -3031,7 +3046,7 @@ export function OneLocationAgentPageContent({
         setSosIncident(error.partialIncident);
       }
       toast.error(
-        error instanceof Error ? error.message : "Could not send SOS alert.",
+        error instanceof Error ? error.message : "Could not send SMS alert.",
       );
     } finally {
       setBusy(null);
@@ -3040,11 +3055,57 @@ export function OneLocationAgentPageContent({
     ensureForegroundLocationReady,
     permission,
     publishEnvelopeWithRetry,
-    sosActionRecipients,
+    smsActionRecipients,
     refresh,
     sosIncident,
     vaultOwnerToken,
   ]);
+
+  const handleAddSmsContact = useCallback(
+    async (recipientUserId: string) => {
+      if (!vaultOwnerToken || busy) return;
+      setBusy(`sms-contact:${recipientUserId}`);
+      try {
+        await OneLocationService.addSmsContact({
+          vaultOwnerToken,
+          recipientUserId,
+        });
+        await refresh();
+        toast.success("SMS contact added.");
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Could not add SMS contact.",
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, refresh, vaultOwnerToken],
+  );
+
+  const handleRemoveSmsContact = useCallback(
+    async (recipientUserId: string) => {
+      if (!vaultOwnerToken || busy) return;
+      setBusy(`sms-contact:${recipientUserId}`);
+      try {
+        await OneLocationService.removeSmsContact({
+          vaultOwnerToken,
+          recipientUserId,
+        });
+        await refresh();
+        toast.success("SMS contact removed.");
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not remove SMS contact.",
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, refresh, vaultOwnerToken],
+  );
 
   const handlePublish = useCallback(
     async (grant: OneLocationGrant) => {
@@ -3631,7 +3692,7 @@ export function OneLocationAgentPageContent({
     // subsequent refresh() failure cannot trigger a misleading "Could not stop" toast.
     clearSosIncident();
     setSosIncident(null);
-    toast.success("SOS ended. Live location sharing stopped.");
+    toast.success("SMS ended. Live location sharing stopped.");
     try {
       await refresh();
     } catch {
@@ -5395,6 +5456,9 @@ export function OneLocationAgentPageContent({
     mapLocationHref: googleMapsLocationUrl,
     decryptedPoints,
     sosRecipients: sosActionRecipients,
+    smsRecipients: smsActionRecipients,
+    smsContactCandidates: sosActionRecipients,
+    smsContactUserIds,
     sosActive: Boolean(sosIncident?.grantIds.length),
     sosBusy: busy === "sos",
     sosStartedAtLabel: sosIncident
@@ -5402,6 +5466,10 @@ export function OneLocationAgentPageContent({
       : null,
     onTriggerSos: handleTriggerSos,
     onStopSos: handleStopSos,
+    onAddSmsContact: (recipientUserId) =>
+      void handleAddSmsContact(recipientUserId),
+    onRemoveSmsContact: (recipientUserId) =>
+      void handleRemoveSmsContact(recipientUserId),
     onCheckIn: (recipientIds, durationHoursValue, messageValue) =>
       void handleCheckIn(recipientIds, durationHoursValue, messageValue),
   };

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1761,7 +1761,9 @@ export function OneLocationAgentPageContent({
     }
   }, [auth.userId, vaultOwnerToken]);
   const updateLocationWorkspace = useCallback(
-    (updater: (current: LocationWorkspaceMemory) => LocationWorkspaceMemory) => {
+    (
+      updater: (current: LocationWorkspaceMemory) => LocationWorkspaceMemory,
+    ) => {
       setLocationWorkspace((current) => {
         const next = updater(current);
         writeLocationWorkspaceMemory(auth.userId, next);
@@ -1777,9 +1779,11 @@ export function OneLocationAgentPageContent({
         ...current,
         myLocationPoint:
           typeof next === "function"
-            ? (next as (value: PlainLocationPoint | null) => PlainLocationPoint | null)(
-                current.myLocationPoint,
-              )
+            ? (
+                next as (
+                  value: PlainLocationPoint | null,
+                ) => PlainLocationPoint | null
+              )(current.myLocationPoint)
             : next,
       }));
     },
@@ -1796,9 +1800,11 @@ export function OneLocationAgentPageContent({
         ...current,
         decryptedPoints:
           typeof next === "function"
-            ? (next as (
-                value: Record<string, PlainLocationPoint>,
-              ) => Record<string, PlainLocationPoint>)(current.decryptedPoints)
+            ? (
+                next as (
+                  value: Record<string, PlainLocationPoint>,
+                ) => Record<string, PlainLocationPoint>
+              )(current.decryptedPoints)
             : next,
       }));
     },
@@ -2196,133 +2202,139 @@ export function OneLocationAgentPageContent({
     );
   }, [pendingCircleInviteToken, router, vaultOwnerToken]);
 
-  const refresh = useCallback(async (options?: { background?: boolean }) => {
-    if (!auth.userId) {
-      setBusy(null);
-      setLoadError("Sign in before loading location sharing.");
-      return;
-    }
-    if (!vaultOwnerToken) {
-      setBusy(null);
-      // `/one/location` is already protected by OneAuthGate -> VaultLockGuard.
-      // A missing owner token means that canonical hard gate is taking over;
-      // do not flash a second route-local unlock/error presentation first.
-      setLoadError(null);
-      return;
-    }
-    if (refreshInFlightRef.current) {
-      return refreshInFlightRef.current;
-    }
-    const activeUserId = auth.userId;
-    const activeUser = auth.user;
-    const activeVaultOwnerToken = vaultOwnerToken;
-    const hasUsableState = stateEntry?.userId === activeUserId;
-    // A memory snapshot is safe only for this unlocked session. Keep it visible
-    // while the network reconciles instead of replacing a usable Location page
-    // with the same foreground loader on every focus, push, or route re-entry.
-    const showForegroundLoad = !options?.background && !hasUsableState;
-    if (showForegroundLoad) {
-      setBusy((current) => current ?? "load");
-    }
-    const task = (async () => {
-      setLoadError(null);
-      try {
-        if (!activeUser) {
-          throw new Error(
-            "Refresh your session before loading location sharing.",
-          );
-        }
-        if (workspaceBootstrapUserRef.current !== activeUserId) {
-          await AccountIdentityService.syncCurrentUser(activeUser).catch(
-            (error) => {
-              console.warn(
-                "[OneLocation] Failed to sync account identity:",
-                error,
-              );
-            },
-          );
-          const key = await ensureLocationRecipientKey(activeUserId);
-          await OneLocationService.registerRecipientKey({
-            vaultOwnerToken: activeVaultOwnerToken,
-            keyId: key.keyId,
-            publicKeyJwk: key.publicKeyJwk,
-            algorithm: key.algorithm,
-          });
-          workspaceBootstrapUserRef.current = activeUserId;
-        }
-        const [nextPermission, nextState] = await Promise.all([
-          OneLocationService.getPermissionState().catch(() => ({
-            state: "unavailable" as const,
-            precise: false,
-            background: "unavailable" as const,
-          })),
-          OneLocationStateResource.load(activeUserId, () =>
-            OneLocationService.getState(activeVaultOwnerToken),
-          ),
-        ]);
-        setPermission(nextPermission);
-        const rankedNextRecipients = rankRecipientsForRecommendation(
-          enrichRecipientsWithContactSignal(
-            nextState.recipients,
-            contactMatchedUserIds,
-          ),
-          contactMatchedUserIds,
-        );
-        const firstRecommendedRecipient = rankedNextRecipients[0];
-        const shouldAutoSelectFallback =
-          !suppressAutoRecipientSelectionRef.current;
-        const nextRecipientIds = new Set(
-          nextState.recipients.map((recipient) => recipient.userId),
-        );
-        setSelectedRecipientId((current) =>
-          current && nextRecipientIds.has(current)
-            ? current
-            : shouldAutoSelectFallback
-              ? firstRecommendedRecipient?.userId || ""
-              : "",
-        );
-        setSelectedRequestOwnerId((current) =>
-          current && nextRecipientIds.has(current)
-            ? current
-            : shouldAutoSelectFallback
-              ? firstRecommendedRecipient?.userId || ""
-              : "",
-        );
-        // Multi-select share/request lists must never auto-select a default
-        // person: the redesign hub ("Who can see you?" / "Make it comfortable")
-        // requires the user to pick explicitly. We only preserve selections that
-        // are still valid after a refresh and otherwise leave the list empty.
-        setSelectedRecipientIds((current) =>
-          current.filter((recipientId) => nextRecipientIds.has(recipientId)),
-        );
-        setSelectedRequestOwnerIds((current) =>
-          current.filter((recipientId) => nextRecipientIds.has(recipientId)),
-        );
-        suppressAutoRecipientSelectionRef.current = false;
-      } catch (error) {
-        suppressAutoRecipientSelectionRef.current = false;
-        // ApiService handles rejected VAULT_OWNER tokens for web and native by
-        // locking the vault. Do not briefly render the backend auth message
-        // while VaultLockGuard switches to the standard re-unlock flow.
-        if (!isVaultOwnerAuthError(error)) {
-          setLoadError(
-            oneLocationErrorMessage(error, "Could not load location sharing."),
-          );
-        }
-      } finally {
-        refreshInFlightRef.current = null;
-        if (showForegroundLoad) setBusy(null);
+  const refresh = useCallback(
+    async (options?: { background?: boolean }) => {
+      if (!auth.userId) {
+        setBusy(null);
+        setLoadError("Sign in before loading location sharing.");
+        return;
       }
-    })();
-    refreshInFlightRef.current = task;
-    return task;
-  }, [
-    auth.user,
-    auth.userId,
-    contactMatchedUserIds,
-    stateEntry?.userId,
-    vaultOwnerToken,
-  ]);
+      if (!vaultOwnerToken) {
+        setBusy(null);
+        // `/one/location` is already protected by OneAuthGate -> VaultLockGuard.
+        // A missing owner token means that canonical hard gate is taking over;
+        // do not flash a second route-local unlock/error presentation first.
+        setLoadError(null);
+        return;
+      }
+      if (refreshInFlightRef.current) {
+        return refreshInFlightRef.current;
+      }
+      const activeUserId = auth.userId;
+      const activeUser = auth.user;
+      const activeVaultOwnerToken = vaultOwnerToken;
+      const hasUsableState = stateEntry?.userId === activeUserId;
+      // A memory snapshot is safe only for this unlocked session. Keep it visible
+      // while the network reconciles instead of replacing a usable Location page
+      // with the same foreground loader on every focus, push, or route re-entry.
+      const showForegroundLoad = !options?.background && !hasUsableState;
+      if (showForegroundLoad) {
+        setBusy((current) => current ?? "load");
+      }
+      const task = (async () => {
+        setLoadError(null);
+        try {
+          if (!activeUser) {
+            throw new Error(
+              "Refresh your session before loading location sharing.",
+            );
+          }
+          if (workspaceBootstrapUserRef.current !== activeUserId) {
+            await AccountIdentityService.syncCurrentUser(activeUser).catch(
+              (error) => {
+                console.warn(
+                  "[OneLocation] Failed to sync account identity:",
+                  error,
+                );
+              },
+            );
+            const key = await ensureLocationRecipientKey(activeUserId);
+            await OneLocationService.registerRecipientKey({
+              vaultOwnerToken: activeVaultOwnerToken,
+              keyId: key.keyId,
+              publicKeyJwk: key.publicKeyJwk,
+              algorithm: key.algorithm,
+            });
+            workspaceBootstrapUserRef.current = activeUserId;
+          }
+          const [nextPermission, nextState] = await Promise.all([
+            OneLocationService.getPermissionState().catch(() => ({
+              state: "unavailable" as const,
+              precise: false,
+              background: "unavailable" as const,
+            })),
+            OneLocationStateResource.load(activeUserId, () =>
+              OneLocationService.getState(activeVaultOwnerToken),
+            ),
+          ]);
+          setPermission(nextPermission);
+          const rankedNextRecipients = rankRecipientsForRecommendation(
+            enrichRecipientsWithContactSignal(
+              nextState.recipients,
+              contactMatchedUserIds,
+            ),
+            contactMatchedUserIds,
+          );
+          const firstRecommendedRecipient = rankedNextRecipients[0];
+          const shouldAutoSelectFallback =
+            !suppressAutoRecipientSelectionRef.current;
+          const nextRecipientIds = new Set(
+            nextState.recipients.map((recipient) => recipient.userId),
+          );
+          setSelectedRecipientId((current) =>
+            current && nextRecipientIds.has(current)
+              ? current
+              : shouldAutoSelectFallback
+                ? firstRecommendedRecipient?.userId || ""
+                : "",
+          );
+          setSelectedRequestOwnerId((current) =>
+            current && nextRecipientIds.has(current)
+              ? current
+              : shouldAutoSelectFallback
+                ? firstRecommendedRecipient?.userId || ""
+                : "",
+          );
+          // Multi-select share/request lists must never auto-select a default
+          // person: the redesign hub ("Who can see you?" / "Make it comfortable")
+          // requires the user to pick explicitly. We only preserve selections that
+          // are still valid after a refresh and otherwise leave the list empty.
+          setSelectedRecipientIds((current) =>
+            current.filter((recipientId) => nextRecipientIds.has(recipientId)),
+          );
+          setSelectedRequestOwnerIds((current) =>
+            current.filter((recipientId) => nextRecipientIds.has(recipientId)),
+          );
+          suppressAutoRecipientSelectionRef.current = false;
+        } catch (error) {
+          suppressAutoRecipientSelectionRef.current = false;
+          // ApiService handles rejected VAULT_OWNER tokens for web and native by
+          // locking the vault. Do not briefly render the backend auth message
+          // while VaultLockGuard switches to the standard re-unlock flow.
+          if (!isVaultOwnerAuthError(error)) {
+            setLoadError(
+              oneLocationErrorMessage(
+                error,
+                "Could not load location sharing.",
+              ),
+            );
+          }
+        } finally {
+          refreshInFlightRef.current = null;
+          if (showForegroundLoad) setBusy(null);
+        }
+      })();
+      refreshInFlightRef.current = task;
+      return task;
+    },
+    [
+      auth.user,
+      auth.userId,
+      contactMatchedUserIds,
+      stateEntry?.userId,
+      vaultOwnerToken,
+    ],
+  );
 
   const refreshLocationPermission = useCallback(async () => {
     const nextPermission = await OneLocationService.getPermissionState().catch(
@@ -2443,10 +2455,7 @@ export function OneLocationAgentPageContent({
   }, [auth.loading, auth.userId, refresh, stateEntry?.userId]);
 
   useEffect(() => {
-    if (
-      locationOnboardingGate !== "show" ||
-      !auth.user
-    ) {
+    if (locationOnboardingGate !== "show" || !auth.user) {
       return;
     }
 
@@ -2555,11 +2564,7 @@ export function OneLocationAgentPageContent({
     return () => {
       cancelled = true;
     };
-  }, [
-    auth.user,
-    locationOnboardingGate,
-    locationOnboardingPeopleRefresh,
-  ]);
+  }, [auth.user, locationOnboardingGate, locationOnboardingPeopleRefresh]);
 
   useEffect(() => {
     if (auth.loading) {
@@ -2993,118 +2998,138 @@ export function OneLocationAgentPageContent({
     vaultOwnerToken,
   ]);
 
-  const handleTriggerSos = useCallback(async (
-    note?: "Come get me" | "I'm not safe" | null,
-  ) => {
-    if (sosIncident) return; // re-entry guard: never overwrite/orphan an active incident
-    if (!vaultOwnerToken || locationPermissionBlocksSharing(permission)) return;
-    const readyRecipients = smsActionRecipients.filter(
-      isSosShareReadyRecipient,
-    );
-    const totalSelected = smsActionRecipients.length;
-    if (!readyRecipients.length) {
-      toast.error(
-        totalSelected
-          ? "Your SMS contacts are not ready to receive location yet."
-          : "Add at least one SMS contact before sending an alert.",
+  const handleTriggerSos = useCallback(
+    async (note?: "Come get me" | "I'm not safe" | null) => {
+      if (sosIncident) return; // re-entry guard: never overwrite/orphan an active incident
+      if (!vaultOwnerToken || locationPermissionBlocksSharing(permission))
+        return;
+      const readyRecipients = smsActionRecipients.filter(
+        isSosShareReadyRecipient,
       );
-      return;
-    }
-    setBusy("sos");
-    try {
-      const readiness = await ensureForegroundLocationReady({
-        capturePoint: true,
-        autoOpenSettings: true,
-      });
-      if (!readiness.ready || !readiness.point) {
+      const totalSelected = smsActionRecipients.length;
+      if (!readyRecipients.length) {
         toast.error(
-          "Couldn't get your location — SMS not sent. Check location permissions.",
+          totalSelected
+            ? "Your SMS contacts are not ready to receive location yet."
+            : "Add at least one SMS contact before sending an alert.",
         );
         return;
       }
-      const point = readiness.point;
-      const incident = await runSosPanic({
-        vaultOwnerToken,
-        recipients: readyRecipients,
-        point,
-        note,
-        publish: (grant, recipient, pt) =>
-          publishEnvelopeWithRetry(grant, recipient, "manual", pt),
-      });
-      setSosIncident(incident);
-      const skipped = totalSelected - readyRecipients.length;
-      toast.success(
-        skipped > 0
-          ? `SMS sent to ${readyRecipients.length} of ${totalSelected} contacts (${skipped} not ready).`
-          : `SMS sent to ${readyRecipients.length} contact(s).`,
-      );
-      await refresh();
-    } catch (error) {
-      // Recover from memory — SosPanicError carries any partial incident
-      // in-process, so the SOS banner stays up even if localStorage failed.
-      if (error instanceof SosPanicError && error.partialIncident) {
-        setSosIncident(error.partialIncident);
-      }
-      toast.error(
-        error instanceof Error ? error.message : "Could not send SMS alert.",
-      );
-    } finally {
-      setBusy(null);
-    }
-  }, [
-    ensureForegroundLocationReady,
-    permission,
-    publishEnvelopeWithRetry,
-    smsActionRecipients,
-    refresh,
-    sosIncident,
-    vaultOwnerToken,
-  ]);
-
-  const handleAddSmsContact = useCallback(
-    async (recipientUserId: string) => {
-      if (!vaultOwnerToken || busy) return;
-      setBusy(`sms-contact:${recipientUserId}`);
+      setBusy("sos");
       try {
-        await OneLocationService.addSmsContact({
-          vaultOwnerToken,
-          recipientUserId,
+        const readiness = await ensureForegroundLocationReady({
+          capturePoint: true,
+          autoOpenSettings: true,
         });
+        if (!readiness.ready || !readiness.point) {
+          toast.error(
+            "Couldn't get your location — SMS not sent. Check location permissions.",
+          );
+          return;
+        }
+        const point = readiness.point;
+        const incident = await runSosPanic({
+          vaultOwnerToken,
+          recipients: readyRecipients,
+          point,
+          note,
+          publish: (grant, recipient, pt) =>
+            publishEnvelopeWithRetry(grant, recipient, "manual", pt),
+        });
+        setSosIncident(incident);
+        const skipped = totalSelected - readyRecipients.length;
+        toast.success(
+          skipped > 0
+            ? `SMS sent to ${readyRecipients.length} of ${totalSelected} contacts (${skipped} not ready).`
+            : `SMS sent to ${readyRecipients.length} contact(s).`,
+        );
         await refresh();
-        toast.success("SMS contact added.");
       } catch (error) {
+        // Recover from memory — SosPanicError carries any partial incident
+        // in-process, so the SOS banner stays up even if localStorage failed.
+        if (error instanceof SosPanicError && error.partialIncident) {
+          setSosIncident(error.partialIncident);
+        }
         toast.error(
-          error instanceof Error ? error.message : "Could not add SMS contact.",
+          error instanceof Error ? error.message : "Could not send SMS alert.",
         );
       } finally {
         setBusy(null);
       }
     },
-    [busy, refresh, vaultOwnerToken],
+    [
+      ensureForegroundLocationReady,
+      permission,
+      publishEnvelopeWithRetry,
+      smsActionRecipients,
+      refresh,
+      sosIncident,
+      vaultOwnerToken,
+    ],
+  );
+
+  const handleAddSmsContact = useCallback(
+    async (recipientUserId: string) => {
+      if (!auth.userId || !vaultOwnerToken || busy) return false;
+      setBusy(`sms-contact:${recipientUserId}`);
+      try {
+        const smsContactUserIds = await OneLocationService.addSmsContact({
+          vaultOwnerToken,
+          recipientUserId,
+        });
+        if (
+          !OneLocationStateResource.replaceSmsContactUserIds(
+            auth.userId,
+            smsContactUserIds,
+          )
+        ) {
+          await refresh();
+        }
+        toast.success("SMS contact added.");
+        return true;
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Could not add SMS contact.",
+        );
+        return false;
+      } finally {
+        setBusy(null);
+      }
+    },
+    [auth.userId, busy, refresh, vaultOwnerToken],
   );
 
   const handleRemoveSmsContact = useCallback(
     async (recipientUserId: string) => {
-      if (!vaultOwnerToken || busy) return;
+      if (!auth.userId || !vaultOwnerToken || busy) return false;
       setBusy(`sms-contact:${recipientUserId}`);
       try {
-        await OneLocationService.removeSmsContact({
+        const smsContactUserIds = await OneLocationService.removeSmsContact({
           vaultOwnerToken,
           recipientUserId,
         });
-        await refresh();
+        if (
+          !OneLocationStateResource.replaceSmsContactUserIds(
+            auth.userId,
+            smsContactUserIds,
+          )
+        ) {
+          await refresh();
+        }
         toast.success("SMS contact removed.");
+        return true;
       } catch (error) {
         toast.error(
           error instanceof Error
             ? error.message
             : "Could not remove SMS contact.",
         );
+        return false;
       } finally {
         setBusy(null);
       }
     },
-    [busy, refresh, vaultOwnerToken],
+    [auth.userId, busy, refresh, vaultOwnerToken],
   );
 
   const handlePublish = useCallback(
@@ -3245,7 +3270,13 @@ export function OneLocationAgentPageContent({
         if (!silent) setBusy(null);
       }
     },
-    [auth.userId, vaultOwnerToken, vaultKey, state?.myRecipientKey, setDecryptedPoints],
+    [
+      auth.userId,
+      vaultOwnerToken,
+      vaultKey,
+      state?.myRecipientKey,
+      setDecryptedPoints,
+    ],
   );
 
   // Recipient-side "ask them to share again": re-request access from the owner
@@ -3592,7 +3623,12 @@ export function OneLocationAgentPageContent({
         void OneLocationService.clearLocationWatch(watchId).catch(() => null);
       }
     };
-  }, [selfPreviewStreaming, activeOwnerGrants.length, permission?.state, setMyLocationPoint]);
+  }, [
+    selfPreviewStreaming,
+    activeOwnerGrants.length,
+    permission?.state,
+    setMyLocationPoint,
+  ]);
 
   useEffect(() => {
     if (!activeVisibleReceivedGrants.length) return;
@@ -5299,8 +5335,8 @@ export function OneLocationAgentPageContent({
       surface === "map"
         ? "native-route-one-location-map"
         : mode === "setup"
-        ? "native-route-one-setup-location"
-        : "native-route-one-location",
+          ? "native-route-one-setup-location"
+          : "native-route-one-location",
     authState: auth.loading
       ? "pending"
       : auth.isAuthenticated
@@ -5468,8 +5504,7 @@ export function OneLocationAgentPageContent({
     onStopSos: handleStopSos,
     onAddSmsContact: (recipientUserId) =>
       void handleAddSmsContact(recipientUserId),
-    onRemoveSmsContact: (recipientUserId) =>
-      void handleRemoveSmsContact(recipientUserId),
+    onRemoveSmsContact: handleRemoveSmsContact,
     onCheckIn: (recipientIds, durationHoursValue, messageValue) =>
       void handleCheckIn(recipientIds, durationHoursValue, messageValue),
   };
@@ -5542,7 +5577,10 @@ export function OneLocationAgentPageContent({
               className="h-9 rounded-full px-3"
             >
               {busy === "load" ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                <Loader2
+                  className="mr-2 h-4 w-4 animate-spin"
+                  aria-hidden="true"
+                />
               ) : (
                 <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
               )}

--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -12,13 +12,7 @@
  * CacheProvider enables data sharing across page navigations to reduce API calls.
  */
 
-import {
-  CSSProperties,
-  ReactNode,
-  Suspense,
-  useEffect,
-  useMemo,
-} from "react";
+import { CSSProperties, ReactNode, Suspense, useEffect, useMemo } from "react";
 import { AuthProvider } from "@/lib/firebase";
 import { VaultProvider } from "@/lib/vault/vault-context";
 import { StepProgressProvider } from "@/lib/progress/step-progress-context";
@@ -27,7 +21,10 @@ import { CacheProvider } from "@/lib/cache/cache-context";
 import { ConsentNotificationProvider } from "@/components/consent/notification-provider";
 import { ConsentSheetProvider } from "@/components/consent/consent-sheet-controller";
 import { resolveTopShellRouteProfile } from "@/components/app-ui/top-shell-metrics";
-import { resolveAppRouteLayout } from "@/lib/navigation/app-route-layout";
+import {
+  resolveAppRouteLayout,
+  shouldSuppressPersistentChromeForRouteState,
+} from "@/lib/navigation/app-route-layout";
 import { AppTopShell } from "@/components/app-ui/top-app-bar";
 import { AppEdgeBackGesture } from "@/components/app-ui/app-edge-back-gesture";
 import { TopShellRouteSwipe } from "@/components/app-ui/top-shell-route-swipe";
@@ -56,7 +53,11 @@ import {
   useKaiBottomChromeProgressCssVar,
 } from "@/lib/navigation/kai-bottom-chrome-visibility";
 import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
-import { ROUTES, isFoundationPublicRoute, isRiaRoute } from "@/lib/navigation/routes";
+import {
+  ROUTES,
+  isFoundationPublicRoute,
+  isRiaRoute,
+} from "@/lib/navigation/routes";
 import { useAuth } from "@/hooks/use-auth";
 import { PersonaProvider } from "@/lib/persona/persona-context";
 import { resolveSignedInShellContentOffset } from "@/components/app-ui/signed-in-shell-content-offset";
@@ -105,7 +106,12 @@ function AppShellFrame({ children }: ProvidersProps) {
     [shellPathname],
   );
   const routeLayoutMode = routeLayout.mode;
-  const hidesPersistentChrome = routeLayout.persistentChrome === "none";
+  const hidesPersistentChrome =
+    routeLayout.persistentChrome === "none" ||
+    shouldSuppressPersistentChromeForRouteState(
+      shellPathname,
+      searchParams?.get("action"),
+    );
   const topShellRouteProfile = useMemo(() => {
     const query = searchParams?.toString() ?? "";
     return resolveTopShellRouteProfile(
@@ -131,7 +137,8 @@ function AppShellFrame({ children }: ProvidersProps) {
     topShellModel.mode === "bar-with-tabs"
       ? `${shellPathname}:${topShellModel.tabs.id}:${topShellModel.tabs.activeValue}`
       : shellPathname;
-  const hideGlobalChrome = !topShellMetrics.shellVisible || hidesPersistentChrome;
+  const hideGlobalChrome =
+    !topShellMetrics.shellVisible || hidesPersistentChrome;
   const isFullscreenTopFlow = routeLayoutMode === "flow";
   const shouldLockFullscreenRoot = isFullscreenTopFlow || hidesPersistentChrome;
   const isFoundationRoute = isFoundationPublicRoute(pathname);
@@ -210,10 +217,10 @@ function AppShellFrame({ children }: ProvidersProps) {
         "--app-scroll-bottom-pad": hidesPersistentChrome
           ? "0px"
           : isRiaRoute(pathname)
-          ? "calc(var(--onboarding-agent-bar-clearance) + 1.5rem)"
-          : hideGlobalChrome || isPublicStandaloneRoute
             ? "calc(var(--onboarding-agent-bar-clearance) + 1.5rem)"
-            : "var(--bottom-chrome-stack-height)",
+            : hideGlobalChrome || isPublicStandaloneRoute
+              ? "calc(var(--onboarding-agent-bar-clearance) + 1.5rem)"
+              : "var(--bottom-chrome-stack-height)",
       }) as CSSProperties,
     [
       chromeState.hideCommandBar,
@@ -236,7 +243,8 @@ function AppShellFrame({ children }: ProvidersProps) {
     isFoundationRoute ||
     chromeState.useOnboardingChrome;
   const bottomShellModel = {
-    ambientEnabled: ambientChromeEnabled && !isFullscreenTopFlow && !hidesPersistentChrome,
+    ambientEnabled:
+      ambientChromeEnabled && !isFullscreenTopFlow && !hidesPersistentChrome,
     navigationHidden: chromeState.hideCommandBar,
     hidden: hidesPersistentChrome,
   };
@@ -256,7 +264,9 @@ function AppShellFrame({ children }: ProvidersProps) {
   // while omitting that glass, and the persistent Agent Bar must still travel
   // with it. This matches Navbar's non-onboarding scroll-hide policy.
   useKaiBottomChromeProgressCssVar(
-    !chromeState.useOnboardingChrome && !riaPinnedChrome && !hidesPersistentChrome,
+    !chromeState.useOnboardingChrome &&
+      !riaPinnedChrome &&
+      !hidesPersistentChrome,
   );
   // Add a root platform class for native-iOS specific CSS hooks.
   useEffect(() => {
@@ -297,13 +307,18 @@ function AppShellFrame({ children }: ProvidersProps) {
       // Route programmatic navigations through the shared exit -> enter envelope
       // so they crossfade exactly like /one -> /one/* link clicks instead of
       // hard-cutting on exit.
-      beginRouteTransition(href, () => {
-        if (replace) {
-          router.replace(href, { scroll });
-          return;
-        }
-        router.push(href, { scroll });
-      }, customEvent.detail?.source ?? "programmatic", customEvent.detail?.transitionMode ?? "full");
+      beginRouteTransition(
+        href,
+        () => {
+          if (replace) {
+            router.replace(href, { scroll });
+            return;
+          }
+          router.push(href, { scroll });
+        },
+        customEvent.detail?.source ?? "programmatic",
+        customEvent.detail?.transitionMode ?? "full",
+      );
     };
 
     window.addEventListener(
@@ -399,8 +414,8 @@ function AppShellFrame({ children }: ProvidersProps) {
               <NativeTestRouter />
               <NativeTestBootstrap />
               <NativeTestRouteStatus />
-      <InteractionRuntime />
-      <FoundationPublicAmbient />
+              <InteractionRuntime />
+              <FoundationPublicAmbient />
               {!hidesPersistentChrome ? (
                 <AmbientChromeController enabled={ambientChromeEnabled} />
               ) : null}

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -4091,7 +4091,7 @@ export function AgentChatWorkspace({
                     confirmLabel={
                       (pendingSpecialistDirective.directive.payload as Record<string, unknown>)
                         .type === "sos_panic"
-                        ? "Send SOS"
+                        ? "Send SMS"
                         : (pendingSpecialistDirective.directive.payload as Record<string, unknown>)
                               .type === "request_device_location_permission"
                           ? "Allow location"
@@ -4106,7 +4106,7 @@ export function AgentChatWorkspace({
                       );
                       const confirmText =
                         directivePayloadType === "sos_panic"
-                          ? "Send SOS"
+                          ? "Send SMS"
                           : directivePayloadType === "request_device_location_permission"
                             ? "Allow location"
                             : "Share";

--- a/hushh-webapp/components/app-ui/debate-task-center.tsx
+++ b/hushh-webapp/components/app-ui/debate-task-center.tsx
@@ -12,6 +12,7 @@ import {
   ExternalLink,
   X,
   RotateCw,
+  Siren,
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -43,8 +44,10 @@ import { useVault } from "@/lib/vault/vault-context";
 import { buildKaiMarketRoute } from "@/lib/navigation/routes";
 
 function statusLabel(task: DebateRunTask): string {
-  if (task.status === "running" && task.streamState === "reconnecting") return "Reconnecting";
-  if (task.status === "running" && task.streamState === "paused") return "Updates paused";
+  if (task.status === "running" && task.streamState === "reconnecting")
+    return "Reconnecting";
+  if (task.status === "running" && task.streamState === "paused")
+    return "Updates paused";
   if (task.status === "running") return "Running";
   if (task.status === "completed") return "Completed";
   if (task.status === "failed") return "Failed";
@@ -53,35 +56,110 @@ function statusLabel(task: DebateRunTask): string {
 
 function statusIcon(task: DebateRunTask) {
   if (task.status === "running") {
-    return <Icon icon={Loader2} size="sm" className="animate-spin text-accent-strong" aria-hidden="true" />;
+    return (
+      <Icon
+        icon={Loader2}
+        size="sm"
+        className="animate-spin text-accent-strong"
+        aria-hidden="true"
+      />
+    );
   }
   if (task.status === "completed") {
-    return <Icon icon={CheckCircle2} size="sm" className="text-emerald-500" aria-hidden="true" />;
+    return (
+      <Icon
+        icon={CheckCircle2}
+        size="sm"
+        className="text-emerald-500"
+        aria-hidden="true"
+      />
+    );
   }
   if (task.status === "failed") {
-    return <Icon icon={XCircle} size="sm" className="text-rose-500" aria-hidden="true" />;
+    return (
+      <Icon
+        icon={XCircle}
+        size="sm"
+        className="text-rose-500"
+        aria-hidden="true"
+      />
+    );
   }
-  return <Icon icon={Ban} size="sm" className="text-amber-500" aria-hidden="true" />;
+  return (
+    <Icon icon={Ban} size="sm" className="text-amber-500" aria-hidden="true" />
+  );
 }
 
 function appTaskStatusLabel(task: AppBackgroundTask): string {
+  if (isEmergencySmsTask(task)) return "Emergency";
   if (task.status === "running") return "Running";
   if (task.status === "completed") return "Completed";
   if (task.status === "canceled") return "Canceled";
   return "Failed";
 }
 
+function isEmergencySmsTask(task: AppBackgroundTask): boolean {
+  const metadata =
+    task.metadata && typeof task.metadata === "object"
+      ? (task.metadata as Record<string, unknown>)
+      : null;
+  return (
+    task.kind === "one_location_share" &&
+    String(metadata?.shareKind || "")
+      .trim()
+      .toLowerCase() === "sos"
+  );
+}
+
 function appTaskStatusIcon(task: AppBackgroundTask) {
+  if (isEmergencySmsTask(task)) {
+    return (
+      <Icon
+        icon={Siren}
+        size="sm"
+        className="animate-pulse text-destructive motion-reduce:animate-none"
+        aria-hidden="true"
+      />
+    );
+  }
   if (task.status === "running") {
-    return <Icon icon={Loader2} size="sm" className="animate-spin text-accent-strong" aria-hidden="true" />;
+    return (
+      <Icon
+        icon={Loader2}
+        size="sm"
+        className="animate-spin text-accent-strong"
+        aria-hidden="true"
+      />
+    );
   }
   if (task.status === "completed") {
-    return <Icon icon={CheckCircle2} size="sm" className="text-emerald-500" aria-hidden="true" />;
+    return (
+      <Icon
+        icon={CheckCircle2}
+        size="sm"
+        className="text-emerald-500"
+        aria-hidden="true"
+      />
+    );
   }
   if (task.status === "canceled") {
-    return <Icon icon={Ban} size="sm" className="text-amber-500" aria-hidden="true" />;
+    return (
+      <Icon
+        icon={Ban}
+        size="sm"
+        className="text-amber-500"
+        aria-hidden="true"
+      />
+    );
   }
-  return <Icon icon={XCircle} size="sm" className="text-rose-500" aria-hidden="true" />;
+  return (
+    <Icon
+      icon={XCircle}
+      size="sm"
+      className="text-rose-500"
+      aria-hidden="true"
+    />
+  );
 }
 
 function appTaskStatusItems(task: AppBackgroundTask): string[] {
@@ -111,15 +189,24 @@ function appTaskTimingSummary(task: AppBackgroundTask): string | null {
   if (!timings) {
     return null;
   }
-  const totalMs = typeof timings.totalMs === "number" ? Math.round(timings.totalMs) : null;
+  const totalMs =
+    typeof timings.totalMs === "number" ? Math.round(timings.totalMs) : null;
   const manifestMs =
-    typeof timings.manifestReadMs === "number" ? Math.round(timings.manifestReadMs) : null;
+    typeof timings.manifestReadMs === "number"
+      ? Math.round(timings.manifestReadMs)
+      : null;
   const decryptMs =
-    typeof timings.decryptLoadMs === "number" ? Math.round(timings.decryptLoadMs) : null;
+    typeof timings.decryptLoadMs === "number"
+      ? Math.round(timings.decryptLoadMs)
+      : null;
   const transformMs =
-    typeof timings.transformMs === "number" ? Math.round(timings.transformMs) : null;
+    typeof timings.transformMs === "number"
+      ? Math.round(timings.transformMs)
+      : null;
   const validationMs =
-    typeof timings.validationMs === "number" ? Math.round(timings.validationMs) : null;
+    typeof timings.validationMs === "number"
+      ? Math.round(timings.validationMs)
+      : null;
   if (
     totalMs === null &&
     manifestMs === null &&
@@ -153,7 +240,10 @@ type TaskActivityPresentation = "dropdown" | "section";
 
 interface DebateTaskCenterProps {
   triggerClassName?: string;
-  renderTrigger?: (state: { activeCount: number; badgeCount: number }) => ReactElement;
+  renderTrigger?: (state: {
+    activeCount: number;
+    badgeCount: number;
+  }) => ReactElement;
   presentation?: TaskActivityPresentation;
   onActivityChange?: (state: TaskActivityState) => void;
 }
@@ -193,8 +283,12 @@ export function DebateTaskCenter({
   const router = useRouter();
   const { userId } = useAuth();
   const { vaultOwnerToken } = useVault();
-  const [debateState, setDebateState] = useState(DebateRunManagerService.getState());
-  const [appTaskState, setAppTaskState] = useState(AppBackgroundTaskService.getState());
+  const [debateState, setDebateState] = useState(
+    DebateRunManagerService.getState(),
+  );
+  const [appTaskState, setAppTaskState] = useState(
+    AppBackgroundTaskService.getState(),
+  );
   const [isBusy, setIsBusy] = useState<Record<string, boolean>>({});
   const [open, setOpen] = useState(false);
   const [showPassiveActivity, setShowPassiveActivity] = useState(false);
@@ -210,24 +304,28 @@ export function DebateTaskCenter({
 
   const debateTasks = useMemo(() => {
     if (!userId) return [];
-    return debateState.tasks.filter((task) => task.userId === userId && !task.dismissedAt);
+    return debateState.tasks.filter(
+      (task) => task.userId === userId && !task.dismissedAt,
+    );
   }, [debateState.tasks, userId]);
 
   const appTasks = useMemo(() => {
     if (!userId) return [];
-    return appTaskState.tasks.filter((task) => task.userId === userId && !task.dismissedAt);
+    return appTaskState.tasks.filter(
+      (task) => task.userId === userId && !task.dismissedAt,
+    );
   }, [appTaskState.tasks, userId]);
   const visibleAppTasks = useMemo(
     () => appTasks.filter((task) => isAppBackgroundTaskVisible(task)),
-    [appTasks]
+    [appTasks],
   );
   const primaryAppTasks = useMemo(
     () => visibleAppTasks.filter((task) => task.visibility !== "passive"),
-    [visibleAppTasks]
+    [visibleAppTasks],
   );
   const passiveAppTasks = useMemo(
     () => visibleAppTasks.filter((task) => task.visibility === "passive"),
-    [visibleAppTasks]
+    [visibleAppTasks],
   );
 
   const notifications = useMemo<NotificationItem[]>(() => {
@@ -243,7 +341,9 @@ export function DebateTaskCenter({
       sortAt: Date.parse(task.updatedAt || task.startedAt),
       task,
     }));
-    return [...debateNotifications, ...appNotifications].sort((a, b) => b.sortAt - a.sortAt);
+    return [...debateNotifications, ...appNotifications].sort(
+      (a, b) => b.sortAt - a.sortAt,
+    );
   }, [primaryAppTasks, debateTasks]);
 
   const activeCount =
@@ -253,6 +353,7 @@ export function DebateTaskCenter({
     debateTasks.filter((task) => task.status !== "running").length +
     visibleAppTasks.filter((task) => task.status !== "running").length;
   const badgeCount = activeCount + completedCount;
+  const hasEmergencySmsAlert = primaryAppTasks.some(isEmergencySmsTask);
   const latestActiveTask = useMemo(() => {
     return debateTasks
       .filter((task) => task.status === "running")
@@ -266,19 +367,24 @@ export function DebateTaskCenter({
   }, [activeCount, badgeCount, hasActivity, onActivityChange]);
 
   const openAnalysis = (focusRunId?: string | null) => {
-    const normalizedRunId = typeof focusRunId === "string" ? focusRunId.trim() : "";
+    const normalizedRunId =
+      typeof focusRunId === "string" ? focusRunId.trim() : "";
     if (normalizedRunId) {
       const params = new URLSearchParams();
       params.set("focus", "active");
       params.set("run_id", normalizedRunId);
-      router.push(buildKaiMarketRoute("analysis", Object.fromEntries(params.entries())));
+      router.push(
+        buildKaiMarketRoute("analysis", Object.fromEntries(params.entries())),
+      );
       return;
     }
     if (latestActiveTask) {
       const params = new URLSearchParams();
       params.set("focus", "active");
       params.set("run_id", latestActiveTask.runId);
-      router.push(buildKaiMarketRoute("analysis", Object.fromEntries(params.entries())));
+      router.push(
+        buildKaiMarketRoute("analysis", Object.fromEntries(params.entries())),
+      );
       return;
     }
     router.push(buildKaiMarketRoute("analysis"));
@@ -345,13 +451,33 @@ export function DebateTaskCenter({
   };
 
   const renderAppTask = (task: AppBackgroundTask, listRole?: string) => (
-    <div key={task.taskId} role={listRole} className="px-3 py-3">
+    <div
+      key={task.taskId}
+      role={listRole}
+      className={cn(
+        "px-3 py-3",
+        isEmergencySmsTask(task) &&
+          "border-l-4 border-destructive bg-destructive/10",
+      )}
+    >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             {appTaskStatusIcon(task)}
-            <span className="text-sm font-semibold">{task.title}</span>
-            <span className="text-xs text-muted-foreground">
+            <span
+              className={cn(
+                "text-sm font-semibold",
+                isEmergencySmsTask(task) && "text-destructive",
+              )}
+            >
+              {task.title}
+            </span>
+            <span
+              className={cn(
+                "text-xs text-muted-foreground",
+                isEmergencySmsTask(task) && "font-semibold text-destructive",
+              )}
+            >
               {appTaskStatusLabel(task)}
             </span>
           </div>
@@ -415,7 +541,9 @@ export function DebateTaskCenter({
                 })
               }
               aria-label={
-                task.kind === "plaid_refresh" ? "Cancel refresh" : "Cancel import"
+                task.kind === "plaid_refresh"
+                  ? "Cancel refresh"
+                  : "Cancel import"
               }
             >
               <Icon icon={X} size="xs" aria-hidden="true" />
@@ -445,7 +573,11 @@ export function DebateTaskCenter({
       No activity yet.
     </div>
   ) : (
-    <div role="list" aria-label="Activity" className="divide-y divide-border/45">
+    <div
+      role="list"
+      aria-label="Activity"
+      className="divide-y divide-border/45"
+    >
       {notifications.map((item) =>
         item.kind === "debate" ? (
           <div key={item.id} role="listitem" className="px-3 py-3">
@@ -453,7 +585,9 @@ export function DebateTaskCenter({
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
                   {statusIcon(item.task)}
-                  <span className="text-sm font-semibold">{item.task.ticker}</span>
+                  <span className="text-sm font-semibold">
+                    {item.task.ticker}
+                  </span>
                   <span className="text-xs text-muted-foreground">
                     {statusLabel(item.task)}
                   </span>
@@ -467,7 +601,9 @@ export function DebateTaskCenter({
                   </p>
                 ) : null}
                 {item.task.persistenceState === "pending" ? (
-                  <p className="mt-1 text-xs text-amber-500">Saving to history…</p>
+                  <p className="mt-1 text-xs text-amber-500">
+                    Saving to history…
+                  </p>
                 ) : null}
                 {item.task.persistenceState === "failed" ? (
                   <p className="mt-1 text-xs text-rose-500">
@@ -492,7 +628,9 @@ export function DebateTaskCenter({
                     effect="fade"
                     size="icon"
                     className="h-8 w-8"
-                    disabled={!vaultOwnerToken || Boolean(isBusy[item.task.runId])}
+                    disabled={
+                      !vaultOwnerToken || Boolean(isBusy[item.task.runId])
+                    }
                     onClick={() =>
                       runAction(item.task.runId, async () => {
                         if (!vaultOwnerToken) return;
@@ -516,7 +654,9 @@ export function DebateTaskCenter({
                     disabled={Boolean(isBusy[item.task.runId])}
                     onClick={() =>
                       runAction(item.task.runId, async () => {
-                        await DebateRunManagerService.retryTaskPersistence(item.task.runId);
+                        await DebateRunManagerService.retryTaskPersistence(
+                          item.task.runId,
+                        );
                       })
                     }
                     aria-label="Retry save"
@@ -530,7 +670,9 @@ export function DebateTaskCenter({
                     effect="fade"
                     size="icon"
                     className="h-8 w-8"
-                    onClick={() => DebateRunManagerService.dismissTask(item.task.runId)}
+                    onClick={() =>
+                      DebateRunManagerService.dismissTask(item.task.runId)
+                    }
                     aria-label="Dismiss task"
                   >
                     <Icon icon={X} size="xs" aria-hidden="true" />
@@ -541,7 +683,7 @@ export function DebateTaskCenter({
           </div>
         ) : (
           renderAppTask(item.task, "listitem")
-        )
+        ),
       )}
       {passiveAppTasks.length > 0 ? (
         <div className="px-3 py-2.5">
@@ -551,7 +693,9 @@ export function DebateTaskCenter({
             onClick={() => setShowPassiveActivity((value) => !value)}
           >
             <div className="min-w-0">
-              <p className="text-sm font-semibold text-foreground">Background activity</p>
+              <p className="text-sm font-semibold text-foreground">
+                Background activity
+              </p>
               <p className="text-xs text-muted-foreground">
                 Routine updates stay here unless something needs your attention.
               </p>
@@ -584,11 +728,23 @@ export function DebateTaskCenter({
       <section aria-label="Background activity" className="py-1">
         <div className="flex items-center justify-between gap-3 px-1 py-2.5">
           <div>
-            <p className="text-sm font-semibold text-foreground">Notifications</p>
-            <p className="text-[11px] text-muted-foreground">Updates from One and Kai</p>
+            <p className="text-sm font-semibold text-foreground">
+              Notifications
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              Updates from One and Kai
+            </p>
           </div>
-          {activeCount > 0 ? (
-            <Loader2 className="h-4 w-4 animate-spin text-accent-strong" aria-label="Activity in progress" />
+          {hasEmergencySmsAlert ? (
+            <Siren
+              className="h-4 w-4 animate-pulse text-destructive motion-reduce:animate-none"
+              aria-label="Emergency SMS alert"
+            />
+          ) : activeCount > 0 ? (
+            <Loader2
+              className="h-4 w-4 animate-spin text-accent-strong"
+              aria-label="Activity in progress"
+            />
           ) : null}
         </div>
         {notificationContent}
@@ -607,13 +763,28 @@ export function DebateTaskCenter({
             className={cn(DEFAULT_TRIGGER_CLASSNAME, triggerClassName)}
             aria-label="Notifications"
           >
-            {activeCount > 0 ? (
-              <Loader2 className="h-5 w-5 animate-spin text-accent-strong" aria-hidden="true" />
+            {hasEmergencySmsAlert ? (
+              <Siren
+                className="h-5 w-5 animate-pulse text-destructive motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+            ) : activeCount > 0 ? (
+              <Loader2
+                className="h-5 w-5 animate-spin text-accent-strong"
+                aria-hidden="true"
+              />
             ) : (
               <Bell className="h-5 w-5" aria-hidden="true" />
             )}
             {badgeCount > 0 ? (
-              <span className="absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold text-[#1d1d1f]">
+              <span
+                className={cn(
+                  "absolute -right-1 -top-1 inline-flex min-h-5 min-w-5 items-center justify-center rounded-full px-1 text-[10px] font-semibold",
+                  hasEmergencySmsAlert
+                    ? "bg-destructive text-destructive-foreground"
+                    : "bg-accent text-[#1d1d1f]",
+                )}
+              >
                 {badgeCount}
               </span>
             ) : null}
@@ -625,7 +796,9 @@ export function DebateTaskCenter({
           <p className="text-sm font-semibold text-foreground">Notifications</p>
         </div>
 
-        <div className={TOP_SHELL_DROPDOWN_BODY_CLASSNAME}>{notificationContent}</div>
+        <div className={TOP_SHELL_DROPDOWN_BODY_CLASSNAME}>
+          {notificationContent}
+        </div>
       </TopShellDropdownContent>
     </DropdownMenu>
   );

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -16,7 +16,8 @@
  * Product rule:
  * - Web Sonner toasts are used for live events and unreviewed catch-up requests.
  * - Hydration/offline catch-up must surface actionable approvals once per session.
- * - iOS system banners stay authoritative; Android uses an in-app foreground toast.
+ * - iOS system banners stay authoritative except foreground emergency SMS,
+ *   which uses the shared cross-platform alarm surface.
  */
 
 import {
@@ -76,6 +77,7 @@ import {
   buildOneLocationWorkflowHref,
   dismissOneLocationShareNotification,
   isOneLocationGrantUnwatched,
+  isOneLocationSmsEmergencyAlert,
   locationShareNotificationCopy,
   locationWorkflowNotificationCopy,
   markOneLocationGrantOpened,
@@ -91,6 +93,7 @@ import { OneLocationService } from "@/lib/one-location/service";
 import { OneLocationStateResource } from "@/lib/one-location/one-location-state-resource";
 import { buildOneLocationNotificationPayloads } from "@/lib/one-location/notification-reconciliation";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
+import { EmergencySmsNotificationToast } from "@/components/one-location/emergency-sms-notification-toast";
 
 // ============================================================================
 // Helpers
@@ -760,32 +763,51 @@ export function ConsentNotificationProvider({
         data.notification_body,
         generatedCopy.description,
       );
-      playOneLocationNotificationSound();
+      const isEmergencySms = isOneLocationSmsEmergencyAlert({
+        shareKind: data.share_kind,
+        notificationProfile: data.notification_profile,
+      });
+      playOneLocationNotificationSound(data.share_kind);
 
       toast(
-        <div className="flex flex-col gap-2">
-          <div className="space-y-0.5">
-            <p className="line-clamp-1 text-sm font-semibold">{title}</p>
-            <p className="line-clamp-2 text-xs text-muted-foreground">
-              {description}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => {
+        isEmergencySms ? (
+          <EmergencySmsNotificationToast
+            title={title}
+            description={description}
+            onOpen={() => {
               markOneLocationGrantOpened(user.uid, grantId);
               toast.dismiss(toastKey);
               router.push(href, { scroll: false });
             }}
-            className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors"
-          >
-            Open
-          </button>
-        </div>,
+          />
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="space-y-0.5">
+              <p className="line-clamp-1 text-sm font-semibold">{title}</p>
+              <p className="line-clamp-2 text-xs text-muted-foreground">
+                {description}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                markOneLocationGrantOpened(user.uid, grantId);
+                toast.dismiss(toastKey);
+                router.push(href, { scroll: false });
+              }}
+              className="rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors"
+            >
+              Open
+            </button>
+          </div>
+        ),
         {
           id: toastKey,
-          duration: 10000,
+          duration: isEmergencySms ? 30000 : 10000,
           position: "top-center",
+          className: isEmergencySms
+            ? "one-location-emergency-toast !border-destructive/70 !bg-destructive !text-destructive-foreground"
+            : undefined,
         },
       );
     },
@@ -1326,8 +1348,12 @@ export function ConsentNotificationProvider({
           notification_title: String(notification.title || "").trim(),
           notification_body: String(notification.body || "").trim(),
         };
+        const isEmergencySms = isOneLocationSmsEmergencyAlert({
+          shareKind: data.share_kind,
+          notificationProfile: data.notification_profile,
+        });
         const shouldPresent = isNativePlatform
-          ? Capacitor.getPlatform() === "android"
+          ? Capacitor.getPlatform() === "android" || isEmergencySms
           : typeof document !== "undefined" &&
             document.visibilityState === "visible";
         if (!user?.uid) {
@@ -1557,13 +1583,14 @@ export function ConsentNotificationProvider({
     window.addEventListener("online", reconcileWhenVisible);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
-    const removeLifecycleListener = appInteractionCoordinator.subscribeLifecycle(
-      () => {
-        if (appInteractionCoordinator.getLifecycleSnapshot().state === "active") {
+    const removeLifecycleListener =
+      appInteractionCoordinator.subscribeLifecycle(() => {
+        if (
+          appInteractionCoordinator.getLifecycleSnapshot().state === "active"
+        ) {
           reconcileWhenVisible();
         }
-      },
-    );
+      });
 
     const intervalMs = deliveryMode === "push_active" ? 5 * 60_000 : 30_000;
     const intervalId = window.setInterval(reconcileWhenVisible, intervalMs);

--- a/hushh-webapp/components/consent/notification-provider.tsx
+++ b/hushh-webapp/components/consent/notification-provider.tsx
@@ -806,7 +806,7 @@ export function ConsentNotificationProvider({
           duration: isEmergencySms ? 30000 : 10000,
           position: "top-center",
           className: isEmergencySms
-            ? "one-location-emergency-toast !border-destructive/70 !bg-destructive !text-destructive-foreground"
+            ? "one-location-emergency-toast !border-red-500 !bg-red-600 !text-white !shadow-xl !shadow-red-950/25"
             : undefined,
         },
       );

--- a/hushh-webapp/components/one-location/emergency-sms-notification-toast.tsx
+++ b/hushh-webapp/components/one-location/emergency-sms-notification-toast.tsx
@@ -18,24 +18,26 @@ export function EmergencySmsNotificationToast({
       role="alert"
       aria-live="assertive"
       data-one-location-emergency-sms-alert
-      className="flex w-full flex-col gap-3 text-left text-destructive-foreground"
+      className="flex w-full flex-col gap-3 text-left text-white"
     >
       <div className="flex items-start gap-3">
-        <span className="relative mt-0.5 grid size-10 shrink-0 place-items-center rounded-full bg-background/20">
-          <span className="absolute inset-0 animate-ping rounded-full bg-background/20 motion-reduce:animate-none" />
+        <span className="relative mt-0.5 grid size-10 shrink-0 place-items-center rounded-full bg-white/15 ring-1 ring-inset ring-white/30">
+          <span className="absolute inset-0 animate-ping rounded-full bg-white/25 motion-reduce:animate-none" />
           <Icon
             icon={Siren}
             size="md"
-            className="relative text-destructive-foreground"
+            className="relative text-white"
             aria-hidden="true"
           />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-destructive-foreground/80">
+          <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-white">
             Emergency SMS
           </p>
-          <p className="mt-0.5 text-[15px] font-bold leading-5">{title}</p>
-          <p className="mt-1 line-clamp-3 text-[13px] leading-5 text-destructive-foreground/90">
+          <p className="mt-0.5 text-[15px] font-bold leading-5 text-white">
+            {title}
+          </p>
+          <p className="mt-1 line-clamp-3 text-[13px] leading-5 text-white">
             {description}
           </p>
         </div>
@@ -44,11 +46,11 @@ export function EmergencySmsNotificationToast({
       <button
         type="button"
         onClick={onOpen}
-        className="press-scale flex min-h-11 w-full items-center justify-between rounded-[var(--app-radius-pill)] bg-background px-4 text-sm font-semibold text-foreground"
+        className="press-scale flex min-h-11 w-full items-center justify-between rounded-[var(--app-radius-pill)] border border-white bg-white px-4 text-sm font-semibold text-red-700 shadow-sm transition-colors hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-red-600"
       >
         <span className="flex items-center gap-2">
           <Icon icon={MapPin} size="sm" aria-hidden="true" />
-          Open live location
+          View live location
         </span>
         <Icon icon={ChevronRight} size="sm" aria-hidden="true" />
       </button>

--- a/hushh-webapp/components/one-location/emergency-sms-notification-toast.tsx
+++ b/hushh-webapp/components/one-location/emergency-sms-notification-toast.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ChevronRight, MapPin, Siren } from "lucide-react";
+
+import { Icon } from "@/lib/morphy-ux/ui";
+
+export function EmergencySmsNotificationToast({
+  title,
+  description,
+  onOpen,
+}: {
+  title: string;
+  description: string;
+  onOpen: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-one-location-emergency-sms-alert
+      className="flex w-full flex-col gap-3 text-left text-destructive-foreground"
+    >
+      <div className="flex items-start gap-3">
+        <span className="relative mt-0.5 grid size-10 shrink-0 place-items-center rounded-full bg-background/20">
+          <span className="absolute inset-0 animate-ping rounded-full bg-background/20 motion-reduce:animate-none" />
+          <Icon
+            icon={Siren}
+            size="md"
+            className="relative text-destructive-foreground"
+            aria-hidden="true"
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-bold uppercase tracking-[0.14em] text-destructive-foreground/80">
+            Emergency SMS
+          </p>
+          <p className="mt-0.5 text-[15px] font-bold leading-5">{title}</p>
+          <p className="mt-1 line-clamp-3 text-[13px] leading-5 text-destructive-foreground/90">
+            {description}
+          </p>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onOpen}
+        className="press-scale flex min-h-11 w-full items-center justify-between rounded-[var(--app-radius-pill)] bg-background px-4 text-sm font-semibold text-foreground"
+      >
+        <span className="flex items-center gap-2">
+          <Icon icon={MapPin} size="sm" aria-hidden="true" />
+          Open live location
+        </span>
+        <Icon icon={ChevronRight} size="sm" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -12,6 +12,7 @@ import { preload } from "react-dom";
 import {
   ArrowLeft,
   Check,
+  ChevronLeft,
   Loader2,
   MapPin,
   Navigation,
@@ -196,12 +197,14 @@ function PrimaryButton({
   disabled = false,
   busy = false,
   inverse = false,
+  className,
 }: {
   children: ReactNode;
   onClick: () => void;
   disabled?: boolean;
   busy?: boolean;
   inverse?: boolean;
+  className?: string;
 }) {
   return (
     <button
@@ -214,6 +217,7 @@ function PrimaryButton({
         inverse
           ? "bg-white text-[color:var(--app-accent-deep)] dark:bg-white dark:text-[#07111f]"
           : "bg-[color:var(--app-accent)] text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent-hover)]",
+        className,
       )}
     >
       {busy ? (
@@ -228,10 +232,12 @@ function OnboardingSkipButton({
   onClick,
   disabled = false,
   inverse = false,
+  floating = false,
 }: {
   onClick: () => void;
   disabled?: boolean;
   inverse?: boolean;
+  floating?: boolean;
 }) {
   return (
     <button
@@ -239,10 +245,12 @@ function OnboardingSkipButton({
       onClick={onClick}
       disabled={disabled}
       className={cn(
-        "min-h-11 rounded-full px-2 text-[16px] font-bold disabled:opacity-50",
-        inverse
+        "rounded-full text-[16px] font-bold disabled:opacity-50",
+        floating
+          ? "h-10 min-h-10 bg-white px-5 text-[color:var(--app-accent-deep)] shadow-[0_4px_14px_rgba(26,42,65,0.12)] dark:bg-[#1b222d] dark:text-[color:var(--app-accent-bright)]"
+          : inverse
           ? "text-white"
-          : "text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]",
+          : "min-h-11 px-2 text-[color:var(--app-accent-deep)] dark:text-[color:var(--app-accent-bright)]",
       )}
     >
       Skip
@@ -382,7 +390,7 @@ function WelcomeScreen({
 type UseCaseCardProps = {
   tag: string;
   titleLines: readonly [string, string];
-  bodyLines: readonly [string, string];
+  bodyLines: readonly string[];
   alertText: string;
   kind: "sms" | "share" | "checkin";
   tone: "danger" | "success" | "info";
@@ -419,12 +427,12 @@ function UseCaseArt({
       aria-hidden="true"
     >
       {kind === "sms" ? (
-        <div className="absolute right-[12%] top-[22%] flex h-[98px] w-[98px] items-center justify-center rounded-full border-[9px] border-[#fff0f0] bg-[#ef302f] text-center text-white shadow-[0_13px_26px_rgba(239,48,47,0.22)] dark:border-[#4b2528]">
+        <div className="absolute right-[12%] top-[22%] flex h-[98px] w-[98px] items-center justify-center rounded-full border-[14px] border-[#fff0f0] bg-[#ef302f] text-center text-white shadow-[0_13px_26px_rgba(239,48,47,0.22)] dark:border-[#4b2528]">
           <span>
-            <span className="block text-[25px] font-extrabold leading-none">
+            <span className="block text-[19px] font-extrabold leading-none">
               SMS
             </span>
-            <span className="mt-1 block text-[10px] font-bold">
+            <span className="mt-1 block text-[8px] font-bold">
               Tap for help
             </span>
           </span>
@@ -432,18 +440,18 @@ function UseCaseArt({
       ) : null}
       {kind === "share" ? (
         <>
-          <span className="absolute bottom-[34%] left-[15%] h-3 w-3 rounded-full bg-[#61a8ff] ring-4 ring-[#dbeeff] dark:ring-[#183e69]" />
-          <span className="absolute bottom-[39%] left-[25%] h-1.5 w-1.5 rounded-full bg-[#338df2]" />
-          <span className="absolute bottom-[45%] left-[34%] h-1.5 w-1.5 rounded-full bg-[#338df2]" />
-          <span className="absolute bottom-[51%] left-[43%] h-1.5 w-1.5 rounded-full bg-[#338df2]" />
-          <span className="absolute right-[15%] top-[24%] flex h-[76px] w-[76px] items-center justify-center rounded-full bg-[#288af0] text-white shadow-[0_13px_26px_rgba(40,138,240,0.28)]">
-            <Navigation className="h-9 w-9 fill-current" strokeWidth={1.5} />
+          <span className="absolute bottom-[34%] left-[36%] h-3 w-3 rounded-full bg-[#61a8ff] ring-4 ring-[#dbeeff] dark:ring-[#183e69]" />
+          <span className="absolute bottom-[40%] left-[45%] h-1.5 w-1.5 rounded-full bg-[#338df2]" />
+          <span className="absolute bottom-[46%] left-[53%] h-1.5 w-1.5 rounded-full bg-[#338df2]" />
+          <span className="absolute bottom-[52%] left-[61%] h-1.5 w-1.5 rounded-full bg-[#338df2]" />
+          <span className="absolute right-[10%] top-[24%] flex h-[50px] w-[50px] items-center justify-center rounded-full bg-[#288af0] text-white shadow-[0_13px_26px_rgba(40,138,240,0.28)]">
+            <Navigation className="h-[26px] w-[26px] fill-current" strokeWidth={1.5} />
           </span>
         </>
       ) : null}
       {kind === "checkin" ? (
         <span
-          className="absolute right-[5%] top-[12%] h-[96px] w-[96px]"
+          className="absolute right-[5%] top-[12%] h-[68px] w-[68px]"
           data-one-checkin-art
         >
           <span className="absolute bottom-[7%] left-[5%] h-[31%] w-[90%] rounded-[50%] border border-[#16a895]/20 bg-[radial-gradient(ellipse_at_center,rgba(22,168,149,0.16)_0%,rgba(22,168,149,0.05)_48%,transparent_72%)] dark:border-[#42d6c2]/20 dark:bg-[radial-gradient(ellipse_at_center,rgba(66,214,194,0.16)_0%,rgba(66,214,194,0.04)_50%,transparent_74%)]" />
@@ -460,7 +468,10 @@ function UseCaseArt({
         </span>
       ) : null}
       <span
-        className="absolute bottom-[13%] right-[4%] flex w-max items-center gap-1 rounded-full bg-white/95 px-3 py-1.5 text-[9px] font-bold text-[#151b26] shadow-[0_5px_16px_rgba(22,35,58,0.16)] dark:bg-[#f4f7fb]"
+        className={cn(
+          "absolute bottom-[19%] right-[4%] flex w-max items-center gap-1 rounded-full bg-white/95 py-1.5 text-[9px] font-bold text-[#151b26] shadow-[0_5px_16px_rgba(22,35,58,0.16)] dark:bg-[#f4f7fb]",
+          kind === "sms" ? "px-3.5" : "px-2.5",
+        )}
         data-one-use-case-alert
       >
         {kind !== "sms" ? (
@@ -502,13 +513,13 @@ function UseCaseCard({
   const colors = USE_CASE_TONES[tone];
   return (
     <article
-      className="relative h-full min-h-0 overflow-hidden rounded-[24px] border border-black/[0.04] bg-[#fbfcfe] shadow-[0_8px_26px_rgba(21,41,70,0.08)] dark:border-white/[0.08] dark:bg-[#171d27] dark:shadow-none"
+      className="relative h-full min-h-0 overflow-hidden rounded-[22px] border border-black/[0.03] bg-white shadow-[0_8px_26px_rgba(21,41,70,0.09)] dark:border-white/[0.08] dark:bg-[#171d27] dark:shadow-none"
       data-testid={testId}
       data-one-use-case-card
     >
-      <span className={cn("absolute inset-y-0 left-0 w-1", colors.line)} />
+      <span className={cn("absolute inset-y-0 left-0 w-[5px]", colors.line)} />
       <div
-        className="relative z-10 flex h-full min-h-0 w-[64%] min-w-0 flex-col justify-center py-3 pl-5 pr-2"
+        className="relative z-10 flex h-full min-h-0 w-[64%] min-w-0 flex-col justify-center py-3 pl-4 pr-2"
         data-one-use-case-copy
       >
         <span
@@ -523,7 +534,7 @@ function UseCaseCard({
         <div
           role="heading"
           aria-level={2}
-          className="mt-2.5 font-[family-name:var(--font-app-display)] text-[18px] font-bold leading-[1.12] text-[#091126] dark:text-white"
+          className="mt-2.5 font-[family-name:var(--font-app-display)] text-[16px] font-bold leading-[1.18] text-[#091126] dark:text-white"
           data-one-use-case-title
         >
           {titleLines.map((line) => (
@@ -583,22 +594,29 @@ function FeaturesScreen({
 
   return (
     <div
-      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-white px-5 pb-[calc(env(safe-area-inset-bottom,0px)+12px)] dark:bg-[#0c1017]"
+      className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-[#f5f5f7] pb-[max(env(safe-area-inset-bottom,0px),11px)] pl-6 pr-5 pt-[max(env(safe-area-inset-top,0px),55px)] dark:bg-[#0c1017]"
       data-one-feature-screen
     >
-      <header className="flex h-[clamp(48px,7dvh,64px)] shrink-0 items-center justify-between">
+      <header
+        className="flex h-[42px] shrink-0 items-center justify-between"
+        data-one-feature-header
+      >
         <button
           type="button"
           onClick={onBack}
-          className="press-scale flex h-11 w-11 items-center justify-center rounded-full bg-black/[0.05] text-[#1f2b3d] dark:bg-white/[0.08] dark:text-white"
+          className="press-scale flex h-[42px] w-[42px] items-center justify-center rounded-full bg-white text-[#7b8088] shadow-[0_4px_14px_rgba(26,42,65,0.12)] dark:bg-white/[0.08] dark:text-white"
           aria-label="Go back"
         >
-          <ArrowLeft className="h-6 w-6" />
+          <ChevronLeft className="h-[22px] w-[22px]" strokeWidth={2} />
         </button>
-        <OnboardingSkipButton onClick={onSkip} disabled={leaving} />
+        <OnboardingSkipButton
+          floating
+          onClick={onSkip}
+          disabled={leaving}
+        />
       </header>
       <h1
-        className="shrink-0 text-[clamp(30px,4.4dvh,39px)] font-bold leading-[1.04] tracking-normal text-[#091126] dark:text-[#f6f8fc]"
+        className="mt-[15px] shrink-0 text-[32px] font-bold leading-[1.05] tracking-[-0.02em] text-[#091126] dark:text-[#f6f8fc]"
         data-one-feature-heading
       >
         Stay connected
@@ -606,15 +624,16 @@ function FeaturesScreen({
         when you need it.
       </h1>
       <div
-        className="mt-[clamp(8px,1.8dvh,20px)] grid min-h-0 flex-1 grid-rows-3 gap-[clamp(7px,1.35dvh,16px)]"
+        className="mt-[18px] grid min-h-0 flex-1 grid-rows-3 gap-3"
         data-one-feature-grid
       >
         <UseCaseCard
-          tag="SMS - Save My Soul"
-          titleLines={["Need help, but", "can't call or speak?"]}
+          tag="SMS · Save my soul"
+          titleLines={["Need help,", "but can’t call or speak?"]}
           bodyLines={[
-            "Send an emergency SMS with your",
-            "live location to trusted contacts.",
+            "Send an emergency SMS",
+            "with your live location to",
+            "trusted contacts.",
           ]}
           alertText="Sent to 3 contacts"
           kind="sms"
@@ -623,19 +642,19 @@ function FeaturesScreen({
         />
         <UseCaseCard
           tag="Share location"
-          titleLines={["Still answering", '"Where are you?"']}
+          titleLines={["Still answering", "“Where are you?”"]}
           bodyLines={[
             "Share your live location safely in",
             "one tap. Stop anytime.",
           ]}
-          alertText="Location shared securely"
+          alertText="Shared securely"
           kind="share"
           tone="info"
           testId="location-use-case-trip"
         />
         <UseCaseCard
           tag="Check in"
-          titleLines={["Meeting up, but", "can't find each other?"]}
+          titleLines={["Meeting up,", "but can’t find each other?"]}
           bodyLines={["Check in once so everyone sees", "your exact spot."]}
           alertText="Checked in at Gate 3"
           kind="checkin"
@@ -644,21 +663,25 @@ function FeaturesScreen({
         />
       </div>
       <p
-        className="shrink-0 pt-[clamp(4px,0.9dvh,12px)] text-center text-[10px] font-semibold leading-4 text-[#7d838d] dark:text-[#9ba7b7]"
+        className={cn(
+          "shrink-0 pt-2 text-center text-[10px] font-semibold leading-4 text-[#7d838d] dark:text-[#9ba7b7]",
+          !waitingForLocation && !permissionBusy && "sr-only",
+        )}
         aria-live="polite"
       >
         {status}
       </p>
       <div
-        className="mt-[clamp(4px,0.8dvh,10px)] shrink-0"
+        className="mt-[11px] shrink-0"
         data-one-feature-cta
       >
         <PrimaryButton
           onClick={onContinue}
           busy={permissionBusy}
           disabled={permissionBusy}
+          className="h-[52px] min-h-[52px]"
         >
-          {waitingForLocation ? "Allow location" : "Continue"}
+          Continue
         </PrimaryButton>
       </div>
       <style>{`
@@ -670,7 +693,10 @@ function FeaturesScreen({
           [data-one-use-case-art] { width: 42%; }
         }
         @media (max-height: 760px) {
-          [data-one-feature-screen] { padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 8px); }
+          [data-one-feature-screen] {
+            padding-top: max(env(safe-area-inset-top, 0px), 24px);
+            padding-bottom: max(env(safe-area-inset-bottom, 0px), 8px);
+          }
           [data-one-feature-heading] { font-size: 29px; }
           [data-one-use-case-card] { border-radius: 20px; }
           [data-one-use-case-copy] { width: 64%; padding: 8px 6px 8px 16px; }
@@ -678,7 +704,7 @@ function FeaturesScreen({
           [data-one-use-case-title] { margin-top: 5px; font-size: 16px; line-height: 1.08; }
           [data-one-use-case-body] { margin-top: 4px; font-size: 11.5px; line-height: 1.22; }
           [data-one-use-case-art] { width: 42%; }
-          [data-one-use-case-kind="sms"] > div { width: 64px; height: 64px; border-width: 5px; }
+          [data-one-use-case-kind="sms"] > div { width: 76px; height: 76px; border-width: 10px; }
           [data-one-use-case-kind="sms"] > div span span:first-child { font-size: 18px; }
           [data-one-use-case-kind="sms"] > div span span:last-child { margin-top: 2px; font-size: 8px; }
           [data-one-use-case-kind="share"] > span:nth-child(5) { width: 54px; height: 54px; }
@@ -687,7 +713,7 @@ function FeaturesScreen({
           [data-one-use-case-alert] { right: 2%; bottom: 8%; padding: 4px 8px; font-size: 8px; }
           [data-one-use-case-alert] > span:first-child { width: 13px; height: 13px; }
           [data-one-use-case-alert] > span:first-child svg { width: 10px; height: 10px; }
-          [data-one-feature-cta] button { min-height: 44px; }
+          [data-one-feature-cta] button { min-height: 44px; height: 44px; }
         }
         @media (max-height: 680px) {
           [data-one-feature-heading] { font-size: 26px; }

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -13,7 +13,7 @@ const recipients: OneLocationRecipient[] = [
     phoneVerified: true,
     keyId: "key-selected",
     publicKeyJwk: { kty: "EC" },
-    keyAlgorithm: "ECDH-P256-AES256-GCM",
+    keyAlgorithm: "fixture",
     canReceiveLocation: true,
   },
   {
@@ -23,7 +23,7 @@ const recipients: OneLocationRecipient[] = [
     phoneVerified: true,
     keyId: "key-available",
     publicKeyJwk: { kty: "EC" },
-    keyAlgorithm: "ECDH-P256-AES256-GCM",
+    keyAlgorithm: "fixture",
     canReceiveLocation: true,
   },
 ];

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { SmsContactsFlow } from "@/components/one-location/redesign/sms-contacts-flow";
@@ -60,8 +60,8 @@ describe("SmsContactsFlow", () => {
     expect(onAdd).toHaveBeenCalledWith("available");
   });
 
-  it("requires confirmation before removing membership", () => {
-    const onRemove = vi.fn();
+  it("requires confirmation and waits for successful removal", async () => {
+    const onRemove = vi.fn().mockResolvedValue(true);
     render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Remove" }));
@@ -72,6 +72,46 @@ describe("SmsContactsFlow", () => {
       hidden: true,
     });
     fireEvent.click(removeButtons[removeButtons.length - 1]!);
-    expect(onRemove).toHaveBeenCalledWith("selected");
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledWith("selected");
+      expect(screen.queryByText("Remove Kushal?")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the confirmation open when removal fails", async () => {
+    const onRemove = vi.fn().mockResolvedValue(false);
+    render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    const removeButtons = screen.getAllByRole("button", {
+      name: "Remove",
+      hidden: true,
+    });
+    fireEvent.click(removeButtons[removeButtons.length - 1]!);
+
+    await waitFor(() => expect(onRemove).toHaveBeenCalledWith("selected"));
+    expect(screen.getByText("Remove Kushal?")).toBeInTheDocument();
+  });
+
+  it("owns a full-screen settings canvas and a bottom-sheet confirmation", () => {
+    render(
+      <SmsContactsFlow
+        {...baseProps}
+        onRemove={vi.fn().mockResolvedValue(true)}
+      />,
+    );
+
+    expect(screen.getByTestId("sms-contacts-screen")).toHaveClass(
+      "fixed",
+      "inset-0",
+      "bg-[#f2f3f7]",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(screen.getByRole("alertdialog")).toHaveClass(
+      "!bottom-0",
+      "!top-auto",
+      "!max-w-[430px]",
+      "!rounded-t-[24px]",
+    );
   });
 });

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SmsContactsFlow } from "@/components/one-location/redesign/sms-contacts-flow";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+const recipients: OneLocationRecipient[] = [
+  {
+    userId: "selected",
+    displayName: "Kushal",
+    maskedPhone: "•••• 303",
+    phoneVerified: true,
+    keyId: "key-selected",
+    publicKeyJwk: { kty: "EC" },
+    keyAlgorithm: "ECDH-P256-AES256-GCM",
+    canReceiveLocation: true,
+  },
+  {
+    userId: "available",
+    displayName: "Neelesh",
+    maskedPhone: "•••• 404",
+    phoneVerified: true,
+    keyId: "key-available",
+    publicKeyJwk: { kty: "EC" },
+    keyAlgorithm: "ECDH-P256-AES256-GCM",
+    canReceiveLocation: true,
+  },
+];
+
+const baseProps = {
+  recipients,
+  selectedUserIds: ["selected"],
+  busyKey: null,
+  onBack: vi.fn(),
+  onAdd: vi.fn(),
+  onRemove: vi.fn(),
+  recipientLabel: (recipient: OneLocationRecipient) => recipient.displayName,
+  recipientSubtitle: (recipient: OneLocationRecipient) =>
+    recipient.maskedPhone || "Connected",
+  isRecipientShareReady: (recipient: OneLocationRecipient) =>
+    recipient.canReceiveLocation,
+};
+
+describe("SmsContactsFlow", () => {
+  it("separates selected and available circle members", () => {
+    render(<SmsContactsFlow {...baseProps} />);
+
+    expect(screen.getByText("Alerted on SMS")).toBeInTheDocument();
+    expect(screen.getByText("Add from your circle")).toBeInTheDocument();
+    expect(screen.getByText("Kushal")).toBeInTheDocument();
+    expect(screen.getByText("Neelesh")).toBeInTheDocument();
+  });
+
+  it("adds an available recipient", () => {
+    const onAdd = vi.fn();
+    render(<SmsContactsFlow {...baseProps} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(onAdd).toHaveBeenCalledWith("available");
+  });
+
+  it("requires confirmation before removing membership", () => {
+    const onRemove = vi.fn();
+    render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(screen.getByText("Remove Kushal?")).toBeInTheDocument();
+    const removeButtons = screen.getAllByRole("button", {
+      name: "Remove",
+      hidden: true,
+    });
+    fireEvent.click(removeButtons[removeButtons.length - 1]!);
+    expect(onRemove).toHaveBeenCalledWith("selected");
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -40,12 +40,22 @@ describe("SosPanel", () => {
     render(<SosPanel {...baseProps} />);
 
     expect(screen.getByText("SMS · Save my soul")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Press and hold. An SMS with your live location goes to your people — even with no internet.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(/SMS goes to Carol/)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /call 911/i })).toHaveAttribute(
       "href",
       "tel:911",
     );
     expect(screen.queryByText(/voice note/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("sms-safety-screen")).toHaveClass(
+      "fixed",
+      "inset-0",
+      "bg-black",
+    );
   });
 
   it("does not send when the hold is released before two seconds", () => {

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -1,28 +1,31 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, act } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import { SosPanel } from "@/components/one-location/redesign/sos-panel";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
 
-const recipient = (over: Partial<OneLocationRecipient>): OneLocationRecipient => ({
+const recipient = (
+  overrides: Partial<OneLocationRecipient>,
+): OneLocationRecipient => ({
   userId: "u1",
   displayName: "Carol",
   phoneVerified: true,
   keyAlgorithm: "ECDH-P256-AES256-GCM",
   canReceiveLocation: true,
-  ...over,
+  ...overrides,
 });
 
 const baseProps = {
   recipients: [recipient({ userId: "u1", displayName: "Carol" })],
   active: false,
   busy: false,
-  startedAtLabel: null,
   onTrigger: vi.fn(),
-  onStop: vi.fn(),
-  recipientLabel: (r: OneLocationRecipient) => r.displayName,
-  isRecipientShareReady: (r: OneLocationRecipient) => r.canReceiveLocation,
-  countdownSeconds: 3,
+  onClose: vi.fn(),
+  onEditContacts: vi.fn(),
+  recipientLabel: (value: OneLocationRecipient) => value.displayName,
+  isRecipientShareReady: (value: OneLocationRecipient) =>
+    value.canReceiveLocation,
 };
 
 beforeEach(() => vi.useFakeTimers());
@@ -33,36 +36,85 @@ afterEach(() => {
 });
 
 describe("SosPanel", () => {
-  it("shows the SOS-ready state and the alert recipients when idle", () => {
+  it("renders the Save My Soul UI, selected recipients, and US dialer", () => {
     render(<SosPanel {...baseProps} />);
-    expect(screen.getByText(/SOS READY/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /open alert/i })).toBeInTheDocument();
-    expect(screen.getByText(/notify Carol/i)).toBeInTheDocument();
+
+    expect(screen.getByText("SMS · Save my soul")).toBeInTheDocument();
+    expect(screen.getByText(/SMS goes to Carol/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /call 911/i })).toHaveAttribute(
+      "href",
+      "tel:911",
+    );
+    expect(screen.queryByText(/voice note/i)).not.toBeInTheDocument();
   });
 
-  it("opening the alert starts a countdown that can be cancelled (no trigger)", () => {
+  it("does not send when the hold is released before two seconds", () => {
     const onTrigger = vi.fn();
     render(<SosPanel {...baseProps} onTrigger={onTrigger} />);
-    fireEvent.click(screen.getByRole("button", { name: /open alert/i }));
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    act(() => vi.advanceTimersByTime(5000));
+    const hold = screen.getByRole("button", {
+      name: /press and hold for two seconds/i,
+    });
+
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(1_500));
+    fireEvent.pointerUp(hold, { pointerId: 1 });
+    act(() => vi.advanceTimersByTime(1_000));
+
     expect(onTrigger).not.toHaveBeenCalled();
   });
 
-  it("fires onTrigger when the countdown elapses", () => {
+  it("sends exactly once after a continuous two-second hold", () => {
     const onTrigger = vi.fn();
-    render(<SosPanel {...baseProps} onTrigger={onTrigger} countdownSeconds={3} />);
-    fireEvent.click(screen.getByRole("button", { name: /open alert/i }));
-    act(() => vi.advanceTimersByTime(3000));
+    render(<SosPanel {...baseProps} onTrigger={onTrigger} />);
+    const hold = screen.getByRole("button", {
+      name: /press and hold for two seconds/i,
+    });
+
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.pointerUp(hold, { pointerId: 1 });
+    act(() => vi.advanceTimersByTime(2_000));
+
     expect(onTrigger).toHaveBeenCalledTimes(1);
+    expect(onTrigger).toHaveBeenCalledWith(null);
   });
 
-  it("shows the active alert state and calls onStop", () => {
-    const onStop = vi.fn();
-    render(<SosPanel {...baseProps} active startedAtLabel="10:57 AM" onStop={onStop} />);
-    expect(screen.getByText(/ALERT ACTIVE/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /i'm safe/i }));
-    expect(onStop).toHaveBeenCalledTimes(1);
+  it("passes the selected fixed message and exposes Edit and Cancel", () => {
+    const onTrigger = vi.fn();
+    const onClose = vi.fn();
+    const onEditContacts = vi.fn();
+    render(
+      <SosPanel
+        {...baseProps}
+        onTrigger={onTrigger}
+        onClose={onClose}
+        onEditContacts={onEditContacts}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "I'm not safe" }));
+    const hold = screen.getByRole("button", {
+      name: /press and hold for two seconds/i,
+    });
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(onTrigger).toHaveBeenCalledWith("I'm not safe");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onEditContacts).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when no selected recipient is ready", () => {
+    const onTrigger = vi.fn();
+    render(<SosPanel {...baseProps} recipients={[]} onTrigger={onTrigger} />);
+    const hold = screen.getByRole("button", {
+      name: /press and hold for two seconds/i,
+    });
+    expect(hold).toBeDisabled();
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(3_000));
+    expect(onTrigger).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
+++ b/hushh-webapp/components/one-location/redesign/action-confirm-card.tsx
@@ -9,7 +9,7 @@ const CONFIRM_LABEL: Record<ClientAction["type"], string> = {
   publish_share: "Share",
   view_envelope: "View",
   create_public_link: "Create link",
-  sos_panic: "Send SOS",
+  sos_panic: "Send SMS",
   check_in: "Check in",
 };
 

--- a/hushh-webapp/components/one-location/redesign/local-emergency-dialer-row.tsx
+++ b/hushh-webapp/components/one-location/redesign/local-emergency-dialer-row.tsx
@@ -1,11 +1,11 @@
 import { Phone } from "lucide-react";
 
-/** Opens the device dialer without guessing a country-specific emergency number. */
+/** US-only emergency action. Opens the dialer; the user still confirms the call. */
 export function LocalEmergencyDialerRow() {
   return (
     <a
-      href="tel:"
-      aria-label="Open local emergency dialer"
+      href="tel:911"
+      aria-label="Call 911"
       className="flex min-h-16 items-center gap-3 rounded-[14px] px-3 py-3 transition-colors hover:bg-black/[0.025] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#e0342c]/45 dark:hover:bg-white/[0.04]"
     >
       <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[#fdeeec] dark:bg-[#e0342c]/15">
@@ -13,10 +13,10 @@ export function LocalEmergencyDialerRow() {
       </span>
       <span className="min-w-0 flex-1">
         <span className="block text-[15px] font-bold text-foreground">
-          Local Emergency
+          Emergency services
         </span>
         <span className="mt-px block truncate text-[13px] text-black/45 dark:text-white/45">
-          Open your phone dialer
+          United States
         </span>
       </span>
       <span
@@ -24,7 +24,7 @@ export function LocalEmergencyDialerRow() {
         className="flex shrink-0 items-center gap-1.5 rounded-full bg-[#fdeeec] px-[15px] py-[9px] text-[14px] font-semibold text-[#d92c24] dark:bg-[#e0342c]/15 dark:text-[#ff6f66]"
       >
         <Phone className="h-3.5 w-3.5" strokeWidth={2} />
-        Call
+        Call 911
       </span>
     </a>
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -197,7 +197,7 @@ export type LocationHubViewModel = {
   onTriggerSos: (message?: "Come get me" | "I'm not safe" | null) => void;
   onStopSos: () => void;
   onAddSmsContact: (recipientUserId: string) => void;
-  onRemoveSmsContact: (recipientUserId: string) => void;
+  onRemoveSmsContact: (recipientUserId: string) => Promise<boolean>;
 
   /* Check-In (quick action) — reuses the encrypted share pipeline. The message
      is surfaced in the recipient's notification (e.g. "Alex: I've checked in
@@ -353,8 +353,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     } else if (section === "people") {
       nextTab = "people";
     }
-    const legacyInbox =
-      searchParams.get(LOCATION_HUB_TAB_PARAM) === "inbox";
+    const legacyInbox = searchParams.get(LOCATION_HUB_TAB_PARAM) === "inbox";
     if (detailAction || nextTab || legacyInbox) {
       setFlow("none");
       const params = new URLSearchParams(searchParams.toString());
@@ -527,8 +526,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             recipientSubtitle={vm.recipientSubtitle}
             isRecipientShareReady={vm.isRecipientShareReady}
           />
-        ) :
-          flow === "active-shares" ||
+        ) : flow === "active-shares" ||
           flow === "shared-with-me" ||
           flow === "needs-review" ? (
           <LocationDetailFlow
@@ -635,11 +633,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   );
 }
 
-function LocationHubPanel({
-  children,
-}: {
-  children: ReactNode;
-}) {
+function LocationHubPanel({ children }: { children: ReactNode }) {
   return (
     <div className="space-y-5 px-[var(--page-inline-gutter-standard)]">
       {children}
@@ -822,14 +816,17 @@ function LocationDetailFlow({
           <div className="space-y-3">
             {vm.receivedGrants.map((grant) => {
               const point = vm.decryptedPoints[grant.id];
-              const expanded = Boolean(point) && !collapsedGrantIds.has(grant.id);
+              const expanded =
+                Boolean(point) && !collapsedGrantIds.has(grant.id);
               return (
                 <SharedWithMeCard
                   key={grant.id}
                   name={vm.grantOwnerLabel(grant)}
                   statusLine={vm.expiresLabel(grant.expiresAt)}
                   metaLine={
-                    point ? `Updated ${vm.formatDateTime(point.capturedAt)}` : undefined
+                    point
+                      ? `Updated ${vm.formatDateTime(point.capturedAt)}`
+                      : undefined
                   }
                   previewExpanded={expanded}
                   mapHref={point ? vm.mapLocationHref(point) : undefined}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -34,9 +34,7 @@ import {
   Lock,
   Map,
   MapPin,
-  MessageCircle,
   Navigation,
-  Phone,
   Plus,
   RefreshCw,
   Send,
@@ -80,6 +78,7 @@ import {
   type ReasonValue,
 } from "./selectors";
 import { SosPanel } from "@/components/one-location/redesign/sos-panel";
+import { SmsContactsFlow } from "@/components/one-location/redesign/sms-contacts-flow";
 import {
   QuickActionCard,
   QuickActionsSection,
@@ -87,7 +86,6 @@ import {
 import { CheckInFlow } from "@/components/one-location/redesign/check-in-flow";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { ROUTES } from "@/lib/navigation/routes";
-import { LocalEmergencyDialerRow } from "./local-emergency-dialer-row";
 
 type ReadinessTone = "ready" | "warning" | "blocked" | "checking";
 
@@ -186,13 +184,20 @@ export type LocationHubViewModel = {
   onShareCircleInvite: () => void;
   onRevokeCircleInvite: (invite: OneLocationCircleInvite) => void;
 
-  /* SOS panic */
+  /* Save My Soul (internal compatibility identifier remains SOS). */
+  /** Connected, share-ready circle used by non-SMS quick actions. */
   sosRecipients: OneLocationRecipient[];
+  /** Explicit owner-selected Save My Soul recipients. */
+  smsRecipients: OneLocationRecipient[];
+  smsContactCandidates: OneLocationRecipient[];
+  smsContactUserIds: string[];
   sosActive: boolean;
   sosBusy: boolean;
   sosStartedAtLabel: string | null;
-  onTriggerSos: () => void;
+  onTriggerSos: (message?: "Come get me" | "I'm not safe" | null) => void;
   onStopSos: () => void;
+  onAddSmsContact: (recipientUserId: string) => void;
+  onRemoveSmsContact: (recipientUserId: string) => void;
 
   /* Check-In (quick action) — reuses the encrypted share pipeline. The message
      is surfaced in the recipient's notification (e.g. "Alex: I've checked in
@@ -232,6 +237,7 @@ type FlowKind =
   | "temp-link"
   | "check-in"
   | "sos"
+  | "sms-contacts"
   | "privacy"
   | "active-shares"
   | "shared-with-me"
@@ -249,6 +255,7 @@ const FLOW_TO_ACTION: Record<Exclude<FlowKind, "none">, string> = {
   "temp-link": "temp-link",
   "check-in": "check-in",
   sos: "sos",
+  "sms-contacts": "sms-contacts",
   privacy: "privacy",
   "active-shares": "active-shares",
   "shared-with-me": "shared-with-me",
@@ -503,7 +510,23 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         ) : flow === "check-in" ? (
           <CheckInFlow vm={vm} onClose={closeFlow} />
         ) : flow === "sos" ? (
-          <SosFlow vm={vm} />
+          <SosFlow
+            vm={vm}
+            onClose={() => closeFlow("now")}
+            onEditContacts={() => openFlow("sms-contacts")}
+          />
+        ) : flow === "sms-contacts" ? (
+          <SmsContactsFlow
+            recipients={vm.smsContactCandidates}
+            selectedUserIds={vm.smsContactUserIds}
+            busyKey={vm.busy}
+            onBack={() => closeFlow("now")}
+            onAdd={vm.onAddSmsContact}
+            onRemove={vm.onRemoveSmsContact}
+            recipientLabel={vm.recipientLabel}
+            recipientSubtitle={vm.recipientSubtitle}
+            isRecipientShareReady={vm.isRecipientShareReady}
+          />
         ) :
           flow === "active-shares" ||
           flow === "shared-with-me" ||
@@ -527,7 +550,11 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         ) : flow === "invite" ? (
           <InviteFlow vm={vm} onClose={closeFlow} />
         ) : flow === "privacy" ? (
-          <PrivacyFlow onManageSharing={() => closeFlow("people")} />
+          <PrivacyFlow
+            smsContactCount={vm.smsContactUserIds.length}
+            onManageSharing={() => closeFlow("people")}
+            onManageSmsContacts={() => openFlow("sms-contacts")}
+          />
         ) : (
           <TemporaryLinkFlow
             vm={vm}
@@ -718,8 +745,8 @@ function NowHub({
         <QuickActionCard
           tone="red"
           icon={<Shield className="h-5 w-5" />}
-          title="Alert"
-          subtitle={vm.sosActive ? "Live now" : "Notify circle"}
+          title="SMS"
+          subtitle={vm.sosActive ? "Live now" : "Save my soul"}
           onClick={onSos}
         />
       </QuickActionsSection>
@@ -890,7 +917,15 @@ function LocationToggle({
   );
 }
 
-function PrivacyFlow({ onManageSharing }: { onManageSharing: () => void }) {
+function PrivacyFlow({
+  smsContactCount,
+  onManageSharing,
+  onManageSmsContacts,
+}: {
+  smsContactCount: number;
+  onManageSharing: () => void;
+  onManageSmsContacts: () => void;
+}) {
   // Inert local state for now — real auto-share / pause wiring comes later.
   const [autoShare, setAutoShare] = useState(false);
   const [paused, setPaused] = useState(false);
@@ -964,6 +999,24 @@ function PrivacyFlow({ onManageSharing }: { onManageSharing: () => void }) {
             See and change who has your live location
           </p>
         </div>
+        <ChevronRight className="h-4 w-4 shrink-0 text-black/30 dark:text-muted-foreground" />
+      </button>
+
+      <p className="mt-7 px-1 text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
+        Safety
+      </p>
+      <button
+        type="button"
+        onClick={onManageSmsContacts}
+        className="mt-2.5 flex w-full items-center gap-3 rounded-2xl bg-white p-4 text-left shadow-[0_2px_10px_rgba(0,0,0,0.05)] transition-colors hover:bg-black/[0.02] dark:bg-[color:var(--app-card-surface-default-solid)]"
+        data-testid="one-location-sms-contacts-entry"
+      >
+        <span className="min-w-0 flex-1 text-[16px] font-semibold text-[#1c1c2e] dark:text-foreground">
+          SMS contacts
+        </span>
+        <span className="text-[14px] text-black/40 dark:text-muted-foreground">
+          {smsContactCount}
+        </span>
         <ChevronRight className="h-4 w-4 shrink-0 text-black/30 dark:text-muted-foreground" />
       </button>
     </div>
@@ -1376,145 +1429,29 @@ function LinksHub({
 }
 
 /* =================================================================== */
-/* SOS FLOW (Quick Action wrapper around the existing SOS panic panel)  */
+/* SAVE MY SOUL FLOW (internal action identifier remains `sos`)          */
 /* =================================================================== */
 
-/** Circle avatar tones for the "Location shared with …" stack. */
-const SOS_AVATAR_TONES = [
-  "bg-amber-500",
-  "bg-blue-600",
-  "bg-rose-500",
-  "bg-teal-500",
-  "bg-violet-500",
-];
-
-function sosInitials(label: string): string {
-  const words = label.trim().split(/\s+/).filter(Boolean);
-  if (words.length >= 2) {
-    return `${words[0]![0] ?? ""}${words[1]![0] ?? ""}`.toUpperCase();
-  }
-  return (words[0]?.slice(0, 1) || "?").toUpperCase();
-}
-
-/** Small square shortcut card (Call / Message / Share live location). */
-function SosQuickCard({
-  icon: Icon,
-  title,
-  subtitle,
-  onClick,
+function SosFlow({
+  vm,
+  onClose,
+  onEditContacts,
 }: {
-  icon: typeof Phone;
-  title: string;
-  subtitle: string;
-  onClick?: () => void;
+  vm: LocationHubViewModel;
+  onClose: () => void;
+  onEditContacts: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="flex min-w-0 flex-col gap-3 rounded-[16px] bg-white p-3 text-left shadow-[0_2px_8px_rgba(0,0,0,0.04)] dark:bg-white/[0.05]"
-    >
-      <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[#fdeeec] dark:bg-[#e0342c]/15">
-        <Icon className="h-[17px] w-[17px] text-[#e0342c]" strokeWidth={1.8} />
-      </span>
-      <span className="min-w-0">
-        <span className="block text-[14px] font-bold text-foreground">
-          {title}
-        </span>
-        <span className="mt-2 flex items-end justify-between gap-2.5">
-          <span className="min-w-0 truncate text-[12px] text-black/45 dark:text-white/45">
-            {subtitle}
-          </span>
-          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#eef2f8] dark:bg-white/10">
-            <ChevronRight className="h-3 w-3 text-black/40 dark:text-white/40" />
-          </span>
-        </span>
-      </span>
-    </button>
-  );
-}
-
-function SosFlow({ vm }: { vm: LocationHubViewModel }) {
-  const recipients = vm.sosRecipients;
-  const sharedCount = recipients.length;
-
-  return (
-    <div className="space-y-3.5">
-      {/* Title only — the single back affordance is the top-left app-chrome back
-          arrow, which returns to the Location hub. */}
-      <h1 className="text-[33px] font-bold tracking-[-0.6px] text-foreground">
-        Safety
-      </h1>
-
-      <SosPanel
-        recipients={recipients}
-        active={vm.sosActive}
-        busy={vm.sosBusy}
-        startedAtLabel={vm.sosStartedAtLabel}
-        onTrigger={vm.onTriggerSos}
-        onStop={vm.onStopSos}
-        recipientLabel={vm.recipientLabel}
-        isRecipientShareReady={vm.isRecipientShareReady}
-      />
-
-      {/* Location shared with N people */}
-      {sharedCount > 0 ? (
-        <div className="rounded-[18px] bg-white p-[18px] shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-white/[0.05]">
-          <div className="text-[16px] font-bold text-foreground">
-            Location shared with {sharedCount}{" "}
-            {sharedCount === 1 ? "person" : "people"}
-          </div>
-          <div className="mt-3.5 flex items-center justify-between gap-3">
-            <div className="flex -space-x-1">
-              {recipients.slice(0, 4).map((r, index) => (
-                <span
-                  key={r.userId}
-                  className={cn(
-                    "flex h-[52px] w-[52px] items-center justify-center rounded-full text-sm font-semibold text-white ring-[2.5px] ring-white dark:ring-[#1c1c1e]",
-                    SOS_AVATAR_TONES[index % SOS_AVATAR_TONES.length],
-                  )}
-                  aria-hidden
-                >
-                  {sosInitials(vm.recipientLabel(r))}
-                </span>
-              ))}
-            </div>
-            <button
-              type="button"
-              className="shrink-0 whitespace-nowrap rounded-[14px] border-[1.5px] border-[color:var(--app-accent)] px-[18px] py-[11px] text-[14px] font-semibold text-[color:var(--app-accent)] dark:border-[color:var(--app-accent)] dark:text-[color:var(--app-accent)]"
-            >
-              View all
-            </button>
-          </div>
-        </div>
-      ) : null}
-
-      {/* Quick shortcuts */}
-      <div className="grid grid-cols-3 gap-2.5">
-        <SosQuickCard icon={Phone} title="Call" subtitle="Call for help" />
-        <SosQuickCard
-          icon={MessageCircle}
-          title="Message"
-          subtitle="Message contacts"
-        />
-        <SosQuickCard
-          icon={MapPin}
-          title="Share live location"
-          subtitle="With your circle"
-        />
-      </div>
-
-      {/* Reach out for help */}
-      <div className="rounded-[18px] bg-white px-4 py-[18px] shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-white/[0.05]">
-        <div className="text-[16px] font-bold text-foreground">
-          Reach out for help
-        </div>
-        <div className="mt-3 rounded-[14px] bg-[#f5f6f8] dark:bg-white/[0.04]">
-          <LocalEmergencyDialerRow />
-        </div>
-      </div>
-
-    </div>
+    <SosPanel
+      recipients={vm.smsRecipients}
+      active={vm.sosActive}
+      busy={vm.sosBusy}
+      onTrigger={vm.onTriggerSos}
+      onClose={onClose}
+      onEditContacts={onEditContacts}
+      recipientLabel={vm.recipientLabel}
+      isRecipientShareReady={vm.isRecipientShareReady}
+    />
   );
 }
 

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState, type ReactNode } from "react";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ChevronLeft, Loader2 } from "lucide-react";
 
 import {
   AlertDialog,
@@ -29,7 +29,7 @@ type SmsContactsFlowProps = {
   busyKey: string | null;
   onBack: () => void;
   onAdd: (recipientUserId: string) => void;
-  onRemove: (recipientUserId: string) => void;
+  onRemove: (recipientUserId: string) => Promise<boolean>;
   recipientLabel: (recipient: OneLocationRecipient) => string;
   recipientSubtitle: (recipient: OneLocationRecipient) => string;
   isRecipientShareReady: (recipient: OneLocationRecipient) => boolean;
@@ -133,6 +133,7 @@ export function SmsContactsFlow({
 }: SmsContactsFlowProps) {
   const [pendingRemoval, setPendingRemoval] =
     useState<OneLocationRecipient | null>(null);
+  const [removing, setRemoving] = useState(false);
   const selectedIds = useMemo(
     () => new Set(selectedUserIds),
     [selectedUserIds],
@@ -144,14 +145,23 @@ export function SmsContactsFlow({
     (recipient) => !selectedIds.has(recipient.userId),
   );
 
-  const removePending = () => {
-    if (!pendingRemoval) return;
-    onRemove(pendingRemoval.userId);
-    setPendingRemoval(null);
+  const removePending = async () => {
+    if (!pendingRemoval || removing) return;
+    setRemoving(true);
+    try {
+      const removed = await onRemove(pendingRemoval.userId);
+      if (removed) setPendingRemoval(null);
+    } finally {
+      setRemoving(false);
+    }
   };
 
   return (
-    <section className="fixed inset-0 z-[90] overflow-y-auto bg-[#f2f3f7] text-[#17171c]">
+    <section
+      className="fixed inset-0 z-[540] h-[100dvh] min-h-[100dvh] overflow-y-auto overscroll-none bg-[#f2f3f7] text-[#17171c]"
+      data-ambient-chrome-ignore
+      data-testid="sms-contacts-screen"
+    >
       <div className="mx-auto min-h-[100dvh] w-full max-w-[430px] px-3.5 pb-[max(28px,env(safe-area-inset-bottom))] pt-[max(38px,env(safe-area-inset-top))]">
         <button
           type="button"
@@ -159,10 +169,10 @@ export function SmsContactsFlow({
           aria-label="Back"
           className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.045]"
         >
-          <ArrowLeft className="h-[18px] w-[18px]" />
+          <ChevronLeft className="h-[19px] w-[19px]" />
         </button>
 
-        <h1 className="mt-3 text-[29px] font-bold leading-tight tracking-[-0.65px]">
+        <h1 className="mt-3 !text-[29px] !font-bold !leading-tight !tracking-[-0.65px]">
           SMS contacts
         </h1>
         <p className="mt-1 max-w-[350px] text-[13px] leading-[1.45] text-black/47">
@@ -231,38 +241,52 @@ export function SmsContactsFlow({
       <AlertDialog
         open={Boolean(pendingRemoval)}
         onOpenChange={(open) => {
-          if (!open) setPendingRemoval(null);
+          if (!open && !removing) setPendingRemoval(null);
         }}
       >
-        <AlertDialogContent className="bottom-0 left-1/2 top-auto w-full max-w-[430px] -translate-x-1/2 translate-y-0 rounded-b-none rounded-t-[24px] border-0 px-4 pb-[max(20px,env(safe-area-inset-bottom))] pt-5">
-          <AlertDialogHeader className="items-center text-center">
+        <AlertDialogContent
+          size="sm"
+          className="!bottom-0 !left-1/2 !top-auto !w-full !max-w-[430px] !-translate-x-1/2 !translate-y-0 !gap-0 !rounded-b-none !rounded-t-[24px] !border-0 !bg-white !px-4 !pb-[max(20px,env(safe-area-inset-bottom))] !pt-5 !shadow-none"
+        >
+          <AlertDialogHeader className="!place-items-center !text-center sm:!place-items-center sm:!text-center">
             <span
               className="flex h-14 w-14 items-center justify-center rounded-full bg-[#f29918] text-xl font-semibold text-white"
               aria-hidden
             >
-              {pendingRemoval
-                ? initials(recipientLabel(pendingRemoval))
-                : "?"}
+              {pendingRemoval ? initials(recipientLabel(pendingRemoval)) : "?"}
             </span>
-            <AlertDialogTitle className="text-center text-[20px]">
+            <AlertDialogTitle className="mt-1 !text-center !text-[20px] !font-bold !leading-tight">
               Remove{" "}
               {pendingRemoval
                 ? `${recipientLabel(pendingRemoval).split(/\s+/)[0]}?`
                 : "contact?"}
             </AlertDialogTitle>
-            <AlertDialogDescription className="max-w-[290px] text-center text-[13px] leading-[1.45]">
+            <AlertDialogDescription className="mt-1 !max-w-[290px] !text-center !text-[13px] !leading-[1.45]">
               They&apos;ll no longer be alerted with your live location when you
               trigger SMS.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="mt-4 grid gap-2">
             <AlertDialogAction
-              onClick={removePending}
-              className="h-12 rounded-full bg-[#ff3b30] text-[15px] font-semibold hover:bg-[#ff3b30]/90"
+              variant="destructive"
+              disabled={removing}
+              onClick={(event) => {
+                event.preventDefault();
+                void removePending();
+              }}
+              className="!h-12 !rounded-full !bg-[#ff3b30] !text-[15px] !font-semibold !text-white hover:!bg-[#ff3b30]/90 disabled:!opacity-60"
             >
-              Remove
+              {removing ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                "Remove"
+              )}
             </AlertDialogAction>
-            <AlertDialogCancel className="mt-0 h-12 rounded-full border-0 bg-[#efeff4] text-[15px] font-semibold">
+            <AlertDialogCancel
+              variant="secondary"
+              disabled={removing}
+              className="!mt-0 !h-12 !rounded-full !border-0 !bg-[#efeff4] !text-[15px] !font-semibold !text-[#17171c] hover:!bg-[#e5e5ea] disabled:!opacity-60"
+            >
               Cancel
             </AlertDialogCancel>
           </div>

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { ArrowLeft, Loader2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+const AVATAR_TONES = [
+  "bg-[#2f80ed]",
+  "bg-[#9b51e0]",
+  "bg-[#f29918]",
+  "bg-[#10a89a]",
+  "bg-[#eb5757]",
+] as const;
+
+type SmsContactsFlowProps = {
+  recipients: OneLocationRecipient[];
+  selectedUserIds: string[];
+  busyKey: string | null;
+  onBack: () => void;
+  onAdd: (recipientUserId: string) => void;
+  onRemove: (recipientUserId: string) => void;
+  recipientLabel: (recipient: OneLocationRecipient) => string;
+  recipientSubtitle: (recipient: OneLocationRecipient) => string;
+  isRecipientShareReady: (recipient: OneLocationRecipient) => boolean;
+};
+
+function initials(value: string): string {
+  const parts = value.trim().split(/\s+/).filter(Boolean);
+  return ((parts[0]?.[0] ?? "?") + (parts[1]?.[0] ?? ""))
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function ContactRow({
+  recipient,
+  index,
+  selected,
+  busy,
+  ready,
+  onAdd,
+  onAskRemove,
+  recipientLabel,
+  recipientSubtitle,
+}: {
+  recipient: OneLocationRecipient;
+  index: number;
+  selected: boolean;
+  busy: boolean;
+  ready: boolean;
+  onAdd: () => void;
+  onAskRemove: () => void;
+  recipientLabel: (recipient: OneLocationRecipient) => string;
+  recipientSubtitle: (recipient: OneLocationRecipient) => string;
+}) {
+  const label = recipientLabel(recipient);
+  return (
+    <div className="flex min-h-[64px] items-center gap-3 px-3.5 py-2.5">
+      <span
+        className={cn(
+          "flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[16px] font-semibold text-white",
+          AVATAR_TONES[index % AVATAR_TONES.length],
+        )}
+        aria-hidden
+      >
+        {initials(label)}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[15px] font-semibold text-[#17171c]">
+          {label}
+        </span>
+        <span className="mt-0.5 block truncate text-[12px] text-black/45">
+          {recipientSubtitle(recipient) || "Connected in One"}
+        </span>
+      </span>
+      {selected ? (
+        <button
+          type="button"
+          onClick={onAskRemove}
+          disabled={busy}
+          className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full border border-[#ff3b30]/35 px-3 text-[13px] font-semibold text-[#ff3b30] disabled:opacity-45"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Remove"}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={onAdd}
+          disabled={busy || !ready}
+          className="press-scale flex h-8 min-w-[58px] items-center justify-center rounded-full bg-[color:var(--app-accent)] px-3 text-[13px] font-semibold text-[color:var(--app-accent-fg)] disabled:bg-black/10 disabled:text-black/35"
+        >
+          {busy ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : ready ? (
+            "Add"
+          ) : (
+            "Setup"
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ContactGroup({ children }: { children: ReactNode }) {
+  return (
+    <div className="divide-y divide-black/[0.055] overflow-hidden rounded-[15px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.02)]">
+      {children}
+    </div>
+  );
+}
+
+export function SmsContactsFlow({
+  recipients,
+  selectedUserIds,
+  busyKey,
+  onBack,
+  onAdd,
+  onRemove,
+  recipientLabel,
+  recipientSubtitle,
+  isRecipientShareReady,
+}: SmsContactsFlowProps) {
+  const [pendingRemoval, setPendingRemoval] =
+    useState<OneLocationRecipient | null>(null);
+  const selectedIds = useMemo(
+    () => new Set(selectedUserIds),
+    [selectedUserIds],
+  );
+  const selected = recipients.filter((recipient) =>
+    selectedIds.has(recipient.userId),
+  );
+  const available = recipients.filter(
+    (recipient) => !selectedIds.has(recipient.userId),
+  );
+
+  const removePending = () => {
+    if (!pendingRemoval) return;
+    onRemove(pendingRemoval.userId);
+    setPendingRemoval(null);
+  };
+
+  return (
+    <section className="fixed inset-0 z-[90] overflow-y-auto bg-[#f2f3f7] text-[#17171c]">
+      <div className="mx-auto min-h-[100dvh] w-full max-w-[430px] px-3.5 pb-[max(28px,env(safe-area-inset-bottom))] pt-[max(38px,env(safe-area-inset-top))]">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back"
+          className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.045]"
+        >
+          <ArrowLeft className="h-[18px] w-[18px]" />
+        </button>
+
+        <h1 className="mt-3 text-[29px] font-bold leading-tight tracking-[-0.65px]">
+          SMS contacts
+        </h1>
+        <p className="mt-1 max-w-[350px] text-[13px] leading-[1.45] text-black/47">
+          These people are alerted with your live location the moment you send
+          the SMS.
+        </p>
+
+        <p className="mb-2 mt-6 px-1 text-[11px] font-bold uppercase tracking-[0.35px] text-black/40">
+          Alerted on SMS
+        </p>
+        {selected.length ? (
+          <ContactGroup>
+            {selected.map((recipient, index) => (
+              <ContactRow
+                key={recipient.userId}
+                recipient={recipient}
+                index={index}
+                selected
+                ready={isRecipientShareReady(recipient)}
+                busy={busyKey === `sms-contact:${recipient.userId}`}
+                onAdd={() => onAdd(recipient.userId)}
+                onAskRemove={() => setPendingRemoval(recipient)}
+                recipientLabel={recipientLabel}
+                recipientSubtitle={recipientSubtitle}
+              />
+            ))}
+          </ContactGroup>
+        ) : (
+          <div className="rounded-[15px] bg-white px-4 py-5 text-center text-[13px] leading-relaxed text-black/45">
+            No SMS contacts yet. Add someone from your circle below.
+          </div>
+        )}
+
+        <p className="mb-2 mt-6 px-1 text-[11px] font-bold uppercase tracking-[0.35px] text-black/40">
+          Add from your circle
+        </p>
+        {available.length ? (
+          <ContactGroup>
+            {available.map((recipient, index) => (
+              <ContactRow
+                key={recipient.userId}
+                recipient={recipient}
+                index={index + selected.length}
+                selected={false}
+                ready={isRecipientShareReady(recipient)}
+                busy={busyKey === `sms-contact:${recipient.userId}`}
+                onAdd={() => onAdd(recipient.userId)}
+                onAskRemove={() => setPendingRemoval(recipient)}
+                recipientLabel={recipientLabel}
+                recipientSubtitle={recipientSubtitle}
+              />
+            ))}
+          </ContactGroup>
+        ) : (
+          <div className="rounded-[15px] bg-white px-4 py-5 text-center text-[13px] text-black/45">
+            Everyone in your ready circle is already selected.
+          </div>
+        )}
+
+        <p className="mt-4 px-1 text-[12px] leading-[1.45] text-black/43">
+          Only people in your circle can be SMS contacts. They&apos;re never
+          notified unless you send the SMS.
+        </p>
+      </div>
+
+      <AlertDialog
+        open={Boolean(pendingRemoval)}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemoval(null);
+        }}
+      >
+        <AlertDialogContent className="bottom-0 left-1/2 top-auto w-full max-w-[430px] -translate-x-1/2 translate-y-0 rounded-b-none rounded-t-[24px] border-0 px-4 pb-[max(20px,env(safe-area-inset-bottom))] pt-5">
+          <AlertDialogHeader className="items-center text-center">
+            <span
+              className="flex h-14 w-14 items-center justify-center rounded-full bg-[#f29918] text-xl font-semibold text-white"
+              aria-hidden
+            >
+              {pendingRemoval
+                ? initials(recipientLabel(pendingRemoval))
+                : "?"}
+            </span>
+            <AlertDialogTitle className="text-center text-[20px]">
+              Remove{" "}
+              {pendingRemoval
+                ? `${recipientLabel(pendingRemoval).split(/\s+/)[0]}?`
+                : "contact?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="max-w-[290px] text-center text-[13px] leading-[1.45]">
+              They&apos;ll no longer be alerted with your live location when you
+              trigger SMS.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="mt-4 grid gap-2">
+            <AlertDialogAction
+              onClick={removePending}
+              className="h-12 rounded-full bg-[#ff3b30] text-[15px] font-semibold hover:bg-[#ff3b30]/90"
+            >
+              Remove
+            </AlertDialogAction>
+            <AlertDialogCancel className="mt-0 h-12 rounded-full border-0 bg-[#efeff4] text-[15px] font-semibold">
+              Cancel
+            </AlertDialogCancel>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -9,7 +9,7 @@ import {
   type KeyboardEvent,
   type PointerEvent,
 } from "react";
-import { ArrowLeft, Phone } from "lucide-react";
+import { ChevronLeft, Phone } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
@@ -90,12 +90,12 @@ export function SosPanel({
     onTrigger(message);
   }, [clearHold, disabled, message, onTrigger]);
 
-  const updateProgress = useCallback(() => {
+  const updateProgress = useCallback(function tickProgress() {
     if (!holdStartedAtRef.current || firedRef.current) return;
     const elapsed = performance.now() - holdStartedAtRef.current;
     setProgress(Math.min(elapsed / HOLD_DURATION_MS, 1));
     if (elapsed < HOLD_DURATION_MS) {
-      frameRef.current = requestAnimationFrame(updateProgress);
+      frameRef.current = requestAnimationFrame(tickProgress);
     }
   }, []);
 
@@ -161,7 +161,8 @@ export function SosPanel({
 
   return (
     <section
-      className="fixed inset-0 z-[90] overflow-y-auto bg-black text-white"
+      className="fixed inset-0 z-[540] h-[100dvh] min-h-[100dvh] overflow-y-auto overscroll-none bg-black text-white"
+      data-ambient-chrome-ignore
       data-testid="sms-safety-screen"
     >
       <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))]">
@@ -171,16 +172,16 @@ export function SosPanel({
           aria-label="Back to Location"
           className="press-scale flex h-10 w-10 items-center justify-center rounded-full bg-[#202023] text-white"
         >
-          <ArrowLeft className="h-5 w-5" strokeWidth={2} />
+          <ChevronLeft className="h-6 w-6" strokeWidth={2} />
         </button>
 
         <header className="mt-1 px-3 text-center">
-          <h1 className="text-[28px] font-bold leading-[1.15] tracking-[-0.45px]">
+          <h1 className="whitespace-nowrap !text-[28px] !font-bold !leading-[1.15] !tracking-[-0.45px]">
             SMS · Save my soul
           </h1>
           <p className="mx-auto mt-2 max-w-[290px] text-[14px] leading-[1.45] text-white/70">
-            Press and hold. Your SMS contacts get your live location in One —
-            when connected.
+            Press and hold. An SMS with your live location goes to your people —
+            even with no internet.
           </p>
         </header>
 
@@ -206,7 +207,7 @@ export function SosPanel({
               className={cn(
                 "relative z-10 flex h-[152px] w-[152px] touch-none select-none flex-col items-center justify-center rounded-full bg-[#ff3b30] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
                 progress > 0 && progress < 1 && "scale-[1.035]",
-                disabled && "cursor-not-allowed opacity-45",
+                disabled && "cursor-not-allowed",
               )}
               style={{
                 boxShadow:
@@ -233,8 +234,7 @@ export function SosPanel({
 
         <div className="mt-auto">
           <p className="truncate px-2 text-center text-[13px] text-white/70">
-            {names ? `SMS goes to ${names}` : "No SMS contacts selected"}{" "}
-            ·{" "}
+            {names ? `SMS goes to ${names}` : "No SMS contacts selected"} ·{" "}
             <button
               type="button"
               onClick={onEditContacts}
@@ -281,12 +281,6 @@ export function SosPanel({
               Cancel
             </button>
           </div>
-
-          {!names ? (
-            <p className="mt-2 text-center text-[12px] text-white/55">
-              Add a ready connection before sending an SMS.
-            </p>
-          ) : null}
         </div>
       </div>
     </section>

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -1,220 +1,294 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Shield, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+} from "react";
+import { ArrowLeft, Phone } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
+
+const HOLD_DURATION_MS = 2_000;
+export type SmsQuickMessage = "Come get me" | "I'm not safe";
 
 export type SosPanelProps = {
   recipients: OneLocationRecipient[];
   active: boolean;
   busy: boolean;
-  startedAtLabel: string | null;
-  onTrigger: () => void;
-  onStop: () => void;
-  recipientLabel: (r: OneLocationRecipient) => string;
-  isRecipientShareReady: (r: OneLocationRecipient) => boolean;
-  countdownSeconds?: number;
+  onTrigger: (message?: SmsQuickMessage | null) => void;
+  onClose: () => void;
+  onEditContacts: () => void;
+  recipientLabel: (recipient: OneLocationRecipient) => string;
+  isRecipientShareReady: (recipient: OneLocationRecipient) => boolean;
 };
 
-/** First name only, for the "notify Ankit, Akshat and Kushal" sentence. */
 function firstNameOf(label: string): string {
-  const trimmed = label.trim();
-  const first = trimmed.split(/\s+/)[0];
-  return first || trimmed;
+  return label.trim().split(/\s+/)[0] || label.trim();
 }
 
-/** "Ankit", "Ankit and Akshat", "Ankit, Akshat and Kushal", "… and 2 others". */
 function formatNames(names: string[]): string {
-  if (names.length === 0) return "your circle";
+  if (names.length === 0) return "";
   if (names.length === 1) return names[0]!;
   if (names.length === 2) return `${names[0]} and ${names[1]}`;
-  const shown = names.slice(0, 3);
-  if (names.length === 3) return `${shown[0]}, ${shown[1]} and ${shown[2]}`;
-  return `${shown[0]}, ${shown[1]} and ${names.length - 2} others`;
+  if (names.length === 3) return `${names[0]}, ${names[1]} and ${names[2]}`;
+  return `${names[0]}, ${names[1]} and ${names.length - 2} others`;
 }
 
-/**
- * SOS card for the Safety screen (Apple Blue v2 design).
- *
- * Behaviour is unchanged from the original panel: the primary red button arms a
- * short, cancellable countdown before firing `onTrigger` (never fires by
- * accident); while active it shows the "alerted" state with an "I'm safe" stop.
- * Only the presentation is reskinned to the design — literal red values with
- * dark variants layered on.
- */
 export function SosPanel({
   recipients,
   active,
   busy,
-  startedAtLabel,
   onTrigger,
-  onStop,
+  onClose,
+  onEditContacts,
   recipientLabel,
   isRecipientShareReady,
-  countdownSeconds = 5,
 }: SosPanelProps) {
-  const [remaining, setRemaining] = useState<number | null>(null);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [message, setMessage] = useState<SmsQuickMessage | null>(null);
+  const [progress, setProgress] = useState(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const holdStartedAtRef = useRef(0);
   const firedRef = useRef(false);
+  const observedBusyRef = useRef(false);
 
-  const stopTimer = () => {
-    if (timerRef.current) {
-      clearInterval(timerRef.current);
-      timerRef.current = null;
-    }
-  };
+  const readyRecipients = useMemo(
+    () => recipients.filter(isRecipientShareReady),
+    [isRecipientShareReady, recipients],
+  );
+  const names = useMemo(
+    () =>
+      formatNames(
+        readyRecipients.map((recipient) =>
+          firstNameOf(recipientLabel(recipient)),
+        ),
+      ),
+    [readyRecipients, recipientLabel],
+  );
+  const disabled = busy || active || readyRecipients.length === 0;
 
-  useEffect(() => stopTimer, []);
-
-  // Stable reference so the active-flip effect can list it without re-firing every render.
-  const cancelCountdown = useCallback(() => {
-    stopTimer();
-    firedRef.current = false;
-    setRemaining(null);
+  const clearHold = useCallback((resetProgress = true) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    timeoutRef.current = null;
+    frameRef.current = null;
+    holdStartedAtRef.current = 0;
+    if (resetProgress && !firedRef.current) setProgress(0);
   }, []);
 
-  const startCountdown = () => {
-    if (busy || active) return;
-    firedRef.current = false;
-    setRemaining(countdownSeconds);
-    stopTimer();
-    timerRef.current = setInterval(() => {
-      // Pure decrement only — side-effects (onTrigger) live in a useEffect below.
-      setRemaining((prev) => (prev === null ? null : prev - 1));
-    }, 1000);
+  const completeHold = useCallback(() => {
+    if (firedRef.current || disabled) return;
+    firedRef.current = true;
+    clearHold(false);
+    setProgress(1);
+    onTrigger(message);
+  }, [clearHold, disabled, message, onTrigger]);
+
+  const updateProgress = useCallback(() => {
+    if (!holdStartedAtRef.current || firedRef.current) return;
+    const elapsed = performance.now() - holdStartedAtRef.current;
+    setProgress(Math.min(elapsed / HOLD_DURATION_MS, 1));
+    if (elapsed < HOLD_DURATION_MS) {
+      frameRef.current = requestAnimationFrame(updateProgress);
+    }
+  }, []);
+
+  const startHold = useCallback(() => {
+    if (disabled || holdStartedAtRef.current || firedRef.current) return;
+    holdStartedAtRef.current = performance.now();
+    setProgress(0);
+    frameRef.current = requestAnimationFrame(updateProgress);
+    timeoutRef.current = setTimeout(completeHold, HOLD_DURATION_MS);
+  }, [completeHold, disabled, updateProgress]);
+
+  const cancelHold = useCallback(() => clearHold(true), [clearHold]);
+
+  useEffect(() => {
+    const onWindowBlur = () => cancelHold();
+    const onVisibility = () => {
+      if (document.hidden) cancelHold();
+    };
+    window.addEventListener("blur", onWindowBlur);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("blur", onWindowBlur);
+      document.removeEventListener("visibilitychange", onVisibility);
+      clearHold();
+    };
+  }, [cancelHold, clearHold]);
+
+  useEffect(() => {
+    if (busy) observedBusyRef.current = true;
+    if (!busy && observedBusyRef.current && !active) {
+      observedBusyRef.current = false;
+      firedRef.current = false;
+      setProgress(0);
+    }
+  }, [active, busy]);
+
+  const handlePointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    if (event.button > 0) return;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    startHold();
   };
 
-  // Fire onTrigger exactly once when the countdown reaches zero.
-  // Keeping it outside the functional updater prevents double-firing under StrictMode.
-  useEffect(() => {
-    if (remaining === 0 && !firedRef.current) {
-      firedRef.current = true;
-      stopTimer();
-      setRemaining(null);
-      onTrigger();
+  const handlePointerEnd = (event: PointerEvent<HTMLButtonElement>) => {
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
     }
-  }, [remaining, onTrigger]);
+    cancelHold();
+  };
 
-  // Cancel any running countdown when the SOS becomes active externally.
-  useEffect(() => {
-    if (active) cancelCountdown();
-  }, [active, cancelCountdown]);
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if ((event.key === " " || event.key === "Enter") && !event.repeat) {
+      event.preventDefault();
+      startHold();
+    }
+  };
 
-  const readyRecipients = recipients.filter(isRecipientShareReady);
-  const readyCount = readyRecipients.length;
-  const names = formatNames(
-    (readyCount > 0 ? readyRecipients : recipients).map((r) =>
-      firstNameOf(recipientLabel(r)),
-    ),
-  );
+  const handleKeyUp = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      cancelHold();
+    }
+  };
 
-  // ACTIVE — the alert is live.
-  if (active) {
-    return (
-      <section className="relative overflow-hidden rounded-[18px] bg-[#fbe9e6] p-[22px] shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[#3a1512]">
-        <div
-          className="pointer-events-none absolute right-6 top-1/2 flex h-[66px] w-[66px] -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-[0_4px_16px_rgba(148,32,26,0.2)] dark:bg-white/10"
-          aria-hidden
+  return (
+    <section
+      className="fixed inset-0 z-[90] overflow-y-auto bg-black text-white"
+      data-testid="sms-safety-screen"
+    >
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))]">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Back to Location"
+          className="press-scale flex h-10 w-10 items-center justify-center rounded-full bg-[#202023] text-white"
         >
-          <Shield className="h-7 w-7 text-[#e0342c]" strokeWidth={1.5} />
-        </div>
-        <div className="relative z-[1] max-w-[210px]">
-          <div className="flex items-center gap-2">
-            <span className="h-[11px] w-[11px] rounded-full bg-[#e0342c]" />
-            <span className="text-[14px] font-bold tracking-[0.04em] text-[#d92c24] dark:text-[#ff6f66]">
-              ALERT ACTIVE
-            </span>
-          </div>
-          <h2 className="mt-3.5 max-w-[200px] text-[29px] font-bold leading-[1.15] tracking-[-0.4px] text-foreground">
-            Your circle has been alerted
-          </h2>
-          <p className="mt-3 text-[15px] leading-[1.5] text-black/50 dark:text-white/55">
-            Your trusted contacts have been notified and can see your live
-            location.
+          <ArrowLeft className="h-5 w-5" strokeWidth={2} />
+        </button>
+
+        <header className="mt-1 px-3 text-center">
+          <h1 className="text-[28px] font-bold leading-[1.15] tracking-[-0.45px]">
+            SMS · Save my soul
+          </h1>
+          <p className="mx-auto mt-2 max-w-[290px] text-[14px] leading-[1.45] text-white/70">
+            Press and hold. Your SMS contacts get your live location in One —
+            when connected.
           </p>
-          <div className="mt-5 flex items-center gap-2">
-            <span className="h-2.5 w-2.5 rounded-full bg-[#34c759]" />
-            <span className="text-[16px] font-bold text-foreground">Live now</span>
+        </header>
+
+        <div className="flex min-h-[310px] flex-1 items-center justify-center py-6">
+          <div className="relative flex h-[252px] w-[252px] items-center justify-center">
+            <span className="absolute inset-0 rounded-full border border-white/10" />
+            <span className="absolute inset-[24px] rounded-full border border-white/15" />
+            <button
+              type="button"
+              disabled={disabled}
+              aria-label={
+                active
+                  ? "SMS sharing is active"
+                  : "Press and hold for two seconds to send SMS"
+              }
+              onPointerDown={handlePointerDown}
+              onPointerUp={handlePointerEnd}
+              onPointerCancel={handlePointerEnd}
+              onPointerLeave={cancelHold}
+              onKeyDown={handleKeyDown}
+              onKeyUp={handleKeyUp}
+              onContextMenu={(event) => event.preventDefault()}
+              className={cn(
+                "relative z-10 flex h-[152px] w-[152px] touch-none select-none flex-col items-center justify-center rounded-full bg-[#ff3b30] text-white outline-none transition-transform focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-4 focus-visible:ring-offset-black",
+                progress > 0 && progress < 1 && "scale-[1.035]",
+                disabled && "cursor-not-allowed opacity-45",
+              )}
+              style={{
+                boxShadow:
+                  progress > 0
+                    ? `0 0 0 ${Math.round(progress * 8)}px rgba(255,59,48,.18)`
+                    : undefined,
+              }}
+            >
+              <span className="text-[31px] font-bold leading-none">
+                {active ? "SENT" : "SMS"}
+              </span>
+              <span className="mt-1.5 text-[12px] text-white/85">
+                {busy
+                  ? "Sending…"
+                  : active
+                    ? "Live now"
+                    : progress > 0
+                      ? `${Math.max(0, 2 - progress * 2).toFixed(1)} s`
+                      : "Hold 2 s"}
+              </span>
+            </button>
           </div>
-          {startedAtLabel ? (
-            <p className="ml-[18px] mt-1 text-[14px] text-black/45 dark:text-white/45">
-              Started {startedAtLabel}
+        </div>
+
+        <div className="mt-auto">
+          <p className="truncate px-2 text-center text-[13px] text-white/70">
+            {names ? `SMS goes to ${names}` : "No SMS contacts selected"}{" "}
+            ·{" "}
+            <button
+              type="button"
+              onClick={onEditContacts}
+              className="font-semibold text-[#2997ff]"
+            >
+              Edit
+            </button>
+          </p>
+
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            {(["Come get me", "I'm not safe"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={message === option}
+                onClick={() =>
+                  setMessage((current) => (current === option ? null : option))
+                }
+                className={cn(
+                  "press-scale h-10 rounded-full border text-[13px] font-semibold",
+                  message === option
+                    ? "border-white bg-white text-black"
+                    : "border-white/5 bg-[#1c1c1e] text-white",
+                )}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-3 grid grid-cols-2 gap-2.5">
+            <a
+              href="tel:911"
+              className="press-scale flex h-12 items-center justify-center gap-2 rounded-full bg-[#ff3b30] text-[15px] font-semibold text-white"
+            >
+              <Phone className="h-4 w-4 fill-current" aria-hidden />
+              Call 911
+            </a>
+            <button
+              type="button"
+              onClick={onClose}
+              className="press-scale h-12 rounded-full border border-white/55 text-[15px] font-semibold text-white"
+            >
+              Cancel
+            </button>
+          </div>
+
+          {!names ? (
+            <p className="mt-2 text-center text-[12px] text-white/55">
+              Add a ready connection before sending an SMS.
             </p>
           ) : null}
-          <Button
-            variant="destructive"
-            onClick={onStop}
-            isLoading={busy}
-            className="mt-5 h-12 w-full rounded-full text-[15px] font-semibold"
-          >
-            I&apos;m safe — Stop sharing
-          </Button>
         </div>
-      </section>
-    );
-  }
-
-  // ARMED — countdown running, still cancellable.
-  if (remaining !== null) {
-    return (
-      <section className="rounded-[18px] bg-white p-[22px] text-center shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-white/[0.05]">
-        <p className="text-[15px] font-semibold text-[#d92c24] dark:text-[#ff6f66]">
-          Alerting {names} in
-        </p>
-        <p
-          className="my-2 text-6xl font-bold text-[#e0342c]"
-          aria-live="assertive"
-        >
-          {remaining}
-        </p>
-        <Button
-          variant="outline"
-          onClick={cancelCountdown}
-          className="h-12 w-full rounded-full text-[15px] font-semibold"
-        >
-          <X className="mr-1.5 h-4 w-4" aria-hidden />
-          Cancel
-        </Button>
-      </section>
-    );
-  }
-
-  // CALM — SOS ready.
-  return (
-    <section className="rounded-[18px] bg-white p-[22px] shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-white/[0.05]">
-      <div className="flex items-center gap-2">
-        <span className="h-2.5 w-2.5 rounded-full bg-[#34c759]" />
-        <span className="text-[14px] font-bold tracking-[0.04em] text-[#28a745] dark:text-[#4ade80]">
-          SOS READY
-        </span>
       </div>
-      <h2 className="mt-3 text-[26px] font-bold leading-[1.15] tracking-[-0.4px] text-foreground">
-        You&apos;re covered
-      </h2>
-      <p className="mt-2.5 text-[15px] leading-[1.5] text-black/50 dark:text-white/55">
-        Hold Alert to notify {names} with your live location. It never fires by
-        accident.
-      </p>
-      <button
-        type="button"
-        onClick={startCountdown}
-        disabled={busy || readyCount === 0}
-        className={cn(
-          "mt-[18px] flex w-full items-center justify-center gap-2 rounded-full bg-[#e0342c] py-[14px] text-[15px] font-semibold text-white transition-opacity",
-          (busy || readyCount === 0) && "opacity-50",
-        )}
-      >
-        <Shield className="h-4 w-4" strokeWidth={1.8} />
-        Open Alert
-      </button>
-      {readyCount === 0 ? (
-        <p className="mt-2.5 text-center text-[12px] text-black/45 dark:text-white/45">
-          Add a trusted contact who&apos;s ready to receive your location.
-        </p>
-      ) : null}
     </section>
   );
 }

--- a/hushh-webapp/components/one-location/redesign/use-location-chat.ts
+++ b/hushh-webapp/components/one-location/redesign/use-location-chat.ts
@@ -22,6 +22,7 @@ import { describeSelection } from "@/lib/agent/describe-selection";
 import {
   isSosShareReadyRecipient,
   runSosPanic,
+  selectSmsRecipients,
   selectSosConnectedRecipients,
 } from "@/lib/one-location/sos-trigger";
 import { runCheckIn } from "@/lib/one-location/check-in-trigger";
@@ -336,7 +337,10 @@ export function useLocationChat(params: {
           state.networkConnections,
           userId || null,
         );
-        const ready = connected.filter(isSosShareReadyRecipient);
+        const ready = selectSmsRecipients(
+          connected,
+          state.smsContactUserIds,
+        ).filter(isSosShareReadyRecipient);
         if (!ready.length) {
           await report({ id: action.id, type: action.type, status: "cancelled" });
           return;

--- a/hushh-webapp/ios/App/App/AppDelegate.swift
+++ b/hushh-webapp/ios/App/App/AppDelegate.swift
@@ -5,6 +5,7 @@ import FirebaseAuth
 import FirebaseMessaging
 import GoogleSignIn
 import UserNotifications
+import AVFoundation
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -12,6 +13,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let consentReviewAction = "CONSENT_REVIEW"
     private static let consentApproveAction = "CONSENT_APPROVE"
     private static let consentDenyAction = "CONSENT_DENY"
+    private static let emergencySmsNotificationCategory = "ONE_LOCATION_SMS_EMERGENCY"
+    private static let emergencySmsOpenAction = "ONE_LOCATION_SMS_OPEN"
+    private static let emergencySmsProfile = "one_location_sms_emergency"
+    private static let emergencySmsSound = "one_location_sms_alarm.wav"
 
     var window: UIWindow?
     private let nativeTestConfig = NativeTestConfiguration()
@@ -37,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Configure the delegate so notification presentation and tap handling work
         // after the app explicitly requests permission from the notification init flow.
         UNUserNotificationCenter.current().delegate = self
+        prepareEmergencySmsSound()
         registerNotificationCategories()
         Messaging.messaging().delegate = self
         logNotificationSettings(context: "didFinishLaunching")
@@ -132,6 +138,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         print(
             "📬 [AppDelegate] Foreground notification received while appState=\(UIApplication.shared.applicationState.debugLabel)"
         )
+        let profile = String(
+            describing: notification.request.content.userInfo["notification_profile"] ?? ""
+        ).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if profile == Self.emergencySmsProfile {
+            // The shared Capacitor UI renders the assertive red emergency card and
+            // plays its three-pulse alarm. Suppress the duplicate iOS foreground
+            // banner/sound while retaining the badge; background delivery still
+            // uses the APNs category and generated custom sound.
+            completionHandler([.badge])
+            return
+        }
         // Present as a real system notification even while the app is active.
         completionHandler([.banner, .list, .sound, .badge])
     }
@@ -187,8 +204,93 @@ private extension AppDelegate {
             intentIdentifiers: [],
             options: [.customDismissAction]
         )
-        UNUserNotificationCenter.current().setNotificationCategories([consentCategory])
-        print("✅ [AppDelegate] Registered notification categories: \(Self.consentNotificationCategory)")
+        let emergencyOpenAction = UNNotificationAction(
+            identifier: Self.emergencySmsOpenAction,
+            title: "Open live location",
+            options: [.foreground]
+        )
+        let emergencyCategory = UNNotificationCategory(
+            identifier: Self.emergencySmsNotificationCategory,
+            actions: [emergencyOpenAction],
+            intentIdentifiers: [],
+            options: [.customDismissAction]
+        )
+        UNUserNotificationCenter.current().setNotificationCategories([
+            consentCategory,
+            emergencyCategory,
+        ])
+        print(
+            "✅ [AppDelegate] Registered notification categories: \(Self.consentNotificationCategory), \(Self.emergencySmsNotificationCategory)"
+        )
+    }
+
+    func prepareEmergencySmsSound() {
+        do {
+            let fileManager = FileManager.default
+            guard let libraryDirectory = fileManager.urls(
+                for: .libraryDirectory,
+                in: .userDomainMask
+            ).first else {
+                return
+            }
+            let soundsDirectory = libraryDirectory.appendingPathComponent(
+                "Sounds",
+                isDirectory: true
+            )
+            try fileManager.createDirectory(
+                at: soundsDirectory,
+                withIntermediateDirectories: true
+            )
+            let soundURL = soundsDirectory.appendingPathComponent(Self.emergencySmsSound)
+            if fileManager.fileExists(atPath: soundURL.path) {
+                return
+            }
+
+            let sampleRate = 44_100.0
+            let duration = 0.94
+            guard
+                let format = AVAudioFormat(
+                    commonFormat: .pcmFormatInt16,
+                    sampleRate: sampleRate,
+                    channels: 1,
+                    interleaved: false
+                ),
+                let buffer = AVAudioPCMBuffer(
+                    pcmFormat: format,
+                    frameCapacity: AVAudioFrameCount(sampleRate * duration)
+                ),
+                let samples = buffer.int16ChannelData?[0]
+            else {
+                return
+            }
+
+            buffer.frameLength = buffer.frameCapacity
+            var phase = 0.0
+            for frame in 0..<Int(buffer.frameLength) {
+                let time = Double(frame) / sampleRate
+                let pulseOffset = time.truncatingRemainder(dividingBy: 0.34)
+                let isPulse = pulseOffset < 0.24
+                let frequency = 980.0 - (360.0 * min(pulseOffset / 0.24, 1.0))
+                phase += (2.0 * Double.pi * frequency) / sampleRate
+                let envelope = isPulse
+                    ? sin(Double.pi * pulseOffset / 0.24) * 0.55
+                    : 0.0
+                samples[frame] = Int16(
+                    max(-1.0, min(1.0, sin(phase) * envelope)) * Double(Int16.max)
+                )
+            }
+
+            let audioFile = try AVAudioFile(
+                forWriting: soundURL,
+                settings: format.settings,
+                commonFormat: .pcmFormatInt16,
+                interleaved: false
+            )
+            try audioFile.write(from: buffer)
+            print("✅ [AppDelegate] Emergency SMS notification sound ready")
+        } catch {
+            print("⚠️ [AppDelegate] Emergency SMS sound setup failed: \(error.localizedDescription)")
+        }
     }
 
     func logNotificationSettings(context: String) {

--- a/hushh-webapp/lib/agent/__tests__/specialist-directive-runtime.sos.test.ts
+++ b/hushh-webapp/lib/agent/__tests__/specialist-directive-runtime.sos.test.ts
@@ -76,6 +76,7 @@ function makeStateWithRecipients(
     publicInvites: [],
     publicInviteSubmissions: [],
     capabilityScopes: [],
+    smsContactUserIds: recipients.map((recipient) => recipient.userId),
   };
 }
 
@@ -106,8 +107,8 @@ describe("runLocationDirective sos_panic", () => {
     vi.clearAllMocks();
   });
 
-  it("calls createGrant with reason:'sos_panic' and durationHours 8 ONLY for connected+ready recipients, stores one envelope per recipient, returns status:'completed'", async () => {
-    // "me" is connected to userA and userB (both share-ready)
+  it("creates grants only for selected, connected, ready SMS contacts", async () => {
+    // "me" selected and is connected to userA and userB (both share-ready)
     // userC is in the recipients list but NOT a network connection — must be excluded
     getStateMock.mockResolvedValueOnce(
       makeStateWithRecipients(

--- a/hushh-webapp/lib/agent/specialist-directive-runtime.ts
+++ b/hushh-webapp/lib/agent/specialist-directive-runtime.ts
@@ -4,6 +4,7 @@ import { encryptLocationForRecipient } from "@/lib/one-location/encryption";
 import {
   isSosShareReadyRecipient,
   runSosPanic,
+  selectSmsRecipients,
   selectSosConnectedRecipients,
 } from "@/lib/one-location/sos-trigger";
 import { runCheckIn } from "@/lib/one-location/check-in-trigger";
@@ -153,7 +154,10 @@ export async function runLocationDirective(
         state.networkConnections,
         currentUserId,
       );
-      const ready = connected.filter(isSosShareReadyRecipient);
+      const ready = selectSmsRecipients(
+        connected,
+        state.smsContactUserIds,
+      ).filter(isSosShareReadyRecipient);
       if (!ready.length) {
         return {
           delegate_agent_id: "agent_location",

--- a/hushh-webapp/lib/consent/location-consent.ts
+++ b/hushh-webapp/lib/consent/location-consent.ts
@@ -68,13 +68,13 @@ export function locationConsentWorkflowHref(metadata: MetadataLike): string {
 
 
 /**
- * Short human tag for a location consent row's share kind (SOS / Check-In /
+ * Short human tag for a location consent row's share kind (SMS / Check-In /
  * Share). Returns "" for rows that carry no share_kind (e.g. access requests,
  * public/circle invites) so the caller can omit the badge entirely.
  */
 export function locationConsentShareKindLabel(metadata: MetadataLike): string {
   const kind = readString(metadata, "share_kind").toLowerCase();
-  if (kind === "sos") return "SOS";
+  if (kind === "sos") return "SMS";
   if (kind === "check_in" || kind === "checkin") return "Check-In";
   if (kind === "share") return "Share";
   return "";
@@ -84,7 +84,7 @@ export function locationConsentShareKindLabel(metadata: MetadataLike): string {
  * Human summary for a location consent row. Coordinate-free by contract:
  * we never surface latitude/longitude in consent metadata or copy. When the row
  * is a share grant the summary is kind-aware so the Consent Manager can tell an
- * emergency SOS from a friendly Check-In (with its note) from a plain share,
+ * Save My Soul from a friendly Check-In (with its note) from a plain share,
  * instead of the same generic "wants to see your location" line for every row.
  */
 export function locationConsentSummary(metadata: MetadataLike): string {
@@ -95,7 +95,9 @@ export function locationConsentSummary(metadata: MetadataLike): string {
   const shareMessage = readString(metadata, "share_message");
   const durationSuffix = durationLabel ? ` for ${durationLabel}` : "";
   if (shareKind === "sos") {
-    return `${who} triggered an SOS and is sharing live location with you${durationSuffix}.`;
+    return shareMessage
+      ? `${who}: ${shareMessage}`
+      : `${who} sent an SMS and is sharing live location with you${durationSuffix}.`;
   }
   if (shareKind === "check_in" || shareKind === "checkin") {
     if (shareMessage) {
@@ -196,4 +198,3 @@ export function parseLocationConsentEntry(
 
   return { kind, id, requestId };
 }
-

--- a/hushh-webapp/lib/navigation/app-route-layout.ts
+++ b/hushh-webapp/lib/navigation/app-route-layout.ts
@@ -142,3 +142,18 @@ export function resolveAppRouteLayoutMode(
 ): AppRouteLayoutMode {
   return resolveAppRouteLayout(pathname).mode;
 }
+
+/**
+ * These focused Location safety surfaces own the complete viewport and their
+ * own exit controls. Persistent top/bottom chrome would obscure their actions.
+ */
+export function shouldSuppressPersistentChromeForRouteState(
+  pathname: string,
+  action: string | null | undefined,
+): boolean {
+  const normalizedAction = String(action || "").trim();
+  return (
+    normalizePathname(pathname) === "/one/location" &&
+    (normalizedAction === "sos" || normalizedAction === "sms-contacts")
+  );
+}

--- a/hushh-webapp/lib/one-location/__tests__/service-sos.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/service-sos.test.ts
@@ -95,4 +95,33 @@ describe("OneLocationService SOS additions", () => {
     expect("reason" in body).toBe(false);
   });
 
+  it("adds and removes owner-scoped SMS contacts through the Location API", async () => {
+    const addCalls = stubFetch({ smsContactUserIds: ["r1"] });
+    await expect(
+      OneLocationService.addSmsContact({
+        vaultOwnerToken: "tok",
+        recipientUserId: "r1",
+      }),
+    ).resolves.toEqual(["r1"]);
+    expect(addCalls[0]).toMatchObject({
+      url: "/api/one/location/sms-contacts",
+      init: {
+        method: "POST",
+        body: JSON.stringify({ recipientUserId: "r1" }),
+      },
+    });
+
+    const removeCalls = stubFetch({ smsContactUserIds: [] });
+    await expect(
+      OneLocationService.removeSmsContact({
+        vaultOwnerToken: "tok",
+        recipientUserId: "r1",
+      }),
+    ).resolves.toEqual([]);
+    expect(removeCalls[0]).toMatchObject({
+      url: "/api/one/location/sms-contacts/r1",
+      init: { method: "DELETE" },
+    });
+  });
+
 });

--- a/hushh-webapp/lib/one-location/__tests__/sos-trigger.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/sos-trigger.test.ts
@@ -30,6 +30,7 @@ import type {
 import {
   isSosShareReadyRecipient,
   runSosPanic,
+  selectSmsRecipients,
   selectShareReadyRecipients,
   selectSosConnectedRecipients,
   SosPanicError,
@@ -222,6 +223,27 @@ describe("selectShareReadyRecipients", () => {
   });
 });
 
+describe("selectSmsRecipients", () => {
+  const recipients = [
+    makeRecipient("a"),
+    makeRecipient("b"),
+    makeRecipient("c"),
+  ];
+
+  it("returns only explicitly selected recipients", () => {
+    expect(
+      selectSmsRecipients(recipients, ["a", "c"]).map(
+        (recipient) => recipient.userId,
+      ),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("fails closed for an empty or unavailable selection", () => {
+    expect(selectSmsRecipients(recipients, [])).toEqual([]);
+    expect(selectSmsRecipients(recipients, undefined)).toEqual([]);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Tests: runSosPanic
 // ---------------------------------------------------------------------------
@@ -273,6 +295,7 @@ describe("runSosPanic", () => {
       recipientKeyId: "key-userA",
       durationHours: 8,
       reason: "sos_panic",
+      shareKind: "sos",
     });
     expect(createGrantMock).toHaveBeenNthCalledWith(2, {
       vaultOwnerToken: "tok",
@@ -280,6 +303,29 @@ describe("runSosPanic", () => {
       recipientKeyId: "key-userB",
       durationHours: 8,
       reason: "sos_panic",
+      shareKind: "sos",
+    });
+  });
+
+  it("sends a selected fixed message while preserving the SOS share kind", async () => {
+    const selected = makeRecipient("userA");
+    createGrantMock.mockResolvedValueOnce(makeGrant("g1", "userA"));
+
+    await runSosPanic({
+      vaultOwnerToken: "tok",
+      recipients: [selected],
+      point: makePoint(),
+      note: "Come get me",
+      publish: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(createGrantMock).toHaveBeenCalledWith({
+      vaultOwnerToken: "tok",
+      recipientUserId: "userA",
+      recipientKeyId: "key-userA",
+      durationHours: 8,
+      reason: "Come get me",
+      shareKind: "sos",
     });
   });
 

--- a/hushh-webapp/lib/one-location/notification-reconciliation.ts
+++ b/hushh-webapp/lib/one-location/notification-reconciliation.ts
@@ -4,6 +4,8 @@ import type {
   OneLocationState,
 } from "@/lib/one-location/types";
 import {
+  ONE_LOCATION_SMS_EMERGENCY_CATEGORY,
+  ONE_LOCATION_SMS_EMERGENCY_PROFILE,
   privacySafeOneLocationNotificationLabel,
   type OneLocationWorkflowNotificationType,
 } from "@/lib/one-location/notifications";
@@ -40,7 +42,9 @@ function networkCounterpartyId(
   connection: OneLocationNetworkConnection,
   userId: string,
 ): string {
-  return connection.userAId === userId ? connection.userBId : connection.userAId;
+  return connection.userAId === userId
+    ? connection.userBId
+    : connection.userAId;
 }
 
 export function buildOneLocationNotificationPayloads(
@@ -82,7 +86,9 @@ export function buildOneLocationNotificationPayloads(
     ) {
       continue;
     }
-    const payload: OneLocationNotificationPayload = { type: "location_share_created" };
+    const payload: OneLocationNotificationPayload = {
+      type: "location_share_created",
+    };
     addValue(payload, "grant_id", grant.id);
     addValue(payload, "owner_user_id", grant.ownerUserId);
     addValue(
@@ -97,12 +103,29 @@ export function buildOneLocationNotificationPayloads(
     addValue(payload, "duration_hours", grant.durationHours);
     addValue(payload, "share_kind", grant.shareKind);
     addValue(payload, "share_message", grant.shareMessage);
+    if (grant.shareKind === "sos") {
+      addValue(
+        payload,
+        "notification_profile",
+        ONE_LOCATION_SMS_EMERGENCY_PROFILE,
+      );
+      addValue(
+        payload,
+        "notification_category",
+        ONE_LOCATION_SMS_EMERGENCY_CATEGORY,
+      );
+    }
     payloads.push(payload);
   }
 
   for (const request of state.requests ?? []) {
-    if (request.ownerUserId === normalizedUserId && request.status === "pending") {
-      const payload: OneLocationNotificationPayload = { type: "location_access_request" };
+    if (
+      request.ownerUserId === normalizedUserId &&
+      request.status === "pending"
+    ) {
+      const payload: OneLocationNotificationPayload = {
+        type: "location_access_request",
+      };
       addValue(payload, "request_id", request.id);
       addValue(payload, "requester_user_id", request.requesterUserId);
       addValue(
@@ -128,14 +151,18 @@ export function buildOneLocationNotificationPayloads(
       "Location owner",
     );
     if (request.status === "approved" && request.approvedGrantId) {
-      const payload: OneLocationNotificationPayload = { type: "location_access_approved" };
+      const payload: OneLocationNotificationPayload = {
+        type: "location_access_approved",
+      };
       addValue(payload, "request_id", request.id);
       addValue(payload, "grant_id", request.approvedGrantId);
       addValue(payload, "owner_user_id", request.ownerUserId);
       addValue(payload, "owner_display_label", ownerLabel);
       payloads.push(payload);
     } else if (request.status === "denied") {
-      const payload: OneLocationNotificationPayload = { type: "location_access_denied" };
+      const payload: OneLocationNotificationPayload = {
+        type: "location_access_denied",
+      };
       addValue(payload, "request_id", request.id);
       addValue(payload, "owner_user_id", request.ownerUserId);
       addValue(payload, "owner_display_label", ownerLabel);
@@ -169,8 +196,14 @@ export function buildOneLocationNotificationPayloads(
   }
 
   for (const referral of state.referrals ?? []) {
-    if (referral.referredUserId !== normalizedUserId || referral.status !== "pending") continue;
-    const payload: OneLocationNotificationPayload = { type: "location_referral_invite" };
+    if (
+      referral.referredUserId !== normalizedUserId ||
+      referral.status !== "pending"
+    )
+      continue;
+    const payload: OneLocationNotificationPayload = {
+      type: "location_referral_invite",
+    };
     addValue(payload, "referral_id", referral.id);
     addValue(payload, "request_id", referral.requestId);
     addValue(payload, "grant_id", referral.grantId);
@@ -203,7 +236,8 @@ export function buildOneLocationNotificationPayloads(
   for (const connection of state.networkConnections ?? []) {
     if (
       connection.status !== "active" ||
-      (connection.userAId !== normalizedUserId && connection.userBId !== normalizedUserId)
+      (connection.userAId !== normalizedUserId &&
+        connection.userBId !== normalizedUserId)
     ) {
       continue;
     }

--- a/hushh-webapp/lib/one-location/notification-reconciliation.ts
+++ b/hushh-webapp/lib/one-location/notification-reconciliation.ts
@@ -74,6 +74,10 @@ export function buildOneLocationNotificationPayloads(
     if (
       grant.status !== "active" ||
       approvedGrantIds.has(grant.id) ||
+      // SMS grants are created immediately before their first encrypted
+      // envelope. Do not tell the recipient that live location is available
+      // until the backend has durably linked that first envelope.
+      (grant.shareKind === "sos" && !grant.latestEnvelopeId) ||
       options.isGrantUnwatched?.(grant.id)
     ) {
       continue;

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -3,7 +3,8 @@
 import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
 import { CONSENT_STATE_CHANGED_EVENT } from "@/lib/consent/consent-events";
 
-export const ONE_LOCATION_GRANT_OPENED_EVENT = "hushh:one-location-grant-opened";
+export const ONE_LOCATION_GRANT_OPENED_EVENT =
+  "hushh:one-location-grant-opened";
 export const ONE_LOCATION_NOTIFICATION_OPEN_PARAM = "locationNotification";
 export const ONE_LOCATION_NOTIFICATION_OPEN_VALUE = "opened";
 export const ONE_LOCATION_GRANT_ID_PARAM = "grantId";
@@ -79,11 +80,13 @@ const WORKFLOW_COPY: Record<
   },
   location_referral_invite: {
     title: "Location referral pending",
-    fallbackDescription: "A trusted person referred you into a location request flow.",
+    fallbackDescription:
+      "A trusted person referred you into a location request flow.",
   },
   location_public_invite_submitted: {
     title: "Public location request",
-    fallbackDescription: "Someone requested location access from your public link.",
+    fallbackDescription:
+      "Someone requested location access from your public link.",
   },
   location_one_network_joined: {
     title: "Connected on One",
@@ -136,13 +139,19 @@ function writeOpenedGrantIds(userId: string, grantIds: string[]): void {
   }
 }
 
-export function isOneLocationGrantOpened(userId: string | null | undefined, grantId: string): boolean {
+export function isOneLocationGrantOpened(
+  userId: string | null | undefined,
+  grantId: string,
+): boolean {
   const normalizedGrantId = String(grantId || "").trim();
   if (!userId || !normalizedGrantId) return false;
   return readOpenedGrantIds(userId).includes(normalizedGrantId);
 }
 
-export function markOneLocationGrantOpened(userId: string | null | undefined, grantId: string): void {
+export function markOneLocationGrantOpened(
+  userId: string | null | undefined,
+  grantId: string,
+): void {
   const normalizedUserId = String(userId || "").trim();
   const normalizedGrantId = String(grantId || "").trim();
   if (!normalizedUserId || !normalizedGrantId) return;
@@ -181,9 +190,7 @@ function readSeenNotificationIds(userId: string): Set<string> {
     if (!raw) return new Set();
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed)
-      ? new Set(
-          parsed.map((item) => String(item || "").trim()).filter(Boolean),
-        )
+      ? new Set(parsed.map((item) => String(item || "").trim()).filter(Boolean))
       : new Set();
   } catch {
     return new Set();
@@ -199,7 +206,8 @@ function writeSeenNotificationIds(userId: string, ids: Set<string>): void {
     // Cap the stored history so it can never grow unbounded.
     const MAX_SEEN = 500;
     const all = Array.from(ids).filter(Boolean);
-    const trimmed = all.length > MAX_SEEN ? all.slice(all.length - MAX_SEEN) : all;
+    const trimmed =
+      all.length > MAX_SEEN ? all.slice(all.length - MAX_SEEN) : all;
     storage.setItem(
       seenNotificationsStorageKey(normalizedUserId),
       JSON.stringify(trimmed),
@@ -312,7 +320,9 @@ export function oneLocationGrantTaskId(grantId: string): string {
 export function dismissOneLocationShareNotification(grantId: string): void {
   const normalizedGrantId = String(grantId || "").trim();
   if (!normalizedGrantId) return;
-  AppBackgroundTaskService.dismissTask(oneLocationGrantTaskId(normalizedGrantId));
+  AppBackgroundTaskService.dismissTask(
+    oneLocationGrantTaskId(normalizedGrantId),
+  );
 }
 
 export function oneLocationWorkflowTaskId(
@@ -325,7 +335,10 @@ export function oneLocationWorkflowTaskId(
 export function buildOneLocationNotificationHref(grantId: string): string {
   const params = new URLSearchParams();
   params.set(ONE_LOCATION_GRANT_ID_PARAM, grantId);
-  params.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
+  params.set(
+    ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
+    ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
+  );
   params.set(ONE_LOCATION_SECTION_PARAM, "shared");
   return `/one/location?${params.toString()}`;
 }
@@ -380,7 +393,10 @@ export function buildOneLocationWorkflowHref(params: {
   if (submissionId) query.set(ONE_LOCATION_SUBMISSION_ID_PARAM, submissionId);
   if (section) query.set(ONE_LOCATION_SECTION_PARAM, section);
   if (grantId && params.openGrant) {
-    query.set(ONE_LOCATION_NOTIFICATION_OPEN_PARAM, ONE_LOCATION_NOTIFICATION_OPEN_VALUE);
+    query.set(
+      ONE_LOCATION_NOTIFICATION_OPEN_PARAM,
+      ONE_LOCATION_NOTIFICATION_OPEN_VALUE,
+    );
   }
   const suffix = query.toString();
   return suffix ? `/one/location?${suffix}` : "/one/location";
@@ -419,7 +435,8 @@ export function privacySafeOneLocationNotificationLabel(
   fallback = "A trusted person",
 ): string {
   const normalized = String(value || "").trim();
-  if (!normalized || MASKED_PHONE_ONLY_PATTERN.test(normalized)) return fallback;
+  if (!normalized || MASKED_PHONE_ONLY_PATTERN.test(normalized))
+    return fallback;
   return normalized.replace(MASKED_PHONE_SUFFIX_PATTERN, "").trim() || fallback;
 }
 
@@ -435,18 +452,36 @@ export function privacySafeOneLocationNotificationBody(
   return normalized.replace(MASKED_PHONE_BODY_PATTERN, "").trim() || fallback;
 }
 
-export function locationShareNotificationDescription(ownerLabel?: string | null): string {
+export function locationShareNotificationDescription(
+  ownerLabel?: string | null,
+): string {
   const label = privacySafeOneLocationNotificationLabel(ownerLabel);
   return `${label} shared location access with you.`;
 }
 
 /** The share intents a recipient notification can represent. */
 export type OneLocationShareKind = "sos" | "check_in" | "drive_to" | "share";
+export const ONE_LOCATION_SMS_EMERGENCY_PROFILE = "one_location_sms_emergency";
+export const ONE_LOCATION_SMS_EMERGENCY_CATEGORY = "ONE_LOCATION_SMS_EMERGENCY";
+
+export function isOneLocationSmsEmergencyAlert(params: {
+  shareKind?: string | null;
+  notificationProfile?: string | null;
+}): boolean {
+  return (
+    String(params.notificationProfile || "")
+      .trim()
+      .toLowerCase() === ONE_LOCATION_SMS_EMERGENCY_PROFILE ||
+    normalizeOneLocationShareKind(params.shareKind) === "sos"
+  );
+}
 
 export function normalizeOneLocationShareKind(
   value?: string | null,
 ): OneLocationShareKind {
-  const normalized = String(value || "").trim().toLowerCase();
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
   if (normalized === "sos") return "sos";
   if (normalized === "check_in" || normalized === "checkin") return "check_in";
   if (normalized === "drive_to" || normalized === "drive") return "drive_to";
@@ -508,7 +543,6 @@ export function locationShareNotificationCopy(params: {
   };
 }
 
-
 export function locationWorkflowNotificationCopy(params: {
   type: OneLocationWorkflowNotificationType;
   ownerLabel?: string | null;
@@ -523,9 +557,16 @@ export function locationWorkflowNotificationCopy(params: {
     params.requesterLabel,
     "Someone",
   );
-  const referringLabel = privacySafeOneLocationNotificationLabel(params.referringLabel);
-  const visitorLabel = privacySafeOneLocationNotificationLabel(params.visitorLabel, "Someone");
-  const networkLabel = privacySafeOneLocationNotificationLabel(params.networkLabel);
+  const referringLabel = privacySafeOneLocationNotificationLabel(
+    params.referringLabel,
+  );
+  const visitorLabel = privacySafeOneLocationNotificationLabel(
+    params.visitorLabel,
+    "Someone",
+  );
+  const networkLabel = privacySafeOneLocationNotificationLabel(
+    params.networkLabel,
+  );
 
   switch (params.type) {
     case "location_share_created":
@@ -617,7 +658,8 @@ export function recordOneLocationShareNotification(params: {
 }): boolean {
   const userId = String(params.userId || "").trim();
   const grantId = String(params.grantId || "").trim();
-  if (!userId || !grantId || isOneLocationGrantOpened(userId, grantId)) return false;
+  if (!userId || !grantId || isOneLocationGrantOpened(userId, grantId))
+    return false;
   // The recipient explicitly stopped watching this share - never re-notify.
   if (isOneLocationGrantUnwatched(userId, grantId)) return false;
 
@@ -632,7 +674,8 @@ export function recordOneLocationShareNotification(params: {
   // share is reachable from the bell - not only the transient toast. The copy is
   // kind-aware so the bell entry reads "SMS · Save my soul" / "Check-in shared" (with the
   // note) / "Location shared" instead of one generic line for every share.
-  const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
+  const ownerLabel =
+    String(params.ownerLabel || "").trim() || "A trusted person";
   const shareKind = normalizeOneLocationShareKind(params.shareKind);
   const { title, description } = locationShareNotificationCopy({
     ownerLabel,
@@ -665,7 +708,6 @@ export function recordOneLocationShareNotification(params: {
   notifyConsentSurfaceRefresh("location_share_created", grantId);
   return true;
 }
-
 
 export function recordOneLocationWorkflowNotification(params: {
   userId: string;
@@ -714,28 +756,50 @@ export function recordOneLocationWorkflowNotification(params: {
   return true;
 }
 
-
-export function playOneLocationNotificationSound(): void {
+export function playOneLocationNotificationSound(
+  shareKind?: string | null,
+): void {
   if (typeof window === "undefined") return;
+  const isEmergency = normalizeOneLocationShareKind(shareKind) === "sos";
+  if (isEmergency && typeof navigator !== "undefined" && navigator.vibrate) {
+    navigator.vibrate([240, 120, 240, 120, 520]);
+  }
   const audioContextConstructor =
     window.AudioContext ||
-    (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
   if (!audioContextConstructor) return;
 
   try {
     const context = new audioContextConstructor();
     const oscillator = context.createOscillator();
     const gain = context.createGain();
-    oscillator.type = "sine";
-    oscillator.frequency.setValueAtTime(880, context.currentTime);
-    oscillator.frequency.exponentialRampToValueAtTime(660, context.currentTime + 0.12);
-    gain.gain.setValueAtTime(0.0001, context.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.08, context.currentTime + 0.02);
-    gain.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + 0.22);
+    const startedAt = context.currentTime;
+    oscillator.type = isEmergency ? "square" : "sine";
+    if (isEmergency) {
+      for (const offset of [0, 0.34, 0.68]) {
+        const pulseStart = startedAt + offset;
+        oscillator.frequency.setValueAtTime(980, pulseStart);
+        oscillator.frequency.exponentialRampToValueAtTime(
+          620,
+          pulseStart + 0.2,
+        );
+        gain.gain.setValueAtTime(0.0001, pulseStart);
+        gain.gain.exponentialRampToValueAtTime(0.1, pulseStart + 0.025);
+        gain.gain.setValueAtTime(0.1, pulseStart + 0.15);
+        gain.gain.exponentialRampToValueAtTime(0.0001, pulseStart + 0.24);
+      }
+    } else {
+      oscillator.frequency.setValueAtTime(880, startedAt);
+      oscillator.frequency.exponentialRampToValueAtTime(660, startedAt + 0.12);
+      gain.gain.setValueAtTime(0.0001, startedAt);
+      gain.gain.exponentialRampToValueAtTime(0.08, startedAt + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, startedAt + 0.22);
+    }
     oscillator.connect(gain);
     gain.connect(context.destination);
     oscillator.start();
-    oscillator.stop(context.currentTime + 0.24);
+    oscillator.stop(startedAt + (isEmergency ? 0.94 : 0.24));
     oscillator.onended = () => {
       void context.close().catch(() => undefined);
     };

--- a/hushh-webapp/lib/one-location/notifications.ts
+++ b/hushh-webapp/lib/one-location/notifications.ts
@@ -453,11 +453,11 @@ export function normalizeOneLocationShareKind(
   return "share";
 }
 
-/** Short, human tag per share kind for badges/labels (SOS / Check-In / Share). */
+/** Short, human tag per share kind for badges/labels (SMS / Check-In / Share). */
 export function oneLocationShareKindLabel(kind?: string | null): string {
   switch (normalizeOneLocationShareKind(kind)) {
     case "sos":
-      return "SOS";
+      return "SMS";
     case "check_in":
       return "Check-In";
     case "drive_to":
@@ -469,9 +469,8 @@ export function oneLocationShareKindLabel(kind?: string | null): string {
 
 /**
  * Kind-aware title + description for a received location share so the recipient
- * instantly sees WHAT it is (emergency SOS vs friendly Check-In vs plain share)
- * and WHY. A Check-In note is surfaced verbatim ("<Owner>: <message>"); SOS gets
- * urgent dedicated copy; a plain share keeps the neutral line.
+ * instantly sees WHAT it is (Save My Soul vs friendly Check-In vs plain share)
+ * and WHY. Fixed SMS and Check-In messages are surfaced with the sender label.
  */
 export function locationShareNotificationCopy(params: {
   ownerLabel?: string | null;
@@ -483,8 +482,10 @@ export function locationShareNotificationCopy(params: {
   const kind = normalizeOneLocationShareKind(params.shareKind);
   if (kind === "sos") {
     return {
-      title: "SOS alert",
-      description: `${label} triggered an SOS and is sharing live location with you. Open to view it now.`,
+      title: "SMS · Save my soul",
+      description: message
+        ? `${label}: ${message}`
+        : `${label} sent an SMS and shared live location with you. Open to view it now.`,
     };
   }
   if (kind === "check_in") {
@@ -629,7 +630,7 @@ export function recordOneLocationShareNotification(params: {
   // Surface in the bell (DebateTaskCenter / AppBackgroundTaskService) with an
   // "Open" deep-link into the recipient's "Shared with me" section, so the
   // share is reachable from the bell - not only the transient toast. The copy is
-  // kind-aware so the bell entry reads "SOS alert" / "Check-in shared" (with the
+  // kind-aware so the bell entry reads "SMS · Save my soul" / "Check-in shared" (with the
   // note) / "Location shared" instead of one generic line for every share.
   const ownerLabel = String(params.ownerLabel || "").trim() || "A trusted person";
   const shareKind = normalizeOneLocationShareKind(params.shareKind);

--- a/hushh-webapp/lib/one-location/one-location-state-resource.ts
+++ b/hushh-webapp/lib/one-location/one-location-state-resource.ts
@@ -34,11 +34,26 @@ export const OneLocationStateResource = {
   },
 
   write(userId: string, state: OneLocationState): void {
-    CacheService.getInstance().set(
-      this.key(userId),
-      state,
-      CACHE_TTL.SHORT,
+    CacheService.getInstance().set(this.key(userId), state, CACHE_TTL.SHORT);
+  },
+
+  replaceSmsContactUserIds(userId: string, userIds: string[]): boolean {
+    const snapshot = this.peek(userId);
+    if (!snapshot) return false;
+
+    const smsContactUserIds = Array.from(
+      new Set(
+        userIds.map((value) => String(value || "").trim()).filter(Boolean),
+      ),
     );
+    // Invalidate first so a slower pre-mutation state request cannot overwrite
+    // the authoritative membership returned by the Add/Remove API.
+    this.invalidate(userId);
+    this.write(userId, {
+      ...snapshot.data,
+      smsContactUserIds,
+    });
+    return true;
   },
 
   load(

--- a/hushh-webapp/lib/one-location/service.ts
+++ b/hushh-webapp/lib/one-location/service.ts
@@ -167,6 +167,35 @@ export class OneLocationService {
     });
   }
 
+  static async addSmsContact(params: {
+    vaultOwnerToken: string;
+    recipientUserId: string;
+  }): Promise<string[]> {
+    const response = await apiJson<{ smsContactUserIds: string[] }>(
+      "/api/one/location/sms-contacts",
+      {
+        method: "POST",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+        body: JSON.stringify({ recipientUserId: params.recipientUserId }),
+      },
+    );
+    return response.smsContactUserIds ?? [];
+  }
+
+  static async removeSmsContact(params: {
+    vaultOwnerToken: string;
+    recipientUserId: string;
+  }): Promise<string[]> {
+    const response = await apiJson<{ smsContactUserIds: string[] }>(
+      `/api/one/location/sms-contacts/${encodeURIComponent(params.recipientUserId)}`,
+      {
+        method: "DELETE",
+        headers: jsonAuthHeaders(params.vaultOwnerToken),
+      },
+    );
+    return response.smsContactUserIds ?? [];
+  }
+
   /** Read-only, fresh ciphertext inventory for the immersive Your Map route. */
   static async getMapState(vaultOwnerToken: string): Promise<OneLocationMapState> {
     return apiJson<OneLocationMapState>("/api/one/location/map-state", {

--- a/hushh-webapp/lib/one-location/sos-trigger.ts
+++ b/hushh-webapp/lib/one-location/sos-trigger.ts
@@ -108,6 +108,19 @@ export function selectShareReadyRecipients(
   return recipients.filter((r) => r.canReceiveLocation === true);
 }
 
+/**
+ * Fail-closed Save My Soul selection. An empty or unavailable membership list
+ * never falls back to every connected person.
+ */
+export function selectSmsRecipients(
+  recipients: OneLocationRecipient[],
+  smsContactUserIds: string[] | undefined,
+): OneLocationRecipient[] {
+  const selectedIds = new Set(smsContactUserIds ?? []);
+  if (selectedIds.size === 0) return [];
+  return recipients.filter((recipient) => selectedIds.has(recipient.userId));
+}
+
 // ---------------------------------------------------------------------------
 // 4. Panic execution
 // ---------------------------------------------------------------------------
@@ -117,6 +130,8 @@ export interface RunSosPanicParams {
   /** Only share-ready recipients — caller must pre-filter with isSosShareReadyRecipient. */
   recipients: SosShareReadyRecipient[];
   point: PlainLocationPoint;
+  /** Optional fixed quick message shown in the recipient notification. */
+  note?: "Come get me" | "I'm not safe" | null;
   /**
    * Caller-supplied publish function so the core stays decoupled from the
    * encrypt+store implementation (and is therefore easy to unit-test).
@@ -146,10 +161,10 @@ export interface RunSosPanicParams {
 export async function runSosPanic(
   params: RunSosPanicParams,
 ): Promise<SosIncident> {
-  const { vaultOwnerToken, recipients, point, publish } = params;
+  const { vaultOwnerToken, recipients, point, publish, note } = params;
 
   if (!recipients.length) {
-    throw new SosPanicError("No SOS recipients provided.", null);
+    throw new SosPanicError("No SMS contacts provided.", null);
   }
 
   // Capture a single timestamp used for both the success incident and any
@@ -164,7 +179,8 @@ export async function runSosPanic(
         recipientUserId: recipient.userId,
         recipientKeyId: recipient.keyId,
         durationHours: 8,
-        reason: "sos_panic",
+        reason: note || "sos_panic",
+        shareKind: "sos",
       });
       // Record the grant id BEFORE publish so it is never orphaned even if
       // publish throws for this or a later recipient.

--- a/hushh-webapp/lib/one-location/types.ts
+++ b/hushh-webapp/lib/one-location/types.ts
@@ -288,6 +288,8 @@ export type OneLocationState = {
   publicInvites: OneLocationPublicInvite[];
   circleInvites?: OneLocationCircleInvite[];
   networkConnections?: OneLocationNetworkConnection[];
+  /** Owner-selected, connected recipients eligible for Save My Soul alerts. */
+  smsContactUserIds?: string[];
   publicInviteSubmissions: OneLocationPublicInviteSubmission[];
   capabilityScopes: string[];
 };

--- a/hushh-webapp/public/firebase-messaging-sw.js
+++ b/hushh-webapp/public/firebase-messaging-sw.js
@@ -24,12 +24,29 @@ function waitForForegroundDeliveryAck(deliveryId) {
 }
 
 function isHandledByVisibleApp(data) {
-  const type = String(data?.type || "").trim().toLowerCase();
+  const type = String(data?.type || "")
+    .trim()
+    .toLowerCase();
   return (
     type.startsWith("location_") ||
     type === "consent_request" ||
     type === "consent_opened" ||
     type === "consent_resolved"
+  );
+}
+
+function isEmergencySmsAlert(data) {
+  const profile = String(data?.notification_profile || "")
+    .trim()
+    .toLowerCase();
+  if (profile === "one_location_sms_emergency") return true;
+  return (
+    String(data?.type || "")
+      .trim()
+      .toLowerCase() === "location_share_created" &&
+    String(data?.share_kind || "")
+      .trim()
+      .toLowerCase() === "sos"
   );
 }
 
@@ -92,13 +109,17 @@ self.addEventListener("push", function (event) {
       data.data?.notification_tag ||
       data.notification?.tag ||
       "consent-request";
-    const requireInteraction =
-      data.notification?.requireInteraction ?? true;
+    const requireInteraction = data.notification?.requireInteraction ?? true;
+    const isEmergencySms = isEmergencySmsAlert(data.data);
     const notificationOptions = {
       body,
       data: { ...(data.data || {}), url },
       tag,
       requireInteraction,
+      icon: "/hushh_icon.png",
+      renotify: isEmergencySms,
+      silent: false,
+      vibrate: isEmergencySms ? [240, 120, 240, 120, 520] : undefined,
     };
     event.waitUntil(
       (async () => {
@@ -126,7 +147,7 @@ self.addEventListener("push", function (event) {
         if (!acknowledged) {
           await self.registration.showNotification(title, notificationOptions);
         }
-      })()
+      })(),
     );
   } catch (_) {
     event.waitUntil(
@@ -149,15 +170,14 @@ self.addEventListener("push", function (event) {
           tag: fallback.tag,
           requireInteraction: fallback.requireInteraction,
         });
-      })()
+      })(),
     );
   }
 });
 
 self.addEventListener("notificationclick", function (event) {
   event.notification.close();
-  const url =
-    event.notification.data?.url || self.__HUSHH_FCM_DEFAULT_TARGET__;
+  const url = event.notification.data?.url || self.__HUSHH_FCM_DEFAULT_TARGET__;
   event.waitUntil(
     (async () => {
       await broadcastToClients({
@@ -166,7 +186,7 @@ self.addEventListener("notificationclick", function (event) {
         reason: "notification_click",
       });
       return focusOrOpenClient(url);
-    })()
+    })(),
   );
 });
 
@@ -189,6 +209,6 @@ self.addEventListener("message", function (event) {
         reason: "test_click",
       });
       return focusOrOpenClient(url);
-    })()
+    })(),
   );
 });

--- a/scripts/ops/generate_runtime_topology_index.py
+++ b/scripts/ops/generate_runtime_topology_index.py
@@ -42,7 +42,10 @@ def read_json(path: Path) -> Any:
 
 
 def source_digest(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    # Git checks text inputs out with platform-specific line endings. Normalize
+    # CRLF so Windows and Linux generate the same governed topology artifact.
+    content = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(content).hexdigest()
 
 
 def stable_json(value: Any) -> str:


### PR DESCRIPTION
## Summary

- match the One Location feature-introduction screen to the supplied 406×787 reference, keeping all three cards and Continue visible without scrolling
- replace the former SOS action UI with the supplied black `SMS · Save my soul` press-and-hold screen
- add Settings → Safety → SMS contacts with persistent, owner-selected emergency contacts and remove confirmation
- fail closed so Save My Soul alerts go only to the user's selected, connected, location-ready contacts—not the whole circle
- include the optional `Come get me` / `I'm not safe` message in the recipient notification
- use the US-only `tel:911` dialer and return Cancel/back to Location Now
- keep the internal `sos` / `sos_panic` identifiers for compatibility while changing user-facing copy to SMS

`SMS` means **Save My Soul** in this product. Live location remains recipient-encrypted inside One and requires connectivity; this change does not claim carrier-SMS or offline delivery.

## UI proof

The onboarding screen was verified in Chromium at 406×787 with no vertical overflow. The SMS and SMS contacts screens were also visually compared at their supplied mobile viewport sizes, including the hold target, footer actions, contact groups, and removal sheet.

## Safety and data contract

- migration `116_one_location_sms_contacts.sql` adds an owner-scoped selected-contact set with no backfill (empty means no recipients)
- add/remove APIs are authenticated, idempotent, and never mutate the underlying connection graph
- grant creation rejects an SMS recipient outside the selected list
- the recipient notification is deferred until the first encrypted location envelope is stored
- account reset/deletion removes rows where the account is either owner or selected contact
- agent/chat confirmations use the same selected-contact contract; the generated product-agent registry is updated from `AgentManifestV2`

## Impact map

- routes: `/one/setup/location`, `/one/location`, and Location specialist confirmation surfaces
- API: `POST /api/one/location/sms-contacts`, `DELETE /api/one/location/sms-contacts/{recipient_user_id}`
- schema: additive migration 116 plus rollback
- native: shared Capacitor UI; US emergency action opens `tel:911`; no plugin contract changes
- rollback: revert commit `900247e89` and, if migration 116 was applied, run its checked-in rollback

## Verification

- frontend focused suites: 92/92 passed
- One Location page suite: 36/36 passed
- specialist directive/permission suites: 6/6 passed
- frontend TypeScript: passed
- backend Location/API/migration/account suites: 78/78 passed
- product-agent suites: 90/90 passed
- ADK foundation: 8/8 passed
- Location chat directive suite: 11/11 passed
- full consent-protocol Ruff lint + format check: passed
- service boundary, design system, native static parity, and native plugin contracts: passed
- agent hierarchy and generated registry drift checks: passed
- release migration contract: head/UAT version 116 aligned
- docs parity/governance/links/brand/encryption checks: passed
- `git diff --check`: passed

`verify:routes` requires the maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`, so it was not run locally; no credentials were invented or persisted.