### PR TITLE
webapp: top-shell tabs, ambient mask, news + map surfaces, breadcrumb trail; Android auth fix

### DIFF
--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -66,6 +66,7 @@ Promotion targets:
 - [one-nav-runtime-plan.md](./one-nav-runtime-plan.md): planning-only migration path from the current One Voice/Kai compatibility runtime to the One/Kai/Nav/KYC ontology
 - [pkm-slice-marketplace-plan.md](./pkm-slice-marketplace-plan.md): planning-only phased plan for a PKM data-slice subscription marketplace under One (backend-led, user-set price per slice, reuses default_available/consent/export)
 - [information-marketplace-agent-plan.md](./information-marketplace-agent-plan.md): Information Marketplace conversational agent — what's built on `feat/personal-information-agent` plus the product-grade forward path (persist requests end-to-end, approve/deny over One A2A, inline publish-for-offers nudge)
+- [one-docusign-fund-setup-plan.md](./one-docusign-fund-setup-plan.md): planning-only vendor-neutral agreement execution and fund-setup workflow under One, with Nav/Connections authorization, trusted action confirmation, and MuleSoft/DocuSign provider options
 
 ## References
 

--- a/docs/future/one-docusign-fund-setup-plan.md
+++ b/docs/future/one-docusign-fund-setup-plan.md
@@ -1,0 +1,290 @@
+# One DocuSign and Fund Setup Workflow Plan
+
+> Status: future roadmap, planning only. No DocuSign runtime, fund-signing
+> action, or production connector is shipped by this document.
+
+## Visual Map
+
+```mermaid
+flowchart LR
+  user["User"]
+  one["One<br/>semantic router"]
+  fund["Fund Operations<br/>workflow owner"]
+  kai["Kai<br/>finance context"]
+  kyc["KYC<br/>approved identity outputs"]
+  nav["Nav<br/>consent review"]
+  connections["Connections<br/>DocuSign authorization"]
+  gateway["Generated action gateway<br/>confirmation + settlement"]
+  provider["AgreementExecutionProvider"]
+  mule["MuleSoft DocuSign connector"]
+  mcp["DocuSign MCP<br/>optional beta provider"]
+  events["Verified status events"]
+  pkm["Encrypted PKM source artifact<br/>+ metadata receipt"]
+
+  user --> one
+  one --> fund
+  fund --> kai
+  fund --> kyc
+  fund --> nav
+  nav --> connections
+  fund --> gateway
+  gateway --> provider
+  provider --> mule
+  provider -. UAT only .-> mcp
+  mule --> events
+  mcp --> events
+  events --> fund
+  events --> pkm
+```
+
+## Current truth
+
+- One is the only semantic router. It proposes actions but does not execute a
+  model-originated action without the existing trusted confirmation and
+  settlement contract.
+- Nav owns consent. Connections, as Nav's child, is the right owner for
+  DocuSign connection readiness, authorization status, and revocation.
+- Hussh has no current DocuSign manifest, generated action, connector, webhook
+  consumer, or signing workflow.
+- The private-agent work on
+  `claude/hushh-infrastructure-analysis-7o991c` is branch-only and feature
+  flagged off. It proves a backend-neutral compute seam and a bounded GCP
+  deployment loop, but official per-user A2A routing, remote revocation
+  enforcement, sensitive-action step-up, live Anypoint provisioning, and
+  concrete pod storage remain incomplete.
+- Signature Vault is a north-star consent pattern, not a shipped e-signature
+  service. DocuSign remains the signing system until a separately verified
+  native signing capability exists.
+- Fund setup is a legal and operational workflow. DocuSign can execute and
+  evidence agreements, but it cannot establish entities, decide fund terms,
+  perform KYC/AML, determine investor eligibility, or approve legal documents.
+
+## Recommendation
+
+Do not create a top-level "DocuSign Agent." Create a vendor-neutral agreement
+execution capability beneath a stateful Fund Operations workflow.
+
+- One understands the request and explains progress.
+- Fund Operations owns the fund-setup state machine.
+- KYC supplies only approved identity and eligibility workflow outputs.
+- Kai supplies finance context only when the workflow requires it.
+- Nav presents exact information and action consent.
+- Connections owns DocuSign account connection and permission posture.
+- An agreement adapter executes bounded DocuSign operations.
+- DocuSign performs the signing ceremony and retains its system-of-record
+  agreement evidence.
+
+This preserves the product ontology if DocuSign is replaced or supplemented by
+another agreement provider later.
+
+## Why MuleSoft is the primary execution lane
+
+The MuleSoft DocuSign Connector exposes the eSignature API v2.1 surface,
+including envelopes, templates, recipients, tabs, views, documents, audit
+events, updates, and related administration. It supports Authorization, JWT,
+and OAuth Authorization Code connection providers.
+
+The DocuSign MCP Server is useful as a blueprint and optional provider. Its
+published beta catalog includes envelope, template, recipient, reminder,
+Workflow Builder, and Agreement Manager tools. It currently requires
+Confidential Authorization Code Grant access tokens and carries explicit beta
+and human-confirmation cautions.
+
+Therefore:
+
+1. Use the MuleSoft connector or direct eSignature API as the initial
+   deterministic production adapter.
+2. Put it behind `AgreementExecutionProvider`, so the workflow is not coupled
+   to MuleSoft.
+3. Admit the DocuSign MCP provider only through the same capability catalog,
+   schemas, confirmation policy, and settlement gateway.
+4. Keep the beta MCP provider read-only or UAT-only until its live `tools/list`,
+   authorization, latency, error, and mutation semantics pass rehearsal.
+5. Never expose the provider's broad raw tool catalog directly to One.
+
+The per-user private-agent pod may orchestrate this workflow later, but connector
+credentials and webhook verification remain in the enterprise connector plane.
+The pod receives only connection readiness, exact attenuated authority, bounded
+inputs, and safe settlement results. It never receives DocuSign OAuth secrets or
+a broad `pkm.read` grant.
+
+## Fund setup lifecycle
+
+### 1. Readiness
+
+One starts a Fund Operations workflow and returns a specific readiness state:
+
+- `legal_documents_required`
+- `counsel_approval_required`
+- `kyc_required`
+- `docusign_connection_required`
+- `recipient_information_required`
+- `ready_to_prepare`
+
+The workflow must fail closed when the approved legal documents or current
+template versions do not exist. An LLM cannot invent fund terms or substitute
+for counsel approval.
+
+### 2. Information assembly
+
+The workflow requests exact scopes for the fields required by the approved
+template and recipient roles. It may use intelligence to propose field bindings
+from sanitized descriptors, but deterministic code validates:
+
+- every source is inside the approved scope
+- every destination tab exists in the selected template revision
+- required values are present
+- no value is inferred or fabricated
+- no broad PKM or raw KYC document is transferred
+
+The consent screen identifies DocuSign as the external recipient and explains
+that approved information and agreement documents will exist outside the Hussh
+zero-knowledge boundary.
+
+### 3. Draft preparation
+
+The provider creates a draft envelope only. The workflow binds:
+
+- workflow ID and revision
+- approved template and document hashes
+- DocuSign account and envelope ID
+- recipients, roles, routing order, and authentication requirements
+- exact field-binding revision
+- consent receipt references
+
+Draft creation and sending are separate actions.
+
+### 4. Review and confirmation
+
+One presents the exact documents, recipients, roles, routing order, and
+material fields. The user reviews through a DocuSign sender or recipient view.
+
+Sending requires:
+
+- unchanged workflow and document revisions
+- fresh trusted activation
+- fresh step-up authentication for legally consequential actions
+- one-time directive identity
+- an idempotency key
+
+Typed or spoken phrases alone are not confirmation. A materially changed draft
+invalidates the prior confirmation.
+
+### 5. Send and signing
+
+After confirmation, the provider sends the envelope. DocuSign owns the
+signature ceremony. Hussh does not inject a stored signature, simulate a click,
+or claim that its confirmation is the legal signature.
+
+### 6. Settlement and events
+
+Use verified DocuSign Connect events when available, with guarded polling as a
+recovery lane. Event processing must:
+
+- authenticate the sender and verify the event signature
+- reject replay and cross-tenant envelope references
+- deduplicate by event identity
+- enforce monotonic state transitions
+- correlate every transition to the same user, workflow, envelope, and revision
+- record metadata only in telemetry
+
+Expected terminal states are `completed`, `declined`, `voided`, `expired`, and
+`failed`.
+
+### 7. Completed package
+
+After completion, retrieve the final documents and certificate of completion.
+Re-encrypt the package for the user's vault before persistent Hussh storage.
+Store it as an encrypted PKM source artifact, while keeping only bounded
+metadata in the workflow and audit planes.
+
+## Vendor-neutral capability surface
+
+Do not expose raw provider operations. Project them into stable capabilities:
+
+| Capability | Behavior | Confirmation |
+| --- | --- | --- |
+| `agreements.connection.status` | Read connection and permission readiness | No |
+| `agreements.templates.list` | List approved template metadata | No |
+| `agreements.envelope.prepare_draft` | Create a draft bound to reviewed inputs | Yes |
+| `agreements.envelope.review` | Open a bounded review view | No |
+| `agreements.envelope.send` | Send the unchanged draft | Yes plus step-up |
+| `agreements.envelope.status` | Read envelope and recipient status | No |
+| `agreements.envelope.remind` | Send a reminder to pending recipients | Yes |
+| `agreements.envelope.correct_recipients` | Change recipients or routing | Yes plus step-up |
+| `agreements.envelope.void` | Void an in-flight envelope | Yes plus step-up |
+| `agreements.envelope.retrieve_completed` | Retrieve the completed package | Yes for disclosure |
+
+Every mutation uses the existing action directive, confirmation receipt, and
+settlement contract. Chained mutations remain:
+
+`proposal -> confirmation -> settlement -> refreshed workflow state -> new proposal`
+
+## Reliability and security requirements
+
+- Use tenant-bound OAuth or JWT configuration selected from the actual
+  DocuSign account ownership model. Do not choose a grant type from convenience.
+- Keep credentials in the connector trust domain, never in agent prompts,
+  browser caches, PKM plaintext, or personal-agent pods.
+- Make draft and send idempotent by workflow, operation, and revision.
+- Pin approved templates and documents by immutable revision and hash.
+- Do not log documents, tab values, recipients, access tokens, or webhook
+  bodies. The MuleSoft example logs full payloads; production must not copy that.
+- Separate invocation, information, and action authority at every hop.
+- A provider outage must leave the workflow in a recoverable state and must
+  never cause an automatic replay after an observable side effect.
+- Revocation blocks future reads and actions but does not pretend to erase a
+  legally completed agreement from DocuSign.
+
+## Delivery plan
+
+1. **Contract rehearsal**
+   - Use DocuSign demo and synthetic documents.
+   - Capture actual Mule connector and DocuSign MCP schemas.
+   - Verify OAuth, draft, review, send, status, completed-document retrieval,
+     webhook/poll recovery, and error behavior.
+2. **Provider seam**
+   - Add `AgreementExecutionProvider` with an inert default.
+   - Implement MuleSoft first.
+   - Keep DocuSign MCP behind a separate UAT flag.
+3. **Workflow and authority**
+   - Add Fund Operations workflow state.
+   - Add exact consent scopes and vendor-neutral capabilities.
+   - Reuse the generated action gateway and durable settlement ledger.
+4. **Connections and Nav**
+   - Add DocuSign connection readiness and revoke UX under Connections.
+   - Add Nav disclosure and action-consent review.
+5. **End-to-end UAT**
+   - Use approved synthetic templates and test recipients.
+   - Rehearse duplicate events, stale confirmations, changed documents, wrong
+     tenant, revocation, provider outage, decline, void, and completion.
+6. **Legal production gate**
+   - Require counsel-approved templates and workflow wording.
+   - Require production DocuSign account configuration, retention policy,
+     incident ownership, and rollback.
+7. **Private-agent portability**
+   - Move orchestration into a per-user private runtime only after official A2A
+     routing, remote revocation enforcement, step-up, durable sessions, and
+     connector settlement are proven.
+
+## Promotion criteria
+
+This plan may move into execution only when:
+
+1. The owning Fund Operations workflow and product surface are approved.
+2. Counsel-approved document and template ownership is explicit.
+3. The DocuSign account ownership and OAuth/JWT model are decided.
+4. Exact consent scopes and external-disclosure language are approved.
+5. Send, void, reminder, and recipient-correction actions pass trusted
+   confirmation and stale-revision tests.
+6. Event verification, idempotency, and completed-package encryption pass UAT.
+7. The provider abstraction proves that the workflow does not depend on raw
+   MuleSoft or DocuSign MCP tool names.
+
+## Sources
+
+- [MuleSoft DocuSign Connector](https://docs.mulesoft.com/docusign-connector/latest/)
+- [MuleSoft DocuSign Connector examples](https://docs.mulesoft.com/docusign-connector/latest/docusign-connector-examples)
+- [MuleSoft DocuSign Connector reference](https://docs.mulesoft.com/docusign-connector/latest/docusign-connector-reference)
+- [DocuSign MCP Server](https://developers.docusign.com/platform/mcp-server/)
+- Internal Hussh agent hierarchy, consent, PKM, action-safety, and private-agent architecture references.

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -52,6 +52,7 @@ const {
     getCurrentUser: vi.fn(),
     getIdToken: vi.fn(),
     signOut: vi.fn(),
+    signIn: vi.fn(),
     signInWithApple: vi.fn(),
   },
   mockCapacitor: {
@@ -746,6 +747,60 @@ describe("AuthService.restoreNativeSession", () => {
     expect(
       AuthService.isLocalDevPhoneVerificationId("uat-test-phone:abc123"),
     ).toBe(false);
+  });
+});
+
+describe("AuthService native Google provider parity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCapacitor.isNativePlatform.mockReturnValue(true);
+    mockAuth.currentUser = null;
+  });
+
+  it("uses the app-owned activity-result contract on Android", async () => {
+    mockCapacitor.getPlatform.mockReturnValue("android");
+    vi.mocked(HushhAuth.signIn).mockResolvedValue({
+      idToken: createIdToken(3_600),
+      accessToken: "google-provider-token",
+      user: {
+        id: "android-user",
+        email: "android@example.com",
+        displayName: "Android User",
+        photoUrl: "",
+      },
+    });
+
+    const result = await AuthService.signInWithGoogle();
+
+    expect(HushhAuth.signIn).toHaveBeenCalledTimes(1);
+    expect(FirebaseAuthentication.signInWithGoogle).not.toHaveBeenCalled();
+    expect(result.user.uid).toBe("android-user");
+    expect(result.idToken).toBeTruthy();
+  });
+
+  it("keeps the FirebaseAuthentication provider contract on iOS", async () => {
+    mockCapacitor.getPlatform.mockReturnValue("ios");
+    const nativeUser = {
+      uid: "ios-user",
+      email: "ios@example.com",
+      displayName: "iOS User",
+      photoUrl: "",
+    };
+    vi.mocked(FirebaseAuthentication.signInWithGoogle).mockResolvedValue({
+      user: nativeUser,
+      credential: {
+        idToken: "google-id-token",
+        accessToken: "google-access-token",
+      },
+    } as any);
+    vi.mocked(FirebaseAuthentication.getIdToken).mockResolvedValue({
+      token: createIdToken(3_600),
+    });
+
+    await AuthService.signInWithGoogle();
+
+    expect(FirebaseAuthentication.signInWithGoogle).toHaveBeenCalledTimes(1);
+    expect(HushhAuth.signIn).not.toHaveBeenCalled();
   });
 });
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -422,7 +422,7 @@ textarea {
     var(--app-safe-area-top-probe)
   );
   --app-top-bar-height: 72px;
-  --kai-route-tabs-height: 32px;
+  --kai-route-tabs-height: 42px;
   --kai-route-tabs-content-gap: 14px;
   /* Global top-shell geometry contract (consumed by providers + top-app-bar).
    * Keep these tokens defined at root so web and native share deterministic spacing. */
@@ -2778,26 +2778,32 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
   /* Percentages vary with a device's safe-area inset and can begin fading
      inside the tab row. Pin the opaque tint to the exact shell boundary,
      then dissolve only in the visual tail below the active underline. */
+  /* Multi-stop ease so the tail below the tab underline dissolves smoothly
+     instead of stepping through a single mid alpha. Stops are fractions of the
+     resolved fade tail (--top-fade-active) so they stay in order and adapt to
+     the device safe-area inset. */
   -webkit-mask-image: linear-gradient(
     to bottom,
     #000 0,
     #000 var(--top-shell-reserved-height),
-    rgba(0, 0, 0, 0.38)
-      calc(
-        var(--top-shell-reserved-height) +
-          var(--top-ambient-tab-tail-midpoint, 32px)
-      ),
+    rgba(0, 0, 0, 0.82)
+      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.24),
+    rgba(0, 0, 0, 0.5)
+      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.46),
+    rgba(0, 0, 0, 0.2)
+      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.72),
     transparent var(--top-shell-visual-height)
   );
   mask-image: linear-gradient(
     to bottom,
     #000 0,
     #000 var(--top-shell-reserved-height),
-    rgba(0, 0, 0, 0.38)
-      calc(
-        var(--top-shell-reserved-height) +
-          var(--top-ambient-tab-tail-midpoint, 32px)
-      ),
+    rgba(0, 0, 0, 0.82)
+      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.24),
+    rgba(0, 0, 0, 0.5)
+      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.46),
+    rgba(0, 0, 0, 0.2)
+      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.72),
     transparent var(--top-shell-visual-height)
   );
 }

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -649,6 +649,13 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
     () => getTopBarTitle(normalizedPathname, primaryHeaderOutOfView),
     [normalizedPathname, primaryHeaderOutOfView],
   );
+  const breadcrumbTrailItems = useMemo(() => {
+    const raw = topShellBreadcrumb?.items ?? [];
+    // Inner/"subagent" routes read as "Kai > Analysis", not
+    // "One > Kai > Analysis": drop the app-root crumb from the visible trail.
+    return raw.length > 0 && raw[0]?.label === "One" ? raw.slice(1) : raw;
+  }, [topShellBreadcrumb]);
+  const hasBreadcrumbTrail = !centerTitle && breadcrumbTrailItems.length > 0;
   const canShowPersonaSwitcher = useMemo(
     () => isPersonaSwitchTopBarRoute(normalizedPathname),
     [normalizedPathname],
@@ -827,7 +834,12 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
                 <div
                   data-testid="top-app-bar-nav-slot"
                   className="pointer-events-none flex h-full shrink-0 items-center justify-start"
-                  style={{ width: "var(--top-bar-side-w)" }}
+                  style={{
+                    // Collapse the fixed side gutter to the back button's width
+                    // when a breadcrumb trail is showing, so the trail sits
+                    // right beside the back arrow instead of centered.
+                    width: hasBreadcrumbTrail ? "auto" : "var(--top-bar-side-w)",
+                  }}
                 >
                   {topShellBreadcrumb && !topShellBreadcrumb.hideBack ? (
                     <div className="pointer-events-auto flex h-11 w-11 items-center justify-center">
@@ -884,17 +896,13 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
                 <div
                   className={cn(
                     "pointer-events-none flex min-w-0 flex-1 items-center",
-                    showOnboardingActions ||
-                      (!centerTitle && (topShellBreadcrumb?.items?.length ?? 0) > 0)
+                    showOnboardingActions || hasBreadcrumbTrail
                       ? "justify-start"
                       : "justify-center",
                   )}
                 >
-                  {!centerTitle &&
-                  (topShellBreadcrumb?.items?.length ?? 0) > 0 ? (
-                    <TopShellBreadcrumbTrail
-                      items={topShellBreadcrumb?.items ?? []}
-                    />
+                  {hasBreadcrumbTrail ? (
+                    <TopShellBreadcrumbTrail items={breadcrumbTrailItems} />
                   ) : centerTitle ? (
                     centerTitle.interactive && canShowPersonaSwitcher ? (
                       <div className="pointer-events-auto inline-flex min-w-0 max-w-full items-center justify-center">

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -25,6 +25,7 @@ import {
   ChartNoAxesCombined,
   Check,
   ChevronDown,
+  ChevronRight,
   Code2,
   Database,
   FileCheck2,
@@ -90,6 +91,7 @@ import type { Persona } from "@/lib/services/ria-service";
 import {
   resolveTopShellBreadcrumb,
   type TopShellBreadcrumbConfig,
+  type TopShellBreadcrumbItem,
 } from "@/lib/navigation/top-shell-breadcrumbs";
 import { navigateTopShellBack } from "@/lib/navigation/top-shell-back";
 import { OneSetupCompletionHintService } from "@/lib/services/one-setup-completion-hint-service";
@@ -351,6 +353,69 @@ function readTopShellReservedHeight(): number {
 function isPrimaryHeaderOutOfView(header: HTMLElement | null): boolean {
   if (!header) return false;
   return header.getBoundingClientRect().bottom <= readTopShellReservedHeight();
+}
+
+/* ── TopShellBreadcrumbTrail ───────────────────────────────────────── */
+/**
+ * Renders the resolved breadcrumb items as a compact, tappable trail beside the
+ * back arrow once the user is inside an inner/subagent route (e.g.
+ * `Kai › Analysis › AAPL run`). Ancestor crumbs navigate back to their level;
+ * the last crumb is the current, non-interactive location. The back arrow still
+ * owns single-step back; this trail is the multi-level "go back and forth"
+ * affordance. Uses currentColor so it tracks the ambient top-surface tone.
+ */
+function TopShellBreadcrumbTrail({ items }: { items: TopShellBreadcrumbItem[] }) {
+  if (!items.length) return null;
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      data-testid="top-app-bar-breadcrumb-trail"
+      className="top-shell-ambient-ink pointer-events-auto flex min-w-0 items-center gap-1 text-[15px] font-medium text-current"
+    >
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <span
+            key={`${item.label}-${index}`}
+            className="flex min-w-0 items-center gap-1"
+          >
+            {index > 0 ? (
+              <ChevronRight
+                className="h-3.5 w-3.5 shrink-0 opacity-40"
+                aria-hidden
+              />
+            ) : null}
+            {item.href && !isLast ? (
+              <button
+                type="button"
+                className="max-w-[9rem] shrink-0 truncate opacity-65 transition-opacity hover:opacity-100"
+                onClick={() =>
+                  requestInternalAppNavigation({
+                    href: item.href!,
+                    scroll: false,
+                    source: "tap",
+                    transitionMode: "full",
+                  })
+                }
+              >
+                {item.label}
+              </button>
+            ) : (
+              <span
+                className={cn(
+                  "min-w-0 truncate",
+                  isLast ? "font-semibold" : "opacity-65",
+                )}
+                aria-current={isLast ? "page" : undefined}
+              >
+                {item.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
 }
 
 /* ── AppTopShell ───────────────────────────────────────────────────── */
@@ -819,10 +884,18 @@ export function AppTopShell({ className, model }: AppTopShellProps) {
                 <div
                   className={cn(
                     "pointer-events-none flex min-w-0 flex-1 items-center",
-                    showOnboardingActions ? "justify-start" : "justify-center",
+                    showOnboardingActions ||
+                      (!centerTitle && (topShellBreadcrumb?.items?.length ?? 0) > 0)
+                      ? "justify-start"
+                      : "justify-center",
                   )}
                 >
-                  {centerTitle ? (
+                  {!centerTitle &&
+                  (topShellBreadcrumb?.items?.length ?? 0) > 0 ? (
+                    <TopShellBreadcrumbTrail
+                      items={topShellBreadcrumb?.items ?? []}
+                    />
+                  ) : centerTitle ? (
                     centerTitle.interactive && canShowPersonaSwitcher ? (
                       <div className="pointer-events-auto inline-flex min-w-0 max-w-full items-center justify-center">
                         <DropdownMenu>

--- a/hushh-webapp/components/app-ui/top-shell-tabs.tsx
+++ b/hushh-webapp/components/app-ui/top-shell-tabs.tsx
@@ -124,7 +124,7 @@ export function TopShellTabs({
               tabIndex={isActive ? 0 : -1}
               className={cn(
                 "relative z-10 flex h-full flex-1 items-center justify-center overflow-hidden transition-[color,opacity] duration-150",
-                isActive ? "text-current" : "text-current opacity-65 hover:opacity-100",
+                isActive ? "text-current" : "text-current opacity-60 hover:opacity-100",
               )}
               onClick={() => selectIndex(index, false)}
               onKeyDown={(event) => {
@@ -164,7 +164,7 @@ export function TopShellTabs({
             width: tabWidth,
           }}
         >
-          <div className="mx-1 h-full rounded-xl bg-current/[0.07]" />
+          <div className="mx-1 h-full rounded-full bg-current/[0.09] shadow-[0_1px_2px_rgba(0,0,0,0.05)] ring-1 ring-inset ring-current/[0.05]" />
         </div>
         <div
           aria-hidden

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -175,6 +175,8 @@ const oneMarketRootClassName = cn(
   "dark:[--one-blue:var(--app-accent)] dark:[--one-link:var(--app-accent-deep)]",
   "[--one-up:#34c759] [--one-up-t:rgba(52,199,89,0.12)]",
   "[--one-down:#ff3b30] [--one-down-t:rgba(255,59,48,0.10)]",
+  "[--one-news-neutral:#dfe1e6] [--one-news-neutral-ink:#565a63]",
+  "dark:[--one-news-neutral:#8e8e93] dark:[--one-news-neutral-ink:#ffffff]",
   "[--one-indigo:#5856d6] [--one-indigo-t:rgba(88,86,214,0.12)]",
   "[--one-orange:#ff9500] [--one-orange-t:rgba(255,149,0,0.14)]",
   "[--one-teal:#30b0c7] [--one-teal-t:rgba(48,176,199,0.13)]",
@@ -382,7 +384,7 @@ function oneMarketNewsCoverClassName(row: KaiHomeNewsItem): string {
   const tone = oneMarketNewsTone(row);
   if (tone === "positive") return "bg-[color:var(--one-up)]";
   if (tone === "negative") return "bg-[color:var(--one-down)]";
-  return "bg-[#8e8e93]";
+  return "bg-[color:var(--one-news-neutral)]";
 }
 
 function oneMarketNewsContext(row: KaiHomeNewsItem): string {
@@ -702,9 +704,17 @@ function OneMarketNewsCover({
   }, [logoUrl]);
 
   const showLogo = Boolean(logoUrl) && !logoFailed;
+  // The neutral cover is a light surface in light mode, so its newspaper glyph
+  // and wave switch to a readable ink instead of always-white. Positive and
+  // negative covers stay vivid with white foreground.
+  const coverInk =
+    !showLogo && oneMarketNewsTone(row) === "neutral"
+      ? "var(--one-news-neutral-ink)"
+      : "#ffffff";
 
   return (
     <div
+      style={{ color: coverInk }}
       className={cn(
         "relative flex h-[116px] items-center justify-center overflow-hidden",
         "after:pointer-events-none after:absolute after:inset-y-0 after:-left-[80%] after:w-[60%] after:skew-x-[-20deg] after:bg-[linear-gradient(105deg,transparent,rgba(255,255,255,0.44),transparent)] after:transition-[left] after:duration-700 group-hover/news:after:left-[130%]",
@@ -724,7 +734,7 @@ function OneMarketNewsCover({
         />
       ) : (
         <>
-          <span className="relative grid h-11 w-11 place-items-center rounded-2xl bg-white/18 text-white shadow-[0_2px_4px_rgba(0,0,0,0.16)]">
+          <span className="relative grid h-11 w-11 place-items-center rounded-2xl bg-current/[0.18] text-current shadow-[0_2px_4px_rgba(0,0,0,0.16)]">
             <Newspaper className="h-6 w-6" aria-hidden="true" />
           </span>
           <svg
@@ -741,7 +751,7 @@ function OneMarketNewsCover({
                     ? "M0 20 L20 24 L40 14 L60 18 L80 8 L100 12 L100 30 L0 30 Z"
                     : "M0 22 L20 16 L40 20 L60 10 L80 14 L100 6 L100 30 L0 30 Z"
               }
-              fill="#ffffff"
+              fill="currentColor"
             />
           </svg>
         </>

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -29,6 +29,7 @@ import {
   writeLocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
 import {
+  DARK_MAP_STYLES,
   getBrowserMapsApiKey,
   getNativeMapsApiKey,
 } from "@/lib/one-location/maps-config";
@@ -416,6 +417,14 @@ export function LocationImmersiveMap() {
             ? 11
             : 2,
         disableDefaultUI: true,
+        // Open dark to match the mobile dark theme. Read the resolved theme from
+        // the <html> `dark` class that next-themes sets, so no camera-recreating
+        // hook dependency is introduced; a cloud-styled mapId can supersede this.
+        styles:
+          typeof document !== "undefined" &&
+          document.documentElement.classList.contains("dark")
+            ? DARK_MAP_STYLES
+            : undefined,
       },
     })
       .then(async (map) => {
@@ -526,29 +535,43 @@ export function LocationImmersiveMap() {
     const map = mapRef.current;
     if (!map || !mapReady) return;
     let paddingTimer: number | null = null;
+    let lastPaddingKey = "";
+    // The people tray is a bottom-sheet overlay that animates its height when
+    // expanded. Anchor the camera's bottom inset to the tray's stable bottom
+    // edge plus its COLLAPSED footprint, never its live expanded height, so
+    // toggling the tray open/closed never re-frames (zooms/pans) the map.
+    const COLLAPSED_TRAY_HEIGHT = 56; // 3.5rem, matches the collapsed tray
     const publishPadding = () => {
       const top = topControlsRef.current?.getBoundingClientRect().bottom ?? 72;
-      const trayTop =
-        peopleTrayRef.current?.getBoundingClientRect().top ??
-        window.innerHeight - 160;
-      void map.setPadding({
+      const trayRect = peopleTrayRef.current?.getBoundingClientRect();
+      const trayBottomInset = trayRect
+        ? Math.max(0, window.innerHeight - trayRect.bottom)
+        : 12;
+      const padding = {
         top: Math.ceil(top + 12),
         right: 20,
-        bottom: Math.ceil(window.innerHeight - trayTop + 12),
+        bottom: Math.ceil(trayBottomInset + COLLAPSED_TRAY_HEIGHT + 12),
         left: 20,
-      });
+      };
+      const key = `${padding.top}:${padding.right}:${padding.bottom}:${padding.left}`;
+      // Never re-hit the native bridge with identical padding: a redundant
+      // setPadding can still nudge the camera on some SDK versions.
+      if (key === lastPaddingKey) return;
+      lastPaddingKey = key;
+      void map.setPadding(padding);
     };
     const schedulePadding = () => {
       if (paddingTimer !== null) window.clearTimeout(paddingTimer);
-      // ResizeObserver fires throughout the card-to-button morph. Publish only
-      // after geometry settles so the native bridge does not receive a call on
-      // every animation frame.
+      // ResizeObserver fires throughout the top-controls layout settle. Publish
+      // only after geometry settles so the native bridge does not receive a call
+      // on every animation frame.
       paddingTimer = window.setTimeout(publishPadding, 80);
     };
     publishPadding();
+    // Observe only the top controls (a stable input). The people tray is left
+    // out on purpose: its expand/collapse animation must not drive the camera.
     const observer = new ResizeObserver(schedulePadding);
     if (topControlsRef.current) observer.observe(topControlsRef.current);
-    if (peopleTrayRef.current) observer.observe(peopleTrayRef.current);
     window.addEventListener("resize", schedulePadding);
     return () => {
       if (paddingTimer !== null) window.clearTimeout(paddingTimer);

--- a/hushh-webapp/components/one-location/redesign/quick-actions.tsx
+++ b/hushh-webapp/components/one-location/redesign/quick-actions.tsx
@@ -124,14 +124,8 @@ export function QuickActionsSection({
 }) {
   return (
     <section className="space-y-3">
-      <div className="flex items-center justify-between px-1">
+      <div className="flex items-center px-1">
         <h2 className={SECTION_HEADING}>{title}</h2>
-        <span className="inline-flex items-center gap-[7px] rounded-full bg-[#eef2f8] px-3 py-1.5 dark:bg-white/10">
-          <span className="h-2 w-2 rounded-full bg-[color:var(--app-accent)]" />
-          <span className="text-[13px] font-semibold text-black/55 dark:text-muted-foreground">
-            Live features
-          </span>
-        </span>
       </div>
       <div
         className={cn(

--- a/hushh-webapp/lib/one-location/maps-config.ts
+++ b/hushh-webapp/lib/one-location/maps-config.ts
@@ -26,3 +26,95 @@ export function getNativeMapsApiKey(platform: "ios" | "android"): string {
       : process.env.NEXT_PUBLIC_GOOGLE_MAPS_ANDROID_API_KEY;
   return (configured ?? "").trim();
 }
+
+/**
+ * Google Maps "night" styling for the native immersive map so "Your Map" opens
+ * dark, matching the mobile dark theme. Cloud-styled map IDs are the long-term
+ * path; this inline array keeps the dark surface self-contained without a Google
+ * Cloud console dependency. Applied only when the app is in dark mode.
+ */
+export const DARK_MAP_STYLES: google.maps.MapTypeStyle[] = [
+  { elementType: "geometry", stylers: [{ color: "#212121" }] },
+  { elementType: "labels.icon", stylers: [{ visibility: "off" }] },
+  { elementType: "labels.text.fill", stylers: [{ color: "#757575" }] },
+  { elementType: "labels.text.stroke", stylers: [{ color: "#212121" }] },
+  {
+    featureType: "administrative",
+    elementType: "geometry",
+    stylers: [{ color: "#757575" }],
+  },
+  {
+    featureType: "administrative.country",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#9e9e9e" }],
+  },
+  {
+    featureType: "administrative.land_parcel",
+    stylers: [{ visibility: "off" }],
+  },
+  {
+    featureType: "administrative.locality",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#bdbdbd" }],
+  },
+  {
+    featureType: "poi",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#757575" }],
+  },
+  {
+    featureType: "poi.park",
+    elementType: "geometry",
+    stylers: [{ color: "#181818" }],
+  },
+  {
+    featureType: "poi.park",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#616161" }],
+  },
+  {
+    featureType: "road",
+    elementType: "geometry.fill",
+    stylers: [{ color: "#2c2c2c" }],
+  },
+  {
+    featureType: "road",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#8a8a8a" }],
+  },
+  {
+    featureType: "road.arterial",
+    elementType: "geometry",
+    stylers: [{ color: "#373737" }],
+  },
+  {
+    featureType: "road.highway",
+    elementType: "geometry",
+    stylers: [{ color: "#3c3c3c" }],
+  },
+  {
+    featureType: "road.highway.controlled_access",
+    elementType: "geometry",
+    stylers: [{ color: "#4e4e4e" }],
+  },
+  {
+    featureType: "road.local",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#616161" }],
+  },
+  {
+    featureType: "transit",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#757575" }],
+  },
+  {
+    featureType: "water",
+    elementType: "geometry",
+    stylers: [{ color: "#000000" }],
+  },
+  {
+    featureType: "water",
+    elementType: "labels.text.fill",
+    stylers: [{ color: "#3d3d3d" }],
+  },
+];

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -460,23 +460,45 @@ export class AuthService {
         "🍎 [AuthService] Calling FirebaseAuthentication.signInWithGoogle()...",
       );
 
-      const result = await FirebaseAuthentication.signInWithGoogle();
+      // The Capawesome Android Google provider can return to the WebView
+      // without settling its saved Capacitor call when the provider activity
+      // is recreated. HusshAuth owns an ActivityResultLauncher and the
+      // Firebase exchange on Android, so use that native contract there.
+      // iOS keeps the Capawesome path, which is its canonical implementation.
+      let nativeAuthUser: AuthUser | NonNullable<
+        Awaited<
+          ReturnType<typeof FirebaseAuthentication.signInWithGoogle>
+        >["user"]
+      >;
+      let idToken = "";
+      let accessToken: string | undefined;
+      if (Capacitor.getPlatform() === "android") {
+        const result = await HushhAuth.signIn();
+        nativeAuthUser = result.user;
+        idToken = result.idToken;
+        accessToken = result.accessToken;
+      } else {
+        const result = await FirebaseAuthentication.signInWithGoogle();
+        if (!result.user) {
+          throw new Error("Invalid response from native sign-in");
+        }
+        nativeAuthUser = result.user;
+        const nativeIdTokenResult =
+          await FirebaseAuthentication.getIdToken();
+        idToken =
+          nativeIdTokenResult.token || result.credential?.idToken || "";
+        accessToken = result.credential?.accessToken;
+      }
 
       this.debugLog("✅ [AuthService] Native sign-in returned result");
 
-      if (!result.user) {
+      if (!nativeAuthUser) {
         this.debugError(
           "❌ [AuthService] Invalid response from native sign-in",
         );
         toast.error("Invalid native auth response", { id: toastId });
         throw new Error("Invalid response from native sign-in");
       }
-
-      const nativeIdTokenResult = await FirebaseAuthentication.getIdToken();
-      const idToken =
-        nativeIdTokenResult.token || result.credential?.idToken || "";
-      const accessToken = result.credential?.accessToken;
-      const nativeAuthUser = result.user; // AuthUser type
 
       this.debugLog("✅ [AuthService] Got native ID token");
 


### PR DESCRIPTION
## Summary

UI polish across the One shell + One Location, a native Android Google sign-in fix, and a future-planning doc.

### Frontend (UI polish)
- Top-shell tabs: taller 42px row + rounded segmented active pill; dimmer inactive tabs
- Ambient top mask: smooth 4-stop ease tail so the dissolve below the tab underline is smooth
- Market news neutral cover: theme-aware light-mode variant with readable ink (dark unchanged)
- Top app bar: breadcrumb trail beside the back arrow on inner routes (drops the root "One" crumb, hugs the back button)
- One Location map: fix spurious zoom on the people-tray toggle; open the native map dark to match the mobile theme; remove the "Live features" pill

### Native auth — please review
- `route Android Google sign-in through the HushhAuth native contract`: on Android, uses HushhAuth's ActivityResultLauncher + Firebase exchange instead of the Capawesome provider (iOS unchanged). Security-sensitive surface; wants a review before merge.

### Docs
- One DocuSign + fund-setup planning note (future, planning-only)

## Verification
- `tsc --noEmit` green; eslint clean on changed files
- Intended deploy: UAT, `frontend` scope

DCO: all commits signed off.
