### PR TITLE
fix(ui): login copy, toast icon clarity, location on/off toggle

### DIFF
--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -1132,10 +1132,6 @@ export function AuthStep({
               </span>
             </div>
 
-            <p className="type-footnote mx-auto max-w-[18.75rem] text-center text-[#86868b] dark:text-white/45">
-              You&apos;ll verify your phone number right after signing in.
-            </p>
-
             <p className="type-footnote mx-auto max-w-[19.5rem] text-center text-[#86868b] dark:text-white/45">
               By continuing, you agree to One&apos;s{" "}
               <button

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -36,7 +36,6 @@ import {
   MapPin,
   Navigation,
   Plus,
-  RefreshCw,
   Send,
   Shield,
   ShieldCheck,
@@ -576,22 +575,47 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         accent="neutral"
         actionsInlineMobile
         actions={
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={vm.onRefresh}
-            disabled={BUSY(vm, "load")}
-            className="gap-2"
-          >
-            <RefreshCw
-              className={cn("h-4 w-4", BUSY(vm, "load") && "animate-spin")}
-              aria-hidden="true"
-            />
-            Refresh
-          </Button>
+          (() => {
+            const locationOn = Boolean(vm.myLocationPoint);
+            const toggling = BUSY(vm, "selfLocation");
+            return (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                role="switch"
+                aria-checked={locationOn}
+                aria-label={
+                  locationOn ? "Turn location off" : "Turn location on"
+                }
+                onClick={
+                  locationOn ? vm.onHideMyLocation : vm.onShowMyLocation
+                }
+                disabled={toggling || BUSY(vm, "load")}
+                className={cn(
+                  "gap-2 rounded-full font-semibold transition-colors",
+                  locationOn
+                    ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15 dark:border-emerald-400/30 dark:bg-emerald-400/10 dark:text-emerald-200"
+                    : "border-border/70 bg-muted/40 text-muted-foreground hover:bg-muted/60",
+                )}
+              >
+                <span
+                  className={cn(
+                    "h-2 w-2 rounded-full transition-colors",
+                    locationOn
+                      ? "bg-emerald-500 dark:bg-emerald-400"
+                      : "bg-muted-foreground/40",
+                    toggling && "animate-pulse",
+                  )}
+                  aria-hidden="true"
+                />
+                {locationOn ? "Location on" : "Location off"}
+              </Button>
+            );
+          })()
         }
       />
+
 
       <div className="-mx-[var(--page-inline-gutter-standard)]">
         <SwipeViews

--- a/hushh-webapp/components/ui/sonner.tsx
+++ b/hushh-webapp/components/ui/sonner.tsx
@@ -2,10 +2,10 @@
 
 import type { CSSProperties } from "react"
 import {
+  CircleAlertIcon,
   CircleCheckIcon,
   InfoIcon,
   Loader2Icon,
-  OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react"
 import { useTheme } from "next-themes"
@@ -27,7 +27,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,
         warning: <TriangleAlertIcon className="size-4" />,
-        error: <OctagonXIcon className="size-4" />,
+        error: <CircleAlertIcon className="size-4" />,
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       toastOptions={{

--- a/hushh-webapp/lib/morphy-ux/toast-utils.tsx
+++ b/hushh-webapp/lib/morphy-ux/toast-utils.tsx
@@ -6,7 +6,7 @@ import {
   CheckCircleIcon,
   InfoIcon,
   WarningIcon,
-  XCircleIcon,
+  WarningCircleIcon,
   SparkleIcon,
 } from "@phosphor-icons/react";
 import { useIconWeight } from "./icon-theme-context";
@@ -212,7 +212,7 @@ export const useMorphyToast = () => {
       duration,
       description,
       icon: (
-        <XCircleIcon
+        <WarningCircleIcon
           className="h-4 w-4 text-current"
           weight={iconWeight}
         />
@@ -228,7 +228,7 @@ export const useMorphyToast = () => {
       duration,
       description,
       icon: (
-        <XCircleIcon
+        <WarningCircleIcon
           className="h-4 w-4 text-current"
           weight={iconWeight}
         />


### PR DESCRIPTION
## Summary

Three small, focused UI/UX fixes across login, toasts, and the Location Agent header.

## Changes

### 1. Login screen — remove redundant copy
- Removed the line **"You'll verify your phone number right after signing in."** from the sign-in screen.
- File: `hushh-webapp/components/onboarding/AuthStep.tsx`

### 2. Toast notifications — fix "two crosses" confusion
Error/danger toasts showed an X-style **status icon** on the left of the content, right next to the real **close (X)** button — making it look like two cancel actions. Only the leading status icon was changed so it clearly means "error" without resembling a second dismiss button.
- `hushh-webapp/components/ui/sonner.tsx`: default error icon `OctagonXIcon` → `CircleAlertIcon`.
- `hushh-webapp/lib/morphy-ux/toast-utils.tsx`: `error`/`danger` leading icons `XCircleIcon` → `WarningCircleIcon`.
- Result: success = check-circle, error = alert-circle, and the dismiss **X** is the only cross in a toast.

### 3. Location Agent header — on/off toggle
Replaced the header **Refresh** button with a **location on/off toggle**:
- Green dot + "Location on" (emerald pill) when active; faded grey dot + "Location off" when off.
- Reuses existing handlers (`onShowMyLocation` / `onHideMyLocation`) and state (`myLocationPoint`); consent/crypto behavior unchanged.
- Accessible switch (`role="switch"`, `aria-checked`, label); pulses + disables while turning on (`busy === "selfLocation"`).
- Removed the now-unused `RefreshCw` import.
- File: `hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx`

## Testing
- [ ] Login screen no longer shows the phone-verification line.
- [ ] Error/danger toasts show an alert-circle (no double-cross); success still shows check-circle.
- [ ] Location Agent header toggle switches on/off with the correct green/grey dot.
