### PR TITLE
fix(onboarding): gate Location workspace behind master Finish Setup

### DIFF
--- a/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
+++ b/hushh-webapp/__tests__/components/onboarding-journey-guard.test.tsx
@@ -61,14 +61,8 @@ vi.mock("@/lib/navigation/routes", () => ({
   buildOneSetupRoute: ({ returnTo }: { returnTo: string }) =>
     `/one/setup?return_to=${encodeURIComponent(returnTo)}`,
   isCapabilityOnboardingRoute: () => false,
-  isCompletedLocationWorkspaceRoute: (
-    completedCapabilityIds: readonly string[] | null | undefined,
-    pathname: string,
-  ) =>
-    Boolean(completedCapabilityIds?.includes("location")) &&
-    pathname.replace(/\/index\.html$/i, "").replace(/\/+$/, "") ===
-      "/one/location",
   isOnboardingAdmissionExemptRoute: () => false,
+
   isOneSetupRoute: (pathname: string) =>
     pathname.replace(/\/index\.html$/i, "").replace(/\/+$/, "") ===
     "/one/setup",
@@ -226,7 +220,11 @@ describe("OnboardingJourneyGuard", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("admits completed Location without widening the unresolved setup gate", () => {
+  it("gates the Location workspace until overall setup is finished, even when Location is done", async () => {
+    // Completing the Location capability alone must NOT unlock the main
+    // Location workspace. The user still has to return to /one/setup and
+    // finish setup (which requires Connections). Direct navigation to
+    // /one/location while setup is unresolved is redirected back to setup.
     pathnameValue = "/one/location";
     window.history.replaceState(null, "", pathnameValue);
     getCachedBootstrapStateMock.mockReturnValue({
@@ -240,10 +238,14 @@ describe("OnboardingJourneyGuard", () => {
       </OnboardingJourneyGuard>,
     );
 
-    expect(screen.getByText("location workspace")).toBeTruthy();
-    expect(bootstrapStateMock).not.toHaveBeenCalled();
-    expect(replace).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        "/one/setup?return_to=%2Fone%2Flocation",
+      );
+    });
+    expect(screen.queryByText("location workspace")).toBeNull();
   });
+
 
   it("admits the canonical setup hub even when setup is incomplete", async () => {
     pathnameValue = "/one/setup";

--- a/hushh-webapp/__tests__/components/setup-capability-coordinator.test.ts
+++ b/hushh-webapp/__tests__/components/setup-capability-coordinator.test.ts
@@ -34,7 +34,10 @@ describe("setup capability journey settlement", () => {
     ).toBe("/one");
   });
 
-  it("lands a finished Location setup on its workspace without widening skip", () => {
+  it("keeps a finished Location setup on the hub while overall setup is still incomplete", () => {
+    // The master "Finish setup" (which requires Connections) is not done yet,
+    // so finishing Location must return the user to /one/setup — not jump
+    // straight into the Location workspace.
     expect(
       resolveSetupCapabilityTerminalTarget({
         capabilityId: "location",
@@ -42,7 +45,7 @@ describe("setup capability journey settlement", () => {
         hasExplicitIncompleteSetup: true,
         kind: "finish",
       }),
-    ).toBe("/one/location");
+    ).toBe("/one/setup");
     expect(
       resolveSetupCapabilityTerminalTarget({
         capabilityId: "location",
@@ -51,6 +54,28 @@ describe("setup capability journey settlement", () => {
         kind: "skip",
       }),
     ).toBe("/one/setup");
+  });
+
+  it("lands a finished Location setup on its workspace once overall setup is resolved", () => {
+    // Overall setup is complete (Finish setup done), so finishing Location may
+    // hand off directly to the Location workspace.
+    expect(
+      resolveSetupCapabilityTerminalTarget({
+        capabilityId: "location",
+        journeyMode: "root",
+        hasExplicitIncompleteSetup: false,
+        kind: "finish",
+      }),
+    ).toBe("/one/location");
+    // Skip never widens into the workspace shortcut.
+    expect(
+      resolveSetupCapabilityTerminalTarget({
+        capabilityId: "location",
+        journeyMode: "root",
+        hasExplicitIncompleteSetup: false,
+        kind: "skip",
+      }),
+    ).toBe("/one/location");
     expect(
       resolveSetupCapabilityTerminalTarget({
         capabilityId: "location",
@@ -67,3 +92,4 @@ describe("setup capability journey settlement", () => {
     );
   });
 });
+

--- a/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
+++ b/hushh-webapp/components/onboarding/onboarding-journey-guard.tsx
@@ -10,7 +10,6 @@ import { useAuth } from "@/hooks/use-auth";
 import {
   buildOneSetupRoute,
   isCapabilityOnboardingRoute,
-  isCompletedLocationWorkspaceRoute,
   isOnboardingAdmissionExemptRoute,
   isOneSetupRoute,
   isOneSetupSurfaceRoute,
@@ -50,13 +49,16 @@ function admissionAllowsCurrentRoute(params: {
   setupSurface: boolean;
 }): boolean {
   const { pathname, setupSurface, state } = params;
+  // Product routes (including the Location workspace at /one/location) stay
+  // gated until the overall first-run setup is resolved via the master
+  // "Finish setup" action, which requires the Connections step. Completing an
+  // individual capability like Location is NOT sufficient on its own — the
+  // user must still return to /one/setup and finish setup before any main
+  // workspace becomes reachable.
   return (
     !hasExplicitIncompleteSetup(state) ||
     setupSurface ||
-    isCapabilityOnboardingRoute(state.onboardingActiveCapability, pathname) ||
-    // Completed Location setup may open its workspace while the wider setup
-    // funnel remains unresolved. Other product routes stay gated.
-    isCompletedLocationWorkspaceRoute(state.setupCapabilityIds, pathname)
+    isCapabilityOnboardingRoute(state.onboardingActiveCapability, pathname)
   );
 }
 

--- a/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
+++ b/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
@@ -85,9 +85,16 @@ export function resolveSetupCapabilityTerminalTarget({
   hasExplicitIncompleteSetup: boolean;
   kind: "finish" | "skip";
 }): string {
+  // A capability may prefer to hand off straight to its own workspace after a
+  // Finish (e.g. Location). That shortcut is only safe once the overall
+  // first-run setup is actually resolved. If setup is still explicitly
+  // incomplete — the master "Finish setup" (which requires Connections) has
+  // not been completed yet — finishing an individual capability like Location
+  // must return the user to the /one/setup hub, never jump into the workspace.
   if (
     kind === "finish" &&
     journeyMode !== "individual" &&
+    !hasExplicitIncompleteSetup &&
     LAND_ON_WORKSPACE_AFTER_FINISH.has(capabilityId)
   ) {
     return resolveCapabilityHandoffTarget(capabilityId);


### PR DESCRIPTION
## Summary

During first-run setup, finishing the **Location** capability was jumping the user straight into the `/one/location` workspace via the `LAND_ON_WORKSPACE_AFTER_FINISH` shortcut — even though the overall setup funnel (which requires the **Connections** step and the master **"Finish setup"** action) was still incomplete. On top of that, the onboarding admission guard explicitly exempted the completed Location workspace route, so the main product surface could load before setup was actually resolved.

This PR keeps **every** product route — including `/one/location` — gated to `/one/setup` until the overall first-run setup is genuinely resolved. Completing an individual capability like Location is no longer sufficient on its own; the user must return to `/one/setup` and complete the master **Finish setup** action first.

## Changes

- **`setup-capability-coordinator.tsx`** — `resolveSetupCapabilityTerminalTarget` now only takes the workspace hand-off shortcut after a Finish when `!hasExplicitIncompleteSetup`. If setup is still explicitly incomplete, finishing Location returns the user to the `/one/setup` hub instead of jumping into the workspace.
- **`onboarding-journey-guard.tsx`** — Removed the `isCompletedLocationWorkspaceRoute` exemption from `admissionAllowsCurrentRoute` (and its now-unused import), so `/one/location` stays gated to `/one/setup` until overall setup resolves.
- **Tests** — Updated `setup-capability-coordinator.test.ts` and `onboarding-journey-guard.test.tsx` to cover the new gating behavior.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Finish Location while setup incomplete | Lands on `/one/location` | Returns to `/one/setup` |
| Visit `/one/location` while setup incomplete | Allowed | Redirected to `/one/setup` |
| Finish Location after master Finish Setup done | Lands on `/one/location` | Lands on `/one/location` (unchanged) |

## Testing

- Updated unit tests for the coordinator terminal target resolution and the journey-guard admission logic.

Signed-off-by: Damrianeelesh &lt;66689602+DamriaNeelesh@users.noreply.github.com&gt;
