### PR TITLE
feat(kyc): streamline identity onboarding

### DIFF
--- a/hushh-webapp/__tests__/components/ambient-chrome-tabs.contract.test.ts
+++ b/hushh-webapp/__tests__/components/ambient-chrome-tabs.contract.test.ts
@@ -19,7 +19,7 @@ describe("tabbed ambient chrome contract", () => {
     expect(topShell).toContain(': "var(--top-shell-visual-height)"');
     expect(styles).toContain(".ambient-chrome-mask--top-with-tabs");
     expect(styles).toContain("var(--top-shell-reserved-height)");
-    expect(styles).toContain("var(--top-ambient-tab-tail-midpoint, 32px)");
+    expect(styles).toContain("var(--top-fade-active)");
     expect(styles).not.toContain(
       "calc(var(--top-shell-reserved-height) + 50px)",
     );

--- a/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
+++ b/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KycIdentityPreface } from "@/components/onboarding/setup/kyc-identity-preface";
+import { KycIdentityProfilePkmService } from "@/lib/services/kyc-identity-profile-pkm-service";
+
+const mocks = vi.hoisted(() => ({
+  saveProfile: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { uid: "user_1" } }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    vaultKey: "vault-key",
+    vaultOwnerToken: "owner-token",
+  }),
+}));
+
+vi.mock("@/components/vault/vault-unlock-dialog", () => ({
+  VaultUnlockDialog: () => null,
+}));
+
+vi.mock("@/components/app-ui/onboarding-stepper", () => ({
+  OnboardingStepper: ({ currentIndex }: { currentIndex: number }) => (
+    <div data-testid="onboarding-stepper">Step {currentIndex + 1}</div>
+  ),
+}));
+
+vi.mock("@/lib/services/kyc-identity-profile-pkm-service", () => ({
+  KycIdentityProfilePkmService: {
+    saveProfile: mocks.saveProfile,
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+describe("KycIdentityPreface", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.saveProfile.mockResolvedValue({ success: true });
+  });
+
+  it("collects the three identity fields and saves them to the encrypted identity domain", async () => {
+    const onComplete = vi.fn();
+    render(<KycIdentityPreface onComplete={onComplete} />);
+
+    fireEvent.change(screen.getByLabelText("Legal name"), {
+      target: { value: "Avery Example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(screen.getByLabelText("Date of birth")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Date of birth"), {
+      target: { value: "1994-04-15" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    fireEvent.change(screen.getByLabelText("Primary residence"), {
+      target: { value: "IN" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save and continue" }));
+
+    await waitFor(() => {
+      expect(KycIdentityProfilePkmService.saveProfile).toHaveBeenCalledWith({
+        userId: "user_1",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "owner-token",
+        profile: {
+          legalName: "Avery Example",
+          dateOfBirth: "1994-04-15",
+          countryCode: "IN",
+          countryName: "India",
+        },
+      });
+    });
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Identity details saved to your private vault.",
+    );
+  });
+});

--- a/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
+++ b/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
@@ -7,7 +7,6 @@ import { KycIdentityProfilePkmService } from "@/lib/services/kyc-identity-profil
 const mocks = vi.hoisted(() => ({
   saveProfile: vi.fn(),
   toastError: vi.fn(),
-  toastSuccess: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -40,7 +39,7 @@ vi.mock("@/lib/services/kyc-identity-profile-pkm-service", () => ({
 vi.mock("sonner", () => ({
   toast: {
     error: mocks.toastError,
-    success: mocks.toastSuccess,
+    success: vi.fn(),
   },
 }));
 
@@ -50,8 +49,15 @@ describe("KycIdentityPreface", () => {
     mocks.saveProfile.mockResolvedValue({ success: true });
   });
 
-  it("collects the three identity fields and saves them to the encrypted identity domain", async () => {
+  it("continues immediately while saving the three identity fields in the background", async () => {
     const onComplete = vi.fn();
+    let resolveSave: ((value: { success: boolean }) => void) | undefined;
+    mocks.saveProfile.mockImplementation(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
     render(<KycIdentityPreface onComplete={onComplete} />);
 
     fireEvent.change(screen.getByLabelText("Legal name"), {
@@ -68,7 +74,9 @@ describe("KycIdentityPreface", () => {
     fireEvent.change(screen.getByLabelText("Primary residence"), {
       target: { value: "IN" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save and continue" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(KycIdentityProfilePkmService.saveProfile).toHaveBeenCalledWith({
@@ -83,10 +91,23 @@ describe("KycIdentityPreface", () => {
         },
       });
     });
-    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
 
-    expect(mocks.toastSuccess).toHaveBeenCalledWith(
-      "Identity details saved to your private vault.",
-    );
+    resolveSave?.({ success: true });
+  });
+
+  it("lets a user skip questions without writing a partial identity profile", () => {
+    const onComplete = vi.fn();
+    render(<KycIdentityPreface onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip this question" }));
+    expect(screen.getByLabelText("Date of birth")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip this question" }));
+    expect(screen.getByLabelText("Primary residence")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip KYC setup" }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(KycIdentityProfilePkmService.saveProfile).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-sos-emergency.contract.test.tsx
@@ -30,7 +30,7 @@ describe("One Location SMS emergency actions", () => {
     ).toHaveAttribute("href", "tel:911");
     expect(screen.getByText("Emergency services")).toBeInTheDocument();
     expect(screen.getByText("United States")).toBeInTheDocument();
-    expect(SMS_PANEL_SOURCE).toContain('href="tel:911"');
+    expect(SMS_PANEL_SOURCE).toContain("href={`tel:${emergency.number}`}");
   });
 
   it("does not advertise unimplemented SOS support actions", () => {

--- a/hushh-webapp/__tests__/services/kyc-identity-profile-pkm-service.test.ts
+++ b/hushh-webapp/__tests__/services/kyc-identity-profile-pkm-service.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+vi.mock("@/lib/services/pkm-write-coordinator", () => ({
+  PkmWriteCoordinator: {
+    saveMergedDomain: vi.fn(),
+  },
+}));
+
+import {
+  KYC_IDENTITY_PKM_DOMAIN,
+  KycIdentityProfilePkmService,
+} from "@/lib/services/kyc-identity-profile-pkm-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+
+describe("KycIdentityProfilePkmService", () => {
+  it("merges the completed identity preface into the encrypted identity domain", async () => {
+    let writtenDomainData: Record<string, unknown> | null = null;
+    let writtenSummary: Record<string, unknown> | null = null;
+
+    (PkmWriteCoordinator.saveMergedDomain as Mock).mockImplementationOnce(async (params) => {
+      const plan = await params.build({
+        currentDomainData: {
+          existing_identity_fact: "preserved",
+          identity_profile: {
+            existing_field: "preserved",
+          },
+        },
+      });
+      writtenDomainData = plan.domainData;
+      writtenSummary = plan.summary;
+      return {
+        saveState: "saved",
+        success: true,
+        fullBlob: {},
+      };
+    });
+
+    await KycIdentityProfilePkmService.saveProfile({
+      userId: "user_1",
+      vaultKey: "vault-key",
+      vaultOwnerToken: "owner-token",
+      profile: {
+        legalName: "Avery Example",
+        dateOfBirth: "1994-04-15",
+        countryCode: "IN",
+        countryName: "India",
+      },
+    });
+
+    expect(KYC_IDENTITY_PKM_DOMAIN).toBe("identity");
+    expect(PkmWriteCoordinator.saveMergedDomain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user_1",
+        domain: "identity",
+        vaultKey: "vault-key",
+        vaultOwnerToken: "owner-token",
+        confirmation: expect.objectContaining({
+          confirmedByUser: true,
+          source: "kyc_identity_onboarding",
+        }),
+      }),
+    );
+    expect(writtenDomainData).toMatchObject({
+      existing_identity_fact: "preserved",
+      identity_profile: {
+        existing_field: "preserved",
+        full_name: "Avery Example",
+        legal_name: "Avery Example",
+        date_of_birth: "1994-04-15",
+        country_code: "IN",
+        country_of_residence: "India",
+        schema_version: 1,
+      },
+    });
+    expect(writtenSummary).toEqual({ identity_profile_updated: true });
+  });
+});

--- a/hushh-webapp/app/one/setup/email/email-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/email/email-onboarding-setup-client.tsx
@@ -18,6 +18,7 @@ import {
   SetupCapabilityTerminalFooter,
   useSetupCapabilityCoordinator,
 } from "@/components/onboarding/setup/setup-capability-coordinator";
+import { KycIdentityPreface } from "@/components/onboarding/setup/kyc-identity-preface";
 import { Switch } from "@/components/ui/switch";
 import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
 import { useAuth } from "@/hooks/use-auth";
@@ -40,6 +41,7 @@ export function EmailOnboardingSetupClient() {
   const [saving, setSaving] = useState(false);
   const [vaultOpen, setVaultOpen] = useState(false);
   const [enablePending, setEnablePending] = useState(false);
+  const [identityPrefaceComplete, setIdentityPrefaceComplete] = useState(false);
   const enableAttemptRef = useRef(0);
 
   const loadPreference = useCallback(async () => {
@@ -167,6 +169,12 @@ export function EmailOnboardingSetupClient() {
       }
     });
   }, [enablePending, persistPreference, vaultKey, vaultOwnerToken]);
+
+  if (!user) return <SetupCapabilityLoading label="Preparing KYC setup…" />;
+
+  if (!identityPrefaceComplete) {
+    return <KycIdentityPreface onComplete={() => setIdentityPrefaceComplete(true)} />;
+  }
 
   if (!coordinator.isReady) return <SetupCapabilityLoading label="Preparing KYC setup…" />;
 

--- a/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
+++ b/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+import { toast } from "sonner";
+
+import { OnboardingStepper } from "@/components/app-ui/onboarding-stepper";
+import { Input } from "@/components/ui/input";
+import { VaultUnlockDialog } from "@/components/vault/vault-unlock-dialog";
+import { useAuth } from "@/hooks/use-auth";
+import { Button } from "@/lib/morphy-ux/button";
+import { COUNTRY_PHONE_OPTIONS } from "@/lib/constants/country-phone-options";
+import {
+  KycIdentityProfilePkmService,
+  type KycIdentityProfile,
+} from "@/lib/services/kyc-identity-profile-pkm-service";
+import { cn } from "@/lib/utils";
+import { useVault } from "@/lib/vault/vault-context";
+
+const STEPS = [
+  { id: "legal-name", label: "Legal name" },
+  { id: "date-of-birth", label: "Date of birth" },
+  { id: "residence", label: "Primary residence" },
+] as const;
+
+export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  const [step, setStep] = useState(0);
+  const [legalName, setLegalName] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState("");
+  const [countryCode, setCountryCode] = useState("");
+  const [vaultOpen, setVaultOpen] = useState(false);
+  const [pendingProfile, setPendingProfile] = useState<KycIdentityProfile | null>(null);
+  const [saving, setSaving] = useState(false);
+  const attemptedProfileRef = useRef<string | null>(null);
+
+  const selectedCountry = useMemo(
+    () => COUNTRY_PHONE_OPTIONS.find((country) => country.value === countryCode),
+    [countryCode],
+  );
+  const canContinue =
+    step === 0
+      ? legalName.trim().length > 1
+      : step === 1
+        ? Boolean(dateOfBirth)
+        : Boolean(selectedCountry);
+
+  const saveProfile = useCallback(
+    async (profile: KycIdentityProfile) => {
+      if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+
+      const attemptKey = `${profile.legalName}|${profile.dateOfBirth}|${profile.countryCode}`;
+      if (attemptedProfileRef.current === attemptKey) return;
+      attemptedProfileRef.current = attemptKey;
+      setSaving(true);
+
+      try {
+        const result = await KycIdentityProfilePkmService.saveProfile({
+          userId: user.uid,
+          vaultKey,
+          vaultOwnerToken,
+          profile,
+        });
+        if (!result.success) {
+          throw new Error(result.message);
+        }
+        toast.success("Identity details saved to your private vault.");
+        setPendingProfile(null);
+        setVaultOpen(false);
+        onComplete();
+      } catch {
+        attemptedProfileRef.current = null;
+        toast.error("We couldn't save your identity details. Please try again.");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [onComplete, user?.uid, vaultKey, vaultOwnerToken],
+  );
+
+  useEffect(() => {
+    if (!pendingProfile || !vaultKey || !vaultOwnerToken) return;
+    void saveProfile(pendingProfile);
+  }, [pendingProfile, saveProfile, vaultKey, vaultOwnerToken]);
+
+  const handlePrimary = () => {
+    if (!canContinue || saving) return;
+    if (step < STEPS.length - 1) {
+      setStep((current) => current + 1);
+      return;
+    }
+    if (!user?.uid || !selectedCountry) {
+      toast.error("Sign in before saving your identity details.");
+      return;
+    }
+
+    const profile = {
+      legalName: legalName.trim(),
+      dateOfBirth,
+      countryCode: selectedCountry.value,
+      countryName: selectedCountry.label,
+    };
+    setPendingProfile(profile);
+    if (!vaultKey || !vaultOwnerToken) {
+      setVaultOpen(true);
+    }
+  };
+
+  const primaryLabel = step === STEPS.length - 1 ? "Save and continue" : "Next";
+
+  return (
+    <main
+      data-top-content-anchor="true"
+      className="flex min-h-[100dvh] w-full flex-col bg-transparent px-5 pb-[var(--app-screen-footer-pad)] pt-[var(--top-content-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+    >
+      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[25rem] flex-col justify-center py-6">
+        <div className="w-full">
+          <div className="space-y-2.5">
+            <div className="flex min-h-8 items-center justify-between gap-3">
+              <Button
+                type="button"
+                variant="link"
+                effect="fade"
+                size="sm"
+                onClick={() => setStep((current) => Math.max(0, current - 1))}
+                disabled={step === 0 || saving}
+                className={cn(
+                  "h-8 rounded-full px-2.5 text-[14px] font-medium text-primary hover:bg-primary/10",
+                  step === 0 && "invisible pointer-events-none",
+                )}
+                showRipple={false}
+                aria-label="Previous question"
+                tabIndex={step === 0 ? -1 : 0}
+              >
+                <ArrowLeft className="mr-1 h-4 w-4" />
+                Back
+              </Button>
+              <span className="type-footnote tabular-nums text-muted-foreground">
+                Step {step + 1} of {STEPS.length}
+              </span>
+            </div>
+            <OnboardingStepper
+              steps={STEPS}
+              currentIndex={step}
+              showLabel={false}
+              ariaLabel="KYC identity setup"
+            />
+          </div>
+
+          <div className="mx-auto flex w-full flex-col pt-8 sm:pt-9">
+            <div className="space-y-2 text-left">
+              <p className="type-subhead text-muted-foreground">
+                This information stays encrypted in your private vault.
+              </p>
+              <h1 className="type-title1 text-balance text-foreground">
+                {step === 0
+                  ? "What is your legal name?"
+                  : step === 1
+                    ? "What is your date of birth?"
+                    : "Where is your primary residence?"}
+              </h1>
+            </div>
+
+            <div className="mt-8 sm:mt-9">
+              {step === 0 ? (
+                <Input
+                  value={legalName}
+                  onChange={(event) => setLegalName(event.target.value)}
+                  placeholder="Full legal name"
+                  autoComplete="name"
+                  autoCapitalize="words"
+                  disabled={saving}
+                  className="h-14 rounded-xl px-4 text-base"
+                  aria-label="Legal name"
+                />
+              ) : null}
+              {step === 1 ? (
+                <Input
+                  type="date"
+                  value={dateOfBirth}
+                  onChange={(event) => setDateOfBirth(event.target.value)}
+                  autoComplete="bday"
+                  disabled={saving}
+                  className="h-14 rounded-xl px-4 text-base"
+                  aria-label="Date of birth"
+                />
+              ) : null}
+              {step === 2 ? (
+                <select
+                  value={countryCode}
+                  onChange={(event) => setCountryCode(event.target.value)}
+                  autoComplete="country-name"
+                  disabled={saving}
+                  aria-label="Primary residence"
+                  className="h-14 w-full appearance-none rounded-xl border border-input bg-background px-4 text-base text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30"
+                >
+                  <option value="">Select country or region</option>
+                  {COUNTRY_PHONE_OPTIONS.map((country) => (
+                    <option key={country.value} value={country.value}>
+                      {country.label}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+            </div>
+
+            <div className="space-y-3 pt-8">
+              <Button
+                type="button"
+                variant="none"
+                effect="fill"
+                size="lg"
+                fullWidth
+                onClick={handlePrimary}
+                disabled={!canContinue || saving}
+                loading={saving}
+                showRipple
+                className={cn(
+                  "h-12 rounded-full type-headline",
+                  "transition-[background-color,transform] duration-[var(--motion-duration-sm)] ease-[var(--motion-ease-standard)]",
+                  "active:scale-[0.99] motion-reduce:transition-none motion-reduce:active:scale-100",
+                  canContinue
+                    ? "!bg-primary !text-primary-foreground hover:!bg-primary/90"
+                    : "!bg-muted !text-muted-foreground",
+                )}
+              >
+                {saving ? "Saving to your private vault..." : primaryLabel}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {user ? (
+        <VaultUnlockDialog
+          user={user}
+          open={vaultOpen}
+          onOpenChange={setVaultOpen}
+          title="Open your private vault"
+          description="Your KYC identity details are encrypted before they are saved."
+          onSuccess={() => setVaultOpen(false)}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
+++ b/hushh-webapp/components/onboarding/setup/kyc-identity-preface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 
@@ -31,9 +31,8 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
   const [dateOfBirth, setDateOfBirth] = useState("");
   const [countryCode, setCountryCode] = useState("");
   const [vaultOpen, setVaultOpen] = useState(false);
-  const [pendingProfile, setPendingProfile] = useState<KycIdentityProfile | null>(null);
-  const [saving, setSaving] = useState(false);
-  const attemptedProfileRef = useRef<string | null>(null);
+  const [profileAwaitingUnlock, setProfileAwaitingUnlock] =
+    useState<KycIdentityProfile | null>(null);
 
   const selectedCountry = useMemo(
     () => COUNTRY_PHONE_OPTIONS.find((country) => country.value === countryCode),
@@ -45,15 +44,12 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
       : step === 1
         ? Boolean(dateOfBirth)
         : Boolean(selectedCountry);
+  const hasCompleteProfile =
+    legalName.trim().length > 1 && Boolean(dateOfBirth) && Boolean(selectedCountry);
 
-  const saveProfile = useCallback(
+  const saveProfileInBackground = useCallback(
     async (profile: KycIdentityProfile) => {
       if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
-
-      const attemptKey = `${profile.legalName}|${profile.dateOfBirth}|${profile.countryCode}`;
-      if (attemptedProfileRef.current === attemptKey) return;
-      attemptedProfileRef.current = attemptKey;
-      setSaving(true);
 
       try {
         const result = await KycIdentityProfilePkmService.saveProfile({
@@ -65,29 +61,31 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
         if (!result.success) {
           throw new Error(result.message);
         }
-        toast.success("Identity details saved to your private vault.");
-        setPendingProfile(null);
-        setVaultOpen(false);
-        onComplete();
       } catch {
-        attemptedProfileRef.current = null;
         toast.error("We couldn't save your identity details. Please try again.");
-      } finally {
-        setSaving(false);
       }
     },
-    [onComplete, user?.uid, vaultKey, vaultOwnerToken],
+    [user?.uid, vaultKey, vaultOwnerToken],
   );
 
   useEffect(() => {
-    if (!pendingProfile || !vaultKey || !vaultOwnerToken) return;
-    void saveProfile(pendingProfile);
-  }, [pendingProfile, saveProfile, vaultKey, vaultOwnerToken]);
+    if (!profileAwaitingUnlock || !vaultKey || !vaultOwnerToken) return;
+
+    const profile = profileAwaitingUnlock;
+    setProfileAwaitingUnlock(null);
+    setVaultOpen(false);
+    void saveProfileInBackground(profile);
+    onComplete();
+  }, [onComplete, profileAwaitingUnlock, saveProfileInBackground, vaultKey, vaultOwnerToken]);
 
   const handlePrimary = () => {
-    if (!canContinue || saving) return;
+    if (!canContinue) return;
     if (step < STEPS.length - 1) {
       setStep((current) => current + 1);
+      return;
+    }
+    if (!hasCompleteProfile) {
+      onComplete();
       return;
     }
     if (!user?.uid || !selectedCountry) {
@@ -101,20 +99,33 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
       countryCode: selectedCountry.value,
       countryName: selectedCountry.label,
     };
-    setPendingProfile(profile);
     if (!vaultKey || !vaultOwnerToken) {
+      setProfileAwaitingUnlock(profile);
       setVaultOpen(true);
+      return;
     }
+
+    void saveProfileInBackground(profile);
+    onComplete();
   };
 
-  const primaryLabel = step === STEPS.length - 1 ? "Save and continue" : "Next";
+  const handleSkip = () => {
+    if (step < STEPS.length - 1) {
+      setStep((current) => current + 1);
+      return;
+    }
+
+    onComplete();
+  };
+
+  const primaryLabel = "Next";
 
   return (
     <main
       data-top-content-anchor="true"
-      className="flex min-h-[100dvh] w-full flex-col bg-transparent px-5 pb-[var(--app-screen-footer-pad)] pt-[var(--top-content-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
+      className="flex h-[100dvh] w-full flex-col overflow-hidden bg-transparent px-5 pb-[var(--app-screen-footer-pad)] pt-[var(--top-content-pad)] sm:px-6 lg:px-[var(--page-inline-gutter-standard)]"
     >
-      <div className="mx-auto flex min-h-[calc(100dvh-var(--top-content-pad)-var(--app-screen-footer-pad))] w-full max-w-[25rem] flex-col justify-center py-6">
+      <div className="mx-auto flex min-h-0 w-full max-w-[25rem] flex-1 flex-col justify-start pb-0 pt-2 sm:pt-4">
         <div className="w-full">
           <div className="space-y-2.5">
             <div className="flex min-h-8 items-center justify-between gap-3">
@@ -124,7 +135,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                 effect="fade"
                 size="sm"
                 onClick={() => setStep((current) => Math.max(0, current - 1))}
-                disabled={step === 0 || saving}
+                disabled={step === 0}
                 className={cn(
                   "h-8 rounded-full px-2.5 text-[14px] font-medium text-primary hover:bg-primary/10",
                   step === 0 && "invisible pointer-events-none",
@@ -136,10 +147,26 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                 <ArrowLeft className="mr-1 h-4 w-4" />
                 Back
               </Button>
-              <span className="type-footnote tabular-nums text-muted-foreground">
-                Step {step + 1} of {STEPS.length}
-              </span>
+              <Button
+                type="button"
+                variant="link"
+                effect="fade"
+                size="sm"
+                onClick={handleSkip}
+                className="h-8 rounded-full px-2.5 text-[14px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+                showRipple={false}
+                aria-label={
+                  step === STEPS.length - 1
+                    ? "Skip KYC setup"
+                    : "Skip this question"
+                }
+              >
+                Skip
+              </Button>
             </div>
+            <span className="block text-right type-footnote tabular-nums text-muted-foreground">
+              Step {step + 1} of {STEPS.length}
+            </span>
             <OnboardingStepper
               steps={STEPS}
               currentIndex={step}
@@ -151,7 +178,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
           <div className="mx-auto flex w-full flex-col pt-8 sm:pt-9">
             <div className="space-y-2 text-left">
               <p className="type-subhead text-muted-foreground">
-                This information stays encrypted in your private vault.
+                A few details to get started.
               </p>
               <h1 className="type-title1 text-balance text-foreground">
                 {step === 0
@@ -170,7 +197,6 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                   placeholder="Full legal name"
                   autoComplete="name"
                   autoCapitalize="words"
-                  disabled={saving}
                   className="h-14 rounded-xl px-4 text-base"
                   aria-label="Legal name"
                 />
@@ -181,7 +207,6 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                   value={dateOfBirth}
                   onChange={(event) => setDateOfBirth(event.target.value)}
                   autoComplete="bday"
-                  disabled={saving}
                   className="h-14 rounded-xl px-4 text-base"
                   aria-label="Date of birth"
                 />
@@ -191,7 +216,6 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                   value={countryCode}
                   onChange={(event) => setCountryCode(event.target.value)}
                   autoComplete="country-name"
-                  disabled={saving}
                   aria-label="Primary residence"
                   className="h-14 w-full appearance-none rounded-xl border border-input bg-background px-4 text-base text-foreground shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30"
                 >
@@ -213,8 +237,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                 size="lg"
                 fullWidth
                 onClick={handlePrimary}
-                disabled={!canContinue || saving}
-                loading={saving}
+                disabled={!canContinue}
                 showRipple
                 className={cn(
                   "h-12 rounded-full type-headline",
@@ -225,7 +248,7 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
                     : "!bg-muted !text-muted-foreground",
                 )}
               >
-                {saving ? "Saving to your private vault..." : primaryLabel}
+                {primaryLabel}
               </Button>
             </div>
           </div>
@@ -237,8 +260,8 @@ export function KycIdentityPreface({ onComplete }: { onComplete: () => void }) {
           user={user}
           open={vaultOpen}
           onOpenChange={setVaultOpen}
-          title="Open your private vault"
-          description="Your KYC identity details are encrypted before they are saved."
+          title="Unlock to continue"
+          description="Enter your passphrase to save these KYC details securely."
           onSuccess={() => setVaultOpen(false)}
         />
       ) : null}

--- a/hushh-webapp/lib/one-location/emergency-numbers.ts
+++ b/hushh-webapp/lib/one-location/emergency-numbers.ts
@@ -64,7 +64,7 @@ type CountryEmergency = {
 const COUNTRIES: readonly CountryEmergency[] = [
   // South Asia
   { code: "IN", name: "India", number: "112", boxes: [[6.5, 35.6, 68.0, 97.5]] },
-  { code: "PK", name: "Pakistan", number: "15", boxes: [[23.5, 37.1, 60.9, 77.9]] },
+  { code: "PK", name: "Pakistan", number: "15", boxes: [[23.5, 37.1, 60.9, 77.0]] },
   { code: "LK", name: "Sri Lanka", number: "119", boxes: [[5.8, 9.9, 79.6, 81.9]] },
   { code: "BD", name: "Bangladesh", number: "999", boxes: [[20.6, 26.7, 88.0, 92.7]] },
   { code: "NP", name: "Nepal", number: "112", boxes: [[26.3, 30.5, 80.0, 88.2]] },

--- a/hushh-webapp/lib/services/kyc-identity-profile-pkm-service.ts
+++ b/hushh-webapp/lib/services/kyc-identity-profile-pkm-service.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import type { PkmWriteCoordinatorResult } from "@/lib/services/pkm-write-coordinator";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+
+export const KYC_IDENTITY_PKM_DOMAIN = "identity" as const;
+
+export type KycIdentityProfile = {
+  legalName: string;
+  dateOfBirth: string;
+  countryCode: string;
+  countryName: string;
+};
+
+type KycIdentityProfilePkmWriteParams = {
+  userId: string;
+  vaultKey: string | null;
+  vaultOwnerToken: string | null;
+  profile: KycIdentityProfile;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** Persists user-entered identity onboarding fields in the encrypted identity domain. */
+export class KycIdentityProfilePkmService {
+  static saveProfile(
+    params: KycIdentityProfilePkmWriteParams,
+  ): Promise<PkmWriteCoordinatorResult> {
+    const savedAt = new Date().toISOString();
+
+    return PkmWriteCoordinator.saveMergedDomain({
+      userId: params.userId,
+      domain: KYC_IDENTITY_PKM_DOMAIN,
+      vaultKey: params.vaultKey,
+      vaultOwnerToken: params.vaultOwnerToken,
+      confirmation: {
+        confirmedByUser: true,
+        surface: "web",
+        source: "kyc_identity_onboarding",
+      },
+      build: (context) => ({
+        domainData: {
+          ...(context.currentDomainData ?? {}),
+          identity_profile: {
+            ...asRecord(context.currentDomainData?.identity_profile),
+            full_name: params.profile.legalName,
+            legal_name: params.profile.legalName,
+            date_of_birth: params.profile.dateOfBirth,
+            country_code: params.profile.countryCode,
+            country_of_residence: params.profile.countryName,
+            updated_at: savedAt,
+            schema_version: 1,
+          },
+        },
+        // Keep sensitive identity values out of the readable PKM projection.
+        summary: {
+          identity_profile_updated: true,
+        },
+      }),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a three-step KYC identity onboarding
- persist completed profile information in PKM without delaying navigation
- tighten desktop and mobile layout and add per-step skipping
- repair inherited local emergency number CI regressions

## Verification
- `source ~/.nvm/nvm.sh && nvm use 22 && ./bin/hushh codex pre-pr`