### PR TITLE
ci(founder): founder sandbox deploy config (devops only)

### DIFF
--- a/.github/workflows/deploy-founder.yml
+++ b/.github/workflows/deploy-founder.yml
@@ -1,0 +1,1053 @@
+name: Deploy to Founder
+
+# Founder Sandbox Lane: founder deploys are decoupled from main (same shape as
+# the dev fast lane). main stays the UAT -> production signoff lane; founder is
+# the fast sandbox for highly-unstable features — it deploys any CI-green ref a
+# governed maintainer chooses (integration/pr-train by default) into its OWN
+# project, so unstable work never disrupts shared dev. It NEVER promotes to
+# uat/production. Runbook: docs/reference/operations/founder-sandbox.md
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "Auto-detect deploy lane, or force backend/frontend/all"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - all
+          - backend
+          - frontend
+      ref:
+        description: "Branch/ref to deploy (default: integration/pr-train, the agentic intake lane)"
+        required: false
+        default: "integration/pr-train"
+        type: string
+      sha:
+        description: "Exact CI-green SHA to deploy (blank defaults to head of ref; must be reachable from ref)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  checks: read
+  id-token: write
+
+env:
+  GCP_PROJECT_ID: hushh-pda-founder
+  GCP_REGION: us-central1
+  BACKEND_SERVICE: consent-protocol
+  RUNTIME_SERVICE_ACCOUNT: consent-protocol-runtime@hushh-pda-founder.iam.gserviceaccount.com
+  FRONTEND_SERVICE: hushh-webapp
+  APP_FRONTEND_ORIGIN: https://founder.one.hushh.ai
+  FOUNDER_CLOUDSQL_INSTANCE: hushh-pda-founder:us-central1:hushh-founder-pg
+  FOUNDER_DB_UNIX_SOCKET: /cloudsql/hushh-pda-founder:us-central1:hushh-founder-pg
+  BACKEND_REVISION_RETENTION: "3"
+  FRONTEND_REVISION_RETENTION: "10"
+  PROTOCOL_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
+
+concurrency:
+  group: deploy-founder
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Founder Scope
+    runs-on: ubuntu-latest
+    environment: founder
+
+    steps:
+      # The workflow DEFINITION always runs from main (single routing
+      # authority); the CONTENT deployed comes from inputs.ref / inputs.sha.
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing founder deploy from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Assert manual founder dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface founder --actor "${GITHUB_ACTOR}"
+
+      - name: Capture deployment timing start
+        id: timing-start
+        shell: bash
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve deployment SHA
+        id: resolve-sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEPLOY_REF="${{ github.event.inputs.ref }}"
+          DEPLOY_REF="${DEPLOY_REF:-integration/pr-train}"
+          git fetch --no-tags origin "$DEPLOY_REF"
+          if [ -n "${{ github.event.inputs.sha }}" ]; then
+            DEPLOY_SHA="${{ github.event.inputs.sha }}"
+          else
+            DEPLOY_SHA="$(git rev-parse "origin/${DEPLOY_REF}")"
+          fi
+          echo "ref=$DEPLOY_REF" >> "$GITHUB_OUTPUT"
+          echo "sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
+
+      # Founder correctness gate: the SHA must be reachable from the requested
+      # ref AND carry a green authoritative full-CI check. The check name
+      # differs by commit kind (PR head / merge-queue train head / main
+      # merge commit), so this is an any-of list. No signoff gate here by
+      # design — dev does not route through main.
+      - name: Validate deployment SHA against requested ref
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIRED_BRANCH: ${{ steps.resolve-sha.outputs.ref }}
+          REQUIRE_CI_SUCCESS: "1"
+          REQUIRED_CHECK_NAME: "CI Status Gate,Queue Validation,Main Post-Merge Smoke Gate"
+        run: bash scripts/ci/require-deploy-sha-on-main.sh "${{ steps.resolve-sha.outputs.sha }}"
+
+      - name: Checkout deployment SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --detach "${{ steps.resolve-sha.outputs.sha }}"
+
+      - name: Validate Google Cloud workload identity configuration
+        shell: bash
+        env:
+          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        run: |
+          set -euo pipefail
+          test -n "$WIF_PROVIDER" || { echo "Missing environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
+          test -n "$DEPLOY_SERVICE_ACCOUNT" || { echo "Missing environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
+
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set GCP project context
+        run: gcloud config set project "${{ env.GCP_PROJECT_ID }}"
+
+      - name: Assert GCP project scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null)"
+          if [ "$ACTIVE_PROJECT" != "${{ env.GCP_PROJECT_ID }}" ]; then
+            echo "Refusing deploy: expected project '${{ env.GCP_PROJECT_ID }}' but got '$ACTIVE_PROJECT'."
+            exit 1
+          fi
+
+      - name: Set up Python + uv runtime
+        uses: ./consent-protocol/.github/actions/setup-python-uv
+        with:
+          python-version: "3.13"
+          protocol-dir: ./consent-protocol
+
+      - name: Capture predeploy Cloud Run state
+        id: predeploy-state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+
+          backend_sha=""
+          if [ -n "${backend_revision}" ]; then
+            backend_sha="$(gcloud run revisions describe "${backend_revision}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --format='value(metadata.labels.deploy-sha)' 2>/dev/null || true)"
+          fi
+          frontend_sha=""
+          if [ -n "${frontend_revision}" ]; then
+            frontend_sha="$(gcloud run revisions describe "${frontend_revision}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --format='value(metadata.labels.deploy-sha)' 2>/dev/null || true)"
+          fi
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "backend_sha=${backend_sha}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_sha=${frontend_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve deployment scope
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/resolve-deploy-scope.py \
+            --requested-scope "${{ github.event.inputs.scope }}" \
+            --target-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --backend-base-sha "${{ steps.predeploy-state.outputs.backend_sha }}" \
+            --frontend-base-sha "${{ steps.predeploy-state.outputs.frontend_sha }}" \
+            --github-output "$GITHUB_OUTPUT" \
+            --json
+
+      - name: Sync canonical hosted runtime secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_backend_runtime_secrets.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --environment uat \
+            --app-frontend-origin "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --db-host "cloudsql-socket" \
+            --db-port "5432" \
+            --db-name "postgres" \
+            --db-unix-socket "${{ env.FOUNDER_DB_UNIX_SOCKET }}" \
+            --cloudsql-instance-connection-name "${{ env.FOUNDER_CLOUDSQL_INSTANCE }}" \
+            --consent-sse-enabled "true" \
+            --sync-remote-enabled "false" \
+            --developer-api-enabled "true" \
+            --remote-mcp-enabled "true" \
+            --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --obs-data-stale-ratio-threshold "0.25" \
+            --passkey-allowed-rp-ids "localhost,127.0.0.1,one.hushh.ai,founder.one.hushh.ai" \
+            --plaid-env "production" \
+            --plaid-client-name "Hushh Kai" \
+            --plaid-country-codes "US" \
+            --plaid-webhook-url "${{ env.APP_FRONTEND_ORIGIN }}/api/kai/plaid/webhook" \
+            --plaid-redirect-path "/kai/plaid/oauth/return" \
+            --plaid-tx-history-days "730" \
+            > /tmp/dev-runtime-secret-sync.json
+
+          # Same main-workflow vs train-tree skew guard as the backend sync:
+          # newer trees accept --environment dev; older train SHAs only know
+          # uat|production. Probe --help and fall back to uat (dev's runtime
+          # identity IS uat — see dev-environment-setup.md Identity Model).
+          FE_HELP="$("${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py --help 2>/dev/null || true)"
+          FE_ENV="uat"
+          if grep -q "'dev'" <<<"$FE_HELP" || grep -q 'dev,' <<<"$FE_HELP" || grep -qE '\bdev\b.*production' <<<"$FE_HELP"; then
+            FE_ENV="dev"
+          fi
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --environment "$FE_ENV" \
+            > /tmp/dev-frontend-runtime-secret-sync.json
+
+      - name: Install Cloud SQL Auth Proxy
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
+            -o /usr/local/bin/cloud-sql-proxy
+          chmod +x /usr/local/bin/cloud-sql-proxy
+
+      - name: Apply dev DB migrations and predeploy schema gate
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
+          DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"
+          echo "::add-mask::${DB_USER}"
+          echo "::add-mask::${DB_PASSWORD}"
+
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 6543 \
+            ${GOOGLE_GHA_CREDS_PATH:+--credentials-file="${GOOGLE_GHA_CREDS_PATH}"} \
+            "${{ env.FOUNDER_CLOUDSQL_INSTANCE }}" >/tmp/cloud-sql-proxy-founder.log 2>&1 &
+          PROXY_PID=$!
+          trap 'kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
+
+          python3 - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 20
+          while time.time() < deadline:
+              with socket.socket() as sock:
+                  sock.settimeout(0.5)
+                  if sock.connect_ex(("127.0.0.1", 6543)) == 0:
+                      raise SystemExit(0)
+              time.sleep(0.25)
+          raise SystemExit("Cloud SQL proxy did not bind 127.0.0.1:6543 in time")
+          PY
+
+          export DB_HOST=127.0.0.1
+          export DB_PORT=6543
+          export DB_NAME=postgres
+          export DB_USER
+          export DB_PASSWORD
+
+          (
+            cd consent-protocol
+            "${{ env.PROTOCOL_PYTHON }}" db/migrate.py --release --migration-mode replay
+          )
+          # Skew guard (same class as the secret-sync probes): the dev
+          # contract file may not exist on older train SHAs. Fall back to the
+          # UAT contract, which dev replicates by design.
+          CONTRACT_FILE="consent-protocol/db/contracts/dev_minimum_schema.json"
+          if [ ! -f "$CONTRACT_FILE" ]; then
+            CONTRACT_FILE="consent-protocol/db/contracts/uat_integrated_schema.json"
+            echo "dev contract missing on this SHA; falling back to $CONTRACT_FILE"
+          fi
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
+            --contract-file "$CONTRACT_FILE" \
+            --report-path /tmp/dev-db-migration-guard-predeploy.json
+
+      - name: Deploy backend using Cloud Build
+        id: deploy-backend
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="$(date +%s)"
+          # Founder starts with no shared Workspace or Pub/Sub ingress. Those
+          # integrations require a separately reviewed connection authority.
+          SUBSTITUTIONS="_BACKEND_SERVICE=${{ env.BACKEND_SERVICE }}##_REGION=${{ env.GCP_REGION }}##_CLOUDSQL_INSTANCES=${{ env.FOUNDER_CLOUDSQL_INSTANCE }}##_PLAID_CLIENT_ID_SECRET=PLAID_CLIENT_ID##_PLAID_SECRET_SECRET=PLAID_SECRET##_PLAID_ACCESS_TOKEN_KEY_SECRET=PLAID_ACCESS_TOKEN_KEY##_FINNHUB_API_KEY_SECRET=FINNHUB_API_KEY##_PMP_API_KEY_SECRET=PMP_API_KEY##_NEWSAPI_KEY_SECRET=NEWSAPI_KEY##_GMAIL_OAUTH_CLIENT_ID_SECRET=GMAIL_OAUTH_CLIENT_ID##_GMAIL_OAUTH_CLIENT_SECRET_SECRET=GMAIL_OAUTH_CLIENT_SECRET##_GMAIL_OAUTH_REDIRECT_URI_SECRET=GMAIL_OAUTH_REDIRECT_URI##_GMAIL_OAUTH_TOKEN_KEY_SECRET=GMAIL_OAUTH_TOKEN_KEY##_OPENAI_API_KEY_SECRET=OPENAI_API_KEY##_GOOGLE_MAPS_API_KEY_SECRET=GOOGLE_MAPS_API_KEY##_VOICE_RUNTIME_CONFIG_JSON_SECRET=VOICE_RUNTIME_CONFIG_JSON##_HUSHH_DEVELOPER_TOKEN_SECRET=HUSHH_DEVELOPER_TOKEN##_HUSHH_UAT_PHONE_TEST_NUMBERS_SECRET=HUSHH_UAT_PHONE_TEST_NUMBERS##_HUSHH_UAT_PHONE_TEST_CODE_SECRET=HUSHH_UAT_PHONE_TEST_CODE##_REVIEWER_UID_SECRET=REVIEWER_UID##_REVIEWER_VAULT_PASSPHRASE_SECRET=REVIEWER_VAULT_PASSPHRASE##_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET=RIA_INTELLIGENCE_VERIFY_BASE_URL##_ONE_EMAIL_WEBHOOK_AUTH_ENABLED=false##_ONE_EMAIL_WATCH_RENEW_AUTH_ENABLED=false##_APP_REVIEW_MODE=true##_DB_POOL_MIN_SIZE=1##_DB_POOL_MAX_SIZE=8##_CLOUD_RUN_MIN_INSTANCES=1##_CLOUD_RUN_MAX_INSTANCES=5##_CLOUD_RUN_NO_TRAFFIC=true##_RUNTIME_ENVIRONMENT=uat##_IMAGE_TAG=founder-${{ steps.resolve-sha.outputs.sha }}##_DEPLOY_ENV=founder##_DEPLOY_SOURCE=deploy-founder##_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }}##_GITHUB_RUN_ID=${{ github.run_id }}"
+          SUBSTITUTIONS="${SUBSTITUTIONS}##_RUNTIME_SERVICE_ACCOUNT=${{ env.RUNTIME_SERVICE_ACCOUNT }}"
+          # Skew guard (same class as #4399/#4401/#4402): the workflow file
+          # (from main) may pass substitutions the train SHA's cloudbuild
+          # template doesn't declare — gcloud rejects unmatched keys. Filter
+          # SUBSTITUTIONS down to keys actually present in the template.
+          FILTERED=""
+          while IFS= read -r pair; do
+            key="${pair%%=*}"
+            if grep -qF "\${${key}}" deploy/backend.cloudbuild.yaml; then
+              FILTERED="${FILTERED:+${FILTERED}##}${pair}"
+            else
+              echo "skew guard: dropping substitution ${key} (not in template on this SHA)"
+            fi
+          done < <(printf '%s' "${SUBSTITUTIONS//##/$'\n'}" | awk 'NF')
+          SUBSTITUTIONS="$FILTERED"
+          gcloud builds submit \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --config=deploy/backend.cloudbuild.yaml \
+            "--substitutions=^##^${SUBSTITUTIONS}"
+          finished_at="$(date +%s)"
+          echo "started_at_epoch=${started_at}" >> "$GITHUB_OUTPUT"
+          echo "finished_at_epoch=${finished_at}" >> "$GITHUB_OUTPUT"
+          echo "duration_seconds=$((finished_at - started_at))" >> "$GITHUB_OUTPUT"
+
+      - name: Retain latest backend revisions
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.BACKEND_REVISION_RETENTION }}"
+
+      - name: Deploy frontend using Cloud Build
+        id: deploy-frontend
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          started_at="$(date +%s)"
+          gcloud builds submit \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --config=deploy/frontend.cloudbuild.yaml \
+            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_APP_ENV=uat,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=founder-${{ steps.resolve-sha.outputs.sha }},_DEPLOY_ENV=founder,_DEPLOY_SOURCE=deploy-founder,_DEPLOY_SHA=${{ steps.resolve-sha.outputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+          finished_at="$(date +%s)"
+          echo "started_at_epoch=${started_at}" >> "$GITHUB_OUTPUT"
+          echo "finished_at_epoch=${finished_at}" >> "$GITHUB_OUTPUT"
+          echo "duration_seconds=$((finished_at - started_at))" >> "$GITHUB_OUTPUT"
+
+      - name: Retain latest frontend revisions
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
+        run: bash scripts/ci/cloudrun-retention.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.FRONTEND_REVISION_RETENTION }}"
+
+      - name: Resolve deployed candidate revisions
+        id: candidate-state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestCreatedRevisionName)')"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestCreatedRevisionName)')"
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify backend candidate runtime identity
+        if: steps.scope.outputs.deploy_backend == 'true'
+        run: >-
+          bash scripts/ci/assert-cloud-run-runtime-identity.sh
+          "${{ env.GCP_PROJECT_ID }}"
+          "${{ env.GCP_REGION }}"
+          "${{ steps.candidate-state.outputs.backend_revision }}"
+          "${{ env.RUNTIME_SERVICE_ACCOUNT }}"
+
+      - name: Promote deployed revisions to dev traffic
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ]; then
+            gcloud run services update-traffic "${{ env.BACKEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --to-revisions="${{ steps.candidate-state.outputs.backend_revision }}=100"
+          fi
+
+          if [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ]; then
+            gcloud run services update-traffic "${{ env.FRONTEND_SERVICE }}" \
+              --project="${{ env.GCP_PROJECT_ID }}" \
+              --region="${{ env.GCP_REGION }}" \
+              --to-revisions="${{ steps.candidate-state.outputs.frontend_revision }}=100"
+          fi
+
+      - name: Resolve current deployed Cloud Run state
+        id: current-state
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)')"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)')"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)')"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)')"
+
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify backend deployment provenance
+        id: verify-backend-provenance
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ci/verify-cloudrun-revision-provenance.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --service "${{ env.BACKEND_SERVICE }}" \
+            --expected-env founder \
+            --expected-source deploy-founder \
+            --expected-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --expected-run-id "${{ github.run_id }}" \
+            --report-path /tmp/dev-backend-provenance.json
+
+      - name: Verify frontend deployment provenance
+        id: verify-frontend-provenance
+        if: steps.scope.outputs.deploy_frontend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ci/verify-cloudrun-revision-provenance.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --service "${{ env.FRONTEND_SERVICE }}" \
+            --expected-env founder \
+            --expected-source deploy-founder \
+            --expected-sha "${{ steps.resolve-sha.outputs.sha }}" \
+            --expected-run-id "${{ github.run_id }}" \
+            --report-path /tmp/dev-frontend-provenance.json
+
+      - name: Verify founder runtime env parity
+        id: verify-parity-1
+        continue-on-error: true
+        run: |
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify-env-secrets-parity.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --backend-service "${{ env.BACKEND_SERVICE }}" \
+            --frontend-service "${{ env.FRONTEND_SERVICE }}" \
+            --require-plaid \
+            --require-market-data \
+            --require-gmail \
+            --require-voice \
+            --require-reviewer-smoke \
+            --assert-runtime-env-contract \
+            --report-path /tmp/dev-runtime-parity-attempt-1.json
+
+      - name: Verify founder runtime env parity retry
+        id: verify-parity-2
+        if: steps.verify-parity-1.outcome == 'failure'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          sleep 20
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify-env-secrets-parity.py \
+            --project "${{ env.GCP_PROJECT_ID }}" \
+            --region "${{ env.GCP_REGION }}" \
+            --backend-service "${{ env.BACKEND_SERVICE }}" \
+            --frontend-service "${{ env.FRONTEND_SERVICE }}" \
+            --require-plaid \
+            --require-market-data \
+            --require-gmail \
+            --require-voice \
+            --require-reviewer-smoke \
+            --assert-runtime-env-contract \
+            --report-path /tmp/dev-runtime-parity-attempt-2.json
+
+      - name: Post-deploy founder schema contract gate
+        id: postdeploy-db-gate
+        if: steps.scope.outputs.deploy_backend == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
+          DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"
+          echo "::add-mask::${DB_USER}"
+          echo "::add-mask::${DB_PASSWORD}"
+
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 6543 \
+            ${GOOGLE_GHA_CREDS_PATH:+--credentials-file="${GOOGLE_GHA_CREDS_PATH}"} \
+            "${{ env.FOUNDER_CLOUDSQL_INSTANCE }}" >/tmp/cloud-sql-proxy-founder-postdeploy.log 2>&1 &
+          PROXY_PID=$!
+          trap 'kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
+
+          python3 - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 20
+          while time.time() < deadline:
+              with socket.socket() as sock:
+                  sock.settimeout(0.5)
+                  if sock.connect_ex(("127.0.0.1", 6543)) == 0:
+                      raise SystemExit(0)
+              time.sleep(0.25)
+          raise SystemExit("Cloud SQL proxy did not bind 127.0.0.1:6543 in time")
+          PY
+
+          export DB_HOST=127.0.0.1
+          export DB_PORT=6543
+          export DB_NAME=postgres
+          export DB_USER
+          export DB_PASSWORD
+
+          # Skew guard (same class as the secret-sync probes): the dev
+          # contract file may not exist on older train SHAs. Fall back to the
+          # UAT contract, which dev replicates by design.
+          CONTRACT_FILE="consent-protocol/db/contracts/dev_minimum_schema.json"
+          if [ ! -f "$CONTRACT_FILE" ]; then
+            CONTRACT_FILE="consent-protocol/db/contracts/uat_integrated_schema.json"
+            echo "dev contract missing on this SHA; falling back to $CONTRACT_FILE"
+          fi
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
+            --contract-file "$CONTRACT_FILE" \
+            --report-path /tmp/dev-db-migration-guard-postdeploy.json
+
+      - name: Bootstrap dev runtime files for semantic verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          BOOTSTRAP_FOCUS_PROFILE=dev bash scripts/env/bootstrap_profiles.sh --strict
+          bash scripts/env/use_profile.sh dev
+
+      - name: Load maintainer smoke overlay
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_user_id="$(gcloud secrets versions access latest \
+            --secret=UAT_SMOKE_USER_ID \
+            --project="${{ env.GCP_PROJECT_ID }}")"
+          smoke_passphrase="$(gcloud secrets versions access latest \
+            --secret=UAT_SMOKE_PASSPHRASE \
+            --project="${{ env.GCP_PROJECT_ID }}")"
+          echo "::add-mask::$smoke_user_id"
+          echo "::add-mask::$smoke_passphrase"
+          {
+            echo "UAT_SMOKE_USER_ID<<EOF"
+            printf '%s\n' "$smoke_user_id"
+            echo "EOF"
+            echo "UAT_SMOKE_PASSPHRASE<<EOF"
+            printf '%s\n' "$smoke_passphrase"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Semantic founder verification
+        id: verify-dev-1
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify_uat_release.py \
+            --backend-url "${{ steps.current-state.outputs.backend_url }}" \
+            --frontend-url "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --protocol-env consent-protocol/.env \
+            --web-env hushh-webapp/.env.local \
+            --report-path /tmp/dev-release-verify-attempt-1.json
+
+      - name: Semantic founder verification retry
+        id: verify-dev-2
+        if: steps.verify-dev-1.outcome == 'failure'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          sleep 20
+          "${{ env.PROTOCOL_PYTHON }}" scripts/ops/verify_uat_release.py \
+            --backend-url "${{ steps.current-state.outputs.backend_url }}" \
+            --frontend-url "${{ env.APP_FRONTEND_ORIGIN }}" \
+            --protocol-env consent-protocol/.env \
+            --web-env hushh-webapp/.env.local \
+            --report-path /tmp/dev-release-verify-attempt-2.json
+
+      - name: Classify founder release outcome
+        if: always()
+        id: classify-dev-release
+        shell: bash
+        env:
+          DEPLOY_BACKEND: ${{ steps.scope.outputs.deploy_backend }}
+          DEPLOY_FRONTEND: ${{ steps.scope.outputs.deploy_frontend }}
+          PARITY_ATTEMPT_1: ${{ steps.verify-parity-1.outcome }}
+          PARITY_ATTEMPT_2: ${{ steps.verify-parity-2.outcome }}
+          BACKEND_PROVENANCE_OUTCOME: ${{ steps.verify-backend-provenance.outcome }}
+          FRONTEND_PROVENANCE_OUTCOME: ${{ steps.verify-frontend-provenance.outcome }}
+          DB_OUTCOME: ${{ steps.postdeploy-db-gate.outcome }}
+          SEMANTIC_ATTEMPT_1: ${{ steps.verify-dev-1.outcome }}
+          SEMANTIC_ATTEMPT_2: ${{ steps.verify-dev-2.outcome }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          def load_json(path: str) -> dict:
+              candidate = Path(path)
+              if not candidate.exists():
+                  return {}
+              try:
+                  parsed = json.loads(candidate.read_text(encoding="utf-8"))
+              except json.JSONDecodeError:
+                  return {}
+              return parsed if isinstance(parsed, dict) else {}
+
+          def has_runtime_failures(entries: list[dict]) -> bool:
+              return any(str(entry.get("status")) in {"missing", "legacy"} for entry in entries)
+
+          def append_unique(target: list[str], values: list[str]) -> None:
+              for value in values:
+                  if value and value not in target:
+                      target.append(value)
+
+          parity_report = load_json("/tmp/dev-runtime-parity-attempt-2.json") or load_json(
+              "/tmp/dev-runtime-parity-attempt-1.json"
+          )
+          backend_provenance_report = load_json("/tmp/dev-backend-provenance.json")
+          frontend_provenance_report = load_json("/tmp/dev-frontend-provenance.json")
+          semantic_report = load_json("/tmp/dev-release-verify-attempt-2.json") or load_json(
+              "/tmp/dev-release-verify-attempt-1.json"
+          )
+          semantic_report_present = bool(semantic_report)
+
+          parity_success = os.environ.get("PARITY_ATTEMPT_1") == "success" or os.environ.get("PARITY_ATTEMPT_2") == "success"
+          backend_provenance_success = (
+              os.environ.get("DEPLOY_BACKEND") != "true"
+              or os.environ.get("BACKEND_PROVENANCE_OUTCOME") == "success"
+          )
+          frontend_provenance_success = (
+              os.environ.get("DEPLOY_FRONTEND") != "true"
+              or os.environ.get("FRONTEND_PROVENANCE_OUTCOME") == "success"
+          )
+          semantic_success = os.environ.get("SEMANTIC_ATTEMPT_1") == "success" or os.environ.get("SEMANTIC_ATTEMPT_2") == "success"
+          db_outcome = os.environ.get("DB_OUTCOME", "")
+
+          blocking: list[str] = []
+          backend_failure = False
+          frontend_failure = False
+
+          required = parity_report.get("required") or {}
+          missing_secrets = set(parity_report.get("missing_secrets") or [])
+          backend_secret_names = set(
+              required.get("backend", [])
+              + required.get("gmail", [])
+              + required.get("one_email", [])
+              + required.get("voice", [])
+              + required.get("plaid", [])
+              + required.get("market", [])
+          )
+          frontend_secret_names = set(required.get("frontend", []))
+
+          runtime_contract = parity_report.get("runtime_contract") or {}
+          frontend_runtime_entries = runtime_contract.get("frontend") or []
+          backend_runtime_entries = (
+              (runtime_contract.get("backend") or [])
+              + (runtime_contract.get("backend_gmail") or [])
+              + (runtime_contract.get("backend_one_email") or [])
+              + (runtime_contract.get("backend_voice") or [])
+          )
+
+          if not parity_success:
+              append_unique(blocking, list(parity_report.get("classifications") or ["runtime_mount_missing"]))
+          if missing_secrets & backend_secret_names:
+              backend_failure = True
+          if missing_secrets & frontend_secret_names:
+              frontend_failure = True
+          if has_runtime_failures(frontend_runtime_entries):
+              frontend_failure = True
+          if has_runtime_failures(backend_runtime_entries):
+              backend_failure = True
+
+          if not backend_provenance_success:
+              append_unique(
+                  blocking,
+                  list(backend_provenance_report.get("classifications") or ["deploy_authority_drift"]),
+              )
+              backend_failure = True
+          if not frontend_provenance_success:
+              append_unique(
+                  blocking,
+                  list(frontend_provenance_report.get("classifications") or ["deploy_authority_drift"]),
+              )
+              frontend_failure = True
+
+          semantic_failures = set(semantic_report.get("failures") or [])
+          advisory_semantic_failures = sorted(
+              item for item in semantic_failures if item.startswith("signed_in_routes:")
+          )
+          blocking_semantic_failures = {
+              item for item in semantic_failures if not item.startswith("signed_in_routes:")
+          }
+          if not semantic_success:
+              if not semantic_report_present:
+                  append_unique(blocking, ["semantic_verifier_failed"])
+              if blocking_semantic_failures:
+                  append_unique(blocking, ["runtime_behavior_failed"])
+              if "smoke_auth" in blocking_semantic_failures:
+                  append_unique(blocking, ["smoke_overlay_dependency_leak"])
+              if blocking_semantic_failures & {"backend_health", "smoke_auth", "gmail_status", "voice_capability", "voice_realtime_session"}:
+                  backend_failure = True
+              if "frontend_login" in blocking_semantic_failures:
+                  frontend_failure = True
+
+          if db_outcome == "failure":
+              append_unique(blocking, ["db_contract_drift"])
+              backend_failure = True
+
+          blocking = list(dict.fromkeys(blocking))
+          release_failed = bool(blocking)
+
+          payload = {
+              "status": "blocked" if release_failed else "healthy",
+              "release_failed": release_failed,
+              "blocking_classifications": blocking,
+              "backend_failure": backend_failure,
+              "frontend_failure": frontend_failure,
+              "parity": {
+                  "attempt_1": os.environ.get("PARITY_ATTEMPT_1", ""),
+                  "attempt_2": os.environ.get("PARITY_ATTEMPT_2", ""),
+                  "success": parity_success,
+              },
+              "provenance": {
+                  "backend": {
+                      "outcome": os.environ.get("BACKEND_PROVENANCE_OUTCOME", ""),
+                      "success": backend_provenance_success,
+                      "report": backend_provenance_report,
+                  },
+                  "frontend": {
+                      "outcome": os.environ.get("FRONTEND_PROVENANCE_OUTCOME", ""),
+                      "success": frontend_provenance_success,
+                      "report": frontend_provenance_report,
+                  },
+              },
+              "semantic": {
+                  "attempt_1": os.environ.get("SEMANTIC_ATTEMPT_1", ""),
+                  "attempt_2": os.environ.get("SEMANTIC_ATTEMPT_2", ""),
+                  "success": semantic_success,
+                  "report_present": semantic_report_present,
+                  "failures": sorted(semantic_failures),
+                  "blocking_failures": sorted(blocking_semantic_failures),
+                  "advisory_failures": advisory_semantic_failures,
+              },
+              "db_contract": {
+                  "outcome": db_outcome,
+              },
+          }
+
+          Path("/tmp/dev-release-classification.json").write_text(
+              json.dumps(payload, indent=2), encoding="utf-8"
+          )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"release_failed={'true' if release_failed else 'false'}\n")
+              handle.write(f"backend_failure={'true' if backend_failure else 'false'}\n")
+              handle.write(f"frontend_failure={'true' if frontend_failure else 'false'}\n")
+              handle.write(f"blocking_classifications={','.join(blocking)}\n")
+              handle.write(f"parity_success={'true' if parity_success else 'false'}\n")
+              handle.write(f"provenance_success={'true' if backend_provenance_success and frontend_provenance_success else 'false'}\n")
+              handle.write(f"semantic_success={'true' if semantic_success else 'false'}\n")
+          PY
+
+      - name: Roll back backend revision
+        id: rollback-backend
+        if: always() && steps.classify-dev-release.outputs.release_failed == 'true' && steps.classify-dev-release.outputs.backend_failure == 'true' && steps.scope.outputs.deploy_backend == 'true' && steps.predeploy-state.outputs.backend_revision != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.backend_revision }}"
+
+      - name: Roll back frontend revision
+        id: rollback-frontend
+        if: always() && steps.classify-dev-release.outputs.release_failed == 'true' && steps.classify-dev-release.outputs.frontend_failure == 'true' && steps.scope.outputs.deploy_frontend == 'true' && steps.predeploy-state.outputs.frontend_revision != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/cloudrun-rollback.sh "${{ env.FRONTEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ steps.predeploy-state.outputs.frontend_revision }}"
+
+      - name: Resolve final Cloud Run state
+        if: always()
+        id: final-state
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+          backend_url="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          frontend_revision="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.traffic[0].revisionName)' 2>/dev/null || true)"
+          frontend_url="$(gcloud run services describe "${{ env.FRONTEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.url)' 2>/dev/null || true)"
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+          echo "backend_url=${backend_url}" >> "$GITHUB_OUTPUT"
+          echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+
+      - name: Write founder release status artifact
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          BACKEND_ROLLBACK_REQUIRED=false
+          FRONTEND_ROLLBACK_REQUIRED=false
+          BACKEND_ROLLBACK_DONE=true
+          FRONTEND_ROLLBACK_DONE=true
+
+          if [ "${{ steps.classify-dev-release.outputs.release_failed }}" != "true" ]; then
+            STATUS="healthy"
+          else
+            if [ "${{ steps.classify-dev-release.outputs.backend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_backend }}" = "true" ] && [ "${{ steps.predeploy-state.outputs.backend_revision }}" != "" ]; then
+              BACKEND_ROLLBACK_REQUIRED=true
+              if [ "${{ steps.rollback-backend.outcome }}" != "success" ]; then
+                BACKEND_ROLLBACK_DONE=false
+              fi
+            fi
+            if [ "${{ steps.classify-dev-release.outputs.frontend_failure }}" = "true" ] && [ "${{ steps.scope.outputs.deploy_frontend }}" = "true" ] && [ "${{ steps.predeploy-state.outputs.frontend_revision }}" != "" ]; then
+              FRONTEND_ROLLBACK_REQUIRED=true
+              if [ "${{ steps.rollback-frontend.outcome }}" != "success" ]; then
+                FRONTEND_ROLLBACK_DONE=false
+              fi
+            fi
+
+            if { [ "$BACKEND_ROLLBACK_REQUIRED" = true ] || [ "$FRONTEND_ROLLBACK_REQUIRED" = true ]; } && [ "$BACKEND_ROLLBACK_DONE" = true ] && [ "$FRONTEND_ROLLBACK_DONE" = true ]; then
+              STATUS="rolled_back"
+            else
+              STATUS="blocked"
+            fi
+          fi
+
+          export STATUS
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              "status": os.environ["STATUS"],
+              "sha": "${{ steps.resolve-sha.outputs.sha }}",
+              "scope": "${{ steps.scope.outputs.scope }}",
+              "app_frontend_origin": "${{ env.APP_FRONTEND_ORIGIN }}",
+              "predeploy": {
+                  "backend_revision": "${{ steps.predeploy-state.outputs.backend_revision }}",
+                  "backend_url": "${{ steps.predeploy-state.outputs.backend_url }}",
+                  "frontend_revision": "${{ steps.predeploy-state.outputs.frontend_revision }}",
+                  "frontend_url": "${{ steps.predeploy-state.outputs.frontend_url }}",
+              },
+              "current": {
+                  "backend_candidate_revision": "${{ steps.candidate-state.outputs.backend_revision }}",
+                  "backend_revision": "${{ steps.current-state.outputs.backend_revision }}",
+                  "backend_url": "${{ steps.current-state.outputs.backend_url }}",
+                  "frontend_candidate_revision": "${{ steps.candidate-state.outputs.frontend_revision }}",
+                  "frontend_revision": "${{ steps.current-state.outputs.frontend_revision }}",
+                  "frontend_url": "${{ steps.current-state.outputs.frontend_url }}",
+              },
+              "final": {
+                  "backend_revision": "${{ steps.final-state.outputs.backend_revision }}",
+                  "backend_url": "${{ steps.final-state.outputs.backend_url }}",
+                  "frontend_revision": "${{ steps.final-state.outputs.frontend_revision }}",
+                  "frontend_url": "${{ steps.final-state.outputs.frontend_url }}",
+              },
+              "verification": {
+                  "parity_attempt_1": "${{ steps.verify-parity-1.outcome }}",
+                  "parity_attempt_2": "${{ steps.verify-parity-2.outcome }}",
+                  "parity_success": "${{ steps.classify-dev-release.outputs.parity_success }}",
+                  "backend_provenance": "${{ steps.verify-backend-provenance.outcome }}",
+                  "frontend_provenance": "${{ steps.verify-frontend-provenance.outcome }}",
+                  "provenance_success": "${{ steps.classify-dev-release.outputs.provenance_success }}",
+                  "attempt_1": "${{ steps.verify-dev-1.outcome }}",
+                  "attempt_2": "${{ steps.verify-dev-2.outcome }}",
+                  "semantic_success": "${{ steps.classify-dev-release.outputs.semantic_success }}",
+                  "db_contract": "${{ steps.postdeploy-db-gate.outcome }}",
+                  "blocking_classifications": "${{ steps.classify-dev-release.outputs.blocking_classifications }}",
+              },
+              "rollback_targets": {
+                  "backend_revision": "${{ steps.predeploy-state.outputs.backend_revision }}",
+                  "frontend_revision": "${{ steps.predeploy-state.outputs.frontend_revision }}",
+              },
+              "timing_seconds": {
+                  "backend_cloud_build": "${{ steps.deploy-backend.outputs.duration_seconds || '0' }}",
+                  "frontend_cloud_build": "${{ steps.deploy-frontend.outputs.duration_seconds || '0' }}",
+              },
+          }
+          Path("/tmp/dev-release-status.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+          PY
+
+      - name: Upload dev deploy artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dev-release-${{ github.run_id }}
+          if-no-files-found: ignore
+          path: |
+            /tmp/dev-runtime-secret-sync.json
+            /tmp/dev-frontend-runtime-secret-sync.json
+            /tmp/dev-runtime-parity-attempt-1.json
+            /tmp/dev-runtime-parity-attempt-2.json
+            /tmp/dev-backend-provenance.json
+            /tmp/dev-frontend-provenance.json
+            /tmp/dev-db-migration-guard-predeploy.json
+            /tmp/dev-db-migration-guard-postdeploy.json
+            /tmp/cloud-sql-proxy-founder.log
+            /tmp/cloud-sql-proxy-founder-postdeploy.log
+            /tmp/dev-release-verify-attempt-1.json
+            /tmp/dev-release-verify-attempt-2.json
+            /tmp/dev-release-classification.json
+            /tmp/dev-release-status.json
+
+      - name: Deployment summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            total_seconds=$(( $(date +%s) - ${{ steps.timing-start.outputs.epoch || '0' }} ))
+            if [ "${{ steps.timing-start.outputs.epoch || '' }}" = "" ]; then
+              total_seconds=0
+            fi
+            backend_build_seconds="${{ steps.deploy-backend.outputs.duration_seconds || '0' }}"
+            frontend_build_seconds="${{ steps.deploy-frontend.outputs.duration_seconds || '0' }}"
+            build_seconds=$(( backend_build_seconds + frontend_build_seconds ))
+            non_build_seconds=$(( total_seconds - build_seconds ))
+            if [ "$non_build_seconds" -lt 0 ]; then
+              non_build_seconds=0
+            fi
+            echo "## Dev Release"
+            echo ""
+            echo "- SHA: \`${{ steps.resolve-sha.outputs.sha }}\`"
+            echo "- Requested scope: \`${{ github.event.inputs.scope }}\`"
+            echo "- Scope: \`${{ steps.scope.outputs.scope }}\`"
+            echo "- Scope reason: \`${{ steps.scope.outputs.reason }}\`"
+            echo "- Backend deployed SHA before run: \`${{ steps.predeploy-state.outputs.backend_sha || 'unknown' }}\`"
+            echo "- Frontend deployed SHA before run: \`${{ steps.predeploy-state.outputs.frontend_sha || 'unknown' }}\`"
+            echo "- Status: \`$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/dev-release-status.json').read_text(encoding='utf-8'))['status'])")\`"
+            echo "- Blocking classifications: \`${{ steps.classify-dev-release.outputs.blocking_classifications || 'none' }}\`"
+            echo "- Backend URL: \`${{ steps.final-state.outputs.backend_url }}\`"
+            echo "- Frontend URL: \`${{ env.APP_FRONTEND_ORIGIN }}\`"
+            echo "- Backend revision: \`${{ steps.final-state.outputs.backend_revision }}\`"
+            echo "- Frontend revision: \`${{ steps.final-state.outputs.frontend_revision }}\`"
+            echo "- Parity attempt 1: \`${{ steps.verify-parity-1.outcome }}\`"
+            echo "- Parity attempt 2: \`${{ steps.verify-parity-2.outcome }}\`"
+            echo "- Backend provenance: \`${{ steps.verify-backend-provenance.outcome }}\`"
+            echo "- Frontend provenance: \`${{ steps.verify-frontend-provenance.outcome }}\`"
+            echo "- Post-deploy DB contract: \`${{ steps.postdeploy-db-gate.outcome }}\`"
+            echo "- Verify attempt 1: \`${{ steps.verify-dev-1.outcome }}\`"
+            echo "- Verify attempt 2: \`${{ steps.verify-dev-2.outcome }}\`"
+            echo "- Backend rollback: \`${{ steps.rollback-backend.outcome }}\`"
+            echo "- Frontend rollback: \`${{ steps.rollback-frontend.outcome }}\`"
+            echo ""
+            echo "### Deploy Timing"
+            echo ""
+            echo "- Total job time so far: \`${total_seconds}s\`"
+            echo "- Backend Cloud Build: \`${backend_build_seconds}s\`"
+            echo "- Frontend Cloud Build: \`${frontend_build_seconds}s\`"
+            echo "- Non-build gates and verification: \`${non_build_seconds}s\`"
+            echo ""
+            echo "### Auto Scope Evidence"
+            echo ""
+            echo "- Backend changed files: \`${{ steps.scope.outputs.backend_changed_files || 'none' }}\`"
+            echo "- Frontend changed files: \`${{ steps.scope.outputs.frontend_changed_files || 'none' }}\`"
+            echo "- Shared changed files: \`${{ steps.scope.outputs.shared_changed_files || 'none' }}\`"
+            echo "- Neutral changed files: \`${{ steps.scope.outputs.neutral_changed_files || 'none' }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail workflow when founder release did not end healthy
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          STATUS="$(python3 -c "import json; from pathlib import Path; print(json.loads(Path('/tmp/dev-release-status.json').read_text(encoding='utf-8'))['status'])")"
+          if [ "$STATUS" != "healthy" ]; then
+            echo "Founder release finished with status: $STATUS"
+            exit 1
+          fi

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -102,6 +102,18 @@
       "ahujagautam024"
     ]
   },
+  "founder": {
+    "environment": "founder",
+    "manual_dispatch_users": [
+      "kushaltrivedi5",
+      "RGlodAkshat",
+      "ankitkumarsingh1702",
+      "azfx",
+      "Jhumma-hushh",
+      "DamriaNeelesh",
+      "ahujagautam024"
+    ]
+  },
   "uat": {
     "auto_deploy_workflow": "Main Post-Merge Smoke",
     "required_post_merge_check": "Main Post-Merge Smoke Gate",

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -123,7 +123,11 @@ def test_production_secret_parity_fails_closed_before_traffic() -> None:
 
 
 def test_nonproduction_rollback_targets_are_traffic_bearing_revisions() -> None:
-    for path in (".github/workflows/deploy-uat.yml", ".github/workflows/deploy-dev.yml"):
+    for path in (
+        ".github/workflows/deploy-uat.yml",
+        ".github/workflows/deploy-dev.yml",
+        ".github/workflows/deploy-founder.yml",
+    ):
         workflow = _read(path)
         assert workflow.count("status.latestReadyRevisionName") == 0
         assert workflow.count("status.latestCreatedRevisionName") == 2

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -295,11 +295,12 @@ Manual dispatch now supports `scope`:
 
 **For seamless deployment:**
 
-1. **GitHub environment variables:** configure `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SERVICE_ACCOUNT` in each of `dev`, `uat`, and `production`. The deploy principal must use GitHub OIDC Workload Identity Federation, receive only the deploy permissions it needs, and have `roles/iam.serviceAccountUser` on that environment's exact runtime service account. Do not create or upload a JSON service-account key.
+1. **GitHub environment variables:** configure `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SERVICE_ACCOUNT` in each of `dev`, `founder`, `uat`, and `production`. The deploy principal must use GitHub OIDC Workload Identity Federation, receive only the deploy permissions it needs, and have `roles/iam.serviceAccountUser` on that environment's exact runtime service account. Do not create or upload a JSON service-account key.
 2. **Backup variables:** configure repository variables `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_BACKUP_SERVICE_ACCOUNT` for the scheduled production backup posture check. The backup identity should be read-only for the governed backup bucket.
 3. **Branch flow:** merge to `main` for UAT rollout; use manual dispatch for production rollout from a green `main` SHA.
 4. **Environment policy:** keep only the canonical deploy environments in active use:
    - `dev` (UAT infrastructure replica; see [consent-protocol/docs/reference/dev-environment-setup.md](../consent-protocol/docs/reference/dev-environment-setup.md))
+   - `founder` (founder/leadership fast sandbox for highly-unstable features; a dev-shaped replica in its own project that never promotes — see [docs/reference/operations/founder-sandbox.md](../docs/reference/operations/founder-sandbox.md))
    - `uat`
    - `production`
    Legacy unused production environments should not remain as parallel approval lanes.

--- a/docs/reference/operations/founder-sandbox.md
+++ b/docs/reference/operations/founder-sandbox.md
@@ -1,0 +1,121 @@
+# Founder Sandbox environment (`hushh-pda-founder`)
+
+> A dedicated GCP environment that mirrors `hushh-pda-dev`, reserved as the
+> founder/leadership **fast sandbox** for **highly-unstable features**: deploy any
+> CI-green ref in real time, validate a new direction, iterate — without disrupting
+> the shared dev environment. The dev team then reviews, refines, and picks up the
+> stable workstreams. It is a **disposable sandbox**, never a promotion lane.
+
+## Visual Map
+
+```mermaid
+flowchart LR
+  maintainer["Governed maintainer"] --> dispatch["Deploy to Founder\nworkflow dispatched from main"]
+  dispatch --> gate["CI-green SHA + actor + provenance gates"]
+  gate --> founder["Founder GCP project\nseparate Cloud SQL and Cloud Run"]
+  founder --> review["Founder validation"]
+  review --> normal["Normal PR review and merge flow"]
+  founder -. never promotes .-> uat["UAT / production"]
+```
+
+## Status — scaffolding, inert until two things happen
+
+Everything in this document is **repo-side configuration**. It does nothing on its
+own. The Founder environment becomes live only when **both** of these are done:
+
+1. **The config below is on `main`.** The deploy workflow is `workflow_dispatch`-only
+   and guarded to run its *definition* from `main`, so on any feature branch it is
+   inert YAML that cannot be dispatched. A maintainer must land these files on `main`.
+2. **The GCP project is provisioned** (the [one-time runbook](#one-time-provisioning-operator)
+   below). Until `hushh-pda-founder` and its GitHub `founder` environment exist, no
+   deploy can target it.
+
+No live cloud resources or billing are created by adding these files.
+
+## Why a separate project (not just reuse dev)
+
+`hushh-pda-dev` is the shared integration environment the whole team relies on.
+Highly-unstable, exploratory work can leave it in a broken state. A **separate
+project** isolates that blast radius: the founder lane can be red, half-migrated, or
+mid-experiment while dev stays trustworthy for everyone else. The pattern, gates, and
+behavior are otherwise identical to dev (this is a faithful clone).
+
+> This is a **GCP dev/sandbox** environment and is intentionally independent of the
+> product's runtime posture (general/mass deployments are primary on Anypoint via the
+> pre-purchased Titanium capacity; the FedRAMP-High / regulated tier is primary on
+> GCP). The sandbox simply mirrors the existing GCP-based dev infrastructure.
+
+## Repo artifacts (this change)
+
+| File | Role | Cloned from |
+|---|---|---|
+| `.github/workflows/deploy-founder.yml` | The deploy lane (dispatch). `environment: founder`, project `hushh-pda-founder`, `--surface founder`. Keeps the full CI-green SHA gate + auto-rollback. | `deploy-dev.yml` |
+| `config/ci-governance.json` → `founder` block | The actor allowlist for `--surface founder` (same maintainer cohort as dev). | `dev` block |
+| `scripts/ci/assert-governed-actor.py` | `--surface` now accepts `founder`. | — |
+
+The shared builds `deploy/backend.cloudbuild.yaml` and `deploy/frontend.cloudbuild.yaml`
+are **unchanged** — every environment-specific value is passed in as a substitution,
+so the founder lane reuses them verbatim and cannot drift.
+
+## Deploy lane
+
+**Primary — dispatch (any CI-green ref, real time).** This is the fast path for
+unstable feature branches. A governed maintainer runs Actions → **Deploy to Founder**,
+choosing an eligible feature branch and optionally an exact `sha`. The
+same guards as dev apply:
+- The workflow *definition* runs from `main`; the *content* deployed is `inputs.ref` / `inputs.sha`.
+- Actor must be in the `founder` allowlist (`assert-governed-actor.py --surface founder`).
+- The SHA must be reachable from the ref **and** carry a green authoritative CI check
+  (`CI Status Gate` / `Queue Validation` / `Main Post-Merge Smoke Gate`, any-of). Full
+  quality gate, zero promotion gate — exactly the dev fast-lane contract.
+
+## Guardrails (inherited from the dev fast lane)
+
+- **Never promotes.** Founder deploys nothing to UAT or production; UAT/production
+  remain `main`-only, GitHub-Actions-only, and stricter-gated. Never point a founder
+  trigger at them.
+- **Behavior parity via `ENVIRONMENT=uat`.** Like dev, the founder runtime runs with
+  `_RUNTIME_ENVIRONMENT=uat` (and `_APP_ENV=uat`) so behavior gates match UAT. Do
+  **not** introduce a literal `ENVIRONMENT=founder` — the backend would treat the
+  unknown string as *local* dev and silently flip auth/debug defaults.
+- **Full CI gate.** `CI Status Gate` runs on every PR regardless of environment, so
+  founder work is held to the same quality bar as everything else.
+- **No shared email ingress.** One Email KYC, Gmail watch renewal, and UAT Pub/Sub
+  subscriptions are disabled. They require a separate connector authority and an
+  environment-specific audience before they can be enabled.
+- **Governance-protected.** `.github/workflows/`, `deploy/`, `scripts/ci/`, and
+  `config/ci-governance.json` are in `main.protected_pipeline_paths`, so these files
+  are edit-restricted to the maintainer cohort once on `main`.
+
+## One-time provisioning (operator)
+
+Requires GCP org admin + GitHub org admin. Mirror the dev runbook
+([`consent-protocol/docs/reference/dev-environment-setup.md`](../../../consent-protocol/docs/reference/dev-environment-setup.md)),
+substituting `hushh-pda-founder` for `hushh-pda-dev`:
+
+1. **Project + region.** Create project `hushh-pda-founder` (region `us-central1`),
+   link billing, enable the same APIs the dispatch lane uses (Cloud Run, Cloud Build,
+   Cloud SQL, Secret Manager, and AI Platform).
+2. **Cloud SQL.** Create instance `hushh-founder-pg` (mirror dev's Postgres shape).
+3. **Service accounts + WIF.** Create `consent-protocol-runtime@hushh-pda-founder…`
+   (runtime identity, `roles/aiplatform.user` + the dev runtime roles) and a
+   `github-deployer` SA with a Workload Identity Federation binding for GitHub Actions.
+4. **Secrets.** Seed only the founder project's required runtime secrets and
+   `BACKEND_RUNTIME_CONFIG_JSON`. Do not copy Workspace credentials, One Email KYC
+   credentials, or a UAT Pub/Sub subscription into the sandbox.
+5. **GitHub environment.** Create a repo environment named **`founder`** carrying
+   `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SERVICE_ACCOUNT` (pointing at the
+   SAs above), matching how `dev` is wired.
+6. **Schema floor.** The lane reuses `consent-protocol/db/contracts/dev_minimum_schema.json`
+   as its release floor (dev's skew-guard fallback behavior is unchanged).
+7. **Domain mapping.** Point `founder.one.hushh.ai` to the founder frontend before
+   dispatching a hosted browser rehearsal; the workflow uses that origin for CORS and
+   frontend verification.
+
+## How the team uses it
+
+- A maintainer deploys an eligible feature branch via **Deploy to Founder** to see
+  exploratory work running end-to-end without disrupting shared dev.
+- Leadership validates the direction live; the dev team then reviews the diff, refines
+  it, and merges the *stable* slice through the normal `integration/pr-train` → `main`
+  flow. The sandbox stays disposable — reset or redeploy freely.

--- a/scripts/ci/assert-governed-actor.py
+++ b/scripts/ci/assert-governed-actor.py
@@ -17,7 +17,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Assert that a GitHub actor is allowed to dispatch a governed workflow."
     )
-    parser.add_argument("--surface", choices=("dev", "uat", "production"), required=True)
+    parser.add_argument("--surface", choices=("dev", "uat", "founder", "production"), required=True)
     parser.add_argument("--actor", required=True)
     args = parser.parse_args()
 


### PR DESCRIPTION
## What this is

Adds the guarded Founder sandbox deploy lane for the isolated `hushh-pda-founder` project. This is deployment configuration only; it does not provision cloud resources or deploy a revision.

## Included

- Manual **Deploy to Founder** GitHub Actions workflow, dispatched from its `main` definition.
- Governed-actor allowlist and exact CI-green SHA validation.
- No-traffic candidate deployment, provenance, runtime, semantic, and rollback checks.
- Founder operations runbook and a no-traffic deployment contract test.

## Deliberately deferred

- Cloud Build auto-deploy triggers and their separate deployment authority.
- One Email KYC, Gmail watch renewal, and shared UAT Pub/Sub ingress.

## Provisioning boundary

The lane remains inert until the separate GCP project, Cloud SQL instance, user-managed runtime identity, GitHub OIDC/WIF deploy identity, required founder secrets, and founder domain mapping are provisioned.