### PR TITLE
feat: Preference Subscription Fabric backend — PWM store + grants/receipts + subscriber read (PCHP RFC-002)

### DIFF
--- a/consent-protocol/api/routes/fabric.py
+++ b/consent-protocol/api/routes/fabric.py
@@ -20,7 +20,7 @@ Subscriber endpoint (developer-principal auth; Bearer token):
 """
 
 import logging
-from typing import Any
+from typing import Any, NoReturn
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
@@ -63,7 +63,7 @@ class ReadRequest(BaseModel):
     handle: str = Field(min_length=8, max_length=4096)
 
 
-def _raise(err: FabricGrantError) -> None:
+def _raise(err: FabricGrantError) -> NoReturn:
     raise HTTPException(
         status_code=err.status_code, detail={"code": err.code, "message": err.message}
     )
@@ -75,7 +75,7 @@ async def create_grant(
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
     try:
-        return await get_fabric_grant_service().create_grant(
+        created: dict[str, Any] = await get_fabric_grant_service().create_grant(
             user_id=firebase_uid,
             subscriber_id=request.subscriber_id,
             scopes=request.scopes,
@@ -85,6 +85,7 @@ async def create_grant(
             price_cents=request.price_cents,
             currency=request.currency,
         )
+        return created
     except FabricGrantError as err:
         _raise(err)
 
@@ -103,9 +104,10 @@ async def revoke_grant(
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
     try:
-        return await get_fabric_grant_service().revoke_grant(
+        revoked: dict[str, Any] = await get_fabric_grant_service().revoke_grant(
             user_id=firebase_uid, grant_id=grant_id
         )
+        return revoked
     except FabricGrantError as err:
         _raise(err)
 
@@ -123,7 +125,8 @@ async def list_receipts(
 async def verify_receipts(
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
-    return await get_fabric_receipts_service().verify_chain(firebase_uid)
+    verification: dict[str, Any] = await get_fabric_receipts_service().verify_chain(firebase_uid)
+    return verification
 
 
 @router.post("/read")
@@ -140,10 +143,11 @@ async def subscriber_read(
             },
         )
     try:
-        return await get_fabric_grant_service().read_for_subscriber(
+        result: dict[str, Any] = await get_fabric_grant_service().read_for_subscriber(
             handle=body.handle,
             subscriber_id=principal.agent_id,
             pwm_doc_loader=get_pwm_service().get_document,
         )
+        return result
     except FabricGrantError as err:
         _raise(err)

--- a/consent-protocol/api/routes/fabric.py
+++ b/consent-protocol/api/routes/fabric.py
@@ -1,0 +1,149 @@
+# consent-protocol/api/routes/fabric.py
+"""
+Preference Subscription Fabric API routes (PCHP RFC-002).
+
+Turns the Personal World Model (/api/pwm) from a private store into a
+subscribable fabric: a person grants a subscriber scoped, dated, priced,
+revocable read access to specific PWM fields, and every grant/read/revoke
+writes a signed, hash-chained receipt.
+
+Owner endpoints (Firebase auth; uid only from the verified token):
+    POST   /api/fabric/grants               -> create a grant, return the handle
+    GET    /api/fabric/grants               -> list my grants (no handles)
+    POST   /api/fabric/grants/{id}/revoke   -> revoke a grant
+    GET    /api/fabric/receipts             -> my hash-chained receipt ledger
+    GET    /api/fabric/receipts/verify      -> verify my chain integrity
+
+Subscriber endpoint (developer-principal auth; Bearer token):
+    POST   /api/fabric/read                 -> present a grant handle, receive
+                                               only the granted fields + a receipt
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from api.developer_auth import authenticate_developer_principal
+from api.middleware import require_firebase_auth
+from hushh_mcp.services.developer_registry_service import DeveloperPrincipal
+from hushh_mcp.services.fabric_grant_service import FabricGrantError, get_fabric_grant_service
+from hushh_mcp.services.fabric_receipts_service import get_fabric_receipts_service
+from hushh_mcp.services.pwm_service import get_pwm_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/fabric", tags=["subscription-fabric"])
+
+
+def require_subscriber_principal(request: Request) -> DeveloperPrincipal:
+    """Authenticate the calling third-party subscriber (brand/agent).
+
+    Reuses the developer-principal auth (static ``hdk_`` token or OAuth
+    client-credentials); the subscriber identity is the principal's agent_id.
+    """
+    return authenticate_developer_principal(
+        authorization=request.headers.get("authorization"),
+        request=request,
+    )
+
+
+class CreateGrantRequest(BaseModel):
+    subscriber_id: str = Field(min_length=1, max_length=200)
+    scopes: list[str] = Field(min_length=1, max_length=64)
+    purpose: str = Field(min_length=1, max_length=500)
+    subscriber_label: str | None = Field(default=None, max_length=200)
+    ttl_ms: int | None = Field(default=None, ge=1)
+    price_cents: int | None = Field(default=None, ge=0)
+    currency: str | None = Field(default=None, max_length=8)
+
+
+class ReadRequest(BaseModel):
+    handle: str = Field(min_length=8, max_length=4096)
+
+
+def _raise(err: FabricGrantError) -> None:
+    raise HTTPException(
+        status_code=err.status_code, detail={"code": err.code, "message": err.message}
+    )
+
+
+@router.post("/grants")
+async def create_grant(
+    request: CreateGrantRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    try:
+        return await get_fabric_grant_service().create_grant(
+            user_id=firebase_uid,
+            subscriber_id=request.subscriber_id,
+            scopes=request.scopes,
+            purpose=request.purpose,
+            subscriber_label=request.subscriber_label,
+            ttl_ms=request.ttl_ms,
+            price_cents=request.price_cents,
+            currency=request.currency,
+        )
+    except FabricGrantError as err:
+        _raise(err)
+
+
+@router.get("/grants")
+async def list_grants(
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    grants = await get_fabric_grant_service().list_grants(firebase_uid)
+    return {"grants": grants, "count": len(grants)}
+
+
+@router.post("/grants/{grant_id}/revoke")
+async def revoke_grant(
+    grant_id: str,
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    try:
+        return await get_fabric_grant_service().revoke_grant(
+            user_id=firebase_uid, grant_id=grant_id
+        )
+    except FabricGrantError as err:
+        _raise(err)
+
+
+@router.get("/receipts")
+async def list_receipts(
+    firebase_uid: str = Depends(require_firebase_auth),
+    limit: int = 200,
+) -> dict[str, Any]:
+    receipts = await get_fabric_receipts_service().list_receipts(firebase_uid, limit=limit)
+    return {"receipts": receipts, "count": len(receipts)}
+
+
+@router.get("/receipts/verify")
+async def verify_receipts(
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    return await get_fabric_receipts_service().verify_chain(firebase_uid)
+
+
+@router.post("/read")
+async def subscriber_read(
+    body: ReadRequest = Body(...),
+    principal: DeveloperPrincipal = Depends(require_subscriber_principal),
+) -> dict[str, Any]:
+    if not principal.agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "FABRIC_SUBSCRIBER_UNIDENTIFIED",
+                "message": "Subscriber has no agent id.",
+            },
+        )
+    try:
+        return await get_fabric_grant_service().read_for_subscriber(
+            handle=body.handle,
+            subscriber_id=principal.agent_id,
+            pwm_doc_loader=get_pwm_service().get_document,
+        )
+    except FabricGrantError as err:
+        _raise(err)

--- a/consent-protocol/api/routes/pwm.py
+++ b/consent-protocol/api/routes/pwm.py
@@ -65,7 +65,7 @@ def _sanitize_partial(body: Any) -> dict[str, Any]:
 async def get_pwm_document(
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
-    doc = await get_pwm_service().get_document(firebase_uid)
+    doc: dict[str, Any] | None = await get_pwm_service().get_document(firebase_uid)
     if doc is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -86,7 +86,8 @@ async def put_pwm_document(
         await service.delete_document(firebase_uid)
         return {}
     try:
-        return await service.merge_document(firebase_uid, partial)
+        merged: dict[str, Any] = await service.merge_document(firebase_uid, partial)
+        return merged
     except PwmDocumentTooLargeError as exc:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,

--- a/consent-protocol/api/routes/pwm.py
+++ b/consent-protocol/api/routes/pwm.py
@@ -1,0 +1,102 @@
+# consent-protocol/api/routes/pwm.py
+"""
+Personal World Model (PWM) API routes.
+
+The server-side home of the person's own preference document behind
+``/api/pwm`` — the cross-device "your private agent already knows you" loop for
+the PCHP RFC-002 Preference Subscription Fabric. This replaces the frontend's
+interim Stripe-metadata store; the client contract is unchanged.
+
+Contract
+--------
+    GET    /api/pwm  -> the caller's stored doc as JSON, or 404 if none.
+    PUT    /api/pwm  -> merge a partial doc into the caller's doc
+                        (section-level last-writer-wins by ``updatedAt``);
+                        an empty body ({} or no body) wipes it.
+    DELETE /api/pwm  -> wipe the caller's doc.
+
+Security
+--------
+    - Auth required; the uid is taken ONLY from the verified Firebase token,
+      never from the body (any uid/user_id field in the body is dropped).
+    - Storage is keyed by uid; a document is returned only to its owner and is
+      fully wipeable. Consent-first: this is the person's own data.
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+
+from api.middleware import require_firebase_auth
+from hushh_mcp.services.pwm_service import (
+    PWM_MAX_TOP_LEVEL_KEYS,
+    PwmDocumentTooLargeError,
+    get_pwm_service,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/pwm", tags=["pwm"])
+
+# Identity is asserted by the verified token alone; a body must never carry it.
+_RESERVED_BODY_KEYS = {"uid", "user_id", "userId"}
+
+
+def _sanitize_partial(body: Any) -> dict[str, Any]:
+    """Validate the PUT body and strip any identity-asserting keys."""
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"code": "PWM_BODY_INVALID", "message": "Body must be a JSON object."},
+        )
+    if len(body) > PWM_MAX_TOP_LEVEL_KEYS:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "code": "PWM_BODY_TOO_LARGE",
+                "message": f"Body exceeds {PWM_MAX_TOP_LEVEL_KEYS} top-level keys.",
+            },
+        )
+    return {key: value for key, value in body.items() if key not in _RESERVED_BODY_KEYS}
+
+
+@router.get("")
+async def get_pwm_document(
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    doc = await get_pwm_service().get_document(firebase_uid)
+    if doc is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "PWM_NOT_FOUND", "message": "No world model for this user."},
+        )
+    return doc
+
+
+@router.put("")
+async def put_pwm_document(
+    body: dict[str, Any] | None = Body(default=None),
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    partial = _sanitize_partial(body if body is not None else {})
+    service = get_pwm_service()
+    # An empty PUT clears the document (part of the contract).
+    if not partial:
+        await service.delete_document(firebase_uid)
+        return {}
+    try:
+        return await service.merge_document(firebase_uid, partial)
+    except PwmDocumentTooLargeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={"code": "PWM_DOC_TOO_LARGE", "message": str(exc)},
+        ) from exc
+
+
+@router.delete("")
+async def delete_pwm_document(
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    existed = await get_pwm_service().delete_document(firebase_uid)
+    return {"deleted": True, "existed": existed}

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 117,
+  "expected_migration_version": 119,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/118_preference_world_model.sql
+++ b/consent-protocol/db/migrations/118_preference_world_model.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration 118: pwm_documents (Personal World Model store)
+-- ============================================================================
+-- The self-owned, uid-keyed Personal World Model document behind /api/pwm and
+-- the cross-device "your private agent already knows you" loop of the PCHP
+-- RFC-002 Preference Subscription Fabric.
+--
+-- One row per verified Firebase uid. `doc` is the person's OWN plaintext
+-- preference document (for example { "connect": { "want", "zip", "updatedAt" } }),
+-- returned only to them, merged section-level last-writer-wins by `updatedAt`,
+-- and fully wipeable (DELETE or an empty PUT).
+--
+-- This is deliberately NOT a vault/ciphertext table: it never stores another
+-- party's data and never vault-protected content. It is the owner's own
+-- preference doc, written and read under their own consent, keyed by the uid
+-- that only the verified token can assert.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS pwm_documents (
+  user_id TEXT PRIMARY KEY,
+  doc JSONB NOT NULL DEFAULT '{}'::jsonb,
+  revision BIGINT NOT NULL DEFAULT 1,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pwm_documents_updated_at
+  ON pwm_documents (updated_at DESC);
+
+COMMENT ON TABLE pwm_documents IS
+  'Owner-keyed Personal World Model doc for /api/pwm (PCHP RFC-002 subscription fabric). One row per verified Firebase uid; owner-only plaintext preference doc, section-level last-writer-wins by updatedAt, wipeable. Not a vault/ciphertext table.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/119_preference_subscription_fabric.sql
+++ b/consent-protocol/db/migrations/119_preference_subscription_fabric.sql
@@ -1,0 +1,82 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration 119: Preference Subscription Fabric (PCHP RFC-002)
+-- ============================================================================
+-- The two tables that turn the Personal World Model (migration 118) from a
+-- private store into a subscribable fabric: a person grants a subscriber
+-- (a brand/agent developer principal) scoped, dated, priced, revocable read
+-- access to specific PWM fields, and every grant/read/revoke writes a signed,
+-- hash-chained receipt the owner can audit.
+--
+--  * fabric_subscription_grants -- one row per (owner uid -> subscriber) grant,
+--    binding { subscriber, scopes[], purpose, ttl, price? } to the owner's uid.
+--    The signed grant handle is a consent token; only its fingerprint is
+--    stored here. Revocation is fail-closed via `status`.
+--
+--  * fabric_receipts -- append-only, per-owner hash-chained ledger. Each row
+--    links to the previous by `prev_hash`; `hash` = sha256(prev_hash || payload)
+--    and `signature` = HMAC-SHA256(APP_SIGNING_KEY, hash). This is the PCHP
+--    receipt primitive built here (hushh-research's consent ledger is
+--    event-sourced + HMAC-signed but not chained; the fabric adds the chain).
+--
+-- Neither table stores PWM values or ciphertext -- only grant metadata and
+-- receipt hashes. Owner-only; the uid is asserted by the verified token alone.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS fabric_subscription_grants (
+  grant_id           TEXT PRIMARY KEY,
+  user_id            TEXT NOT NULL,
+  subscriber_id      TEXT NOT NULL,
+  subscriber_label   TEXT,
+  scopes             JSONB NOT NULL DEFAULT '[]'::jsonb,
+  fields             JSONB NOT NULL DEFAULT '[]'::jsonb,
+  purpose            TEXT NOT NULL,
+  price_cents        BIGINT,
+  currency           TEXT,
+  token_fingerprint  TEXT NOT NULL UNIQUE,
+  status             TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'revoked')),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at         TIMESTAMPTZ,
+  revoked_at         TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_grants_user_created
+  ON fabric_subscription_grants (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_grants_subscriber
+  ON fabric_subscription_grants (subscriber_id);
+
+COMMENT ON TABLE fabric_subscription_grants IS
+  'PCHP RFC-002 subscription grants: (owner uid -> subscriber) scoped, dated, priced, revocable read access to PWM fields. Stores grant metadata + the handle fingerprint, never PWM values.';
+
+CREATE TABLE IF NOT EXISTS fabric_receipts (
+  id             BIGSERIAL PRIMARY KEY,
+  user_id        TEXT NOT NULL,
+  seq            BIGINT NOT NULL,
+  event_type     TEXT NOT NULL CHECK (event_type IN ('GRANT', 'READ', 'REVOKE')),
+  subscriber_id  TEXT,
+  grant_id       TEXT,
+  scopes         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  fields         JSONB NOT NULL DEFAULT '[]'::jsonb,
+  purpose        TEXT,
+  prev_hash      TEXT NOT NULL,
+  hash           TEXT NOT NULL,
+  signature      TEXT NOT NULL,
+  metadata       JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at_ms  BIGINT NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, seq),
+  UNIQUE (user_id, hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_receipts_user_id
+  ON fabric_receipts (user_id, id);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_receipts_grant
+  ON fabric_receipts (grant_id);
+
+COMMENT ON TABLE fabric_receipts IS
+  'PCHP RFC-002 hash-chained receipt ledger. Append-only, per-owner chain: hash = sha256(prev_hash || canonical payload), signature = HMAC-SHA256(APP_SIGNING_KEY, hash). One receipt per grant/read/revoke.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -95,7 +95,8 @@
     "114_one_action_directive_ledger.sql",
     "115_one_location_map_presence.sql",
     "116_one_location_sms_contacts.sql",
-    "117_feed_events.sql"
+    "117_feed_events.sql",
+    "118_preference_world_model.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -96,7 +96,8 @@
     "115_one_location_map_presence.sql",
     "116_one_location_sms_contacts.sql",
     "117_feed_events.sql",
-    "118_preference_world_model.sql"
+    "118_preference_world_model.sql",
+    "119_preference_subscription_fabric.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/hushh_mcp/services/fabric_grant_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_grant_service.py
@@ -1,0 +1,438 @@
+"""Preference Subscription Fabric grants (PCHP RFC-002).
+
+A grant binds ``{ subscriber, scopes[], purpose, ttl, price? }`` to the owner's
+uid and yields a signed, expiring, revocable **grant handle** plus a
+hash-chained GRANT receipt. The subscriber later presents the handle to the read
+API to receive the granted PWM fields at their current values -- each read
+writing a READ receipt. Revocation writes a REVOKE receipt and is fail-closed:
+any read after revocation is denied.
+
+Reuse:
+- The grant **handle** is signed with the same HMAC-SHA256 primitive and
+  ``APP_SIGNING_KEY`` the consent tokens use, under an ``HFG`` (Hushh Fabric
+  Grant) prefix. It carries the owner uid, subscriber, issue/expiry, and the
+  priced (``commercial``) flag, all covered by the signature. Only its
+  fingerprint is persisted; the plaintext handle is returned once, at creation.
+  Revocation is enforced fail-closed by the grant-row status, so a revoked
+  handle stops working immediately even though it remains cryptographically
+  well-formed.
+- Receipts use the hash-chained ledger (``fabric_receipts_service``).
+- Field resolution uses the server-side scope registry (fail-closed).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+from db.connection import get_pool
+from hushh_mcp.config import APP_SIGNING_KEY
+from hushh_mcp.services.fabric_receipts_service import get_fabric_receipts_service
+from hushh_mcp.services.fabric_scope_registry import resolve_fields
+
+logger = logging.getLogger(__name__)
+
+FABRIC_GRANT_PREFIX = "HFG"  # noqa: S105 - Hushh Fabric Grant handle prefix, not a secret
+_MAX_TTL_MS = 365 * 24 * 60 * 60 * 1000  # one year ceiling
+_DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000  # 30 days
+
+
+class FabricGrantError(Exception):
+    """Base error carrying a stable code + HTTP-ish status for the route layer."""
+
+    def __init__(self, code: str, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def _fingerprint(handle: str) -> str:
+    return hashlib.sha256(handle.encode()).hexdigest()
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _sign_handle_body(raw: str) -> str:
+    return hmac.new(APP_SIGNING_KEY.encode(), raw.encode(), hashlib.sha256).hexdigest()
+
+
+def mint_handle(
+    *,
+    grant_id: str,
+    user_id: str,
+    subscriber_id: str,
+    issued_ms: int,
+    expires_ms: int,
+    commercial: bool,
+) -> str:
+    """Mint a signed, opaque grant handle: ``HFG:<b64url(payload)>.<hmac>``."""
+    payload = {
+        "gid": grant_id,
+        "uid": user_id,
+        "sub": subscriber_id,
+        "iat": issued_ms,
+        "exp": expires_ms,
+        "c": bool(commercial),
+    }
+    raw = (
+        base64.urlsafe_b64encode(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
+    return f"{FABRIC_GRANT_PREFIX}:{raw}.{_sign_handle_body(raw)}"
+
+
+def verify_handle(handle: str) -> dict[str, Any] | None:
+    """Verify a handle's signature and decode its payload, or None if invalid."""
+    try:
+        prefix, rest = handle.split(":", 1)
+        raw, signature = rest.rsplit(".", 1)
+    except ValueError:
+        return None
+    if prefix != FABRIC_GRANT_PREFIX:
+        return None
+    if not hmac.compare_digest(signature, _sign_handle_body(raw)):
+        return None
+    try:
+        padded = raw + "=" * (-len(raw) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded).decode())
+    except (ValueError, TypeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+class FabricGrantService:
+    def __init__(self) -> None:
+        self._table_ready = False
+        self._receipts = get_fabric_receipts_service()
+
+    async def ensure_table(self) -> None:
+        """Idempotent safety-net; migration 119 is authoritative."""
+        if self._table_ready:
+            return
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS fabric_subscription_grants (
+                    grant_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    subscriber_id TEXT NOT NULL,
+                    subscriber_label TEXT,
+                    scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    fields JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    purpose TEXT NOT NULL,
+                    price_cents BIGINT,
+                    currency TEXT,
+                    token_fingerprint TEXT NOT NULL UNIQUE,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    expires_at TIMESTAMPTZ,
+                    revoked_at TIMESTAMPTZ
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fabric_grants_user_created "
+                "ON fabric_subscription_grants (user_id, created_at DESC)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fabric_grants_subscriber "
+                "ON fabric_subscription_grants (subscriber_id)"
+            )
+        await self._receipts.ensure_table()
+        self._table_ready = True
+
+    async def create_grant(
+        self,
+        *,
+        user_id: str,
+        subscriber_id: str,
+        scopes: list[str],
+        purpose: str,
+        subscriber_label: str | None = None,
+        ttl_ms: int | None = None,
+        price_cents: int | None = None,
+        currency: str | None = None,
+    ) -> dict[str, Any]:
+        await self.ensure_table()
+        subscriber_id = subscriber_id.strip()
+        purpose = purpose.strip()
+        scopes = [s.strip() for s in scopes if s and s.strip()]
+        if not subscriber_id:
+            raise FabricGrantError("FABRIC_SUBSCRIBER_REQUIRED", "A subscriber is required.", 422)
+        if not scopes:
+            raise FabricGrantError("FABRIC_SCOPES_REQUIRED", "At least one scope is required.", 422)
+        if not purpose:
+            raise FabricGrantError("FABRIC_PURPOSE_REQUIRED", "A purpose is required.", 422)
+        if price_cents is not None and (price_cents < 0 or currency is None):
+            raise FabricGrantError(
+                "FABRIC_PRICE_INVALID",
+                "A priced grant needs a non-negative price_cents and a currency.",
+                422,
+            )
+
+        ttl_ms = _DEFAULT_TTL_MS if ttl_ms is None else max(1, min(int(ttl_ms), _MAX_TTL_MS))
+        fields, _unmapped = resolve_fields(scopes)
+
+        grant_id = uuid.uuid4().hex
+        now_ms = _now_ms()
+        expires_ms = now_ms + ttl_ms
+        # Signed with the same HMAC primitive/key as consent tokens. `commercial`
+        # records that this is a priced subscription.
+        handle = mint_handle(
+            grant_id=grant_id,
+            user_id=user_id,
+            subscriber_id=subscriber_id,
+            issued_ms=now_ms,
+            expires_ms=expires_ms,
+            commercial=price_cents is not None,
+        )
+
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))", f"fabric_receipts:{user_id}"
+                )
+                await conn.execute(
+                    """
+                    INSERT INTO fabric_subscription_grants (
+                        grant_id, user_id, subscriber_id, subscriber_label,
+                        scopes, fields, purpose, price_cents, currency,
+                        token_fingerprint, status, created_at, expires_at
+                    )
+                    VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7,$8,$9,$10,'active',
+                            to_timestamp($11/1000.0), to_timestamp($12/1000.0))
+                    """,
+                    grant_id,
+                    user_id,
+                    subscriber_id,
+                    subscriber_label,
+                    _json(scopes),
+                    _json(fields),
+                    purpose,
+                    price_cents,
+                    currency,
+                    _fingerprint(handle),
+                    now_ms,
+                    expires_ms,
+                )
+                receipt = await self._receipts.append_in_conn(
+                    conn,
+                    user_id=user_id,
+                    event_type="GRANT",
+                    created_at_ms=now_ms,
+                    subscriber_id=subscriber_id,
+                    grant_id=grant_id,
+                    scopes=scopes,
+                    fields=fields,
+                    purpose=purpose,
+                    metadata={"price_cents": price_cents, "currency": currency, "ttl_ms": ttl_ms},
+                )
+
+        return {
+            "grant_id": grant_id,
+            "handle": handle,  # returned once, at creation
+            "subscriber_id": subscriber_id,
+            "scopes": scopes,
+            "fields": fields,
+            "purpose": purpose,
+            "price_cents": price_cents,
+            "currency": currency,
+            "expires_at_ms": expires_ms,
+            "receipt": receipt,
+        }
+
+    async def list_grants(self, user_id: str) -> list[dict[str, Any]]:
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT grant_id, subscriber_id, subscriber_label, scopes, fields,
+                       purpose, price_cents, currency, status,
+                       (EXTRACT(EPOCH FROM created_at) * 1000)::BIGINT AS created_at_ms,
+                       (EXTRACT(EPOCH FROM expires_at) * 1000)::BIGINT AS expires_at_ms,
+                       (EXTRACT(EPOCH FROM revoked_at) * 1000)::BIGINT AS revoked_at_ms
+                FROM fabric_subscription_grants
+                WHERE user_id = $1
+                ORDER BY created_at DESC
+                """,
+                user_id,
+            )
+        return [_row_to_grant(row) for row in rows]
+
+    async def revoke_grant(self, *, user_id: str, grant_id: str) -> dict[str, Any]:
+        await self.ensure_table()
+        now_ms = _now_ms()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))", f"fabric_receipts:{user_id}"
+                )
+                row = await conn.fetchrow(
+                    """
+                    SELECT subscriber_id, scopes, fields, purpose, status
+                    FROM fabric_subscription_grants
+                    WHERE grant_id = $1 AND user_id = $2
+                    FOR UPDATE
+                    """,
+                    grant_id,
+                    user_id,
+                )
+                if row is None:
+                    raise FabricGrantError("FABRIC_GRANT_NOT_FOUND", "Grant not found.", 404)
+                if row["status"] != "active":
+                    # Idempotent: already revoked.
+                    return {"grant_id": grant_id, "status": "revoked", "already": True}
+                await conn.execute(
+                    """
+                    UPDATE fabric_subscription_grants
+                    SET status = 'revoked', revoked_at = to_timestamp($3/1000.0)
+                    WHERE grant_id = $1 AND user_id = $2
+                    """,
+                    grant_id,
+                    user_id,
+                    now_ms,
+                )
+                receipt = await self._receipts.append_in_conn(
+                    conn,
+                    user_id=user_id,
+                    event_type="REVOKE",
+                    created_at_ms=now_ms,
+                    subscriber_id=row["subscriber_id"],
+                    grant_id=grant_id,
+                    scopes=_as_list(row["scopes"]),
+                    fields=_as_list(row["fields"]),
+                    purpose=row["purpose"],
+                )
+        return {"grant_id": grant_id, "status": "revoked", "already": False, "receipt": receipt}
+
+    async def read_for_subscriber(
+        self, *, handle: str, subscriber_id: str, pwm_doc_loader: Any
+    ) -> dict[str, Any]:
+        """Resolve a subscriber's read against a grant handle.
+
+        Fail-closed at every step: the handle signature must verify and be
+        unexpired; its subscriber must equal the authenticated subscriber; a
+        matching, active grant row must exist. Returns only the granted fields
+        present in the current PWM document and writes a READ receipt.
+
+        ``pwm_doc_loader`` is an async callable ``uid -> dict | None`` (the PWM
+        service), injected to keep this service free of a hard import cycle.
+        """
+        await self.ensure_table()
+        payload = verify_handle(handle)
+        if payload is None:
+            raise FabricGrantError("FABRIC_HANDLE_INVALID", "Invalid grant handle.", 403)
+        if int(payload.get("exp", 0)) <= _now_ms():
+            raise FabricGrantError("FABRIC_HANDLE_EXPIRED", "This grant handle has expired.", 403)
+        if payload.get("sub") != subscriber_id:
+            raise FabricGrantError(
+                "FABRIC_SUBSCRIBER_MISMATCH",
+                "This grant handle was not issued to the calling subscriber.",
+                403,
+            )
+        user_id = str(payload.get("uid") or "")
+        fingerprint = _fingerprint(handle)
+
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            grant = await conn.fetchrow(
+                """
+                SELECT grant_id, scopes, fields, purpose, status
+                FROM fabric_subscription_grants
+                WHERE token_fingerprint = $1 AND user_id = $2 AND subscriber_id = $3
+                """,
+                fingerprint,
+                user_id,
+                subscriber_id,
+            )
+        if grant is None:
+            raise FabricGrantError("FABRIC_GRANT_NOT_FOUND", "No grant for this handle.", 404)
+        if grant["status"] != "active":
+            raise FabricGrantError("FABRIC_GRANT_REVOKED", "This grant has been revoked.", 403)
+
+        fields = _as_list(grant["fields"])
+        doc = await pwm_doc_loader(user_id) or {}
+        from hushh_mcp.services.fabric_scope_registry import project_fields
+
+        projected = project_fields(doc, fields)
+
+        now_ms = _now_ms()
+        receipt = await self._receipts.append(
+            user_id=user_id,
+            event_type="READ",
+            created_at_ms=now_ms,
+            subscriber_id=subscriber_id,
+            grant_id=grant["grant_id"],
+            scopes=_as_list(grant["scopes"]),
+            fields=list(projected.keys()),
+            purpose=grant["purpose"],
+        )
+        return {
+            "user_id": user_id,
+            "subscriber_id": subscriber_id,
+            "grant_id": grant["grant_id"],
+            "scopes": _as_list(grant["scopes"]),
+            "fields": projected,
+            "receipt": receipt,
+        }
+
+
+def _json(value: Any) -> str:
+    import json
+
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def _as_list(value: Any) -> list[str]:
+    import json
+
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            return []
+        return list(parsed) if isinstance(parsed, list) else []
+    return list(value) if isinstance(value, (list, tuple)) else []
+
+
+def _row_to_grant(row: Any) -> dict[str, Any]:
+    return {
+        "grant_id": row["grant_id"],
+        "subscriber_id": row["subscriber_id"],
+        "subscriber_label": row["subscriber_label"],
+        "scopes": _as_list(row["scopes"]),
+        "fields": _as_list(row["fields"]),
+        "purpose": row["purpose"],
+        "price_cents": row["price_cents"],
+        "currency": row["currency"],
+        "status": row["status"],
+        "created_at_ms": int(row["created_at_ms"]) if row["created_at_ms"] is not None else None,
+        "expires_at_ms": int(row["expires_at_ms"]) if row["expires_at_ms"] is not None else None,
+        "revoked_at_ms": int(row["revoked_at_ms"]) if row["revoked_at_ms"] is not None else None,
+    }
+
+
+_fabric_grant_service: FabricGrantService | None = None
+
+
+def get_fabric_grant_service() -> FabricGrantService:
+    global _fabric_grant_service
+    if _fabric_grant_service is None:
+        _fabric_grant_service = FabricGrantService()
+    return _fabric_grant_service

--- a/consent-protocol/hushh_mcp/services/fabric_receipts_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_receipts_service.py
@@ -1,0 +1,332 @@
+"""Hash-chained receipt ledger for the Preference Subscription Fabric (PCHP RFC-002).
+
+Every subscription event -- a grant, a subscribed-field read, or a revocation --
+appends one receipt to a per-owner append-only chain:
+
+    hash      = sha256( prev_hash || "\\n" || canonical_payload )
+    signature = HMAC-SHA256( APP_SIGNING_KEY, hash )
+
+The chain lets the owner verify no receipt was inserted, dropped, or reordered;
+the signature makes each receipt tamper-evident on its own. This is the PCHP
+receipt primitive built here: hushh-research's consent ledger is event-sourced
+and HMAC-signed but not chained, so the fabric adds the chain rather than
+extending a chain that does not exist.
+
+Appends are serialized per owner with a transaction-scoped Postgres advisory
+lock so concurrent events cannot fork the chain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from typing import Any
+
+import asyncpg
+
+from db.connection import get_pool
+from hushh_mcp.config import APP_SIGNING_KEY
+
+logger = logging.getLogger(__name__)
+
+GENESIS_HASH = "0" * 64
+_ALLOWED_EVENTS = frozenset({"GRANT", "READ", "REVOKE"})
+
+
+def _canonical_payload(
+    *,
+    user_id: str,
+    seq: int,
+    event_type: str,
+    subscriber_id: str | None,
+    grant_id: str | None,
+    scopes: list[str],
+    fields: list[str],
+    purpose: str | None,
+    created_at_ms: int,
+    metadata: dict[str, Any],
+) -> str:
+    """Deterministic JSON for the hashed body (stable key order, compact)."""
+    return json.dumps(
+        {
+            "user_id": user_id,
+            "seq": seq,
+            "event_type": event_type,
+            "subscriber_id": subscriber_id,
+            "grant_id": grant_id,
+            "scopes": scopes,
+            "fields": fields,
+            "purpose": purpose,
+            "created_at_ms": created_at_ms,
+            "metadata": metadata,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def _chain_hash(prev_hash: str, payload: str) -> str:
+    return hashlib.sha256(f"{prev_hash}\n{payload}".encode()).hexdigest()
+
+
+def _sign(hash_hex: str) -> str:
+    # Mirrors hushh_mcp.consent.token._sign: HMAC-SHA256 with APP_SIGNING_KEY.
+    return hmac.new(APP_SIGNING_KEY.encode(), hash_hex.encode(), hashlib.sha256).hexdigest()
+
+
+class FabricReceiptsService:
+    def __init__(self) -> None:
+        self._table_ready = False
+
+    async def ensure_table(self) -> None:
+        """Idempotent safety-net; migration 119 is authoritative."""
+        if self._table_ready:
+            return
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS fabric_receipts (
+                    id BIGSERIAL PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    seq BIGINT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    subscriber_id TEXT,
+                    grant_id TEXT,
+                    scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    fields JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    purpose TEXT,
+                    prev_hash TEXT NOT NULL,
+                    hash TEXT NOT NULL,
+                    signature TEXT NOT NULL,
+                    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    created_at_ms BIGINT NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    UNIQUE (user_id, seq),
+                    UNIQUE (user_id, hash)
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fabric_receipts_user_id "
+                "ON fabric_receipts (user_id, id)"
+            )
+        self._table_ready = True
+
+    async def append_in_conn(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        user_id: str,
+        event_type: str,
+        created_at_ms: int,
+        subscriber_id: str | None = None,
+        grant_id: str | None = None,
+        scopes: list[str] | None = None,
+        fields: list[str] | None = None,
+        purpose: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Append one receipt using an existing connection/transaction.
+
+        The caller MUST already hold the per-owner advisory lock (see
+        ``append``); this lets a grant/revoke insert its row and its receipt in
+        one atomic transaction. Serialization is what keeps the chain sound.
+        """
+        if event_type not in _ALLOWED_EVENTS:
+            raise ValueError(f"Unknown fabric receipt event: {event_type!r}")
+        scopes = list(scopes or [])
+        fields = list(fields or [])
+        metadata = dict(metadata or {})
+
+        prev = await conn.fetchrow(
+            "SELECT seq, hash FROM fabric_receipts WHERE user_id = $1 ORDER BY seq DESC LIMIT 1",
+            user_id,
+        )
+        seq = (int(prev["seq"]) + 1) if prev is not None else 1
+        prev_hash = str(prev["hash"]) if prev is not None else GENESIS_HASH
+
+        payload = _canonical_payload(
+            user_id=user_id,
+            seq=seq,
+            event_type=event_type,
+            subscriber_id=subscriber_id,
+            grant_id=grant_id,
+            scopes=scopes,
+            fields=fields,
+            purpose=purpose,
+            created_at_ms=created_at_ms,
+            metadata=metadata,
+        )
+        hash_hex = _chain_hash(prev_hash, payload)
+        signature = _sign(hash_hex)
+
+        row = await conn.fetchrow(
+            """
+            INSERT INTO fabric_receipts (
+                user_id, seq, event_type, subscriber_id, grant_id,
+                scopes, fields, purpose, prev_hash, hash, signature,
+                metadata, created_at_ms
+            )
+            VALUES ($1,$2,$3,$4,$5,$6::jsonb,$7::jsonb,$8,$9,$10,$11,$12::jsonb,$13)
+            RETURNING id, seq, prev_hash, hash, signature, created_at_ms
+            """,
+            user_id,
+            seq,
+            event_type,
+            subscriber_id,
+            grant_id,
+            json.dumps(scopes, separators=(",", ":")),
+            json.dumps(fields, separators=(",", ":")),
+            purpose,
+            prev_hash,
+            hash_hex,
+            signature,
+            json.dumps(metadata, separators=(",", ":")),
+            created_at_ms,
+        )
+        return {
+            "id": int(row["id"]),
+            "seq": int(row["seq"]),
+            "event_type": event_type,
+            "prev_hash": row["prev_hash"],
+            "hash": row["hash"],
+            "signature": row["signature"],
+            "created_at_ms": int(row["created_at_ms"]),
+        }
+
+    async def append(
+        self,
+        *,
+        user_id: str,
+        event_type: str,
+        created_at_ms: int,
+        subscriber_id: str | None = None,
+        grant_id: str | None = None,
+        scopes: list[str] | None = None,
+        fields: list[str] | None = None,
+        purpose: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Append one receipt in its own advisory-locked transaction."""
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))", f"fabric_receipts:{user_id}"
+                )
+                return await self.append_in_conn(
+                    conn,
+                    user_id=user_id,
+                    event_type=event_type,
+                    created_at_ms=created_at_ms,
+                    subscriber_id=subscriber_id,
+                    grant_id=grant_id,
+                    scopes=scopes,
+                    fields=fields,
+                    purpose=purpose,
+                    metadata=metadata,
+                )
+
+    async def list_receipts(self, user_id: str, *, limit: int = 200) -> list[dict[str, Any]]:
+        await self.ensure_table()
+        limit = max(1, min(int(limit), 1000))
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT seq, event_type, subscriber_id, grant_id, scopes, fields,
+                       purpose, prev_hash, hash, signature, metadata, created_at_ms
+                FROM fabric_receipts
+                WHERE user_id = $1
+                ORDER BY seq ASC
+                LIMIT $2
+                """,
+                user_id,
+                limit,
+            )
+        return [self._row_to_receipt(row) for row in rows]
+
+    @staticmethod
+    def _row_to_receipt(row: Any) -> dict[str, Any]:
+        def _as_list(value: Any) -> list[str]:
+            if isinstance(value, str):
+                try:
+                    parsed = json.loads(value)
+                except (ValueError, TypeError):
+                    return []
+                return list(parsed) if isinstance(parsed, list) else []
+            return list(value) if isinstance(value, (list, tuple)) else []
+
+        def _as_obj(value: Any) -> dict[str, Any]:
+            if isinstance(value, str):
+                try:
+                    parsed = json.loads(value)
+                except (ValueError, TypeError):
+                    return {}
+                return parsed if isinstance(parsed, dict) else {}
+            return dict(value) if isinstance(value, dict) else {}
+
+        return {
+            "seq": int(row["seq"]),
+            "event_type": row["event_type"],
+            "subscriber_id": row["subscriber_id"],
+            "grant_id": row["grant_id"],
+            "scopes": _as_list(row["scopes"]),
+            "fields": _as_list(row["fields"]),
+            "purpose": row["purpose"],
+            "prev_hash": row["prev_hash"],
+            "hash": row["hash"],
+            "signature": row["signature"],
+            "metadata": _as_obj(row["metadata"]),
+            "created_at_ms": int(row["created_at_ms"]),
+        }
+
+    async def verify_chain(self, user_id: str) -> dict[str, Any]:
+        """Recompute the chain and signatures; report the first break, if any."""
+        receipts = await self.list_receipts(user_id, limit=1000)
+        prev_hash = GENESIS_HASH
+        for receipt in receipts:
+            payload = _canonical_payload(
+                user_id=user_id,
+                seq=receipt["seq"],
+                event_type=receipt["event_type"],
+                subscriber_id=receipt["subscriber_id"],
+                grant_id=receipt["grant_id"],
+                scopes=receipt["scopes"],
+                fields=receipt["fields"],
+                purpose=receipt["purpose"],
+                created_at_ms=receipt["created_at_ms"],
+                metadata=receipt["metadata"],
+            )
+            expected_hash = _chain_hash(prev_hash, payload)
+            if receipt["prev_hash"] != prev_hash:
+                return {
+                    "ok": False,
+                    "broken_at_seq": receipt["seq"],
+                    "reason": "prev_hash_mismatch",
+                }
+            if receipt["hash"] != expected_hash:
+                return {"ok": False, "broken_at_seq": receipt["seq"], "reason": "hash_mismatch"}
+            if not hmac.compare_digest(receipt["signature"], _sign(receipt["hash"])):
+                return {
+                    "ok": False,
+                    "broken_at_seq": receipt["seq"],
+                    "reason": "signature_mismatch",
+                }
+            prev_hash = receipt["hash"]
+        return {"ok": True, "count": len(receipts), "head_hash": prev_hash}
+
+
+_fabric_receipts_service: FabricReceiptsService | None = None
+
+
+def get_fabric_receipts_service() -> FabricReceiptsService:
+    global _fabric_receipts_service
+    if _fabric_receipts_service is None:
+        _fabric_receipts_service = FabricReceiptsService()
+    return _fabric_receipts_service

--- a/consent-protocol/hushh_mcp/services/fabric_scope_registry.py
+++ b/consent-protocol/hushh_mcp/services/fabric_scope_registry.py
@@ -1,0 +1,76 @@
+"""Server-side scope -> PWM-field resolver for the subscription fabric.
+
+A subscription grant is expressed in PCHP scope labels (``wants.money.advisor``,
+``privacy.marketing-email``, ...). The subscriber read API must turn those labels
+into concrete values from the owner's Personal World Model document. This module
+is the single server-side authority for that mapping.
+
+Design:
+- The public scope catalogue lives in the frontend (``/pchp/scopes.json``); this
+  is the *field binding* -- which PWM document paths a granted scope authorizes.
+- It is **fail-closed**: a scope with no registered field binding resolves to no
+  fields and is reported as unmapped, so an un-modelled scope can never leak an
+  un-intended field.
+- Bindings are seeded with the fields the PWM actually holds today (the shipped
+  connect-the-dots flow) and grow as the PWM schema grows -- add the binding here
+  when a new PWM section becomes subscribable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# scope label -> ordered list of dot-paths into the PWM document.
+# Seeded from the live PWM shape: the connect-the-dots section stores
+# `connect = { want, zip, updatedAt }` (see hushh-search-console pwm-local /
+# /api/pwm). A subscriber granted the "advisor want" receives the want + ZIP so
+# it can make the local match -- and nothing else.
+_SCOPE_FIELD_MAP: dict[str, list[str]] = {
+    "wants.money.advisor": ["connect.want", "connect.zip"],
+    "wants.financial-services": ["connect.want", "connect.zip"],
+}
+
+
+def resolve_fields(scopes: list[str]) -> tuple[list[str], list[str]]:
+    """Return ``(fields, unmapped_scopes)`` for the requested scopes.
+
+    ``fields`` is the de-duplicated, order-stable union of PWM dot-paths the
+    scopes authorize. ``unmapped_scopes`` lists any scope with no binding
+    (fail-closed: it contributes nothing).
+    """
+    fields: list[str] = []
+    unmapped: list[str] = []
+    for scope in scopes:
+        bound = _SCOPE_FIELD_MAP.get(scope)
+        if not bound:
+            unmapped.append(scope)
+            continue
+        for path in bound:
+            if path not in fields:
+                fields.append(path)
+    return fields, unmapped
+
+
+def _get_path(doc: dict[str, Any], path: str) -> Any:
+    """Traverse a dot-path in a nested dict; return None if any hop is absent."""
+    current: Any = doc
+    for key in path.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def project_fields(doc: dict[str, Any], fields: list[str]) -> dict[str, Any]:
+    """Project the requested dot-paths out of ``doc``.
+
+    Returns ``{dot_path: value}`` for every path that is present; paths absent
+    from the current document are simply omitted (the subscriber receives only
+    what exists now, at its current value).
+    """
+    out: dict[str, Any] = {}
+    for path in fields:
+        value = _get_path(doc, path)
+        if value is not None:
+            out[path] = value
+    return out

--- a/consent-protocol/hushh_mcp/services/pwm_service.py
+++ b/consent-protocol/hushh_mcp/services/pwm_service.py
@@ -1,0 +1,202 @@
+"""Personal World Model (PWM) store.
+
+The owner-keyed preference document behind ``/api/pwm`` — the server-side home
+of the cross-device "your private agent already knows you" loop for the PCHP
+RFC-002 Preference Subscription Fabric.
+
+Trust contract:
+- One row per verified Firebase uid (the caller's own uid, taken from the
+  verified token, never from a request body).
+- The document is the owner's own plaintext preference doc, returned only to
+  them. This is NOT vault/ciphertext content and never another party's data.
+- Merge is section-level last-writer-wins by ``updatedAt``; the store is fully
+  wipeable (a DELETE, or an empty PUT).
+
+The store deliberately uses the lightweight async pool idiom (mirrors
+``market_cache_store``) rather than the encrypted vault path: a PWM document is
+small, owner-only preference metadata, not vault-protected content.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from db.connection import get_pool
+
+logger = logging.getLogger(__name__)
+
+# Defensive bounds (CWE-400 / DoS). A PWM document is small preference
+# metadata, not a data lake — reject anything that tries to make it one.
+PWM_MAX_TOP_LEVEL_KEYS = 64
+PWM_MAX_SERIALIZED_BYTES = 64 * 1024
+
+
+class PwmDocumentTooLargeError(ValueError):
+    """Raised when a merged PWM document exceeds the size/complexity bound."""
+
+
+class PwmService:
+    def __init__(self) -> None:
+        self._table_ready = False
+        self._init_lock = asyncio.Lock()
+
+    async def ensure_table(self) -> None:
+        """Create the ``pwm_documents`` table if the migration has not run yet.
+
+        Migration ``118_preference_world_model.sql`` is authoritative; this
+        idempotent safety-net mirrors the established belt-and-suspenders idiom
+        (see ``market_cache_store`` / ``DeveloperRegistryService.ensure_tables``)
+        so a fresh environment cannot 500 before the migration lands.
+        """
+        if self._table_ready:
+            return
+        async with self._init_lock:
+            if self._table_ready:
+                return
+            pool = await get_pool()
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS pwm_documents (
+                        user_id TEXT PRIMARY KEY,
+                        doc JSONB NOT NULL DEFAULT '{}'::jsonb,
+                        revision BIGINT NOT NULL DEFAULT 1,
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                    )
+                    """
+                )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_pwm_documents_updated_at "
+                    "ON pwm_documents (updated_at DESC)"
+                )
+            self._table_ready = True
+
+    @staticmethod
+    def _as_obj(value: Any) -> dict[str, Any]:
+        """Coerce a JSONB column value (dict or JSON string) into a dict."""
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except (ValueError, TypeError):
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
+    @staticmethod
+    def _section_updated_at(section: Any) -> float | None:
+        """Return a section's numeric ``updatedAt`` (ms epoch), or None."""
+        if isinstance(section, dict):
+            raw = section.get("updatedAt")
+            # bool is an int subclass — exclude it explicitly.
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+                return float(raw)
+        return None
+
+    @classmethod
+    def merge(cls, stored: dict[str, Any], partial: dict[str, Any]) -> dict[str, Any]:
+        """Section-level last-writer-wins merge by ``updatedAt``.
+
+        For each top-level key in ``partial``: if both the stored and incoming
+        sections carry a numeric ``updatedAt`` and the stored one is strictly
+        newer, the stored section is kept (a stale write is rejected).
+        Otherwise the incoming section replaces the stored one. Top-level keys
+        absent from ``partial`` are left untouched. This matches the fabric's
+        ``{ "connect": { ..., "updatedAt": <ms> } }`` document shape, where each
+        top-level section carries its own last-write timestamp.
+        """
+        merged = dict(stored)
+        for key, incoming in partial.items():
+            incoming_ts = cls._section_updated_at(incoming)
+            existing_ts = cls._section_updated_at(merged.get(key))
+            if incoming_ts is not None and existing_ts is not None and existing_ts > incoming_ts:
+                # Stored section is strictly newer — reject the stale write.
+                continue
+            merged[key] = incoming
+        return merged
+
+    @classmethod
+    def _serialize_guarded(cls, doc: dict[str, Any]) -> str:
+        if len(doc) > PWM_MAX_TOP_LEVEL_KEYS:
+            raise PwmDocumentTooLargeError(
+                f"PWM document exceeds {PWM_MAX_TOP_LEVEL_KEYS} top-level keys."
+            )
+        serialized = json.dumps(doc, separators=(",", ":"), ensure_ascii=False)
+        if len(serialized.encode("utf-8")) > PWM_MAX_SERIALIZED_BYTES:
+            raise PwmDocumentTooLargeError("PWM document exceeds the size limit.")
+        return serialized
+
+    async def get_document(self, user_id: str) -> dict[str, Any] | None:
+        """Return the caller's stored document, or None if none exists."""
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT doc FROM pwm_documents WHERE user_id = $1",
+                user_id,
+            )
+        if row is None:
+            return None
+        return self._as_obj(row["doc"])
+
+    async def merge_document(self, user_id: str, partial: dict[str, Any]) -> dict[str, Any]:
+        """Merge ``partial`` into the caller's document and return the result.
+
+        Read-modify-write under a row lock so concurrent multi-device writes
+        resolve deterministically by ``updatedAt`` instead of clobbering.
+        """
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    "SELECT doc FROM pwm_documents WHERE user_id = $1 FOR UPDATE",
+                    user_id,
+                )
+                stored = self._as_obj(row["doc"]) if row is not None else {}
+                merged = self.merge(stored, partial)
+                serialized = self._serialize_guarded(merged)
+                await conn.execute(
+                    """
+                    INSERT INTO pwm_documents (user_id, doc, revision, created_at, updated_at)
+                    VALUES ($1, $2::jsonb, 1, now(), now())
+                    ON CONFLICT (user_id) DO UPDATE SET
+                        doc = EXCLUDED.doc,
+                        revision = pwm_documents.revision + 1,
+                        updated_at = now()
+                    """,
+                    user_id,
+                    serialized,
+                )
+        return merged
+
+    async def delete_document(self, user_id: str) -> bool:
+        """Wipe the caller's document. Returns True if a row existed."""
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                "DELETE FROM pwm_documents WHERE user_id = $1",
+                user_id,
+            )
+        # asyncpg returns a command tag such as "DELETE 1".
+        try:
+            return int(str(result).split()[-1]) > 0
+        except (ValueError, IndexError):
+            return False
+
+
+_pwm_service: PwmService | None = None
+
+
+def get_pwm_service() -> PwmService:
+    """Return the process-wide PwmService singleton."""
+    global _pwm_service
+    if _pwm_service is None:
+        _pwm_service = PwmService()
+    return _pwm_service

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -357,6 +357,12 @@ from api.routes import pwm  # noqa: E402
 
 app.include_router(pwm.router)
 
+# Preference Subscription Fabric (PCHP RFC-002): grants + hash-chained receipts
+# (/api/fabric/*) and the subscriber read API that turns a grant into value.
+from api.routes import fabric  # noqa: E402
+
+app.include_router(fabric.router)
+
 # Account deletion and management
 app.include_router(account.router)
 
@@ -678,6 +684,28 @@ async def startup_pwm_documents_table():
             raise
         logger.warning(
             "startup.pwm_documents_table_skipped environment=%s reason=%s",
+            _environment(),
+            exc,
+        )
+
+
+@app.on_event("startup")
+async def startup_fabric_tables():
+    """Ensure the subscription-fabric tables exist before any /api/fabric request."""
+    from hushh_mcp.services.fabric_grant_service import get_fabric_grant_service
+
+    try:
+        await get_fabric_grant_service().ensure_table()
+    except Exception as exc:
+        if _require_database_on_startup():
+            logger.critical(
+                "startup.fabric_tables_failed environment=%s reason=%s",
+                _environment(),
+                exc,
+            )
+            raise
+        logger.warning(
+            "startup.fabric_tables_skipped environment=%s reason=%s",
             _environment(),
             exc,
         )

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -351,6 +351,12 @@ from api.routes import world_model  # noqa: E402
 
 app.include_router(world_model.router)
 
+# Personal World Model store (PCHP RFC-002 subscription fabric): the uid-keyed
+# preference doc behind /api/pwm and cross-device "your private agent knows you".
+from api.routes import pwm  # noqa: E402
+
+app.include_router(pwm.router)
+
 # Account deletion and management
 app.include_router(account.router)
 
@@ -650,6 +656,28 @@ async def startup_market_cache_store_table():
             raise
         logger.warning(
             "startup.market_cache_store_table_skipped environment=%s reason=%s",
+            _environment(),
+            exc,
+        )
+
+
+@app.on_event("startup")
+async def startup_pwm_documents_table():
+    """Ensure the Personal World Model table exists before any /api/pwm request."""
+    from hushh_mcp.services.pwm_service import get_pwm_service
+
+    try:
+        await get_pwm_service().ensure_table()
+    except Exception as exc:
+        if _require_database_on_startup():
+            logger.critical(
+                "startup.pwm_documents_table_failed environment=%s reason=%s",
+                _environment(),
+                exc,
+            )
+            raise
+        logger.warning(
+            "startup.pwm_documents_table_skipped environment=%s reason=%s",
             _environment(),
             exc,
         )

--- a/consent-protocol/tests/test_fabric_routes.py
+++ b/consent-protocol/tests/test_fabric_routes.py
@@ -1,0 +1,207 @@
+"""Tests for the Preference Subscription Fabric (grants, receipts, subscriber read).
+
+Route tests mock the service layer (no DB); the full DB-backed grant -> read ->
+revoke -> chain-verify flow is exercised against a real Postgres in
+scripts/smoke (see PR notes). Scope-registry and receipt-hash tests are pure.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import fabric
+from hushh_mcp.services import fabric_receipts_service as receipts_mod
+from hushh_mcp.services.fabric_scope_registry import project_fields, resolve_fields
+
+_UID = "owner-uid-1"
+_SUBSCRIBER = "developer:acme-rialabs"
+
+
+# ---------------------------------------------------------------------------
+# Scope registry (pure, fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_fields_maps_known_scope():
+    fields, unmapped = resolve_fields(["wants.money.advisor"])
+    assert fields == ["connect.want", "connect.zip"]
+    assert unmapped == []
+
+
+def test_resolve_fields_is_fail_closed_for_unknown_scope():
+    fields, unmapped = resolve_fields(["favorites.secret-unmodelled"])
+    assert fields == []
+    assert unmapped == ["favorites.secret-unmodelled"]
+
+
+def test_resolve_fields_dedupes_across_scopes():
+    fields, _ = resolve_fields(["wants.money.advisor", "wants.financial-services"])
+    assert fields == ["connect.want", "connect.zip"]
+
+
+def test_project_fields_returns_only_present_paths():
+    doc = {"connect": {"want": "wants.money.advisor", "zip": "98033", "updatedAt": 1}}
+    out = project_fields(doc, ["connect.want", "connect.zip", "connect.missing"])
+    assert out == {"connect.want": "wants.money.advisor", "connect.zip": "98033"}
+
+
+# ---------------------------------------------------------------------------
+# Receipt hashing (pure, deterministic + chain-linked)
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_hash_is_deterministic_and_chains():
+    payload = receipts_mod._canonical_payload(
+        user_id=_UID,
+        seq=1,
+        event_type="GRANT",
+        subscriber_id=_SUBSCRIBER,
+        grant_id="g1",
+        scopes=["wants.money.advisor"],
+        fields=["connect.want"],
+        purpose="local match",
+        created_at_ms=1000,
+        metadata={},
+    )
+    h1 = receipts_mod._chain_hash(receipts_mod.GENESIS_HASH, payload)
+    h1_again = receipts_mod._chain_hash(receipts_mod.GENESIS_HASH, payload)
+    assert h1 == h1_again  # deterministic
+    # next link folds the previous hash in -> different hash for same payload
+    h2 = receipts_mod._chain_hash(h1, payload)
+    assert h2 != h1
+    # signature is stable HMAC over the hash
+    assert receipts_mod._sign(h1) == receipts_mod._sign(h1)
+    assert receipts_mod._sign(h1) != receipts_mod._sign(h2)
+
+
+# ---------------------------------------------------------------------------
+# Owner routes (Firebase auth; service mocked)
+# ---------------------------------------------------------------------------
+
+
+def _owner_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(fabric.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _UID
+    return app
+
+
+def test_create_grant_returns_handle_and_receipt():
+    created = {
+        "grant_id": "g-abc",
+        "handle": "HCT:payload.sig",
+        "subscriber_id": _SUBSCRIBER,
+        "scopes": ["wants.money.advisor"],
+        "fields": ["connect.want", "connect.zip"],
+        "purpose": "local match",
+        "price_cents": None,
+        "currency": None,
+        "expires_at_ms": 9999,
+        "receipt": {"seq": 1, "hash": "abc", "event_type": "GRANT"},
+    }
+    with patch.object(fabric, "get_fabric_grant_service") as factory:
+        factory.return_value.create_grant = AsyncMock(return_value=created)
+        resp = TestClient(_owner_app()).post(
+            "/api/fabric/grants",
+            json={
+                "subscriber_id": _SUBSCRIBER,
+                "scopes": ["wants.money.advisor"],
+                "purpose": "local match",
+            },
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["handle"] == "HCT:payload.sig"
+    assert body["receipt"]["event_type"] == "GRANT"
+    # uid passed to the service is the verified token's, not the body's.
+    assert factory.return_value.create_grant.await_args.kwargs["user_id"] == _UID
+
+
+def test_create_grant_maps_service_error_to_http():
+    from hushh_mcp.services.fabric_grant_service import FabricGrantError
+
+    with patch.object(fabric, "get_fabric_grant_service") as factory:
+        factory.return_value.create_grant = AsyncMock(
+            side_effect=FabricGrantError("FABRIC_SCOPES_REQUIRED", "At least one scope.", 422)
+        )
+        resp = TestClient(_owner_app()).post(
+            "/api/fabric/grants",
+            json={"subscriber_id": _SUBSCRIBER, "scopes": ["x"], "purpose": "p"},
+        )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == "FABRIC_SCOPES_REQUIRED"
+
+
+def test_revoke_grant():
+    with patch.object(fabric, "get_fabric_grant_service") as factory:
+        factory.return_value.revoke_grant = AsyncMock(
+            return_value={"grant_id": "g1", "status": "revoked", "already": False}
+        )
+        resp = TestClient(_owner_app()).post("/api/fabric/grants/g1/revoke")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "revoked"
+
+
+def test_list_receipts():
+    with patch.object(fabric, "get_fabric_receipts_service") as factory:
+        factory.return_value.list_receipts = AsyncMock(
+            return_value=[{"seq": 1, "event_type": "GRANT", "hash": "h1"}]
+        )
+        resp = TestClient(_owner_app()).get("/api/fabric/receipts")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Subscriber read route (developer-principal auth; service mocked)
+# ---------------------------------------------------------------------------
+
+
+def _subscriber_app(agent_id: str = _SUBSCRIBER) -> FastAPI:
+    app = FastAPI()
+    app.include_router(fabric.router)
+    app.dependency_overrides[fabric.require_subscriber_principal] = lambda: SimpleNamespace(
+        agent_id=agent_id, app_id="acme"
+    )
+    return app
+
+
+def test_subscriber_read_returns_only_granted_fields():
+    result = {
+        "user_id": _UID,
+        "subscriber_id": _SUBSCRIBER,
+        "grant_id": "g1",
+        "scopes": ["wants.money.advisor"],
+        "fields": {"connect.want": "wants.money.advisor", "connect.zip": "98033"},
+        "receipt": {"seq": 2, "hash": "h2", "event_type": "READ"},
+    }
+    with patch.object(fabric, "get_fabric_grant_service") as factory:
+        factory.return_value.read_for_subscriber = AsyncMock(return_value=result)
+        resp = TestClient(_subscriber_app()).post(
+            "/api/fabric/read", json={"handle": "HCT:cGF5bG9hZA.c2lnbmF0dXJl"}
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["fields"] == {"connect.want": "wants.money.advisor", "connect.zip": "98033"}
+    assert body["receipt"]["event_type"] == "READ"
+    # the subscriber id used is the authenticated principal's, never the body's.
+    assert (
+        factory.return_value.read_for_subscriber.await_args.kwargs["subscriber_id"] == _SUBSCRIBER
+    )
+
+
+def test_subscriber_read_revoked_grant_denied():
+    from hushh_mcp.services.fabric_grant_service import FabricGrantError
+
+    with patch.object(fabric, "get_fabric_grant_service") as factory:
+        factory.return_value.read_for_subscriber = AsyncMock(
+            side_effect=FabricGrantError("FABRIC_GRANT_REVOKED", "Revoked.", 403)
+        )
+        resp = TestClient(_subscriber_app()).post(
+            "/api/fabric/read", json={"handle": "HCT:cGF5bG9hZA.c2lnbmF0dXJl"}
+        )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "FABRIC_GRANT_REVOKED"

--- a/consent-protocol/tests/test_pwm_routes.py
+++ b/consent-protocol/tests/test_pwm_routes.py
@@ -1,0 +1,144 @@
+"""Tests for the Personal World Model store (/api/pwm) and its merge semantics."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import pwm
+from hushh_mcp.services.pwm_service import PwmService
+
+_UID = "firebase-uid-123"
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(pwm.router)
+    # uid comes only from the verified token; the override stands in for it.
+    app.dependency_overrides[require_firebase_auth] = lambda: _UID
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Merge semantics (pure unit — no DB, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_upserts_new_section():
+    stored = {}
+    partial = {"connect": {"want": "wants.money.advisor", "zip": "98033", "updatedAt": 1000}}
+    assert PwmService.merge(stored, partial) == partial
+
+
+def test_merge_last_writer_wins_newer_incoming_replaces():
+    stored = {"connect": {"want": "wants.money.advisor", "zip": "98033", "updatedAt": 1000}}
+    partial = {"connect": {"want": "wants.home.plumber", "zip": "10001", "updatedAt": 2000}}
+    assert PwmService.merge(stored, partial)["connect"]["zip"] == "10001"
+
+
+def test_merge_rejects_stale_incoming_section():
+    stored = {"connect": {"want": "wants.money.advisor", "zip": "98033", "updatedAt": 2000}}
+    partial = {"connect": {"want": "stale", "zip": "00000", "updatedAt": 1000}}
+    # Stored section is strictly newer -> stale write rejected.
+    assert PwmService.merge(stored, partial)["connect"]["zip"] == "98033"
+
+
+def test_merge_leaves_untouched_sections_intact():
+    stored = {"connect": {"zip": "98033", "updatedAt": 1000}, "prefs": {"theme": "dark"}}
+    partial = {"connect": {"zip": "10001", "updatedAt": 2000}}
+    merged = PwmService.merge(stored, partial)
+    assert merged["prefs"] == {"theme": "dark"}
+    assert merged["connect"]["zip"] == "10001"
+
+
+def test_merge_incoming_without_timestamp_wins_over_untimestamped():
+    stored = {"connect": {"zip": "98033"}}
+    partial = {"connect": {"zip": "10001"}}
+    assert PwmService.merge(stored, partial)["connect"]["zip"] == "10001"
+
+
+# ---------------------------------------------------------------------------
+# Route behavior (service layer patched)
+# ---------------------------------------------------------------------------
+
+
+def test_get_returns_stored_doc():
+    doc = {"connect": {"want": "wants.money.advisor", "zip": "98033", "updatedAt": 1000}}
+    with patch.object(pwm, "get_pwm_service") as factory:
+        factory.return_value.get_document = AsyncMock(return_value=doc)
+        client = TestClient(_make_app())
+        resp = client.get("/api/pwm")
+    assert resp.status_code == 200
+    assert resp.json() == doc
+
+
+def test_get_returns_404_when_absent():
+    with patch.object(pwm, "get_pwm_service") as factory:
+        factory.return_value.get_document = AsyncMock(return_value=None)
+        client = TestClient(_make_app())
+        resp = client.get("/api/pwm")
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["code"] == "PWM_NOT_FOUND"
+
+
+def test_put_merges_and_returns_doc():
+    merged = {"connect": {"want": "wants.money.advisor", "zip": "98033", "updatedAt": 1000}}
+    with patch.object(pwm, "get_pwm_service") as factory:
+        factory.return_value.merge_document = AsyncMock(return_value=merged)
+        client = TestClient(_make_app())
+        resp = client.put("/api/pwm", json={"connect": merged["connect"]})
+    assert resp.status_code == 200
+    assert resp.json() == merged
+
+
+def test_put_ignores_uid_in_body():
+    captured = {}
+
+    async def _capture(uid, partial):
+        captured["uid"] = uid
+        captured["partial"] = partial
+        return partial
+
+    with patch.object(pwm, "get_pwm_service") as factory:
+        factory.return_value.merge_document = AsyncMock(side_effect=_capture)
+        client = TestClient(_make_app())
+        resp = client.put(
+            "/api/pwm",
+            json={"user_id": "attacker", "uid": "attacker", "connect": {"zip": "98033"}},
+        )
+    assert resp.status_code == 200
+    # uid is the verified token's, never the body's; identity keys are dropped.
+    assert captured["uid"] == _UID
+    assert "user_id" not in captured["partial"]
+    assert "uid" not in captured["partial"]
+    assert captured["partial"] == {"connect": {"zip": "98033"}}
+
+
+def test_empty_put_wipes():
+    with patch.object(pwm, "get_pwm_service") as factory:
+        delete_mock = AsyncMock(return_value=True)
+        factory.return_value.delete_document = delete_mock
+        client = TestClient(_make_app())
+        resp = client.put("/api/pwm", json={})
+    assert resp.status_code == 200
+    assert resp.json() == {}
+    delete_mock.assert_awaited_once_with(_UID)
+
+
+def test_delete_wipes():
+    with patch.object(pwm, "get_pwm_service") as factory:
+        factory.return_value.delete_document = AsyncMock(return_value=True)
+        client = TestClient(_make_app())
+        resp = client.delete("/api/pwm")
+    assert resp.status_code == 200
+    assert resp.json() == {"deleted": True, "existed": True}
+
+
+def test_unauthenticated_request_is_rejected():
+    # No dependency override -> the real Firebase auth dependency runs and 401s
+    # (no Authorization header present).
+    app = FastAPI()
+    app.include_router(pwm.router)
+    client = TestClient(app)
+    assert client.get("/api/pwm").status_code == 401

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -925,6 +925,16 @@
       "primary_access_path": "client-side PKM cutover, server-issued upgrade claims, idempotent commit receipts, and generic PKM upgrade orchestration"
     },
     {
+      "data_class": "personal_metadata",
+      "exact_tables": [
+        "pwm_documents"
+      ],
+      "id": "preference_world_model",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "the owner's own Personal World Model doc behind /api/pwm (cross-device preference sync)"
+    },
+    {
       "data_class": "reference",
       "exact_tables": [
         "investor_profiles",
@@ -952,6 +962,26 @@
       "lifecycle_status": "current",
       "owner": "iam-consent-governance",
       "primary_access_path": "RIA profile, marketplace deck actions, client relationship, invite, and share-grant services"
+    },
+    {
+      "data_class": "personal_metadata",
+      "exact_tables": [
+        "fabric_subscription_grants"
+      ],
+      "id": "subscription_fabric_grants",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "PCHP RFC-002 subscription grants: owner-issued, subscriber-scoped read access to PWM fields (/api/fabric/grants)"
+    },
+    {
+      "data_class": "audit_regulated",
+      "exact_tables": [
+        "fabric_receipts"
+      ],
+      "id": "subscription_fabric_receipts",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "PCHP RFC-002 hash-chained receipt ledger for grant/read/revoke events (/api/fabric/receipts)"
     },
     {
       "data_class": "workflow_state",
@@ -4223,7 +4253,7 @@
     "action_gateway": "afac5b3a07a1ec2e6ab4f87231b37edb81a0d771daae2cf4900dd6fb9a35f049",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
     "cache_manifest": "36a64f281e836ea255caedfb78feac08bb3d862932352d11e1fcc0771a9af8c3",
-    "data_plane": "dff54bb9aaf3a3771050897ba56a91273026d2346848807a10de0f6a7144c16e",
+    "data_plane": "ac69d1fe4fa5b2cfe9a6eb7bc06784472238a3d557f477ba371fd0e56d7b11d9",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
     "route_index": "46d94273cc53d297b8a4f4cdc7916f6cb23d602209555b5328201c0a9b78423b",
@@ -4242,6 +4272,6 @@
     "one_specialist_tools": 5,
     "physical_routes": 113,
     "semantic_routes": 14,
-    "table_families": 33
+    "table_families": 36
   }
 }

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -627,6 +627,51 @@
       "trust_boundary": "Presentation-only fan-out from each domain's own audit/event tables (consent, location, connected systems) or from a domain's completion point (Kai, KYC, connections). Never stores ciphertext, vault content, or full domain payloads; only bounded, non-sensitive metadata used to render a feed line.",
       "plaintext_posture": "metadata_only",
       "expected_row_growth": "medium_append_only"
+    },
+    {
+      "id": "preference_world_model",
+      "owner": "iam-consent-governance",
+      "data_class": "personal_metadata",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "pwm_documents"
+      ],
+      "primary_access_path": "the owner's own Personal World Model doc behind /api/pwm (cross-device preference sync)",
+      "retention_policy": "Retain while the account exists; one row per owner, overwritten in place on update.",
+      "deletion_behavior": "Hard-delete on account deletion, an explicit DELETE /api/pwm, or an empty PUT.",
+      "trust_boundary": "The owner's own plaintext preference metadata, keyed by and returned only to the verified uid; never another party's data and never vault ciphertext.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "low_per_user"
+    },
+    {
+      "id": "subscription_fabric_grants",
+      "owner": "iam-consent-governance",
+      "data_class": "personal_metadata",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "fabric_subscription_grants"
+      ],
+      "primary_access_path": "PCHP RFC-002 subscription grants: owner-issued, subscriber-scoped read access to PWM fields (/api/fabric/grants)",
+      "retention_policy": "Retain while the grant is active or for audit; revoked/expired grants compacted per retention policy.",
+      "deletion_behavior": "Delete on account deletion; revoke (fail-closed status) on owner revocation or expiry.",
+      "trust_boundary": "Grant metadata only (subscriber, scopes, purpose, price, handle fingerprint); never the PWM values and never the plaintext handle.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "medium_per_consent"
+    },
+    {
+      "id": "subscription_fabric_receipts",
+      "owner": "iam-consent-governance",
+      "data_class": "audit_regulated",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "fabric_receipts"
+      ],
+      "primary_access_path": "PCHP RFC-002 hash-chained receipt ledger for grant/read/revoke events (/api/fabric/receipts)",
+      "retention_policy": "Long-retention append-only audit chain; redact payload detail rather than deleting chain rows.",
+      "deletion_behavior": "Account export may include safe receipt metadata; deletion redacts user linkage only if legally required, preserving chain integrity.",
+      "trust_boundary": "Signed, hash-chained receipt metadata only (hashes, signatures, scope + field-path labels); no PWM values.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "medium_append_only"
     }
   ]
 }


### PR DESCRIPTION
# Description

The backend for the **🤫 Preference Subscription Fabric** (PCHP RFC-002): the human publishes one self-owned profile and the world **subscribes** to exactly the fields they grant — scoped, dated, receipted, revocable, priced. This is the backend counterpart to the frontend fabric already live in `hushh-search-console`.

Two commits, three steps:

### Step 2 — Personal World Model store (`/api/pwm`)
The uid-keyed preference doc behind cross-device "your private agent already knows you." Matches the interim frontend store's contract exactly, so the frontend proxy flips off Stripe-metadata with **zero client change**.
- `GET` → stored doc or 404 · `PUT` → partial merge, **section-level last-writer-wins by `updatedAt`**; empty body wipes · `DELETE` → wipe
- uid only from the verified Firebase token; owner-only; bounded (CWE-400); row-locked merges

### Steps 3 + 4 — fabric grants, hash-chained receipts, subscriber read
- **Owner** (Firebase auth): `POST /api/fabric/grants` (bind `{subscriber, scopes[], purpose, ttl, price?}` → signed handle), `GET /api/fabric/grants`, `POST /api/fabric/grants/{id}/revoke`, `GET /api/fabric/receipts`, `GET /api/fabric/receipts/verify`
- **Subscriber** (developer-principal auth): `POST /api/fabric/read` → present a handle, receive **only the granted fields at current values** + a READ receipt

**Gaps from the inventory, now filled (not papered over):**
- **Hash-chained receipts didn't exist here** (the consent ledger is event-sourced + HMAC-signed, not chained). `fabric_receipts` is a per-owner append-only chain — `hash = sha256(prev_hash‖canonical)`, `signature = HMAC-SHA256(APP_SIGNING_KEY, hash)`, appends serialized by a per-owner advisory lock; `verify_chain` detects insert/drop/reorder/tamper.
- **No price primitive** (only a boolean `commercial` flag) → grants carry `price_cents` + `currency`.
- **No server-side scope→field authority** → `fabric_scope_registry` is **fail-closed** (an unmodelled scope leaks nothing), seeded with the shipped connect fields.

**Reuse (no rebuilds):** `DeveloperPrincipal` + `authenticate_developer_principal` (subscriber identity), `require_firebase_auth` (owner binding), the PWM service (current values), the async pool + numbered-migration idioms. The grant handle is signed with the same HMAC primitive/key as consent tokens (`HFG` prefix), self-contained rather than coupling a new scope into `ConsentScope`; revocation is fail-closed by grant-row status.

## 📌 Impact Map

- **Routes touched:** new `GET/PUT/DELETE /api/pwm`; new `/api/fabric/*` (grants, grants/{id}/revoke, receipts, receipts/verify, read). All registered in `server.py`.
- **API / schema changes:** contracts above; new tables via migrations `118_preference_world_model.sql` (`pwm_documents`) and `119_preference_subscription_fabric.sql` (`fabric_subscription_grants`, `fabric_receipts`), both registered in the release manifest.
- **Runtime DB data-plane changes:** three new owner-keyed tables. No vault/ciphertext content. Idempotent `ensure_table` safety-nets + authoritative migrations.
- **Trust boundary:** owner uid **only** from the verified Firebase token (identity keys in a body are dropped); subscriber identity **only** from the authenticated principal (never the request body); read is **fail-closed** at every step (handle signature → expiry → subscriber match → active grant → scope→field allowlist); revocation propagates via grant-row status; every access writes a signed, hash-chained receipt.
- **Caller / proxy pairing:** frontend `/api/pwm` (interim Stripe store) flips to a thin proxy to this endpoint — identical contract, no client change.
- **Rollback:** additive-only (new tables + new routes); revert removes the router includes + tables; the frontend proxy already degrades to device-local if the endpoint is absent.
- **Verification commands executed:**
  - `ruff check` + `ruff format --check` — clean on all touched files
  - `pytest tests/test_pwm_routes.py tests/test_fabric_routes.py` — **23 passed** (merge/LWW, scope-registry fail-closed, receipt-hash determinism + chaining, route contracts, owner/subscriber auth binding)
  - full `server.py` boot — all `/api/pwm` + `/api/fabric/*` routes registered
  - **real Postgres**: migrations 118+119 apply; PWM upsert/cross-device-LWW/stale-reject/wipe; full fabric flow — priced grant, subscriber read returns only granted fields, subscriber-mismatch denied, **scope isolation (a private section never leaks)**, revoke→read denied, 4-event chain verifies, **receipt tamper detected**

Not verifiable in sandbox (consistent with the repo's note): the deployed rail on Cloud SQL — to be verified on UAT.

**Follow-up before third-party subscribers go live:** `DEVELOPER_API_ENABLED` is off in prod by default, so subscriber onboarding must be enabled and a subscriber app/credential provisioned.
