### PR TITLE
feat(fabric): brand-initiated consent handshake — device-flow pairing (PCHP RFC-002)

### DIFF
--- a/consent-protocol/api/routes/fabric.py
+++ b/consent-protocol/api/routes/fabric.py
@@ -14,9 +14,18 @@ Owner endpoints (Firebase auth; uid only from the verified token):
     GET    /api/fabric/receipts             -> my hash-chained receipt ledger
     GET    /api/fabric/receipts/verify      -> verify my chain integrity
 
-Subscriber endpoint (developer-principal auth; Bearer token):
+Subscriber endpoints (developer-principal auth; Bearer token):
     POST   /api/fabric/read                 -> present a grant handle, receive
                                                only the granted fields + a receipt
+    POST   /api/fabric/requests             -> open a pairing request; returns a
+                                               short code to show the person
+    GET    /api/fabric/requests/{id}        -> poll; on approval the signed
+                                               handle is returned exactly once
+
+Owner handshake endpoints (Firebase auth):
+    GET    /api/fabric/requests/code/{code} -> who is asking, for what, why
+    POST   /api/fabric/requests/{id}/approve -> mint the grant (+ receipt)
+    POST   /api/fabric/requests/{id}/deny    -> one-tap no
 """
 
 import logging
@@ -30,6 +39,7 @@ from api.middleware import require_firebase_auth
 from hushh_mcp.services.developer_registry_service import DeveloperPrincipal
 from hushh_mcp.services.fabric_grant_service import FabricGrantError, get_fabric_grant_service
 from hushh_mcp.services.fabric_receipts_service import get_fabric_receipts_service
+from hushh_mcp.services.fabric_request_service import get_fabric_request_service
 from hushh_mcp.services.pwm_service import get_pwm_service
 
 logger = logging.getLogger(__name__)
@@ -149,5 +159,124 @@ async def subscriber_read(
             pwm_doc_loader=get_pwm_service().get_document,
         )
         return result
+    except FabricGrantError as err:
+        _raise(err)
+
+
+# ---------------------------------------------------------------------------
+# The brand-initiated handshake (device-authorization-style pairing).
+# The subscriber opens a request and shows a short code; the person's agent
+# looks the code up, sees exactly who is asking for what and why, and approves
+# or denies. Approval mints the grant; the subscriber claims the handle once.
+# ---------------------------------------------------------------------------
+
+
+class CreateRequestBody(BaseModel):
+    scopes: list[str] = Field(min_length=1, max_length=64)
+    purpose: str = Field(min_length=1, max_length=500)
+    subscriber_label: str | None = Field(default=None, max_length=200)
+    ttl_ms: int | None = Field(default=None, ge=1)
+    price_cents: int | None = Field(default=None, ge=0)
+    currency: str | None = Field(default=None, max_length=8)
+
+
+class RespondRequestBody(BaseModel):
+    pairing_code: str = Field(min_length=8, max_length=16)
+
+
+@router.post("/requests")
+async def create_consent_request(
+    body: CreateRequestBody,
+    principal: DeveloperPrincipal = Depends(require_subscriber_principal),
+) -> dict[str, Any]:
+    if not principal.agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "FABRIC_SUBSCRIBER_UNIDENTIFIED",
+                "message": "Subscriber has no agent id.",
+            },
+        )
+    try:
+        created: dict[str, Any] = await get_fabric_request_service().create_request(
+            subscriber_id=principal.agent_id,
+            scopes=body.scopes,
+            purpose=body.purpose,
+            subscriber_label=body.subscriber_label or principal.display_name,
+            ttl_ms=body.ttl_ms,
+            price_cents=body.price_cents,
+            currency=body.currency,
+        )
+        return created
+    except FabricGrantError as err:
+        _raise(err)
+
+
+@router.get("/requests/code/{code}")
+async def lookup_consent_request(
+    code: str,
+    _firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    """What is this code asking me to share? Sign-in required; no uid binding yet."""
+    try:
+        found: dict[str, Any] = await get_fabric_request_service().lookup_by_code(code)
+        return found
+    except FabricGrantError as err:
+        _raise(err)
+
+
+@router.post("/requests/{request_id}/approve")
+async def approve_consent_request(
+    request_id: str,
+    body: RespondRequestBody,
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    try:
+        approved: dict[str, Any] = await get_fabric_request_service().approve(
+            user_id=firebase_uid,
+            request_id=request_id,
+            pairing_code=body.pairing_code,
+        )
+        return approved
+    except FabricGrantError as err:
+        _raise(err)
+
+
+@router.post("/requests/{request_id}/deny")
+async def deny_consent_request(
+    request_id: str,
+    body: RespondRequestBody,
+    firebase_uid: str = Depends(require_firebase_auth),
+) -> dict[str, Any]:
+    try:
+        denied: dict[str, Any] = await get_fabric_request_service().deny(
+            user_id=firebase_uid,
+            request_id=request_id,
+            pairing_code=body.pairing_code,
+        )
+        return denied
+    except FabricGrantError as err:
+        _raise(err)
+
+
+@router.get("/requests/{request_id}")
+async def poll_consent_request(
+    request_id: str,
+    principal: DeveloperPrincipal = Depends(require_subscriber_principal),
+) -> dict[str, Any]:
+    if not principal.agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "FABRIC_SUBSCRIBER_UNIDENTIFIED",
+                "message": "Subscriber has no agent id.",
+            },
+        )
+    try:
+        polled: dict[str, Any] = await get_fabric_request_service().poll(
+            subscriber_id=principal.agent_id,
+            request_id=request_id,
+        )
+        return polled
     except FabricGrantError as err:
         _raise(err)

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 119,
+  "expected_migration_version": 120,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/120_fabric_consent_requests.sql
+++ b/consent-protocol/db/migrations/120_fabric_consent_requests.sql
@@ -1,0 +1,53 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration 120: fabric_consent_requests (the brand-initiated handshake)
+-- ============================================================================
+-- The missing verb of the Permission Gateway (PCHP RFC-002): a verified
+-- subscriber (brand / professional) REQUESTS scoped access, and the person
+-- approves it into a fabric grant from their own agent.
+--
+-- Modeled as a device-authorization-style pairing flow so the brand never
+-- learns who the person is before consent:
+--   1. subscriber creates a request -> gets request_id + short pairing code
+--   2. the person's agent looks up the code, shows who/what/why/how-long/price
+--   3. approve binds the verified uid, mints the grant (+ GRANT receipt), and
+--      parks the signed handle for a SINGLE subscriber claim
+--   4. the subscriber polls and claims the handle exactly once
+--
+-- `handle_once` holds the signed grant handle only between approval and the
+-- single claim; it is cleared on claim, and requests expire in minutes. This
+-- table stores workflow state and grant metadata only — never PWM values.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS fabric_consent_requests (
+  request_id       TEXT PRIMARY KEY,
+  pairing_code     TEXT NOT NULL UNIQUE,
+  subscriber_id    TEXT NOT NULL,
+  subscriber_label TEXT,
+  scopes           JSONB NOT NULL DEFAULT '[]'::jsonb,
+  purpose          TEXT NOT NULL,
+  ttl_ms           BIGINT,
+  price_cents      BIGINT,
+  currency         TEXT,
+  status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'approved', 'denied', 'expired', 'claimed')),
+  user_id          TEXT,
+  grant_id         TEXT,
+  handle_once      TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at       TIMESTAMPTZ NOT NULL,
+  responded_at     TIMESTAMPTZ,
+  claimed_at       TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_requests_subscriber_created
+  ON fabric_consent_requests (subscriber_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_requests_status_expires
+  ON fabric_consent_requests (status, expires_at);
+
+COMMENT ON TABLE fabric_consent_requests IS
+  'Brand-initiated PCHP RFC-002 consent requests (device-authorization-style pairing). Workflow state + grant metadata only; handle_once holds the signed grant handle solely between approval and its single claim. Never stores PWM values.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -97,7 +97,8 @@
     "116_one_location_sms_contacts.sql",
     "117_feed_events.sql",
     "118_preference_world_model.sql",
-    "119_preference_subscription_fabric.sql"
+    "119_preference_subscription_fabric.sql",
+    "120_fabric_consent_requests.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/hushh_mcp/services/fabric_request_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_request_service.py
@@ -1,0 +1,378 @@
+"""Brand-initiated consent requests for the Permission Gateway (PCHP RFC-002).
+
+The missing verb of the subscription fabric: a verified subscriber (brand or
+professional) *requests* scoped access, and the person approves it into a
+fabric grant from their own agent.
+
+Modeled as a device-authorization-style pairing flow (the same shape as the
+OAuth 2.0 Device Authorization Grant) so the brand never learns who the person
+is before consent:
+
+    1. subscriber: create_request(...)      -> request_id + short pairing code
+    2. person:     lookup_by_code(code)     -> who is asking, for what, why,
+                                               how long, at what price
+    3. person:     approve(...)             -> binds the verified uid, mints
+                                               the grant (+ GRANT receipt),
+                                               parks the handle for ONE claim
+       or          deny(...)
+    4. subscriber: poll(...)                -> status; on approval returns the
+                                               signed handle exactly once
+
+Trust contract:
+- the person's uid enters only at approve time, and only from the verified
+  token; the subscriber never sees it through this flow
+- the pairing code is high-entropy, single-use, and expires in minutes
+- the signed handle is stored only between approval and its single claim,
+  then cleared; every read after that flows through the receipted read API
+- fail-closed everywhere: expired, denied, claimed, or mismatched requests
+  return errors, never data
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+import uuid
+from typing import Any
+
+from db.connection import get_pool
+from hushh_mcp.services.fabric_grant_service import (
+    FabricGrantError,
+    get_fabric_grant_service,
+)
+from hushh_mcp.services.fabric_scope_registry import resolve_fields
+
+# Unambiguous alphabet (no vowels -> no words; no 0/O/1/I/L lookalikes).
+_CODE_ALPHABET = "BCDFGHJKMNPQRSTVWXYZ23456789"
+_CODE_LENGTH = 8
+_REQUEST_TTL_MS = 15 * 60 * 1000  # a pairing request lives minutes, not days
+_MAX_PENDING_PER_SUBSCRIBER = 100  # backstop against pairing-code farming
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _mint_pairing_code() -> str:
+    raw = "".join(secrets.choice(_CODE_ALPHABET) for _ in range(_CODE_LENGTH))
+    return f"{raw[:4]}-{raw[4:]}"
+
+
+def _normalize_code(code: str) -> str:
+    cleaned = "".join(ch for ch in code.upper() if ch.isalnum())
+    return f"{cleaned[:4]}-{cleaned[4:]}" if len(cleaned) == _CODE_LENGTH else code.strip().upper()
+
+
+class FabricRequestService:
+    def __init__(self) -> None:
+        self._table_ready = False
+
+    async def ensure_table(self) -> None:
+        """Idempotent safety-net; migration 120 is authoritative."""
+        if self._table_ready:
+            return
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS fabric_consent_requests (
+                    request_id TEXT PRIMARY KEY,
+                    pairing_code TEXT NOT NULL UNIQUE,
+                    subscriber_id TEXT NOT NULL,
+                    subscriber_label TEXT,
+                    scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    purpose TEXT NOT NULL,
+                    ttl_ms BIGINT,
+                    price_cents BIGINT,
+                    currency TEXT,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    user_id TEXT,
+                    grant_id TEXT,
+                    handle_once TEXT,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    expires_at TIMESTAMPTZ NOT NULL,
+                    responded_at TIMESTAMPTZ,
+                    claimed_at TIMESTAMPTZ
+                )
+                """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fabric_requests_subscriber_created "
+                "ON fabric_consent_requests (subscriber_id, created_at DESC)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fabric_requests_status_expires "
+                "ON fabric_consent_requests (status, expires_at)"
+            )
+        self._table_ready = True
+
+    async def create_request(
+        self,
+        *,
+        subscriber_id: str,
+        scopes: list[str],
+        purpose: str,
+        subscriber_label: str | None = None,
+        ttl_ms: int | None = None,
+        price_cents: int | None = None,
+        currency: str | None = None,
+    ) -> dict[str, Any]:
+        """Subscriber side: open a pairing request and get the code to show."""
+        await self.ensure_table()
+        scopes = [s.strip() for s in scopes if s and s.strip()]
+        purpose = purpose.strip()
+        if not scopes:
+            raise FabricGrantError("FABRIC_SCOPES_REQUIRED", "At least one scope is required.", 422)
+        if not purpose:
+            raise FabricGrantError("FABRIC_PURPOSE_REQUIRED", "A purpose is required.", 422)
+        if price_cents is not None and (price_cents < 0 or currency is None):
+            raise FabricGrantError(
+                "FABRIC_PRICE_INVALID",
+                "A priced request needs a non-negative price_cents and a currency.",
+                422,
+            )
+
+        now_ms = _now_ms()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            pending = await conn.fetchval(
+                "SELECT COUNT(*) FROM fabric_consent_requests "
+                "WHERE subscriber_id = $1 AND status = 'pending' AND expires_at > now()",
+                subscriber_id,
+            )
+            if int(pending or 0) >= _MAX_PENDING_PER_SUBSCRIBER:
+                raise FabricGrantError(
+                    "FABRIC_REQUESTS_RATE_LIMITED",
+                    "Too many pending requests for this subscriber.",
+                    429,
+                )
+            request_id = uuid.uuid4().hex
+            # Pairing codes are UNIQUE; retry the 1-in-3.8e11 collision.
+            for _ in range(3):
+                code = _mint_pairing_code()
+                try:
+                    await conn.execute(
+                        """
+                        INSERT INTO fabric_consent_requests (
+                            request_id, pairing_code, subscriber_id, subscriber_label,
+                            scopes, purpose, ttl_ms, price_cents, currency,
+                            status, expires_at
+                        )
+                        VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9,'pending',
+                                to_timestamp($10/1000.0))
+                        """,
+                        request_id,
+                        code,
+                        subscriber_id,
+                        subscriber_label,
+                        _json(scopes),
+                        purpose,
+                        ttl_ms,
+                        price_cents,
+                        currency,
+                        now_ms + _REQUEST_TTL_MS,
+                    )
+                    break
+                except Exception as exc:  # unique_violation on pairing_code
+                    if "unique" not in str(exc).lower():
+                        raise
+            else:
+                raise FabricGrantError(
+                    "FABRIC_CODE_MINT_FAILED", "Could not mint a pairing code.", 500
+                )
+        return {
+            "request_id": request_id,
+            "pairing_code": code,
+            "expires_at_ms": now_ms + _REQUEST_TTL_MS,
+            "poll_interval_ms": 2500,
+        }
+
+    async def lookup_by_code(self, code: str) -> dict[str, Any]:
+        """Person side: what am I being asked to share? (no uid binding yet)."""
+        await self.ensure_table()
+        row = await self._fetch_by_code(code)
+        self._require_pending(row)
+        scopes = _as_list(row["scopes"])
+        fields, unmapped = resolve_fields(scopes)
+        return {
+            "request_id": row["request_id"],
+            "subscriber_id": row["subscriber_id"],
+            "subscriber_label": row["subscriber_label"],
+            "scopes": scopes,
+            "fields": fields,
+            "unmapped_scopes": unmapped,
+            "purpose": row["purpose"],
+            "ttl_ms": row["ttl_ms"],
+            "price_cents": row["price_cents"],
+            "currency": row["currency"],
+            "expires_at_ms": _dt_ms(row["expires_at"]),
+        }
+
+    async def approve(self, *, user_id: str, request_id: str, pairing_code: str) -> dict[str, Any]:
+        """Person side: approve -> mint the grant, park the handle for one claim.
+
+        uid comes ONLY from the verified token of the caller; the pairing code
+        must match the request so a request_id alone is never enough.
+        """
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    "SELECT * FROM fabric_consent_requests WHERE request_id = $1 FOR UPDATE",
+                    request_id,
+                )
+                self._require_pending(row)
+                if row["pairing_code"] != _normalize_code(pairing_code):
+                    raise FabricGrantError(
+                        "FABRIC_CODE_MISMATCH", "Pairing code does not match.", 403
+                    )
+                grant = await get_fabric_grant_service().create_grant(
+                    user_id=user_id,
+                    subscriber_id=row["subscriber_id"],
+                    scopes=_as_list(row["scopes"]),
+                    purpose=row["purpose"],
+                    subscriber_label=row["subscriber_label"],
+                    ttl_ms=int(row["ttl_ms"]) if row["ttl_ms"] is not None else None,
+                    price_cents=int(row["price_cents"]) if row["price_cents"] is not None else None,
+                    currency=row["currency"],
+                )
+                await conn.execute(
+                    """
+                    UPDATE fabric_consent_requests
+                    SET status = 'approved', user_id = $2, grant_id = $3,
+                        handle_once = $4, responded_at = now()
+                    WHERE request_id = $1
+                    """,
+                    request_id,
+                    user_id,
+                    grant["grant_id"],
+                    grant["handle"],
+                )
+        # The owner gets the grant summary + receipt — never the handle; the
+        # handle belongs to the subscriber and is claimable exactly once.
+        return {
+            "request_id": request_id,
+            "status": "approved",
+            "grant_id": grant["grant_id"],
+            "scopes": grant["scopes"],
+            "fields": grant["fields"],
+            "receipt": grant["receipt"],
+        }
+
+    async def deny(self, *, user_id: str, request_id: str, pairing_code: str) -> dict[str, Any]:
+        """Person side: one-tap no. Fail-closed and terminal."""
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    "SELECT * FROM fabric_consent_requests WHERE request_id = $1 FOR UPDATE",
+                    request_id,
+                )
+                self._require_pending(row)
+                if row["pairing_code"] != _normalize_code(pairing_code):
+                    raise FabricGrantError(
+                        "FABRIC_CODE_MISMATCH", "Pairing code does not match.", 403
+                    )
+                await conn.execute(
+                    "UPDATE fabric_consent_requests "
+                    "SET status = 'denied', user_id = $2, responded_at = now() "
+                    "WHERE request_id = $1",
+                    request_id,
+                    user_id,
+                )
+        return {"request_id": request_id, "status": "denied"}
+
+    async def poll(self, *, subscriber_id: str, request_id: str) -> dict[str, Any]:
+        """Subscriber side: status; on approval the handle is returned ONCE."""
+        await self.ensure_table()
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                row = await conn.fetchrow(
+                    "SELECT * FROM fabric_consent_requests WHERE request_id = $1 FOR UPDATE",
+                    request_id,
+                )
+                if row is None or row["subscriber_id"] != subscriber_id:
+                    # Same error for absent and foreign requests: no oracle.
+                    raise FabricGrantError("FABRIC_REQUEST_NOT_FOUND", "Request not found.", 404)
+                status = self._effective_status(row)
+                if status == "approved" and row["handle_once"]:
+                    await conn.execute(
+                        "UPDATE fabric_consent_requests "
+                        "SET status = 'claimed', handle_once = NULL, claimed_at = now() "
+                        "WHERE request_id = $1",
+                        request_id,
+                    )
+                    return {
+                        "request_id": request_id,
+                        "status": "approved",
+                        "handle": row["handle_once"],
+                        "grant_id": row["grant_id"],
+                    }
+        return {"request_id": request_id, "status": status}
+
+    # ------------------------------------------------------------------ utils
+
+    async def _fetch_by_code(self, code: str) -> Any:
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            return await conn.fetchrow(
+                "SELECT * FROM fabric_consent_requests WHERE pairing_code = $1",
+                _normalize_code(code),
+            )
+
+    @staticmethod
+    def _effective_status(row: Any) -> str:
+        status = str(row["status"])
+        if status == "pending" and _dt_ms(row["expires_at"]) <= _now_ms():
+            return "expired"
+        return status
+
+    @classmethod
+    def _require_pending(cls, row: Any) -> None:
+        if row is None:
+            raise FabricGrantError("FABRIC_REQUEST_NOT_FOUND", "Request not found.", 404)
+        status = cls._effective_status(row)
+        if status != "pending":
+            raise FabricGrantError(
+                "FABRIC_REQUEST_NOT_PENDING",
+                f"This request is {status}.",
+                410 if status == "expired" else 409,
+            )
+
+
+def _json(value: Any) -> str:
+    import json
+
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def _as_list(value: Any) -> list[str]:
+    import json
+
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            return []
+        return list(parsed) if isinstance(parsed, list) else []
+    return list(value) if isinstance(value, (list, tuple)) else []
+
+
+def _dt_ms(value: Any) -> int:
+    try:
+        return int(value.timestamp() * 1000)
+    except (AttributeError, TypeError, ValueError):
+        return 0
+
+
+_fabric_request_service: FabricRequestService | None = None
+
+
+def get_fabric_request_service() -> FabricRequestService:
+    global _fabric_request_service
+    if _fabric_request_service is None:
+        _fabric_request_service = FabricRequestService()
+    return _fabric_request_service

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -693,9 +693,11 @@ async def startup_pwm_documents_table():
 async def startup_fabric_tables():
     """Ensure the subscription-fabric tables exist before any /api/fabric request."""
     from hushh_mcp.services.fabric_grant_service import get_fabric_grant_service
+    from hushh_mcp.services.fabric_request_service import get_fabric_request_service
 
     try:
         await get_fabric_grant_service().ensure_table()
+        await get_fabric_request_service().ensure_table()
     except Exception as exc:
         if _require_database_on_startup():
             logger.critical(

--- a/consent-protocol/tests/test_fabric_request_routes.py
+++ b/consent-protocol/tests/test_fabric_request_routes.py
@@ -1,0 +1,156 @@
+"""Tests for the brand-initiated handshake (fabric consent requests).
+
+Route tests mock the service layer (no DB); the full DB-backed
+request -> lookup -> approve -> claim -> read flow is exercised against a real
+Postgres in the PR verification. Pairing-code tests are pure.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.middleware import require_firebase_auth
+from api.routes import fabric
+from hushh_mcp.services import fabric_request_service as req_mod
+
+_UID = "owner-uid-1"
+_SUBSCRIBER = "developer:acme-clinic"
+
+
+# ---------------------------------------------------------------------------
+# Pairing code (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_pairing_code_shape_and_alphabet():
+    for _ in range(50):
+        code = req_mod._mint_pairing_code()
+        assert len(code) == 9 and code[4] == "-"
+        for ch in code.replace("-", ""):
+            assert ch in req_mod._CODE_ALPHABET  # no vowels, no 0/O/1/I/L
+
+
+def test_normalize_code_accepts_human_input():
+    assert req_mod._normalize_code("bcdf-ghjk") == "BCDF-GHJK"
+    assert req_mod._normalize_code("bcdfghjk") == "BCDF-GHJK"
+    assert req_mod._normalize_code(" BCDF GHJK ") == "BCDF-GHJK"
+
+
+# ---------------------------------------------------------------------------
+# Route contract (services mocked)
+# ---------------------------------------------------------------------------
+
+
+def _owner_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(fabric.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _UID
+    return app
+
+
+def _subscriber_app(agent_id: str = _SUBSCRIBER) -> FastAPI:
+    app = FastAPI()
+    app.include_router(fabric.router)
+    app.dependency_overrides[fabric.require_subscriber_principal] = lambda: SimpleNamespace(
+        agent_id=agent_id, app_id="acme", display_name="Acme Clinic"
+    )
+    return app
+
+
+def test_subscriber_creates_request():
+    created = {
+        "request_id": "r1",
+        "pairing_code": "BCDF-GHJK",
+        "expires_at_ms": 999,
+        "poll_interval_ms": 2500,
+    }
+    with patch.object(fabric, "get_fabric_request_service") as factory:
+        factory.return_value.create_request = AsyncMock(return_value=created)
+        resp = TestClient(_subscriber_app()).post(
+            "/api/fabric/requests",
+            json={"scopes": ["privacy.marketing-email"], "purpose": "cookie compliance"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["pairing_code"] == "BCDF-GHJK"
+    # subscriber identity comes from the authenticated principal, not the body
+    assert factory.return_value.create_request.await_args.kwargs["subscriber_id"] == _SUBSCRIBER
+
+
+def test_owner_lookup_by_code():
+    found = {
+        "request_id": "r1",
+        "subscriber_id": _SUBSCRIBER,
+        "subscriber_label": "Acme Clinic",
+        "scopes": ["privacy.marketing-email"],
+        "fields": [],
+        "unmapped_scopes": ["privacy.marketing-email"],
+        "purpose": "cookie compliance",
+        "ttl_ms": None,
+        "price_cents": None,
+        "currency": None,
+        "expires_at_ms": 999,
+    }
+    with patch.object(fabric, "get_fabric_request_service") as factory:
+        factory.return_value.lookup_by_code = AsyncMock(return_value=found)
+        resp = TestClient(_owner_app()).get("/api/fabric/requests/code/BCDF-GHJK")
+    assert resp.status_code == 200
+    assert resp.json()["subscriber_label"] == "Acme Clinic"
+
+
+def test_owner_approve_binds_token_uid():
+    approved = {
+        "request_id": "r1",
+        "status": "approved",
+        "grant_id": "g1",
+        "scopes": ["privacy.marketing-email"],
+        "fields": [],
+        "receipt": {"seq": 1, "event_type": "GRANT"},
+    }
+    with patch.object(fabric, "get_fabric_request_service") as factory:
+        factory.return_value.approve = AsyncMock(return_value=approved)
+        resp = TestClient(_owner_app()).post(
+            "/api/fabric/requests/r1/approve", json={"pairing_code": "BCDF-GHJK"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "approved"
+    # uid is the verified token's, never from the body
+    assert factory.return_value.approve.await_args.kwargs["user_id"] == _UID
+
+
+def test_owner_deny():
+    with patch.object(fabric, "get_fabric_request_service") as factory:
+        factory.return_value.deny = AsyncMock(return_value={"request_id": "r1", "status": "denied"})
+        resp = TestClient(_owner_app()).post(
+            "/api/fabric/requests/r1/deny", json={"pairing_code": "BCDF-GHJK"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "denied"
+
+
+def test_subscriber_poll_claims_handle_once():
+    with patch.object(fabric, "get_fabric_request_service") as factory:
+        factory.return_value.poll = AsyncMock(
+            return_value={
+                "request_id": "r1",
+                "status": "approved",
+                "handle": "HFG:abc.def",
+                "grant_id": "g1",
+            }
+        )
+        resp = TestClient(_subscriber_app()).get("/api/fabric/requests/r1")
+    assert resp.status_code == 200
+    assert resp.json()["handle"].startswith("HFG:")
+    assert factory.return_value.poll.await_args.kwargs["subscriber_id"] == _SUBSCRIBER
+
+
+def test_foreign_subscriber_poll_is_not_found():
+    from hushh_mcp.services.fabric_grant_service import FabricGrantError
+
+    with patch.object(fabric, "get_fabric_request_service") as factory:
+        factory.return_value.poll = AsyncMock(
+            side_effect=FabricGrantError("FABRIC_REQUEST_NOT_FOUND", "Request not found.", 404)
+        )
+        resp = TestClient(_subscriber_app("developer:evil")).get("/api/fabric/requests/r1")
+    assert resp.status_code == 404

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -986,6 +986,16 @@
     {
       "data_class": "workflow_state",
       "exact_tables": [
+        "fabric_consent_requests"
+      ],
+      "id": "subscription_fabric_requests",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "brand-initiated PCHP RFC-002 pairing requests: create, code lookup, approve/deny, single handle claim (/api/fabric/requests)"
+    },
+    {
+      "data_class": "workflow_state",
+      "exact_tables": [
         "trusted_connections"
       ],
       "id": "trusted_connections_graph",
@@ -4253,7 +4263,7 @@
     "action_gateway": "afac5b3a07a1ec2e6ab4f87231b37edb81a0d771daae2cf4900dd6fb9a35f049",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
     "cache_manifest": "36a64f281e836ea255caedfb78feac08bb3d862932352d11e1fcc0771a9af8c3",
-    "data_plane": "ac69d1fe4fa5b2cfe9a6eb7bc06784472238a3d557f477ba371fd0e56d7b11d9",
+    "data_plane": "741bd6db61bfcd8d5bb1f27a1fe84240a88c9c2b4f82ccbafec45a1c1c1875a2",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
     "route_index": "46d94273cc53d297b8a4f4cdc7916f6cb23d602209555b5328201c0a9b78423b",
@@ -4272,6 +4282,6 @@
     "one_specialist_tools": 5,
     "physical_routes": 113,
     "semantic_routes": 14,
-    "table_families": 36
+    "table_families": 37
   }
 }

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -672,6 +672,21 @@
       "trust_boundary": "Signed, hash-chained receipt metadata only (hashes, signatures, scope + field-path labels); no PWM values.",
       "plaintext_posture": "metadata_only",
       "expected_row_growth": "medium_append_only"
+    },
+    {
+      "id": "subscription_fabric_requests",
+      "owner": "iam-consent-governance",
+      "data_class": "workflow_state",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "fabric_consent_requests"
+      ],
+      "primary_access_path": "brand-initiated PCHP RFC-002 pairing requests: create, code lookup, approve/deny, single handle claim (/api/fabric/requests)",
+      "retention_policy": "Short-lived pairing workflow: requests expire in minutes; terminal rows compacted per retention policy.",
+      "deletion_behavior": "Delete on account deletion for bound rows; expired/denied/claimed rows are terminal and compactable.",
+      "trust_boundary": "Workflow state and grant metadata only; the signed handle is held solely between approval and its single claim, then cleared. Never PWM values; uid binds only at approval from the verified token.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "medium_per_consent"
     }
   ]
 }


### PR DESCRIPTION
# Description

The missing verb of the **Permission Gateway** (PCHP RFC-002), on top of the merged fabric (#4670): a verified subscriber — a brand or any professional (doctor's office, bank, hotel, retailer, RIA) — **requests** scoped access, and the person approves it into a fabric grant **from their own agent**. Modeled as a **device-authorization-style pairing flow** (the OAuth 2.0 Device Grant shape) so the brand never learns who the person is before consent.

**Flow**
1. Subscriber: `POST /api/fabric/requests {scopes, purpose, ttl?, price?}` → `request_id` + short **pairing code** (show as QR/tap: "Approve in your 🤫 agent").
2. Person: `GET /api/fabric/requests/code/{code}` → sees exactly **who is asking, for what fields, why, how long, at what price** — before any identity binding.
3. Person: `POST /api/fabric/requests/{id}/approve` (or `/deny`) → binds the **verified token uid**, mints the grant + **GRANT receipt**, parks the signed handle for **one** claim.
4. Subscriber: `GET /api/fabric/requests/{id}` → poll; on approval the handle is returned **exactly once**, then every read flows through the receipted `/api/fabric/read`.

## 📌 Impact Map (Required)

- Routes touched: **new** `POST /api/fabric/requests`, `GET /api/fabric/requests/code/{code}`, `POST /api/fabric/requests/{id}/approve`, `POST /api/fabric/requests/{id}/deny`, `GET /api/fabric/requests/{id}` (added to the existing fabric router; startup `ensure_table` extended in `server.py`).
- API / schema changes: contracts above; new table `fabric_consent_requests` via migration `120_fabric_consent_requests.sql`.
- Runtime DB data-plane changes: one new workflow-state table, registered in the release manifest; **UAT schema contract bumped 119 → 120**; classified in the data-plane contract (`subscription_fabric_requests`, workflow_state); topology index regenerated.
- World-model domain summary effects: none.
- Mobile parity impacts: none (API surface).
- Trust boundary — auth/consent:
  - uid binds **only at approval** and **only from the verified Firebase token**; the subscriber never sees it via this flow.
  - Pairing code: 8 chars over an unambiguous no-vowel alphabet (~3.8×10¹¹ space), **single-use**, **15-minute expiry**, human-typed forms normalized; per-subscriber pending cap (anti farming).
  - The signed handle is stored **only between approval and its single claim**, then cleared.
  - Fail-closed everywhere: wrong code, expired, denied, claimed, foreign subscriber all error — and a foreign poll is indistinguishable from not-found (no oracle).
- Rollback: additive-only (new table + routes); revert removes them; nothing existing changes.
- Verification commands executed:
  - `ruff check` + `ruff format --check` — clean
  - `mypy` on routes + service — clean
  - `pytest` — **31 passed** (8 new: pairing-code shape/normalization, route contracts, token-uid binding, once-only claim, foreign-subscriber 404)
  - Migration-contract verifier — manifest head 120 = UAT contract 120 (exact), prod 117 (minimum) ✓
  - Data-model audit — 0 unclassified, 0 failures ✓
  - **Real Postgres end-to-end**: migrations 118–120 apply; full handshake — request → code lookup → wrong-code rejected → approve (GRANT receipt) → foreign poll blocked → **handle claimed exactly once** → read returns only granted fields → chain verifies → deny path terminal
  - Full app boot — all five handshake routes registered

Not verifiable in sandbox: the live Cloud SQL rail — verify on UAT post-deploy.

**Follow-ups (tracked in the Permission Gateway plan):** owner approval UI in the 🤫 agent; privacy-scope → Consent Mode v2 / TCF / GPC mapping; `DEVELOPER_API_ENABLED` + subscriber self-serve onboarding before third-party brands go live.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Bh75gyp1KvHncgyWoCy8F)_