### PR TITLE
feat(fabric): the privacy wedge — Consent Mode v2 / GPC projection (PCHP RFC-002)

### DIFF
--- a/consent-protocol/hushh_mcp/services/fabric_grant_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_grant_service.py
@@ -368,9 +368,13 @@ class FabricGrantService:
 
         fields = _as_list(grant["fields"])
         doc = await pwm_doc_loader(user_id) or {}
+        from hushh_mcp.services.fabric_privacy import project_privacy_signals
         from hushh_mcp.services.fabric_scope_registry import project_fields
 
         projected = project_fields(doc, fields)
+        # The cookie-banner-replacement payload: when privacy fields were
+        # granted, hand the brand ready-to-apply Consent Mode v2 / GPC signals.
+        privacy_signals = project_privacy_signals(projected)
 
         now_ms = _now_ms()
         receipt = await self._receipts.append(
@@ -383,7 +387,7 @@ class FabricGrantService:
             fields=list(projected.keys()),
             purpose=grant["purpose"],
         )
-        return {
+        result = {
             "user_id": user_id,
             "subscriber_id": subscriber_id,
             "grant_id": grant["grant_id"],
@@ -391,6 +395,9 @@ class FabricGrantService:
             "fields": projected,
             "receipt": receipt,
         }
+        if privacy_signals is not None:
+            result["privacy_signals"] = privacy_signals
+        return result
 
 
 def _json(value: Any) -> str:

--- a/consent-protocol/hushh_mcp/services/fabric_privacy.py
+++ b/consent-protocol/hushh_mcp/services/fabric_privacy.py
@@ -1,0 +1,84 @@
+"""Privacy-preference projection for the subscription fabric (PCHP RFC-002).
+
+The adoption wedge of the Permission Gateway: one subscription to a person's
+published privacy preferences replaces the cookie banner. This module turns
+granted ``privacy.*`` PWM fields into the signals brands already run, so
+honoring "ask my agent" is one call on the brand side:
+
+    gtag("consent", "update", response["privacy_signals"]["consent_mode_v2"])
+
+Pure functions only (no I/O, no framework) — bacterial DNA. Everything is
+FAIL-CLOSED: a preference that is absent, ungranted, or not a boolean projects
+as denied / opted-out, never as granted.
+
+The field vocabulary mirrors the shipped public scope registry
+(/pchp/scopes.json v0.2.0): privacy.analytics, privacy.ads,
+privacy.personalization, privacy.marketing-email, privacy.marketing-sms,
+privacy.data-sale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Strictly-necessary storage is always granted under every consent regime;
+# everything else defaults to denied unless the person granted it.
+_ALWAYS_GRANTED = ("functionality_storage", "security_storage")
+
+# Google Consent Mode v2 key <- the privacy.* field that authorizes it.
+_CONSENT_MODE_MAP = {
+    "analytics_storage": "privacy.analytics",
+    "ad_storage": "privacy.ads",
+    "ad_user_data": "privacy.ads",
+    "ad_personalization": "privacy.ads",
+    "personalization_storage": "privacy.personalization",
+}
+
+
+def _granted(fields: dict[str, Any], key: str) -> bool:
+    # Only a literal True grants; absence, None, strings, etc. deny.
+    return fields.get(key) is True
+
+
+def to_consent_mode_v2(fields: dict[str, Any]) -> dict[str, str]:
+    """Project granted privacy fields onto Google Consent Mode v2 signals."""
+    signals = {
+        key: ("granted" if _granted(fields, source) else "denied")
+        for key, source in _CONSENT_MODE_MAP.items()
+    }
+    for key in _ALWAYS_GRANTED:
+        signals[key] = "granted"
+    return signals
+
+
+def to_gpc(fields: dict[str, Any]) -> bool:
+    """Global Privacy Control: True asserts the opt-out-of-sale/share signal.
+
+    ``privacy.data-sale`` is the person's permission TO sell/share (CCPA/CPRA);
+    the GPC signal is its inverse, and absence fails closed to opted-out.
+    """
+    return not _granted(fields, "privacy.data-sale")
+
+
+def to_channels(fields: dict[str, Any]) -> dict[str, bool]:
+    """Direct-marketing channel permissions (not part of Consent Mode)."""
+    return {
+        "email": _granted(fields, "privacy.marketing-email"),
+        "sms": _granted(fields, "privacy.marketing-sms"),
+    }
+
+
+def project_privacy_signals(fields: dict[str, Any]) -> dict[str, Any] | None:
+    """The full brand-side privacy payload, or None if no privacy field granted.
+
+    ``fields`` is the already-consent-filtered projection from the subscriber
+    read (dot-path -> value), so only granted-and-present preferences reach
+    this function; everything ungranted has already failed closed upstream.
+    """
+    if not any(path.startswith("privacy.") for path in fields):
+        return None
+    return {
+        "consent_mode_v2": to_consent_mode_v2(fields),
+        "gpc_opt_out": to_gpc(fields),
+        "channels": to_channels(fields),
+    }

--- a/consent-protocol/hushh_mcp/services/fabric_scope_registry.py
+++ b/consent-protocol/hushh_mcp/services/fabric_scope_registry.py
@@ -25,9 +25,21 @@ from typing import Any
 # `connect = { want, zip, updatedAt }` (see hushh-search-console pwm-local /
 # /api/pwm). A subscriber granted the "advisor want" receives the want + ZIP so
 # it can make the local match -- and nothing else.
+#
+# The privacy.* scopes mirror the shipped public scope registry
+# (/pchp/scopes.json v0.2.0) one-to-one: each scope authorizes exactly its own
+# boolean preference in the PWM privacy section -- the wedge stream that
+# replaces the cookie banner (see fabric_privacy for the brand-side
+# Consent Mode v2 / GPC projection).
 _SCOPE_FIELD_MAP: dict[str, list[str]] = {
     "wants.money.advisor": ["connect.want", "connect.zip"],
     "wants.financial-services": ["connect.want", "connect.zip"],
+    "privacy.marketing-email": ["privacy.marketing-email"],
+    "privacy.marketing-sms": ["privacy.marketing-sms"],
+    "privacy.analytics": ["privacy.analytics"],
+    "privacy.personalization": ["privacy.personalization"],
+    "privacy.ads": ["privacy.ads"],
+    "privacy.data-sale": ["privacy.data-sale"],
 }
 
 

--- a/consent-protocol/tests/test_fabric_privacy.py
+++ b/consent-protocol/tests/test_fabric_privacy.py
@@ -1,0 +1,120 @@
+"""Tests for the privacy wedge: scope registry bindings + Consent Mode v2 / GPC
+projection. All pure — no DB, no HTTP."""
+
+from hushh_mcp.services.fabric_privacy import (
+    project_privacy_signals,
+    to_channels,
+    to_consent_mode_v2,
+    to_gpc,
+)
+from hushh_mcp.services.fabric_scope_registry import project_fields, resolve_fields
+
+# ---------------------------------------------------------------------------
+# Registry: the six shipped privacy scopes bind one-to-one, fail-closed intact
+# ---------------------------------------------------------------------------
+
+_PRIVACY_SCOPES = [
+    "privacy.marketing-email",
+    "privacy.marketing-sms",
+    "privacy.analytics",
+    "privacy.personalization",
+    "privacy.ads",
+    "privacy.data-sale",
+]
+
+
+def test_privacy_scopes_bind_one_to_one():
+    for scope in _PRIVACY_SCOPES:
+        fields, unmapped = resolve_fields([scope])
+        assert fields == [scope]  # scope key == field path, by design
+        assert unmapped == []
+
+
+def test_unknown_privacy_scope_stays_fail_closed():
+    fields, unmapped = resolve_fields(["privacy.location-history"])
+    assert fields == []
+    assert unmapped == ["privacy.location-history"]
+
+
+def test_project_fields_keeps_explicit_false():
+    # A denied preference must project as False, not vanish - the brand needs
+    # the explicit denial to set Consent Mode to "denied".
+    doc = {"privacy": {"analytics": False, "ads": True, "updatedAt": 1}}
+    out = project_fields(doc, ["privacy.analytics", "privacy.ads"])
+    assert out == {"privacy.analytics": False, "privacy.ads": True}
+
+
+# ---------------------------------------------------------------------------
+# Consent Mode v2 projection
+# ---------------------------------------------------------------------------
+
+
+def test_consent_mode_all_granted():
+    fields = {"privacy.analytics": True, "privacy.ads": True, "privacy.personalization": True}
+    cm = to_consent_mode_v2(fields)
+    assert cm["analytics_storage"] == "granted"
+    assert cm["ad_storage"] == "granted"
+    assert cm["ad_user_data"] == "granted"
+    assert cm["ad_personalization"] == "granted"
+    assert cm["personalization_storage"] == "granted"
+
+
+def test_consent_mode_fails_closed_on_absent_or_denied():
+    cm = to_consent_mode_v2({"privacy.analytics": False})  # ads absent entirely
+    assert cm["analytics_storage"] == "denied"
+    assert cm["ad_storage"] == "denied"
+    assert cm["ad_personalization"] == "denied"
+
+
+def test_consent_mode_rejects_non_boolean_grants():
+    # "true"/1 must not grant - only a literal True does.
+    cm = to_consent_mode_v2({"privacy.analytics": "true", "privacy.ads": 1})
+    assert cm["analytics_storage"] == "denied"
+    assert cm["ad_storage"] == "denied"
+
+
+def test_strictly_necessary_always_granted():
+    cm = to_consent_mode_v2({})
+    assert cm["functionality_storage"] == "granted"
+    assert cm["security_storage"] == "granted"
+
+
+# ---------------------------------------------------------------------------
+# GPC + channels
+# ---------------------------------------------------------------------------
+
+
+def test_gpc_asserts_opt_out_unless_sale_permitted():
+    assert to_gpc({}) is True  # absence fails closed to opted-out
+    assert to_gpc({"privacy.data-sale": False}) is True
+    assert to_gpc({"privacy.data-sale": True}) is False
+
+
+def test_channels():
+    ch = to_channels({"privacy.marketing-email": True})
+    assert ch == {"email": True, "sms": False}
+
+
+# ---------------------------------------------------------------------------
+# Full payload composition
+# ---------------------------------------------------------------------------
+
+
+def test_project_privacy_signals_none_without_privacy_fields():
+    assert project_privacy_signals({"connect.zip": "98033"}) is None
+
+
+def test_project_privacy_signals_full_payload():
+    signals = project_privacy_signals(
+        {
+            "privacy.analytics": True,
+            "privacy.ads": False,
+            "privacy.data-sale": False,
+            "privacy.marketing-email": True,
+        }
+    )
+    assert signals is not None
+    assert signals["consent_mode_v2"]["analytics_storage"] == "granted"
+    assert signals["consent_mode_v2"]["ad_storage"] == "denied"
+    assert signals["gpc_opt_out"] is True
+    assert signals["channels"] == {"email": True, "sms": False}


### PR DESCRIPTION
# Description

The **adoption wedge** of the Permission Gateway: privacy preferences are the one stream every site on earth already needs — what the cookie banner pretends to collect. This PR makes honoring *"ask my agent"* a **one-line integration** on the brand side:

```js
gtag("consent", "update", response.privacy_signals.consent_mode_v2)
```

Person sets privacy once in their 🤫 agent (account-level, cross-device via the PWM) → a brand granted the `privacy.*` scopes reads **ready-to-apply signals** — never raw data it has to interpret.

**What's in it (no new tables, routes, or migrations — a pure capability on the existing receipted read path):**
- **`fabric_scope_registry`** — binds the six shipped `privacy.*` scopes (mirrors the public `/pchp/scopes.json` **v0.2.0** one-to-one: `marketing-email`, `marketing-sms`, `analytics`, `personalization`, `ads`, `data-sale`) to the PWM `privacy` section. Fail-closed posture unchanged.
- **`fabric_privacy`** (new; pure functions only — bacterial DNA) — projects granted privacy fields to:
  - **Google Consent Mode v2**: `analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`, `personalization_storage` (strictly-necessary `functionality_storage`/`security_storage` always granted)
  - **Global Privacy Control**: `gpc_opt_out` = inverse of `data-sale` permission; **absence fails closed to opted-out**
  - **Channels**: email/SMS direct-marketing permissions
  - Grant semantics: **only a literal `True` grants** — absent, `None`, `"true"`, `1` all deny.
- **`read_for_subscriber`** — attaches `privacy_signals` when (and only when) privacy fields were granted; non-privacy reads unchanged.

## 📌 Impact Map (Required)

- Routes touched: none new — `/api/fabric/read` response gains an optional `privacy_signals` object (additive).
- API / schema changes: additive response field only. No migrations; no data-plane changes.
- Trust boundary: unchanged — privacy fields flow through the same consent-filtered, fail-closed, receipted read; the projection only ever sees already-granted fields. A denied preference projects as an explicit `denied` (the brand needs the denial), and everything absent fails closed.
- Rollback: revert the three-file change; the response field disappears, nothing else moves.
- Parallel-safe with #4671 (no overlapping files).
- Verification commands executed:
  - `ruff` + `mypy` — clean
  - `pytest` — **34 passed** (11 new: one-to-one scope binding, fail-closed unknown scope, explicit-`False` projection, all-granted/denied/non-boolean Consent Mode cases, strictly-necessary always granted, GPC semantics, channels, payload composition)
  - **Real Postgres end-to-end**: person sets prefs once → brand granted the six privacy scopes reads `consent_mode_v2 {analytics: granted, ads: denied, …}` + `gpc_opt_out: true` + channels, with a READ receipt — and a non-privacy grant carries **no** privacy payload.

**Follow-ups (Permission Gateway plan):** the set-once privacy editor in the 🤫 app (writes the PWM `privacy` section — the store already merges it, verified); extend the frontend `/api/pwm` proxy's accepted-shape allowlist to include `privacy`; IAB TCF string emission (Consent Mode v2 + GPC first, TCF when a brand needs it); legal review that a fabric grant + hash-chained receipt constitutes valid consent per GDPR/CCPA before this replaces a production banner.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Bh75gyp1KvHncgyWoCy8F)_