### PR TITLE
harden(fabric): DoD/NIST-bar hardening of the subscription fabric

### DIFF
--- a/consent-protocol/api/middlewares/rate_limit.py
+++ b/consent-protocol/api/middlewares/rate_limit.py
@@ -95,6 +95,21 @@ class RateLimits:
     # Agent chat - moderate limit
     AGENT_CHAT = "30/minute"  # noqa: S105
 
+    # Preference Subscription Fabric (PCHP RFC-002).
+    # FABRIC_READ is the third-party-facing, monetizable subscriber read path;
+    # it must be firmly bounded per principal so no brand can drain an owner's
+    # data or flood the receipt ledger (SC-5 / CWE-400). Owner grant writes are
+    # conservative; owner reads (list/verify) are cheap and higher-frequency.
+    FABRIC_READ = "60/minute"  # noqa: S105 - subscriber read of granted fields
+    FABRIC_GRANT_WRITE = "20/minute"  # noqa: S105 - owner create/revoke a grant
+    FABRIC_OWNER_READ = "60/minute"  # noqa: S105 - owner list grants/receipts
+    # Pairing-code lookup is the code-probe surface of the handshake; bound it
+    # tightly (defense-in-depth on top of the CSPRNG code + 15-min TTL + the
+    # sign-in requirement) so no authenticated caller can farm codes.
+    FABRIC_REQUEST_LOOKUP = "20/minute"  # noqa: S105 - owner lookup of a pairing code
+    PWM_WRITE = "30/minute"  # noqa: S105 - owner PUT/DELETE own PWM
+    PWM_READ = "60/minute"  # noqa: S105 - owner GET own PWM
+
     # Global fallback per IP
     GLOBAL_PER_IP = "100/minute"  # noqa: S105
 

--- a/consent-protocol/api/routes/fabric.py
+++ b/consent-protocol/api/routes/fabric.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field
 
 from api.developer_auth import authenticate_developer_principal
 from api.middleware import require_firebase_auth
+from api.middlewares.rate_limit import RateLimits, limiter
 from hushh_mcp.services.developer_registry_service import DeveloperPrincipal
 from hushh_mcp.services.fabric_grant_service import FabricGrantError, get_fabric_grant_service
 from hushh_mcp.services.fabric_receipts_service import get_fabric_receipts_service
@@ -45,6 +46,20 @@ from hushh_mcp.services.pwm_service import get_pwm_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/fabric", tags=["subscription-fabric"])
+
+# Handle/grant authorization failures are collapsed to one generic denial for
+# the subscriber so the /read response cannot be used as an oracle (forged vs.
+# valid-but-wrong-subscriber vs. revoked vs. expired). The specific code is
+# logged server-side for the owner's audit, never returned to the caller.
+_READ_DENY_CODES = frozenset(
+    {
+        "FABRIC_HANDLE_INVALID",
+        "FABRIC_HANDLE_EXPIRED",
+        "FABRIC_SUBSCRIBER_MISMATCH",
+        "FABRIC_GRANT_NOT_FOUND",
+        "FABRIC_GRANT_REVOKED",
+    }
+)
 
 
 def require_subscriber_principal(request: Request) -> DeveloperPrincipal:
@@ -80,20 +95,22 @@ def _raise(err: FabricGrantError) -> NoReturn:
 
 
 @router.post("/grants")
+@limiter.limit(RateLimits.FABRIC_GRANT_WRITE)
 async def create_grant(
-    request: CreateGrantRequest,
+    request: Request,
+    payload: CreateGrantRequest,
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
     try:
         created: dict[str, Any] = await get_fabric_grant_service().create_grant(
             user_id=firebase_uid,
-            subscriber_id=request.subscriber_id,
-            scopes=request.scopes,
-            purpose=request.purpose,
-            subscriber_label=request.subscriber_label,
-            ttl_ms=request.ttl_ms,
-            price_cents=request.price_cents,
-            currency=request.currency,
+            subscriber_id=payload.subscriber_id,
+            scopes=payload.scopes,
+            purpose=payload.purpose,
+            subscriber_label=payload.subscriber_label,
+            ttl_ms=payload.ttl_ms,
+            price_cents=payload.price_cents,
+            currency=payload.currency,
         )
         return created
     except FabricGrantError as err:
@@ -101,7 +118,9 @@ async def create_grant(
 
 
 @router.get("/grants")
+@limiter.limit(RateLimits.FABRIC_OWNER_READ)
 async def list_grants(
+    request: Request,
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
     grants = await get_fabric_grant_service().list_grants(firebase_uid)
@@ -109,7 +128,9 @@ async def list_grants(
 
 
 @router.post("/grants/{grant_id}/revoke")
+@limiter.limit(RateLimits.FABRIC_GRANT_WRITE)
 async def revoke_grant(
+    request: Request,
     grant_id: str,
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
@@ -123,7 +144,9 @@ async def revoke_grant(
 
 
 @router.get("/receipts")
+@limiter.limit(RateLimits.FABRIC_OWNER_READ)
 async def list_receipts(
+    request: Request,
     firebase_uid: str = Depends(require_firebase_auth),
     limit: int = 200,
 ) -> dict[str, Any]:
@@ -132,15 +155,28 @@ async def list_receipts(
 
 
 @router.get("/receipts/verify")
+@limiter.limit(RateLimits.FABRIC_OWNER_READ)
 async def verify_receipts(
+    request: Request,
     firebase_uid: str = Depends(require_firebase_auth),
+    expected_head_seq: int | None = None,
+    expected_head_hash: str | None = None,
 ) -> dict[str, Any]:
-    verification: dict[str, Any] = await get_fabric_receipts_service().verify_chain(firebase_uid)
+    # The owner's client may pin the last head it saw (trust-on-first-use) and
+    # pass it back to detect tail-truncation / a wiped ledger, which a plain
+    # prev_hash walk cannot see.
+    verification: dict[str, Any] = await get_fabric_receipts_service().verify_chain(
+        firebase_uid,
+        expected_head_seq=expected_head_seq,
+        expected_head_hash=expected_head_hash,
+    )
     return verification
 
 
 @router.post("/read")
+@limiter.limit(RateLimits.FABRIC_READ)
 async def subscriber_read(
+    request: Request,
     body: ReadRequest = Body(...),
     principal: DeveloperPrincipal = Depends(require_subscriber_principal),
 ) -> dict[str, Any]:
@@ -160,6 +196,22 @@ async def subscriber_read(
         )
         return result
     except FabricGrantError as err:
+        # Collapse every handle/grant authz failure to one generic denial so the
+        # response is not a signature/existence oracle; log the real reason for
+        # the owner's audit trail only.
+        if err.code in _READ_DENY_CODES:
+            logger.info(
+                "fabric.read_denied",
+                extra={
+                    "event_type": "fabric_read_denied",
+                    "subscriber_id": principal.agent_id,
+                    "reason_code": err.code,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"code": "FABRIC_READ_DENIED", "message": "Read denied."},
+            )
         _raise(err)
 
 
@@ -185,7 +237,9 @@ class RespondRequestBody(BaseModel):
 
 
 @router.post("/requests")
+@limiter.limit(RateLimits.FABRIC_GRANT_WRITE)
 async def create_consent_request(
+    request: Request,
     body: CreateRequestBody,
     principal: DeveloperPrincipal = Depends(require_subscriber_principal),
 ) -> dict[str, Any]:
@@ -213,7 +267,9 @@ async def create_consent_request(
 
 
 @router.get("/requests/code/{code}")
+@limiter.limit(RateLimits.FABRIC_REQUEST_LOOKUP)
 async def lookup_consent_request(
+    request: Request,
     code: str,
     _firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
@@ -226,7 +282,9 @@ async def lookup_consent_request(
 
 
 @router.post("/requests/{request_id}/approve")
+@limiter.limit(RateLimits.FABRIC_GRANT_WRITE)
 async def approve_consent_request(
+    request: Request,
     request_id: str,
     body: RespondRequestBody,
     firebase_uid: str = Depends(require_firebase_auth),
@@ -243,7 +301,9 @@ async def approve_consent_request(
 
 
 @router.post("/requests/{request_id}/deny")
+@limiter.limit(RateLimits.FABRIC_GRANT_WRITE)
 async def deny_consent_request(
+    request: Request,
     request_id: str,
     body: RespondRequestBody,
     firebase_uid: str = Depends(require_firebase_auth),
@@ -260,7 +320,9 @@ async def deny_consent_request(
 
 
 @router.get("/requests/{request_id}")
+@limiter.limit(RateLimits.FABRIC_READ)
 async def poll_consent_request(
+    request: Request,
     request_id: str,
     principal: DeveloperPrincipal = Depends(require_subscriber_principal),
 ) -> dict[str, Any]:

--- a/consent-protocol/api/routes/pwm.py
+++ b/consent-protocol/api/routes/pwm.py
@@ -26,9 +26,10 @@ Security
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 
 from api.middleware import require_firebase_auth
+from api.middlewares.rate_limit import RateLimits, limiter
 from hushh_mcp.services.pwm_service import (
     PWM_MAX_TOP_LEVEL_KEYS,
     PwmDocumentTooLargeError,
@@ -62,7 +63,9 @@ def _sanitize_partial(body: Any) -> dict[str, Any]:
 
 
 @router.get("")
+@limiter.limit(RateLimits.PWM_READ)
 async def get_pwm_document(
+    request: Request,
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
     doc: dict[str, Any] | None = await get_pwm_service().get_document(firebase_uid)
@@ -75,7 +78,9 @@ async def get_pwm_document(
 
 
 @router.put("")
+@limiter.limit(RateLimits.PWM_WRITE)
 async def put_pwm_document(
+    request: Request,
     body: dict[str, Any] | None = Body(default=None),
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
@@ -96,7 +101,9 @@ async def put_pwm_document(
 
 
 @router.delete("")
+@limiter.limit(RateLimits.PWM_WRITE)
 async def delete_pwm_document(
+    request: Request,
     firebase_uid: str = Depends(require_firebase_auth),
 ) -> dict[str, Any]:
     existed = await get_pwm_service().delete_document(firebase_uid)

--- a/consent-protocol/hushh_mcp/services/fabric_grant_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_grant_service.py
@@ -349,44 +349,65 @@ class FabricGrantService:
         user_id = str(payload.get("uid") or "")
         fingerprint = _fingerprint(handle)
 
-        pool = await get_pool()
-        async with pool.acquire() as conn:
-            grant = await conn.fetchrow(
-                """
-                SELECT grant_id, scopes, fields, purpose, status
-                FROM fabric_subscription_grants
-                WHERE token_fingerprint = $1 AND user_id = $2 AND subscriber_id = $3
-                """,
-                fingerprint,
-                user_id,
-                subscriber_id,
-            )
-        if grant is None:
-            raise FabricGrantError("FABRIC_GRANT_NOT_FOUND", "No grant for this handle.", 404)
-        if grant["status"] != "active":
-            raise FabricGrantError("FABRIC_GRANT_REVOKED", "This grant has been revoked.", 403)
-
-        fields = _as_list(grant["fields"])
-        doc = await pwm_doc_loader(user_id) or {}
         from hushh_mcp.services.fabric_privacy import project_privacy_signals
         from hushh_mcp.services.fabric_scope_registry import project_fields
 
-        projected = project_fields(doc, fields)
-        # The cookie-banner-replacement payload: when privacy fields were
-        # granted, hand the brand ready-to-apply Consent Mode v2 / GPC signals.
-        privacy_signals = project_privacy_signals(projected)
-
+        # Serialize the whole read against a concurrent revoke, and write the READ
+        # receipt in the SAME advisory-locked transaction. This closes two gaps:
+        #   * TOCTOU on revoke -- revoke_grant holds the same per-owner advisory
+        #     lock, so a read that observes `active` cannot interleave with a
+        #     committing revoke; whoever gets the lock second sees the final
+        #     status and, if revoked, fails closed before any data leaves.
+        #   * Atomic accountability (AU-12) -- data can never be projected and
+        #     returned without its READ receipt committing in the same txn.
+        # The PWM doc is loaded on a separate pooled connection (a plain SELECT,
+        # no shared row locks), so no deadlock with the receipt insert.
         now_ms = _now_ms()
-        receipt = await self._receipts.append(
-            user_id=user_id,
-            event_type="READ",
-            created_at_ms=now_ms,
-            subscriber_id=subscriber_id,
-            grant_id=grant["grant_id"],
-            scopes=_as_list(grant["scopes"]),
-            fields=list(projected.keys()),
-            purpose=grant["purpose"],
-        )
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))", f"fabric_receipts:{user_id}"
+                )
+                grant = await conn.fetchrow(
+                    """
+                    SELECT grant_id, scopes, fields, purpose, status
+                    FROM fabric_subscription_grants
+                    WHERE token_fingerprint = $1 AND user_id = $2 AND subscriber_id = $3
+                    FOR SHARE
+                    """,
+                    fingerprint,
+                    user_id,
+                    subscriber_id,
+                )
+                if grant is None:
+                    raise FabricGrantError(
+                        "FABRIC_GRANT_NOT_FOUND", "No grant for this handle.", 404
+                    )
+                if grant["status"] != "active":
+                    raise FabricGrantError(
+                        "FABRIC_GRANT_REVOKED", "This grant has been revoked.", 403
+                    )
+
+                fields = _as_list(grant["fields"])
+                doc = await pwm_doc_loader(user_id) or {}
+                projected = project_fields(doc, fields)
+                # The cookie-banner-replacement payload: when privacy fields were
+                # granted, hand the brand ready-to-apply Consent Mode v2 / GPC
+                # signals.
+                privacy_signals = project_privacy_signals(projected)
+
+                receipt = await self._receipts.append_in_conn(
+                    conn,
+                    user_id=user_id,
+                    event_type="READ",
+                    created_at_ms=now_ms,
+                    subscriber_id=subscriber_id,
+                    grant_id=grant["grant_id"],
+                    scopes=_as_list(grant["scopes"]),
+                    fields=list(projected.keys()),
+                    purpose=grant["purpose"],
+                )
         result = {
             "user_id": user_id,
             "subscriber_id": subscriber_id,

--- a/consent-protocol/hushh_mcp/services/fabric_receipts_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_receipts_service.py
@@ -286,11 +286,39 @@ class FabricReceiptsService:
             "created_at_ms": int(row["created_at_ms"]),
         }
 
-    async def verify_chain(self, user_id: str) -> dict[str, Any]:
-        """Recompute the chain and signatures; report the first break, if any."""
+    async def verify_chain(
+        self,
+        user_id: str,
+        *,
+        expected_head_seq: int | None = None,
+        expected_head_hash: str | None = None,
+    ) -> dict[str, Any]:
+        """Recompute the chain and signatures; report the first break, if any.
+
+        Beyond per-link integrity this enforces two whole-chain invariants that a
+        pure prev_hash walk misses:
+
+        1. **Gap-free sequence.** Seq must run 1..N with no gaps. A mid-chain
+           delete already breaks the next row's prev_hash, but requiring a dense
+           sequence makes any missing row explicit rather than inferred.
+        2. **Head anchoring (optional).** A prev_hash walk cannot detect
+           *tail-truncation* or a *full wipe*: dropping the newest receipts (or
+           all of them) leaves rows 1..k -- or zero rows -- linking perfectly, so
+           a naive check returns ok. The owner's client pins the last head it saw
+           (``head_seq``/``head_hash`` from a prior call, trust-on-first-use) and
+           passes it back here; if the current head has regressed below or diverged
+           from the pinned head, the chain has been truncated and we fail closed.
+        """
         receipts = await self.list_receipts(user_id, limit=1000)
         prev_hash = GENESIS_HASH
+        expected_seq = 1
         for receipt in receipts:
+            if receipt["seq"] != expected_seq:
+                return {
+                    "ok": False,
+                    "broken_at_seq": receipt["seq"],
+                    "reason": "sequence_gap",
+                }
             payload = _canonical_payload(
                 user_id=user_id,
                 seq=receipt["seq"],
@@ -319,7 +347,34 @@ class FabricReceiptsService:
                     "reason": "signature_mismatch",
                 }
             prev_hash = receipt["hash"]
-        return {"ok": True, "count": len(receipts), "head_hash": prev_hash}
+            expected_seq += 1
+
+        head_seq = len(receipts)
+        # Tail-truncation / wipe detection against a client-pinned head. Absence
+        # of a pin means first-use: we return the head so the client can pin it.
+        if expected_head_seq is not None:
+            if head_seq < int(expected_head_seq):
+                return {
+                    "ok": False,
+                    "broken_at_seq": head_seq,
+                    "reason": "head_regressed",
+                    "head_seq": head_seq,
+                    "head_hash": prev_hash,
+                    "expected_head_seq": int(expected_head_seq),
+                }
+            if (
+                head_seq == int(expected_head_seq)
+                and expected_head_hash is not None
+                and not hmac.compare_digest(prev_hash, str(expected_head_hash))
+            ):
+                return {
+                    "ok": False,
+                    "broken_at_seq": head_seq,
+                    "reason": "head_diverged",
+                    "head_seq": head_seq,
+                    "head_hash": prev_hash,
+                }
+        return {"ok": True, "count": head_seq, "head_seq": head_seq, "head_hash": prev_hash}
 
 
 _fabric_receipts_service: FabricReceiptsService | None = None

--- a/consent-protocol/tests/test_fabric_routes.py
+++ b/consent-protocol/tests/test_fabric_routes.py
@@ -5,6 +5,7 @@ revoke -> chain-verify flow is exercised against a real Postgres in
 scripts/smoke (see PR notes). Scope-registry and receipt-hash tests are pure.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -14,6 +15,7 @@ from fastapi.testclient import TestClient
 from api.middleware import require_firebase_auth
 from api.routes import fabric
 from hushh_mcp.services import fabric_receipts_service as receipts_mod
+from hushh_mcp.services.fabric_receipts_service import FabricReceiptsService
 from hushh_mcp.services.fabric_scope_registry import project_fields, resolve_fields
 
 _UID = "owner-uid-1"
@@ -75,6 +77,104 @@ def test_receipt_hash_is_deterministic_and_chains():
     # signature is stable HMAC over the hash
     assert receipts_mod._sign(h1) == receipts_mod._sign(h1)
     assert receipts_mod._sign(h1) != receipts_mod._sign(h2)
+
+
+# ---------------------------------------------------------------------------
+# verify_chain whole-chain invariants (gap-free sequence + head anchoring).
+# Pure logic: a real service with list_receipts stubbed to a crafted chain, so
+# no DB is needed. Truncation/wipe of the head is the nation-state/insider case
+# a naive prev_hash walk cannot see.
+# ---------------------------------------------------------------------------
+
+
+def _valid_chain(user_id: str, n: int) -> list[dict]:
+    """Build n correctly-linked, correctly-signed receipts (seq 1..n)."""
+    chain: list[dict] = []
+    prev_hash = receipts_mod.GENESIS_HASH
+    for seq in range(1, n + 1):
+        payload = receipts_mod._canonical_payload(
+            user_id=user_id,
+            seq=seq,
+            event_type="READ",
+            subscriber_id=_SUBSCRIBER,
+            grant_id="g1",
+            scopes=["wants.money.advisor"],
+            fields=["connect.zip"],
+            purpose="local match",
+            created_at_ms=1000 + seq,
+            metadata={},
+        )
+        hash_hex = receipts_mod._chain_hash(prev_hash, payload)
+        chain.append(
+            {
+                "seq": seq,
+                "event_type": "READ",
+                "subscriber_id": _SUBSCRIBER,
+                "grant_id": "g1",
+                "scopes": ["wants.money.advisor"],
+                "fields": ["connect.zip"],
+                "purpose": "local match",
+                "prev_hash": prev_hash,
+                "hash": hash_hex,
+                "signature": receipts_mod._sign(hash_hex),
+                "metadata": {},
+                "created_at_ms": 1000 + seq,
+            }
+        )
+        prev_hash = hash_hex
+    return chain
+
+
+def _verify(chain: list[dict], **kwargs) -> dict:
+    svc = FabricReceiptsService()
+    svc.list_receipts = AsyncMock(return_value=chain)  # type: ignore[method-assign]
+    return asyncio.run(svc.verify_chain(_UID, **kwargs))
+
+
+def test_verify_chain_ok_returns_head():
+    chain = _valid_chain(_UID, 3)
+    out = _verify(chain)
+    assert out["ok"] is True
+    assert out["head_seq"] == 3
+    assert out["head_hash"] == chain[-1]["hash"]
+
+
+def test_verify_chain_detects_sequence_gap():
+    chain = _valid_chain(_UID, 3)
+    del chain[1]  # drop seq 2 -> remaining seqs are 1,3
+    out = _verify(chain)
+    assert out["ok"] is False
+    assert out["reason"] in {"sequence_gap", "prev_hash_mismatch"}
+
+
+def test_verify_chain_detects_tail_truncation_against_pinned_head():
+    """The blind spot a naive walk misses: dropping the newest receipts leaves
+    1..k linking perfectly. A client that pinned head_seq=3 must see the
+    regression to head_seq=2."""
+    full = _valid_chain(_UID, 3)
+    truncated = full[:2]  # newest receipt (seq 3) dropped
+    # Without a pin, the truncated chain looks internally valid (the gap the
+    # attacker relies on).
+    assert _verify(truncated)["ok"] is True
+    # With the pinned head, truncation is caught and fails closed.
+    out = _verify(
+        truncated, expected_head_seq=3, expected_head_hash=full[-1]["hash"]
+    )
+    assert out["ok"] is False
+    assert out["reason"] == "head_regressed"
+
+
+def test_verify_chain_detects_head_divergence():
+    chain = _valid_chain(_UID, 2)
+    out = _verify(chain, expected_head_seq=2, expected_head_hash="deadbeef")
+    assert out["ok"] is False
+    assert out["reason"] == "head_diverged"
+
+
+def test_verify_chain_detects_full_wipe_against_pin():
+    out = _verify([], expected_head_seq=2, expected_head_hash="whatever")
+    assert out["ok"] is False
+    assert out["reason"] == "head_regressed"
 
 
 # ---------------------------------------------------------------------------
@@ -193,15 +293,29 @@ def test_subscriber_read_returns_only_granted_fields():
     )
 
 
-def test_subscriber_read_revoked_grant_denied():
+def test_subscriber_read_denied_codes_collapse_to_generic_no_oracle():
+    """Every handle/grant authz failure must return one generic 403 so the read
+    response cannot be used as a signature/existence oracle (forged vs.
+    valid-but-wrong-subscriber vs. revoked vs. expired must be indistinguishable
+    to the caller). The specific reason is logged server-side only."""
     from hushh_mcp.services.fabric_grant_service import FabricGrantError
 
-    with patch.object(fabric, "get_fabric_grant_service") as factory:
-        factory.return_value.read_for_subscriber = AsyncMock(
-            side_effect=FabricGrantError("FABRIC_GRANT_REVOKED", "Revoked.", 403)
-        )
-        resp = TestClient(_subscriber_app()).post(
-            "/api/fabric/read", json={"handle": "HCT:cGF5bG9hZA.c2lnbmF0dXJl"}
-        )
-    assert resp.status_code == 403
-    assert resp.json()["detail"]["code"] == "FABRIC_GRANT_REVOKED"
+    for specific_code in (
+        "FABRIC_HANDLE_INVALID",
+        "FABRIC_HANDLE_EXPIRED",
+        "FABRIC_SUBSCRIBER_MISMATCH",
+        "FABRIC_GRANT_NOT_FOUND",
+        "FABRIC_GRANT_REVOKED",
+    ):
+        with patch.object(fabric, "get_fabric_grant_service") as factory:
+            factory.return_value.read_for_subscriber = AsyncMock(
+                side_effect=FabricGrantError(specific_code, "denied", 403)
+            )
+            resp = TestClient(_subscriber_app()).post(
+                "/api/fabric/read", json={"handle": "HCT:cGF5bG9hZA.c2lnbmF0dXJl"}
+            )
+        assert resp.status_code == 403
+        detail = resp.json()["detail"]
+        # Generic to the caller; the specific reason is never leaked.
+        assert detail["code"] == "FABRIC_READ_DENIED"
+        assert specific_code not in resp.text


### PR DESCRIPTION
## What & why

Security hardening of the Preference Subscription Fabric (PCHP RFC-002), driven by an adversarial code review + a NIST 800-53 High control-readiness pass + live UAT probing, against the FedRAMP-High / DoD-IL posture we build for. **All changes are additive and backward-compatible; the client contract is unchanged.**

The live UAT surface was already fail-closed everywhere (every `/api/fabric/*` and `/api/pwm` route returns 401 unauthenticated; token tampering, body-injected uid, method tampering, and injection payloads are all rejected; TLS 1.0 refused, 1.2+ enforced; CORS does not reflect untrusted origins). This PR closes the code-level gaps the review found beyond that boundary — including the brand-initiated handshake, which merged to `main` after this branch's original base.

## Changes

- **SC-5 / CWE-400 — rate limiting.** Every fabric + PWM route was unthrottled in code (the `Limiter` had no `default_limits`). Added explicit per-principal limits to: subscriber read (`/api/fabric/read`, the monetizable path), grant write/revoke, receipt list/verify, PWM read/write, **and the whole handshake** (create / lookup / approve / deny / poll). The pairing-code lookup is the code-probe surface and gets the tightest bound (on top of the CSPRNG code + 15-min TTL + sign-in requirement). Cross-instance precision lands when `RATE_LIMIT_STORAGE_URI` (Redis) is set.
- **AU-12 + revocation TOCTOU — atomic, serialized read.** `read_for_subscriber` now re-checks grant status and writes the READ receipt inside **one** advisory-locked transaction (the same per-owner lock `revoke_grant` holds). A read that observes `active` can no longer interleave with a committing revoke, and data can never be served without its receipt committing atomically. **Read-after-revoke provably fails closed.**
- **AU-9 — audit-chain tail-truncation detection.** `verify_chain` now enforces a gap-free sequence and accepts a client-pinned expected head (trust-on-first-use). A plain prev_hash walk returns `ok` after the newest receipts are dropped or the ledger is wiped; pinning the head catches both. Returns `head_seq`/`head_hash` for the client to pin.
- **Info-leak — no read oracle.** Every handle/grant authz failure on `/read` collapses to one generic `FABRIC_READ_DENIED` (403); the specific reason is logged server-side for the owner's audit only.

## Verification

- `pytest` fabric/pwm/privacy/request suites — **47 passed** (5 new: read-deny collapse across all codes, gap-free sequence, tail-truncation vs pinned head, head divergence, full-wipe detection).
- `mypy` + `ruff` clean on all changed files.
- **Real-Postgres smoke** (migrations 118+119, live DB): grant → read (only granted fields + READ receipt) → wrong-subscriber denied → revoke → read-again **fails closed** → `verify_chain` gap-free with `head_seq` → truncation detected against pinned head → ledger is exactly `[GRANT, READ, REVOKE]` with no receipt for denied reads.

## Deferred (tracked in #4677 — need founder/ops decisions, out of code scope)

Asymmetric/KMS-held receipt signing key with rotation + HKDF domain separation; WORM/append-only DB grants for `fabric_receipts`; PWM at-rest encryption vs. a documented data-classification decision; plus smaller code-scope follow-ups (bind READ receipt to connection metadata, keyset-paginate the ledger, scope-registry coverage test).

## Honesty note

This raises code-level conformance to the control objectives; it is **not** a certification. FedRAMP/DoD-IL posture remains **"in pursuit"** pending a 3PAO assessment and ATO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)