### PR TITLE
fix(deploy): authorize production traffic promotion

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -493,7 +493,7 @@ jobs:
 
       - name: Post-deploy backend runtime health gate
         id: health-backend
-        if: steps.scope.outputs.deploy_backend == 'true'
+        if: steps.scope.outputs.deploy_backend == 'true' && steps.promote-traffic.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |
@@ -507,7 +507,7 @@ jobs:
 
       - name: Post-deploy frontend runtime health gate
         id: health-frontend
-        if: steps.scope.outputs.deploy_frontend == 'true'
+        if: steps.scope.outputs.deploy_frontend == 'true' && steps.promote-traffic.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -144,9 +144,26 @@ def test_production_wif_has_one_keyless_setup_path() -> None:
     assert "roles/iam.workloadIdentityUser" in setup_script
     assert 'build_service_account_email="${prod_project_number}-compute' in setup_script
     assert setup_script.count('"roles/iam.serviceAccountUser"') == 1
+    assert 'readonly BACKEND_ARTIFACT_REPOSITORY="gcr.io"' in setup_script
+    assert 'readonly BACKEND_ARTIFACT_LOCATION="us"' in setup_script
+    assert "gcloud artifacts repositories add-iam-policy-binding" in setup_script
+    assert '"roles/artifactregistry.reader"' in setup_script
     assert "gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER" in setup_script
     assert "gh variable set GCP_DEPLOY_SERVICE_ACCOUNT" in setup_script
     assert "service-account keys create" not in setup_script
+
+
+def test_production_health_gates_only_probe_after_successful_promotion() -> None:
+    workflow = _read(".github/workflows/deploy-production.yml")
+
+    assert (
+        "if: steps.scope.outputs.deploy_backend == 'true' "
+        "&& steps.promote-traffic.outcome == 'success'"
+    ) in workflow
+    assert (
+        "if: steps.scope.outputs.deploy_frontend == 'true' "
+        "&& steps.promote-traffic.outcome == 'success'"
+    ) in workflow
 
 
 def test_nonproduction_rollback_targets_are_traffic_bearing_revisions() -> None:

--- a/deploy/iam/README.md
+++ b/deploy/iam/README.md
@@ -18,7 +18,8 @@ The script is idempotent. It:
 3. restricts OIDC subjects to this repository, the `production` GitHub
    environment, and the `main` branch
 4. applies the deployment roles used by the governed production workflow,
-   including act-as authority only on the project build service account
+   including act-as authority only on the project build service account and
+   image-read authority only on the production backend artifact repository
 5. writes the provider and service-account identifiers as GitHub `production`
    environment variables
 6. runs the live deployment-environment governance verifier

--- a/deploy/iam/setup_production_github_wif.sh
+++ b/deploy/iam/setup_production_github_wif.sh
@@ -11,6 +11,8 @@ readonly POOL_ID="github-actions-prod"
 readonly PROVIDER_ID="hushh-research-prod"
 readonly DEPLOY_SERVICE_ACCOUNT_ID="github-actions-prod-deployer"
 readonly DEPLOY_SERVICE_ACCOUNT_EMAIL="${DEPLOY_SERVICE_ACCOUNT_ID}@${PROD_PROJECT_ID}.iam.gserviceaccount.com"
+readonly BACKEND_ARTIFACT_REPOSITORY="gcr.io"
+readonly BACKEND_ARTIFACT_LOCATION="us"
 readonly ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref"
 readonly ATTRIBUTE_CONDITION="assertion.sub == 'repo:${GITHUB_REPOSITORY}:environment:${GITHUB_ENVIRONMENT}' && assertion.ref == 'refs/heads/main'"
 
@@ -121,6 +123,17 @@ gcloud iam service-accounts add-iam-policy-binding "${build_service_account_emai
 for deploy_role in "${DEPLOY_PROJECT_ROLES[@]}"; do
   add_project_role_binding "${deploy_role}"
 done
+
+# Cloud Run validates the candidate image while shifting traffic. Keep image
+# read authority scoped to the production backend repository instead of adding
+# Artifact Registry read access across the entire project.
+gcloud artifacts repositories add-iam-policy-binding "${BACKEND_ARTIFACT_REPOSITORY}" \
+  --project="${PROD_PROJECT_ID}" \
+  --location="${BACKEND_ARTIFACT_LOCATION}" \
+  --role="roles/artifactregistry.reader" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT_EMAIL}" \
+  --quiet \
+  --format=none
 
 readonly provider_resource="projects/${prod_project_number}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
 printf '%s' "${provider_resource}" | gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER \


### PR DESCRIPTION
## Current truth

The first keyless production run authenticated, backed up, migrated, built, and validated the candidate revision. Traffic promotion failed closed because the deploy identity could not read the candidate image from the production `gcr.io` Artifact Registry repository. The old revision remained at 100% traffic.

## Change

- grant the canonical production deploy identity repository-scoped Artifact Registry reader authority
- keep the authority in the idempotent WIF setup script so there is still one setup path
- run backend/frontend health gates only after traffic promotion succeeds, preventing an old serving revision from being mistaken for candidate health
- add focused contract coverage and update the IAM ownership documentation

## Verification

- 10 focused deployment-contract tests passed
- Ruff passed for the changed Python test
- shell syntax and `git diff --check` passed
- the exact repository IAM binding is already applied in production

## Release evidence

Failed-closed production run: https://github.com/hushh-labs/hushh-research/actions/runs/30308582814

The follow-up production dispatch will remain backend-only and use the governed backup/migration path.