### PR TITLE
fix(deploy): authorize production runtime identity

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -493,7 +493,7 @@ jobs:
 
       - name: Post-deploy backend runtime health gate
         id: health-backend
-        if: steps.scope.outputs.deploy_backend == 'true'
+        if: steps.scope.outputs.deploy_backend == 'true' && steps.promote-traffic.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |
@@ -507,7 +507,7 @@ jobs:
 
       - name: Post-deploy frontend runtime health gate
         id: health-frontend
-        if: steps.scope.outputs.deploy_frontend == 'true'
+        if: steps.scope.outputs.deploy_frontend == 'true' && steps.promote-traffic.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -144,9 +144,26 @@ def test_production_wif_has_one_keyless_setup_path() -> None:
     assert "roles/iam.workloadIdentityUser" in setup_script
     assert 'build_service_account_email="${prod_project_number}-compute' in setup_script
     assert setup_script.count('"roles/iam.serviceAccountUser"') == 1
+    assert 'readonly BACKEND_ARTIFACT_REPOSITORY="gcr.io"' in setup_script
+    assert 'readonly BACKEND_ARTIFACT_LOCATION="us"' in setup_script
+    assert "gcloud artifacts repositories add-iam-policy-binding" in setup_script
+    assert '"roles/artifactregistry.reader"' in setup_script
     assert "gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER" in setup_script
     assert "gh variable set GCP_DEPLOY_SERVICE_ACCOUNT" in setup_script
     assert "service-account keys create" not in setup_script
+
+
+def test_production_health_gates_only_probe_after_successful_promotion() -> None:
+    workflow = _read(".github/workflows/deploy-production.yml")
+
+    assert (
+        "if: steps.scope.outputs.deploy_backend == 'true' "
+        "&& steps.promote-traffic.outcome == 'success'"
+    ) in workflow
+    assert (
+        "if: steps.scope.outputs.deploy_frontend == 'true' "
+        "&& steps.promote-traffic.outcome == 'success'"
+    ) in workflow
 
 
 def test_nonproduction_rollback_targets_are_traffic_bearing_revisions() -> None:

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -143,7 +143,10 @@ def test_production_wif_has_one_keyless_setup_path() -> None:
     assert "assertion.ref == 'refs/heads/main'" in setup_script
     assert "roles/iam.workloadIdentityUser" in setup_script
     assert 'build_service_account_email="${prod_project_number}-compute' in setup_script
-    assert setup_script.count('"roles/iam.serviceAccountUser"') == 1
+    assert (
+        'RUNTIME_SERVICE_ACCOUNT_EMAIL="consent-protocol-runtime@${PROD_PROJECT_ID}' in setup_script
+    )
+    assert setup_script.count('"roles/iam.serviceAccountUser"') == 2
     assert 'readonly BACKEND_ARTIFACT_REPOSITORY="gcr.io"' in setup_script
     assert 'readonly BACKEND_ARTIFACT_LOCATION="us"' in setup_script
     assert "gcloud artifacts repositories add-iam-policy-binding" in setup_script

--- a/deploy/iam/README.md
+++ b/deploy/iam/README.md
@@ -18,8 +18,9 @@ The script is idempotent. It:
 3. restricts OIDC subjects to this repository, the `production` GitHub
    environment, and the `main` branch
 4. applies the deployment roles used by the governed production workflow,
-   including act-as authority only on the project build service account and
-   image-read authority only on the production backend artifact repository
+   including act-as authority only on the exact build and backend runtime
+   service accounts, plus image-read authority only on the production backend
+   artifact repository
 5. writes the provider and service-account identifiers as GitHub `production`
    environment variables
 6. runs the live deployment-environment governance verifier

--- a/deploy/iam/README.md
+++ b/deploy/iam/README.md
@@ -18,7 +18,8 @@ The script is idempotent. It:
 3. restricts OIDC subjects to this repository, the `production` GitHub
    environment, and the `main` branch
 4. applies the deployment roles used by the governed production workflow,
-   including act-as authority only on the project build service account
+   including act-as authority only on the project build service account and
+   image-read authority only on the production backend artifact repository
 5. writes the provider and service-account identifiers as GitHub `production`
    environment variables
 6. runs the live deployment-environment governance verifier

--- a/deploy/iam/setup_production_github_wif.sh
+++ b/deploy/iam/setup_production_github_wif.sh
@@ -11,6 +11,7 @@ readonly POOL_ID="github-actions-prod"
 readonly PROVIDER_ID="hushh-research-prod"
 readonly DEPLOY_SERVICE_ACCOUNT_ID="github-actions-prod-deployer"
 readonly DEPLOY_SERVICE_ACCOUNT_EMAIL="${DEPLOY_SERVICE_ACCOUNT_ID}@${PROD_PROJECT_ID}.iam.gserviceaccount.com"
+readonly RUNTIME_SERVICE_ACCOUNT_EMAIL="consent-protocol-runtime@${PROD_PROJECT_ID}.iam.gserviceaccount.com"
 readonly BACKEND_ARTIFACT_REPOSITORY="gcr.io"
 readonly BACKEND_ARTIFACT_LOCATION="us"
 readonly ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref"
@@ -114,6 +115,15 @@ gcloud iam service-accounts add-iam-policy-binding "${DEPLOY_SERVICE_ACCOUNT_EMA
   --format=none
 
 gcloud iam service-accounts add-iam-policy-binding "${build_service_account_email}" \
+  --project="${PROD_PROJECT_ID}" \
+  --role="roles/iam.serviceAccountUser" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT_EMAIL}" \
+  --quiet \
+  --format=none
+
+# Cloud Run revalidates act-as authority on the revision runtime identity when
+# traffic changes. Keep this binding on the exact runtime service account.
+gcloud iam service-accounts add-iam-policy-binding "${RUNTIME_SERVICE_ACCOUNT_EMAIL}" \
   --project="${PROD_PROJECT_ID}" \
   --role="roles/iam.serviceAccountUser" \
   --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT_EMAIL}" \

--- a/deploy/iam/setup_production_github_wif.sh
+++ b/deploy/iam/setup_production_github_wif.sh
@@ -11,6 +11,8 @@ readonly POOL_ID="github-actions-prod"
 readonly PROVIDER_ID="hushh-research-prod"
 readonly DEPLOY_SERVICE_ACCOUNT_ID="github-actions-prod-deployer"
 readonly DEPLOY_SERVICE_ACCOUNT_EMAIL="${DEPLOY_SERVICE_ACCOUNT_ID}@${PROD_PROJECT_ID}.iam.gserviceaccount.com"
+readonly BACKEND_ARTIFACT_REPOSITORY="gcr.io"
+readonly BACKEND_ARTIFACT_LOCATION="us"
 readonly ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref"
 readonly ATTRIBUTE_CONDITION="assertion.sub == 'repo:${GITHUB_REPOSITORY}:environment:${GITHUB_ENVIRONMENT}' && assertion.ref == 'refs/heads/main'"
 
@@ -121,6 +123,17 @@ gcloud iam service-accounts add-iam-policy-binding "${build_service_account_emai
 for deploy_role in "${DEPLOY_PROJECT_ROLES[@]}"; do
   add_project_role_binding "${deploy_role}"
 done
+
+# Cloud Run validates the candidate image while shifting traffic. Keep image
+# read authority scoped to the production backend repository instead of adding
+# Artifact Registry read access across the entire project.
+gcloud artifacts repositories add-iam-policy-binding "${BACKEND_ARTIFACT_REPOSITORY}" \
+  --project="${PROD_PROJECT_ID}" \
+  --location="${BACKEND_ARTIFACT_LOCATION}" \
+  --role="roles/artifactregistry.reader" \
+  --member="serviceAccount:${DEPLOY_SERVICE_ACCOUNT_EMAIL}" \
+  --quiet \
+  --format=none
 
 readonly provider_resource="projects/${prod_project_number}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
 printf '%s' "${provider_resource}" | gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER \


### PR DESCRIPTION
## Current truth

The second governed production attempt passed backup, migrations, build, candidate identity, and environment parity, then failed closed before traffic moved. Cloud Run revalidates `iam.serviceAccounts.actAs` on the candidate runtime identity during traffic promotion. The old revision remains at 100% traffic.

## Change

- grant Service Account User only on the exact production backend runtime service account
- retain the existing exact build-service-account binding; no project-wide act-as grant
- document both narrow authority boundaries in the one canonical WIF setup path
- update focused contract coverage

## Verification

- 10 focused deployment-contract tests passed
- Ruff and format checks passed
- shell syntax and `git diff --check` passed
- the exact runtime-service-account IAM binding is already applied in production

Failed-closed evidence: https://github.com/hushh-labs/hushh-research/actions/runs/30309777759