### PR TITLE
fix(ci): scope migration workflow to the production GitHub Environment

### DIFF
--- a/.github/workflows/migrate-uat-to-prod-cloudsql.yml
+++ b/.github/workflows/migrate-uat-to-prod-cloudsql.yml
@@ -62,6 +62,11 @@ jobs:
     name: Migrate UAT to Prod Cloud SQL
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # WIF vars (GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_DEPLOY_SERVICE_ACCOUNT) are
+    # scoped to the `production` GitHub Environment, not the repo; every other
+    # job touching prod declares this. Without it both vars resolve empty and
+    # google-github-actions/auth fails closed.
+    environment: production
     steps:
       - name: Validate apply authorization
         shell: bash


### PR DESCRIPTION
One-line fix: the UAT->prod Cloud SQL migration workflow needs `environment: production` to see the environment-scoped WIF vars, same as every other job touching hushh-pda. Confirmed via a failed dry-run dispatch (auth failed closed with both WIF vars empty).