### PR TITLE
fix(ci): pre-seed extension set on prod before UAT->prod Cloud SQL restore

### DIFF
--- a/.github/workflows/migrate-uat-to-prod-cloudsql.yml
+++ b/.github/workflows/migrate-uat-to-prod-cloudsql.yml
@@ -222,6 +222,45 @@ jobs:
             exit 1
           fi
 
+      - name: Reset production schema and pre-seed extensions
+        if: inputs.mode == 'apply'
+        shell: bash
+        env:
+          PGPASSWORD_UAT: ${{ steps.creds.outputs.uat_db_password }}
+          PGPASSWORD_PROD: ${{ steps.creds.outputs.prod_db_password }}
+        run: |
+          set -euo pipefail
+          PSQL=/usr/lib/postgresql/15/bin/psql
+          PROD_DSN="host=127.0.0.1 port=${PROD_PROXY_PORT} user=${{ steps.creds.outputs.prod_db_user }} dbname=${PROD_DB_NAME}"
+
+          # A schema-scoped custom-format dump doesn't reliably record the
+          # dependency edge between an extension (e.g. pgvector) and a table
+          # column that uses its type, so pg_restore can try to create that
+          # column before the extension exists ("type public.vector does not
+          # exist"), in every section including pre-data alone. Fully wiping
+          # `public` and pre-creating exactly UAT's extension set (in the same
+          # order UAT reports) before pg_restore ever runs removes the ordering
+          # hazard: the extensions already exist, so restore's own
+          # `CREATE EXTENSION IF NOT EXISTS` becomes a no-op, and no table can
+          # be created before a type it needs.
+          PGPASSWORD="${PGPASSWORD_PROD}" "${PSQL}" "${PROD_DSN}" -v ON_ERROR_STOP=1 -c \
+            "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+
+          UAT_EXTENSIONS="$(PGPASSWORD="${PGPASSWORD_UAT}" "${PSQL}" \
+            "host=127.0.0.1 port=${UAT_PROXY_PORT} user=${{ steps.creds.outputs.uat_db_user }} dbname=postgres" \
+            -tAX -c "SELECT extname FROM pg_extension WHERE extname != 'plpgsql' ORDER BY extname;")"
+
+          if [ -n "${UAT_EXTENSIONS}" ]; then
+            echo "Pre-seeding extensions: ${UAT_EXTENSIONS}"
+            while IFS= read -r ext; do
+              [ -n "${ext}" ] || continue
+              PGPASSWORD="${PGPASSWORD_PROD}" "${PSQL}" "${PROD_DSN}" -v ON_ERROR_STOP=1 -c \
+                "CREATE EXTENSION IF NOT EXISTS \"${ext}\";"
+            done <<< "${UAT_EXTENSIONS}"
+          else
+            echo "UAT reports no non-default extensions; nothing to pre-seed."
+          fi
+
       - name: Restore into production Cloud SQL
         if: inputs.mode == 'apply'
         shell: bash
@@ -229,27 +268,17 @@ jobs:
           PGPASSWORD: ${{ steps.creds.outputs.prod_db_password }}
         run: |
           set -euo pipefail
-          # Sectioned restore, not a single pass. A schema-scoped custom-format
-          # dump doesn't reliably record the dependency edge between an
-          # extension (e.g. pgvector) and a table column that uses its type, so
-          # a single-pass restore can try to create that column before the
-          # extension exists. Restoring pre-data (schemas, extensions, types,
-          # table shells) to completion first, then data, then post-data
-          # (indexes/constraints/FKs) removes the ordering hazard entirely.
-          # --clean --if-exists only applies to the pre-data pass, which is
-          # where the schema/extension/table drops live; it also makes the
-          # whole restore idempotent when re-run against a target that was
-          # partially populated by an earlier attempt.
-          DSN="host=127.0.0.1 port=${PROD_PROXY_PORT} user=${{ steps.creds.outputs.prod_db_user }} dbname=${PROD_DB_NAME}"
-          for section in pre-data data post-data; do
-            args=(--dbname="${DSN}" --no-owner --no-privileges --exit-on-error --section="${section}")
-            if [ "${section}" = "pre-data" ]; then
-              args+=(--clean --if-exists)
-            fi
-            echo "::group::pg_restore --section=${section}"
-            /usr/lib/postgresql/15/bin/pg_restore "${args[@]}" /tmp/uat.dump
-            echo "::endgroup::"
-          done
+          # No --clean: the previous step already wiped the target schema and
+          # pre-seeded its extensions, so a plain restore just creates
+          # everything into a known-empty, correctly-provisioned schema.
+          # --clean here would try to DROP SCHEMA public again and fail on the
+          # very extensions this step just pre-seeded.
+          /usr/lib/postgresql/15/bin/pg_restore \
+            --dbname="host=127.0.0.1 port=${PROD_PROXY_PORT} user=${{ steps.creds.outputs.prod_db_user }} dbname=${PROD_DB_NAME}" \
+            --no-owner \
+            --no-privileges \
+            --exit-on-error \
+            /tmp/uat.dump
 
       - name: Verify parity
         if: inputs.mode == 'apply'


### PR DESCRIPTION
Follow-up to #4689: sectioning the restore did not fix the pgvector ordering hazard (the same error reproduced inside pre-data alone). Explicitly wipes the target schema and pre-creates UAT's live-queried extension set before pg_restore runs, dropping --clean since the wipe already happened. Confirmed against the live production Cloud SQL cutover in progress.