### PR TITLE
fix(deploy): production migration steps use Cloud SQL Auth Proxy, matching UAT

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -269,37 +269,59 @@ jobs:
           echo "backup_id=${BACKUP_ID}" >> "$GITHUB_OUTPUT"
           echo "backup_completed_at=${BACKUP_COMPLETED_AT}" >> "$GITHUB_OUTPUT"
 
+      - name: Install Cloud SQL Auth Proxy
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64 \
+            -o /usr/local/bin/cloud-sql-proxy
+          chmod +x /usr/local/bin/cloud-sql-proxy
+
       - name: Apply production release migrations
         if: steps.scope.outputs.deploy_backend == 'true'
         shell: bash
         run: |
           set -euo pipefail
 
-          SERVICE_JSON="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
-            --project="${{ env.GCP_PROJECT_ID }}" \
-            --region="${{ env.GCP_REGION }}" \
-            --format=json)"
-
-          # Keep the production DB migration runner aligned with the UAT deploy lane:
-          # apply the canonical release manifest before deploying code that reads it.
-          DB_HOST="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_HOST") | .value // empty' | tail -n 1)"
-          DB_PORT="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_PORT") | .value // empty' | tail -n 1)"
-          DB_NAME="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_NAME") | .value // empty' | tail -n 1)"
-
+          # Production is Cloud SQL, reached only through the Auth Proxy from this
+          # runner (there is no plain DB_HOST/DB_PORT env var on the deployed
+          # service to scrape -- that approach never matched how this app actually
+          # resolves its DB connection, see BACKEND_RUNTIME_CONFIG_JSON's
+          # db_unix_socket key and hydrate_runtime_environment()). Mirrors the UAT
+          # deploy lane's proven pattern exactly.
           DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
           DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"
           echo "::add-mask::${DB_USER}"
           echo "::add-mask::${DB_PASSWORD}"
 
-          if [ -z "${DB_HOST}" ] || [ -z "${DB_USER}" ] || [ -z "${DB_PASSWORD}" ]; then
-            echo "Failed to resolve DB credentials/host for production release migrations."
-            exit 1
-          fi
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 6544 \
+            ${GOOGLE_GHA_CREDS_PATH:+--credentials-file="${GOOGLE_GHA_CREDS_PATH}"} \
+            "${{ env.PROD_CLOUDSQL_INSTANCE }}" >/tmp/cloud-sql-proxy-prod.log 2>&1 &
+          PROXY_PID=$!
+          trap 'kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
 
-          export DB_HOST DB_USER DB_PASSWORD
-          export DB_PORT="${DB_PORT:-5432}"
-          export DB_NAME="${DB_NAME:-postgres}"
-          export DB_SSLMODE=require
+          python3 - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 20
+          while time.time() < deadline:
+              with socket.socket() as sock:
+                  sock.settimeout(0.5)
+                  if sock.connect_ex(("127.0.0.1", 6544)) == 0:
+                      raise SystemExit(0)
+              time.sleep(0.25)
+          raise SystemExit("Cloud SQL proxy did not bind 127.0.0.1:6544 in time")
+          PY
+
+          export DB_HOST=127.0.0.1
+          export DB_PORT=6544
+          export DB_NAME="${{ env.PROD_DB_NAME }}"
+          export DB_USER DB_PASSWORD
 
           (
             cd consent-protocol
@@ -312,34 +334,37 @@ jobs:
         run: |
           set -euo pipefail
 
-          SERVICE_JSON="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
-            --project="${{ env.GCP_PROJECT_ID }}" \
-            --region="${{ env.GCP_REGION }}" \
-            --format=json)"
-
-          # DB host/port/name come from the deployed service when present, but newer
-          # revisions no longer expose DB_HOST as a plain env var (it moved into the
-          # runtime config JSON), so the template scrape can return empty. Fall back to
-          # the canonical prod DB host used by the secret-sync step above so the gate
-          # does not break just because a prior failed revision changed the env shape.
-          # `// empty` guards against jq emitting the literal string "null".
-          DB_HOST="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_HOST") | .value // empty' | tail -n 1)"
-          DB_PORT="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_PORT") | .value // empty' | tail -n 1)"
-          DB_NAME="$(printf '%s' "${SERVICE_JSON}" | jq -r '.spec.template.spec.containers[0].env[] | select(.name=="DB_NAME") | .value // empty' | tail -n 1)"
-
           DB_USER="$(gcloud secrets versions access latest --secret=DB_USER --project="${{ env.GCP_PROJECT_ID }}")"
           DB_PASSWORD="$(gcloud secrets versions access latest --secret=DB_PASSWORD --project="${{ env.GCP_PROJECT_ID }}")"
           echo "::add-mask::${DB_USER}"
           echo "::add-mask::${DB_PASSWORD}"
 
-          if [ -z "${DB_HOST}" ] || [ -z "${DB_USER}" ] || [ -z "${DB_PASSWORD}" ]; then
-            echo "Failed to resolve DB credentials/host for migration governance gate."
-            exit 1
-          fi
+          cloud-sql-proxy \
+            --address 127.0.0.1 \
+            --port 6544 \
+            ${GOOGLE_GHA_CREDS_PATH:+--credentials-file="${GOOGLE_GHA_CREDS_PATH}"} \
+            "${{ env.PROD_CLOUDSQL_INSTANCE }}" >/tmp/cloud-sql-proxy-prod-drift-gate.log 2>&1 &
+          PROXY_PID=$!
+          trap 'kill "${PROXY_PID}" >/dev/null 2>&1 || true' EXIT
 
-          export DB_HOST DB_USER DB_PASSWORD
-          export DB_PORT="${DB_PORT:-5432}"
-          export DB_NAME="${DB_NAME:-postgres}"
+          python3 - <<'PY'
+          import socket
+          import time
+
+          deadline = time.time() + 20
+          while time.time() < deadline:
+              with socket.socket() as sock:
+                  sock.settimeout(0.5)
+                  if sock.connect_ex(("127.0.0.1", 6544)) == 0:
+                      raise SystemExit(0)
+              time.sleep(0.25)
+          raise SystemExit("Cloud SQL proxy did not bind 127.0.0.1:6544 in time")
+          PY
+
+          export DB_HOST=127.0.0.1
+          export DB_PORT=6544
+          export DB_NAME="${{ env.PROD_DB_NAME }}"
+          export DB_USER DB_PASSWORD
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/db_migration_release_guard.py \
             --report-path /tmp/db-migration-guard-report.json
 


### PR DESCRIPTION
Both DB-touching steps in deploy-production.yml derived DB_HOST by scraping the deployed Cloud Run service's env vars, which has never been how this app resolves its DB connection (that's BACKEND_RUNTIME_CONFIG_JSON's db_unix_socket key). This never surfaced before because production never actually pointed at Cloud SQL. Fixed by installing and driving a Cloud SQL Auth Proxy from the runner, mirroring deploy-uat.yml's proven pattern exactly. Confirmed against the live production Cloud SQL cutover deploy in progress.