### PR TITLE
feat(deploy): enable remote MCP and developer API in production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -225,8 +225,8 @@ jobs:
             --cloudsql-instance-connection-name "${{ env.PROD_CLOUDSQL_INSTANCE }}" \
             --consent-sse-enabled "false" \
             --sync-remote-enabled "false" \
-            --developer-api-enabled "false" \
-            --remote-mcp-enabled "false" \
+            --developer-api-enabled "true" \
+            --remote-mcp-enabled "true" \
             --cors-allowed-origins "${{ env.APP_FRONTEND_ORIGIN }}" \
             --obs-data-stale-ratio-threshold "0.25" \
             --passkey-allowed-rp-ids "localhost,127.0.0.1,one.hushh.ai" \


### PR DESCRIPTION
Makes the developer-API/remote-MCP posture standing, not a one-off secret patch: the 'Sync canonical hosted runtime secrets' step regenerates BACKEND_RUNTIME_CONFIG_JSON from scratch on every production deploy, so a manual secret edit enabling these flags was silently reverted on the very next deploy (confirmed live: version 28 enabled it, version 29 reverted it moments later during this exact cutover). Production now carries the same developer-API/remote-MCP posture as UAT on every future deploy.