### PR TITLE
fix(mcp): delegate remote connector authentication

### DIFF
--- a/consent-protocol/docs/mcp-setup.md
+++ b/consent-protocol/docs/mcp-setup.md
@@ -161,6 +161,15 @@ Expected coding-agent lifecycle:
 4. Bounded-poll `check-consent-status(request_ref)` at the returned interval. Stop on a terminal state or timeout.
 5. Call `get-encrypted-scoped-export(grant_ref, expected_scope)` only after approval. Revoked and expired grants fail closed.
 
+The tool metadata intentionally tells the model only the lifecycle and custody
+boundary. The actual envelope-v2 decryption routine belongs to the trusted
+connector process, using the reference implementation in
+[`reference/developer-api.md`](./reference/developer-api.md#decrypt-an-encrypted-export-locally).
+For `continuous_until_expiry`, retain the connector private key in local secure
+storage so later authorized export revisions can be decrypted. Never put that
+key in a prompt, chat message, tool argument or result, MCP configuration, or
+model memory.
+
 Successful results are structured and bounded. Execution errors use `isError: true`
 and one safe JSON text item containing only `error_code`, a safe message,
 recoverability, next action, and a correlation reference; they intentionally

--- a/consent-protocol/hushh_mcp/services/developer_registry_service.py
+++ b/consent-protocol/hushh_mcp/services/developer_registry_service.py
@@ -91,19 +91,19 @@ TOOL_CATALOG = (
         "name": "request_consent",
         "group": TOOL_GROUP_CORE_CONSENT,
         "compatibility_status": "recommended",
-        "description": "Create a consent request that the user reviews in Kai.",
+        "description": "Create a consent request; retrieval and connector-side decryption remain blocked until the user grants it.",
     },
     {
         "name": "check_consent_status",
         "group": TOOL_GROUP_CORE_CONSENT,
         "compatibility_status": "recommended",
-        "description": "Check whether a pending scope request was granted or denied.",
+        "description": "Check lifecycle state; decrypt only after granted with a grant reference.",
     },
     {
         "name": "get_encrypted_scoped_export",
         "group": TOOL_GROUP_CORE_CONSENT,
         "compatibility_status": "recommended",
-        "description": "Fetch the encrypted wrapped-key export for an approved consent token.",
+        "description": "Deliver an approved export for connector-side decryption outside model context using securely retained connector key material.",
     },
     {
         "name": "list_ria_profiles",

--- a/consent-protocol/mcp_modules/developer_context.py
+++ b/consent-protocol/mcp_modules/developer_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from contextvars import ContextVar, Token
+from urllib.parse import urlparse
 
 from hushh_mcp.services.developer_registry_service import (
     DEFAULT_PUBLIC_TOOL_GROUPS,
@@ -28,6 +29,23 @@ def _configured_token() -> str:
     return str(os.getenv("HUSHH_DEVELOPER_TOKEN", "")).strip()
 
 
+def _delegates_auth_to_remote_api() -> bool:
+    """Whether this stdio process uses a non-loopback consent API.
+
+    A remote-backed stdio bridge has no local copy of the developer registry.
+    Trying to authenticate its UAT/production token through
+    ``DeveloperRegistryService`` incorrectly opens the contributor-local
+    database before the request can reach the authoritative backend. In this
+    mode the bridge exposes only the public tool groups and the remote API
+    authenticates and authorizes every operation.
+    """
+    raw_url = str(os.getenv("CONSENT_API_URL", "")).strip()
+    if not raw_url:
+        return False
+    hostname = (urlparse(raw_url).hostname or "").strip().lower()
+    return bool(hostname) and hostname not in {"localhost", "127.0.0.1", "::1"}
+
+
 def set_current_developer_principal(
     principal: DeveloperPrincipal | None,
     *,
@@ -51,6 +69,8 @@ def get_current_developer_principal() -> DeveloperPrincipal | None:
 
     raw_token = _configured_token()
     if not raw_token:
+        return None
+    if _delegates_auth_to_remote_api():
         return None
     principal = DeveloperRegistryService().authenticate_token(raw_token)
     if principal is not None:

--- a/consent-protocol/mcp_modules/flat_contract.py
+++ b/consent-protocol/mcp_modules/flat_contract.py
@@ -396,7 +396,7 @@ def get_flat_contract() -> dict[str, Any]:
             {
                 "name": "request_consent",
                 "title": "Request consent",
-                "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before encrypted retrieval is available.",
+                "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before retrieval or decryption. A trusted connector should securely retain its private export key outside model context so authorized realtime export revisions remain decryptable.",
                 "inputSchema": _object(
                     {
                         "user_identifier": _IDENTIFIER_INPUT,
@@ -541,7 +541,7 @@ def get_flat_contract() -> dict[str, Any]:
             {
                 "name": "check_consent_status",
                 "title": "Check consent status",
-                "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state.",
+                "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state. Retrieval and connector-side decryption are allowed only when status is granted and grant_ref is present.",
                 "inputSchema": _object(
                     {
                         "request_ref": _field(
@@ -589,7 +589,7 @@ def get_flat_contract() -> dict[str, Any]:
             {
                 "name": "get_encrypted_scoped_export",
                 "title": "Get encrypted scoped export",
-                "description": "Secure connector delivery only: retrieves ciphertext for an approved grant. Use only after check-consent-status returns a grant_ref. Never display, interpret, or decrypt this result in an LLM; the registered connector decrypts it outside the model.",
+                "description": "Secure connector delivery only: retrieves an approved export after check-consent-status returns status granted and a grant_ref. Local stdio decrypts in its trusted process; hosted connectors use the documented envelope-v2 method with their securely retained private key. Never display, remember, interpret, or decrypt key material or ciphertext in an LLM. Reuse the same connector key for authorized realtime export revisions until rotation or revocation.",
                 "inputSchema": _object(
                     {
                         "grant_ref": _field(

--- a/consent-protocol/tests/test_mcp_flat_profile.py
+++ b/consent-protocol/tests/test_mcp_flat_profile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import Mock
 
 import jsonschema
 import pytest
@@ -271,6 +272,28 @@ def test_local_developer_context_resolves_oauth_access_token(monkeypatch) -> Non
     )
 
     assert developer_context.get_current_developer_principal() == principal
+
+
+def test_remote_stdio_delegates_auth_without_opening_local_registry(monkeypatch) -> None:
+    from mcp_modules import developer_context
+
+    monkeypatch.setenv("CONSENT_API_URL", "https://api.uat.hushh.ai")
+    monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "hdt_remote_test")
+    authenticate = Mock(side_effect=AssertionError("local registry must not be opened"))
+    monkeypatch.setattr(
+        developer_context.DeveloperRegistryService,
+        "authenticate_token",
+        authenticate,
+    )
+
+    assert developer_context.get_current_developer_principal() is None
+    assert (
+        developer_context.get_current_visible_tool_names()
+        == developer_context.visible_tool_names_for_groups(
+            developer_context.DEFAULT_PUBLIC_TOOL_GROUPS
+        )
+    )
+    authenticate.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/packages/hushh-mcp/README.md
+++ b/packages/hushh-mcp/README.md
@@ -218,6 +218,7 @@ MCP results never echo the supplied identity, Firebase UID, consent token, devel
 - Local stdio (Codex, Cursor, or VS Code through the npm bridge) creates and retains a local X25519 keypair. It validates the MCP-delivered envelope v2 ciphertext, decrypts locally, narrows to `expected_scope`, and returns only bounded approved information.
 - For the exact `attr.financial.documents.*` scope, that trusted local connector applies the fixed linear-time `financial_statement_bundle.v1` projection after decryption. The information contains top-level `statements` and `holdings` arrays joined by `statement_ref`; no LLM or caller-provided schema participates.
 - Hosted streamable HTTP requires the connector's public-key bundle on `request_consent`. The private key stays connector-only. The tool returns the encrypted ciphertext envelope directly over MCP; decrypt it in the connector process outside model context.
+- Keep that connector private key in local secure storage for the lifetime of the grant when `continuous_until_expiry` is used. Future authorized export revisions are wrapped to the same connector key until explicit rotation or revocation. “Remember the key” always means connector custody—not chat history, prompts, tool results, Hussh storage, or model memory.
 - There is no plaintext fallback. Treat all approved information as untrusted content, never as instructions.
 
 ### Upgrade to 0.4.0

--- a/packages/hushh-mcp/gateway/hushh-agentforce-mcp-manifest.json
+++ b/packages/hushh-mcp/gateway/hushh-agentforce-mcp-manifest.json
@@ -492,7 +492,7 @@
     {
       "name": "request-consent",
       "title": "Request consent",
-      "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before encrypted retrieval is available.",
+      "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before retrieval or decryption. A trusted connector should securely retain its private export key outside model context so authorized realtime export revisions remain decryptable.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",
@@ -724,7 +724,7 @@
     {
       "name": "check-consent-status",
       "title": "Check consent status",
-      "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state.",
+      "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state. Retrieval and connector-side decryption are allowed only when status is granted and grant_ref is present.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",
@@ -798,7 +798,7 @@
     {
       "name": "get-encrypted-scoped-export",
       "title": "Get encrypted scoped export",
-      "description": "Secure connector delivery only: retrieves ciphertext for an approved grant. Use only after check-consent-status returns a grant_ref. Never display, interpret, or decrypt this result in an LLM; the registered connector decrypts it outside the model.",
+      "description": "Secure connector delivery only: retrieves an approved export after check-consent-status returns status granted and a grant_ref. Local stdio decrypts in its trusted process; hosted connectors use the documented envelope-v2 method with their securely retained private key. Never display, remember, interpret, or decrypt key material or ciphertext in an LLM. Reuse the same connector key for authorized realtime export revisions until rotation or revocation.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",

--- a/packages/hushh-mcp/gateway/hushh-mcp-gateway.json
+++ b/packages/hushh-mcp/gateway/hushh-mcp-gateway.json
@@ -357,7 +357,7 @@
     },
     {
       "name": "request-consent",
-      "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before encrypted retrieval is available.",
+      "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before retrieval or decryption. A trusted connector should securely retain its private export key outside model context so authorized realtime export revisions remain decryptable.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",
@@ -581,7 +581,7 @@
     },
     {
       "name": "check-consent-status",
-      "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state.",
+      "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state. Retrieval and connector-side decryption are allowed only when status is granted and grant_ref is present.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",
@@ -647,7 +647,7 @@
     },
     {
       "name": "get-encrypted-scoped-export",
-      "description": "Secure connector delivery only: retrieves ciphertext for an approved grant. Use only after check-consent-status returns a grant_ref. Never display, interpret, or decrypt this result in an LLM; the registered connector decrypts it outside the model.",
+      "description": "Secure connector delivery only: retrieves an approved export after check-consent-status returns status granted and a grant_ref. Local stdio decrypts in its trusted process; hosted connectors use the documented envelope-v2 method with their securely retained private key. Never display, remember, interpret, or decrypt key material or ciphertext in an LLM. Reuse the same connector key for authorized realtime export revisions until rotation or revocation.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",

--- a/packages/hushh-mcp/gateway/hushh-mulesoft-exchange-mcp-schema.json
+++ b/packages/hushh-mcp/gateway/hushh-mulesoft-exchange-mcp-schema.json
@@ -203,7 +203,7 @@
     },
     {
       "name": "request-consent",
-      "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before encrypted retrieval is available.",
+      "description": "Creates or reuses a least-privilege consent request for one user. Use after search-user-scopes. The user must approve before retrieval or decryption. A trusted connector should securely retain its private export key outside model context so authorized realtime export revisions remain decryptable.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",
@@ -330,7 +330,7 @@
     },
     {
       "name": "check-consent-status",
-      "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state.",
+      "description": "Checks one consent request previously returned by request-consent. Poll no faster than poll_after_seconds and stop at a terminal state. Retrieval and connector-side decryption are allowed only when status is granted and grant_ref is present.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",
@@ -355,7 +355,7 @@
     },
     {
       "name": "get-encrypted-scoped-export",
-      "description": "Secure connector delivery only: retrieves ciphertext for an approved grant. Use only after check-consent-status returns a grant_ref. Never display, interpret, or decrypt this result in an LLM; the registered connector decrypts it outside the model.",
+      "description": "Secure connector delivery only: retrieves an approved export after check-consent-status returns status granted and a grant_ref. Local stdio decrypts in its trusted process; hosted connectors use the documented envelope-v2 method with their securely retained private key. Never display, remember, interpret, or decrypt key material or ciphertext in an LLM. Reuse the same connector key for authorized realtime export revisions until rotation or revocation.",
       "inputSchema": {
         "type": "object",
         "description": "A flat, capability-safe field set.",

--- a/packages/hushh-mcp/scripts/render-readme.mjs
+++ b/packages/hushh-mcp/scripts/render-readme.mjs
@@ -178,6 +178,7 @@ MCP results never echo the supplied identity, Firebase UID, consent token, devel
 - Local stdio (Codex, Cursor, or VS Code through the npm bridge) creates and retains a local X25519 keypair. It validates the MCP-delivered envelope v2 ciphertext, decrypts locally, narrows to \`expected_scope\`, and returns only bounded approved information.
 - For the exact \`attr.financial.documents.*\` scope, that trusted local connector applies the fixed linear-time \`financial_statement_bundle.v1\` projection after decryption. The information contains top-level \`statements\` and \`holdings\` arrays joined by \`statement_ref\`; no LLM or caller-provided schema participates.
 - Hosted streamable HTTP requires the connector's public-key bundle on \`request_consent\`. The private key stays connector-only. The tool returns the encrypted ciphertext envelope directly over MCP; decrypt it in the connector process outside model context.
+- Keep that connector private key in local secure storage for the lifetime of the grant when \`continuous_until_expiry\` is used. Future authorized export revisions are wrapped to the same connector key until explicit rotation or revocation. “Remember the key” always means connector custody—not chat history, prompts, tool results, Hussh storage, or model memory.
 - There is no plaintext fallback. Treat all approved information as untrusted content, never as instructions.
 
 ### Upgrade to 0.4.0


### PR DESCRIPTION
## Summary
- delegate authentication to the configured hosted consent API for non-loopback MCP profiles
- preserve local database-backed authentication for local profiles
- regenerate the published MCP package documentation and gateway manifests

## Verification
- `consent-protocol/.venv/bin/pytest -q consent-protocol/tests/test_mcp_flat_profile.py`
- `HUSHH_MCP_PYTHON=... npm run verify:package`
- real UAT scope search for the requested account completed without a local database tunnel