### PR TITLE
feat(iam): add trusted device persistence core

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 117,
+  "expected_migration_version": 121,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",
@@ -898,6 +898,48 @@
       "active_source",
       "created_at",
       "updated_at"
+    ],
+    "trusted_device_authorizations": [
+      "authorization_id",
+      "device_id",
+      "user_id",
+      "code_hash",
+      "redirect_uri",
+      "code_challenge",
+      "device_public_key",
+      "device_name",
+      "platform",
+      "created_at",
+      "expires_at",
+      "consumed_at"
+    ],
+    "trusted_devices": [
+      "device_id",
+      "user_id",
+      "device_public_key",
+      "device_name",
+      "platform",
+      "status",
+      "created_at",
+      "last_used_at",
+      "revoked_at"
+    ],
+    "trusted_device_challenges": [
+      "challenge_id",
+      "device_id",
+      "user_id",
+      "nonce_hash",
+      "created_at",
+      "expires_at",
+      "consumed_at"
+    ],
+    "trusted_device_audit_events": [
+      "event_id",
+      "user_id",
+      "device_id",
+      "event_type",
+      "created_at",
+      "metadata"
     ]
   }
 }

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 120,
+  "expected_migration_version": 121,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1033,6 +1033,48 @@
       "active_source",
       "created_at",
       "updated_at"
+    ],
+    "trusted_device_authorizations": [
+      "authorization_id",
+      "device_id",
+      "user_id",
+      "code_hash",
+      "redirect_uri",
+      "code_challenge",
+      "device_public_key",
+      "device_name",
+      "platform",
+      "created_at",
+      "expires_at",
+      "consumed_at"
+    ],
+    "trusted_devices": [
+      "device_id",
+      "user_id",
+      "device_public_key",
+      "device_name",
+      "platform",
+      "status",
+      "created_at",
+      "last_used_at",
+      "revoked_at"
+    ],
+    "trusted_device_challenges": [
+      "challenge_id",
+      "device_id",
+      "user_id",
+      "nonce_hash",
+      "created_at",
+      "expires_at",
+      "consumed_at"
+    ],
+    "trusted_device_audit_events": [
+      "event_id",
+      "user_id",
+      "device_id",
+      "event_type",
+      "created_at",
+      "metadata"
     ]
   }
 }

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 120,
+  "expected_migration_version": 121,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1033,6 +1033,48 @@
       "active_source",
       "created_at",
       "updated_at"
+    ],
+    "trusted_device_authorizations": [
+      "authorization_id",
+      "device_id",
+      "user_id",
+      "code_hash",
+      "redirect_uri",
+      "code_challenge",
+      "device_public_key",
+      "device_name",
+      "platform",
+      "created_at",
+      "expires_at",
+      "consumed_at"
+    ],
+    "trusted_devices": [
+      "device_id",
+      "user_id",
+      "device_public_key",
+      "device_name",
+      "platform",
+      "status",
+      "created_at",
+      "last_used_at",
+      "revoked_at"
+    ],
+    "trusted_device_challenges": [
+      "challenge_id",
+      "device_id",
+      "user_id",
+      "nonce_hash",
+      "created_at",
+      "expires_at",
+      "consumed_at"
+    ],
+    "trusted_device_audit_events": [
+      "event_id",
+      "user_id",
+      "device_id",
+      "event_type",
+      "created_at",
+      "metadata"
     ]
   }
 }

--- a/consent-protocol/db/migrations/121_trusted_devices.sql
+++ b/consent-protocol/db/migrations/121_trusted_devices.sql
@@ -1,0 +1,71 @@
+BEGIN;
+
+-- First-party native device authorization. These tables contain identity,
+-- device-key, replay-prevention, and metadata-only audit state. They never
+-- contain a Firebase refresh token, vault passphrase, vault key, PKM plaintext,
+-- or consent export key.
+
+CREATE TABLE IF NOT EXISTS trusted_device_authorizations (
+  authorization_id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  code_hash TEXT NOT NULL UNIQUE,
+  redirect_uri TEXT NOT NULL,
+  code_challenge TEXT NOT NULL,
+  device_public_key TEXT NOT NULL,
+  device_name TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  expires_at BIGINT NOT NULL,
+  consumed_at BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_trusted_device_authorizations_expiry
+  ON trusted_device_authorizations (expires_at);
+
+CREATE TABLE IF NOT EXISTS trusted_devices (
+  device_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  device_public_key TEXT NOT NULL,
+  device_name TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'revoked')),
+  created_at BIGINT NOT NULL,
+  last_used_at BIGINT,
+  revoked_at BIGINT,
+  UNIQUE (user_id, device_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trusted_devices_user
+  ON trusted_devices (user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS trusted_device_challenges (
+  challenge_id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL REFERENCES trusted_devices(device_id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  nonce_hash TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  expires_at BIGINT NOT NULL,
+  consumed_at BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_trusted_device_challenges_expiry
+  ON trusted_device_challenges (expires_at);
+
+CREATE TABLE IF NOT EXISTS trusted_device_audit_events (
+  event_id BIGSERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  device_id TEXT,
+  event_type TEXT NOT NULL,
+  created_at BIGINT NOT NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_trusted_device_audit_user
+  ON trusted_device_audit_events (user_id, created_at DESC);
+
+COMMENT ON TABLE trusted_devices IS
+  'First-party trusted-device registry. Public device keys and metadata only; no user or vault secrets.';
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -98,7 +98,8 @@
     "117_feed_events.sql",
     "118_preference_world_model.sql",
     "119_preference_subscription_fabric.sql",
-    "120_fabric_consent_requests.sql"
+    "120_fabric_consent_requests.sql",
+    "121_trusted_devices.sql"
   ],
   "groups": {
     "iam": [
@@ -153,7 +154,8 @@
       "114_one_action_directive_ledger.sql",
       "115_one_location_map_presence.sql",
       "116_one_location_sms_contacts.sql",
-      "117_feed_events.sql"
+      "117_feed_events.sql",
+      "121_trusted_devices.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -206,6 +206,16 @@ class AccountService:
                    OR trusted_user_id = :user_id
                 """
             ),
+            "trusted_device_challenges": text(
+                "DELETE FROM trusted_device_challenges WHERE user_id = :user_id"
+            ),
+            "trusted_device_authorizations": text(
+                "DELETE FROM trusted_device_authorizations WHERE user_id = :user_id"
+            ),
+            "trusted_device_audit_events": text(
+                "DELETE FROM trusted_device_audit_events WHERE user_id = :user_id"
+            ),
+            "trusted_devices": text("DELETE FROM trusted_devices WHERE user_id = :user_id"),
             "one_location_recipient_keys": text(
                 "DELETE FROM one_location_recipient_keys WHERE user_id = :user_id"
             ),
@@ -516,6 +526,10 @@ class AccountService:
                 "connected_system_audit_events",
                 "connected_system_record_bindings",
                 "connected_system_intents",
+                "trusted_device_challenges",
+                "trusted_device_authorizations",
+                "trusted_device_audit_events",
+                "trusted_devices",
                 "pkm_default_available_projections",
                 "pkm_upgrade_claims",
                 "pkm_domain_commits",
@@ -848,6 +862,10 @@ class AccountService:
             "one_location_public_invites": False,
             "one_location_circle_invites": False,
             "trusted_connections": False,
+            "trusted_device_challenges": False,
+            "trusted_device_authorizations": False,
+            "trusted_device_audit_events": False,
+            "trusted_devices": False,
             "one_location_share_grants": False,
             "one_location_recipient_keys": False,
             "runtime_persona_state": False,
@@ -886,6 +904,10 @@ class AccountService:
                         "connected_system_audit_events",
                         "connected_system_record_bindings",
                         "connected_system_intents",
+                        "trusted_device_challenges",
+                        "trusted_device_authorizations",
+                        "trusted_device_audit_events",
+                        "trusted_devices",
                         "pkm_default_available_projections",
                         "pkm_upgrade_claims",
                         "pkm_domain_commits",

--- a/consent-protocol/hushh_mcp/services/consent_db.py
+++ b/consent-protocol/hushh_mcp/services/consent_db.py
@@ -1068,6 +1068,27 @@ class ConsentDBService:
 
         return results
 
+    async def is_trusted_device_active(self, user_id: str, device_id: str) -> bool:
+        """Confirm a device-bound principal is still active.
+
+        Callers intentionally receive database errors rather than a fallback:
+        device-bound owner capabilities must fail closed when revocation state
+        cannot be confirmed.
+        """
+        rows = (
+            self._get_db()
+            .table("trusted_devices")
+            .select("device_id")
+            .eq("user_id", user_id)
+            .eq("device_id", device_id)
+            .eq("status", "active")
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return bool(rows)
+
     async def is_token_active(
         self,
         user_id: str,

--- a/consent-protocol/hushh_mcp/services/trusted_device_service.py
+++ b/consent-protocol/hushh_mcp/services/trusted_device_service.py
@@ -1,0 +1,594 @@
+"""First-party trusted-device authorization and proof-of-possession.
+
+The device registry is deliberately separate from developer OAuth. A developer
+principal identifies an application; this service binds a signed-in person to
+one local installation. It stores only public device keys, one-time hashes, and
+metadata-only audit events.
+
+Postgres is the shared state tier today. ``TrustedDeviceStore`` is the seam for
+a later Redis/Memorystore nonce and replay cache without changing route
+contracts.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from db.db_client import JsonParam, get_db
+from hushh_mcp.runtime_settings import get_core_security_settings
+from hushh_mcp.services.developer_oauth_service import (
+    OAuthValidationError,
+    append_oauth_parameters,
+    normalize_redirect_uri,
+)
+
+_AUTHORIZATION_TTL_MS = 5 * 60 * 1000
+_CHALLENGE_TTL_MS = 2 * 60 * 1000
+_PKCE_RE = re.compile(r"^[A-Za-z0-9_-]{43,128}$")
+_DEVICE_ID_RE = re.compile(r"^tdv_[A-Za-z0-9_-]{20,80}$")
+
+
+class TrustedDeviceError(ValueError):
+    """Stable, non-secret trusted-device error safe for an API response."""
+
+    def __init__(self, code: str, message: str, *, status_code: int = 400):
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class DeviceAuthorization:
+    authorization_id: str
+    device_id: str
+    redirect_uri: str
+    redirect_url: str
+    expires_at: int
+
+
+class TrustedDeviceStore(Protocol):
+    def insert_authorization(self, row: dict[str, Any]) -> None: ...
+
+    def consume_authorization(
+        self, *, code_hash: str, code_challenge: str, now_ms: int
+    ) -> dict[str, Any] | None: ...
+
+    def upsert_device(self, row: dict[str, Any]) -> None: ...
+
+    def list_devices(self, *, user_id: str) -> list[dict[str, Any]]: ...
+
+    def get_active_device(self, *, user_id: str, device_id: str) -> dict[str, Any] | None: ...
+
+    def revoke_device(self, *, user_id: str, device_id: str, now_ms: int) -> bool: ...
+
+    def insert_challenge(self, row: dict[str, Any]) -> None: ...
+
+    def get_challenge(
+        self, *, challenge_id: str, user_id: str, device_id: str, now_ms: int
+    ) -> dict[str, Any] | None: ...
+
+    def consume_challenge(
+        self, *, challenge_id: str, user_id: str, device_id: str, nonce_hash: str, now_ms: int
+    ) -> bool: ...
+
+    def touch_device(self, *, user_id: str, device_id: str, now_ms: int) -> None: ...
+
+    def audit(
+        self,
+        *,
+        user_id: str,
+        device_id: str | None,
+        event_type: str,
+        created_at: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class PostgresTrustedDeviceStore:
+    """Synchronous Postgres adapter; routes run calls in a worker thread."""
+
+    def __init__(self) -> None:
+        self._db = get_db()
+
+    def insert_authorization(self, row: dict[str, Any]) -> None:
+        self._db.table("trusted_device_authorizations").insert(row).execute()
+
+    def consume_authorization(
+        self, *, code_hash: str, code_challenge: str, now_ms: int
+    ) -> dict[str, Any] | None:
+        result = self._db.execute_raw(
+            """UPDATE trusted_device_authorizations
+               SET consumed_at = :now_ms
+               WHERE code_hash = :code_hash
+                 AND consumed_at IS NULL
+                 AND expires_at > :now_ms
+                 AND code_challenge = :code_challenge
+               RETURNING *""",
+            {
+                "code_hash": code_hash,
+                "code_challenge": code_challenge,
+                "now_ms": now_ms,
+            },
+        )
+        return result.data[0] if result.data else None
+
+    def upsert_device(self, row: dict[str, Any]) -> None:
+        self._db.execute_raw(
+            """INSERT INTO trusted_devices
+               (device_id, user_id, device_public_key, device_name, platform,
+                status, created_at, last_used_at, revoked_at)
+               VALUES
+               (:device_id, :user_id, :device_public_key, :device_name, :platform,
+                'active', :created_at, :last_used_at, NULL)
+               ON CONFLICT (device_id) DO UPDATE SET
+                 device_public_key = EXCLUDED.device_public_key,
+                 device_name = EXCLUDED.device_name,
+                 platform = EXCLUDED.platform,
+                 status = 'active',
+                 last_used_at = EXCLUDED.last_used_at,
+                 revoked_at = NULL
+               WHERE trusted_devices.user_id = EXCLUDED.user_id""",
+            row,
+        )
+
+    def list_devices(self, *, user_id: str) -> list[dict[str, Any]]:
+        return (
+            self._db.table("trusted_devices")
+            .select("device_id,device_name,platform,status,created_at,last_used_at,revoked_at")
+            .eq("user_id", user_id)
+            .order("created_at", desc=True)
+            .execute()
+            .data
+            or []
+        )
+
+    def get_active_device(self, *, user_id: str, device_id: str) -> dict[str, Any] | None:
+        rows = (
+            self._db.table("trusted_devices")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("device_id", device_id)
+            .eq("status", "active")
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return rows[0] if rows else None
+
+    def revoke_device(self, *, user_id: str, device_id: str, now_ms: int) -> bool:
+        result = self._db.execute_raw(
+            """UPDATE trusted_devices
+               SET status = 'revoked', revoked_at = :now_ms
+               WHERE user_id = :user_id AND device_id = :device_id AND status = 'active'
+               RETURNING device_id""",
+            {"user_id": user_id, "device_id": device_id, "now_ms": now_ms},
+        )
+        return bool(result.data)
+
+    def insert_challenge(self, row: dict[str, Any]) -> None:
+        self._db.table("trusted_device_challenges").insert(row).execute()
+
+    def get_challenge(
+        self, *, challenge_id: str, user_id: str, device_id: str, now_ms: int
+    ) -> dict[str, Any] | None:
+        rows = (
+            self._db.table("trusted_device_challenges")
+            .select("challenge_id,nonce_hash,expires_at")
+            .eq("challenge_id", challenge_id)
+            .eq("user_id", user_id)
+            .eq("device_id", device_id)
+            .is_("consumed_at", None)
+            .gt("expires_at", now_ms)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return rows[0] if rows else None
+
+    def consume_challenge(
+        self, *, challenge_id: str, user_id: str, device_id: str, nonce_hash: str, now_ms: int
+    ) -> bool:
+        result = self._db.execute_raw(
+            """UPDATE trusted_device_challenges
+               SET consumed_at = :now_ms
+               WHERE challenge_id = :challenge_id
+                 AND user_id = :user_id
+                 AND device_id = :device_id
+                 AND nonce_hash = :nonce_hash
+                 AND consumed_at IS NULL
+                 AND expires_at > :now_ms
+               RETURNING challenge_id""",
+            {
+                "challenge_id": challenge_id,
+                "user_id": user_id,
+                "device_id": device_id,
+                "nonce_hash": nonce_hash,
+                "now_ms": now_ms,
+            },
+        )
+        return bool(result.data)
+
+    def touch_device(self, *, user_id: str, device_id: str, now_ms: int) -> None:
+        (
+            self._db.table("trusted_devices")
+            .update({"last_used_at": now_ms})
+            .eq("user_id", user_id)
+            .eq("device_id", device_id)
+            .eq("status", "active")
+            .execute()
+        )
+
+    def audit(
+        self,
+        *,
+        user_id: str,
+        device_id: str | None,
+        event_type: str,
+        created_at: int,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._db.table("trusted_device_audit_events").insert(
+            {
+                "user_id": user_id,
+                "device_id": device_id,
+                "event_type": event_type,
+                "created_at": created_at,
+                "metadata": JsonParam(metadata or {}),
+            }
+        ).execute()
+
+
+def trusted_devices_enabled() -> bool:
+    return str(os.getenv("HUSSH_TRUSTED_DEVICE_ENABLED") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+        "enabled",
+    }
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _pepper() -> bytes:
+    configured = str(os.getenv("TRUSTED_DEVICE_PEPPER") or "").strip()
+    if configured:
+        return configured.encode("utf-8")
+    return get_core_security_settings().app_signing_key.encode("utf-8")
+
+
+def _secret_hash(value: str) -> str:
+    return hmac.new(_pepper(), value.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _pkce_digest(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _validate_public_key(public_key_b64: str) -> None:
+    try:
+        encoded = base64.b64decode(public_key_b64, validate=True)
+        key = serialization.load_der_public_key(encoded)
+    except Exception as exc:
+        raise TrustedDeviceError(
+            "TRUSTED_DEVICE_INVALID_PUBLIC_KEY",
+            "The device public key is invalid.",
+        ) from exc
+    if not isinstance(key, ec.EllipticCurvePublicKey) or not isinstance(key.curve, ec.SECP256R1):
+        raise TrustedDeviceError(
+            "TRUSTED_DEVICE_UNSUPPORTED_PUBLIC_KEY",
+            "The device must use a P-256 signing key.",
+        )
+
+
+def _loopback_redirect_uri(value: str) -> str:
+    try:
+        normalized = normalize_redirect_uri(value)
+    except OAuthValidationError as exc:
+        raise TrustedDeviceError("TRUSTED_DEVICE_INVALID_REDIRECT", exc.message) from exc
+    hostname = (urlsplit(normalized).hostname or "").lower()
+    if hostname not in {"localhost", "127.0.0.1", "::1"}:
+        raise TrustedDeviceError(
+            "TRUSTED_DEVICE_INVALID_REDIRECT",
+            "Hermes device authorization requires a loopback redirect URI.",
+        )
+    return normalized
+
+
+def _safe_device(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "device_id": str(row.get("device_id") or ""),
+        "device_name": str(row.get("device_name") or ""),
+        "platform": str(row.get("platform") or ""),
+        "status": str(row.get("status") or "active"),
+        "created_at": int(row.get("created_at") or 0),
+        "last_used_at": int(row["last_used_at"]) if row.get("last_used_at") else None,
+        "revoked_at": int(row["revoked_at"]) if row.get("revoked_at") else None,
+    }
+
+
+class TrustedDeviceService:
+    def __init__(self, store: TrustedDeviceStore | None = None) -> None:
+        self._store = store or PostgresTrustedDeviceStore()
+
+    def create_authorization(
+        self,
+        *,
+        user_id: str,
+        redirect_uri: str,
+        code_challenge: str,
+        device_public_key: str,
+        device_name: str,
+        platform: str,
+        state: str,
+    ) -> DeviceAuthorization:
+        if not _PKCE_RE.fullmatch(code_challenge):
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_INVALID_PKCE",
+                "A valid S256 PKCE challenge is required.",
+            )
+        _validate_public_key(device_public_key)
+        normalized_redirect = _loopback_redirect_uri(redirect_uri)
+        clean_name = device_name.strip()
+        clean_platform = platform.strip().lower()
+        if not clean_name or len(clean_name) > 100:
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_INVALID_NAME", "A valid device name is required."
+            )
+        if clean_platform != "macos":
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_UNSUPPORTED_PLATFORM",
+                "The trusted-device MVP currently supports macOS only.",
+            )
+
+        now_ms = _now_ms()
+        authorization_id = f"tda_{secrets.token_urlsafe(24)}"
+        device_id = f"tdv_{secrets.token_urlsafe(24)}"
+        code = f"tdc_{secrets.token_urlsafe(32)}"
+        self._store.insert_authorization(
+            {
+                "authorization_id": authorization_id,
+                "device_id": device_id,
+                "user_id": user_id,
+                "code_hash": _secret_hash(code),
+                "redirect_uri": normalized_redirect,
+                "code_challenge": code_challenge,
+                "device_public_key": device_public_key,
+                "device_name": clean_name,
+                "platform": clean_platform,
+                "created_at": now_ms,
+                "expires_at": now_ms + _AUTHORIZATION_TTL_MS,
+            }
+        )
+        self._store.audit(
+            user_id=user_id,
+            device_id=device_id,
+            event_type="authorization_approved",
+            created_at=now_ms,
+            metadata={"platform": clean_platform},
+        )
+        return DeviceAuthorization(
+            authorization_id=authorization_id,
+            device_id=device_id,
+            redirect_uri=normalized_redirect,
+            redirect_url=append_oauth_parameters(
+                normalized_redirect, {"code": code, "state": state}
+            ),
+            expires_at=now_ms + _AUTHORIZATION_TTL_MS,
+        )
+
+    def exchange_authorization(self, *, code: str, code_verifier: str) -> dict[str, Any]:
+        if not code.startswith("tdc_") or not _PKCE_RE.fullmatch(code_verifier):
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_INVALID_GRANT", "The authorization grant is invalid."
+            )
+        now_ms = _now_ms()
+        row = self._store.consume_authorization(
+            code_hash=_secret_hash(code),
+            code_challenge=_pkce_digest(code_verifier),
+            now_ms=now_ms,
+        )
+        if not row:
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_INVALID_GRANT", "The authorization grant is invalid."
+            )
+        device = {
+            "device_id": str(row["device_id"]),
+            "user_id": str(row["user_id"]),
+            "device_public_key": str(row["device_public_key"]),
+            "device_name": str(row["device_name"]),
+            "platform": str(row["platform"]),
+            "created_at": now_ms,
+            "last_used_at": now_ms,
+        }
+        self._store.upsert_device(device)
+        self._store.audit(
+            user_id=device["user_id"],
+            device_id=device["device_id"],
+            event_type="authorization_exchanged",
+            created_at=now_ms,
+        )
+        return device
+
+    def list_devices(self, *, user_id: str) -> list[dict[str, Any]]:
+        return [_safe_device(row) for row in self._store.list_devices(user_id=user_id)]
+
+    def is_active_device(self, *, user_id: str, device_id: str) -> bool:
+        return self._store.get_active_device(user_id=user_id, device_id=device_id) is not None
+
+    def audit_event(
+        self,
+        *,
+        user_id: str,
+        device_id: str,
+        event_type: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._store.audit(
+            user_id=user_id,
+            device_id=device_id,
+            event_type=event_type,
+            created_at=_now_ms(),
+            metadata=metadata,
+        )
+
+    def revoke_device(self, *, user_id: str, device_id: str) -> bool:
+        if not _DEVICE_ID_RE.fullmatch(device_id):
+            return False
+        now_ms = _now_ms()
+        revoked = self._store.revoke_device(user_id=user_id, device_id=device_id, now_ms=now_ms)
+        if revoked:
+            self._store.audit(
+                user_id=user_id,
+                device_id=device_id,
+                event_type="device_revoked",
+                created_at=now_ms,
+            )
+        return revoked
+
+    def create_challenge(self, *, user_id: str, device_id: str) -> dict[str, Any]:
+        device = self._store.get_active_device(user_id=user_id, device_id=device_id)
+        if not device:
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_NOT_ACTIVE",
+                "The trusted device is not active.",
+                status_code=403,
+            )
+        now_ms = _now_ms()
+        challenge_id = f"tdn_{secrets.token_urlsafe(24)}"
+        nonce = secrets.token_urlsafe(32)
+        self._store.insert_challenge(
+            {
+                "challenge_id": challenge_id,
+                "device_id": device_id,
+                "user_id": user_id,
+                "nonce_hash": _secret_hash(nonce),
+                "created_at": now_ms,
+                "expires_at": now_ms + _CHALLENGE_TTL_MS,
+            }
+        )
+        return {
+            "challenge_id": challenge_id,
+            "nonce": nonce,
+            "expires_at": now_ms + _CHALLENGE_TTL_MS,
+            "signing_payload": self.signing_payload(
+                challenge_id=challenge_id,
+                nonce=nonce,
+                user_id=user_id,
+                device_id=device_id,
+            ),
+        }
+
+    @staticmethod
+    def signing_payload(*, challenge_id: str, nonce: str, user_id: str, device_id: str) -> str:
+        return json.dumps(
+            {
+                "challenge_id": challenge_id,
+                "device_id": device_id,
+                "nonce": nonce,
+                "purpose": "vault-owner-capability",
+                "user_id": user_id,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    def verify_challenge(
+        self,
+        *,
+        user_id: str,
+        device_id: str,
+        challenge_id: str,
+        nonce: str,
+        signature_b64: str,
+    ) -> None:
+        device = self._store.get_active_device(user_id=user_id, device_id=device_id)
+        if not device:
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_NOT_ACTIVE",
+                "The trusted device is not active.",
+                status_code=403,
+            )
+        now_ms = _now_ms()
+        challenge = self._store.get_challenge(
+            challenge_id=challenge_id,
+            user_id=user_id,
+            device_id=device_id,
+            now_ms=now_ms,
+        )
+        nonce_hash = _secret_hash(nonce)
+        if not challenge or not hmac.compare_digest(
+            str(challenge.get("nonce_hash") or ""), nonce_hash
+        ):
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_CHALLENGE_INVALID",
+                "The device challenge is expired, mismatched, or already used.",
+                status_code=401,
+            )
+
+        try:
+            key_bytes = base64.b64decode(str(device["device_public_key"]), validate=True)
+            public_key = serialization.load_der_public_key(key_bytes)
+            signature = base64.b64decode(signature_b64, validate=True)
+            if not isinstance(public_key, ec.EllipticCurvePublicKey):
+                raise TypeError("not an EC public key")
+            public_key.verify(
+                signature,
+                self.signing_payload(
+                    challenge_id=challenge_id,
+                    nonce=nonce,
+                    user_id=user_id,
+                    device_id=device_id,
+                ).encode("utf-8"),
+                ec.ECDSA(hashes.SHA256()),
+            )
+        except (InvalidSignature, TypeError, ValueError) as exc:
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_SIGNATURE_INVALID",
+                "The device signature is invalid.",
+                status_code=401,
+            ) from exc
+
+        # Consume only after proof verification. The conditional update is the
+        # replay fence when two valid requests race.
+        consumed = self._store.consume_challenge(
+            challenge_id=challenge_id,
+            user_id=user_id,
+            device_id=device_id,
+            nonce_hash=nonce_hash,
+            now_ms=now_ms,
+        )
+        if not consumed:
+            raise TrustedDeviceError(
+                "TRUSTED_DEVICE_CHALLENGE_INVALID",
+                "The device challenge is expired, mismatched, or already used.",
+                status_code=401,
+            )
+
+        self._store.touch_device(user_id=user_id, device_id=device_id, now_ms=now_ms)
+        self._store.audit(
+            user_id=user_id,
+            device_id=device_id,
+            event_type="device_challenge_verified",
+            created_at=now_ms,
+        )

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -84,6 +84,10 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
         "DELETE FROM connected_system_audit_events",
         "DELETE FROM connected_system_record_bindings",
         "DELETE FROM connected_system_intents",
+        "DELETE FROM trusted_device_challenges",
+        "DELETE FROM trusted_device_authorizations",
+        "DELETE FROM trusted_device_audit_events",
+        "DELETE FROM trusted_devices",
         "DELETE FROM pkm_default_available_projections",
         "DELETE FROM pkm_upgrade_steps",
         "DELETE FROM pkm_upgrade_runs",
@@ -134,6 +138,9 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
     )
     assert executed_sql.index("DELETE FROM connected_system_record_bindings") < executed_sql.index(
         "DELETE FROM connected_system_intents"
+    )
+    assert executed_sql.index("DELETE FROM trusted_device_challenges") < executed_sql.index(
+        "DELETE FROM trusted_devices"
     )
     assert executed_sql.index("DELETE FROM relationship_share_events") < executed_sql.index(
         "DELETE FROM relationship_share_grants"
@@ -207,6 +214,10 @@ async def test_reset_account_clears_data_but_keeps_account_spine(monkeypatch):
         "DELETE FROM pkm_events",
         "DELETE FROM pkm_blobs",
         "DELETE FROM connected_system_intents",
+        "DELETE FROM trusted_device_challenges",
+        "DELETE FROM trusted_device_authorizations",
+        "DELETE FROM trusted_device_audit_events",
+        "DELETE FROM trusted_devices",
         "DELETE FROM consent_audit",
         "DELETE FROM one_kyc_workflows",
         "DELETE FROM one_location_events",

--- a/consent-protocol/tests/test_trusted_device_migration.py
+++ b/consent-protocol/tests/test_trusted_device_migration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_trusted_device_migration_is_release_ordered_and_metadata_only() -> None:
+    manifest = json.loads(
+        (ROOT / "db" / "release_migration_manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["ordered_migrations"][-1] == "121_trusted_devices.sql"
+    assert "121_trusted_devices.sql" in manifest["groups"]["iam"]
+
+    sql = (ROOT / "db" / "migrations" / "121_trusted_devices.sql").read_text(encoding="utf-8")
+    for table in (
+        "trusted_device_authorizations",
+        "trusted_devices",
+        "trusted_device_challenges",
+        "trusted_device_audit_events",
+    ):
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in sql
+    lowered = sql.lower()
+    assert "firebase_refresh_token" not in lowered
+    assert "vault_passphrase" not in lowered
+    assert "vault_key " not in lowered
+
+    expected_columns = {
+        "trusted_device_authorizations": {
+            "authorization_id",
+            "device_id",
+            "user_id",
+            "code_hash",
+            "redirect_uri",
+            "code_challenge",
+            "device_public_key",
+            "device_name",
+            "platform",
+            "created_at",
+            "expires_at",
+            "consumed_at",
+        },
+        "trusted_devices": {
+            "device_id",
+            "user_id",
+            "device_public_key",
+            "device_name",
+            "platform",
+            "status",
+            "created_at",
+            "last_used_at",
+            "revoked_at",
+        },
+        "trusted_device_challenges": {
+            "challenge_id",
+            "device_id",
+            "user_id",
+            "nonce_hash",
+            "created_at",
+            "expires_at",
+            "consumed_at",
+        },
+        "trusted_device_audit_events": {
+            "event_id",
+            "user_id",
+            "device_id",
+            "event_type",
+            "created_at",
+            "metadata",
+        },
+    }
+    for contract_name in (
+        "dev_minimum_schema.json",
+        "uat_integrated_schema.json",
+        "prod_core_schema.json",
+    ):
+        contract = json.loads(
+            (ROOT / "db" / "contracts" / contract_name).read_text(encoding="utf-8")
+        )
+        assert contract["expected_migration_version"] == 121
+        for table, columns in expected_columns.items():
+            assert set(contract["required_tables"][table]) == columns

--- a/consent-protocol/tests/test_trusted_device_service.py
+++ b/consent-protocol/tests/test_trusted_device_service.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from hushh_mcp.services.trusted_device_service import (
+    TrustedDeviceError,
+    TrustedDeviceService,
+)
+
+
+class MemoryStore:
+    def __init__(self) -> None:
+        self.authorizations: dict[str, dict[str, Any]] = {}
+        self.devices: dict[str, dict[str, Any]] = {}
+        self.challenges: dict[str, dict[str, Any]] = {}
+        self.events: list[dict[str, Any]] = []
+
+    def insert_authorization(self, row: dict[str, Any]) -> None:
+        self.authorizations[row["code_hash"]] = dict(row)
+
+    def consume_authorization(
+        self, *, code_hash: str, code_challenge: str, now_ms: int
+    ) -> dict[str, Any] | None:
+        row = self.authorizations.get(code_hash)
+        if (
+            not row
+            or row.get("consumed_at")
+            or row["expires_at"] <= now_ms
+            or row["code_challenge"] != code_challenge
+        ):
+            return None
+        row["consumed_at"] = now_ms
+        return dict(row)
+
+    def upsert_device(self, row: dict[str, Any]) -> None:
+        self.devices[row["device_id"]] = {**row, "status": "active", "revoked_at": None}
+
+    def list_devices(self, *, user_id: str) -> list[dict[str, Any]]:
+        return [row for row in self.devices.values() if row["user_id"] == user_id]
+
+    def get_active_device(self, *, user_id: str, device_id: str) -> dict[str, Any] | None:
+        row = self.devices.get(device_id)
+        if row and row["user_id"] == user_id and row["status"] == "active":
+            return row
+        return None
+
+    def revoke_device(self, *, user_id: str, device_id: str, now_ms: int) -> bool:
+        row = self.get_active_device(user_id=user_id, device_id=device_id)
+        if not row:
+            return False
+        row.update(status="revoked", revoked_at=now_ms)
+        return True
+
+    def insert_challenge(self, row: dict[str, Any]) -> None:
+        self.challenges[row["challenge_id"]] = dict(row)
+
+    def get_challenge(
+        self, *, challenge_id: str, user_id: str, device_id: str, now_ms: int
+    ) -> dict[str, Any] | None:
+        row = self.challenges.get(challenge_id)
+        if (
+            not row
+            or row.get("consumed_at")
+            or row["expires_at"] <= now_ms
+            or row["user_id"] != user_id
+            or row["device_id"] != device_id
+        ):
+            return None
+        return dict(row)
+
+    def consume_challenge(
+        self, *, challenge_id: str, user_id: str, device_id: str, nonce_hash: str, now_ms: int
+    ) -> bool:
+        row = self.challenges.get(challenge_id)
+        if (
+            not row
+            or row.get("consumed_at")
+            or row["expires_at"] <= now_ms
+            or row["user_id"] != user_id
+            or row["device_id"] != device_id
+            or row["nonce_hash"] != nonce_hash
+        ):
+            return False
+        row["consumed_at"] = now_ms
+        return True
+
+    def touch_device(self, *, user_id: str, device_id: str, now_ms: int) -> None:
+        row = self.get_active_device(user_id=user_id, device_id=device_id)
+        assert row is not None
+        row["last_used_at"] = now_ms
+
+    def audit(self, **event: Any) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture(autouse=True)
+def trusted_device_pepper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRUSTED_DEVICE_PEPPER", "unit-test-only-pepper")
+
+
+def _keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    public_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_key, base64.b64encode(public_der).decode("ascii")
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = "a" * 43
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+    return verifier, challenge
+
+
+def _enroll() -> tuple[TrustedDeviceService, MemoryStore, ec.EllipticCurvePrivateKey, dict]:
+    store = MemoryStore()
+    service = TrustedDeviceService(store)
+    private_key, public_key = _keypair()
+    verifier, challenge = _pkce()
+    authorization = service.create_authorization(
+        user_id="user-1",
+        redirect_uri="http://127.0.0.1:43119/callback",
+        code_challenge=challenge,
+        device_public_key=public_key,
+        device_name="Kushal's Mac",
+        platform="macos",
+        state="s" * 32,
+    )
+    code = authorization.redirect_url.split("code=", 1)[1].split("&", 1)[0]
+    device = service.exchange_authorization(code=code, code_verifier=verifier)
+    return service, store, private_key, device
+
+
+def test_pkce_exchange_is_single_use_and_registers_device() -> None:
+    service, store, _private_key, device = _enroll()
+    assert device["user_id"] == "user-1"
+    assert store.devices[device["device_id"]]["status"] == "active"
+    assert {event["event_type"] for event in store.events} == {
+        "authorization_approved",
+        "authorization_exchanged",
+    }
+
+    with pytest.raises(TrustedDeviceError, match="authorization grant is invalid"):
+        service.exchange_authorization(code="tdc_" + "x" * 43, code_verifier="a" * 43)
+
+
+def test_wrong_pkce_verifier_does_not_consume_code() -> None:
+    store = MemoryStore()
+    service = TrustedDeviceService(store)
+    _private_key, public_key = _keypair()
+    verifier, challenge = _pkce()
+    authorization = service.create_authorization(
+        user_id="user-1",
+        redirect_uri="http://localhost:8765/callback",
+        code_challenge=challenge,
+        device_public_key=public_key,
+        device_name="Mac",
+        platform="macos",
+        state="z" * 32,
+    )
+    code = authorization.redirect_url.split("code=", 1)[1].split("&", 1)[0]
+    with pytest.raises(TrustedDeviceError):
+        service.exchange_authorization(code=code, code_verifier="b" * 43)
+    assert service.exchange_authorization(code=code, code_verifier=verifier)["user_id"] == "user-1"
+
+
+def test_signed_challenge_is_single_use_and_revocation_fails_closed() -> None:
+    service, _store, private_key, device = _enroll()
+    challenge = service.create_challenge(user_id="user-1", device_id=device["device_id"])
+    signature = private_key.sign(
+        challenge["signing_payload"].encode("utf-8"),
+        ec.ECDSA(hashes.SHA256()),
+    )
+    encoded_signature = base64.b64encode(signature).decode("ascii")
+    service.verify_challenge(
+        user_id="user-1",
+        device_id=device["device_id"],
+        challenge_id=challenge["challenge_id"],
+        nonce=challenge["nonce"],
+        signature_b64=encoded_signature,
+    )
+
+    with pytest.raises(TrustedDeviceError, match="already used"):
+        service.verify_challenge(
+            user_id="user-1",
+            device_id=device["device_id"],
+            challenge_id=challenge["challenge_id"],
+            nonce=challenge["nonce"],
+            signature_b64=encoded_signature,
+        )
+
+    assert service.revoke_device(user_id="user-1", device_id=device["device_id"])
+    assert not service.is_active_device(user_id="user-1", device_id=device["device_id"])
+    with pytest.raises(TrustedDeviceError, match="not active"):
+        service.create_challenge(user_id="user-1", device_id=device["device_id"])
+
+
+def test_invalid_signature_is_rejected() -> None:
+    service, _store, _private_key, device = _enroll()
+    other_private, _ = _keypair()
+    challenge = service.create_challenge(user_id="user-1", device_id=device["device_id"])
+    signature = other_private.sign(
+        challenge["signing_payload"].encode("utf-8"),
+        ec.ECDSA(hashes.SHA256()),
+    )
+    with pytest.raises(TrustedDeviceError, match="signature is invalid"):
+        service.verify_challenge(
+            user_id="user-1",
+            device_id=device["device_id"],
+            challenge_id=challenge["challenge_id"],
+            nonce=challenge["nonce"],
+            signature_b64=base64.b64encode(signature).decode("ascii"),
+        )

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -1004,6 +1004,37 @@
       "primary_access_path": "Generalized directional trusted-connection graph. Written only via Agent One (add/remove/list intents delegated to the agent_connections lane) and via circle-invite claim (one-way claimer\u2192inviter edge); read in-process by any backend agent (e.g. Location, Email) through TrustedConnectionsService for SOS recipient resolution and check-in targeting. People are resolved read-only through the One Location verified-recipient directory. Supersedes the former one_location_network_connections table; its forward-only removal is pending live row-count, retention, and backup preflight."
     },
     {
+      "data_class": "audit_regulated",
+      "exact_tables": [
+        "trusted_device_audit_events"
+      ],
+      "id": "trusted_device_audit",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "Metadata-only trusted-device authorization, challenge, capability issuance, use, and revocation audit events written by TrustedDeviceService."
+    },
+    {
+      "data_class": "workflow_state",
+      "exact_tables": [
+        "trusted_device_authorizations",
+        "trusted_device_challenges"
+      ],
+      "id": "trusted_device_authorization_workflows",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "Short-lived PKCE authorization codes and single-use proof-of-possession challenges consumed atomically through TrustedDeviceService."
+    },
+    {
+      "data_class": "personal_metadata",
+      "exact_tables": [
+        "trusted_devices"
+      ],
+      "id": "trusted_device_registry",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "First-party Hermes device registration, listing, proof-of-possession lookup, last-used tracking, and revocation through TrustedDeviceService."
+    },
+    {
       "data_class": "workflow_state",
       "exact_tables": [
         "connection_requests",
@@ -4263,7 +4294,7 @@
     "action_gateway": "afac5b3a07a1ec2e6ab4f87231b37edb81a0d771daae2cf4900dd6fb9a35f049",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
     "cache_manifest": "1a02aa456549e92ceea962f8e2daa679d8f2c83eeefdea77b36612e981ecc147",
-    "data_plane": "741bd6db61bfcd8d5bb1f27a1fe84240a88c9c2b4f82ccbafec45a1c1c1875a2",
+    "data_plane": "88c984eead2fd6e0b350b5f5d14194c78b34d87c5b1825d0490508c6d6df66e5",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
     "route_index": "46d94273cc53d297b8a4f4cdc7916f6cb23d602209555b5328201c0a9b78423b",
@@ -4282,6 +4313,6 @@
     "one_specialist_tools": 5,
     "physical_routes": 113,
     "semantic_routes": 14,
-    "table_families": 37
+    "table_families": 40
   }
 }

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -440,6 +440,52 @@
       "expected_row_growth": "medium_per_user_connection"
     },
     {
+      "id": "trusted_device_registry",
+      "owner": "iam-consent-governance",
+      "data_class": "personal_metadata",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "trusted_devices"
+      ],
+      "primary_access_path": "First-party Hermes device registration, listing, proof-of-possession lookup, last-used tracking, and revocation through TrustedDeviceService.",
+      "retention_policy": "Retain active device registrations while the account exists; retain revoked metadata only for bounded security review before compaction.",
+      "deletion_behavior": "Delete all device rows on account deletion; explicit device revocation immediately disables new challenges and records the revocation timestamp.",
+      "trust_boundary": "Public P-256 device keys and device metadata only; never private keys, Firebase tokens, vault passphrases, vault keys, decrypted PKM, or developer credentials.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "low_per_user"
+    },
+    {
+      "id": "trusted_device_authorization_workflows",
+      "owner": "iam-consent-governance",
+      "data_class": "workflow_state",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "trusted_device_authorizations",
+        "trusted_device_challenges"
+      ],
+      "primary_access_path": "Short-lived PKCE authorization codes and single-use proof-of-possession challenges consumed atomically through TrustedDeviceService.",
+      "retention_policy": "Authorization and challenge rows expire within minutes; consumed and expired rows are compacted after the bounded replay-investigation window.",
+      "deletion_behavior": "Delete all user-bound rows on account deletion; revocation prevents new challenges and existing challenges remain unusable after expiry or first consumption.",
+      "trust_boundary": "Stores hashes, public device keys, redirect metadata, opaque identifiers, and expiry/consumption timestamps only; no bearer tokens, private device keys, vault secrets, decrypted PKM, or raw nonce values.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "low_transient_security_nonces"
+    },
+    {
+      "id": "trusted_device_audit",
+      "owner": "iam-consent-governance",
+      "data_class": "audit_regulated",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "trusted_device_audit_events"
+      ],
+      "primary_access_path": "Metadata-only trusted-device authorization, challenge, capability issuance, use, and revocation audit events written by TrustedDeviceService.",
+      "retention_policy": "Long-retention security audit metadata; compact only under the regulated audit-retention policy and redact optional metadata before deleting authority history.",
+      "deletion_behavior": "Account export may include safe event metadata; hard-delete user-linked runtime audit rows on account deletion unless a separate legally mandated retention system owns an immutable copy.",
+      "trust_boundary": "Event type, user/device references, timestamps, and allowlisted metadata only; never authorization codes, nonce values, signatures, tokens, private keys, vault secrets, or decrypted information.",
+      "plaintext_posture": "metadata_only",
+      "expected_row_growth": "medium_append_only"
+    },
+    {
       "id": "relay_ticket_replay_guard",
       "owner": "iam-consent-governance",
       "data_class": "workflow_state",


### PR DESCRIPTION
## Summary
- add the migration-121 trusted-device registry, authorization, challenge, and audit tables
- add the Postgres-backed trusted-device service and active-device lookup seam
- align Dev, UAT, and Production schema contracts and runtime data-plane topology
- include account reset/deletion cleanup and focused persistence tests

The feature remains disabled and no deployment environment enables enrollment.

## Verification
- 50 focused backend tests passed across trusted-device, revocation, Firebase auth, migration, and account cleanup
- `python3 scripts/ops/verify_release_migration_contract.py`
- `python3 scripts/ops/generate_runtime_topology_index.py --check`
- `./bin/hushh codex data-model-audit`
- `./bin/hushh docs verify`