### PR TITLE
feat(iam): enforce trusted device authorization

### DIFF
--- a/consent-protocol/.env.example
+++ b/consent-protocol/.env.example
@@ -80,6 +80,11 @@ GOOGLE_MAPS_API_KEY=replace_with_google_maps_api_key
 # developer lookups. Contributors can leave this blank until they enable
 # developer access from the Kai app.
 HUSHH_DEVELOPER_TOKEN=
+# UAT-only additive Hermes trusted-device rollout. Keep disabled locally unless
+# testing this flow. Allowlist accepts Firebase UIDs or verified account emails.
+HUSSH_TRUSTED_DEVICE_ENABLED=false
+HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST=
+TRUSTED_DEVICE_PEPPER=
 DEVELOPER_API_ENABLED=true
 REMOTE_MCP_ENABLED=false
 CONSENT_SSE_ENABLED=true

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -162,7 +162,7 @@ async def create_trusted_device_authorization(
     if browser_uid != firebase_uid:
         raise HTTPException(status_code=401, detail="Invalid Firebase ID token")
     try:
-        authorization = await run_in_threadpool(
+        device_authorization = await run_in_threadpool(
             TrustedDeviceService().create_authorization,
             user_id=firebase_uid,
             redirect_uri=payload.redirect_uri,
@@ -175,11 +175,11 @@ async def create_trusted_device_authorization(
     except TrustedDeviceError as exc:
         _raise_trusted_device_error(exc)
     return {
-        "authorization_id": authorization.authorization_id,
-        "device_id": authorization.device_id,
-        "redirect_uri": authorization.redirect_uri,
-        "redirect_url": authorization.redirect_url,
-        "expires_at": authorization.expires_at,
+        "authorization_id": device_authorization.authorization_id,
+        "device_id": device_authorization.device_id,
+        "redirect_uri": device_authorization.redirect_uri,
+        "redirect_url": device_authorization.redirect_url,
+        "expires_at": device_authorization.expires_at,
     }
 
 

--- a/consent-protocol/api/routes/account.py
+++ b/consent-protocol/api/routes/account.py
@@ -28,7 +28,7 @@ import re
 import secrets
 from typing import Any, Literal
 
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, Header, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
@@ -39,10 +39,266 @@ from hushh_mcp.services.actor_identity_service import (
     ActorIdentityAliasError,
     ActorIdentityService,
 )
+from hushh_mcp.services.trusted_device_service import (
+    TrustedDeviceError,
+    TrustedDeviceService,
+    trusted_devices_enabled,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/account", tags=["Account"])
+
+
+class TrustedDeviceAuthorizationRequest(BaseModel):
+    redirect_uri: str = Field(min_length=8, max_length=2048)
+    code_challenge: str = Field(min_length=43, max_length=128)
+    code_challenge_method: Literal["S256"] = "S256"
+    device_public_key: str = Field(min_length=80, max_length=2048)
+    device_name: str = Field(min_length=1, max_length=100)
+    platform: Literal["macos"]
+    state: str = Field(min_length=16, max_length=512)
+
+
+class TrustedDeviceExchangeRequest(BaseModel):
+    code: str = Field(min_length=20, max_length=256)
+    code_verifier: str = Field(min_length=43, max_length=128)
+
+
+def _trusted_device_allowlist() -> set[str]:
+    return {
+        value.strip()
+        for value in str(os.getenv("HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST") or "").split(",")
+        if value.strip()
+    }
+
+
+async def _trusted_device_guard(user_id: str | None = None) -> None:
+    if not trusted_devices_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "TRUSTED_DEVICE_DISABLED",
+                "message": "Trusted-device authorization is not enabled.",
+            },
+        )
+    allowlist = _trusted_device_allowlist()
+    # The unauthenticated PKCE exchange is guarded by possession of the
+    # one-time code and verifier; the allowlist was enforced when that code was
+    # created. Every signed-in entrypoint fails closed when rollout membership
+    # is absent or does not match.
+    if not user_id:
+        return
+    if user_id in allowlist:
+        return
+
+    allowed_emails = {value.lower() for value in allowlist if "@" in value}
+    firebase_email = ""
+    if allowed_emails:
+        app = get_firebase_auth_app()
+        if app is not None:
+            try:
+                from firebase_admin import auth as firebase_auth
+
+                record = await run_in_threadpool(firebase_auth.get_user, user_id, app=app)
+                if bool(getattr(record, "email_verified", False)):
+                    firebase_email = str(getattr(record, "email", "") or "").strip().lower()
+            except Exception:
+                logger.exception("trusted_device.allowlist_identity_lookup_failed")
+    if firebase_email not in allowed_emails:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "TRUSTED_DEVICE_NOT_ALLOWED",
+                "message": "This account is not in the trusted-device rollout.",
+            },
+        )
+
+
+def _raise_trusted_device_error(exc: TrustedDeviceError) -> None:
+    raise HTTPException(
+        status_code=exc.status_code,
+        detail={"code": exc.code, "message": exc.message},
+    ) from exc
+
+
+async def _verify_browser_enrollment_identity(authorization: str | None) -> str:
+    """Reject a device-minted Firebase session from approving another device."""
+    raw_header = str(authorization or "").strip()
+    if not raw_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token")
+    raw_token = raw_header.removeprefix("Bearer ").strip()
+    try:
+        from firebase_admin import auth as firebase_auth
+
+        claims = await run_in_threadpool(
+            firebase_auth.verify_id_token,
+            raw_token,
+            app=get_firebase_auth_app(),
+            check_revoked=True,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from exc
+    if str(claims.get("trusted_device_id") or "").strip():
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "TRUSTED_DEVICE_BROWSER_APPROVAL_REQUIRED",
+                "message": "Approve a trusted device from your signed-in browser session.",
+            },
+        )
+    return str(claims.get("uid") or claims.get("sub") or "").strip()
+
+
+@router.post("/trusted-device-authorizations")
+async def create_trusted_device_authorization(
+    payload: TrustedDeviceAuthorizationRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+    authorization: str | None = Header(None, alias="Authorization"),
+):
+    """Approve a PKCE-bound Hermes installation for the signed-in account."""
+    await _trusted_device_guard(firebase_uid)
+    browser_uid = await _verify_browser_enrollment_identity(authorization)
+    if browser_uid != firebase_uid:
+        raise HTTPException(status_code=401, detail="Invalid Firebase ID token")
+    try:
+        authorization = await run_in_threadpool(
+            TrustedDeviceService().create_authorization,
+            user_id=firebase_uid,
+            redirect_uri=payload.redirect_uri,
+            code_challenge=payload.code_challenge,
+            device_public_key=payload.device_public_key,
+            device_name=payload.device_name,
+            platform=payload.platform,
+            state=payload.state,
+        )
+    except TrustedDeviceError as exc:
+        _raise_trusted_device_error(exc)
+    return {
+        "authorization_id": authorization.authorization_id,
+        "device_id": authorization.device_id,
+        "redirect_uri": authorization.redirect_uri,
+        "redirect_url": authorization.redirect_url,
+        "expires_at": authorization.expires_at,
+    }
+
+
+@router.post("/trusted-device-authorizations/exchange")
+async def exchange_trusted_device_authorization(payload: TrustedDeviceExchangeRequest):
+    """Consume a one-time PKCE code and mint a Firebase custom token."""
+    await _trusted_device_guard()
+    try:
+        device = await run_in_threadpool(
+            TrustedDeviceService().exchange_authorization,
+            code=payload.code,
+            code_verifier=payload.code_verifier,
+        )
+    except TrustedDeviceError as exc:
+        _raise_trusted_device_error(exc)
+
+    app = get_firebase_auth_app()
+    if app is None:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "FIREBASE_ADMIN_UNAVAILABLE",
+                "message": "Identity token issuance is unavailable.",
+            },
+        )
+    try:
+        from firebase_admin import auth as firebase_auth
+
+        custom_token = await run_in_threadpool(
+            firebase_auth.create_custom_token,
+            device["user_id"],
+            {"trusted_device_id": device["device_id"]},
+            app=app,
+        )
+    except Exception:
+        logger.exception("trusted_device.custom_token_failed")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "TRUSTED_DEVICE_TOKEN_ISSUANCE_FAILED",
+                "message": "The trusted-device identity token could not be issued.",
+            },
+        )
+    token = custom_token.decode("utf-8") if isinstance(custom_token, bytes) else str(custom_token)
+    return {
+        "firebase_custom_token": token,
+        "device_id": device["device_id"],
+        "user_id": device["user_id"],
+    }
+
+
+@router.get("/trusted-devices")
+async def list_trusted_devices(firebase_uid: str = Depends(require_firebase_auth)):
+    # Recovery remains available after rollout is disabled or membership is
+    # removed. The authenticated user can only list their own device records.
+    devices = await run_in_threadpool(TrustedDeviceService().list_devices, user_id=firebase_uid)
+    return {"devices": devices}
+
+
+@router.post("/trusted-devices/{device_id}/challenge")
+async def create_trusted_device_challenge(
+    device_id: str,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    await _trusted_device_guard(firebase_uid)
+    try:
+        return await run_in_threadpool(
+            TrustedDeviceService().create_challenge,
+            user_id=firebase_uid,
+            device_id=device_id,
+        )
+    except TrustedDeviceError as exc:
+        _raise_trusted_device_error(exc)
+
+
+@router.delete("/trusted-devices/{device_id}")
+async def revoke_trusted_device(
+    device_id: str,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    # Revocation is a recovery operation, not an enrollment operation. Keep it
+    # available even when the feature flag or rollout allowlist is withdrawn.
+    revoked = await run_in_threadpool(
+        TrustedDeviceService().revoke_device,
+        user_id=firebase_uid,
+        device_id=device_id,
+    )
+    if not revoked:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "TRUSTED_DEVICE_NOT_FOUND",
+                "message": "The trusted device was not found or was already revoked.",
+            },
+        )
+
+    # Device owner capabilities use a device-specific agent id. Persisting a
+    # newer REVOKED row makes DB-backed token validation fail across instances.
+    from hushh_mcp.consent.token import revoke_token
+    from hushh_mcp.services.consent_db import ConsentDBService
+
+    consent_service = ConsentDBService()
+    agent_id = f"device:{device_id}"
+    active_tokens = await consent_service.get_active_internal_tokens(
+        firebase_uid, agent_id=agent_id, scope="vault.owner"
+    )
+    for token_row in active_tokens:
+        token_id = str(token_row.get("token_id") or "")
+        if token_id:
+            revoke_token(token_id)
+            await consent_service.insert_internal_event(
+                user_id=firebase_uid,
+                agent_id=agent_id,
+                scope="vault.owner",
+                action="REVOKED",
+                token_id=token_id,
+                metadata={"reason": "trusted_device_revoked"},
+            )
+    return {"success": True, "device_id": device_id}
 
 
 @router.post("/identity/refresh")

--- a/consent-protocol/api/routes/consent.py
+++ b/consent-protocol/api/routes/consent.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 from sqlalchemy.exc import OperationalError as SqlalchemyOperationalError
 
@@ -47,6 +48,11 @@ from hushh_mcp.services.ria_iam_service import (
     IAMSchemaNotReadyError,
     RIAIAMPolicyError,
     RIAIAMService,
+)
+from hushh_mcp.services.trusted_device_service import (
+    TrustedDeviceError,
+    TrustedDeviceService,
+    trusted_devices_enabled,
 )
 
 logger = logging.getLogger(__name__)
@@ -1317,6 +1323,132 @@ async def disconnect_relationship(
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
+async def _issue_or_reuse_vault_owner_token(
+    *, user_id: str, agent_id: str = "self", expires_in_ms: int = 24 * 60 * 60 * 1000
+) -> dict[str, Any]:
+    now_ms = int(time.time() * 1000)
+    service = ConsentDBService()
+    active_tokens = await service.get_active_internal_tokens(
+        user_id,
+        agent_id=agent_id,
+        scope=ConsentScope.VAULT_OWNER.value,
+    )
+    for token_row in active_tokens:
+        expires_at = int(token_row.get("expires_at") or 0)
+        if expires_at <= now_ms + min(60 * 60 * 1000, expires_in_ms // 4):
+            continue
+        candidate_token = str(token_row.get("token_id") or "")
+        if not candidate_token:
+            continue
+        is_valid, _reason, payload = await validate_token_with_db(
+            candidate_token, ConsentScope.VAULT_OWNER
+        )
+        if is_valid and payload:
+            return {
+                "token": candidate_token,
+                "expiresAt": expires_at,
+                "scope": ConsentScope.VAULT_OWNER.value,
+            }
+
+    token_obj = issue_token(
+        user_id=user_id,
+        agent_id=agent_id,
+        scope=ConsentScope.VAULT_OWNER,
+        expires_in_ms=expires_in_ms,
+    )
+    await service.insert_internal_event(
+        user_id=user_id,
+        agent_id=agent_id,
+        scope=ConsentScope.VAULT_OWNER.value,
+        action="CONSENT_GRANTED",
+        token_id=token_obj.token,
+        expires_at=token_obj.expires_at,
+        scope_description=(
+            "Trusted device vault owner session"
+            if agent_id.startswith("device:")
+            else "Vault owner session"
+        ),
+    )
+    return {
+        "token": token_obj.token,
+        "expiresAt": token_obj.expires_at,
+        "scope": ConsentScope.VAULT_OWNER.value,
+    }
+
+
+class TrustedDeviceVaultOwnerRequest(BaseModel):
+    user_id: str = Field(min_length=1, max_length=128)
+    device_id: str = Field(min_length=20, max_length=128)
+    challenge_id: str = Field(min_length=20, max_length=128)
+    nonce: str = Field(min_length=20, max_length=256)
+    signature: str = Field(min_length=40, max_length=2048)
+
+
+@router.post("/vault-owner-token/device")
+async def issue_trusted_device_vault_owner_token(
+    payload: TrustedDeviceVaultOwnerRequest,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    """Issue a short-lived owner capability after device proof-of-possession."""
+    if not trusted_devices_enabled():
+        raise HTTPException(status_code=404, detail="Trusted-device authorization is disabled")
+    if firebase_uid != payload.user_id:
+        raise HTTPException(status_code=403, detail="Cannot access another user's vault")
+    try:
+        await run_in_threadpool(
+            TrustedDeviceService().verify_challenge,
+            user_id=firebase_uid,
+            device_id=payload.device_id,
+            challenge_id=payload.challenge_id,
+            nonce=payload.nonce,
+            signature_b64=payload.signature,
+        )
+    except TrustedDeviceError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": exc.message},
+        ) from exc
+    result = await _issue_or_reuse_vault_owner_token(
+        user_id=firebase_uid,
+        agent_id=f"device:{payload.device_id}",
+        expires_in_ms=15 * 60 * 1000,
+    )
+    still_active = await run_in_threadpool(
+        TrustedDeviceService().is_active_device,
+        user_id=firebase_uid,
+        device_id=payload.device_id,
+    )
+    if not still_active:
+        # Close the race where revocation lands after proof verification but
+        # before capability persistence. If revocation lands after this check,
+        # the revocation route sees the already-persisted token and revokes it.
+        revoke_token(result["token"])
+        await ConsentDBService().insert_internal_event(
+            user_id=firebase_uid,
+            agent_id=f"device:{payload.device_id}",
+            scope=ConsentScope.VAULT_OWNER.value,
+            action="REVOKED",
+            token_id=result["token"],
+            metadata={"reason": "trusted_device_revoked_during_issuance"},
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "TRUSTED_DEVICE_NOT_ACTIVE",
+                "message": "The trusted device is not active.",
+            },
+        )
+    await run_in_threadpool(
+        TrustedDeviceService().audit_event,
+        user_id=firebase_uid,
+        device_id=payload.device_id,
+        event_type="owner_capability_issued",
+        metadata={"expires_at": result["expiresAt"], "scope": result["scope"]},
+    )
+    logger.info("trusted_device.vault_owner_issued")
+    return result
+
+
 @router.post("/vault-owner-token")
 async def issue_vault_owner_token(request: Request):
     """
@@ -1357,73 +1489,9 @@ async def issue_vault_owner_token(request: Request):
                 status_code=403, detail="Cannot issue VAULT_OWNER token for another user"
             )
 
-        # Check for existing active VAULT_OWNER token in the internal ledger
-        now_ms = int(time.time() * 1000)
-        service = ConsentDBService()
-        active_tokens = await service.get_active_internal_tokens(
-            user_id,
-            agent_id="self",
-            scope=ConsentScope.VAULT_OWNER.value,
-        )
-
-        for t in active_tokens:
-            # Match scope = vault.owner and agent = self
-            if t.get("scope") == ConsentScope.VAULT_OWNER.value and t.get("agent_id") == "self":
-                # Check if token has > 1 hour left
-                expires_at = t.get("expires_at", 0)
-                if expires_at > now_ms + (60 * 60 * 1000):  # 1 hour buffer
-                    # REUSE existing token (only if it still validates)
-                    #
-                    # NOTE: In older deployments, some systems stored a non-token identifier in `token_id`.
-                    # If we blindly reuse it, downstream calls fail with "Invalid signature".
-                    candidate_token = t.get("token_id")
-                    if not candidate_token:
-                        logger.warning("vault_owner.reuse_missing_token_id")
-                        break
-
-                    is_valid, reason, payload = await validate_token_with_db(
-                        candidate_token, ConsentScope.VAULT_OWNER
-                    )
-                    if not is_valid or not payload:
-                        logger.warning(
-                            "vault_owner.stored_token_invalid reason=%s",
-                            reason,
-                        )
-                        break
-
-                    logger.info("vault_owner.token_reused expires_at=%s", expires_at)
-                    return {
-                        "token": candidate_token,
-                        "expiresAt": expires_at,
-                        "scope": ConsentScope.VAULT_OWNER.value,
-                    }
-
-        # No valid token found - issue new one
-        logger.info("vault_owner.issue_new_token")
-
-        # Issue new token (24-hour expiry)
-        token_obj = issue_token(
-            user_id=user_id,
-            agent_id="self",  # Vault owner accessing their own data
-            scope=ConsentScope.VAULT_OWNER,
-            expires_in_ms=24 * 60 * 60 * 1000,  # 24 hours
-        )
-
-        # Store in the internal ledger so self-session churn stays out of the investor consent feed.
-        service = ConsentDBService()
-        await service.insert_internal_event(
-            user_id=user_id,
-            agent_id="self",
-            scope="vault.owner",
-            action="CONSENT_GRANTED",
-            token_id=token_obj.token,
-            expires_at=token_obj.expires_at,
-            scope_description="Vault owner session",
-        )
-
-        logger.info("vault_owner.token_issued")
-
-        return {"token": token_obj.token, "expiresAt": token_obj.expires_at, "scope": "vault.owner"}
+        result = await _issue_or_reuse_vault_owner_token(user_id=user_id)
+        logger.info("vault_owner.token_issued_or_reused")
+        return result
 
     except HTTPException:
         raise

--- a/consent-protocol/api/utils/firebase_auth.py
+++ b/consent-protocol/api/utils/firebase_auth.py
@@ -44,6 +44,35 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
         uid = decoded.get("uid")
         if not isinstance(uid, str) or not uid:
             raise HTTPException(status_code=401, detail="Invalid Firebase ID token")
+
+        device_id = str(decoded.get("trusted_device_id") or "").strip()
+        if device_id:
+            # A trusted-device Firebase session remains valid only while its
+            # server-side device registration is active. This check is
+            # independent of rollout flags so disabling enrollment cannot
+            # accidentally preserve a revoked device session.
+            from hushh_mcp.services.trusted_device_service import TrustedDeviceService
+
+            try:
+                active = TrustedDeviceService().is_active_device(
+                    user_id=uid,
+                    device_id=device_id,
+                )
+            except Exception:
+                logger.exception(
+                    "firebase.trusted_device_status_unavailable uid=%s device_id=%s",
+                    uid,
+                    device_id,
+                )
+                raise HTTPException(
+                    status_code=503,
+                    detail="Trusted-device status temporarily unavailable",
+                ) from None
+            if not active:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Trusted-device session is no longer active",
+                )
         return uid
     except HTTPException:
         raise

--- a/consent-protocol/hushh_mcp/consent/token.py
+++ b/consent-protocol/hushh_mcp/consent/token.py
@@ -374,6 +374,16 @@ async def validate_token_with_db(
     if not valid:
         return valid, reason, token_obj
 
+    agent_id = str(token_obj.agent_id) if token_obj is not None else ""
+    is_device_bound_owner = (
+        token_obj is not None
+        and agent_id.startswith("device:")
+        and (
+            token_obj.scope_str == ConsentScope.VAULT_OWNER.value
+            or token_obj.scope == ConsentScope.VAULT_OWNER
+        )
+    )
+
     # Additional DB check for revocation status
     # This catches tokens revoked on other Cloud Run instances
     try:
@@ -397,6 +407,18 @@ async def validate_token_with_db(
                     _token_fingerprint(token_str),
                 )
                 return False, "Token has been revoked (DB check)", None
+            if is_device_bound_owner:
+                device_id = agent_id.removeprefix("device:")
+                if not device_id or not await service.is_trusted_device_active(
+                    str(token_obj.user_id), device_id
+                ):
+                    _revoked_tokens.add(token_str)
+                    logger.warning(
+                        "Device-bound owner token rejected because device is inactive "
+                        "(fingerprint=%s)",
+                        _token_fingerprint(token_str),
+                    )
+                    return False, "Trusted device is not active", None
     except Exception as e:
         # DB is unreachable — apply fail-closed policy based on token scope.
         # VAULT_OWNER tokens get a short grace period to avoid locking users
@@ -406,6 +428,16 @@ async def validate_token_with_db(
         is_vault_owner = token_obj is not None and (
             token_obj.scope_str == "vault.owner" or token_obj.scope == ConsentScope.VAULT_OWNER
         )
+        if is_device_bound_owner:
+            logger.error(
+                "Device-bound owner revocation status could not be confirmed; failing closed: %s",
+                e,
+            )
+            return (
+                False,
+                "Trusted device revocation status could not be confirmed (DB unavailable)",
+                None,
+            )
         if is_vault_owner:
             logger.warning(
                 "DB revocation check failed for VAULT_OWNER token, "

--- a/consent-protocol/tests/quality/test_revocation_persistence.py
+++ b/consent-protocol/tests/quality/test_revocation_persistence.py
@@ -322,3 +322,55 @@ async def test_validate_token_with_db_scoped_token_fails_closed_on_db_error():
     assert valid is False
     assert reason == "Token revocation status could not be confirmed (DB unavailable)"
     assert token_result is None
+
+
+@pytest.mark.asyncio
+async def test_device_owner_token_requires_active_device():
+    device_id = "tdv_" + ("a" * 32)
+    token_obj = issue_token(
+        USER_ID,
+        f"device:{device_id}",
+        ConsentScope.VAULT_OWNER,
+    )
+
+    fake_module = types.ModuleType("hushh_mcp.services.consent_db")
+    mock_service_instance = AsyncMock()
+    mock_service_instance.is_token_active = AsyncMock(return_value=True)
+    mock_service_instance.is_trusted_device_active = AsyncMock(return_value=False)
+    fake_module.ConsentDBService = lambda: mock_service_instance
+
+    with patch.dict(sys.modules, {"hushh_mcp.services.consent_db": fake_module}):
+        valid, reason, result = await validate_token_with_db(
+            token_obj.token, ConsentScope.VAULT_OWNER
+        )
+
+    assert valid is False
+    assert reason == "Trusted device is not active"
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_device_owner_token_fails_closed_when_device_status_is_unavailable():
+    device_id = "tdv_" + ("a" * 32)
+    token_obj = issue_token(
+        USER_ID,
+        f"device:{device_id}",
+        ConsentScope.VAULT_OWNER,
+    )
+
+    fake_module = types.ModuleType("hushh_mcp.services.consent_db")
+    mock_service_instance = AsyncMock()
+    mock_service_instance.is_token_active = AsyncMock(return_value=True)
+    mock_service_instance.is_trusted_device_active = AsyncMock(
+        side_effect=Exception("DB connection refused")
+    )
+    fake_module.ConsentDBService = lambda: mock_service_instance
+
+    with patch.dict(sys.modules, {"hushh_mcp.services.consent_db": fake_module}):
+        valid, reason, result = await validate_token_with_db(
+            token_obj.token, ConsentScope.VAULT_OWNER
+        )
+
+    assert valid is False
+    assert reason == "Trusted device revocation status could not be confirmed (DB unavailable)"
+    assert result is None

--- a/consent-protocol/tests/test_firebase_auth_split.py
+++ b/consent-protocol/tests/test_firebase_auth_split.py
@@ -25,14 +25,109 @@ def test_verify_firebase_bearer_uses_auth_admin_app(monkeypatch):
     )
     monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: fake_app)
 
-    def fake_verify(token: str, app=None):
+    def fake_verify(token: str, app=None, check_revoked: bool = False):
         assert token == bearer_value
         assert app is fake_app
+        assert check_revoked is True
         return {"uid": "user_123"}
 
     monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
 
     assert verify_firebase_bearer(f"Bearer {bearer_value}") == "user_123"
+
+
+def test_verify_firebase_bearer_accepts_active_trusted_device(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    class _TrustedDevices:
+        def is_active_device(self, *, user_id: str, device_id: str) -> bool:
+            assert user_id == "user_123"
+            assert device_id == "tdv_active"
+            return True
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr(
+        firebase_auth,
+        "verify_id_token",
+        lambda *_args, **_kwargs: {
+            "uid": "user_123",
+            "trusted_device_id": "tdv_active",
+        },
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.trusted_device_service.TrustedDeviceService",
+        _TrustedDevices,
+    )
+
+    assert verify_firebase_bearer("Bearer device-token") == "user_123"
+
+
+def test_verify_firebase_bearer_rejects_inactive_trusted_device(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    class _TrustedDevices:
+        def is_active_device(self, **_kwargs) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr(
+        firebase_auth,
+        "verify_id_token",
+        lambda *_args, **_kwargs: {
+            "uid": "user_123",
+            "trusted_device_id": "tdv_revoked",
+        },
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.trusted_device_service.TrustedDeviceService",
+        _TrustedDevices,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        verify_firebase_bearer("Bearer device-token")
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Trusted-device session is no longer active"
+
+
+def test_verify_firebase_bearer_fails_closed_when_device_status_unavailable(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    class _TrustedDevices:
+        def is_active_device(self, **_kwargs) -> bool:
+            raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "test-project"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr(
+        firebase_auth,
+        "verify_id_token",
+        lambda *_args, **_kwargs: {
+            "uid": "user_123",
+            "trusted_device_id": "tdv_active",
+        },
+    )
+    monkeypatch.setattr(
+        "hushh_mcp.services.trusted_device_service.TrustedDeviceService",
+        _TrustedDevices,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        verify_firebase_bearer("Bearer device-token")
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "Trusted-device status temporarily unavailable"
 
 
 def test_verify_firebase_bearer_returns_500_when_auth_admin_missing(monkeypatch):

--- a/consent-protocol/tests/test_trusted_device_routes.py
+++ b/consent-protocol/tests/test_trusted_device_routes.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import account, consent
+from hushh_mcp.services.trusted_device_service import TrustedDeviceError
+
+
+class _FakeTrustedDeviceService:
+    verified: list[dict[str, Any]] = []
+    audited: list[dict[str, Any]] = []
+    error: TrustedDeviceError | None = None
+    active = True
+
+    def verify_challenge(self, **kwargs: Any) -> None:
+        if self.error is not None:
+            raise self.error
+        self.verified.append(kwargs)
+
+    def audit_event(self, **kwargs: Any) -> None:
+        self.audited.append(kwargs)
+
+    def is_active_device(self, **_kwargs: Any) -> bool:
+        return self.active
+
+    def list_devices(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return [{"device_id": "tdv_recoverable", "status": "active"}]
+
+    def revoke_device(self, **_kwargs: Any) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_service() -> None:
+    _FakeTrustedDeviceService.verified = []
+    _FakeTrustedDeviceService.audited = []
+    _FakeTrustedDeviceService.error = None
+    _FakeTrustedDeviceService.active = True
+
+
+@pytest.mark.asyncio
+async def test_device_owner_capability_is_bound_to_firebase_user_and_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    async def _issue(**kwargs):
+        assert kwargs == {
+            "user_id": "user-1",
+            "agent_id": f"device:{device_id}",
+            "expires_in_ms": 15 * 60 * 1000,
+        }
+        return {
+            "token": "opaque-owner-token",
+            "expiresAt": 123456,
+            "scope": "vault.owner",
+        }
+
+    device_id = "tdv_" + ("a" * 32)
+    monkeypatch.setattr(consent, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(consent, "TrustedDeviceService", _FakeTrustedDeviceService)
+    monkeypatch.setattr(consent, "run_in_threadpool", _run_in_threadpool)
+    monkeypatch.setattr(consent, "_issue_or_reuse_vault_owner_token", _issue)
+
+    result = await consent.issue_trusted_device_vault_owner_token(
+        consent.TrustedDeviceVaultOwnerRequest(
+            user_id="user-1",
+            device_id=device_id,
+            challenge_id="tdn_" + ("b" * 32),
+            nonce="n" * 32,
+            signature="s" * 80,
+        ),
+        firebase_uid="user-1",
+    )
+
+    assert result == {
+        "token": "opaque-owner-token",
+        "expiresAt": 123456,
+        "scope": "vault.owner",
+    }
+    assert _FakeTrustedDeviceService.verified == [
+        {
+            "user_id": "user-1",
+            "device_id": device_id,
+            "challenge_id": "tdn_" + ("b" * 32),
+            "nonce": "n" * 32,
+            "signature_b64": "s" * 80,
+        }
+    ]
+    assert _FakeTrustedDeviceService.audited[0]["event_type"] == "owner_capability_issued"
+
+
+@pytest.mark.asyncio
+async def test_device_owner_capability_rejects_cross_user_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(consent, "trusted_devices_enabled", lambda: True)
+    with pytest.raises(HTTPException) as raised:
+        await consent.issue_trusted_device_vault_owner_token(
+            consent.TrustedDeviceVaultOwnerRequest(
+                user_id="other-user",
+                device_id="tdv_" + ("a" * 32),
+                challenge_id="tdn_" + ("b" * 32),
+                nonce="n" * 32,
+                signature="s" * 80,
+            ),
+            firebase_uid="user-1",
+        )
+    assert raised.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_device_owner_capability_maps_revoked_device_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    _FakeTrustedDeviceService.error = TrustedDeviceError(
+        "TRUSTED_DEVICE_NOT_ACTIVE",
+        "The trusted device is not active.",
+        status_code=403,
+    )
+    monkeypatch.setattr(consent, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(consent, "TrustedDeviceService", _FakeTrustedDeviceService)
+    monkeypatch.setattr(consent, "run_in_threadpool", _run_in_threadpool)
+
+    with pytest.raises(HTTPException) as raised:
+        await consent.issue_trusted_device_vault_owner_token(
+            consent.TrustedDeviceVaultOwnerRequest(
+                user_id="user-1",
+                device_id="tdv_" + ("a" * 32),
+                challenge_id="tdn_" + ("b" * 32),
+                nonce="n" * 32,
+                signature="s" * 80,
+            ),
+            firebase_uid="user-1",
+        )
+    assert raised.value.status_code == 403
+    assert raised.value.detail["code"] == "TRUSTED_DEVICE_NOT_ACTIVE"
+
+
+@pytest.mark.asyncio
+async def test_device_owner_capability_closes_revocation_issuance_race(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    revoked: list[str] = []
+    ledger_events: list[dict[str, Any]] = []
+
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    async def _issue(**_kwargs):
+        return {
+            "token": "racing-owner-token",
+            "expiresAt": 123456,
+            "scope": "vault.owner",
+        }
+
+    class _ConsentLedger:
+        async def insert_internal_event(self, **kwargs: Any) -> None:
+            ledger_events.append(kwargs)
+
+    _FakeTrustedDeviceService.active = False
+    monkeypatch.setattr(consent, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(consent, "TrustedDeviceService", _FakeTrustedDeviceService)
+    monkeypatch.setattr(consent, "run_in_threadpool", _run_in_threadpool)
+    monkeypatch.setattr(consent, "_issue_or_reuse_vault_owner_token", _issue)
+    monkeypatch.setattr(consent, "revoke_token", revoked.append)
+    monkeypatch.setattr(consent, "ConsentDBService", _ConsentLedger)
+
+    with pytest.raises(HTTPException) as raised:
+        await consent.issue_trusted_device_vault_owner_token(
+            consent.TrustedDeviceVaultOwnerRequest(
+                user_id="user-1",
+                device_id="tdv_" + ("a" * 32),
+                challenge_id="tdn_" + ("b" * 32),
+                nonce="n" * 32,
+                signature="s" * 80,
+            ),
+            firebase_uid="user-1",
+        )
+
+    assert raised.value.status_code == 403
+    assert revoked == ["racing-owner-token"]
+    assert ledger_events[0]["action"] == "REVOKED"
+
+
+@pytest.mark.asyncio
+async def test_signed_in_trusted_device_rollout_fails_closed_without_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: set())
+
+    with pytest.raises(HTTPException) as raised:
+        await account._trusted_device_guard("user-1")
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail["code"] == "TRUSTED_DEVICE_NOT_ALLOWED"
+
+
+@pytest.mark.asyncio
+async def test_signed_in_trusted_device_rollout_accepts_exact_uid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: {"user-1", "other-user"})
+
+    await account._trusted_device_guard("user-1")
+
+
+@pytest.mark.asyncio
+async def test_pkce_exchange_guard_does_not_require_identity_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: set())
+
+    await account._trusted_device_guard()
+
+
+@pytest.mark.asyncio
+async def test_device_list_remains_available_when_rollout_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: False)
+    monkeypatch.setattr(account, "TrustedDeviceService", _FakeTrustedDeviceService)
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+
+    result = await account.list_trusted_devices(firebase_uid="user-1")
+
+    assert result == {"devices": [{"device_id": "tdv_recoverable", "status": "active"}]}
+
+
+@pytest.mark.asyncio
+async def test_device_revocation_remains_available_when_rollout_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run_in_threadpool(function, **kwargs):
+        return function(**kwargs)
+
+    class _ConsentLedger:
+        async def get_active_internal_tokens(self, *_args, **_kwargs):
+            return []
+
+    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: False)
+    monkeypatch.setattr(account, "TrustedDeviceService", _FakeTrustedDeviceService)
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    monkeypatch.setattr(
+        "hushh_mcp.services.consent_db.ConsentDBService",
+        _ConsentLedger,
+    )
+
+    result = await account.revoke_trusted_device(
+        "tdv_recoverable",
+        firebase_uid="user-1",
+    )
+
+    assert result == {"success": True, "device_id": "tdv_recoverable"}
+
+
+@pytest.mark.asyncio
+async def test_device_minted_firebase_session_cannot_enroll_another_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from firebase_admin import auth as firebase_auth
+
+    async def _run_in_threadpool(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    monkeypatch.setattr(account, "get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr(
+        firebase_auth,
+        "verify_id_token",
+        lambda *_args, **_kwargs: {
+            "uid": "user-1",
+            "trusted_device_id": "tdv_" + ("a" * 32),
+        },
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await account._verify_browser_enrollment_identity("Bearer firebase-id-token")
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail["code"] == "TRUSTED_DEVICE_BROWSER_APPROVAL_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_browser_firebase_session_can_approve_device_enrollment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from firebase_admin import auth as firebase_auth
+
+    async def _run_in_threadpool(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    monkeypatch.setattr(account, "get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr(
+        firebase_auth,
+        "verify_id_token",
+        lambda *_args, **_kwargs: {"uid": "user-1"},
+    )
+
+    assert await account._verify_browser_enrollment_identity("Bearer firebase-id-token") == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_email_rollout_entry_requires_verified_firebase_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from firebase_admin import auth as firebase_auth
+
+    class _Record:
+        email = "owner@example.com"
+        email_verified = False
+
+    async def _run_in_threadpool(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(account, "trusted_devices_enabled", lambda: True)
+    monkeypatch.setattr(account, "_trusted_device_allowlist", lambda: {"owner@example.com"})
+    monkeypatch.setattr(account, "run_in_threadpool", _run_in_threadpool)
+    monkeypatch.setattr(account, "get_firebase_auth_app", lambda: object())
+    monkeypatch.setattr(firebase_auth, "get_user", lambda *_args, **_kwargs: _Record())
+
+    with pytest.raises(HTTPException) as raised:
+        await account._trusted_device_guard("user-1")
+
+    assert raised.value.status_code == 403

--- a/docs/reference/iam/architecture.md
+++ b/docs/reference/iam/architecture.md
@@ -119,6 +119,26 @@ Private data is always consent-gated and scoped.
 
 Cross-device sharing rides the consent protocol as a standard. A live-location grant mints a signed HCT consent token scoped `cap.location.live.view`, bound to a `device:<recipient_user_id>` agent identity, expiring with the grant. The recipient device exercises this token as its capability; the backend validates signature, expiry, and scope before accepting any ciphertext envelope. This makes the grant's authority a verifiable cryptographic capability rather than a descriptive column.
 
+### First-Party Hermes Trusted Devices
+
+Hermes is an additive first-party device surface, not a developer-token
+elevation:
+
+1. Firebase OAuth identifies the account through Authorization Code + PKCE.
+2. A registered P-256 device key proves the exact Hermes installation.
+3. The existing passphrase wrapper is fetched and unwrapped locally; the
+   passphrase and vault key never enter Hussh infrastructure or model context.
+4. A signed, single-use device challenge permits a 15-minute
+   device-bound `VAULT_OWNER` capability.
+5. PKM ciphertext and `PkmMutationPlanV2` continue through the existing
+   validation/store endpoints and optimistic concurrency contract.
+6. Developer tokens remain application identity only. They never map to
+   `VAULT_OWNER`, PKM write, vault unwrap, or a trusted-device credential.
+
+Postgres owns one-time codes, nonce replay protection, device state, and
+metadata-only audit today. `TrustedDeviceStore` is the replaceable seam for a
+future Redis/Memorystore replay and revocation fan-out adapter.
+
 ## Change Control
 
 Any IAM contract change must update, in the same PR:

--- a/docs/reference/iam/validation-checklist.md
+++ b/docs/reference/iam/validation-checklist.md
@@ -38,6 +38,11 @@ Provide the canonical verification gate for Investor + RIA IAM changes.
 2. Audit records include actor/scope/duration metadata.
 3. Telemetry remains metadata-only.
 4. No raw secrets or sensitive payloads in logs.
+5. Trusted-device authorization is UAT-flagged and allowlisted.
+6. Device codes and challenges are short-lived, single-use, and replay-safe.
+7. Device owner capabilities require Firebase identity plus a fresh P-256 signature.
+8. Device revocation rejects challenges and subsequent owner-capability issuance.
+9. Developer tokens cannot mint `VAULT_OWNER`, unwrap the vault, or write PKM.
 
 ## Ecosystem Checks
 


### PR DESCRIPTION
## Summary
- add allowlisted browser approval and one-time PKCE exchange for Hermes device enrollment
- bind Firebase device sessions and 15-minute vault-owner capabilities to active device records
- fail closed when device status cannot be verified and revoke device-bound capabilities immediately
- keep authenticated device listing and revocation available as recovery operations when rollout is disabled

The rollout flag remains disabled and is not configured in hosted environments.

## Verification
- 50 focused backend tests passed
- device-session active, inactive, and database-unavailable cases covered
- owner-token revocation and issuance-race cases covered
- `./bin/hushh docs verify`