### PR TITLE
feat(web): add governed Hermes device surfaces

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -16,6 +16,9 @@ paths = [
   # HCT golden-vector fixture: deterministic test signing key used by
   # apps/one-mac/Sources/OneConsent + consent-protocol/scripts/emit_hct_golden_vectors.py.
   '''^consent-protocol/tests/fixtures/hct_golden_vectors\.json$''',
+  # Deterministic, synthetic Hermes interoperability vector. The encrypted
+  # bytes and hash are fixed test outputs, not deployable credentials.
+  '''^hushh-webapp/__tests__/fixtures/hermes-vault-vector\.json$''',
 ]
 regexes = [
   '''replace_with_64_char_hex_secret_key''',

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -3403,6 +3403,52 @@
       "implementation_override": null,
       "lifecycle": "canonical",
       "native_surface_id": "native-route-profile",
+      "page_file": "app/one/profile/security/devices/page.tsx",
+      "pathname": "/one/profile/security/devices",
+      "route_mode": "standard",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.profile.security.devices"
+      }
+    },
+    {
+      "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": "native-route-profile",
+      "page_file": "app/one/profile/security/devices/authorize/page.tsx",
+      "pathname": "/one/profile/security/devices/authorize",
+      "route_mode": "hidden",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.profile.security.devices.authorize"
+      }
+    },
+    {
+      "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": "native-route-profile",
       "page_file": "app/one/profile/security/session/page.tsx",
       "pathname": "/one/profile/security/session",
       "route_mode": "standard",
@@ -4293,13 +4339,13 @@
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "afac5b3a07a1ec2e6ab4f87231b37edb81a0d771daae2cf4900dd6fb9a35f049",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
-    "cache_manifest": "1a02aa456549e92ceea962f8e2daa679d8f2c83eeefdea77b36612e981ecc147",
+    "cache_manifest": "ebd1c1e5f5fdae7c64cac31ba378f3c8e587a11816fb2a114f032c3f2fa7dea0",
     "data_plane": "88c984eead2fd6e0b350b5f5d14194c78b34d87c5b1825d0490508c6d6df66e5",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
-    "route_index": "46d94273cc53d297b8a4f4cdc7916f6cb23d602209555b5328201c0a9b78423b",
-    "route_layout": "ac0022abfb058ba602f6df3fbd3f08072f1c4b921bee2208f4fd53639d88a760",
-    "surface_map": "32a9777768a88be4e9c1b3146befa55cd1485d49f1fbf000d5fb5f2385055019",
+    "route_index": "f293d17e7d739acf3052aba9436829df846d059e980395de733596bb23b95338",
+    "route_layout": "c9e9f505ddf8745bbe1012fff644aa5a68ad99dc6d120b916a344012311a1642",
+    "surface_map": "f9f450261fbc47005dc040106e94c3dbc86976bf6f80750e1c0463c7e7da43e6",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
@@ -4311,7 +4357,7 @@
     "decision_required": 2,
     "in_process_specialists": 3,
     "one_specialist_tools": 5,
-    "physical_routes": 113,
+    "physical_routes": 115,
     "semantic_routes": 14,
     "table_families": 40
   }

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -3553,6 +3553,92 @@
       "native_surface_id": "native-route-profile"
     },
     {
+      "route_pattern": "/one/profile/security/devices",
+      "page_file": "app/one/profile/security/devices/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.security.devices",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.devices",
+        "purpose": "Help the person review and revoke computers connected to their private agent.",
+        "screen": "profile_security_devices",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Revocation completes only after the backend confirms the device is revoked and the list refreshes.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_security_devices",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": "native-route-profile"
+    },
+    {
+      "route_pattern": "/one/profile/security/devices/authorize",
+      "page_file": "app/one/profile/security/devices/authorize/page.tsx",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.profile.security.devices.authorize",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.devices.authorize",
+        "purpose": "Help the person review and approve a verified Hermes device authorization request.",
+        "screen": "app",
+        "entry_cue": "Review the device request, then approve it or leave without granting access.",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Authorization completes only after the verified loopback redirect receives the backend-issued one-time code.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": "native-route-profile"
+    },
+    {
       "route_pattern": "/one/profile/security/session",
       "page_file": "app/one/profile/security/session/page.tsx",
       "route_mode": "standard",

--- a/docs/reference/architecture/route-contracts.md
+++ b/docs/reference/architecture/route-contracts.md
@@ -70,6 +70,8 @@ Keep navigation documentation aligned with `hushh-webapp/lib/navigation/routes.t
 - `/one/profile/security`
 - `/one/profile/security/vault`
 - `/one/profile/security/session`
+- `/one/profile/security/devices`
+- `/one/profile/security/devices/authorize`
 - `/one/profile/my-data`
 - `/one/profile/my-data/domain?key=<domain_key>`
 - `/one/profile/access`

--- a/hushh-webapp/__tests__/fixtures/hermes-mutation-plan-v2.json
+++ b/hushh-webapp/__tests__/fixtures/hermes-mutation-plan-v2.json
@@ -1,0 +1,40 @@
+{
+  "user_id": "user-fixture",
+  "domain": "hermes_uat_smoke",
+  "scope_path": "profile",
+  "source_revision": 7,
+  "scope_handle": "s_fixture_handle",
+  "summary": "Update the synthetic profile marker.",
+  "sharing_impact": {
+    "active_recipient_count": 1,
+    "recipient_labels": ["Test recipient"],
+    "enters_next_export_revision": true,
+    "summary": "One active recipient is affected.",
+    "affected_grant_ids": ["grant_fixture"],
+    "affected_export_ids": ["export_fixture"]
+  },
+  "expected": {
+    "version": 2,
+    "operation": "update",
+    "source_scope_handle": "s_fixture_handle",
+    "target_scope_handle": "s_fixture_handle",
+    "proposed_domain": "hermes_uat_smoke",
+    "proposed_scope": "profile",
+    "friendly_domain_name": "Hermes Uat Smoke",
+    "friendly_scope_name": "Profile",
+    "confidence": 1,
+    "explanation": "Update the synthetic profile marker.",
+    "affected_grant_ids": ["grant_fixture"],
+    "affected_export_ids": ["export_fixture"],
+    "sharing_impact": {
+      "active_recipient_count": 1,
+      "recipient_labels": ["Test recipient"],
+      "enters_next_export_revision": true,
+      "summary": "One active recipient is affected."
+    },
+    "semantic_contract_version": "6.0.0",
+    "writer_id": "hussh_one_hermes",
+    "structure_agent_id": "pkm_structure_agent",
+    "source_revision": 7
+  }
+}

--- a/hushh-webapp/__tests__/fixtures/hermes-vault-vector.json
+++ b/hushh-webapp/__tests__/fixtures/hermes-vault-vector.json
@@ -1,0 +1,10 @@
+{
+  "vector_id": "hussh-vault-passphrase-v1",
+  "schema_version": 1,
+  "passphrase": "correct horse battery staple",
+  "salt_b64": "AAECAwQFBgcICQoLDA0ODw==",
+  "iv_b64": "AAECAwQFBgcICQoL",
+  "encrypted_vault_key_b64": "Y23IVq92fddVIVsQJnFEBp3CasDwAnYPNgT3bX9L3vJM934H8QKzANCxzOnjzNiV",
+  "vault_key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "vault_key_hash": "6c86c6aac5fb24bcf5d9939cb7d7d5645ce39418f449e03b262dd4fa14b4b92b"
+}

--- a/hushh-webapp/__tests__/vault/hermes-mutation-plan-vector.test.ts
+++ b/hushh-webapp/__tests__/vault/hermes-mutation-plan-vector.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import vector from "@/__tests__/fixtures/hermes-mutation-plan-v2.json";
+import type { DomainManifest } from "@/lib/personal-knowledge-model/manifest";
+import { buildConfirmedPkmMutationPlanV2 } from "@/lib/personal-knowledge-model/mutation-plan";
+
+function manifest(): DomainManifest {
+  return {
+    domain: vector.domain,
+    manifest_version: 1,
+    summary_projection: {},
+    top_level_scope_paths: [vector.scope_path],
+    externalizable_paths: [vector.scope_path],
+    paths: [],
+    scope_registry: [
+      {
+        scope_handle: vector.scope_handle,
+        scope_label: "Profile",
+        segment_ids: ["profile"],
+        summary_projection: {
+          top_level_scope_path: vector.scope_path,
+        },
+      },
+    ],
+  };
+}
+
+describe("Hermes mutation plan v2 golden vector", () => {
+  it("matches the current TypeScript mutation-plan contract", async () => {
+    const currentManifest = manifest();
+    const plan = await buildConfirmedPkmMutationPlanV2({
+      userId: vector.user_id,
+      domain: vector.domain,
+      currentManifest,
+      targetManifest: currentManifest,
+      scopePath: vector.scope_path,
+      operation: "update",
+      confidence: 1,
+      explanation: vector.summary,
+      sourceRevision: vector.source_revision,
+      confirmation: {
+        confirmedByUser: true,
+        surface: "chat",
+        source: "hussh_one_hermes",
+        sharingImpactAcknowledged: true,
+        sharingImpact: {
+          activeRecipientCount: vector.sharing_impact.active_recipient_count,
+          recipientLabels: vector.sharing_impact.recipient_labels,
+          entersNextExportRevision:
+            vector.sharing_impact.enters_next_export_revision,
+          summary: vector.sharing_impact.summary,
+          affectedGrantIds: vector.sharing_impact.affected_grant_ids,
+          affectedExportIds: vector.sharing_impact.affected_export_ids,
+        },
+      },
+    });
+
+    expect(plan).toMatchObject(vector.expected);
+    expect(plan.confirmation_receipt).toMatchObject({
+      version: 2,
+      plan_id: plan.plan_id,
+      confirmed_by_user_id: vector.user_id,
+      surface: "chat",
+      displayed_domain: vector.domain,
+      displayed_scope: vector.scope_path,
+      sharing_impact_acknowledged: true,
+    });
+  });
+});

--- a/hushh-webapp/__tests__/vault/hermes-vault-vector.test.ts
+++ b/hushh-webapp/__tests__/vault/hermes-vault-vector.test.ts
@@ -1,0 +1,18 @@
+import vector from "../fixtures/hermes-vault-vector.json";
+
+import { VaultService } from "@/lib/services/vault-service";
+import { unlockVaultWithPassphrase } from "@/lib/vault/passphrase-key";
+
+describe("Hermes vault crypto vector", () => {
+  it("unwraps and hashes identically to the native bridge", async () => {
+    const vaultKey = await unlockVaultWithPassphrase(
+      vector.passphrase,
+      vector.encrypted_vault_key_b64,
+      vector.salt_b64,
+      vector.iv_b64,
+    );
+
+    expect(vaultKey).toBe(vector.vault_key_hex);
+    expect(await VaultService.hashVaultKey(vaultKey)).toBe(vector.vault_key_hash);
+  });
+});

--- a/hushh-webapp/app/api/account/[...path]/route.ts
+++ b/hushh-webapp/app/api/account/[...path]/route.ts
@@ -84,3 +84,10 @@ export async function POST(
 ) {
   return proxyRequest(request, await props.params);
 }
+
+export async function DELETE(
+  request: NextRequest,
+  props: { params: Promise<{ path: string[] }> }
+) {
+  return proxyRequest(request, await props.params);
+}

--- a/hushh-webapp/app/one/profile/security/devices/authorize/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/authorize/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Laptop, Loader2, ShieldCheck } from "lucide-react";
+
+import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+import { ROUTES } from "@/lib/navigation/routes";
+import { ApiService } from "@/lib/services/api-service";
+import { assignWindowLocation } from "@/lib/utils/browser-navigation";
+
+function requiredParam(
+  params: { get(name: string): string | null },
+  name: string,
+): string {
+  return (params.get(name) || "").trim();
+}
+
+export default function TrustedDeviceAuthorizePage() {
+  const searchParams = useSearchParams();
+  const { user } = useAuth();
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const request = useMemo(
+    () => ({
+      redirect_uri: requiredParam(searchParams, "redirect_uri"),
+      code_challenge: requiredParam(searchParams, "code_challenge"),
+      code_challenge_method: requiredParam(searchParams, "code_challenge_method") || "S256",
+      device_public_key: requiredParam(searchParams, "device_public_key"),
+      device_name: requiredParam(searchParams, "device_name"),
+      platform: requiredParam(searchParams, "platform") || "macos",
+      state: requiredParam(searchParams, "state"),
+    }),
+    [searchParams],
+  );
+  const complete = Object.values(request).every(Boolean);
+
+  async function approve() {
+    if (!user || !complete || submitting) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const response = await ApiService.authorizeTrustedDevice(request);
+      const payload = await response.json();
+      if (!response.ok || typeof payload.redirect_url !== "string") {
+        throw new Error(
+          payload?.detail?.message || "This device could not be authorized.",
+        );
+      }
+      assignWindowLocation(payload.redirect_url);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Authorization failed.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[70vh] max-w-xl items-center px-6 py-12">
+      <NativeRouteMarker
+        routeId={ROUTES.PROFILE_SECURITY_DEVICE_AUTHORIZE}
+        marker="native-route-profile"
+        authState={user ? "authenticated" : "pending"}
+        dataState="loaded"
+      />
+      <section className="w-full rounded-3xl border bg-card p-8 shadow-sm">
+        <div className="mb-6 flex size-12 items-center justify-center rounded-2xl bg-primary/10">
+          <Laptop className="size-6 text-primary" aria-hidden />
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">Connect this Hermes device</h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          Approve this private computer as an extension of One. The vault passphrase
+          remains local to Hermes and is never sent to Hussh. Each signed device
+          proof can issue a 15-minute vault-owner capability for protected actions,
+          including confirmed PKM writes.
+        </p>
+
+        <dl className="mt-6 rounded-2xl bg-muted/50 p-4 text-sm">
+          <div className="flex justify-between gap-4">
+            <dt className="text-muted-foreground">Hussh account</dt>
+            <dd className="truncate font-medium">{user?.email || "Sign in required"}</dd>
+          </div>
+          <div className="flex justify-between gap-4">
+            <dt className="text-muted-foreground">Device</dt>
+            <dd className="font-medium">{request.device_name || "Unknown device"}</dd>
+          </div>
+          <div className="mt-2 flex justify-between gap-4">
+            <dt className="text-muted-foreground">Access</dt>
+            <dd className="text-right font-medium">15-minute vault-owner capability</dd>
+          </div>
+        </dl>
+
+        <div className="mt-6 flex items-start gap-3 text-sm text-muted-foreground">
+          <ShieldCheck className="mt-0.5 size-4 shrink-0 text-emerald-600" aria-hidden />
+          <p>You can revoke this device at any time from Profile → Security → Devices.</p>
+        </div>
+
+        {error ? <p className="mt-5 text-sm text-destructive">{error}</p> : null}
+        {!complete ? (
+          <p className="mt-5 text-sm text-destructive">
+            The Hermes authorization request is incomplete. Return to Hermes and try again.
+          </p>
+        ) : null}
+
+        <Button
+          className="mt-7 w-full"
+          disabled={!user || !complete || submitting}
+          onClick={() => void approve()}
+        >
+          {submitting ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+          Approve device
+        </Button>
+      </section>
+    </main>
+  );
+}

--- a/hushh-webapp/app/one/profile/security/devices/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Laptop, Loader2, Trash2 } from "lucide-react";
+
+import {
+  AppPageContentRegion,
+  AppPageHeaderRegion,
+  AppPageShell,
+} from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+import { ROUTES } from "@/lib/navigation/routes";
+import { ApiService } from "@/lib/services/api-service";
+
+interface TrustedDevice {
+  device_id: string;
+  device_name: string;
+  platform: string;
+  status: "active" | "revoked";
+  created_at: number;
+  last_used_at: number | null;
+}
+
+export default function TrustedDevicesPage() {
+  const { user } = useAuth();
+  const [devices, setDevices] = useState<TrustedDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [pendingRevocation, setPendingRevocation] = useState<TrustedDevice | null>(null);
+  const [revoking, setRevoking] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    try {
+      const response = await ApiService.listTrustedDevices();
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload?.detail?.message || "Devices unavailable.");
+      setDevices(Array.isArray(payload.devices) ? payload.devices : []);
+      setError("");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Devices unavailable.");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function revoke(deviceId: string) {
+    if (!user) return;
+    setRevoking(true);
+    try {
+      const response = await ApiService.revokeTrustedDevice(deviceId);
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        setError(payload?.detail?.message || "The device could not be revoked.");
+        return;
+      }
+      setPendingRevocation(null);
+      await load();
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  return (
+    <AppPageShell
+      as="main"
+      width="reading"
+      nativeTest={{
+        routeId: ROUTES.PROFILE_SECURITY_DEVICES,
+        marker: "native-route-profile",
+        authState: user ? "authenticated" : "pending",
+        dataState: loading ? "loading" : "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          title="Trusted devices"
+          description="Computers connected as an extension of your private agent."
+          accent="neutral"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="size-4 animate-spin" /> Loading devices…
+          </div>
+        ) : null}
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="space-y-3">
+          {devices.map(device => (
+            <article
+              className="flex items-center gap-4 rounded-2xl border bg-card p-4"
+              key={device.device_id}
+            >
+              <div className="flex size-10 items-center justify-center rounded-xl bg-muted">
+                <Laptop className="size-5" aria-hidden />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="truncate text-sm font-medium">{device.device_name}</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {device.status === "active" ? "Active" : "Revoked"} ·{" "}
+                  {device.platform}
+                </p>
+              </div>
+              {device.status === "active" ? (
+                <Button
+                  aria-label={`Revoke ${device.device_name}`}
+                  onClick={() => setPendingRevocation(device)}
+                  size="icon"
+                  variant="ghost"
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              ) : null}
+            </article>
+          ))}
+          {!loading && devices.length === 0 ? (
+            <p className="rounded-2xl border border-dashed p-8 text-center text-sm text-muted-foreground">
+              No trusted devices are connected.
+            </p>
+          ) : null}
+        </div>
+      </AppPageContentRegion>
+      <AlertDialog
+        open={pendingRevocation !== null}
+        onOpenChange={open => {
+          if (!open && !revoking) setPendingRevocation(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke this trusted device?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingRevocation?.device_name || "This device"} will immediately lose
+              access to new owner capabilities and PKM writes. Reconnecting requires
+              browser approval and local vault setup again.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={revoking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={revoking || pendingRevocation === null}
+              onClick={event => {
+                event.preventDefault();
+                if (pendingRevocation) void revoke(pendingRevocation.device_id);
+              }}
+            >
+              {revoking ? "Revoking…" : "Revoke device"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -10,16 +10,16 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 113,
-    "physical_page_count": 113,
-    "route_contract_count": 113,
-    "surface_map_count": 113,
+    "total_screens": 115,
+    "physical_page_count": 115,
+    "route_contract_count": 115,
+    "surface_map_count": 115,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
       "redirect/alias": 40,
-      "vault-backed": 40,
-      "hidden flow": 10,
+      "vault-backed": 41,
+      "hidden flow": 11,
       "auth/pre-vault": 6,
       "RIA/provider": 8,
       "PKM-secure": 6
@@ -3599,6 +3599,96 @@
       "findings": []
     },
     {
+      "route": "/one/profile/security/devices",
+      "page_file": "app/one/profile/security/devices/page.tsx",
+      "route_contract_mode": "standard",
+      "screen_class": "vault-backed",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fdevices",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": true,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
+      "route": "/one/profile/security/devices/authorize",
+      "page_file": "app/one/profile/security/devices/authorize/page.tsx",
+      "route_contract_mode": "hidden",
+      "screen_class": "hidden flow",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fdevices%2Fauthorize",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": true,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": true
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
       "route": "/one/profile/security/session",
       "page_file": "app/one/profile/security/session/page.tsx",
       "route_contract_mode": "standard",
@@ -5066,5 +5156,5 @@
       ]
     }
   ],
-  "content_sha256": "2712e54cc6274310ce0c31c60888570340e19224c850d24fbbfb8f8a2d78ff9e"
+  "content_sha256": "3cc745f2b8ceeb55ce744a306a8fe833dded1d4466b96a7f6f7d6d9933bf2d9c"
 }

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -3553,6 +3553,92 @@
       "native_surface_id": "native-route-profile"
     },
     {
+      "route_pattern": "/one/profile/security/devices",
+      "page_file": "app/one/profile/security/devices/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.profile.security.devices",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.devices",
+        "purpose": "Help the person review and revoke computers connected to their private agent.",
+        "screen": "profile_security_devices",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Revocation completes only after the backend confirms the device is revoked and the list refreshes.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "profile_security_devices",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": "native-route-profile"
+    },
+    {
+      "route_pattern": "/one/profile/security/devices/authorize",
+      "page_file": "app/one/profile/security/devices/authorize/page.tsx",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.profile.security.devices.authorize",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.profile.security.devices.authorize",
+        "purpose": "Help the person review and approve a verified Hermes device authorization request.",
+        "screen": "app",
+        "entry_cue": "Review the device request, then approve it or leave without granting access.",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Authorization completes only after the verified loopback redirect receives the backend-issued one-time code.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": "native-route-profile"
+    },
+    {
       "route_pattern": "/one/profile/security/session",
       "page_file": "app/one/profile/security/session/page.tsx",
       "route_mode": "standard",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -5440,6 +5440,131 @@
       "thread_and_consent_contract": null
     },
     {
+      "route": "/one/profile/security/devices",
+      "page_file": "app/one/profile/security/devices/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "standard",
+        "exemption_reason": null,
+        "shell_verification_file": "app/one/profile/security/devices/page.tsx",
+        "shell_verification_includes": [
+          "AppPageShell",
+          "AppPageHeaderRegion",
+          "AppPageContentRegion",
+          "PageHeader"
+        ],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.profile.security.devices",
+          "purpose": "Help the person review and revoke computers connected to their private agent.",
+          "screen": "profile_security_devices",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Revocation completes only after the backend confirms the device is revoked and the list refreshes.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": {
+        "route": "/one/profile/security/devices",
+        "classification": "native-required-functional",
+        "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fdevices",
+        "expectedMarker": "native-route-profile",
+        "expectedRoute": "/one/profile/security/devices",
+        "autoReviewerLogin": true,
+        "expectedAuth": "authenticated",
+        "allowedDataStates": [
+          "loaded"
+        ]
+      },
+      "shell": {
+        "app_page_shell": true,
+        "page_header": true,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
+      "route": "/one/profile/security/devices/authorize",
+      "page_file": "app/one/profile/security/devices/authorize/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Trusted-device authorization is a short-lived browser-to-Hermes handoff and intentionally bypasses the signed-in app chrome.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.profile.security.devices.authorize",
+          "purpose": "Help the person review and approve a verified Hermes device authorization request.",
+          "screen": "app",
+          "entry_cue": "Review the device request, then approve it or leave without granting access.",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Authorization completes only after the verified loopback redirect receives the backend-issued one-time code.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": {
+        "route": "/one/profile/security/devices/authorize",
+        "classification": "native-required-functional",
+        "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fdevices%2Fauthorize",
+        "expectedMarker": "native-route-profile",
+        "expectedRoute": "/one/profile/security/devices/authorize",
+        "autoReviewerLogin": true,
+        "expectedAuth": "authenticated",
+        "allowedDataStates": [
+          "loaded"
+        ]
+      },
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
       "route": "/one/profile/security/session",
       "page_file": "app/one/profile/security/session/page.tsx",
       "physical_page_exists": true,
@@ -7617,5 +7742,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "a80fc2d258f24a74c5638565229c68cd86315276be591580b3d823846eed989a"
+  "content_sha256": "5f87fa447ef4e4597022a9de422679f61aa9f2a094fd8c09030933ea29a08ffe"
 }

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -2677,6 +2677,68 @@
     }
   },
   {
+    "route": "/one/profile/security/devices",
+    "mode": "standard",
+    "shellVerification": {
+      "file": "app/one/profile/security/devices/page.tsx",
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.profile.security.devices",
+      "purpose": "Help the person review and revoke computers connected to their private agent.",
+      "screen": "profile_security_devices",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Revocation completes only after the backend confirms the device is revoked and the list refreshes.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
+    "route": "/one/profile/security/devices/authorize",
+    "mode": "hidden",
+    "exemptionReason": "Trusted-device authorization is a short-lived browser-to-Hermes handoff and intentionally bypasses the signed-in app chrome.",
+    "voicePlaybook": {
+      "playbookId": "route.profile.security.devices.authorize",
+      "purpose": "Help the person review and approve a verified Hermes device authorization request.",
+      "screen": "app",
+      "entryCue": "Review the device request, then approve it or leave without granting access.",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Authorization completes only after the verified loopback redirect receives the backend-issued one-time code.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
     "route": "/one/profile/my-data",
     "mode": "standard",
     "shellVerification": {

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -76,6 +76,8 @@ export const ROUTES = {
   PROFILE_SECURITY: "/one/profile/security",
   PROFILE_SECURITY_VAULT: "/one/profile/security/vault",
   PROFILE_SECURITY_SESSION: "/one/profile/security/session",
+  PROFILE_SECURITY_DEVICES: "/one/profile/security/devices",
+  PROFILE_SECURITY_DEVICE_AUTHORIZE: "/one/profile/security/devices/authorize",
   PROFILE_MY_DATA: "/one/profile/my-data",
   PROFILE_MY_DATA_DOMAIN: "/one/profile/my-data/domain",
   PROFILE_ACCESS: "/one/profile/access",

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -1478,6 +1478,58 @@ export class ApiService {
     }
   }
 
+  static async authorizeTrustedDevice(data: {
+    redirect_uri: string;
+    code_challenge: string;
+    code_challenge_method: string;
+    device_public_key: string;
+    device_name: string;
+    platform: string;
+    state: string;
+  }): Promise<Response> {
+    const authToken = await this.getFirebaseToken();
+    if (!authToken) {
+      return new Response(JSON.stringify({ error: "Missing Firebase ID token" }), {
+        status: 401,
+      });
+    }
+    return apiFetch("/api/account/trusted-device-authorizations", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+  }
+
+  static async listTrustedDevices(): Promise<Response> {
+    const authToken = await this.getFirebaseToken();
+    if (!authToken) {
+      return new Response(JSON.stringify({ error: "Missing Firebase ID token" }), {
+        status: 401,
+      });
+    }
+    return apiFetch("/api/account/trusted-devices", {
+      method: "GET",
+      headers: { Authorization: `Bearer ${authToken}` },
+      cache: "no-store",
+    });
+  }
+
+  static async revokeTrustedDevice(deviceId: string): Promise<Response> {
+    const authToken = await this.getFirebaseToken();
+    if (!authToken) {
+      return new Response(JSON.stringify({ error: "Missing Firebase ID token" }), {
+        status: 401,
+      });
+    }
+    return apiFetch(`/api/account/trusted-devices/${encodeURIComponent(deviceId)}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${authToken}` },
+    });
+  }
+
   /**
    * Request a backend-minted Firebase custom token for reviewer login.
    * Only available when app-review mode is enabled server-side.

--- a/hushh-webapp/native-route-inventory.json
+++ b/hushh-webapp/native-route-inventory.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-07-19",
-  "total_routes": 101,
-  "native_required_routes": 91,
+  "total_routes": 103,
+  "native_required_routes": 93,
   "excluded_routes": 10,
   "routes": [
     {
@@ -682,6 +682,30 @@
       "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fsession",
       "expectedMarker": "native-route-profile",
       "expectedRoute": "/one/profile/security/session",
+      "autoReviewerLogin": true,
+      "expectedAuth": "authenticated",
+      "allowedDataStates": [
+        "loaded"
+      ]
+    },
+    {
+      "route": "/one/profile/security/devices",
+      "classification": "native-required-functional",
+      "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fdevices",
+      "expectedMarker": "native-route-profile",
+      "expectedRoute": "/one/profile/security/devices",
+      "autoReviewerLogin": true,
+      "expectedAuth": "authenticated",
+      "allowedDataStates": [
+        "loaded"
+      ]
+    },
+    {
+      "route": "/one/profile/security/devices/authorize",
+      "classification": "native-required-functional",
+      "initialRoute": "/login?redirect=%2Fone%2Fprofile%2Fsecurity%2Fdevices%2Fauthorize",
+      "expectedMarker": "native-route-profile",
+      "expectedRoute": "/one/profile/security/devices/authorize",
       "autoReviewerLogin": true,
       "expectedAuth": "authenticated",
       "allowedDataStates": [


### PR DESCRIPTION
## Summary
- add signed-in trusted-device listing, revocation, and browser approval surfaces
- proxy the governed account endpoints and expose typed web service calls
- add Hermes vault and mutation-plan compatibility vectors
- register both visible routes in the canonical route, layout, native inventory, docs, and generated surface-map contracts
- use the shared navigation wrapper for the verified loopback handoff

Enrollment remains disabled in hosted environments pending an explicit rollout decision.

## Verification
- web typecheck, lint, two vault-vector tests, and production build passed
- `npm run verify:surface-map`
- `npm run verify:capacitor:static`
- Android `:app:testDebugUnitTest` passed
- iOS simulator build-for-testing passed
- `./bin/hushh docs verify`