### PR TITLE
Consent cache, trusted-device auth, and MCP developer parity

### DIFF
--- a/docs/reference/operations/coding-agent-mcp.md
+++ b/docs/reference/operations/coding-agent-mcp.md
@@ -82,11 +82,11 @@ Purpose:
 
 Public tools:
 
-1. `search_user_scopes`
-2. `prepare_campaign_context` (Hussh ADK compatibility only)
-3. `request_consent`
-4. `check_consent_status`
-5. `get_encrypted_scoped_export`
+1. `search-user-scopes`
+2. `prepare-campaign-context` (Hussh ADK compatibility only)
+3. `request-consent`
+4. `check-consent-status`
+5. `get-encrypted-scoped-export`
 
 Use bearer-header authentication only. MCP results must not expose caller or Firebase identifiers, developer or consent tokens, private keys, internal URLs, backend payloads, or exception text.
 

--- a/docs/reference/quality/app-surface-design-system.md
+++ b/docs/reference/quality/app-surface-design-system.md
@@ -181,21 +181,15 @@ scrolled fully above fixed chrome on compact viewports. 9. Decorative glass fade
     browser history as its parent resolver. The left edge wins over contextual
     tab swipes, appears only when the route exposes a back action, and never
     runs over a modal surface. Android preserves platform system-back behavior.
-30. Persistent signed-in chrome uses `AmbientChromeMask` and its shared ambient
-    token engine. It samples the painted app surface behind the top and bottom
-    edges, including Foundation's computed `oklch()` theme colors, excludes
-    chrome and transient overlays, and keeps theme-derived fallback tokens
-    until the first valid sample. Do not set global
-    `--background` from a chrome sample or add a route-local blur/tint recipe.
-    The only edge variables are `--ambient-chrome-{top,bottom}-{bg,fg}`;
-    a bottom-specific Foundation/base tint is prohibited. Every chrome child
-    inherits the matching sampled foreground through `currentColor`, so dark
-    tint yields light ink and light tint yields dark ink on both platforms.
-    The top mask height is the resolved shell height plus a mode-specific tail:
-    `bar-with-tabs` must dissolve farther below its tab underline than `bar`.
-    The engine also publishes the top surface tone for native system-bar icon
-    contrast; native bridges consume that shared decision rather than guessing
-    from the global theme.
+30. Persistent signed-in chrome uses `AmbientChromeMask` as the one shared
+    compositor. Both edges paint a neutral `--background` to transparent
+    feather with `--foreground` ink; route colors must not tint either bar.
+    The sampling engine remains limited to publishing the top surface tone for
+    native system-bar icon contrast and must not recolor web chrome. Do not set
+    global `--background` from a sample or add a route-local blur/tint recipe.
+    The top mask height is the currently visible shell height plus a
+    mode-specific tail: `bar-with-tabs` stays solid through the visible tab
+    underline and its dissolve moves with partial or full header collapse.
 31. `AppBottomShell` is the only persistent bottom compositor. It owns the
     bottom mask, safe-area stack, and scroll-hide transform, then renders the
     bottom navigation and Agent Bar as separate accessible slots. Keep route
@@ -379,7 +373,7 @@ Rules:
 2. The flat-control recipe is: `rounded-full` shape, base fill `bg-black/[0.05] dark:bg-white/[0.07]`, hover fill `hover:bg-black/[0.08] dark:hover:bg-white/[0.1]`, press feedback `active:scale-90` for icon controls and `active:scale-[0.97]` for pill controls, and `transition-[color,background-color,transform] duration-200`. Do not add visible borders, drop shadows, or per-control backdrop blur to flat controls.
 3. Icon controls use `h-9 w-9` and color contrast (`text-muted-foreground hover:text-foreground`). Pill controls use `h-9 px-3.5 text-[14px]` with platform text color (`text-[#1d1d1f] dark:text-[#f5f5f7]`).
 4. When using `morphy-ux` `Button`, a flat control maps to `variant="none" effect="fade"`. Do not mix `effect="glass"` and `effect="fade"` between sibling controls in the same group. The vault unlock methods (Vault Key, Passkey, Recovery Key) must all share one effect so the buttons read as a uniform set.
-5. Persistent bars use `AmbientChromeMask` through `AppTopShell` or `AppBottomShell`; the controller is mounted once in `AppShellFrame` and both edges consume its sampled tint and foreground tokens. Foundation/onboarding presentation may add toggles, but may not fork a local bar, blur, tint, or width recipe. Cards use the `--app-card-*` tokens. Controls live on top of those surfaces and stay flat.
+5. Persistent bars use `AmbientChromeMask` through `AppTopShell` or `AppBottomShell`; the controller is mounted once in `AppShellFrame`, and both edges consume the neutral theme feather and foreground contract. Foundation/onboarding presentation may add toggles, but may not fork a local bar, blur, tint, or width recipe. Cards use the `--app-card-*` tokens. Controls live on top of those surfaces and stay flat.
 6. Focus state is the shared Foundation ring `focus-visible:ring-2 focus-visible:ring-accent/70` (gold, theme-aware via the accent token). Do not invent per-control focus styling and do not reintroduce off-palette `ring-sky-*`/`ring-blue-*`.
 
 ## Foundation Color Contract

--- a/docs/reference/quality/design-system.md
+++ b/docs/reference/quality/design-system.md
@@ -202,12 +202,12 @@ canvas, another fixed header, or a route-local tab bar. The top shell owns the
 single contextual tab row, and a tab may own only its one ordinary `PageHeader`.
 
 Persistent chrome uses the single ambient material system in
-`components/app-ui/ambient-chrome-mask.tsx`: both edges use a blur-free sampled
-tint and feathered dissolve; the top mask keeps the shell legible through its
-tab stack before fading into content. Those edges must remain present on mobile
-and desktop wherever the signed-in top/bottom shell is present.
+`components/app-ui/ambient-chrome-mask.tsx`: both edges use a blur-free neutral
+theme feather; the top mask keeps the shell legible through its visible tab
+stack and moves its dissolve with header collapse. Those edges must remain
+present on mobile and desktop wherever the signed-in top/bottom shell is present.
 
-Persistent chrome text and icons inherit the sampled ambient foreground through
+Persistent chrome text and icons inherit the neutral theme foreground through
 `currentColor`; do not pin descendant `text-foreground` or
 `text-muted-foreground` classes. Lucide icons use the shared
 `--lucide-stroke-width: 1.6` baseline, with a deliberate component-level

--- a/hushh-webapp/__tests__/app/one/one-auth-gate.test.tsx
+++ b/hushh-webapp/__tests__/app/one/one-auth-gate.test.tsx
@@ -101,6 +101,20 @@ describe("OneAuthGate", () => {
     expect(screen.getByText("oauth callback")).toBeTruthy();
   });
 
+  it("lets a signed-in user approve a trusted device without unlocking the browser vault", () => {
+    mocks.pathname = "/one/profile/security/devices/authorize";
+
+    render(
+      <OneAuthGate>
+        <div>trusted device approval</div>
+      </OneAuthGate>,
+    );
+
+    expect(screen.queryByTestId("vault-lock-guard")).toBeNull();
+    expect(screen.getByTestId("phone-mandate-guard")).toBeTruthy();
+    expect(screen.getByText("trusted device approval")).toBeTruthy();
+  });
+
   it.each([
     "/one/setup",
     "/one/setup/connections",

--- a/hushh-webapp/__tests__/components/ambient-chrome-tabs.contract.test.ts
+++ b/hushh-webapp/__tests__/components/ambient-chrome-tabs.contract.test.ts
@@ -18,7 +18,9 @@ describe("tabbed ambient chrome contract", () => {
     expect(topShell).toContain("ambient-chrome-mask--top-with-tabs");
     expect(topShell).toContain(': "var(--top-shell-visual-height)"');
     expect(styles).toContain(".ambient-chrome-mask--top-with-tabs");
-    expect(styles).toContain("var(--top-shell-reserved-height)");
+    expect(styles).toContain("--ambient-chrome-top-solid-height");
+    expect(styles).toContain("var(--top-chrome-collapse-px, 0px)");
+    expect(styles).toContain("--ambient-chrome-top-visible-height");
     expect(styles).toContain("var(--top-fade-active)");
     expect(styles).not.toContain(
       "calc(var(--top-shell-reserved-height) + 50px)",
@@ -31,11 +33,15 @@ describe("tabbed ambient chrome contract", () => {
   it("samples past the content-facing mask edge instead of sampling chrome", () => {
     const ambient = read("lib/morphy-ux/ambient-chrome.ts");
 
-    expect(ambient).toContain('const contentEdge = edge === "top" ? rect.bottom : rect.top');
+    expect(ambient).toContain(
+      'const contentEdge = edge === "top" ? rect.bottom : rect.top',
+    );
     expect(ambient).toContain("sampleSurfaceAcrossMask");
     expect(ambient).toContain("AMBIENT_SAMPLE_COLUMNS");
     expect(ambient).toContain("AMBIENT_CHROME_FULL_BLEED_ATTR");
-    expect(ambient).toContain('observer.observe(root, { attributes: true, attributeFilter: ["class"] });');
+    expect(ambient).toContain(
+      'observer.observe(root, { attributes: true, attributeFilter: ["class"] });',
+    );
   });
 
   it("uses the shared Search Console dissolve curve at the bottom edge", () => {
@@ -57,12 +63,16 @@ describe("tabbed ambient chrome contract", () => {
     );
   });
 
-  it("keeps sampled chrome foreground authoritative for text and icons", () => {
+  it("keeps neutral theme foreground authoritative for text and icons", () => {
     const styles = read("app/globals.css");
 
-    expect(styles).toContain("[data-app-top-bar] .top-shell-ambient-ink .text-foreground");
+    expect(styles).toContain(
+      "[data-app-top-bar] .top-shell-ambient-ink .text-foreground",
+    );
     expect(styles).toContain("color: currentColor;");
-    expect(styles).toContain("var(--ambient-chrome-bottom-fg, #1d1d1f)");
+    expect(styles).toContain("--ambient-chrome-material-bg: var(--background)");
+    expect(styles).toContain("--ambient-chrome-material-fg: var(--foreground)");
+    expect(styles).not.toContain("color: var(--ambient-chrome-top-fg");
     expect(styles).not.toContain("ambient-chrome-bottom-base");
     expect(styles).toContain("--lucide-stroke-width: 1.6");
   });

--- a/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
+++ b/hushh-webapp/__tests__/components/consent-center-page-deeplink.test.tsx
@@ -26,6 +26,9 @@ const mocks = vi.hoisted(() => ({
   handleLocationDeny: vi.fn(),
   handleLocationRevoke: vi.fn(),
   busyRequestIds: new Set<string>(),
+  cacheSubscribers: new Set<
+    (event: { type: string; key?: string; keys?: string[] }) => void
+  >(),
 
   busyScopes: new Set<string>(),
   activeAction: null as null | {
@@ -116,7 +119,18 @@ vi.mock("@/lib/services/cache-service", () => ({
   CacheService: {
     getInstance: () => ({
       peek: vi.fn(() => null),
-      subscribe: vi.fn(() => () => {}),
+      subscribe: vi.fn(
+        (
+          subscriber: (event: {
+            type: string;
+            key?: string;
+            keys?: string[];
+          }) => void,
+        ) => {
+          mocks.cacheSubscribers.add(subscriber);
+          return () => mocks.cacheSubscribers.delete(subscriber);
+        },
+      ),
     }),
   },
   CACHE_KEYS: {
@@ -185,9 +199,7 @@ function emptyListResponse() {
   };
 }
 
-function pendingListResponse(
-  entry: Record<string, unknown>,
-) {
+function pendingListResponse(entry: Record<string, unknown>) {
   return {
     ...emptyListResponse(),
     total: 1,
@@ -291,6 +303,7 @@ describe("ConsentCenterPage requestId deep links", () => {
     mocks.handleRevoke.mockResolvedValue(undefined);
     mocks.busyRequestIds = new Set();
     mocks.busyScopes = new Set();
+    mocks.cacheSubscribers.clear();
     mocks.activeAction = null;
     mocks.lookupPendingRequests.mockResolvedValue({
       items: [
@@ -345,9 +358,7 @@ describe("ConsentCenterPage requestId deep links", () => {
       await screen.findByRole("dialog", { name: "Northstar Planning" }),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Allow" })).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Don't allow" }),
-    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Don't allow" })).toBeTruthy();
     expect(screen.queryByText("Requested duration")).toBeNull();
     expect(screen.queryByText("Future updates")).toBeNull();
     expect(
@@ -359,9 +370,7 @@ describe("ConsentCenterPage requestId deep links", () => {
       ),
     ).toBeTruthy();
 
-    fireEvent.click(
-      screen.getByRole("combobox", { name: "Access duration" }),
-    );
+    fireEvent.click(screen.getByRole("combobox", { name: "Access duration" }));
     expect(
       await screen.findByRole("option", { name: "24 hours" }),
     ).toBeTruthy();
@@ -406,9 +415,7 @@ describe("ConsentCenterPage requestId deep links", () => {
     expect(
       screen.queryByRole("combobox", { name: "Access duration" }),
     ).toBeNull();
-    expect(screen.getAllByRole("link", { name: "Open Email" })).toHaveLength(
-      1,
-    );
+    expect(screen.getAllByRole("link", { name: "Open Email" })).toHaveLength(1);
     expect(screen.queryByText("Original request")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Allow" }));
@@ -488,9 +495,7 @@ describe("ConsentCenterPage requestId deep links", () => {
     ).toBeTruthy();
     expect(screen.queryByText("Your decision")).toBeNull();
     expect(screen.queryByRole("button", { name: "Allow" })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Don't allow" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Don't allow" })).toBeNull();
   });
 
   it("resolves a selected pending request that is not present in the current list page", async () => {
@@ -734,11 +739,9 @@ describe("ConsentCenterPage requestId deep links", () => {
 
   it("never reuses rows from the previous Consent Center tab while the next tab loads", async () => {
     let resolveActive:
-      | ((value: ReturnType<typeof emptyListResponse>) => void)
-      | undefined;
+      ((value: ReturnType<typeof emptyListResponse>) => void) | undefined;
     let resolveHistory:
-      | ((value: ReturnType<typeof emptyListResponse>) => void)
-      | undefined;
+      ((value: ReturnType<typeof emptyListResponse>) => void) | undefined;
     const activeResponse = {
       ...emptyListResponse(),
       surface: "active",
@@ -1034,6 +1037,55 @@ describe("ConsentCenterPage requestId deep links", () => {
 
     expect(mocks.listEntries.mock.calls.length).toBe(listCallsBefore);
     expect(mocks.getSummary.mock.calls.length).toBe(summaryCallsBefore);
+  });
+
+  it("refreshes an invalidated visited tab only when the user returns to it", async () => {
+    mocks.search = "tab=requests";
+    const { rerender } = render(<ConsentCenterPage />);
+
+    await waitFor(() => {
+      expect(mocks.listEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ surface: "pending" }),
+      );
+    });
+
+    mocks.search = "tab=active";
+    rerender(<ConsentCenterPage />);
+    await waitFor(() => {
+      expect(mocks.listEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ surface: "active" }),
+      );
+    });
+
+    const pendingCallsBeforeInvalidation = mocks.listEntries.mock.calls.filter(
+      ([options]) => options.surface === "pending",
+    ).length;
+    act(() => {
+      for (const subscriber of mocks.cacheSubscribers) {
+        subscriber({
+          type: "invalidate",
+          keys: ["list:user-1:one:consents:pending::1:20"],
+        });
+      }
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(
+      mocks.listEntries.mock.calls.filter(
+        ([options]) => options.surface === "pending",
+      ),
+    ).toHaveLength(pendingCallsBeforeInvalidation);
+
+    mocks.search = "tab=requests";
+    rerender(<ConsentCenterPage />);
+
+    await waitFor(() => {
+      expect(
+        mocks.listEntries.mock.calls.filter(
+          ([options]) => options.surface === "pending",
+        ),
+      ).toHaveLength(pendingCallsBeforeInvalidation + 1);
+    });
   });
 
   it("keeps grouped history lifecycles out of the history list row", async () => {

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2654,29 +2654,29 @@ html.native-ios {
        chrome disagree, especially in mobile WebKit. */
     background-color: var(--background) !important;
   }
-html.native-ios body {
-  padding-top: 0;
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
-}
+  html.native-ios body {
+    padding-top: 0;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
 
-/* The Capacitor Google Maps renderer is a native surface below the WebView.
+  /* The Capacitor Google Maps renderer is a native surface below the WebView.
  * Only the immersive Map route opts into this class, so its shell layers must
  * be transparent while the controls above remain regular web UI. Keeping the
  * override route-scoped prevents native maps from changing any other screen. */
-html.one-location-map-native,
-html.one-location-map-native body,
-html.one-location-map-native [data-app-shell-root="true"],
-html.one-location-map-native [data-app-scroll-root="true"],
-html.one-location-map-native [data-app-shell-content="true"],
-html.one-location-map-native .one-location-map {
-  background: transparent !important;
-  background-color: transparent !important;
-}
+  html.one-location-map-native,
+  html.one-location-map-native body,
+  html.one-location-map-native [data-app-shell-root="true"],
+  html.one-location-map-native [data-app-scroll-root="true"],
+  html.one-location-map-native [data-app-shell-content="true"],
+  html.one-location-map-native .one-location-map {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
 
-html {
-  overflow-x: hidden;
-}
+  html {
+    overflow-x: hidden;
+  }
 }
 /* Lighter blur variant for performance-critical areas */
 .backdrop-blur-optimized {
@@ -2735,9 +2735,11 @@ md-ripple.morphy-md-ripple {
 }
 
 .ambient-chrome-mask {
-  /* Persistent chrome is a sampled tint and feathered fade, never frosted
-     content. The structure remains opaque through contextual tabs; only the
-     material wash and tail are deliberately light and transparent. */
+  /* Persistent chrome uses one neutral, theme-derived feather. Surface
+     sampling still drives native system-bar contrast, but it must not cast a
+     route color across either app edge. */
+  --ambient-chrome-material-bg: var(--background);
+  --ambient-chrome-material-fg: var(--foreground);
   --tw-backdrop-blur: blur(0px);
   --tw-backdrop-saturate: saturate(1);
   --ambient-chrome-wash: 58%;
@@ -2754,7 +2756,7 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 }
 
 .ambient-chrome-mask--top {
-  --ambient-chrome-bg: var(--ambient-chrome-top-bg, #f5f5f7);
+  --ambient-chrome-bg: var(--ambient-chrome-material-bg);
   background-color: color-mix(
     in srgb,
     var(--ambient-chrome-bg) var(--ambient-chrome-wash),
@@ -2789,34 +2791,52 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
      instead of stepping through a single mid alpha. Stops are fractions of the
      resolved fade tail (--top-fade-active) so they stay in order and adapt to
      the device safe-area inset. */
+  --ambient-chrome-top-solid-height: calc(
+    var(--top-shell-reserved-height) - var(--top-chrome-collapse-px, 0px)
+  );
+  --ambient-chrome-top-visible-height: calc(
+    var(--top-shell-visual-height) - var(--top-chrome-collapse-px, 0px)
+  );
   -webkit-mask-image: linear-gradient(
     to bottom,
     #000 0,
-    #000 var(--top-shell-reserved-height),
+    #000 var(--ambient-chrome-top-solid-height),
     rgba(0, 0, 0, 0.82)
-      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.24),
+      calc(
+        var(--ambient-chrome-top-solid-height) + var(--top-fade-active) * 0.24
+      ),
     rgba(0, 0, 0, 0.5)
-      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.46),
+      calc(
+        var(--ambient-chrome-top-solid-height) + var(--top-fade-active) * 0.46
+      ),
     rgba(0, 0, 0, 0.2)
-      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.72),
-    transparent var(--top-shell-visual-height)
+      calc(
+        var(--ambient-chrome-top-solid-height) + var(--top-fade-active) * 0.72
+      ),
+    transparent var(--ambient-chrome-top-visible-height)
   );
   mask-image: linear-gradient(
     to bottom,
     #000 0,
-    #000 var(--top-shell-reserved-height),
+    #000 var(--ambient-chrome-top-solid-height),
     rgba(0, 0, 0, 0.82)
-      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.24),
+      calc(
+        var(--ambient-chrome-top-solid-height) + var(--top-fade-active) * 0.24
+      ),
     rgba(0, 0, 0, 0.5)
-      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.46),
+      calc(
+        var(--ambient-chrome-top-solid-height) + var(--top-fade-active) * 0.46
+      ),
     rgba(0, 0, 0, 0.2)
-      calc(var(--top-shell-reserved-height) + var(--top-fade-active) * 0.72),
-    transparent var(--top-shell-visual-height)
+      calc(
+        var(--ambient-chrome-top-solid-height) + var(--top-fade-active) * 0.72
+      ),
+    transparent var(--ambient-chrome-top-visible-height)
   );
 }
 
 .ambient-chrome-mask--bottom {
-  --ambient-chrome-bg: var(--ambient-chrome-bottom-bg, #f5f5f7);
+  --ambient-chrome-bg: var(--ambient-chrome-material-bg);
   /* Match the Search Console dock: the bottom edge dissolves content into its
      live sampled tint rather than placing a second frosted slab over cards. */
   background-color: transparent;
@@ -2834,12 +2854,12 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 /* Top controls consume the same foreground token as the top mask. This is
  * intentionally scoped: cards and route content keep their own semantic ink. */
 [data-app-top-bar].ambient-chrome-top-foreground {
-  color: var(--ambient-chrome-top-fg, #1d1d1f);
+  color: var(--foreground);
 }
 
 [data-app-top-bar] .shell-action-surface,
 [data-app-top-bar] .top-shell-ambient-ink {
-  color: var(--ambient-chrome-top-fg, #1d1d1f);
+  color: var(--foreground);
 }
 
 /* A chrome child must not pin its own theme foreground while the sampled edge
@@ -2852,7 +2872,7 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 }
 
 [data-app-top-bar] .shell-action-surface:hover {
-  color: var(--ambient-chrome-top-fg, #1d1d1f);
+  color: var(--foreground);
 }
 
 /* Legacy aliases remain temporarily for non-shell migration callers. New
@@ -3073,29 +3093,16 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
    subtle highlight so the current route stays readable. */
 .bottom-chrome-surface,
 .kai-bottom-nav-pill {
-  color: var(--ambient-chrome-bottom-fg, #1d1d1f);
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--ambient-chrome-bottom-fg, #1d1d1f) 10%,
-      transparent
-    ) !important;
-  background: color-mix(
-    in srgb,
-    var(--ambient-chrome-bottom-bg, #f5f5f7) 74%,
-    transparent
-  ) !important;
+  color: var(--foreground);
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent) !important;
+  background: color-mix(in srgb, var(--background) 74%, transparent) !important;
   box-shadow: none !important;
   -webkit-backdrop-filter: blur(12px) saturate(130%);
   backdrop-filter: blur(12px) saturate(130%);
 }
 
 .kai-bottom-nav-pill [data-segment-indicator] {
-  background: color-mix(
-    in srgb,
-    var(--ambient-chrome-bottom-fg, #1d1d1f) 8%,
-    transparent
-  ) !important;
+  background: color-mix(in srgb, var(--foreground) 8%, transparent) !important;
   border: 0;
   box-shadow: none !important;
 }
@@ -3144,11 +3151,7 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 }
 
 .kai-bottom-nav-pill [role="radio"] {
-  color: color-mix(
-    in srgb,
-    var(--ambient-chrome-bottom-fg, #1d1d1f) 70%,
-    transparent
-  ) !important;
+  color: color-mix(in srgb, var(--foreground) 70%, transparent) !important;
   min-height: 48px;
   gap: 0.2rem !important;
   padding: 0.4rem 0.2rem 0.42rem !important;
@@ -3195,13 +3198,9 @@ html:not([data-ambient-chrome-primed="true"]) .ambient-chrome-mask {
 }
 
 .kai-bottom-search-action {
-  color: var(--ambient-chrome-bottom-fg, #1d1d1f) !important;
+  color: var(--foreground) !important;
   border: 0 !important;
-  background: color-mix(
-    in srgb,
-    var(--ambient-chrome-bottom-fg, #1d1d1f) 6%,
-    transparent
-  ) !important;
+  background: color-mix(in srgb, var(--foreground) 6%, transparent) !important;
   box-shadow: none !important;
   -webkit-backdrop-filter: none;
   backdrop-filter: none;

--- a/hushh-webapp/app/oauth/authorize/page.tsx
+++ b/hushh-webapp/app/oauth/authorize/page.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/lib/morphy-ux/button";
 import { ApiService } from "@/lib/services/api-service";
 
-type OAuthApprovalResponse = { redirect_uri?: string; detail?: { error_description?: string } };
+type OAuthApprovalResponse = {
+  redirect_uri?: string;
+  detail?: { error_description?: string };
+};
 
 export default function OAuthAuthorizePage() {
   const { user, loading } = useAuth();
@@ -16,34 +20,51 @@ export default function OAuthAuthorizePage() {
   const [submitting, setSubmitting] = useState<"approve" | "deny" | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const complete = useCallback(async (decision: "approve" | "deny") => {
-    if (!user || !requestRef) {
-      setError("Sign in to continue with this connection.");
-      return;
-    }
-    setSubmitting(decision);
-    setError(null);
-    try {
-      const idToken = await user.getIdToken();
-      const response = await ApiService.apiFetch(`/api/oauth/authorize/${encodeURIComponent(requestRef)}/${decision}`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${idToken}` },
-        cache: "no-store",
-      });
-      const payload = (await response.json()) as OAuthApprovalResponse;
-      if (!response.ok || !payload.redirect_uri) {
-        throw new Error(payload.detail?.error_description || "This authorization request is no longer available.");
+  const complete = useCallback(
+    async (decision: "approve" | "deny") => {
+      if (!user || !requestRef) {
+        setError("Sign in to continue with this connection.");
+        return;
       }
-      // The backend constructed this only from an exact registered redirect URI.
-      window.location.assign(payload.redirect_uri);
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Could not complete authorization.");
-      setSubmitting(null);
-    }
-  }, [requestRef, user]);
+      setSubmitting(decision);
+      setError(null);
+      try {
+        const idToken = await user.getIdToken();
+        const response = await ApiService.apiFetch(
+          `/api/oauth/authorize/${encodeURIComponent(requestRef)}/${decision}`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${idToken}` },
+            cache: "no-store",
+          },
+        );
+        const payload = (await response.json()) as OAuthApprovalResponse;
+        if (!response.ok || !payload.redirect_uri) {
+          throw new Error(
+            payload.detail?.error_description ||
+              "This authorization request is no longer available.",
+          );
+        }
+        // The backend constructed this only from an exact registered redirect URI.
+        window.location.assign(payload.redirect_uri);
+      } catch (caught) {
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "Could not complete authorization.",
+        );
+        setSubmitting(null);
+      }
+    },
+    [requestRef, user],
+  );
 
   if (loading) {
-    return <main className="mx-auto flex min-h-dvh max-w-lg items-start justify-center px-6 pt-[18vh]">Checking sign-in…</main>;
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-lg items-start justify-center px-6 pt-[18vh]">
+        Checking sign-in…
+      </main>
+    );
   }
 
   return (
@@ -51,16 +72,45 @@ export default function OAuthAuthorizePage() {
       <section className="w-full space-y-5">
         <p className="text-sm font-medium text-primary">Hussh Consent</p>
         <div className="space-y-2">
-          <h1 className="text-3xl font-semibold tracking-tight">Authorize MCP connection</h1>
-          <p className="text-muted-foreground">This signs your connector in. Any information access still requires a separate, scoped consent decision.</p>
+          <h1 className="text-3xl font-semibold tracking-tight">
+            Authorize MCP connection
+          </h1>
+          <p className="text-muted-foreground">
+            This signs your connector in. Any information access still requires
+            a separate, scoped consent decision.
+          </p>
         </div>
-        {!user ? <p className="text-sm text-destructive">Sign in to One, then reopen this authorization request.</p> : null}
+        {!user ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Sign in to One to review this connection. Your authorization
+              request will be preserved.
+            </p>
+            <Button asChild>
+              <Link
+                href={`/login?redirect=${encodeURIComponent(
+                  `/oauth/authorize?request=${encodeURIComponent(requestRef)}`,
+                )}`}
+              >
+                Sign in to continue
+              </Link>
+            </Button>
+          </div>
+        ) : null}
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         <div className="flex gap-3">
-          <Button variant="none" effect="glass" onClick={() => complete("deny")} disabled={!user || !requestRef || submitting !== null}>
+          <Button
+            variant="none"
+            effect="glass"
+            onClick={() => complete("deny")}
+            disabled={!user || !requestRef || submitting !== null}
+          >
             Cancel
           </Button>
-          <Button onClick={() => complete("approve")} disabled={!user || !requestRef || submitting !== null}>
+          <Button
+            onClick={() => complete("approve")}
+            disabled={!user || !requestRef || submitting !== null}
+          >
             {submitting === "approve" ? "Authorizing…" : "Authorize"}
           </Button>
         </div>

--- a/hushh-webapp/app/one/one-auth-gate.tsx
+++ b/hushh-webapp/app/one/one-auth-gate.tsx
@@ -43,7 +43,10 @@ import { useSessionChromeSuppression } from "@/lib/auth/use-session-chrome-suppr
  * scoped vault prerequisite only when the specific operation requires it.
  * Every other private One route uses the hard vault gate below.
  */
-const AUTH_ONLY_ROUTE_PREFIXES = [ROUTES.PROFILE_GMAIL_OAUTH_RETURN] as const;
+const AUTH_ONLY_ROUTE_PREFIXES = [
+  ROUTES.PROFILE_GMAIL_OAUTH_RETURN,
+  ROUTES.PROFILE_SECURITY_DEVICE_AUTHORIZE,
+] as const;
 
 function isAuthOnlyRoute(pathname: string): boolean {
   return AUTH_ONLY_ROUTE_PREFIXES.some(

--- a/hushh-webapp/app/one/profile/security/devices/authorize/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/authorize/page.tsx
@@ -27,7 +27,8 @@ export default function TrustedDeviceAuthorizePage() {
     () => ({
       redirect_uri: requiredParam(searchParams, "redirect_uri"),
       code_challenge: requiredParam(searchParams, "code_challenge"),
-      code_challenge_method: requiredParam(searchParams, "code_challenge_method") || "S256",
+      code_challenge_method:
+        requiredParam(searchParams, "code_challenge_method") || "S256",
       device_public_key: requiredParam(searchParams, "device_public_key"),
       device_name: requiredParam(searchParams, "device_name"),
       platform: requiredParam(searchParams, "platform") || "macos",
@@ -51,7 +52,9 @@ export default function TrustedDeviceAuthorizePage() {
       }
       assignWindowLocation(payload.redirect_url);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Authorization failed.");
+      setError(
+        cause instanceof Error ? cause.message : "Authorization failed.",
+      );
       setSubmitting(false);
     }
   }
@@ -68,38 +71,55 @@ export default function TrustedDeviceAuthorizePage() {
         <div className="mb-6 flex size-12 items-center justify-center rounded-2xl bg-primary/10">
           <Laptop className="size-6 text-primary" aria-hidden />
         </div>
-        <h1 className="text-2xl font-semibold tracking-tight">Connect this Hermes device</h1>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Connect this Hermes device
+        </h1>
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
-          Approve this private computer as an extension of One. The vault passphrase
-          remains local to Hermes and is never sent to Hussh. Each signed device
-          proof can issue a 15-minute vault-owner capability for protected actions,
-          including confirmed PKM writes.
+          Approve this private computer as an extension of One. The vault
+          passphrase remains local to Hermes and is never sent to Hussh. Each
+          signed device proof can issue a 15-minute vault-owner capability for
+          protected actions, including confirmed Personal Data writes.
         </p>
 
         <dl className="mt-6 rounded-2xl bg-muted/50 p-4 text-sm">
           <div className="flex justify-between gap-4">
             <dt className="text-muted-foreground">Hussh account</dt>
-            <dd className="truncate font-medium">{user?.email || "Sign in required"}</dd>
+            <dd className="truncate font-medium">
+              {user?.email || "Sign in required"}
+            </dd>
           </div>
           <div className="flex justify-between gap-4">
             <dt className="text-muted-foreground">Device</dt>
-            <dd className="font-medium">{request.device_name || "Unknown device"}</dd>
+            <dd className="font-medium">
+              {request.device_name || "Unknown device"}
+            </dd>
           </div>
           <div className="mt-2 flex justify-between gap-4">
             <dt className="text-muted-foreground">Access</dt>
-            <dd className="text-right font-medium">15-minute vault-owner capability</dd>
+            <dd className="text-right font-medium">
+              15-minute vault-owner capability
+            </dd>
           </div>
         </dl>
 
         <div className="mt-6 flex items-start gap-3 text-sm text-muted-foreground">
-          <ShieldCheck className="mt-0.5 size-4 shrink-0 text-emerald-600" aria-hidden />
-          <p>You can revoke this device at any time from Profile → Security → Devices.</p>
+          <ShieldCheck
+            className="mt-0.5 size-4 shrink-0 text-emerald-600"
+            aria-hidden
+          />
+          <p>
+            You can revoke this device at any time from Profile → Security →
+            Devices.
+          </p>
         </div>
 
-        {error ? <p className="mt-5 text-sm text-destructive">{error}</p> : null}
+        {error ? (
+          <p className="mt-5 text-sm text-destructive">{error}</p>
+        ) : null}
         {!complete ? (
           <p className="mt-5 text-sm text-destructive">
-            The Hermes authorization request is incomplete. Return to Hermes and try again.
+            The Hermes authorization request is incomplete. Return to Hermes and
+            try again.
           </p>
         ) : null}
 

--- a/hushh-webapp/app/one/profile/security/devices/page.tsx
+++ b/hushh-webapp/app/one/profile/security/devices/page.tsx
@@ -38,7 +38,8 @@ export default function TrustedDevicesPage() {
   const [devices, setDevices] = useState<TrustedDevice[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [pendingRevocation, setPendingRevocation] = useState<TrustedDevice | null>(null);
+  const [pendingRevocation, setPendingRevocation] =
+    useState<TrustedDevice | null>(null);
   const [revoking, setRevoking] = useState(false);
 
   const load = useCallback(async () => {
@@ -47,7 +48,8 @@ export default function TrustedDevicesPage() {
     try {
       const response = await ApiService.listTrustedDevices();
       const payload = await response.json();
-      if (!response.ok) throw new Error(payload?.detail?.message || "Devices unavailable.");
+      if (!response.ok)
+        throw new Error(payload?.detail?.message || "Devices unavailable.");
       setDevices(Array.isArray(payload.devices) ? payload.devices : []);
       setError("");
     } catch (cause) {
@@ -68,7 +70,9 @@ export default function TrustedDevicesPage() {
       const response = await ApiService.revokeTrustedDevice(deviceId);
       if (!response.ok) {
         const payload = await response.json().catch(() => ({}));
-        setError(payload?.detail?.message || "The device could not be revoked.");
+        setError(
+          payload?.detail?.message || "The device could not be revoked.",
+        );
         return;
       }
       setPendingRevocation(null);
@@ -104,7 +108,7 @@ export default function TrustedDevicesPage() {
         ) : null}
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         <div className="space-y-3">
-          {devices.map(device => (
+          {devices.map((device) => (
             <article
               className="flex items-center gap-4 rounded-2xl border bg-card p-4"
               key={device.device_id}
@@ -113,7 +117,9 @@ export default function TrustedDevicesPage() {
                 <Laptop className="size-5" aria-hidden />
               </div>
               <div className="min-w-0 flex-1">
-                <h2 className="truncate text-sm font-medium">{device.device_name}</h2>
+                <h2 className="truncate text-sm font-medium">
+                  {device.device_name}
+                </h2>
                 <p className="mt-1 text-xs text-muted-foreground">
                   {device.status === "active" ? "Active" : "Revoked"} ·{" "}
                   {device.platform}
@@ -140,7 +146,7 @@ export default function TrustedDevicesPage() {
       </AppPageContentRegion>
       <AlertDialog
         open={pendingRevocation !== null}
-        onOpenChange={open => {
+        onOpenChange={(open) => {
           if (!open && !revoking) setPendingRevocation(null);
         }}
       >
@@ -148,16 +154,17 @@ export default function TrustedDevicesPage() {
           <AlertDialogHeader>
             <AlertDialogTitle>Revoke this trusted device?</AlertDialogTitle>
             <AlertDialogDescription>
-              {pendingRevocation?.device_name || "This device"} will immediately lose
-              access to new owner capabilities and PKM writes. Reconnecting requires
-              browser approval and local vault setup again.
+              {pendingRevocation?.device_name || "This device"} will immediately
+              lose access to new owner capabilities and Personal Data writes.
+              Reconnecting requires browser approval and local vault setup
+              again.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={revoking}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               disabled={revoking || pendingRevocation === null}
-              onClick={event => {
+              onClick={(event) => {
                 event.preventDefault();
                 if (pendingRevocation) void revoke(pendingRevocation.device_id);
               }}

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -1025,7 +1025,8 @@ function ConsentEntryDetail({
         : requestRoute
           ? {
               title: "Client workspace",
-              description: "Review this client's access and connected accounts.",
+              description:
+                "Review this client's access and connected accounts.",
               href: requestRoute,
               label: "Open client",
               external: false,
@@ -1098,18 +1099,16 @@ function ConsentEntryDetail({
       : isRevocableConsentStatus(entry.status));
   const requestDeadline =
     entry.approval_timeout_at || (isPendingDecision ? entry.expires_at : null);
-  const detailGroupTitle =
-    isConnectionDecision
-      ? "Connection request"
-      : entry.kind === "active_grant"
+  const detailGroupTitle = isConnectionDecision
+    ? "Connection request"
+    : entry.kind === "active_grant"
       ? "Active access"
       : entry.kind === "history"
         ? "History details"
         : "Request details";
-  const detailGroupDescription =
-    isConnectionDecision
-      ? "Who wants to connect with you and why."
-      : entry.kind === "active_grant"
+  const detailGroupDescription = isConnectionDecision
+    ? "Who wants to connect with you and why."
+    : entry.kind === "active_grant"
       ? "What is currently shared and when access ends."
       : entry.kind === "history"
         ? "The recorded outcome and how this access changed over time."
@@ -1163,10 +1162,7 @@ function ConsentEntryDetail({
     !isConnectionDecision &&
     !showDurationChoice &&
     requestedDurationLabel
-      ? [
-          "Requested duration",
-          requestedDurationLabel,
-        ]
+      ? ["Requested duration", requestedDurationLabel]
       : null,
     entry.is_scope_upgrade && entry.additional_access_summary
       ? ["What changes", entry.additional_access_summary]
@@ -1466,8 +1462,7 @@ function ConsentSurfaceListSection({
                   selectedEntry.request_id === entry.request_id)),
             ) ||
             Boolean(
-              selectedId &&
-              consentEntryMatchesSelectedId(entry, selectedId),
+              selectedId && consentEntryMatchesSelectedId(entry, selectedId),
             )
           }
           onSelect={() => onSelectEntry(entry)}
@@ -1579,10 +1574,7 @@ export function ConsentCenterPage() {
     setMutationTick((value) => value + 1);
   };
   const summaryCacheKey = user?.uid
-    ? CACHE_KEYS.CONSENT_CENTER_SUMMARY(
-        user.uid,
-        `${consentScopeKey}:${mode}`,
-      )
+    ? CACHE_KEYS.CONSENT_CENTER_SUMMARY(user.uid, `${consentScopeKey}:${mode}`)
     : "consent_center_summary_guest";
   const listSurface =
     tab === "requests" ? "pending" : tab === "history" ? "previous" : "active";
@@ -1682,12 +1674,7 @@ export function ConsentCenterPage() {
           error,
         );
       });
-  }, [
-    getVaultOwnerToken,
-    isVaultUnlocked,
-    user?.uid,
-    vaultKey,
-  ]);
+  }, [getVaultOwnerToken, isVaultUnlocked, user?.uid, vaultKey]);
 
   const {
     handleApprove,
@@ -2010,14 +1997,39 @@ export function ConsentCenterPage() {
   });
   // The tab actually visible right now, in the exact shape the rest of this
   // component already expects from "the one active list resource".
-  const listResource = tab === "requests"
-    ? pendingResource
-    : tab === "history"
-      ? previousResource
-      : tab === "active"
-        ? activeResource
-        : null;
+  const listResource =
+    tab === "requests"
+      ? pendingResource
+      : tab === "history"
+        ? previousResource
+        : tab === "active"
+          ? activeResource
+          : null;
   const forcedMutationRefreshRef = useRef(0);
+
+  // CacheSyncService invalidates every consent surface after a real mutation,
+  // while SwipeViews deliberately keeps previously visited panes mounted.
+  // A background pane therefore remains enabled after its cached data is
+  // cleared. Refresh only when that pane becomes visible again and has no
+  // retained resource; this avoids eager fan-out across hidden tabs while
+  // preventing a stale invalidation from rendering as a false empty state.
+  useEffect(() => {
+    if (!user?.uid || tab === "connections") return;
+    if (
+      !listResource ||
+      listResource.data ||
+      listResource.loading ||
+      listResource.refreshing
+    ) {
+      return;
+    }
+    void listResource.refresh();
+    // This is intentionally a tab-entry effect. Watching the resource's
+    // transition-backed data/loading fields can observe the brief state where
+    // loading has settled before React commits data, causing a redundant fetch
+    // loop. Current-tab mutations already use the forced refresh effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, user?.uid]);
 
   useEffect(() => {
     if (!mutationTick) return;
@@ -2177,7 +2189,13 @@ export function ConsentCenterPage() {
             locallyHandledRequestIds,
             locallyRevokedScopes,
           ),
-    [tab, items, pendingResource.data, locallyHandledRequestIds, locallyRevokedScopes],
+    [
+      tab,
+      items,
+      pendingResource.data,
+      locallyHandledRequestIds,
+      locallyRevokedScopes,
+    ],
   );
   const activeSurfaceItems = useMemo(
     () =>
@@ -2189,7 +2207,13 @@ export function ConsentCenterPage() {
             locallyHandledRequestIds,
             locallyRevokedScopes,
           ),
-    [tab, items, activeResource.data, locallyHandledRequestIds, locallyRevokedScopes],
+    [
+      tab,
+      items,
+      activeResource.data,
+      locallyHandledRequestIds,
+      locallyRevokedScopes,
+    ],
   );
   const previousItems = useMemo(
     () =>
@@ -2201,7 +2225,13 @@ export function ConsentCenterPage() {
             locallyHandledRequestIds,
             locallyRevokedScopes,
           ),
-    [tab, items, previousResource.data, locallyHandledRequestIds, locallyRevokedScopes],
+    [
+      tab,
+      items,
+      previousResource.data,
+      locallyHandledRequestIds,
+      locallyRevokedScopes,
+    ],
   );
   const connectionsSurfaceItems = useMemo(
     () =>
@@ -2213,7 +2243,13 @@ export function ConsentCenterPage() {
             locallyHandledRequestIds,
             locallyRevokedScopes,
           ),
-    [tab, items, connectionItems, locallyHandledRequestIds, locallyRevokedScopes],
+    [
+      tab,
+      items,
+      connectionItems,
+      locallyHandledRequestIds,
+      locallyRevokedScopes,
+    ],
   );
   const selectedEntryFromList = useMemo(() => {
     if (!items.length) return null;

--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -32,6 +32,7 @@ import {
   DEVELOPER_SECTIONS,
   FAQ_ITEMS,
   MCP_PUBLIC_LINKS,
+  PUBLIC_MCP_AUTHENTICATION,
   PUBLIC_SCOPE_PATTERNS,
   PUBLIC_MCP_ENVIRONMENT,
   PUBLIC_MCP_TOOLS,
@@ -265,10 +266,7 @@ function PublicToolCatalog() {
   return (
     <div className="divide-y divide-border/60 rounded-[var(--app-radius-lg)] border border-border/60 bg-background/55">
       {PUBLIC_MCP_TOOLS.map((tool) => (
-        <div
-          key={tool.name}
-          className="space-y-1 px-4 py-3"
-        >
+        <div key={tool.name} className="space-y-1 px-4 py-3">
           <code className="block min-w-0 text-xs font-semibold text-foreground">
             {tool.name}
           </code>
@@ -422,7 +420,7 @@ function SignedOutAccessCard({
             <EmptyDescription>
               The docs and live contract stay open to everyone on this page.
               Sign in only when you want a personal developer token, editable
-              app identity, and copy-ready snippets tied to your Kai account.
+              app identity, and copy-ready snippets tied to your Hussh account.
             </EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
@@ -527,14 +525,15 @@ function AccessWorkspace({
             Enable self-serve developer access
           </SurfaceCardTitle>
           <SurfaceCardDescription>
-            One developer app and one active token are created for your Kai
-            account. Consent still happens user-by-user in Kai.
+            One developer app and one active credential are created for your
+            Hussh account. Information access still requires a separate
+            user-by-user decision in the Consent Center.
           </SurfaceCardDescription>
         </SurfaceCardHeader>
         <SurfaceCardContent className="space-y-5">
           <SurfaceInset className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-primary/80">
-              Current Kai account
+              Current Hussh account
             </p>
             <p className="text-sm font-semibold text-foreground">
               {signedInDisplayName || signedInEmail || "Signed-in user"}
@@ -546,7 +545,7 @@ function AccessWorkspace({
               </p>
             ) : (
               <p className="text-sm leading-6 text-muted-foreground">
-                Developer access will be created for the Kai account currently
+                Developer access will be created for the Hussh account currently
                 signed in on this page.
               </p>
             )}
@@ -561,7 +560,7 @@ function AccessWorkspace({
               </EmptyTitle>
               <EmptyDescription>
                 Turn on access once and your app identity, developer token, and
-                live setup snippets will be generated from this signed-in Kai
+                live setup snippets will be generated from this signed-in Hussh
                 account.
               </EmptyDescription>
             </EmptyHeader>
@@ -597,8 +596,9 @@ function AccessWorkspace({
           <div className="space-y-1">
             <SurfaceCardTitle>Developer workspace</SurfaceCardTitle>
             <SurfaceCardDescription>
-              Manage the identity users see in Kai, keep one active token, and
-              copy setup snippets without leaving this page.
+              Manage the identity people see in the Consent Center, keep one
+              active credential, and copy setup snippets without leaving this
+              page.
             </SurfaceCardDescription>
           </div>
           <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
@@ -642,7 +642,7 @@ function AccessWorkspace({
             mobileColumns={2}
             options={[
               { value: "overview", label: "Overview" },
-              { value: "tokens", label: "Tokens" },
+              { value: "tokens", label: "Credentials" },
               { value: "profile", label: "Profile" },
               { value: "contract", label: "Contract" },
             ]}
@@ -656,7 +656,7 @@ function AccessWorkspace({
                     App Identity
                   </p>
                   <h3 className="text-lg font-semibold text-foreground">
-                    {access.app?.display_name || "Kai developer app"}
+                    {access.app?.display_name || "Hussh developer app"}
                   </h3>
                   <p className="text-sm leading-6 text-muted-foreground">
                     Agent id: <code>{access.app?.agent_id}</code>
@@ -811,8 +811,37 @@ function AccessWorkspace({
           {workspaceTab === "tokens" ? (
             <div className="space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
               <p className="text-sm font-semibold text-foreground">
-                Primary token setup
+                Self-serve credentials
               </p>
+              <SurfaceInset className="space-y-3">
+                {PUBLIC_MCP_AUTHENTICATION.selfServeMethods.map((method) => (
+                  <div className="space-y-1" key={method.id}>
+                    <p className="text-sm font-semibold text-foreground">
+                      {method.label}
+                    </p>
+                    <p className="text-sm leading-6 text-muted-foreground">
+                      {method.detail}
+                    </p>
+                  </div>
+                ))}
+                <RuntimeValueRow
+                  label="OAuth discovery"
+                  value={PUBLIC_MCP_AUTHENTICATION.discoveryUrl}
+                  copyLabel="OAuth discovery URL"
+                  isMobile={isMobile}
+                />
+                <RuntimeValueRow
+                  label="Scope"
+                  value={PUBLIC_MCP_AUTHENTICATION.scope}
+                  copyLabel="OAuth scope"
+                  isMobile={isMobile}
+                />
+                <p className="text-xs leading-5 text-muted-foreground">
+                  {PUBLIC_MCP_AUTHENTICATION.partnerOnlyMethod.label} is limited
+                  to operations-provisioned partner integrations. It is not a
+                  self-serve grant and does not issue refresh tokens.
+                </p>
+              </SurfaceInset>
               <RuntimeValueRow
                 label="MCP URL"
                 value={runtime.remoteMcpUrlTemplate.replace(
@@ -856,7 +885,7 @@ function AccessWorkspace({
                     </FieldLabel>
                     <FieldDescription>
                       This is the app identity shown to users when they review
-                      consent in Kai.
+                      consent in the Consent Center.
                     </FieldDescription>
                     <InputGroup>
                       <InputGroupInput
@@ -1416,8 +1445,10 @@ export function DeveloperDocsHub({
                           2. Authenticate
                         </dt>
                         <dd className="text-sm leading-6 text-foreground">
-                          Use a bearer token for a direct host, or OAuth through
-                          your provisioned integration.
+                          Choose a self-serve developer token or OAuth
+                          authorization code with S256 PKCE and rotating refresh
+                          tokens. Both use Authorization: Bearer and scope{" "}
+                          <code>{PUBLIC_MCP_AUTHENTICATION.scope}</code>.
                         </dd>
                       </div>
                       <div className="space-y-1">
@@ -1711,9 +1742,9 @@ export function DeveloperDocsHub({
                       </SurfaceCardHeader>
                       <SurfaceCardContent className="space-y-3 text-sm leading-6 text-muted-foreground">
                         <p>
-                          One self-serve app per Hussh account, one active token,
-                          and the same contract surfaced through remote MCP, the
-                          API, and the npm bridge.
+                          One self-serve app per Hussh account, one active
+                          token, and the same contract surfaced through remote
+                          MCP, the API, and the npm bridge.
                         </p>
                         <p>
                           The data path is the same everywhere: discover scopes,

--- a/hushh-webapp/lib/developers/content.ts
+++ b/hushh-webapp/lib/developers/content.ts
@@ -72,7 +72,7 @@ function renderMcpTemplate(
     apiOrigin: string;
     tokenEnvVar: string;
     developerToken: string;
-  }
+  },
 ) {
   return template
     .replaceAll("{{REMOTE_URL}}", replacements.remoteUrl)
@@ -82,11 +82,14 @@ function renderMcpTemplate(
     .replaceAll("<developer-token>", replacements.developerToken);
 }
 
-function buildMcpHostExamples(developerToken = "<developer-token>"): McpHostExample[] {
-  const remoteUrl = MCP_PUBLIC_DOCS.promotedEnvironment.remoteUrlTemplate.replace(
-    "<developer-token>",
-    developerToken
-  );
+function buildMcpHostExamples(
+  developerToken = "<developer-token>",
+): McpHostExample[] {
+  const remoteUrl =
+    MCP_PUBLIC_DOCS.promotedEnvironment.remoteUrlTemplate.replace(
+      "<developer-token>",
+      developerToken,
+    );
 
   return MCP_PUBLIC_DOCS.hostExamples.map((example) => ({
     id: example.id,
@@ -160,12 +163,15 @@ export const DEVELOPER_SECTIONS: DeveloperSection[] = [
 
 export const PUBLIC_TOOL_NAMES = [...MCP_PUBLIC_DOCS.publicTools] as const;
 export const MCP_PROTOCOL_REVISION = MCP_PUBLIC_DOCS.mcpProtocolRevision;
-export const PUBLIC_RESOURCE_URIS = [...MCP_PUBLIC_DOCS.publicResources] as const;
+export const PUBLIC_RESOURCE_URIS = [
+  ...MCP_PUBLIC_DOCS.publicResources,
+] as const;
 export const PUBLIC_MCP_ENVIRONMENT = {
   label: MCP_PUBLIC_DOCS.promotedEnvironment.label,
   apiOrigin: MCP_PUBLIC_DOCS.promotedEnvironment.apiOrigin,
   remoteUrlTemplate: MCP_PUBLIC_DOCS.promotedEnvironment.remoteUrlTemplate,
 } as const;
+export const PUBLIC_MCP_AUTHENTICATION = MCP_PUBLIC_DOCS.authentication;
 
 // Kept in sync with the live grammar returned by GET /api/v1/list-scopes
 // (verified against api.uat.hushh.ai — v2, 2 scope entries), rather than a
@@ -211,11 +217,13 @@ const PUBLIC_MCP_TOOL_SUMMARIES: Readonly<Record<string, string>> = {
     "Retrieve the encrypted export for an approved scoped grant.",
 };
 
-export const PUBLIC_MCP_TOOLS: readonly PublicMcpTool[] =
-  PUBLIC_TOOL_NAMES.map((name) => ({
+export const PUBLIC_MCP_TOOLS: readonly PublicMcpTool[] = PUBLIC_TOOL_NAMES.map(
+  (name) => ({
     name,
-    summary: PUBLIC_MCP_TOOL_SUMMARIES[name] ?? "Public Hussh consent MCP tool.",
-  }));
+    summary:
+      PUBLIC_MCP_TOOL_SUMMARIES[name] ?? "Public Hussh consent MCP tool.",
+  }),
+);
 
 export const REST_ENDPOINTS: RestEndpoint[] = [
   {
@@ -234,13 +242,15 @@ export const REST_ENDPOINTS: RestEndpoint[] = [
     method: "GET",
     path: "/api/v1/tool-catalog",
     auth: "Optional Authorization: Bearer",
-    purpose: "Current tool visibility for the public developer lane or a specific developer app.",
+    purpose:
+      "Current tool visibility for the public developer lane or a specific developer app.",
   },
   {
     method: "GET",
     path: "/api/v1/user-scopes/{user_id}",
     auth: "Authorization: Bearer required",
-    purpose: "Discovered scope strings and available domains for a specific user.",
+    purpose:
+      "Discovered scope strings and available domains for a specific user.",
   },
   {
     method: "GET",
@@ -258,13 +268,15 @@ export const REST_ENDPOINTS: RestEndpoint[] = [
     method: "POST",
     path: "/api/v1/public-profile-export",
     auth: "Authorization: Bearer required",
-    purpose: "Publish or update an owner-controlled public-profile projection (separate from encrypted attr.* consent grants).",
+    purpose:
+      "Publish or update an owner-controlled public-profile projection (separate from encrypted attr.* consent grants).",
   },
   {
     method: "POST",
     path: "/api/v1/scoped-export",
     auth: "Authorization: Bearer required",
-    purpose: "Return ciphertext and wrapped-key metadata for one approved grant.",
+    purpose:
+      "Return ciphertext and wrapped-key metadata for one approved grant.",
   },
 ];
 
@@ -282,17 +294,19 @@ export const FAQ_ITEMS: DeveloperFaqItem[] = [
   {
     question: "What is the one scalable read path?",
     answer:
-      "Use get_encrypted_scoped_export after approval. Hussh returns ciphertext plus wrapped-key metadata, and your connector decrypts locally.",
+      "Use get-encrypted-scoped-export after approval. Hussh returns ciphertext plus wrapped-key metadata, and your connector decrypts locally.",
   },
   {
-    question: "What happens if I ask for a narrower scope while I already have a broader one?",
+    question:
+      "What happens if I ask for a narrower scope while I already have a broader one?",
     answer:
       "Hussh reuses the existing broader active grant and returns it immediately, but the exported package remains the canonical broader encrypted export. Pass the narrower scope as expected_scope and narrow it locally after decrypting.",
   },
   {
-    question: "What happens if I ask for a broader scope while I already have a narrower one?",
+    question:
+      "What happens if I ask for a broader scope while I already have a narrower one?",
     answer:
-      "That is a privilege increase, so it still requires fresh user approval in Kai. After approval, the broader token becomes canonical and the older narrower token is superseded in the audit trail.",
+      "That is a privilege increase, so it still requires fresh user approval in the Consent Center. After approval, the broader token becomes canonical and the older narrower token is superseded in the audit trail.",
   },
   {
     question: "Where does consent approval happen?",
@@ -302,7 +316,7 @@ export const FAQ_ITEMS: DeveloperFaqItem[] = [
   {
     question: "When is a connector key required?",
     answer:
-      "Hosted MCP and raw HTTP provide connector_public_key, connector_key_id, and connector_wrapping_alg on request_consent. The npm bridge manages its persistent X25519 keypair locally, so stdio callers do not provide private-key material to the model.",
+      "Hosted MCP and raw HTTP provide connector_public_key, connector_key_id, and connector_wrapping_alg on request-consent. The npm bridge manages its persistent X25519 keypair locally, so stdio callers do not provide private-key material to the model.",
   },
   {
     question: "When should I use remote MCP versus npm?",
@@ -320,7 +334,7 @@ export const DEVELOPER_ACCESS_NOTES = [
 export const DEVELOPER_SCOPE_NOTES = [
   "Scopes evolve as Hussh adds richer private-agent coverage and tighter domain metadata.",
   "Discover available scopes per user at runtime instead of hardcoding a fixed universal list.",
-  "The current Kai test-user shape is mostly financial, so early community integrations should expect financial-first examples.",
+  "Current reviewer fixtures are financial-first examples; discover each person's live scopes instead of assuming those examples are universal.",
   "A broader active grant can satisfy a narrower request, but a narrower active grant never auto-upgrades to a broader parent scope.",
 ];
 
@@ -356,13 +370,14 @@ export const DEVELOPER_SAMPLE_PAYLOADS: DeveloperSamplePayload[] = [
   },
 ];
 
-export function buildIntegrationModes(_runtime: DeveloperRuntime): IntegrationMode[] {
+export function buildIntegrationModes(
+  _runtime: DeveloperRuntime,
+): IntegrationMode[] {
   return [
     {
       id: "remote-mcp",
       title: "Remote/Streamable MCP",
-      summary:
-        `Point remote-capable hosts at ${MCP_PUBLIC_DOCS.promotedEnvironment.label} and use the trailing-slash /mcp/ endpoint with a Bearer token.`,
+      summary: `Point remote-capable hosts at ${MCP_PUBLIC_DOCS.promotedEnvironment.label} and use the trailing-slash /mcp/ endpoint with a Bearer token.`,
     },
     {
       id: "rest",
@@ -373,13 +388,15 @@ export function buildIntegrationModes(_runtime: DeveloperRuntime): IntegrationMo
     {
       id: "npm",
       title: "npm Bridge",
-      summary:
-        `Use ${MCP_PUBLIC_DOCS.packageName} only when the host still expects a local stdio MCP process instead of streamable HTTP MCP.`,
+      summary: `Use ${MCP_PUBLIC_DOCS.packageName} only when the host still expects a local stdio MCP process instead of streamable HTTP MCP.`,
     },
   ];
 }
 
-export function buildRestSnippets(runtime: DeveloperRuntime, developerToken = "<developer-token>") {
+export function buildRestSnippets(
+  runtime: DeveloperRuntime,
+  developerToken = "<developer-token>",
+) {
   // The developer API requires "Authorization: Bearer <token>"; it explicitly
   // rejects query-string ?token=... auth (verified live against
   // api.uat.hushh.ai/api/v1/user-scopes/{id}, which returns
@@ -420,11 +437,15 @@ export function buildRestSnippets(runtime: DeveloperRuntime, developerToken = "<
   };
 }
 
-export function buildMcpSnippets(_runtime: DeveloperRuntime, developerToken = "<developer-token>") {
-  const remoteUrl = MCP_PUBLIC_DOCS.promotedEnvironment.remoteUrlTemplate.replace(
-    "<developer-token>",
-    developerToken
-  );
+export function buildMcpSnippets(
+  _runtime: DeveloperRuntime,
+  developerToken = "<developer-token>",
+) {
+  const remoteUrl =
+    MCP_PUBLIC_DOCS.promotedEnvironment.remoteUrlTemplate.replace(
+      "<developer-token>",
+      developerToken,
+    );
   const examples = buildMcpHostExamples(developerToken);
   const byId = new Map(examples.map((example) => [example.id, example]));
 
@@ -437,15 +458,19 @@ export function buildMcpSnippets(_runtime: DeveloperRuntime, developerToken = "<
     codexStdio: byId.get("codex-stdio")?.code || "",
     claudeDesktop: byId.get("claude-desktop")?.code || "",
     primaryExamples: examples.filter(
-      (example) => example.id === "generic-remote"
+      (example) => example.id === "generic-remote",
     ),
     hostExamples: examples.filter(
-      (example) => example.id !== "generic-remote" && example.id !== "npm-bridge"
+      (example) =>
+        example.id !== "generic-remote" && example.id !== "npm-bridge",
     ),
   };
 }
 
-export function buildWorkspaceSnippets(runtime: DeveloperRuntime, developerToken = "<developer-token>") {
+export function buildWorkspaceSnippets(
+  runtime: DeveloperRuntime,
+  developerToken = "<developer-token>",
+) {
   return {
     envVar: `HUSHH_DEVELOPER_TOKEN=${developerToken}`,
     remoteUrl: runtime.remoteMcpUrlTemplate,

--- a/hushh-webapp/lib/developers/public-docs.json
+++ b/hushh-webapp/lib/developers/public-docs.json
@@ -4,6 +4,32 @@
   "noticeSummary": "The published npm package ships package-local LICENSE and NOTICE files for Apache redistribution.",
   "tokenEnvVar": "HUSHH_DEVELOPER_TOKEN",
   "mcpProtocolRevision": "2025-11-25",
+  "authentication": {
+    "discoveryUrl": "https://api.uat.hushh.ai/.well-known/oauth-authorization-server",
+    "authorizationEndpoint": "https://api.uat.hushh.ai/oauth/authorize",
+    "tokenEndpoint": "https://api.uat.hushh.ai/oauth/token",
+    "revocationEndpoint": "https://api.uat.hushh.ai/oauth/revoke",
+    "scope": "mcp:tools",
+    "bearerHeader": "Authorization: Bearer <access-token>",
+    "queryTokensAllowed": false,
+    "selfServeMethods": [
+      {
+        "id": "developer-token",
+        "label": "Developer token",
+        "detail": "A long-lived app credential created or rotated in the signed-in developer workspace."
+      },
+      {
+        "id": "authorization-code",
+        "label": "OAuth authorization code",
+        "detail": "Authorization code with S256 PKCE, exact registered redirect URIs, rotating refresh tokens, and revocation."
+      }
+    ],
+    "partnerOnlyMethod": {
+      "id": "client-credentials",
+      "label": "OAuth client credentials",
+      "detail": "Operations-provisioned partner_crm integrations only. This grant is not self-serve and does not issue refresh tokens."
+    }
+  },
   "promotedEnvironment": {
     "label": "UAT",
     "appUrl": "https://uat.one.hushh.ai",

--- a/packages/hushh-mcp/README.md
+++ b/packages/hushh-mcp/README.md
@@ -53,6 +53,8 @@ npx -y @hushh/mcp --help
 
 The same `/mcp/` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
 
+Self-serve applications may use a developer token or OAuth authorization code with S256 PKCE and rotating refresh tokens. Discover OAuth metadata at `https://api.uat.hushh.ai/.well-known/oauth-authorization-server`, request `mcp:tools`, and send the resulting credential only as `Authorization: Bearer <access-token>`. Query-string tokens are rejected. OAuth client credentials are reserved for operations-provisioned partner integrations and never grant vault or personal-information authority.
+
 Every tool uses shallow, fully described JSON Schema. Successful calls return `structuredContent` as the canonical result and `content[0].text` as its compatibility mirror. Execution errors return `isError: true` with safe JSON text only, so a strict client never validates an error against a success output schema.
 
 ### MuleSoft trusted connector for Salesforce and Agentforce

--- a/packages/hushh-mcp/public-docs.json
+++ b/packages/hushh-mcp/public-docs.json
@@ -4,6 +4,32 @@
   "noticeSummary": "The published npm package ships package-local LICENSE and NOTICE files for Apache redistribution.",
   "tokenEnvVar": "HUSHH_DEVELOPER_TOKEN",
   "mcpProtocolRevision": "2025-11-25",
+  "authentication": {
+    "discoveryUrl": "https://api.uat.hushh.ai/.well-known/oauth-authorization-server",
+    "authorizationEndpoint": "https://api.uat.hushh.ai/oauth/authorize",
+    "tokenEndpoint": "https://api.uat.hushh.ai/oauth/token",
+    "revocationEndpoint": "https://api.uat.hushh.ai/oauth/revoke",
+    "scope": "mcp:tools",
+    "bearerHeader": "Authorization: Bearer <access-token>",
+    "queryTokensAllowed": false,
+    "selfServeMethods": [
+      {
+        "id": "developer-token",
+        "label": "Developer token",
+        "detail": "A long-lived app credential created or rotated in the signed-in developer workspace."
+      },
+      {
+        "id": "authorization-code",
+        "label": "OAuth authorization code",
+        "detail": "Authorization code with S256 PKCE, exact registered redirect URIs, rotating refresh tokens, and revocation."
+      }
+    ],
+    "partnerOnlyMethod": {
+      "id": "client-credentials",
+      "label": "OAuth client credentials",
+      "detail": "Operations-provisioned partner_crm integrations only. This grant is not self-serve and does not issue refresh tokens."
+    }
+  },
   "promotedEnvironment": {
     "label": "UAT",
     "appUrl": "https://uat.one.hushh.ai",

--- a/packages/hushh-mcp/scripts/render-readme.mjs
+++ b/packages/hushh-mcp/scripts/render-readme.mjs
@@ -121,6 +121,8 @@ npx -y ${contract.packageName} --help
 
 The same \`/mcp/\` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
 
+Self-serve applications may use a developer token or OAuth authorization code with S256 PKCE and rotating refresh tokens. Discover OAuth metadata at \`${contract.authentication.discoveryUrl}\`, request \`${contract.authentication.scope}\`, and send the resulting credential only as \`${contract.authentication.bearerHeader}\`. Query-string tokens are rejected. OAuth client credentials are reserved for operations-provisioned partner integrations and never grant vault or personal-information authority.
+
 Every tool uses shallow, fully described JSON Schema. Successful calls return \`structuredContent\` as the canonical result and \`content[0].text\` as its compatibility mirror. Execution errors return \`isError: true\` with safe JSON text only, so a strict client never validates an error against a success output schema.
 
 ### MuleSoft trusted connector for Salesforce and Agentforce


### PR DESCRIPTION
Aligns Consent Center cache invalidation, neutral ambient chrome masks, trusted-device browser approval, and current Consent MCP authentication docs.\n\nVerified: web typecheck/lint, cache/design gates, focused UI tests, trusted-device backend tests, MCP docs checks, UAT reviewer navigation proof.