### PR TITLE
fix(deploy): persist trusted device rollout flags

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -252,6 +252,7 @@ jobs:
             --plaid-webhook-url "${{ env.APP_FRONTEND_ORIGIN }}/api/kai/plaid/webhook" \
             --plaid-redirect-path "/kai/plaid/oauth/return" \
             --plaid-tx-history-days "730" \
+            --hushh-trusted-device-enabled "false" \
             > /tmp/dev-runtime-secret-sync.json
 
           # Same main-workflow vs train-tree skew guard as the backend sync:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -236,6 +236,7 @@ jobs:
             --plaid-webhook-url "${{ env.APP_FRONTEND_ORIGIN }}/api/kai/plaid/webhook" \
             --plaid-redirect-path "/kai/plaid/oauth/return" \
             --plaid-tx-history-days "730" \
+            --hushh-trusted-device-enabled "false" \
             > /tmp/prod-runtime-secret-sync.json
 
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -271,6 +271,8 @@ jobs:
             --one-location-read-only-state-enabled "${{ vars.ONE_LOCATION_READ_ONLY_STATE_ENABLED || 'false' }}" \
             --consent-center-summary-v2-enabled "${{ vars.CONSENT_CENTER_SUMMARY_V2_ENABLED || 'false' }}" \
             --db-bulk-batching-enabled "${{ vars.DB_BULK_BATCHING_ENABLED || 'false' }}" \
+            --hushh-trusted-device-enabled "${{ vars.HUSSH_TRUSTED_DEVICE_ENABLED || 'false' }}" \
+            --hushh-trusted-device-uat-allowlist "${{ vars.HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST || '' }}" \
             > /tmp/uat-runtime-secret-sync.json
 
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \

--- a/consent-protocol/hushh_mcp/runtime_settings.py
+++ b/consent-protocol/hushh_mcp/runtime_settings.py
@@ -76,6 +76,8 @@ _BACKEND_RUNTIME_ENV_MAP: dict[str, str] = {
     "one_location_read_only_state_enabled": "ONE_LOCATION_READ_ONLY_STATE_ENABLED",
     "consent_center_summary_v2_enabled": "CONSENT_CENTER_SUMMARY_V2_ENABLED",
     "db_bulk_batching_enabled": "DB_BULK_BATCHING_ENABLED",
+    "hushh_trusted_device_enabled": "HUSSH_TRUSTED_DEVICE_ENABLED",
+    "hushh_trusted_device_uat_allowlist": "HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST",
 }
 
 

--- a/consent-protocol/tests/test_runtime_settings_maps.py
+++ b/consent-protocol/tests/test_runtime_settings_maps.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from hushh_mcp import runtime_settings
 
 
@@ -19,3 +22,25 @@ def test_google_maps_api_key_defaults_empty(monkeypatch):
     settings = runtime_settings.get_core_security_settings()
     assert settings.google_maps_api_key == ""
     runtime_settings.get_core_security_settings.cache_clear()
+
+
+def test_trusted_device_rollout_is_hydrated_from_canonical_runtime_config(monkeypatch):
+    monkeypatch.delenv("HUSSH_TRUSTED_DEVICE_ENABLED", raising=False)
+    monkeypatch.delenv("HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST", raising=False)
+    monkeypatch.setenv(
+        "BACKEND_RUNTIME_CONFIG_JSON",
+        json.dumps(
+            {
+                "hushh_trusted_device_enabled": "true",
+                "hushh_trusted_device_uat_allowlist": [
+                    "reviewer@example.com",
+                    "reviewer-uid",
+                ],
+            }
+        ),
+    )
+
+    runtime_settings.hydrate_runtime_environment()
+
+    assert os.environ["HUSSH_TRUSTED_DEVICE_ENABLED"] == "true"
+    assert os.environ["HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST"] == "reviewer@example.com,reviewer-uid"

--- a/scripts/ops/sync_backend_runtime_secrets.py
+++ b/scripts/ops/sync_backend_runtime_secrets.py
@@ -182,6 +182,8 @@ def _build_backend_runtime_config(args: argparse.Namespace) -> dict[str, Any]:
         "one_location_read_only_state_enabled": args.one_location_read_only_state_enabled,
         "consent_center_summary_v2_enabled": args.consent_center_summary_v2_enabled,
         "db_bulk_batching_enabled": args.db_bulk_batching_enabled,
+        "hushh_trusted_device_enabled": args.hushh_trusted_device_enabled,
+        "hushh_trusted_device_uat_allowlist": args.hushh_trusted_device_uat_allowlist,
     }
     return _drop_empty(config)
 
@@ -228,6 +230,8 @@ def main() -> int:
     parser.add_argument("--one-location-read-only-state-enabled", default="false")
     parser.add_argument("--consent-center-summary-v2-enabled", default="false")
     parser.add_argument("--db-bulk-batching-enabled", default="false")
+    parser.add_argument("--hushh-trusted-device-enabled", default="false")
+    parser.add_argument("--hushh-trusted-device-uat-allowlist", default="")
     args = parser.parse_args()
 
     sync_summary: list[str] = []


### PR DESCRIPTION
## Summary\n- hydrate trusted-device rollout settings from the canonical backend runtime config\n- source the UAT flag and allowlist from governed environment variables\n- keep Dev and Production explicitly disabled\n\n## Verification\n- 15 focused runtime/trusted-device tests passed\n- runtime config contract passed\n- pre-commit and pre-push protocol lint/format passed\n\nSigned-off-by: Kushal Trivedi <kushaltrivedi1711@gmail.com>