### PR TITLE
fix(deploy): route Dev managed Vertex through UAT

### DIFF
--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -98,6 +98,20 @@ labels and provenance verification.
 2. Everything else (voice, Plaid, market data, Gmail receipts OAuth, Maps, reviewer
    smoke, phone test numbers) replicates UAT, using secret values copied into the dev
    project.
+3. **Managed Vertex inference temporarily uses the UAT Vertex project.** The Dev
+   Cloud Run service continues to run as
+   `consent-protocol-runtime@hushh-pda-dev.iam.gserviceaccount.com`, but
+   `GOOGLE_CLOUD_PROJECT=hushh-pda-uat` for managed Gemini text and One Live calls.
+   Dev keeps its own Cloud Run and database resources while managed Gemini requests
+   use UAT's working Vertex billing entitlement. UAT grants that Dev service account only
+   `roles/aiplatform.user` and `roles/serviceusage.serviceUsageConsumer`; Dev usage
+   therefore consumes UAT Vertex quota and appears in UAT billing and audit logs.
+   The shared backend build rejects this override outside `deploy-env=dev`.
+
+   Roll back after Google clears project `621416509462` by removing the Dev fallback
+   from `deploy/backend.cloudbuild.yaml`, redeploying Dev, proving managed Vertex
+   readiness against `hushh-pda-dev`, and then removing the two UAT IAM bindings from
+   the Dev runtime service account.
 
 ---
 

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -53,6 +53,19 @@ def test_backend_vertex_preflight_uses_supported_service_usage_command() -> None
     assert "gcloud services describe" not in backend_build
 
 
+def test_cross_project_vertex_fallback_is_dev_only_and_shared_by_readiness() -> None:
+    backend_build = _read("deploy/backend.cloudbuild.yaml")
+
+    assert 'if [[ "${_DEPLOY_ENV}" == "dev" ]]; then' in backend_build
+    assert 'genai_project_id="hushh-pda-uat"' in backend_build
+    assert '"${_DEPLOY_ENV}" != "dev"' in backend_build
+    assert "roles/serviceusage.serviceUsageConsumer" in backend_build
+    assert '"GOOGLE_CLOUD_PROJECT=${genai_project_id}"' in backend_build
+    assert backend_build.count('"GOOGLE_CLOUD_PROJECT=${genai_project_id}"') == 1
+    assert "GOOGLE_CLOUD_PROJECT=${genai_project_id}" in backend_build
+    assert '_GENAI_PROJECT_ID: ""' in backend_build
+
+
 def test_production_deploy_builds_candidates_without_serving_traffic() -> None:
     production_workflow = _read(".github/workflows/deploy-production.yml")
 

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -50,23 +50,44 @@ steps:
           echo "Runtime service account must belong to ${PROJECT_ID}; got '${_RUNTIME_SERVICE_ACCOUNT}'." >&2
           exit 1
         fi
+        genai_project_id="${_GENAI_PROJECT_ID}"
+        if [[ -z "${genai_project_id}" ]]; then
+          genai_project_id="$PROJECT_ID"
+          if [[ "${_DEPLOY_ENV}" == "dev" ]]; then
+            genai_project_id="hushh-pda-uat"
+          fi
+        fi
+        if [[ "${genai_project_id}" != "$PROJECT_ID" && "${_DEPLOY_ENV}" != "dev" ]]; then
+          echo "Cross-project managed Vertex is allowed only for the isolated dev lane." >&2
+          exit 1
+        fi
         gcloud iam service-accounts describe "${_RUNTIME_SERVICE_ACCOUNT}" \
           --project="$PROJECT_ID" >/dev/null
         vertex_api_name="$(gcloud services list --enabled \
-          --project="$PROJECT_ID" \
+          --project="${genai_project_id}" \
           --filter='config.name=aiplatform.googleapis.com' \
           --format='value(config.name)' | head -n 1)"
         if [[ "${vertex_api_name}" != "aiplatform.googleapis.com" ]]; then
-          echo "Vertex AI API must be enabled in ${PROJECT_ID}." >&2
+          echo "Vertex AI API must be enabled in ${genai_project_id}." >&2
           exit 1
         fi
-        runtime_vertex_role="$(gcloud projects get-iam-policy "$PROJECT_ID" \
+        runtime_vertex_role="$(gcloud projects get-iam-policy "${genai_project_id}" \
           --flatten='bindings[].members' \
           --filter="bindings.role=roles/aiplatform.user AND bindings.members=serviceAccount:${_RUNTIME_SERVICE_ACCOUNT}" \
           --format='value(bindings.role)' | head -n 1)"
         if [[ "${runtime_vertex_role}" != "roles/aiplatform.user" ]]; then
-          echo "${_RUNTIME_SERVICE_ACCOUNT} must have roles/aiplatform.user in ${PROJECT_ID}." >&2
+          echo "${_RUNTIME_SERVICE_ACCOUNT} must have roles/aiplatform.user in ${genai_project_id}." >&2
           exit 1
+        fi
+        if [[ "${genai_project_id}" != "$PROJECT_ID" ]]; then
+          runtime_service_usage_role="$(gcloud projects get-iam-policy "${genai_project_id}" \
+            --flatten='bindings[].members' \
+            --filter="bindings.role=roles/serviceusage.serviceUsageConsumer AND bindings.members=serviceAccount:${_RUNTIME_SERVICE_ACCOUNT}" \
+            --format='value(bindings.role)' | head -n 1)"
+          if [[ "${runtime_service_usage_role}" != "roles/serviceusage.serviceUsageConsumer" ]]; then
+            echo "${_RUNTIME_SERVICE_ACCOUNT} must have roles/serviceusage.serviceUsageConsumer in ${genai_project_id}." >&2
+            exit 1
+          fi
         fi
         append_optional_secret() {
           local secret_name="$1"
@@ -163,7 +184,7 @@ steps:
           "HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID}"
           "HUSHH_GENAI_AUTH_MODE=vertex_adc"
           "GOOGLE_GENAI_USE_VERTEXAI=true"
-          "GOOGLE_CLOUD_PROJECT=$PROJECT_ID"
+          "GOOGLE_CLOUD_PROJECT=${genai_project_id}"
           "GOOGLE_CLOUD_LOCATION=global"
           "HUSHH_VERTEX_LOCATIONS=global,us,eu"
           "CONSENT_API_PUBLIC_ORIGIN=${_CONSENT_API_PUBLIC_ORIGIN}"
@@ -248,6 +269,13 @@ steps:
       - "-c"
       - |
         set -euo pipefail
+        genai_project_id="${_GENAI_PROJECT_ID}"
+        if [[ -z "${genai_project_id}" ]]; then
+          genai_project_id="$PROJECT_ID"
+          if [[ "${_DEPLOY_ENV}" == "dev" ]]; then
+            genai_project_id="hushh-pda-uat"
+          fi
+        fi
         job_name="${_BACKEND_SERVICE}-genai-readiness"
         gcloud run jobs deploy "${job_name}" \
           --project="$PROJECT_ID" \
@@ -256,7 +284,7 @@ steps:
           --service-account="${_RUNTIME_SERVICE_ACCOUNT}" \
           --command="python" \
           --args="scripts/verify_managed_vertex_runtime.py" \
-          --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=$PROJECT_ID|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
+          --set-env-vars="^|^HUSHH_GENAI_AUTH_MODE=vertex_adc|GOOGLE_GENAI_USE_VERTEXAI=true|GOOGLE_CLOUD_PROJECT=${genai_project_id}|GOOGLE_CLOUD_LOCATION=global|HUSHH_VERTEX_LOCATIONS=global,us,eu|AGENT_ONE_ADK_LOCATION=us-central1" \
           --max-retries=0 \
           --task-timeout=90s \
           --quiet
@@ -277,6 +305,7 @@ timeout: "1800s"
 substitutions:
   _BACKEND_SERVICE: consent-protocol
   _RUNTIME_SERVICE_ACCOUNT: ""
+  _GENAI_PROJECT_ID: ""
   _REGION: us-central1
   _CLOUDSQL_INSTANCES: ""
   _PLAID_CLIENT_ID_SECRET: ""


### PR DESCRIPTION
## Summary
- route managed Gemini calls from the isolated Dev runtime through the working UAT Vertex project while retaining the Dev Cloud Run service account
- fail closed if any non-Dev deployment attempts a cross-project Vertex override
- verify both Vertex and service-usage IAM bindings before deployment and use the same project in the candidate readiness job
- document quota, billing, audit, and rollback implications

## Live recovery evidence
- Dev runtime service account received `roles/aiplatform.user` and `roles/serviceusage.serviceUsageConsumer` in `hushh-pda-uat`
- exact Dev candidate readiness execution `consent-protocol-genai-readiness-2zqcc` passed direct text, ADK text, and One Live
- Dev revision `consent-protocol-00011-cp5` is serving 100% traffic
- `/health` returned HTTP 200
- no `GOOGLE_API_KEY` or `GEMINI_API_KEY` binding is present

## Verification
- `uv run pytest tests/test_uat_deploy_no_traffic_contract.py -q`
- `bash scripts/ci/runtime-contract-check.sh`
- `./bin/hushh docs verify`
- `./bin/hushh codex pre-pr`
- `git diff --check`
