### PR TITLE
docs(dev): record Vertex verifier IAM

### DIFF
--- a/consent-protocol/docs/reference/dev-environment-setup.md
+++ b/consent-protocol/docs/reference/dev-environment-setup.md
@@ -107,11 +107,16 @@ labels and provenance verification.
    `roles/aiplatform.user` and `roles/serviceusage.serviceUsageConsumer`; Dev usage
    therefore consumes UAT Vertex quota and appears in UAT billing and audit logs.
    The shared backend build rejects this override outside `deploy-env=dev`.
+   The Dev Cloud Build identity has the UAT project-local
+   `devVertexDeployVerifier` custom role with only
+   `serviceusage.services.list` and `resourcemanager.projects.getIamPolicy`, allowing
+   the build to verify those runtime grants without broad UAT Viewer access.
 
    Roll back after Google clears project `621416509462` by removing the Dev fallback
    from `deploy/backend.cloudbuild.yaml`, redeploying Dev, proving managed Vertex
-   readiness against `hushh-pda-dev`, and then removing the two UAT IAM bindings from
-   the Dev runtime service account.
+   readiness against `hushh-pda-dev`, removing the two UAT IAM bindings from the Dev
+   runtime service account, and removing the verifier-role binding from the Dev Cloud
+   Build identity. Delete the custom role after no bindings remain.
 
 ---
 


### PR DESCRIPTION
## Summary
- document the narrow UAT custom role used by Dev Cloud Build to verify cross-project Vertex prerequisites
- record its exact permissions and rollback/removal sequence

## Verification
- `./bin/hushh docs verify`
- `git diff --check`
