### PR TITLE
fix(ui): refine shared location cards and phone country hover

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -1687,21 +1687,17 @@ describe("OneLocationAgentPage", () => {
     expect(mapPreview.getAttribute("src")).toContain(
       "https://www.google.com/maps?q=28.613900%2C77.209000",
     );
-    expect(screen.queryAllByText(/Paused · last seen/).length).toBeGreaterThan(
-      0,
-    );
+    expect(screen.queryAllByText(/Paused · last seen/)).toHaveLength(1);
+    expect(screen.queryAllByText(/^Updated /)).toHaveLength(1);
     expect(screen.getByText(/Accuracy \+\/- 18 m/)).toBeTruthy();
     expect(screen.queryByText("Lat")).toBeNull();
     expect(screen.queryByText("Lng")).toBeNull();
 
-    const directionsLink = screen.getByRole("link", {
-      name: "Open Google Maps directions to shared live location",
-    });
-    expect(directionsLink.getAttribute("target")).toBe("_blank");
-    expect(directionsLink.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(directionsLink.getAttribute("href")).toContain(
-      "https://www.google.com/maps/dir/?api=1&destination=28.613900%2C77.209000&travelmode=driving",
-    );
+    expect(
+      screen.queryByRole("link", {
+        name: "Open Google Maps directions to shared live location",
+      }),
+    ).toBeNull();
 
     const openMapLink = screen.getByRole("link", {
       name: "Open shared location in Google Maps",
@@ -1713,22 +1709,31 @@ describe("OneLocationAgentPage", () => {
     );
 
     const viewCallsBeforeCollapse = mockViewEnvelope.mock.calls.length;
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+
+    const collapseButton = screen.getByRole("button", {
+      name: "Collapse shared location from Trusted A",
+    });
+    expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(collapseButton);
 
     expect(screen.queryByTitle("Live location map preview")).toBeNull();
     expect(screen.getByText("Trusted A is sharing with you")).toBeTruthy();
     expect(screen.getByRole("button", { name: "View location" })).toBeTruthy();
+    const expandButton = screen.getByRole("button", {
+      name: "Expand shared location from Trusted A",
+    });
+    expect(expandButton.getAttribute("aria-expanded")).toBe("false");
     expect(
       window.localStorage.getItem("one_location_unwatched_grants_v1:user_b"),
     ).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "View location" }));
+    fireEvent.click(expandButton);
     expect(await screen.findByTitle("Live location map preview")).toBeTruthy();
     expect(mockViewEnvelope).toHaveBeenCalledTimes(viewCallsBeforeCollapse);
 
-    // The duplicate "Start" navigation button was removed from location
-    // previews (it opened the same Google Maps navigation as "Directions").
-    // Only the single "Directions" action should remain.
+    // Inline navigation CTAs are omitted from received-share previews. The
+    // single "Open map" action remains the deliberate provider handoff.
     expect(
       screen.queryByRole("link", {
         name: "Start Google Maps navigation to shared live location",

--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -76,6 +76,28 @@ describe("PhoneVerificationFlow country selector", () => {
     expect(screen.queryByText("India")).toBeNull();
   });
 
+  it("keeps dial codes on the same foreground as each option state", async () => {
+    renderPhoneVerificationFlow();
+    const countryInput = screen.getByRole("combobox", {
+      name: "Country code",
+    });
+
+    fireEvent.focus(countryInput);
+
+    const indiaLabel = await screen.findByText("India");
+    const indiaItem = indiaLabel.closest("[data-slot='combobox-item']");
+    expect(indiaItem).not.toBeNull();
+    expect(indiaItem?.className).toContain(
+      "data-highlighted:text-accent-foreground",
+    );
+
+    const dialCode = Array.from(indiaItem?.querySelectorAll("span") ?? []).find(
+      (element) => element.textContent === "+91",
+    );
+    expect(dialCode?.className).toContain("text-current");
+    expect(dialCode?.className).not.toContain("text-muted-foreground");
+  });
+
   it("shows an honest empty state for an unmatched country query", async () => {
     renderPhoneVerificationFlow();
     const countryInput = screen.getByRole("combobox", {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -948,10 +948,7 @@ function LocalMapPreview({
 
       <div className="space-y-3 p-3">
         <div className="min-w-0">
-          <p className="text-[15px] font-semibold text-foreground">
-            {statusLabel}
-          </p>
-          <p className="mt-1 break-words text-[12px] font-medium text-muted-foreground [overflow-wrap:anywhere]">
+          <p className="break-words text-[12px] font-medium text-muted-foreground [overflow-wrap:anywhere]">
             Updated {captured}
             {accuracy ? ` - ${accuracy}` : ""} -{" "}
             {locationSourceLabel(point.sourcePlatform)}

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -803,7 +803,7 @@ export function PhoneVerificationFlow({
                           >
                             <div className="flex w-full items-center justify-between gap-3">
                               <span className="truncate">{item.label}</span>
-                              <span className="shrink-0 text-muted-foreground">
+                              <span className="shrink-0 text-current">
                                 {item.dialCode}
                               </span>
                             </div>

--- a/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
@@ -75,7 +75,7 @@ describe("LiveMap", () => {
     expect(screen.queryByTitle("Live location map preview")).toBeNull();
   });
 
-  it("constructs the map with the app theme's color scheme", () => {
+  it("constructs a quiet preview map with the app theme's color scheme", () => {
     const Marker = vi.fn(function () {
       return { getPosition: () => null, setPosition: vi.fn() };
     });
@@ -91,7 +91,11 @@ describe("LiveMap", () => {
 
     expect(Map).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ colorScheme: "DARK" }),
+      expect.objectContaining({
+        colorScheme: "DARK",
+        disableDefaultUI: true,
+        keyboardShortcuts: false,
+      }),
     );
     mockTheme.current = "light";
   });

--- a/hushh-webapp/components/one-location/live-map.tsx
+++ b/hushh-webapp/components/one-location/live-map.tsx
@@ -68,6 +68,9 @@ export function LiveMap({ point, className }: LiveMapProps) {
       center: target,
       zoom: 16,
       disableDefaultUI: true,
+      keyboardShortcuts: false,
+      // Google Maps attribution, map-data credits, and Terms are provider-owned
+      // legal UI. They must remain visible and must never be hidden or cropped.
       clickableIcons: false,
       colorScheme,
     });

--- a/hushh-webapp/components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SharedWithMeCard } from "@/components/one-location/redesign/cards";
+
+describe("SharedWithMeCard", () => {
+  it("keeps the live state beside the expiry and exposes an accessible disclosure", () => {
+    const onView = vi.fn();
+    const onDismiss = vi.fn();
+    const props = {
+      name: "Trusted A",
+      statusLine: "Live until Jul 28, 11:19 PM",
+      onView,
+      onDismiss,
+      mapHref: "https://www.google.com/maps/search/?api=1&query=1%2C2",
+    };
+    const { rerender } = render(
+      <SharedWithMeCard {...props} previewExpanded={false}>
+        <div data-testid="map-preview">Map preview</div>
+      </SharedWithMeCard>,
+    );
+
+    const livePill = screen.getByText("Live");
+    expect(livePill.parentElement?.textContent).toContain(
+      "Live until Jul 28, 11:19 PMLive",
+    );
+
+    const expandButton = screen.getByRole("button", {
+      name: "Expand shared location from Trusted A",
+    });
+    expect(expandButton.getAttribute("aria-expanded")).toBe("false");
+    const previewRegion = document.getElementById(
+      expandButton.getAttribute("aria-controls") ?? "",
+    );
+    expect(previewRegion).not.toBeNull();
+    expect(previewRegion?.hidden).toBe(true);
+
+    fireEvent.click(expandButton);
+    expect(onView).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <SharedWithMeCard {...props} previewExpanded viewBusy>
+        <div data-testid="map-preview">Map preview</div>
+      </SharedWithMeCard>,
+    );
+
+    const collapseButton = screen.getByRole("button", {
+      name: "Collapse shared location from Trusted A",
+    });
+    expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
+    expect(collapseButton).not.toBeDisabled();
+    expect(previewRegion?.hidden).toBe(false);
+    expect(
+      screen.getByRole("link", {
+        name: "Open shared location in Google Maps",
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+
+    fireEvent.click(collapseButton);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -10,8 +10,9 @@
  * No business logic lives here.
  */
 
-import type { ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import {
+  ChevronDown,
   Clock3,
   Copy,
   ExternalLink,
@@ -24,6 +25,7 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { ShellActionSurface } from "@/components/app-ui/shell-action-surface";
 import { Button } from "@/components/ui/button";
 import { Avatar, StatusPill } from "./primitives";
 import { MUTED_TEXT, SUBCARD_SURFACE } from "./tokens";
@@ -247,7 +249,6 @@ export function RequestCard({
 export function SharedWithMeCard({
   name,
   statusLine,
-  metaLine,
   onView,
   onDismiss,
   mapHref,
@@ -258,7 +259,6 @@ export function SharedWithMeCard({
 }: {
   name: string;
   statusLine: string;
-  metaLine?: string;
   onView: () => void;
   onDismiss?: () => void;
   mapHref?: string;
@@ -268,31 +268,62 @@ export function SharedWithMeCard({
   message?: string;
 }) {
   const canOpenMap = Boolean(previewExpanded && mapHref);
-  const canDismissPreview = Boolean(previewExpanded && onDismiss);
+  const previewRegionId = useId();
+  const isPreviewExpanded = Boolean(previewExpanded);
+  const canTogglePreview = !isPreviewExpanded || Boolean(onDismiss);
+  const togglePreview = () => {
+    if (isPreviewExpanded) {
+      onDismiss?.();
+      return;
+    }
+    onView();
+  };
 
   return (
     <div className={cn(SUBCARD_SURFACE, "space-y-3 p-3.5")}>
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3">
         <Avatar initials={initialsFrom(name)} />
         <div className="min-w-0 flex-1">
           <p className="truncate text-base font-semibold text-foreground">
             {name} is sharing with you
           </p>
-          <p className={cn(MUTED_TEXT, "truncate")}>{statusLine}</p>
+          <div className="mt-0.5 flex min-w-0 items-center gap-2">
+            <p className={cn(MUTED_TEXT, "min-w-0 truncate")}>{statusLine}</p>
+            <StatusPill tone="live" className="shrink-0">
+              Live
+            </StatusPill>
+          </div>
         </div>
-        <StatusPill tone="live">Live</StatusPill>
+        {canTogglePreview ? (
+          <ShellActionSurface
+            variant="icon"
+            aria-label={`${isPreviewExpanded ? "Collapse" : "Expand"} shared location from ${name}`}
+            aria-expanded={isPreviewExpanded}
+            aria-controls={previewRegionId}
+            disabled={viewBusy && !isPreviewExpanded}
+            onClick={togglePreview}
+          >
+            {viewBusy && !isPreviewExpanded ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform duration-200",
+                  isPreviewExpanded && "rotate-180",
+                )}
+                aria-hidden="true"
+              />
+            )}
+          </ShellActionSurface>
+        ) : null}
       </div>
-      {metaLine ? <p className={MUTED_TEXT}>{metaLine}</p> : null}
-      {children}
+      <div id={previewRegionId} hidden={!isPreviewExpanded}>
+        {children}
+      </div>
       {message ? (
         <p className={cn(MUTED_TEXT, "text-sm")}>{message}</p>
       ) : null}
-      <div
-        className={cn(
-          "grid gap-2",
-          canDismissPreview ? "grid-cols-2" : "grid-cols-1",
-        )}
-      >
+      <div className="grid grid-cols-1 gap-2">
         {canOpenMap ? (
           <Button
             asChild
@@ -320,16 +351,6 @@ export function SharedWithMeCard({
             View location
           </Button>
         )}
-        {canDismissPreview ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onDismiss}
-            className="h-9 rounded-full text-sm"
-          >
-            Dismiss
-          </Button>
-        ) : null}
       </div>
     </div>
   );

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -872,11 +872,6 @@ function LocationDetailFlow({
                   key={grant.id}
                   name={vm.grantOwnerLabel(grant)}
                   statusLine={vm.expiresLabel(grant.expiresAt)}
-                  metaLine={
-                    point
-                      ? `Updated ${vm.formatDateTime(point.capturedAt)}`
-                      : undefined
-                  }
                   previewExpanded={expanded}
                   mapHref={point ? vm.mapLocationHref(point) : undefined}
                   onView={() => onExpandGrant(grant)}
@@ -884,7 +879,7 @@ function LocationDetailFlow({
                   viewBusy={vm.busy === "view"}
                   message={grant.shareMessage ?? undefined}
                 >
-                  {expanded && point ? vm.renderMapPreview(point, true) : null}
+                  {expanded && point ? vm.renderMapPreview(point, false) : null}
                 </SharedWithMeCard>
               );
             })}


### PR DESCRIPTION
## Summary

- simplify received live-location cards by removing the duplicate timestamp, duplicate paused/live status, and inline Directions action
- place the Live state beside the sharing expiry and replace the bottom Dismiss action with an accessible expand/collapse disclosure
- disable optional Google Maps keyboard-shortcut UI while preserving mandatory Google attribution, Map data, and Terms
- make phone-country dial codes inherit the option foreground in normal, highlighted, and selected states
- add regression coverage for the location-card disclosure and country-picker hover treatment

## Root cause

The received-location card rendered the same state in multiple regions and used a separate bottom action for a local-only collapse. The phone picker pinned dial codes to a muted foreground, overriding the combobox option's highlighted foreground.

## Scope

UI presentation and local expand/collapse wiring only. No authentication, OTP/SMS, consent/grant, persistence, API/schema, crypto, or security-boundary behavior was changed.

## Validation

- DCO sign-off: passed for the single commit
- focused location Vitest: 50/50 passed
- phone interaction Vitest: 9/9 passed in isolation
- targeted ESLint: passed
- TypeScript, design-system, cache, and docs checks: passed
- gitleaks: no leaks in `origin/main..HEAD`
- GitHub secret-scanning alerts: 0 open
- branch freshness: current with `origin/main` before push

## Local gate note

The complete local CI mirror reached governance but its final agent-orchestration subcheck is not Windows path-separator safe: it compares canonical `/` markers as `\` in three unchanged policy files. No governance files are part of this PR. Authoritative Linux PR checks remain required before merge.
