### PR TITLE
fix(deploy): isolate UAT verification baselines

### DIFF
--- a/scripts/ci/resolve-uat-verification-plan.py
+++ b/scripts/ci/resolve-uat-verification-plan.py
@@ -35,6 +35,16 @@ def _git_diff(base_sha: str, target_sha: str) -> set[str]:
     return {_normalize(item) for item in result.stdout.splitlines() if _normalize(item)}
 
 
+def _exclude_service_tree(paths: set[str], service_root: str) -> set[str]:
+    """Drop changes owned exclusively by the other deployable service."""
+    prefix = f"{service_root}/"
+    return {
+        path
+        for path in paths
+        if path != service_root and not path.startswith(prefix)
+    }
+
+
 def _is_pkm_upgrade(path: str) -> bool:
     return (
         path in {
@@ -136,9 +146,22 @@ def resolve_plan(
     changed: set[str] = set()
     try:
         if deploy_backend:
-            changed.update(_git_diff(backend_base_sha, target_sha))
+            # Service revisions can advance independently. A stale backend
+            # baseline may therefore include frontend files that the active
+            # frontend revision already verified and deployed.
+            changed.update(
+                _exclude_service_tree(
+                    _git_diff(backend_base_sha, target_sha),
+                    "hushh-webapp",
+                )
+            )
         if deploy_frontend:
-            changed.update(_git_diff(frontend_base_sha, target_sha))
+            changed.update(
+                _exclude_service_tree(
+                    _git_diff(frontend_base_sha, target_sha),
+                    "consent-protocol",
+                )
+            )
     except subprocess.CalledProcessError:
         return VerificationPlan((), 1, True, True, "conservative:comparison_base_unproven")
 

--- a/scripts/ci/test_resolve_uat_verification_plan.py
+++ b/scripts/ci/test_resolve_uat_verification_plan.py
@@ -107,6 +107,78 @@ def test_frontend_vault_change_requires_byok_browser() -> None:
     assert plan.as_dict()["requires_web_dependencies"] is True
 
 
+def test_divergent_service_bases_do_not_reselect_already_deployed_vault_change() -> None:
+    resolver = load_module()
+    changed_by_base = {
+        "backend-base": {
+            "consent-protocol/api/routes/health.py",
+            "hushh-webapp/lib/services/vault-service.ts",
+            "scripts/ci/shared-release-check.py",
+        },
+        "frontend-base": {
+            "hushh-webapp/components/one-location/live-map.tsx",
+            "consent-protocol/api/routes/already-deployed.py",
+            "scripts/ci/shared-release-check.py",
+        },
+    }
+    resolver._git_diff = lambda base, _target: changed_by_base[base]
+
+    plan = resolver.resolve_plan(
+        target_sha="target",
+        backend_base_sha="backend-base",
+        frontend_base_sha="frontend-base",
+        deploy_backend=True,
+        deploy_frontend=True,
+    )
+
+    assert plan.changed_files == (
+        "consent-protocol/api/routes/health.py",
+        "hushh-webapp/components/one-location/live-map.tsx",
+        "scripts/ci/shared-release-check.py",
+    )
+    assert plan.run_pkm_upgrade_gate is False
+    assert plan.run_reviewer_byok is False
+    assert plan.reason == "changed_paths:standard"
+
+
+def test_divergent_service_bases_preserve_owned_and_shared_protected_changes() -> None:
+    resolver = load_module()
+    changed_by_base = {
+        "backend-base": {
+            "consent-protocol/hushh_mcp/services/pkm_upgrade_service.py",
+            "consent-protocol/hushh_mcp/services/vault_reader.py",
+            "hushh-webapp/lib/vault/already-deployed.ts",
+            ".codex/skills/reviewer-app-testing/SKILL.md",
+        },
+        "frontend-base": {
+            "hushh-webapp/lib/services/pkm-upgrade-reader.ts",
+            "hushh-webapp/lib/vault/key.ts",
+            "consent-protocol/hushh_mcp/services/vault_already_deployed.py",
+            ".codex/skills/reviewer-app-testing/SKILL.md",
+        },
+    }
+    resolver._git_diff = lambda base, _target: changed_by_base[base]
+
+    plan = resolver.resolve_plan(
+        target_sha="target",
+        backend_base_sha="backend-base",
+        frontend_base_sha="frontend-base",
+        deploy_backend=True,
+        deploy_frontend=True,
+    )
+
+    assert plan.changed_files == (
+        ".codex/skills/reviewer-app-testing/SKILL.md",
+        "consent-protocol/hushh_mcp/services/pkm_upgrade_service.py",
+        "consent-protocol/hushh_mcp/services/vault_reader.py",
+        "hushh-webapp/lib/services/pkm-upgrade-reader.ts",
+        "hushh-webapp/lib/vault/key.ts",
+    )
+    assert plan.pkm_evaluator_runs == 1
+    assert plan.run_pkm_upgrade_gate is True
+    assert plan.run_reviewer_byok is True
+
+
 def test_missing_deployed_sha_fails_closed() -> None:
     resolver = load_module()
     plan = resolver.resolve_plan(
@@ -122,6 +194,21 @@ def test_missing_deployed_sha_fails_closed() -> None:
     lanes = plan.as_dict()["lanes"]
     assert lanes["pkm_upgrade"]["reason"] == "comparison_base_unproven_fail_closed"
     assert lanes["reviewer_byok"]["reason"] == "comparison_base_unproven_fail_closed"
+
+
+def test_one_missing_service_base_fails_closed_for_all_service_deploy() -> None:
+    resolver = load_module()
+    plan = resolver.resolve_plan(
+        target_sha="target",
+        backend_base_sha="backend-base",
+        frontend_base_sha="",
+        deploy_backend=True,
+        deploy_frontend=True,
+    )
+    assert plan.pkm_evaluator_runs == 1
+    assert plan.run_pkm_upgrade_gate is True
+    assert plan.run_reviewer_byok is True
+    assert plan.reason == "conservative:comparison_base_unproven"
 
 
 def test_unresolvable_comparison_base_fails_closed() -> None:
@@ -155,7 +242,10 @@ def main() -> int:
         test_pkm_gate_policy_change_relies_on_always_on_contract_tests,
         test_unknown_path_keeps_expensive_lanes_skipped,
         test_frontend_vault_change_requires_byok_browser,
+        test_divergent_service_bases_do_not_reselect_already_deployed_vault_change,
+        test_divergent_service_bases_preserve_owned_and_shared_protected_changes,
         test_missing_deployed_sha_fails_closed,
+        test_one_missing_service_base_fails_closed_for_all_service_deploy,
         test_unresolvable_comparison_base_fails_closed,
     ]
     for test in tests:


### PR DESCRIPTION
# Description

Fix the UAT verification-plan selector so independently deployed backend and frontend revisions are compared only against the service tree they actually own.

The failed UAT run built, deployed, and semantically verified both candidates, but a stale backend baseline reintroduced already-deployed frontend paths covered by the protected reviewer-browser lane. That incorrectly selected the reviewer BYOK browser lane, which timed out during protected browser navigation and correctly triggered rollback. The preceding frontend revision had already passed the identical BYOK rehearsal.

This change does not modify product or application runtime behavior. It keeps shared/root paths in scope and preserves fail-closed behavior when an active service baseline is missing or unresolvable.

Failed run: https://github.com/hushh-labs/hushh-research/actions/runs/30386795900
Prior BYOK pass: https://github.com/hushh-labs/hushh-research/actions/runs/30377147085

## Impact Map (Required)

- Routes touched:
  - [x] None
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None; release-planning logic only
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] Listed: `scripts/ci/resolve-uat-verification-plan.py` and its regression suite, attached to the existing UAT/CI verification-plan workflow
- Trust boundary touched:
  - [x] Deploy verification selection only; protected BYOK/PKM gates remain blocking for genuine active-service or shared-contract changes
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Missing/unresolvable active service SHAs still fail closed to both protected lanes; the failed release already proved Cloud Run rollback to the previous revisions
- UI browser or Playwright proof:
  - [x] Not applicable; no application or reviewer-browser behavior changed
- Verification commands executed:
  - [x] `py -3.13 scripts/ci/test_resolve_uat_verification_plan.py`
  - [x] `py -3.13 scripts/ci/test_change_aware_verification_wiring.py`
  - [x] exact failed-range replay using backend `c474117...`, frontend `e757471...`, target `ed760013...`
  - [x] `py -3.13 -m py_compile ...`
  - [x] `git diff --check`
  - [x] DCO signoff check
  - [ ] `./bin/hushh codex pre-pr` (local mirror passed the changed selector, wiring, secret, docs, data-model, licensing, and runtime-config checks, then stopped on three pre-existing governance-marker failures outside this PR; GitHub checks are authoritative)

## Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate another fix.
- [x] This PR changes the current UAT release-planning surface.
- [x] Reachable production attach point: `.github/workflows/deploy-uat.yml` calls this selector before building/promoting candidates.
- [x] New tests import and exercise production selector code.
- [x] New helpers are wired directly into `resolve_plan`.
- [x] Production surface proved by exact replay of the failed deployed-SHA inputs.
- [x] Required checks are current on this head and GitHub shows the branch is mergeable with `main`.
- [x] Maintainer edits are enabled by repository ownership.
- [x] Not a stacked PR.
- [x] Follow-up RCA fix for failed UAT run `30386795900`.

## Tri-Flow Architecture Check

- [x] Web: not applicable; deploy selector only
- [x] iOS: not applicable; deploy selector only
- [x] Android: not applicable; deploy selector only

## Testing

- [x] Service-skew regression excludes already-deployed opposite-service protected paths.
- [x] Owned backend/frontend PKM and BYOK paths remain protected.
- [x] Shared reviewer paths remain protected.
- [x] One missing service baseline in an all-service deploy fails closed.
- [x] Commit is signed off.
- [x] No generated files changed.

## Screenshots / Video

Not applicable; no UI-visible behavior changed.

## Privacy & Consent

- [x] Does not access or change user data.
- [x] Sensitive surface: deploy verification only.
- [x] Safe-failure behavior remains fail-closed; Cloud Run rollback evidence was inspected.

## Licensing

- [x] First-party changes remain Apache-2.0 compatible.
- [x] No dependency or third-party notice changes.

