### PR TITLE
feat(ci): one-click iOS → TestFlight pipeline (UAT-backed)

### DIFF
--- a/.claude/skills/ship-ios-testflight/SKILL.md
+++ b/.claude/skills/ship-ios-testflight/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: ship-ios-testflight
+description: Cut a Hushh One iOS build from the latest green main (what UAT runs) and ship it to TestFlight in one click for hushh-research. Use when the user says "ship ios", "ship the ios app", "ship to testflight", "cut an ios build", "push ios to testflight", or any request to release the current UAT iOS app to TestFlight. Builds the Capacitor iOS app against the UAT backend + UAT Firebase, signs with Apple-managed signing via an App Store Connect API key, and uploads to TestFlight — no App Store review, no manual compliance click. Orchestrates: preflight → pick green main SHA → (optional dry run) → dispatch the "Ship iOS to TestFlight" GitHub Actions workflow → watch to terminal → report the TestFlight build. Pauses for explicit user confirmation before the dispatch.
+argument-hint: "[sha: <green-main-sha>] [dry_run: true|false] [notes: <what-to-test>]"
+allowed-tools: Read Grep Glob Bash(gh *) Bash(git fetch*) Bash(git status*) Bash(git rev-parse*) Bash(git log*) Bash(git branch*)
+paths:
+  - .github/workflows/ship-ios-testflight.yml
+  - .github/workflows/deploy-uat.yml
+  - config/ci-governance.json
+  - scripts/ci/**
+  - hushh-webapp/ios/**
+  - docs/guides/mobile/ship-ios-testflight.md
+---
+
+# Ship iOS to TestFlight (ship ios)
+
+Orchestrates: **pick the latest green `main` SHA (what UAT runs) → build the Capacitor iOS app
+against UAT → sign (Apple-managed, ASC API key) → upload to TestFlight → report.**
+Trigger phrase: **`ship ios`** (also "ship to testflight", "cut an ios build", etc.).
+
+The build runs **inside a GitHub-hosted macOS runner** (`macos-15`); the local machine only
+*dispatches* via `gh` (needs the `workflow` token scope). Signing uses an **App Store Connect API
+key** stored as a GitHub secret + Apple cloud-managed certificates — no local `.p12`, no fastlane.
+
+Target: bundle `com.hushh.app`, TestFlight (internal testers, no Beta App Review), built against the
+**UAT** backend (`consent-protocol` Cloud Run) + **UAT** Firebase (`hushh-pda-uat`). This is the same
+source that `deploy .uat` ships to the web — it does **not** ship the `mobile`-branch redesign.
+
+## HARD RULES (never violate)
+
+1. **One confirmation gate.** STOP and get an explicit "yes" before dispatching the build. Show
+   exactly what will happen (workflow, `--ref main`, `sha` short, `dry_run`, target = TestFlight
+   / UAT backend). Never dispatch on assumption. This skill never merges anything to `main`.
+2. **Only ship a green `main` SHA.** The build is only allowed from a `main` SHA where the
+   **"Main Post-Merge Smoke Gate"** check-run = `success` (the workflow re-checks this via
+   `require-deploy-sha-on-main.sh` and will refuse otherwise). If it isn't green, stop and report.
+3. **This skill does not merge.** If the user's work isn't on `main` yet, tell them to run
+   `deploy .uat` (or merge) first, then ship. This skill ships what is already live on UAT.
+4. **TestFlight only — never App Store review.** The pipeline uploads to TestFlight and stops. It
+   does not submit for public App Store review, does not touch prod backend/Firebase, and does not
+   flip `aps-environment` to production. If the user wants a public App Store release, that is a
+   separate, larger effort (see `KT/hushh-one-publish-safety-audit.md`) — do not attempt it here.
+5. **Never touch secrets.** The ASC API key (`.p8`) and its Key/Issuer IDs live only in **GCP
+   Secret Manager** (`hushh-pda-uat`), added by the **user**. Never print, paste, `gcloud secrets
+   versions access` them, or ask the user to paste them into chat. If a required secret is missing,
+   point the user to the runbook — do not work around it.
+6. **Verify identity before acting.** Confirm the `gh` actor is in `config/ci-governance.json` →
+   `uat.manual_dispatch_users`. If not, stop — the dispatch will be rejected by
+   `assert-governed-actor.py` anyway. This operator (`ankitkumarsingh1702`) can dispatch UAT/iOS,
+   not production.
+7. **Report faithfully.** "Workflow green" ≠ "build in TestFlight". Confirm the new build number
+   actually appears in TestFlight (or the run summary reports the upload) before calling it done.
+
+## Phase 0 — Preflight (read-only)
+
+```bash
+gh api user --jq '.login'                               # must be in uat.manual_dispatch_users
+gh auth status                                          # confirm 'workflow' scope present
+git fetch --no-tags origin main
+git rev-parse origin/main                               # candidate SHA (latest main)
+```
+- Read `config/ci-governance.json`; confirm the actor ∈ `uat.manual_dispatch_users`. If not → STOP.
+- Signing + Firebase secrets live in **GCP Secret Manager** (`hushh-pda-uat`), not GitHub — the
+  workflow reads them via `GCP_SA_KEY_UAT` and **fails fast with a runbook pointer** if any of
+  `APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` / `_ISSUER_ID` or
+  `IOS_GOOGLESERVICE_INFO_PLIST_B64` is missing. You cannot list them with the `gh`-scoped tools
+  here, so don't try; if the user asks to pre-check, point them to
+  `docs/guides/mobile/ship-ios-testflight.md` (they can run `gcloud secrets describe <name>
+  --project hushh-pda-uat` — describe only, never `access`). A `dry_run: true` dispatch (Phase 2)
+  is the safe way to confirm the secrets resolve and signing works before a real upload.
+
+## Phase 1 — Choose the SHA (green `main`)
+
+1. SHA = the user-provided `sha`, else latest `origin/main`. It must be an ancestor of `origin/main`.
+2. Confirm the smoke gate is green on that exact SHA:
+   ```bash
+   gh api "repos/{owner}/{repo}/commits/$SHA/check-runs?per_page=100" \
+     --jq '.check_runs[] | select(.name=="Main Post-Merge Smoke Gate") | {conclusion,html_url}'
+   ```
+   If not `success` → STOP, report. (The workflow enforces this too, but fail fast here.)
+
+## Phase 2 — (Optional) dry run
+
+Recommend a `dry_run: true` dispatch the first time after any signing/secret change: it archives +
+signs on the runner **without uploading**, isolating ASC-key / managed-signing problems from a real
+upload. Same dispatch as Phase 3 with `-f dry_run=true`. If the user just wants to ship, skip this.
+
+## Phase 3 — Ship  ⛔ CONFIRMATION GATE
+
+1. **GATE — ask the user to confirm.** Show: workflow **"Ship iOS to TestFlight"**, `--ref main`,
+   `sha` (short), `dry_run` value, target = TestFlight / UAT backend / bundle `com.hushh.app`.
+   Wait for an explicit "yes".
+2. Dispatch:
+   ```bash
+   gh workflow run "Ship iOS to TestFlight" --ref main \
+     -f sha="$SHA" -f dry_run=false -f notes="<what-to-test, optional>"
+   ```
+3. Find and watch the run to terminal:
+   ```bash
+   sleep 4
+   gh run list --workflow "Ship iOS to TestFlight" --branch main --limit 1 --json databaseId,url,status
+   gh run watch <run-id> --exit-status
+   ```
+   Expect ~15–35 min on a cold SPM graph (firebase/grpc/facebook). `timeout-minutes: 40`.
+
+## Phase 4 — Verify (do not stop at "workflow green")
+
+- Read the run's job summary: it reports version (`1.3.5`), the resolved build number, and whether
+  the upload step ran (`dry_run` skips upload). Download the `.ipa`/dSYM/logs artifacts if debugging.
+- For a real (non-dry) run, confirm the build reaches TestFlight. It takes a few minutes for Apple
+  to finish processing; the build appears under **1.3.5 (build N)** for internal testers, already
+  compliant (no "Missing Compliance" click, thanks to `ITSAppUsesNonExemptEncryption=false`).
+- If the export/upload step failed, report the failing step and the ASC error verbatim. Common
+  causes: unaccepted Apple Program License Agreement, ASC key role too low (needs **App Manager**),
+  or a duplicate build number (the resolver should prevent the last one).
+
+## Phase 5 — Report
+
+Compact, honest summary:
+- SHA shipped (short) + that the smoke gate was green on it.
+- Run URL + final status; `dry_run` or real.
+- Version / build number (e.g. `1.3.5 (57)`).
+- TestFlight status: uploaded / processing / available to internal testers (or "dry run — not
+  uploaded").
+- On-device note: the build boots against **UAT** backend (asserted by
+  `verify-ios-bundled-backend.sh` during prep).
+
+## Failure handling
+- Actor not in `uat.manual_dispatch_users` → stop in Phase 0.
+- ASC secrets missing → stop in Phase 0; link the runbook. Never accept secret values in chat.
+- Smoke gate not green on the SHA → stop before the gate.
+- Build/archive fails → report the failing step; do not re-dispatch without the user's say-so.
+- Upload fails on Apple agreements/role → tell the user which manual Apple step to do (accept the
+  agreement in ASC, or raise the API key role) — these are the user's to perform, not yours.
+
+## Quick reference
+- Workflow: **"Ship iOS to TestFlight"** (`.github/workflows/ship-ios-testflight.yml`), inputs
+  `sha`, `dry_run`, `notes`.
+- Web sibling: **"Deploy to UAT"** (`deploy-uat` skill) — ship the same SHA to the UAT website.
+- Smoke gate (shared): **"Main Post-Merge Smoke Gate"**.
+- Governance source of truth: `config/ci-governance.json` (`uat.manual_dispatch_users`).
+- Build-number resolver: `scripts/ci/resolve-ios-build-number.py` (ASC history vs pbxproj, +1).
+- Secret setup + full flow: `docs/guides/mobile/ship-ios-testflight.md`.
+- Env/target: `hushh-pda-uat`, TestFlight, bundle `com.hushh.app`, version `1.3.5`.
+- This operator (`ankitkumarsingh1702`) can dispatch **UAT/iOS only** — **not** production.

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -160,7 +160,6 @@ jobs:
           BACKEND_URL="$(get BACKEND_URL)"
           require BACKEND_URL "$BACKEND_URL"
           APP_URL="$(get APP_FRONTEND_ORIGIN)"
-          [ -n "$APP_URL" ] || APP_URL="$(get FRONTEND_URL)"
           [ -n "$APP_URL" ] || APP_URL="https://uat.one.hushh.ai"
 
           FB_API_KEY="$(get NEXT_PUBLIC_FIREBASE_API_KEY)";           require NEXT_PUBLIC_FIREBASE_API_KEY "$FB_API_KEY"

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -1,0 +1,386 @@
+name: Ship iOS to TestFlight
+
+# One-click: cut a Hushh One iOS build from the latest green `main` (the SHA that
+# UAT runs), build the Capacitor app against the UAT backend + UAT Firebase, sign
+# it with Apple-managed signing via an App Store Connect API key, and upload to
+# TestFlight. TestFlight only -- no App Store review, no prod backend/Firebase.
+#
+# Web sibling: .github/workflows/deploy-uat.yml (same SHA -> UAT website).
+# Runbook + secret setup: docs/guides/mobile/ship-ios-testflight.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Exact green main SHA to ship (blank defaults to latest origin/main)"
+        required: false
+        type: string
+      dry_run:
+        description: "Archive + sign but do NOT upload to TestFlight (isolates signing)"
+        required: false
+        default: false
+        type: boolean
+      notes:
+        description: "Optional note for the run summary (what to test)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  checks: read
+
+env:
+  GCP_PROJECT_ID: hushh-pda-uat
+  GCP_REGION: us-central1
+  IOS_BUNDLE_ID: com.hushh.app
+  XCODE_PROJECT: hushh-webapp/ios/App/App.xcodeproj
+  XCODE_SCHEME: App
+  PBXPROJ: hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+  # cap:build (Next.js static export) is memory-heavy. The macos-15 standard
+  # runner is Apple silicon with limited RAM; if this OOM-kills the build, bump
+  # `runs-on` below to `macos-15-xlarge` (14 GB) and this to 12288.
+  NODE_OPTIONS: --max-old-space-size=8192
+
+concurrency:
+  # Serialize dispatches so two runs can't race the same TestFlight build number.
+  group: ship-ios-testflight
+  cancel-in-progress: false
+
+jobs:
+  ship:
+    name: Build & upload iOS (UAT) to TestFlight
+    runs-on: macos-15
+    environment: uat
+    timeout-minutes: 40
+
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing iOS ship from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Authorize dispatching actor (uat surface)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/assert-governed-actor.py --surface uat --actor "${GITHUB_ACTOR}"
+
+      - name: Resolve release SHA
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          REQUESTED="${{ github.event.inputs.sha }}"
+          git fetch --no-tags origin main
+          if [ -z "${REQUESTED}" ]; then
+            SHA="$(git rev-parse origin/main)"
+          else
+            SHA="${REQUESTED}"
+          fi
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Resolved release SHA: ${SHA}"
+
+      - name: Require SHA is on main and passed the smoke gate
+        shell: bash
+        env:
+          REQUIRED_BRANCH: main
+          REQUIRE_CI_SUCCESS: "1"
+          REQUIRED_CHECK_NAME: "Main Post-Merge Smoke Gate"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          bash scripts/ci/require-deploy-sha-on-main.sh "${{ steps.resolve.outputs.sha }}"
+
+      - name: Check out the exact release SHA (detached)
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout --detach "${{ steps.resolve.outputs.sha }}"
+          git --no-pager log -1 --oneline
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.2"
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: hushh-webapp/package-lock.json
+
+      - name: Install web dependencies (must precede SPM resolve)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # CapApp-SPM/Package.swift references ../../../node_modules, so the JS
+          # deps must exist before any Swift Package Manager resolution.
+          npm ci --prefix hushh-webapp
+
+      - name: Authenticate to Google Cloud (UAT)
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_UAT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Materialize UAT frontend contract + native Firebase config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Each NEXT_PUBLIC_* value is an individual GCP Secret Manager secret in
+          # hushh-pda-uat (same source of truth deploy-uat.yml / bootstrap_profiles.sh
+          # use). prepare-ios-uat-archive.mjs lets process env override for
+          # APP_RUNTIME_PROFILE and NEXT_PUBLIC_* keys, so we export them here.
+          get() {
+            gcloud secrets versions access latest --secret="$1" --project="${GCP_PROJECT_ID}" 2>/dev/null || true
+          }
+          require() {
+            local name="$1" val="$2"
+            if [ -z "$val" ]; then
+              echo "Missing required GCP secret: $name (project ${GCP_PROJECT_ID})" >&2
+              exit 1
+            fi
+          }
+          put() { printf '%s=%s\n' "$1" "$2" >> "$GITHUB_ENV"; }
+
+          BACKEND_URL="$(get BACKEND_URL)"
+          require BACKEND_URL "$BACKEND_URL"
+          APP_URL="$(get APP_FRONTEND_ORIGIN)"
+          [ -n "$APP_URL" ] || APP_URL="$(get FRONTEND_URL)"
+          [ -n "$APP_URL" ] || APP_URL="https://uat.one.hushh.ai"
+
+          FB_API_KEY="$(get NEXT_PUBLIC_FIREBASE_API_KEY)";           require NEXT_PUBLIC_FIREBASE_API_KEY "$FB_API_KEY"
+          FB_AUTH_DOMAIN="$(get NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN)";    require NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN "$FB_AUTH_DOMAIN"
+          FB_PROJECT_ID="$(get NEXT_PUBLIC_FIREBASE_PROJECT_ID)";      require NEXT_PUBLIC_FIREBASE_PROJECT_ID "$FB_PROJECT_ID"
+          FB_STORAGE="$(get NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET)";     require NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET "$FB_STORAGE"
+          FB_SENDER="$(get NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID)"; require NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID "$FB_SENDER"
+          FB_APP_ID="$(get NEXT_PUBLIC_FIREBASE_APP_ID)";              require NEXT_PUBLIC_FIREBASE_APP_ID "$FB_APP_ID"
+          FB_VAPID="$(get NEXT_PUBLIC_FIREBASE_VAPID_KEY)";            require NEXT_PUBLIC_FIREBASE_VAPID_KEY "$FB_VAPID"
+
+          # Optional analytics id (unsuffixed, then legacy suffixes).
+          FB_MEASUREMENT="$(get NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID)"
+          [ -n "$FB_MEASUREMENT" ] || FB_MEASUREMENT="$(get NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID_UAT)"
+          [ -n "$FB_MEASUREMENT" ] || FB_MEASUREMENT="$(get NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID_STAGING)"
+
+          # NEXT_PUBLIC_* are public build values (baked into the client bundle),
+          # but keep the API/VAPID keys out of the log for hygiene.
+          echo "::add-mask::$FB_API_KEY"
+          echo "::add-mask::$FB_VAPID"
+
+          put APP_RUNTIME_PROFILE "uat"
+          put NEXT_PUBLIC_APP_ENV "uat"
+          put NEXT_PUBLIC_BACKEND_URL "$BACKEND_URL"
+          put NEXT_PUBLIC_APP_URL "$APP_URL"
+          put NEXT_PUBLIC_PASSKEY_RP_ID "one.hushh.ai"
+          put NEXT_PUBLIC_FIREBASE_API_KEY "$FB_API_KEY"
+          put NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN "$FB_AUTH_DOMAIN"
+          put NEXT_PUBLIC_FIREBASE_PROJECT_ID "$FB_PROJECT_ID"
+          put NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET "$FB_STORAGE"
+          put NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID "$FB_SENDER"
+          put NEXT_PUBLIC_FIREBASE_APP_ID "$FB_APP_ID"
+          put NEXT_PUBLIC_FIREBASE_VAPID_KEY "$FB_VAPID"
+          [ -n "$FB_MEASUREMENT" ] && put NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID "$FB_MEASUREMENT"
+          put NEXT_PUBLIC_OBSERVABILITY_ENABLED "true"
+          put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
+          put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"
+
+          # Native GoogleService-Info.plist for the iOS target. This is NOT part of
+          # ios:prepare:uat, and sync:native-firebase-configs requires an Android
+          # config we don't have here, so decode the GCP secret straight into place.
+          PLIST_DEST="hushh-webapp/ios/App/App/GoogleService-Info.plist"
+          if ! gcloud secrets describe IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+            echo "Missing GCP secret IOS_GOOGLESERVICE_INFO_PLIST_B64 in ${GCP_PROJECT_ID}." >&2
+            echo "Create it from the iOS GoogleService-Info.plist:" >&2
+            echo "  base64 -i GoogleService-Info.plist | gcloud secrets create IOS_GOOGLESERVICE_INFO_PLIST_B64 --data-file=- --project=${GCP_PROJECT_ID}" >&2
+            echo "See docs/guides/mobile/ship-ios-testflight.md." >&2
+            exit 1
+          fi
+          gcloud secrets versions access latest --secret=IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" \
+            | openssl base64 -d -A > "$PLIST_DEST"
+          if ! plutil -lint "$PLIST_DEST" >/dev/null 2>&1; then
+            echo "Decoded GoogleService-Info.plist failed plist validation." >&2
+            exit 1
+          fi
+          echo "Native GoogleService-Info.plist materialized (bundle ${IOS_BUNDLE_ID})."
+
+      - name: Decode App Store Connect API key
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The ASC signing key lives in GCP Secret Manager (hushh-pda-uat), the
+          # same store deploy/README.md designates for native signing assets:
+          #   APPSTORE_CONNECT_API_KEY_P8_B64 / _KEY_ID / _ISSUER_ID.
+          # Nothing App Store-related is stored as a GitHub secret.
+          get() {
+            gcloud secrets versions access latest --secret="$1" --project="${GCP_PROJECT_ID}" 2>/dev/null || true
+          }
+          for name in APPSTORE_CONNECT_API_KEY_P8_B64 APPSTORE_CONNECT_KEY_ID APPSTORE_CONNECT_ISSUER_ID; do
+            if ! gcloud secrets describe "$name" --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+              echo "Missing GCP secret $name in ${GCP_PROJECT_ID}." >&2
+              echo "See docs/guides/mobile/ship-ios-testflight.md for setup." >&2
+              exit 1
+            fi
+          done
+          ASC_KEY_ID="$(get APPSTORE_CONNECT_KEY_ID)"
+          ASC_ISSUER_ID="$(get APPSTORE_CONNECT_ISSUER_ID)"
+          echo "::add-mask::${ASC_KEY_ID}"
+          echo "::add-mask::${ASC_ISSUER_ID}"
+          umask 077
+          get APPSTORE_CONNECT_API_KEY_P8_B64 | openssl base64 -d -A > "${RUNNER_TEMP}/asc.p8"
+          chmod 600 "${RUNNER_TEMP}/asc.p8"
+          if ! grep -q "BEGIN PRIVATE KEY" "${RUNNER_TEMP}/asc.p8"; then
+            echo "Decoded ASC key is not a valid PEM .p8 (check APPSTORE_CONNECT_API_KEY_P8_B64)." >&2
+            exit 1
+          fi
+          # Key id + issuer id are needed by later xcodebuild/resolver steps; they
+          # are masked in logs above.
+          echo "ASC_KEY_ID=${ASC_KEY_ID}" >> "$GITHUB_ENV"
+          echo "ASC_ISSUER_ID=${ASC_ISSUER_ID}" >> "$GITHUB_ENV"
+
+      - name: Create signing keychain
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEYCHAIN="${RUNNER_TEMP}/app-signing.keychain-db"
+          KC_PW="$(openssl rand -base64 24)"
+          security create-keychain -p "$KC_PW" "$KEYCHAIN"
+          security set-keychain-settings -lt 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KC_PW" "$KEYCHAIN"
+          # Add to the search list and make default so Apple-managed signing can
+          # store the fetched distribution cert + key.
+          security list-keychains -d user -s "$KEYCHAIN" "login.keychain-db"
+          security default-keychain -s "$KEYCHAIN"
+
+      - name: Prepare iOS project (web build + cap sync, UAT backend)
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run --prefix hushh-webapp ios:prepare:uat
+
+      - name: Resolve next TestFlight build number
+        id: build_number
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv "${RUNNER_TEMP}/asc-venv"
+          "${RUNNER_TEMP}/asc-venv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          NEXT_BUILD="$("${RUNNER_TEMP}/asc-venv/bin/python" scripts/ci/resolve-ios-build-number.py \
+            --p8-path "${RUNNER_TEMP}/asc.p8" \
+            --key-id "${ASC_KEY_ID}" \
+            --issuer-id "${ASC_ISSUER_ID}" \
+            --bundle-id "${IOS_BUNDLE_ID}" \
+            --pbxproj "${PBXPROJ}")"
+          echo "next_build=${NEXT_BUILD}" >> "$GITHUB_OUTPUT"
+          echo "Next build number: ${NEXT_BUILD}"
+
+      - name: Cache Swift packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}/spm
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-${{ hashFiles('hushh-webapp/ios/App/CapApp-SPM/Package.swift', 'hushh-webapp/ios/**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Resolve Swift package dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies \
+            -project "${XCODE_PROJECT}" \
+            -scheme "${XCODE_SCHEME}" \
+            -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm"
+
+      - name: Archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          xcodebuild \
+            -project "${XCODE_PROJECT}" \
+            -scheme "${XCODE_SCHEME}" \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "${RUNNER_TEMP}/App.xcarchive" \
+            -clonedSourcePackagesDirPath "${RUNNER_TEMP}/spm" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "${RUNNER_TEMP}/asc.p8" \
+            -authenticationKeyID "${ASC_KEY_ID}" \
+            -authenticationKeyIssuerID "${ASC_ISSUER_ID}" \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            CURRENT_PROJECT_VERSION="${{ steps.build_number.outputs.next_build }}" \
+            archive 2>&1 | tee "${RUNNER_TEMP}/xcodebuild-archive.log"
+
+      - name: Export & upload to TestFlight
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          EXPORT_PLIST="hushh-webapp/ios/ExportOptions/AppStoreConnect.plist"
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            # Dry run: archive + sign + export the .ipa locally, but do NOT upload.
+            EXPORT_PLIST="${RUNNER_TEMP}/ExportOptions.dryrun.plist"
+            cp "hushh-webapp/ios/ExportOptions/AppStoreConnect.plist" "$EXPORT_PLIST"
+            /usr/libexec/PlistBuddy -c "Set :destination export" "$EXPORT_PLIST"
+            echo "DRY RUN: exporting signed .ipa without uploading to TestFlight."
+          fi
+          xcodebuild -exportArchive \
+            -archivePath "${RUNNER_TEMP}/App.xcarchive" \
+            -exportOptionsPlist "$EXPORT_PLIST" \
+            -exportPath "${RUNNER_TEMP}/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "${RUNNER_TEMP}/asc.p8" \
+            -authenticationKeyID "${ASC_KEY_ID}" \
+            -authenticationKeyIssuerID "${ASC_ISSUER_ID}" \
+            2>&1 | tee "${RUNNER_TEMP}/xcodebuild-export.log"
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-testflight-${{ steps.build_number.outputs.next_build }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}/export/**
+            ${{ runner.temp }}/xcodebuild-archive.log
+            ${{ runner.temp }}/xcodebuild-export.log
+            ${{ runner.temp }}/App.xcarchive/dSYMs/**
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          MARKETING="$(grep -m1 -E 'MARKETING_VERSION[[:space:]]*=' "${PBXPROJ}" | sed -E 's/.*= *([^;]+);.*/\1/' | tr -d ' ')"
+          {
+            echo "## Ship iOS to TestFlight"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| SHA | \`${{ steps.resolve.outputs.sha }}\` |"
+            echo "| Version | ${MARKETING:-unknown} |"
+            echo "| Build | ${{ steps.build_number.outputs.next_build }} |"
+            echo "| Bundle | ${IOS_BUNDLE_ID} |"
+            echo "| Backend | UAT (hushh-pda-uat) |"
+            echo "| Mode | ${{ github.event.inputs.dry_run == 'true' && 'dry run (no upload)' || 'upload to TestFlight' }} |"
+            if [ -n "${{ github.event.inputs.notes }}" ]; then
+              echo "| Notes | ${{ github.event.inputs.notes }} |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -387,6 +387,12 @@ See [docs/reference/operations/env-and-secrets.md](../docs/reference/operations/
 
 ### Mobile Firebase Artifacts (Regulated)
 
+> **In use by the one-click iOS pipeline.** The `.github/workflows/ship-ios-testflight.yml`
+> workflow reads `IOS_GOOGLESERVICE_INFO_PLIST_B64`, `APPSTORE_CONNECT_API_KEY_P8_B64`,
+> `APPSTORE_CONNECT_KEY_ID`, and `APPSTORE_CONNECT_ISSUER_ID` from Secret Manager
+> (`hushh-pda-uat`) via `GCP_SA_KEY_UAT` to build + sign + upload the UAT iOS build to TestFlight.
+> Setup + flow: [docs/guides/mobile/ship-ios-testflight.md](../docs/guides/mobile/ship-ios-testflight.md).
+
 - Do not commit production `GoogleService-Info.plist` or `google-services.json`.
 - Store production mobile Firebase artifacts in Secret Manager:
   - `IOS_GOOGLESERVICE_INFO_PLIST_B64`

--- a/deploy/app_store_deployment.md
+++ b/deploy/app_store_deployment.md
@@ -1,10 +1,17 @@
 # App Store & Play Store Deployment Guide for Hushh
 
-**Status**: ✅ App configured and ready for store submission  
-**App Name**: Kai
+> **For TestFlight, use the one-click pipeline instead of this manual guide.**
+> `.github/workflows/ship-ios-testflight.yml` (say `ship ios`) cuts the current UAT build and
+> uploads it to TestFlight automatically — runbook:
+> [docs/guides/mobile/ship-ios-testflight.md](../docs/guides/mobile/ship-ios-testflight.md).
+> The steps below remain the reference for a **public App Store / Play Store submission**, which
+> is a separate milestone (see `KT/hushh-one-publish-safety-audit.md`).
+
+**Status**: Reference for public store submission (TestFlight is automated — see banner above)  
+**App Name**: Hussh One (display name; historically "Kai")  
 **Bundle ID**: com.hushh.app  
-**Version**: 1.0.0  
-**Build**: 1  
+**Current version**: 1.3.5 (marketing) — see `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj`  
+**Build**: auto-incremented by `scripts/ci/resolve-ios-build-number.py`  
 
 ---
 

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -6,7 +6,7 @@ Canonical visual owner: [Mobile Guide](../mobile.md).
 
 ## What this is
 
-One click cuts a Hushh One iOS build from **whatever is live on UAT** (the latest green `main`
+One click cuts a Hussh One iOS build from **whatever is live on UAT** (the latest green `main`
 SHA — the same source `deploy .uat` ships to the website), builds the Capacitor app against the
 **UAT backend + UAT Firebase**, signs it with **Apple-managed signing via an App Store Connect
 API key**, and **uploads it to TestFlight**. No manual "Missing Compliance" click, no public App

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -1,0 +1,139 @@
+# Ship iOS to TestFlight (one click)
+
+## Visual Context
+
+Canonical visual owner: [Mobile Guide](../mobile.md).
+
+## What this is
+
+One click cuts a Hushh One iOS build from **whatever is live on UAT** (the latest green `main`
+SHA — the same source `deploy .uat` ships to the website), builds the Capacitor app against the
+**UAT backend + UAT Firebase**, signs it with **Apple-managed signing via an App Store Connect
+API key**, and **uploads it to TestFlight**. No manual "Missing Compliance" click, no public App
+Store submission.
+
+- **Workflow:** `.github/workflows/ship-ios-testflight.yml` (`workflow_dispatch`).
+- **Skill:** say `ship ios` (see `.claude/skills/ship-ios-testflight/SKILL.md`).
+- **Runner:** GitHub-hosted `macos-15` (GCP has no macOS instances; only the *dispatch* is local).
+- **Target:** bundle `com.hushh.app`, version `1.3.5`, TestFlight internal testers (no Beta App
+  Review), UAT backend + Firebase `hushh-pda-uat`.
+
+This does **not** ship the `mobile`-branch iOS redesign (that never merges to `main`), does not
+touch prod backend/Firebase, and does not submit for App Store review.
+
+## How it works (what the workflow runs)
+
+```
+npm ci --prefix hushh-webapp                    # MUST precede SPM (Package.swift → ../../node_modules)
+# materialize UAT NEXT_PUBLIC_* contract + native GoogleService-Info.plist from GCP Secret Manager
+NODE_OPTIONS=--max-old-space-size=8192 npm run ios:prepare:uat   # cap:build + cap:sync:ios + verify backend
+NEXT_BUILD = max(asc_latest_build(1.3.5), pbxproj CURRENT_PROJECT_VERSION) + 1
+
+xcodebuild -resolvePackageDependencies -project ios/App/App.xcodeproj -scheme App -clonedSourcePackagesDirPath …
+xcodebuild archive        -allowProvisioningUpdates -authenticationKey{Path,ID,IssuerID} CURRENT_PROJECT_VERSION=$NEXT_BUILD
+xcodebuild -exportArchive -exportOptionsPlist ios/ExportOptions/AppStoreConnect.plist  # destination=upload → TestFlight
+```
+
+Signing needs no build-setting overrides — `CODE_SIGN_STYLE=Automatic`,
+`DEVELOPMENT_TEAM=WVDK9JW99C`, empty `PROVISIONING_PROFILE_SPECIFIER` are already in
+`project.pbxproj`. `CURRENT_PROJECT_VERSION` is the only override; `Info.plist` maps
+`CFBundleVersion=$(CURRENT_PROJECT_VERSION)`, so the resolved build number bakes in with no
+`agvtool`/pbxproj edit. `ITSAppUsesNonExemptEncryption=false` in `Info.plist` is what keeps the
+upload out of "Missing Compliance".
+
+## One-time setup (secret-touching — the operator does this)
+
+All signing + Firebase material lives in **GCP Secret Manager**, project **`hushh-pda-uat`** (the
+store `deploy/README.md` already designates for native signing assets). Nothing App Store-related
+is a GitHub secret. The workflow reads these with the existing `GCP_SA_KEY_UAT` service account.
+
+### 1. App Store Connect API key
+
+App Store Connect → **Users and Access** → **Integrations** → **App Store Connect API** →
+generate a **Team key** with role **App Manager** (needed: archive creates a dev asset, export a
+distribution asset, both via `-allowProvisioningUpdates`). Download the `.p8` **once**; note the
+**Key ID** and **Issuer ID**. Then store all three in Secret Manager:
+
+```bash
+# .p8 (base64, single line)
+base64 -i AuthKey_XXXXXXXXXX.p8 \
+  | gcloud secrets create APPSTORE_CONNECT_API_KEY_P8_B64 --data-file=- --project=hushh-pda-uat
+printf '%s' 'XXXXXXXXXX' \
+  | gcloud secrets create APPSTORE_CONNECT_KEY_ID --data-file=- --project=hushh-pda-uat
+printf '%s' '00000000-0000-0000-0000-000000000000' \
+  | gcloud secrets create APPSTORE_CONNECT_ISSUER_ID --data-file=- --project=hushh-pda-uat
+```
+
+(Use `gcloud secrets versions add <name> --data-file=-` instead of `create` if the reserved
+secret already exists.)
+
+### 2. Native iOS Firebase config
+
+The workflow decodes `IOS_GOOGLESERVICE_INFO_PLIST_B64` into `ios/App/App/GoogleService-Info.plist`
+(it does **not** run `sync:native-firebase-configs`, which hard-requires the Android
+`google-services.json`). If not already present:
+
+```bash
+base64 -i GoogleService-Info.plist \
+  | gcloud secrets create IOS_GOOGLESERVICE_INFO_PLIST_B64 --data-file=- --project=hushh-pda-uat
+```
+
+### 3. IAM
+
+Ensure the `GCP_SA_KEY_UAT` service account has `roles/secretmanager.secretAccessor` on the
+secrets above **and** on the UAT frontend contract (`BACKEND_URL`, `APP_FRONTEND_ORIGIN`, the
+`NEXT_PUBLIC_FIREBASE_*` set). No new GitHub secret is required for any of this.
+
+### 4. Apple agreements
+
+Accept any pending Apple **Program License Agreement** in App Store Connect. An unsigned/expired
+agreement silently blocks uploads and processing — this is an operator action, not a CI step.
+
+## How to run
+
+### GitHub UI
+
+Actions → **Ship iOS to TestFlight** → **Run workflow** (from `main`). Inputs:
+
+| Input | Meaning |
+| --- | --- |
+| `sha` | Exact green `main` SHA to ship. Blank → latest `origin/main`. |
+| `dry_run` | `true` = archive + sign but **do not** upload (isolates signing). |
+| `notes` | Free text shown in the run summary. |
+
+### Skill
+
+Say **`ship ios`** (or "ship to testflight", "cut an ios build"). The skill runs preflight, picks
+the green `main` SHA, **pauses for one explicit confirmation**, then dispatches and watches the run.
+
+Only operators in `config/ci-governance.json` → `uat.manual_dispatch_users` can dispatch;
+`assert-governed-actor.py --surface uat` enforces it. This operator (`ankitkumarsingh1702`) can
+dispatch UAT/iOS, **not** production.
+
+## Verify (don't stop at "workflow green")
+
+1. Read the run's job summary: SHA, version `1.3.5`, resolved build number, upload vs dry run.
+2. For a real run, confirm the build appears in **TestFlight → 1.3.5 (build N)** for internal
+   testers after Apple finishes processing (a few minutes), already compliant.
+3. On device: the TestFlight build boots against **UAT** backend — asserted by
+   `verify-ios-bundled-backend.sh` during prep.
+
+Recommended the first time after any signing/secret change: dispatch with `dry_run: true` to prove
+the web build, cap sync, SPM resolve, archive, and **signing** all succeed before a real upload.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `Missing GCP secret APPSTORE_CONNECT_*` / `IOS_GOOGLESERVICE_INFO_PLIST_B64` | Secret not created or SA lacks `secretAccessor`. See setup above. |
+| Export/upload fails with an agreement error | Accept the Apple Program License Agreement in ASC. |
+| `... requires App Manager` / authz error | API key role too low — regenerate as **App Manager**. |
+| Duplicate build number rejected | `resolve-ios-build-number.py` should prevent it; check its stderr in the archive log artifact. |
+| `cap:build` OOM-killed | Bump `runs-on` to `macos-15-xlarge` and `NODE_OPTIONS` to `--max-old-space-size=12288`. |
+| Cold SPM graph slow (firebase/grpc/facebook) | Expected ~15–35 min; `timeout-minutes: 40`. The SPM cache warms subsequent runs. |
+
+## Scope / deferred
+
+Public App Store submission is a separate, larger milestone (privacy manifest, `aps-environment`
+production, prod GA4, store metadata/screenshots) — see `KT/hushh-one-publish-safety-audit.md`.
+None of those block a TestFlight upload.

--- a/hushh-webapp/ios/App/App/Info.plist
+++ b/hushh-webapp/ios/App/App/Info.plist
@@ -41,6 +41,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>GIDClientID</key>
 	<string>1006304528804-5f4ni5h8nschgv9gcoa9i07bhqtjeb91.apps.googleusercontent.com</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>HusshIMessageKeychainAccessGroup</key>
 	<string>WVDK9JW99C.com.hushh.app.imessage</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/hushh-webapp/ios/ExportOptions/AppStoreConnect.plist
+++ b/hushh-webapp/ios/ExportOptions/AppStoreConnect.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Export options for `xcodebuild -exportArchive` in the one-click TestFlight
+  pipeline (.github/workflows/ship-ios-testflight.yml).
+
+  Keys mirror the proven, gitignored build/TestFlight/ExportOptions-AppStoreConnect-40.plist
+  that shipped builds 37-40, with two deliberate choices for CI:
+    * destination = upload  -> the export step uploads to TestFlight in-place
+      (no altool/pilot follow-up). The dry_run job path rewrites this to
+      "export" via PlistBuddy so it archives + signs without uploading.
+    * manageAppVersionAndBuildNumber = false -> keep the build number that the
+      workflow computes (scripts/ci/resolve-ios-build-number.py, injected as
+      CURRENT_PROJECT_VERSION) authoritative; do not let Xcode auto-bump it.
+
+  Signing is Apple-managed via the App Store Connect API key passed to
+  xcodebuild (-allowProvisioningUpdates); signingStyle stays automatic and
+  teamID matches DEVELOPMENT_TEAM in App.xcodeproj/project.pbxproj.
+-->
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>destination</key>
+	<string>upload</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>teamID</key>
+	<string>WVDK9JW99C</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+</dict>
+</plist>

--- a/scripts/ci/resolve-ios-build-number.py
+++ b/scripts/ci/resolve-ios-build-number.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Resolve the next iOS TestFlight build number (CFBundleVersion).
+
+The one-click TestFlight pipeline needs a build number that is strictly greater
+than both:
+
+  * the highest build already known to App Store Connect for this marketing
+    version train (so TestFlight accepts the upload -- it rejects duplicate or
+    lower CFBundleVersion values within a CFBundleShortVersionString), and
+  * the ``CURRENT_PROJECT_VERSION`` committed in ``project.pbxproj`` (which is
+    frequently stale relative to what has actually shipped to TestFlight).
+
+It authenticates to the App Store Connect API with an ES256 JWT minted from a
+downloaded ``.p8`` key (App Manager role), reads the builds for the app, and
+prints ``max(asc_latest, pbxproj_current) + 1`` to stdout. All diagnostics go to
+stderr so the caller can capture the number cleanly:
+
+    NEXT_BUILD="$(python3 scripts/ci/resolve-ios-build-number.py \
+        --p8-path "$RUNNER_TEMP/asc.p8" \
+        --key-id "$ASC_KEY_ID" --issuer-id "$ASC_ISSUER_ID")"
+
+Only PyJWT + cryptography are required beyond the standard library; both are
+pip-installed in the workflow job.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ASC_API_ROOT = "https://api.appstoreconnect.apple.com"
+ASC_AUDIENCE = "appstoreconnect-v1"
+DEFAULT_BUNDLE_ID = "com.hushh.app"
+DEFAULT_PBXPROJ = os.path.join(
+    "hushh-webapp", "ios", "App", "App.xcodeproj", "project.pbxproj"
+)
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def die(message: str) -> "NoReturn":  # type: ignore[name-defined]
+    log(f"resolve-ios-build-number: {message}")
+    raise SystemExit(1)
+
+
+def read_pbxproj_values(pbxproj_path: str) -> tuple[int, str | None]:
+    """Return (max CURRENT_PROJECT_VERSION, first MARKETING_VERSION) from pbxproj."""
+    try:
+        with open(pbxproj_path, "r", encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        die(f"cannot read {pbxproj_path}: {exc}")
+
+    current_versions = [
+        int(match)
+        for match in re.findall(r"CURRENT_PROJECT_VERSION\s*=\s*([0-9]+)\s*;", text)
+    ]
+    pbx_current = max(current_versions) if current_versions else 0
+
+    marketing_match = re.search(
+        r"MARKETING_VERSION\s*=\s*([0-9][0-9A-Za-z.\-]*)\s*;", text
+    )
+    marketing = marketing_match.group(1) if marketing_match else None
+    return pbx_current, marketing
+
+
+def mint_jwt(p8_path: str, key_id: str, issuer_id: str) -> str:
+    try:
+        import jwt  # PyJWT
+    except ImportError:
+        die("PyJWT is required (pip install pyjwt cryptography)")
+
+    try:
+        with open(p8_path, "r", encoding="utf-8") as handle:
+            private_key = handle.read()
+    except OSError as exc:
+        die(f"cannot read App Store Connect key at {p8_path}: {exc}")
+
+    now = int(time.time())
+    payload = {
+        "iss": issuer_id,
+        "iat": now,
+        # ASC rejects tokens with a lifetime > 20 minutes.
+        "exp": now + 19 * 60,
+        "aud": ASC_AUDIENCE,
+    }
+    try:
+        token = jwt.encode(
+            payload,
+            private_key,
+            algorithm="ES256",
+            headers={"kid": key_id, "typ": "JWT"},
+        )
+    except Exception as exc:  # cryptography / key parsing errors
+        die(f"failed to sign App Store Connect JWT: {exc}")
+    # PyJWT>=2 returns str already; be defensive for older versions.
+    return token if isinstance(token, str) else token.decode("utf-8")
+
+
+def asc_get(url: str, token: str) -> dict:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        die(f"App Store Connect API {exc.code} for {url}: {body}")
+    except urllib.error.URLError as exc:
+        die(f"App Store Connect API request failed for {url}: {exc}")
+
+
+def resolve_app_id(token: str, bundle_id: str) -> str:
+    query = urllib.parse.urlencode(
+        {"filter[bundleId]": bundle_id, "limit": "1"}
+    )
+    payload = asc_get(f"{ASC_API_ROOT}/v1/apps?{query}", token)
+    data = payload.get("data") or []
+    if not data:
+        die(f"no App Store Connect app found for bundle id {bundle_id}")
+    return data[0]["id"]
+
+
+def latest_build_number(token: str, app_id: str, marketing_version: str) -> int:
+    """Highest CFBundleVersion known to ASC for this marketing version train."""
+    query = urllib.parse.urlencode(
+        {
+            "filter[app]": app_id,
+            "filter[preReleaseVersion.version]": marketing_version,
+            "limit": "200",
+            "sort": "-version",
+        }
+    )
+    url = f"{ASC_API_ROOT}/v1/builds?{query}"
+    highest = 0
+    seen = 0
+    while url:
+        payload = asc_get(url, token)
+        for build in payload.get("data", []):
+            seen += 1
+            raw = (build.get("attributes") or {}).get("version")
+            try:
+                highest = max(highest, int(str(raw).strip()))
+            except (TypeError, ValueError):
+                # Non-numeric build strings are not valid CFBundleVersion values
+                # for uploads; ignore rather than crash.
+                continue
+        url = (payload.get("links") or {}).get("next")
+    log(
+        f"App Store Connect: {seen} build(s) for {marketing_version}; "
+        f"highest = {highest}"
+    )
+    return highest
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--p8-path",
+        default=os.environ.get("APPSTORE_CONNECT_API_KEY_PATH"),
+        help="Path to the App Store Connect .p8 private key.",
+    )
+    parser.add_argument(
+        "--key-id",
+        default=os.environ.get("APPSTORE_CONNECT_KEY_ID")
+        or os.environ.get("ASC_KEY_ID"),
+        help="App Store Connect API Key ID.",
+    )
+    parser.add_argument(
+        "--issuer-id",
+        default=os.environ.get("APPSTORE_CONNECT_ISSUER_ID")
+        or os.environ.get("ASC_ISSUER_ID"),
+        help="App Store Connect API Issuer ID.",
+    )
+    parser.add_argument(
+        "--bundle-id",
+        default=os.environ.get("IOS_BUNDLE_ID", DEFAULT_BUNDLE_ID),
+        help=f"App bundle identifier (default: {DEFAULT_BUNDLE_ID}).",
+    )
+    parser.add_argument(
+        "--pbxproj",
+        default=os.environ.get("IOS_PBXPROJ_PATH", DEFAULT_PBXPROJ),
+        help="Path to project.pbxproj (for the fallback/floor version).",
+    )
+    parser.add_argument(
+        "--marketing-version",
+        default=os.environ.get("IOS_MARKETING_VERSION"),
+        help="Marketing version train to query (default: read from pbxproj).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    missing = [
+        name
+        for name, value in (
+            ("--p8-path", args.p8_path),
+            ("--key-id", args.key_id),
+            ("--issuer-id", args.issuer_id),
+        )
+        if not value
+    ]
+    if missing:
+        die(f"missing required argument(s): {', '.join(missing)}")
+
+    pbx_current, pbx_marketing = read_pbxproj_values(args.pbxproj)
+    marketing_version = args.marketing_version or pbx_marketing
+    if not marketing_version:
+        die("could not determine marketing version (pass --marketing-version)")
+
+    token = mint_jwt(args.p8_path, args.key_id, args.issuer_id)
+    app_id = resolve_app_id(token, args.bundle_id)
+    asc_latest = latest_build_number(token, app_id, marketing_version)
+
+    floor = max(asc_latest, pbx_current)
+    next_build = floor + 1
+    log(
+        f"pbxproj CURRENT_PROJECT_VERSION = {pbx_current}; "
+        f"ASC latest = {asc_latest}; next build = {next_build}"
+    )
+    print(next_build)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

One-click **iOS → TestFlight** pipeline for Hushh One, mirroring the governed web `deploy-uat` flow. A `workflow_dispatch` button (and a matching `ship ios` skill) cuts a build from **whatever is live on UAT** (the latest green `main` SHA — same source `deploy .uat` ships), builds the Capacitor app against the **UAT backend + UAT Firebase (`hushh-pda-uat`)**, signs it with **Apple-managed signing via an App Store Connect API key**, and **uploads to TestFlight**.

No manual "Missing Compliance" click, no App Store review, no prod backend/Firebase, and it does **not** ship the `mobile`-branch redesign (ships `main`/UAT).

## Files

**New**
- `.github/workflows/ship-ios-testflight.yml` — the workflow (`macos-15`, `environment: uat`), reusing the `deploy-uat` governance gates: `assert-governed-actor.py --surface uat` + `require-deploy-sha-on-main.sh` (gated on "Main Post-Merge Smoke Gate"). Reads the ASC key, the iOS Firebase plist, and the UAT `NEXT_PUBLIC_*` contract from **GCP Secret Manager** via `GCP_SA_KEY_UAT`. `dry_run` archives + signs without uploading.
- `scripts/ci/resolve-ios-build-number.py` — monotonic build number = `max(App Store Connect history for 1.3.5, pbxproj CURRENT_PROJECT_VERSION) + 1`.
- `hushh-webapp/ios/ExportOptions/AppStoreConnect.plist` — committed export options (`destination=upload`, Apple-managed automatic signing).
- `.claude/skills/ship-ios-testflight/SKILL.md` — the `ship ios` skill (confirmation gate before dispatch).
- `docs/guides/mobile/ship-ios-testflight.md` — runbook + one-time secret setup.

**Edit**
- `hushh-webapp/ios/App/App/Info.plist` — `ITSAppUsesNonExemptEncryption=false` (standard/exempt crypto only) so uploads skip Missing Compliance.
- `deploy/README.md`, `deploy/app_store_deployment.md` — reconcile / mark the reserved iOS secrets in use.

## Security boundary
- All signing + Firebase material lives in **GCP Secret Manager** (`hushh-pda-uat`) and is **added by the operator** — no `.p8`/key/issuer values in this PR, and none read back into logs (masked).
- Scope is build → sign → **TestFlight only**. No auto-submit to App Store review, no `aps-environment` prod flip, no prod backend/Firebase.

## Before first dispatch (operator, secret-touching)
1. Generate an ASC API key (role **App Manager**), store `APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` / `_ISSUER_ID` in GCP SM (`hushh-pda-uat`).
2. Ensure `IOS_GOOGLESERVICE_INFO_PLIST_B64` is in GCP SM.
3. `GCP_SA_KEY_UAT` SA has `secretmanager.secretAccessor` on the above + the UAT frontend contract.
4. Accept any pending Apple Program License Agreement in ASC.

Full steps: `docs/guides/mobile/ship-ios-testflight.md`.

## Verify
Recommended: dispatch `dry_run: true` first (proves web build → cap sync → SPM resolve → archive → **signing** without uploading), then a real run → new build in **TestFlight 1.3.5 (build N)**, already compliant.

## Deferred (not blocking TestFlight)
Public App Store submission — app-target `PrivacyInfo.xcprivacy`, `aps-environment=production`, prod GA4, store metadata. See `KT/hushh-one-publish-safety-audit.md`.