### PR TITLE
Stop telling the subscriber who the person is

### DIFF
--- a/consent-protocol/hushh_mcp/services/fabric_grant_service.py
+++ b/consent-protocol/hushh_mcp/services/fabric_grant_service.py
@@ -65,6 +65,27 @@ def _sign_handle_body(raw: str) -> str:
     return hmac.new(APP_SIGNING_KEY.encode(), raw.encode(), hashlib.sha256).hexdigest()
 
 
+def subject_ref(*, subscriber_id: str, user_id: str) -> str:
+    """A stable pseudonym for one owner, scoped to one subscriber.
+
+    A subscriber genuinely needs to recognise the same person across repeat
+    reads - otherwise it cannot apply a preference it was granted. It does not
+    need to know WHICH person, and it must not be able to compare notes with
+    another subscriber.
+
+    So the reference is keyed on the pair. The same human presents a different
+    reference to every brand, and two brands holding grants from the same person
+    cannot join their records on it. Reversing it requires APP_SIGNING_KEY.
+
+    The subscriber id is length-prefixed rather than merely delimited: without
+    that, ("acme", "b:carol") and ("acme:b", "carol") would hash identically, and
+    two different people could end up sharing one reference.
+    """
+    material = f"{len(subscriber_id)}:{subscriber_id}:{user_id}"
+    digest = hmac.new(APP_SIGNING_KEY.encode(), material.encode(), hashlib.sha256)
+    return f"sub_{digest.hexdigest()[:32]}"
+
+
 def mint_handle(
     *,
     grant_id: str,
@@ -409,12 +430,28 @@ class FabricGrantService:
                     purpose=grant["purpose"],
                 )
         result = {
-            "user_id": user_id,
+            # NOT the owner's uid. The pairing handshake exists so a brand never
+            # learns who the person is; returning the raw Firebase uid handed it
+            # over on every read, and gave any two brands holding grants from the
+            # same person a shared key to join on. See subject_ref().
+            "subject_ref": subject_ref(subscriber_id=subscriber_id, user_id=user_id),
             "subscriber_id": subscriber_id,
             "grant_id": grant["grant_id"],
             "scopes": _as_list(grant["scopes"]),
             "fields": projected,
-            "receipt": receipt,
+            # The subscriber's proof that this read was recorded - and no more.
+            # `seq` and `prev_hash` are the OWNER's position in their own single
+            # receipt chain, shared across every grant they hold. Handing those
+            # out lets two subscribers who read the same person moments apart see
+            # adjacent sequence numbers and join on them - the same correlation
+            # subject_ref exists to prevent. The owner sees the full chain on
+            # their own ledger, where it belongs.
+            "receipt": {
+                "event_type": receipt["event_type"],
+                "hash": receipt["hash"],
+                "signature": receipt["signature"],
+                "created_at_ms": receipt["created_at_ms"],
+            },
         }
         if privacy_signals is not None:
             result["privacy_signals"] = privacy_signals

--- a/consent-protocol/tests/test_fabric_routes.py
+++ b/consent-protocol/tests/test_fabric_routes.py
@@ -270,12 +270,14 @@ def _subscriber_app(agent_id: str = _SUBSCRIBER) -> FastAPI:
 
 def test_subscriber_read_returns_only_granted_fields():
     result = {
-        "user_id": _UID,
+        # Deliberately not the owner's uid, and the receipt is deliberately
+        # missing seq/prev_hash - see test_fabric_subject_ref.py for why.
+        "subject_ref": "sub_0123456789abcdef0123456789abcdef",
         "subscriber_id": _SUBSCRIBER,
         "grant_id": "g1",
         "scopes": ["wants.money.advisor"],
         "fields": {"connect.want": "wants.money.advisor", "connect.zip": "98033"},
-        "receipt": {"seq": 2, "hash": "h2", "event_type": "READ"},
+        "receipt": {"hash": "h2", "event_type": "READ"},
     }
     with patch.object(fabric, "get_fabric_grant_service") as factory:
         factory.return_value.read_for_subscriber = AsyncMock(return_value=result)

--- a/consent-protocol/tests/test_fabric_subject_ref.py
+++ b/consent-protocol/tests/test_fabric_subject_ref.py
@@ -1,0 +1,61 @@
+"""The subscriber must not learn who the person is.
+
+The pairing handshake exists so a brand can read fields a human granted without
+learning their identity. The read path returned the owner's raw Firebase uid on
+every response, which handed that identity over directly and - worse - gave any
+two brands holding grants from the same person a shared key to join on.
+
+These tests pin the properties that make the replacement safe.
+"""
+
+from __future__ import annotations
+
+from hushh_mcp.services.fabric_grant_service import subject_ref
+
+_ALICE = "firebase-uid-alice"
+_BOB = "firebase-uid-bob"
+
+
+def test_same_pair_is_stable():
+    """A subscriber must recognise the same person across reads, or it cannot
+    apply a preference it was granted."""
+    a = subject_ref(subscriber_id="acme", user_id=_ALICE)
+    b = subject_ref(subscriber_id="acme", user_id=_ALICE)
+    assert a == b
+
+
+def test_two_subscribers_cannot_join_on_the_same_human():
+    """The whole point. Alice presents a different reference to each brand, so
+    comparing notes reveals nothing."""
+    acme = subject_ref(subscriber_id="acme", user_id=_ALICE)
+    globex = subject_ref(subscriber_id="globex", user_id=_ALICE)
+    assert acme != globex
+
+
+def test_two_humans_are_distinct_to_one_subscriber():
+    assert subject_ref(subscriber_id="acme", user_id=_ALICE) != subject_ref(
+        subscriber_id="acme", user_id=_BOB
+    )
+
+
+def test_the_owner_uid_does_not_appear_in_the_reference():
+    """A pseudonym that contains the identifier is not a pseudonym."""
+    ref = subject_ref(subscriber_id="acme", user_id=_ALICE)
+    assert _ALICE not in ref
+    assert "alice" not in ref.lower()
+
+
+def test_delimiter_confusion_cannot_collide_two_people():
+    """Without length-prefixing the subscriber id, ("acme", "b:carol") and
+    ("acme:b", "carol") concatenate to the same material and two different
+    people would share one reference."""
+    assert subject_ref(subscriber_id="acme", user_id="b:carol") != subject_ref(
+        subscriber_id="acme:b", user_id="carol"
+    )
+
+
+def test_reference_is_opaque_and_bounded():
+    ref = subject_ref(subscriber_id="acme", user_id=_ALICE)
+    assert ref.startswith("sub_")
+    assert len(ref) == len("sub_") + 32
+    assert all(c in "0123456789abcdef" for c in ref[4:])


### PR DESCRIPTION
## The defect

`read_for_subscriber` returned `"user_id"` — the owner's **raw Firebase uid** — on every read.

The pairing handshake exists precisely so a brand can use fields a human granted *without* learning their identity. This handed the identity over on every single response.

The compounding part: it was the **same value for every subscriber**. Two brands holding grants from the same person could join their records on it and reassemble exactly the shadow profile this protocol exists to replace. That is a live privacy defect on the path we intend to open commercially.

## The fix

```python
subject_ref = "sub_" + HMAC(APP_SIGNING_KEY, f"{len(sub)}:{sub}:{uid}")[:32]
```

- **Stable** for one subscriber, so it can still recognise a returning person and apply the preference it was granted. Without this a subscriber cannot honour what it holds.
- **Different** for every other subscriber, so there is nothing to join on.
- **Not reversible** without `APP_SIGNING_KEY`.

The subscriber id is **length-prefixed** in the HMAC material. Without that, `("acme", "b:carol")` and `("acme:b", "carol")` produce identical material and two different people would share one reference. There is a test for exactly that collision.

## The receipt leaked the same thing by another route

The receipt handed back carried `seq` and `prev_hash` — the owner's position in their **single** receipt chain, shared across every grant they hold. Two subscribers reading the same person moments apart would see adjacent sequence numbers and could join on those instead, defeating the pseudonym entirely.

Narrowed to `event_type`, `hash`, `signature`, `created_at_ms`: enough to prove the read was recorded, nothing about the owner's other relationships. The owner still sees the whole chain on their own ledger via `/api/fabric/receipts`, where it belongs.

## Tests

`tests/test_fabric_subject_ref.py` — six properties:

| Property | Why it matters |
|---|---|
| same pair is stable | a subscriber must recognise a returning person |
| two subscribers differ for one human | the whole point |
| two humans differ for one subscriber | correctness |
| the uid does not appear in the reference | a pseudonym containing the identifier is not one |
| delimiter confusion cannot collide two people | the length-prefix guard |
| opaque and bounded | shape contract |

Also updated the route test's fixture, which had `user_id` baked into a mock and so would have kept passing while the leak was live.

## Verification

**22 passed** — 6 new plus the 16 existing fabric route tests.

**Not verified:** the full suite does not collect in this sandbox (178 errors from a `pyo3` panic in the crypto path). I confirmed this reproduces identically on unmodified `main`, so it is environmental and pre-existing — but this branch has not been run against the whole suite and wants a real CI run.

## Note on ordering

This is independent of #4710 (the resolver). Neither blocks the other, but this one should land before any production fabric traffic — every read today discloses the owner's uid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Bh75gyp1KvHncgyWoCy8F

---
_Generated by [Claude Code](https://claude.ai/code/session_018Bh75gyp1KvHncgyWoCy8F)_

---
Closes #4901
(retroactive board-linkage backfill, 2026-08-06)