### PR TITLE
fix(ci): build iOS with Xcode 16.4 (Swift 6.1) for Firebase 12.11.0

### DIFF
--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -126,7 +126,10 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          # Swift 6.1.2 (default on macos-15). Firebase/GoogleAppMeasurement 12.11.0
+          # ship Package.swift manifests declaring swift-tools-version:6.1, which
+          # Xcode 16.2 (Swift 6.0) cannot resolve. 16.4 is the terminal 16.x.
+          xcode-version: "16.4"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -111,7 +111,10 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.2"
+          # Swift 6.1.2 (default on macos-15). Firebase/GoogleAppMeasurement 12.11.0
+          # ship Package.swift manifests declaring swift-tools-version:6.1, which
+          # Xcode 16.2 (Swift 6.0) cannot resolve. 16.4 is the terminal 16.x.
+          xcode-version: "16.4"
 
       - name: Set up Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem
Both iOS pipelines — **Ship iOS to TestFlight** and **Release iOS to App Store** — fail at `Resolve Swift package dependencies`:

```
package 'analytics' is using Swift tools version 6.1.0 but the installed version is 6.0.0
xcodebuild: error: Could not resolve package dependencies
```

Firebase / GoogleAppMeasurement **12.11.0** (already pinned in `Package.resolved`) ship `Package.swift` manifests declaring `swift-tools-version:6.1`. The workflows pin **Xcode 16.2 → Swift 6.0.3**, which cannot read a 6.1 manifest. Failure is deterministic and identical in both UAT and prod (same Xcode pin), confirmed from the failed step logs of dry-runs 30405839529 (TF) and 30405841346 (prod).

## Fix
Bump the `Select Xcode` step in both workflows from `16.2` → **`16.4`** (Swift 6.1.2, the `macos-15` default). This matches the toolchain the dependency graph requires — the same graph that locally shipped builds 34–40. **No dependency versions change.**

## Scope
- `.github/workflows/ship-ios-testflight.yml`
- `.github/workflows/release-ios-appstore.yml`

Both remain `workflow_dispatch`-only, so merging deploys nothing; the fix is exercised by re-dispatching the two dry-runs from `main`.