### PR TITLE
feat(ci): enforce prod release ⊇ approved UAT commit (P2/P6)

### DIFF
--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -106,6 +106,14 @@ jobs:
           REQUIRED_CHECK_NAME: "Main Post-Merge Smoke Gate"
         run: bash scripts/ci/require-deploy-sha-on-main.sh "${{ github.event.inputs.sha }}"
 
+      - name: Require release contains approved UAT commit
+        id: uatguard
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          UAT_WORKFLOW: deploy-uat.yml
+        run: bash scripts/ci/require-release-contains-uat.sh "${{ github.event.inputs.sha }}"
+
       - name: Check out the exact release SHA (detached)
         shell: bash
         run: |
@@ -447,6 +455,7 @@ jobs:
             echo "| Field | Value |"
             echo "| --- | --- |"
             echo "| SHA | \`${{ github.event.inputs.sha }}\` |"
+            echo "| UAT source | \`${UAT_SOURCE_SHA:-unknown}\` (release ⊇ approved UAT) |"
             echo "| Version | ${MARKETING:-unknown} |"
             echo "| Build | ${{ steps.build_number.outputs.next_build }} |"
             echo "| Bundle | ${IOS_BUNDLE_ID} |"

--- a/scripts/ci/require-release-contains-uat.sh
+++ b/scripts/ci/require-release-contains-uat.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Refuse a production iOS App Store release unless the release commit CONTAINS
+# (is a descendant of, or is equal to) the latest commit that was successfully
+# deployed to UAT. This enforces the promotion invariant  prod ⊇ approved-UAT:
+# every public build must carry code that has already been verified on UAT.
+#
+# The "approved UAT SHA" is the head_sha of the most recent successful
+# "Deploy to UAT" workflow run (deploy-uat.yml). Set UAT_SOURCE_SHA to override
+# the lookup (tests, or a deliberate manual pin).
+#
+# Usage: scripts/ci/require-release-contains-uat.sh <release-commit-sha>
+
+RELEASE_SHA="${1:-${RELEASE_SHA:-}}"
+UAT_WORKFLOW="${UAT_WORKFLOW:-deploy-uat.yml}"
+
+if [ -z "$RELEASE_SHA" ]; then
+  echo "Usage: scripts/ci/require-release-contains-uat.sh <release-commit-sha>" >&2
+  exit 1
+fi
+
+# 1. Resolve the approved UAT source SHA (explicit override wins).
+UAT_SHA="${UAT_SOURCE_SHA:-}"
+if [ -z "$UAT_SHA" ]; then
+  if [ -z "${GITHUB_REPOSITORY:-}" ] || [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "Refusing release: GITHUB_REPOSITORY and GITHUB_TOKEN are required to resolve the approved UAT SHA (or set UAT_SOURCE_SHA)." >&2
+    exit 1
+  fi
+  PAYLOAD="$(curl -fsSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/${UAT_WORKFLOW}/runs?status=success&per_page=1")"
+  UAT_SHA="$(printf '%s' "$PAYLOAD" | python3 -c 'import json,sys; runs=(json.load(sys.stdin).get("workflow_runs") or []); print(runs[0]["head_sha"] if runs else "")')"
+fi
+
+if [ -z "$UAT_SHA" ]; then
+  echo "Refusing release: could not determine the latest successful '${UAT_WORKFLOW}' commit (no successful UAT deploys?)." >&2
+  exit 1
+fi
+
+# 2. Make sure both commits are present in the local clone.
+for sha in "$UAT_SHA" "$RELEASE_SHA"; do
+  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    git fetch --no-tags origin "$sha" >/dev/null 2>&1 || true
+  fi
+  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    echo "Refusing release: commit '$sha' is not available in the local clone." >&2
+    exit 1
+  fi
+done
+
+# 3. prod ⊇ approved-UAT: the release commit must contain the approved UAT commit.
+#    (A commit is its own ancestor, so RELEASE_SHA == UAT_SHA is allowed.)
+if ! git merge-base --is-ancestor "$UAT_SHA" "$RELEASE_SHA"; then
+  echo "Refusing release: release commit '$RELEASE_SHA' does not contain the latest approved UAT commit '$UAT_SHA'." >&2
+  echo "The App Store build would ship code that was never verified on UAT." >&2
+  echo "Promote the release source to UAT first, or cut the release from a newer main." >&2
+  exit 1
+fi
+
+echo "Release promotion preflight passed: '$RELEASE_SHA' contains approved UAT commit '$UAT_SHA'."
+
+# 4. Publish the resolved UAT source SHA for downstream steps / job summary.
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "UAT_SOURCE_SHA=$UAT_SHA" >> "$GITHUB_ENV"
+fi
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "uat_source_sha=$UAT_SHA" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
## Why
The App Store release pipeline validated only that the release SHA is **on main** and passed the **Main Post-Merge Smoke Gate**. It never verified the code had actually been through **UAT**. A commit that landed on main but skipped UAT could therefore ship to the public App Store — violating the promotion invariant **prod ⊇ approved-UAT** (spec P2/P6).

## What
- **New:** `scripts/ci/require-release-contains-uat.sh` — resolves the approved UAT SHA (`head_sha` of the latest **successful** `deploy-uat.yml` run; overridable via `UAT_SOURCE_SHA`) and **fails closed** unless the release commit *contains* it (`git merge-base --is-ancestor`). Equality is allowed (prod == uat is a valid promotion).
- **Wired** as a required step in `release-ios-appstore.yml`, right after the on-main validation and before checkout.
- **Traceability:** records the resolved UAT source SHA in the job summary (`| UAT source | <sha> (release ⊇ approved UAT) |`).

## Verification (local, via `UAT_SOURCE_SHA` override)
| Case | release | uat | result |
| --- | --- | --- | --- |
| contains | `65dd99288` | `ce5b3174a` | ✅ pass |
| equal | `65dd99288` | `65dd99288` | ✅ pass |
| behind | `ce5b3174a` | `65dd99288` | ⛔ refused (exit 1) |

`workflow_dispatch`-only; merging deploys nothing. TestFlight workflow unchanged.