### PR TITLE
fix(ci): build iOS archive with Xcode 26.3 (iOS 26 SDK + Swift 6.2)

### DIFF
--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -126,10 +126,13 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          # Swift 6.1.2 (default on macos-15). Firebase/GoogleAppMeasurement 12.11.0
-          # ship Package.swift manifests declaring swift-tools-version:6.1, which
-          # Xcode 16.2 (Swift 6.0) cannot resolve. 16.4 is the terminal 16.x.
-          xcode-version: "16.4"
+          # Xcode 26.3 → iOS 26 SDK + Swift 6.2 (both preinstalled on macos-15).
+          # The app's Sign in with Apple handler switches over iOS-26 additions to
+          # ASAuthorizationError.Code (.preferSignInWithApple,
+          # .deviceNotConfiguredForPasskeyCreation) that Xcode 16.4's iOS 18.5 SDK
+          # does not define. Swift 6.2 (>= 6.1) still resolves the swift-tools:6.1
+          # Package.swift manifests in Firebase/GoogleAppMeasurement 12.11.0.
+          xcode-version: "26.3"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -111,10 +111,13 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          # Swift 6.1.2 (default on macos-15). Firebase/GoogleAppMeasurement 12.11.0
-          # ship Package.swift manifests declaring swift-tools-version:6.1, which
-          # Xcode 16.2 (Swift 6.0) cannot resolve. 16.4 is the terminal 16.x.
-          xcode-version: "16.4"
+          # Xcode 26.3 → iOS 26 SDK + Swift 6.2 (both preinstalled on macos-15).
+          # The app's Sign in with Apple handler switches over iOS-26 additions to
+          # ASAuthorizationError.Code (.preferSignInWithApple,
+          # .deviceNotConfiguredForPasskeyCreation) that Xcode 16.4's iOS 18.5 SDK
+          # does not define. Swift 6.2 (>= 6.1) still resolves the swift-tools:6.1
+          # Package.swift manifests in Firebase/GoogleAppMeasurement 12.11.0.
+          xcode-version: "26.3"
 
       - name: Set up Node
         uses: actions/setup-node@v6

--- a/hushh-webapp/ios/App/App/Plugins/PersonalKnowledgeModelPlugin.swift
+++ b/hushh-webapp/ios/App/App/Plugins/PersonalKnowledgeModelPlugin.swift
@@ -370,7 +370,12 @@ public class PersonalKnowledgeModelPlugin: CAPPlugin, CAPBridgedPlugin {
         if let claim = call.getObject("upgradeContext"),
            let claimId = claim["claimId"] as? String,
            !claimId.isEmpty {
-            body["upgrade_claim"] = [
+            // Explicit [String: Any] annotation: this heterogeneous literal made of
+            // `as? T ?? default` coercions otherwise exceeds the Swift type-checker's
+            // time budget ("unable to type-check this expression in reasonable time").
+            // Naming the type removes the combinatorial inference cost; contents and
+            // behaviour are unchanged.
+            let upgradeClaim: [String: Any] = [
                 "schema_version": claim["schemaVersion"] as? String ?? "pkm_upgrade_claim.v1",
                 "claim_id": claimId,
                 "commit_id": claim["commitId"] as? String ?? "",
@@ -386,6 +391,7 @@ public class PersonalKnowledgeModelPlugin: CAPPlugin, CAPBridgedPlugin {
                 "expires_at": claim["expiresAt"] as? String ?? "",
                 "mode": claim["mode"] as? String ?? "real"
             ]
+            body["upgrade_claim"] = upgradeClaim
         }
         if let receipt = call.getObject("preservationReceipt") {
             body["preservation_receipt"] = [


### PR DESCRIPTION
## Problem
Both iOS pipelines cleared SPM resolve (the Xcode 16.4 fix in #4714) but then **failed at the `Archive` step** — `** ARCHIVE FAILED **`, `CompileSwift normal arm64`. Not signing, not entitlements (managed signing was succeeding). The App target's own Swift source won't compile against Xcode 16.4's **iOS 18.5 SDK**:

```
Plugins/HushhAuthPlugin.swift:640: error: type 'ASAuthorizationError.Code' has no member 'preferSignInWithApple'
Plugins/HushhAuthPlugin.swift:642: error: type 'ASAuthorizationError.Code' has no member 'deviceNotConfiguredForPasskeyCreation'
Plugins/PersonalKnowledgeModelPlugin.swift:373: error: the compiler is unable to type-check this expression in reasonable time
```

Those two `ASAuthorizationError.Code` cases were **added in iOS 26**; the app was written against the iOS 26 SDK. Xcode 16.4 (iOS 18.5) doesn't define them. Both prod and TestFlight dry-runs failed identically → toolchain issue, independent of prod/uat config.

## Fix
- **Select Xcode 26.3** in both `ship-ios-testflight.yml` and `release-ios-appstore.yml`. `macos-15` already ships Xcode 26.0.1–26.3, so no runner-image change. Xcode 26.3 → iOS 26 SDK (the two enum cases exist) **and** Swift 6.2, which is still ≥ 6.1, so Firebase/GoogleAppMeasurement 12.11.0's `swift-tools:6.1` manifests keep resolving — the reason we moved off 16.2 still holds.
- **Explicit `[String: Any]` type** on `PersonalKnowledgeModelPlugin`'s `upgrade_claim` literal (a 14-entry heterogeneous `as? T ?? default` dictionary). This is the canonical fix for the type-checker timeout; **contents and behaviour unchanged** (same keys, values, defaults, assignment target).

## Verification
- YAML validated for both workflows; Xcode pins now `26.3`.
- `workflow_dispatch`-only — merging deploys nothing.
- Will re-dispatch both dry-runs (`dry_run=true`) off the merged SHA to confirm archive + sign + export succeed before any upload.