### PR TITLE
fix(ci): guard empty SUBMIT_ARGS in App Store prepare step

### DIFF
--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -416,7 +416,7 @@ jobs:
             --pbxproj "${PBXPROJ}" \
             --build-number "${{ steps.build_number.outputs.next_build }}" \
             --release-type MANUAL \
-            "${SUBMIT_ARGS[@]}"
+            "${SUBMIT_ARGS[@]+"${SUBMIT_ARGS[@]}"}"
 
       - name: Upload build artifacts
         if: always()


### PR DESCRIPTION
## What
One-line fix to the **Release iOS to App Store** workflow's `Prepare App Store version` step.

## Why
The step declares `SUBMIT_ARGS=()` and only appends `--submit` when `submit_for_review=true`. In the **default prepare-only** mode the array stays empty, and expanding `"${SUBMIT_ARGS[@]}"` under `set -u` on the runner's bash 3.2 aborts with `SUBMIT_ARGS[@]: unbound variable`. So **every prepare-only release failed at the final attach-build step** — even though the archive, sign, and **upload to App Store Connect had already succeeded**.

Observed in run 30440131779 (build 1.3.6 / 58 uploaded OK, then prepare step died on this line).

## Fix
Portable nounset-safe expansion `"${SUBMIT_ARGS[@]+"${SUBMIT_ARGS[@]}"}"` — expands to nothing when empty, to `--submit` when set. Verified locally on bash 3.2.57 (old form reproduces the error; new form passes 0 args when empty and `--submit` when set).

## Scope
- Only `.github/workflows/release-ios-appstore.yml` (1 line).
- Sibling TestFlight workflow and `submit-appstore-version.py` audited — no other unguarded `[@]` expansions.
- No behavior change to the submit path; only fixes the empty-array crash.