### PR TITLE
feat(ios): retarget public App Store release to UAT backend + one-click submit

### DIFF
--- a/.claude/skills/release-ios-appstore/SKILL.md
+++ b/.claude/skills/release-ios-appstore/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release-ios-appstore
-description: Cut a Hushh One iOS build from the latest green main and take it all the way to the App Store — build against PRODUCTION backend + prod Firebase, sign with Apple-managed signing (Admin ASC API key), upload to App Store Connect, and prepare the App Store version. Use when the user says "release ios to app store", "ship ios to production", "cut a prod ios build", "app store release", "prod ios release", or "make ios-prod-release". Prepares everything up to — but NOT including — the irreversible public "Submit for Review", which is opt-in only via a double gate. Orchestrates: preflight → pick green main SHA → (optional dry run) → dispatch the "Release iOS to App Store" workflow → watch to terminal → report the App Store Connect build/version. Pauses for explicit user confirmation before dispatch, and requires a separate explicit gate before any public submission.
-argument-hint: "[sha: <green-main-sha>] [dry_run: true|false] [submit: true|false] [notes: <text>]"
+description: Cut a Hushh One iOS build from the latest green main and take it all the way to the public App Store — build against the UAT backend + UAT Firebase (the same latest frontend+backend that ships to TestFlight), sign with Apple-managed signing (Admin ASC API key), upload to App Store Connect, auto-set "What's New", attach the build, and (opt-in) submit for public review in one click. Use when the user says "release ios to app store", "ship ios to production", "cut a prod ios build", "app store release", "prod ios release", or "make ios-prod-release". Default prepares everything up to — but NOT including — the irreversible public "Submit for Review". Orchestrates: preflight → pick green main SHA → (optional dry run) → dispatch the "Release iOS to App Store" workflow → watch to terminal → report the App Store Connect build/version. Pauses for explicit user confirmation before dispatch, and requires a separate explicit acknowledgement before any public submission.
+argument-hint: "[sha: <green-main-sha>] [dry_run: true|false] [whats_new: <text>] [submit: true|false] [notes: <text>]"
 allowed-tools: Read Grep Glob Bash(make ios-prod-release*) Bash(make ios-prod-release-dry*) Bash(node scripts/release/dispatch-ios-appstore.mjs*) Bash(gh *) Bash(git fetch*) Bash(git status*) Bash(git rev-parse*) Bash(git log*) Bash(git branch*)
 paths:
   - .github/workflows/release-ios-appstore.yml
@@ -14,20 +14,26 @@ paths:
   - KT/hushh-one-publish-safety-audit.md
 ---
 
-# Release iOS to App Store (prod)
+# Release iOS to App Store (public)
 
 Orchestrates: **pick the latest green `main` SHA → build the Capacitor iOS app against the
-PRODUCTION backend + prod Firebase → sign (Apple-managed, Admin ASC API key) → archive → upload to
-App Store Connect → prepare the App Store version → report.** By default it **stops before** the
-irreversible public "Submit for Review".
+UAT backend + UAT Firebase → sign (Apple-managed, Admin ASC API key) → archive → upload to
+App Store Connect → set "What's New" → attach the build → (opt-in) submit for public review →
+report.** By default it **stops before** the irreversible public "Submit for Review".
+
+**Backend:** the public App Store build ships the **UAT backend + UAT Firebase (`hushh-pda-uat`)** —
+i.e. the *same* latest frontend+backend that is live on UAT and TestFlight, not a separate
+production backend. (It still archives with **production APNs** entitlements, correct for any store
+binary — so the UAT Firebase project must hold a production APNs key for push to deliver.)
 
 One command drives it:
 
 ```bash
-make ios-prod-release                      # prepare-only (upload + attach build, NO public submit) — SHA=origin/main
+make ios-prod-release                      # prepare-only (upload + set What's New + attach build, NO public submit) — SHA=origin/main
 make ios-prod-release ARGS="--dry-run"     # archive + sign on the runner, no upload / no ASC changes
 make ios-prod-release ARGS="--sha <sha>"   # pin an explicit green SHA
-make ios-prod-release ARGS="--submit --ack-blockers"   # ⛔ IRREVERSIBLE public App Store submission
+make ios-prod-release ARGS="--whats-new '<release notes>'"   # set the App Store "What's New" text
+make ios-prod-release ARGS="--submit --ack-blockers"   # ⛔ IRREVERSIBLE one-click public App Store submission
 ```
 
 `make ios-prod-release-dry` is shorthand for `ARGS="--dry-run"`. The Makefile target just calls the
@@ -36,21 +42,24 @@ exactly what will run, asks for confirmation, dispatches `gh workflow run "Relea
 Store"`, and streams the run. The build itself runs **inside a GitHub-hosted macOS runner**
 (`macos-15`, Xcode 26.3) — the local machine only dispatches (needs the `workflow` token scope).
 
-Target: bundle `com.hushh.app`, App Store Connect, built against the **PRODUCTION** backend
-(`api.hushh.ai`) + **prod** Firebase (`hushh-pda`), keyless GCP auth via Workload Identity
-Federation. Sibling for testing: the `ship-ios-testflight` skill (UAT backend → TestFlight).
+Target: bundle `com.hushh.app`, App Store Connect, built against the **UAT** backend + **UAT**
+Firebase (`hushh-pda-uat`), GCP auth via the `GCP_SA_KEY_UAT` service-account key (same as
+TestFlight). Sibling for testing: the `ship-ios-testflight` skill (UAT backend → TestFlight); the
+App Store binary is the same UAT-backed binary, differing only at the submission layer.
 
 ## HARD RULES (never violate)
 
 1. **Two gates, not one.**
    - **Gate 1 (every dispatch):** STOP and get an explicit "yes" before dispatching. Show exactly
      what will happen (workflow, `--ref main`, `sha` short, mode = dry-run / prepare-only / submit,
-     backend = PRODUCTION, bundle `com.hushh.app`). The dispatcher prints this and prompts too.
-   - **Gate 2 (public submission only):** `--submit` is **IRREVERSIBLE** — it publishes to real
-     users. It requires BOTH `--submit --ack-blockers`, a separate explicit user instruction, and
-     every publish-safety blocker in `KT/hushh-one-publish-safety-audit.md` cleared first. **Never**
-     pass `--submit` from an automated/background context or on assumption. Default and near-always
-     correct is **prepare-only** (no `--submit`).
+     backend = UAT (`hushh-pda-uat`), bundle `com.hushh.app`). The dispatcher prints this and prompts too.
+   - **Gate 2 (public submission only):** one-click submit maps to the workflow input
+     `submit_for_review=true`, which is **IRREVERSIBLE** — it publishes to real users. On the CLI
+     path it additionally requires `--submit --ack-blockers` (a local safety gate the dispatcher
+     enforces), a separate explicit user instruction, and every publish-safety blocker in
+     `KT/hushh-one-publish-safety-audit.md` cleared first. **Never** pass `--submit` (or set
+     `submit_for_review=true`) from an automated/background context or on assumption. Default and
+     near-always correct is **prepare-only**.
 2. **Only release a green `main` SHA.** The build is only allowed from a `main` SHA where
    **"Main Post-Merge Smoke Gate"** = `success` (the workflow re-checks via
    `require-deploy-sha-on-main.sh` and refuses otherwise). If it isn't green, stop and report.
@@ -65,7 +74,7 @@ Federation. Sibling for testing: the `ship-ios-testflight` skill (UAT backend �
    next patch, land it on `main`, and re-release. A `--dry-run` will NOT catch this (dry-run skips
    the upload/ASC-validation leg).
 5. **Never touch secrets.** The ASC API key (`.p8`, Admin role) + Key/Issuer IDs and the native
-   `GoogleService-Info.plist` live only in **GCP Secret Manager** (`hushh-pda`), added by the
+   `GoogleService-Info.plist` live only in **GCP Secret Manager** (`hushh-pda-uat`), added by the
    **user**. Never print, paste, `gcloud secrets versions access` them, or ask the user to paste
    them into chat. If a required secret is missing, point to the runbook — do not work around it.
 6. **Verify identity before acting.** Confirm the `gh` actor is in `config/ci-governance.json` →
@@ -87,9 +96,9 @@ git fetch --no-tags origin main
 git rev-parse origin/main          # candidate SHA (latest main)
 ```
 - Read `config/ci-governance.json`; confirm the actor ∈ `production.manual_dispatch_users`. If not → STOP.
-- Signing + Firebase secrets live in **GCP Secret Manager** (`hushh-pda`), not GitHub — the workflow
-  reads them via Workload Identity Federation and fails fast with a runbook pointer if any of
-  `APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` / `_ISSUER_ID` or
+- Signing + Firebase secrets live in **GCP Secret Manager** (`hushh-pda-uat`), not GitHub — the
+  workflow authenticates with the `GCP_SA_KEY_UAT` GitHub secret (same as TestFlight) and fails fast
+  with a runbook pointer if any of `APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` / `_ISSUER_ID` or
   `IOS_GOOGLESERVICE_INFO_PLIST_B64` is missing. Do not try to list/read them here. A `--dry-run` is
   the safe way to confirm signing works before a real upload (but see HARD RULE 4 — it won't catch a
   closed version train).
@@ -107,22 +116,24 @@ git rev-parse origin/main          # candidate SHA (latest main)
 ## Phase 2 — (Optional) dry run
 
 Recommend `make ios-prod-release-dry` the first time after any signing/secret change: it archives +
-signs with production entitlements on the runner **without uploading**, isolating ASC-key / managed
-signing problems. It does **not** validate the marketing-version train (that only happens on a real
-upload). If the user just wants to prepare the release, skip to Phase 3.
+signs with production **APNs** entitlements (correct for any store binary, regardless of the UAT
+backend) on the runner **without uploading**, isolating ASC-key / managed signing problems. It does
+**not** validate the marketing-version train (that only happens on a real upload). If the user just
+wants to prepare the release, skip to Phase 3.
 
 ## Phase 3 — Prepare the release  ⛔ CONFIRMATION GATE (Gate 1)
 
 1. **GATE 1 — ask the user to confirm.** Show: workflow **"Release iOS to App Store"**, `--ref main`,
-   `sha` (short), mode = **prepare-only** (upload + attach build, no public submit), backend =
-   PRODUCTION, bundle `com.hushh.app`. Wait for an explicit "yes".
+   `sha` (short), mode = **prepare-only** (upload + set What's New + attach build, no public submit),
+   backend = UAT (`hushh-pda-uat`), bundle `com.hushh.app`. Wait for an explicit "yes".
 2. Dispatch (prepare-only is the default — no `--submit`):
    ```bash
-   make ios-prod-release ARGS="--sha $SHA --yes --notes '<what changed, optional>'"
+   make ios-prod-release ARGS="--sha $SHA --yes --whats-new '<release notes>' --notes '<what changed, optional>'"
    ```
    (`--yes` skips the dispatcher's own prompt once you've taken Gate 1 in chat. Omit it to keep the
-   interactive confirm. Equivalent raw form:
-   `node scripts/release/dispatch-ios-appstore.mjs --sha $SHA --yes`.)
+   interactive confirm. `--whats-new` sets the App Store "What's New in This Version" text — Apple
+   requires it per version; omit to keep the workflow default / leave existing notes untouched.
+   Equivalent raw form: `node scripts/release/dispatch-ios-appstore.mjs --sha $SHA --yes`.)
 3. The dispatcher finds and watches the run to terminal. Expect ~15–35 min on a cold SPM graph.
    `timeout-minutes` is set on the job.
 
@@ -147,12 +158,16 @@ blockers in `KT/hushh-one-publish-safety-audit.md` are cleared:
 
 1. Restate that this is **IRREVERSIBLE** and publishes to real users. Get a fresh explicit "yes".
 2. ```bash
-   make ios-prod-release ARGS="--sha $SHA --submit --ack-blockers"
+   make ios-prod-release ARGS="--sha $SHA --whats-new '<release notes>' --submit --ack-blockers"
    ```
    (Do not add `--yes`; let the dispatcher require typing `submit`. `--submit` + `--dry-run` are
-   mutually exclusive; the dispatcher enforces `--submit` ⇒ `--ack-blockers`.)
-3. The workflow's "Prepare App Store version" step re-checks `submit_for_review=true` +
-   `ack_publish_blockers=true` before it does anything public.
+   mutually exclusive; the dispatcher enforces `--submit` ⇒ `--ack-blockers` as a local safety gate,
+   then dispatches the workflow with `submit_for_review=true`.)
+3. The workflow uploads, sets What's New, attaches the build, and submits for public review in a
+   single run. Screenshots / age rating / pricing are reused from the existing ASC listing (stable
+   across versions); only "What's New" is version-specific. Alternatively the user can run the
+   workflow straight from the GitHub Actions "Run workflow" button with `submit_for_review` checked —
+   that is the true one-click path.
 
 ## Phase 6 — Report
 
@@ -160,9 +175,10 @@ Compact, honest summary:
 - SHA released (short) + that the smoke gate was green on it.
 - Run URL + final status; mode (dry-run / prepare-only / submitted).
 - Version / build number (e.g. `1.3.6 (57)`).
-- ASC status: uploaded / processing / build attached to version / (prepare-only — NOT submitted for
-  review), or "dry run — not uploaded".
-- On-device note: the build boots against **PRODUCTION** backend (asserted during prep).
+- ASC status: uploaded / processing / What's New set / build attached to version / submitted for
+  review / (prepare-only — NOT submitted for review), or "dry run — not uploaded".
+- On-device note: the build boots against the **UAT** backend (`hushh-pda-uat`, asserted during prep) —
+  the same backend as TestFlight.
 
 ## Failure handling
 - Actor not in `production.manual_dispatch_users` → stop in Phase 0.
@@ -173,16 +189,20 @@ Compact, honest summary:
 - Upload fails on Apple agreements/role → tell the user which manual Apple step to do — the user's to perform.
 
 ## Quick reference
-- Command: `make ios-prod-release` (+ `ARGS="--dry-run" | "--sha <sha>" | "--submit --ack-blockers"`);
+- Command: `make ios-prod-release` (+ `ARGS="--dry-run" | "--sha <sha>" | "--whats-new '<text>'" | "--submit --ack-blockers"`);
   `make ios-prod-release-dry`. Dispatcher: `scripts/release/dispatch-ios-appstore.mjs`.
 - Workflow: **"Release iOS to App Store"** (`.github/workflows/release-ios-appstore.yml`), inputs
-  `sha`, `dry_run`, `submit_for_review`, `ack_publish_blockers`, `notes`; `environment: production`.
-- TestFlight sibling: **"Ship iOS to TestFlight"** (`ship-ios-testflight` skill) — UAT backend, no review.
+  `sha`, `dry_run`, `whats_new`, `submit_for_review`, `notes`; `environment: production` (public
+  submission is a production surface even though the binary is UAT-backed).
+- TestFlight sibling: **"Ship iOS to TestFlight"** (`ship-ios-testflight` skill) — same UAT backend, no review.
 - Smoke gate (shared): **"Main Post-Merge Smoke Gate"**.
 - Governance: `config/ci-governance.json` (`production.manual_dispatch_users`);
   `assert-governed-actor.py --surface production`.
+- Auth: GitHub secret `GCP_SA_KEY_UAT` → GCP Secret Manager `hushh-pda-uat` (same as TestFlight).
+- What's New setter + review submission: `scripts/ci/submit-appstore-version.py` (ASC API — sets
+  `whatsNew` per version, attaches the build, optional `--submit`).
 - Build-number resolver: `scripts/ci/resolve-ios-build-number.py` (reads `MARKETING_VERSION` train + ASC history, +1).
 - Version source: `MARKETING_VERSION` in `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj` (App target, Debug+Release).
 - Full runbook + secret setup: `docs/guides/mobile/release-ios-appstore.md`.
 - Publish-safety blockers (must clear before `--submit`): `KT/hushh-one-publish-safety-audit.md`.
-- Env/target: `hushh-pda` (prod), App Store Connect, bundle `com.hushh.app`.
+- Env/target: `hushh-pda-uat` (UAT backend + Firebase), App Store Connect, bundle `com.hushh.app`.

--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -1,20 +1,25 @@
 name: Release iOS to App Store
 
-# Production App Store release for Hushh One iOS. Cuts a build from an exact green
-# `main` SHA, builds the Capacitor app against the PRODUCTION backend + PRODUCTION
-# Firebase (hushh-pda), signs with Apple-managed signing via an App Store Connect
-# API key using the production APNs entitlement (AppRelease.entitlements), uploads
-# to App Store Connect, and then completes every automatable App Store step up to
-# the final Apple review action.
+# Public App Store release for Hushh One iOS. Cuts a build from an exact green
+# `main` SHA and — by product decision — ships the SAME frontend + backend that
+# is live on UAT: it builds the Capacitor app against the UAT backend + UAT
+# Firebase (hushh-pda-uat), signs with Apple-managed signing via an App Store
+# Connect API key using the production APNs entitlement (AppRelease.entitlements,
+# required for any store binary), uploads to App Store Connect, sets the required
+# "What's New in This Version" notes, attaches the build, and — when asked — takes
+# the single irreversible "submit for App Store review" action.
 #
 # The same archive/export/upload is what feeds TestFlight; the App Store vs
-# TestFlight difference is entirely at the version/submission layer below. This
-# workflow does NOT auto-submit for public review: the irreversible "submit for
-# App Store review" action only runs when BOTH `submit_for_review` and
-# `ack_publish_blockers` are explicitly set true. Left at their defaults, the run
-# stops after attaching the processed build to a MANUAL-release App Store version.
+# TestFlight difference is entirely at the version/submission layer below. Set
+# `submit_for_review=true` for the one-click path (build -> upload -> set What's
+# New -> attach -> submit for public review). Left false, the run stops after
+# attaching the processed build to a MANUAL-release App Store version.
 #
-# Prod web sibling: .github/workflows/deploy-production.yml
+# Backend note: this store build points at the UAT backend on purpose (latest
+# frontend + latest backend, matching UAT). Push on a store binary routes through
+# Apple's PRODUCTION APNs, so the UAT Firebase project must hold a production APNs
+# key for notifications to deliver — see the runbook.
+#
 # TestFlight sibling: .github/workflows/ship-ios-testflight.yml
 # Runbook + secret/IAM setup: docs/guides/mobile/release-ios-appstore.md
 
@@ -31,15 +36,15 @@ on:
         default: false
         type: boolean
       submit_for_review:
-        description: "IRREVERSIBLE: submit the build for public App Store review (requires ack_publish_blockers)"
+        description: "IRREVERSIBLE one-click: upload, set What's New, attach, and SUBMIT for public App Store review. False = stop after attaching the build."
         required: false
         default: false
         type: boolean
-      ack_publish_blockers:
-        description: "I have cleared every publish-safety blocker in docs/guides/mobile/release-ios-appstore.md"
+      whats_new:
+        description: "What's New in This Version (App Store release notes; Apple requires this for every new version)"
         required: false
-        default: false
-        type: boolean
+        default: "Stability improvements and bug fixes."
+        type: string
       notes:
         description: "Optional note for the run summary"
         required: false
@@ -48,10 +53,13 @@ on:
 permissions:
   contents: read
   checks: read
-  id-token: write
 
 env:
-  GCP_PROJECT_ID: hushh-pda
+  # This public App Store build ships the UAT frontend + UAT backend by product
+  # decision (same as what's live on UAT / TestFlight), so it authenticates to
+  # and reads its contract from hushh-pda-uat, exactly like the TestFlight
+  # pipeline. The App Store vs TestFlight difference is only the submission layer.
+  GCP_PROJECT_ID: hushh-pda-uat
   GCP_REGION: us-central1
   IOS_BUNDLE_ID: com.hushh.app
   XCODE_PROJECT: hushh-webapp/ios/App/App.xcodeproj
@@ -113,16 +121,6 @@ jobs:
           git checkout --detach "${{ github.event.inputs.sha }}"
           git --no-pager log -1 --oneline
 
-      - name: Validate Google Cloud workload identity configuration
-        shell: bash
-        env:
-          WIF_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
-        run: |
-          set -euo pipefail
-          test -n "$WIF_PROVIDER" || { echo "Missing environment variable GCP_WORKLOAD_IDENTITY_PROVIDER" >&2; exit 1; }
-          test -n "$DEPLOY_SERVICE_ACCOUNT" || { echo "Missing environment variable GCP_DEPLOY_SERVICE_ACCOUNT" >&2; exit 1; }
-
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -149,15 +147,13 @@ jobs:
           # deps must exist before any Swift Package Manager resolution.
           npm ci --prefix hushh-webapp
 
-      - name: Authenticate to Google Cloud (production, WIF)
-        id: gcp-auth
+      - name: Authenticate to Google Cloud (UAT)
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
-          project_id: ${{ env.GCP_PROJECT_ID }}
-          create_credentials_file: true
-          export_environment_variables: true
+          # UAT-scoped SA key (repo-level secret, inherited by the production
+          # environment). This build's contract, Firebase config, and ASC key all
+          # live in hushh-pda-uat, so it authenticates there like TestFlight does.
+          credentials_json: ${{ secrets.GCP_SA_KEY_UAT }}
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -173,15 +169,16 @@ jobs:
             exit 1
           fi
 
-      - name: Materialize production frontend contract + native Firebase config
+      - name: Materialize UAT frontend contract + native Firebase config
         shell: bash
         run: |
           set -euo pipefail
 
-          # Each NEXT_PUBLIC_* value is a GCP Secret Manager secret in hushh-pda
-          # (same source of truth deploy-production.yml uses). The prod prep script
-          # (prepare-ios-prod-archive.mjs) lets process env override APP_RUNTIME_PROFILE
-          # and NEXT_PUBLIC_* keys, and hard-fails on a UAT or localhost backend.
+          # Each NEXT_PUBLIC_* value is a GCP Secret Manager secret in
+          # hushh-pda-uat (same source of truth deploy-uat.yml / the TestFlight
+          # pipeline use). prepare-ios-uat-archive.mjs lets process env override
+          # APP_RUNTIME_PROFILE and NEXT_PUBLIC_* keys; the guard below requires
+          # the UAT backend, since this store build ships against UAT by design.
           get() {
             gcloud secrets versions access latest --secret="$1" --project="${GCP_PROJECT_ID}" 2>/dev/null || true
           }
@@ -196,16 +193,21 @@ jobs:
 
           BACKEND_URL="$(get BACKEND_URL)"
           require BACKEND_URL "$BACKEND_URL"
-          # Fail fast on a non-production backend before the heavy web build.
+          # This store build ships the UAT backend by design. Fail fast BEFORE the
+          # heavy web build if the resolved backend is not the UAT host (guards
+          # against a mis-scoped project or a prod/localhost URL sneaking in).
           BACKEND_HOST="$(printf '%s' "$BACKEND_URL" | sed -E 's#^https?://##; s#/.*$##' | tr 'A-Z' 'a-z')"
           case "$BACKEND_HOST" in
-            *uat*|*f2gsa4kfsq*|localhost|127.0.0.1|0.0.0.0|10.0.2.2)
-              echo "Refusing release: NEXT_PUBLIC_BACKEND_URL resolves to non-production host '$BACKEND_HOST'." >&2
+            *uat*|*f2gsa4kfsq*)
+              : # expected UAT backend
+              ;;
+            *)
+              echo "Refusing release: this App Store build must ship the UAT backend, but NEXT_PUBLIC_BACKEND_URL resolves to '$BACKEND_HOST' (project ${GCP_PROJECT_ID})." >&2
               exit 1
               ;;
           esac
           APP_URL="$(get APP_FRONTEND_ORIGIN)"
-          [ -n "$APP_URL" ] || APP_URL="https://one.hushh.ai"
+          [ -n "$APP_URL" ] || APP_URL="https://uat.one.hushh.ai"
 
           FB_API_KEY="$(get NEXT_PUBLIC_FIREBASE_API_KEY)";           require NEXT_PUBLIC_FIREBASE_API_KEY "$FB_API_KEY"
           FB_AUTH_DOMAIN="$(get NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN)";    require NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN "$FB_AUTH_DOMAIN"
@@ -222,8 +224,8 @@ jobs:
           echo "::add-mask::$FB_VAPID"
           [ -n "$MAPS_IOS_KEY" ] && echo "::add-mask::$MAPS_IOS_KEY"
 
-          put APP_RUNTIME_PROFILE "prod"
-          put NEXT_PUBLIC_APP_ENV "production"
+          put APP_RUNTIME_PROFILE "uat"
+          put NEXT_PUBLIC_APP_ENV "uat"
           put NEXT_PUBLIC_BACKEND_URL "$BACKEND_URL"
           put NEXT_PUBLIC_APP_URL "$APP_URL"
           put NEXT_PUBLIC_PASSKEY_RP_ID "one.hushh.ai"
@@ -240,11 +242,11 @@ jobs:
           put NEXT_PUBLIC_OBSERVABILITY_DEBUG "false"
           put NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE "1"
 
-          # Native GoogleService-Info.plist for the iOS target (production Firebase).
+          # Native GoogleService-Info.plist for the iOS target (UAT Firebase).
           PLIST_DEST="hushh-webapp/ios/App/App/GoogleService-Info.plist"
           if ! gcloud secrets describe IOS_GOOGLESERVICE_INFO_PLIST_B64 --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
             echo "Missing GCP secret IOS_GOOGLESERVICE_INFO_PLIST_B64 in ${GCP_PROJECT_ID}." >&2
-            echo "Create it from the PRODUCTION iOS GoogleService-Info.plist:" >&2
+            echo "Create it from the UAT iOS GoogleService-Info.plist:" >&2
             echo "  base64 -i GoogleService-Info.plist | gcloud secrets create IOS_GOOGLESERVICE_INFO_PLIST_B64 --data-file=- --project=${GCP_PROJECT_ID}" >&2
             echo "See docs/guides/mobile/release-ios-appstore.md." >&2
             exit 1
@@ -261,7 +263,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # The ASC signing key lives in GCP Secret Manager (hushh-pda):
+          # The ASC signing key lives in GCP Secret Manager (hushh-pda-uat):
           #   APPSTORE_CONNECT_API_KEY_P8_B64 / _KEY_ID / _ISSUER_ID.
           get() {
             gcloud secrets versions access latest --secret="$1" --project="${GCP_PROJECT_ID}" 2>/dev/null || true
@@ -299,11 +301,11 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN" "login.keychain-db"
           security default-keychain -s "$KEYCHAIN"
 
-      - name: Prepare iOS project (web build + cap sync, PRODUCTION backend)
+      - name: Prepare iOS project (web build + cap sync, UAT backend)
         shell: bash
         run: |
           set -euo pipefail
-          npm run --prefix hushh-webapp ios:prepare:prod
+          npm run --prefix hushh-webapp ios:prepare:uat
 
       - name: Create App Store Connect Python venv
         shell: bash
@@ -351,7 +353,10 @@ jobs:
           set -euo pipefail
           set -o pipefail
           # CODE_SIGN_ENTITLEMENTS override swaps aps-environment development ->
-          # production for the released binary without editing the committed pbxproj.
+          # production for the released binary without editing the committed
+          # pbxproj. A store binary must use production APNs regardless of which
+          # backend/Firebase it talks to (here UAT), so the UAT Firebase project
+          # needs a production APNs key for push to deliver -- see the runbook.
           xcodebuild \
             -project "${XCODE_PROJECT}" \
             -scheme "${XCODE_SCHEME}" \
@@ -391,22 +396,20 @@ jobs:
             -authenticationKeyIssuerID "${ASC_ISSUER_ID}" \
             2>&1 | tee "${RUNNER_TEMP}/xcodebuild-export.log"
 
-      - name: Prepare App Store version (attach build; gated submit)
+      - name: Prepare App Store version (set What's New, attach build; one-click submit)
         id: appstore
         if: ${{ github.event.inputs.dry_run != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
+          # bash 3.2 on macos runners: guard the possibly-empty array under set -u.
           SUBMIT_ARGS=()
           if [ "${{ github.event.inputs.submit_for_review }}" = "true" ]; then
-            if [ "${{ github.event.inputs.ack_publish_blockers }}" != "true" ]; then
-              echo "submit_for_review=true requires ack_publish_blockers=true. Refusing to submit for public review." >&2
-              exit 1
-            fi
-            echo "submit_for_review + ack_publish_blockers set: WILL submit for public App Store review (IRREVERSIBLE)."
+            echo "::warning title=Public App Store submission::submit_for_review=true -> this run will SUBMIT the build for public Apple review (IRREVERSIBLE). Confirm the publish-safety blockers in KT/hushh-one-publish-safety-audit.md (led by PrivacyInfo.xcprivacy privacy-label reconciliation) are cleared, and that ASC metadata/screenshots/age rating/pricing are set for this version."
+            echo "submit_for_review=true: will set What's New, attach the build, and SUBMIT for public App Store review."
             SUBMIT_ARGS+=(--submit)
           else
-            echo "Prepare-only: ensuring MANUAL App Store version and attaching build; NOT submitting for review."
+            echo "Prepare-only: setting What's New, ensuring the MANUAL App Store version, and attaching the build; NOT submitting for review."
           fi
           "${RUNNER_TEMP}/asc-venv/bin/python" scripts/ci/submit-appstore-version.py \
             --p8-path "${RUNNER_TEMP}/asc.p8" \
@@ -416,6 +419,7 @@ jobs:
             --pbxproj "${PBXPROJ}" \
             --build-number "${{ steps.build_number.outputs.next_build }}" \
             --release-type MANUAL \
+            --whats-new "${{ github.event.inputs.whats_new }}" \
             "${SUBMIT_ARGS[@]+"${SUBMIT_ARGS[@]}"}"
 
       - name: Upload build artifacts
@@ -453,17 +457,21 @@ jobs:
             echo "| Version | ${MARKETING:-unknown} |"
             echo "| Build | ${{ steps.build_number.outputs.next_build }} |"
             echo "| Bundle | ${IOS_BUNDLE_ID} |"
-            echo "| Backend | PRODUCTION (hushh-pda) |"
+            echo "| Backend | UAT (hushh-pda-uat) |"
             echo "| Mode | ${MODE} |"
             if [ -n "${{ github.event.inputs.notes }}" ]; then
               echo "| Notes | ${{ github.event.inputs.notes }} |"
             fi
             echo ""
             if [ "${{ github.event.inputs.dry_run }}" != "true" ] && [ "${{ github.event.inputs.submit_for_review }}" != "true" ]; then
-              echo "> Prepared the App Store version with the build attached. The final"
-              echo "> **Submit for Review** action (and Apple's manual metadata / screenshots /"
-              echo "> privacy nutrition labels / age rating / pricing) is still required — see"
-              echo "> the runbook. Re-dispatch with \`submit_for_review=true\` +"
-              echo "> \`ack_publish_blockers=true\` to submit programmatically."
+              echo "> Set What's New, prepared the App Store version, and attached the build."
+              echo "> The final **Submit for Review** action was NOT fired. Re-dispatch with"
+              echo "> \`submit_for_review=true\` to submit for public Apple review in one click"
+              echo "> (screenshots / age rating / pricing are reused from the existing ASC"
+              echo "> listing and stay stable across versions — see the runbook). Confirm the"
+              echo "> publish-safety blockers (KT/hushh-one-publish-safety-audit.md) first."
+            elif [ "${{ github.event.inputs.submit_for_review }}" = "true" ] && [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+              echo "> Set What's New, attached the build, and SUBMITTED for public App Store"
+              echo "> review. Track the review state in App Store Connect."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -393,11 +393,12 @@ See [docs/reference/operations/env-and-secrets.md](../docs/reference/operations/
 >   `APPSTORE_CONNECT_KEY_ID`, and `APPSTORE_CONNECT_ISSUER_ID` from Secret Manager
 >   (`hushh-pda-uat`) via `GCP_SA_KEY_UAT` to build + sign + upload the UAT build to TestFlight.
 >   Setup + flow: [docs/guides/mobile/ship-ios-testflight.md](../docs/guides/mobile/ship-ios-testflight.md).
-> - **Production App Store:** `.github/workflows/release-ios-appstore.yml` reads the **same four
->   secret names from the `hushh-pda` (production) project** — plus the production `NEXT_PUBLIC_*`
->   web contract — via **Workload Identity Federation** (`GCP_WORKLOAD_IDENTITY_PROVIDER` +
->   `GCP_DEPLOY_SERVICE_ACCOUNT`, no JSON key). The deploy service account needs
->   `roles/secretmanager.secretAccessor` on each in `hushh-pda`. Setup + flow:
+> - **Public App Store:** `.github/workflows/release-ios-appstore.yml` reads the **same four
+>   secret names — plus the `NEXT_PUBLIC_*` web contract — from the same `hushh-pda-uat` project via
+>   `GCP_SA_KEY_UAT`**, because the public build ships the **UAT backend + UAT Firebase** (the same
+>   latest frontend+backend as TestFlight). It keeps `environment: production` and the production
+>   actor gate (public submission is a production surface) but keeps the production APNs entitlement,
+>   so the UAT Firebase project must hold a production APNs key. Setup + flow:
 >   [docs/guides/mobile/release-ios-appstore.md](../docs/guides/mobile/release-ios-appstore.md).
 
 - Do not commit production `GoogleService-Info.plist` or `google-services.json`.

--- a/deploy/app_store_deployment.md
+++ b/deploy/app_store_deployment.md
@@ -4,10 +4,11 @@
 > - **TestFlight (UAT):** `.github/workflows/ship-ios-testflight.yml` (say `ship ios`) cuts the
 >   current UAT build and uploads it to TestFlight — runbook:
 >   [docs/guides/mobile/ship-ios-testflight.md](../docs/guides/mobile/ship-ios-testflight.md).
-> - **Production App Store:** `make ios-prod-release` (or
->   `.github/workflows/release-ios-appstore.yml`) builds against production, signs with the
->   production entitlement, uploads to App Store Connect, and prepares the App Store version up to
->   Apple's final review — runbook:
+> - **Public App Store:** `make ios-prod-release` (or
+>   `.github/workflows/release-ios-appstore.yml`) builds against the **UAT backend + UAT Firebase**
+>   (`hushh-pda-uat`, the same latest frontend+backend as TestFlight), signs with the production APNs
+>   entitlement, uploads to App Store Connect, sets "What's New," attaches the build, and — one-click,
+>   opt-in — submits for public Apple review — runbook:
 >   [docs/guides/mobile/release-ios-appstore.md](../docs/guides/mobile/release-ios-appstore.md).
 >
 > The manual iOS steps below remain a reference. The human App Store Connect steps that no pipeline
@@ -18,7 +19,7 @@
 **Status**: Reference for public store submission (iOS TestFlight + App Store upload/prepare are automated — see banner above)  
 **App Name**: Hussh One (display name; historically "Kai")  
 **Bundle ID**: com.hushh.app  
-**Current version**: 1.3.5 (marketing) — see `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj`  
+**Current version**: 1.3.6 (marketing) — see `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj`  
 **Build**: auto-incremented by `scripts/ci/resolve-ios-build-number.py`  
 
 ---

--- a/docs/guides/mobile/release-ios-appstore.md
+++ b/docs/guides/mobile/release-ios-appstore.md
@@ -1,4 +1,4 @@
-# Release iOS to the App Store (production, one command)
+# Release iOS to the App Store (public, one command)
 
 ## Visual Context
 
@@ -6,30 +6,38 @@ Canonical visual owner: [Mobile Guide](../mobile.md).
 
 ## What this is
 
-One command builds a **production** Hussh One iOS release from an exact green `main` SHA, wires it
-to the **production backend + production Firebase** (`hushh-pda`), signs it with the **production
-APNs entitlement** via Apple-managed signing, uploads it to **App Store Connect**, and then
-completes every automatable App Store step **up to — but not including — the final, irreversible
-"Submit for App Store Review" action** (which stays behind an explicit double opt-in).
+One command builds a **public App Store** Hussh One iOS release from an exact green `main` SHA,
+wires it to the **UAT backend + UAT Firebase** (`hushh-pda-uat`) — the *same* latest
+frontend+backend that is live on UAT and ships to TestFlight — signs it with the **production APNs
+entitlement** via Apple-managed signing, uploads it to **App Store Connect**, sets the version's
+**"What's New"** text, attaches the build, and (opt-in, one click) **submits it for public Apple
+review**. By default it stops *before* the final, irreversible "Submit for App Store Review".
 
-This is **not** a TestFlight-only command. TestFlight and the App Store share the same
-archive/export/upload; the difference lives entirely in the App Store version + submission layer
-this pipeline drives. For an internal TestFlight build against UAT, use the sibling pipeline
-instead: `ship-ios-testflight` (runbook: [ship-ios-testflight.md](./ship-ios-testflight.md)).
+> **Why UAT backend on a public build?** This is a deliberate decision: the App Store binary ships
+> the same backend+frontend as UAT/TestFlight, so what reviewers and users get is exactly what was
+> tested. The binary is *identical* to the TestFlight binary — only the App Store version +
+> submission layer differs.
+
+The build still archives with **production APNs** entitlements (correct for *any* App Store binary —
+push on a store build routes through Apple's PRODUCTION APNs). That means the **UAT Firebase project
+must hold a production APNs key** for push notifications to deliver on the released app.
+
+For an internal TestFlight build (no review), use the sibling pipeline: `ship-ios-testflight`
+(runbook: [ship-ios-testflight.md](./ship-ios-testflight.md)).
 
 - **Command:** `npm run --prefix hushh-webapp ios:release:prod` **or** `make ios-prod-release`.
 - **Workflow:** `.github/workflows/release-ios-appstore.yml` (`workflow_dispatch`, `environment: production`).
 - **Dispatcher:** `scripts/release/dispatch-ios-appstore.mjs` (resolves SHA, confirms, dispatches, watches).
-- **Runner:** GitHub-hosted `macos-15` — GCP has no macOS instances and local builds hang inside
-  iCloud Drive, so only the *dispatch* runs on your machine; the Apple build runs in CI.
-- **Target:** bundle `com.hushh.app`, version `1.3.5`, production backend `https://api.hushh.ai`,
-  Firebase project `hushh-pda`.
+- **Runner:** GitHub-hosted `macos-15`, Xcode 26.3 — GCP has no macOS instances and local builds
+  hang inside iCloud Drive, so only the *dispatch* runs on your machine; the Apple build runs in CI.
+- **Target:** bundle `com.hushh.app`, version `1.3.6`, **UAT** backend + Firebase (`hushh-pda-uat`),
+  ASC app id `6757718917`.
 
 ## The final command
 
 ```bash
-# Prepare-only (default): build → sign → upload → attach build to a MANUAL App Store
-# version. Stops before the irreversible public-review submission. SHA = origin/main.
+# Prepare-only (default): build → sign → upload → set What's New → attach build to a MANUAL
+# App Store version. Stops before the irreversible public-review submission. SHA = origin/main.
 make ios-prod-release
 # equivalently:
 npm run --prefix hushh-webapp ios:release:prod
@@ -46,108 +54,129 @@ make ios-prod-release ARGS="--sha 1a2b3c4d"
 ```
 
 ```bash
-# IRREVERSIBLE: also submit the build for public App Store review. Requires BOTH flags,
-# and only after every publish-safety blocker below is cleared.
-make ios-prod-release ARGS="--submit --ack-blockers"
+# Set the App Store "What's New in This Version" text for this release.
+make ios-prod-release ARGS="--whats-new 'Faster onboarding and reliability fixes.'"
 ```
 
-The dispatcher prints the workflow, ref, SHA, backend, and mode, then **pauses for one explicit
-confirmation** (`--yes` skips it in trusted automation; a non-TTY shell requires `--yes`). For a
-public submit it demands you type `submit`, not just `yes`.
+```bash
+# IRREVERSIBLE one-click: also submit the build for public App Store review. On this CLI path it
+# requires --ack-blockers too, and only after every publish-safety blocker below is cleared.
+make ios-prod-release ARGS="--whats-new 'What changed…' --submit --ack-blockers"
+```
 
-You can also dispatch from the GitHub UI: **Actions → Release iOS to App Store → Run workflow**
-(from `main`), with inputs `sha` (required), `dry_run`, `submit_for_review`, `ack_publish_blockers`,
-`notes`.
+The dispatcher prints the workflow, ref, SHA, backend, What's New, and mode, then **pauses for one
+explicit confirmation** (`--yes` skips it in trusted automation; a non-TTY shell requires `--yes`).
+For a public submit it demands you type `submit`, not just `yes`.
+
+### True one-click from the GitHub UI
+
+**Actions → Release iOS to App Store → Run workflow** (from `main`), inputs:
+
+| Input | Meaning |
+| --- | --- |
+| `sha` (required) | Exact green `main` SHA to release. |
+| `dry_run` | Archive + sign only; no upload, no ASC changes. |
+| `whats_new` | "What's New in This Version" (defaults to a generic note). |
+| `submit_for_review` | **IRREVERSIBLE.** Upload, set What's New, attach, and **SUBMIT** for public review. Unchecked = stop after attaching the build. |
+| `notes` | Free-text note for the run summary. |
+
+Checking `submit_for_review` and running is the true one-click straight-to-review path — no
+`ack_publish_blockers` input exists anymore; the single toggle is the switch. (The CLI dispatcher
+keeps a local `--ack-blockers` gate purely to prevent an accidental submit from a script.)
 
 ## Every step the pipeline performs
 
 The workflow runs these in order and **fails immediately with a clear error** at the first problem
-(dispatch origin, actor policy, SHA validity, WIF config, missing secret, non-production backend,
-signing, archive, export/upload, or version/build validation):
+(dispatch origin, actor policy, SHA validity, missing secret, non-UAT backend, signing, archive,
+export/upload, or version/build validation):
 
 1. **Assert dispatch origin.** Refuses to run unless triggered from `main`.
 2. **Checkout + actor policy.** `assert-governed-actor.py --surface production` — only operators in
-   `config/ci-governance.json` → `production.manual_dispatch_users` may dispatch.
+   `config/ci-governance.json` → `production.manual_dispatch_users` may dispatch. (Public submission
+   is a production surface, so the production actor gate stays even though the binary is UAT-backed.)
 3. **Validate the release SHA.** `require-deploy-sha-on-main.sh` confirms the SHA is on `main` and
    passed the required check (`Main Post-Merge Smoke Gate`), then checks it out detached.
-4. **Validate WIF config.** Fails fast if the `GCP_WORKLOAD_IDENTITY_PROVIDER` /
-   `GCP_DEPLOY_SERVICE_ACCOUNT` repository variables are missing.
-5. **Toolchain.** Xcode 16.2; Node 22; `npm ci --prefix hushh-webapp` — this must precede any Swift
+4. **Toolchain.** Xcode 26.3; Node 22; `npm ci --prefix hushh-webapp` — this must precede any Swift
    Package step because `CapApp-SPM/Package.swift` resolves its dependencies from the hoisted
    `node_modules` three directory levels up.
-6. **Authenticate to Google Cloud via Workload Identity Federation** (no JSON key), then assert the
-   active project is exactly `hushh-pda`.
-7. **Materialize the production web contract + native Firebase config.** Reads each
-   `NEXT_PUBLIC_*` value and the native `GoogleService-Info.plist` from `hushh-pda` Secret Manager;
-   sets `APP_RUNTIME_PROFILE=prod`, `NEXT_PUBLIC_APP_ENV=production`,
-   `NEXT_PUBLIC_BACKEND_URL=https://api.hushh.ai`, `NEXT_PUBLIC_APP_URL=https://one.hushh.ai`,
-   `NEXT_PUBLIC_PASSKEY_RP_ID=one.hushh.ai`. **Refuses to continue on a UAT or localhost backend**
-   (belt-and-braces on top of the guard inside `prepare-ios-prod-archive.mjs`).
-8. **Decode the App Store Connect API key** (`.p8` + Key ID + Issuer ID) from `hushh-pda` Secret
+5. **Authenticate to Google Cloud** with the `GCP_SA_KEY_UAT` service-account key (the same secret
+   the TestFlight pipeline uses), then assert the active project is exactly `hushh-pda-uat`.
+6. **Materialize the UAT web contract + native Firebase config.** Reads each `NEXT_PUBLIC_*` value
+   and the native `GoogleService-Info.plist` from `hushh-pda-uat` Secret Manager; sets
+   `APP_RUNTIME_PROFILE=uat`, `NEXT_PUBLIC_APP_ENV=uat`, `NEXT_PUBLIC_BACKEND_URL=<UAT backend>`,
+   `NEXT_PUBLIC_APP_URL=https://uat.one.hushh.ai`, `NEXT_PUBLIC_PASSKEY_RP_ID=one.hushh.ai`.
+   **Refuses to continue unless the backend host is the UAT host** (`*uat*` / the UAT Cloud Run id) —
+   belt-and-braces on top of the guard inside `prepare-ios-uat-archive.mjs`, so a mis-scoped project
+   or a prod/localhost URL can never sneak into a store build.
+7. **Decode the App Store Connect API key** (`.p8` + Key ID + Issuer ID) from `hushh-pda-uat` Secret
    Manager into a `chmod 600` temp file; validates it is a real PEM; masks the identifiers.
-9. **Create + unlock a dedicated signing keychain** (Apple-managed cloud signing needs one).
-10. **Prepare the iOS project against production.** `ios:prepare:prod` runs `cap:build` +
-    `cap:sync:ios` and asserts the bundled backend host is the production host.
-11. **Resolve the next build number.** `resolve-ios-build-number.py` mints an ES256 JWT and returns
-    `max(latest ASC build for 1.3.5, pbxproj CURRENT_PROJECT_VERSION) + 1` — monotonic against both
-    App Store history and the committed value.
-12. **Resolve Swift packages** (cached), then **archive** in Release with the **production
+8. **Create + unlock a dedicated signing keychain** (Apple-managed cloud signing needs one).
+9. **Prepare the iOS project against UAT.** `ios:prepare:uat` runs `cap:build` + `cap:sync:ios` and
+   asserts the bundled backend host is the UAT host.
+10. **Resolve the next build number.** `resolve-ios-build-number.py` mints an ES256 JWT and returns
+    `max(latest ASC build for 1.3.6, pbxproj CURRENT_PROJECT_VERSION) + 1` — monotonic against both
+    App Store history and the committed value. (TestFlight and the App Store share one build-number
+    pool per marketing version.)
+11. **Resolve Swift packages** (cached), then **archive** in Release with the **production APNs
     entitlement override** `CODE_SIGN_ENTITLEMENTS=App/AppRelease.entitlements` (flips
     `aps-environment` development → production for the released binary only; the committed pbxproj
-    stays on `App/App.entitlements`, so local/dev/TestFlight builds are unaffected). Signs with
+    stays on `App/App.entitlements`, so local/dev builds are unaffected). Signs with
     `-allowProvisioningUpdates` + the ASC API key; injects the resolved `CURRENT_PROJECT_VERSION`.
-13. **Export + upload to App Store Connect** via `ios/ExportOptions/AppStoreConnect.plist`
+12. **Export + upload to App Store Connect** via `ios/ExportOptions/AppStoreConnect.plist`
     (`destination=upload`). On `--dry-run`, PlistBuddy rewrites `destination` to `export` so the
     step signs and produces the `.ipa` without uploading.
-14. **Prepare the App Store version (gated submit).** `submit-appstore-version.py` finds/creates an
-    **editable App Store version with `releaseType=MANUAL`** (so it never auto-releases to the
-    public), waits for the uploaded build to reach `processingState=VALID`, and **attaches** it.
-    This is the last automatable step before Apple review. It is skipped entirely on `--dry-run`.
-    Only when **both** `submit_for_review=true` **and** `ack_publish_blockers=true` does it add
-    `--submit`, which creates a review submission and marks it submitted (**irreversible**).
-15. **Upload artifacts + job summary.** `.ipa`, dSYMs, and `xcodebuild` logs are archived; the
-    summary reports SHA, version, build number, backend, and mode.
+13. **Prepare the App Store version (set What's New, attach build, one-click submit).**
+    `submit-appstore-version.py` finds/creates an **editable App Store version with
+    `releaseType=MANUAL`** (so it never auto-releases to the public), **sets the version's
+    `whatsNew`** localization from `--whats-new` (Apple requires this per version — an empty field is
+    what blocks "Add for Review"), waits for the uploaded build to reach `processingState=VALID`, and
+    **attaches** it. It is skipped entirely on `--dry-run`. When `submit_for_review=true`, it also
+    creates/reuses a review submission, adds this version, and marks it submitted (**irreversible**).
+14. **Upload artifacts + job summary.** `.ipa`, dSYMs, and `xcodebuild` logs are archived; the
+    summary reports SHA, version, build number, backend (`UAT (hushh-pda-uat)`), and mode.
 
 ## Required secrets and permissions
 
 > **You (the operator) add every secret yourself.** These instructions never ask anyone else to
 > paste a `.p8`, key, certificate, or token. All secrets live in **GCP Secret Manager, project
-> `hushh-pda`** (production); nothing App Store-related is a GitHub secret.
+> `hushh-pda-uat`**; the only GitHub secret involved is `GCP_SA_KEY_UAT` (already present).
 
-### GCP Secret Manager (`hushh-pda`)
+### GCP Secret Manager (`hushh-pda-uat`)
 
 | Secret | Purpose |
 | --- | --- |
-| `APPSTORE_CONNECT_API_KEY_P8_B64` | Base64 of the ASC API key `.p8` (role **App Manager**). |
+| `APPSTORE_CONNECT_API_KEY_P8_B64` | Base64 of the ASC API key `.p8` (role **Admin** — App Manager cannot mint cloud distribution assets). |
 | `APPSTORE_CONNECT_KEY_ID` | ASC API Key ID. |
 | `APPSTORE_CONNECT_ISSUER_ID` | ASC API Issuer ID. |
-| `IOS_GOOGLESERVICE_INFO_PLIST_B64` | Base64 of the **production** iOS `GoogleService-Info.plist`. |
-| `BACKEND_URL` | Production backend origin (`https://api.hushh.ai`). |
-| `APP_FRONTEND_ORIGIN` | Production app origin (`https://one.hushh.ai`). |
-| `NEXT_PUBLIC_FIREBASE_API_KEY` … `NEXT_PUBLIC_FIREBASE_VAPID_KEY` | Production Firebase web contract (see the workflow's `require` list). |
+| `IOS_GOOGLESERVICE_INFO_PLIST_B64` | Base64 of the **UAT** iOS `GoogleService-Info.plist`. |
+| `BACKEND_URL` | UAT backend origin (the `*uat*` / UAT Cloud Run host). |
+| `APP_FRONTEND_ORIGIN` | UAT app origin (`https://uat.one.hushh.ai`). |
+| `NEXT_PUBLIC_FIREBASE_API_KEY` … `NEXT_PUBLIC_FIREBASE_VAPID_KEY` | UAT Firebase web contract (see the workflow's `require` list). |
 
 Create each once (use `versions add` instead of `create` if it already exists):
 
 ```bash
 base64 -i AuthKey_XXXXXXXXXX.p8 \
-  | gcloud secrets create APPSTORE_CONNECT_API_KEY_P8_B64 --data-file=- --project=hushh-pda
-printf '%s' 'XXXXXXXXXX'   | gcloud secrets create APPSTORE_CONNECT_KEY_ID    --data-file=- --project=hushh-pda
+  | gcloud secrets create APPSTORE_CONNECT_API_KEY_P8_B64 --data-file=- --project=hushh-pda-uat
+printf '%s' 'XXXXXXXXXX'   | gcloud secrets create APPSTORE_CONNECT_KEY_ID    --data-file=- --project=hushh-pda-uat
 printf '%s' '00000000-0000-0000-0000-000000000000' \
-  | gcloud secrets create APPSTORE_CONNECT_ISSUER_ID --data-file=- --project=hushh-pda
+  | gcloud secrets create APPSTORE_CONNECT_ISSUER_ID --data-file=- --project=hushh-pda-uat
 base64 -i GoogleService-Info.plist \
-  | gcloud secrets create IOS_GOOGLESERVICE_INFO_PLIST_B64 --data-file=- --project=hushh-pda
+  | gcloud secrets create IOS_GOOGLESERVICE_INFO_PLIST_B64 --data-file=- --project=hushh-pda-uat
 ```
 
-### GitHub repository variables (production environment)
+### GitHub secret
 
-`GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SERVICE_ACCOUNT` — the same WIF pair
-`deploy-production.yml` uses. No GCP JSON key is involved.
+`GCP_SA_KEY_UAT` — a service-account JSON key with `secretAccessor` on the secrets above, in
+`hushh-pda-uat`. It is a repository-level secret inherited by the `production` environment (same key
+the TestFlight pipeline uses). No Workload Identity Federation and no GCP JSON key is needed on the
+prod side anymore.
 
 ### IAM precondition
 
-The deploy service account (`GCP_DEPLOY_SERVICE_ACCOUNT`) must hold
-`roles/secretmanager.secretAccessor` on **every** secret above, in `hushh-pda`. Missing access
-surfaces as a `Missing GCP secret …` failure in the materialize/decode steps.
+The `GCP_SA_KEY_UAT` service account must hold `roles/secretmanager.secretAccessor` on **every**
+secret above, in `hushh-pda-uat`. Missing access surfaces as a `Missing GCP secret …` failure in the
+materialize/decode steps.
 
 ### Actor authorization
 
@@ -162,9 +191,10 @@ the password is never entered by tooling.
 
 ## What Apple does not let us automate
 
-The pipeline automates build → sign → archive → validate → upload → attach → (optional) submit. The
-following must be done **once per version in App Store Connect by a human** and are **not**
-automatable through this pipeline:
+The pipeline automates build → sign → archive → validate → upload → **set What's New** → attach →
+(optional) submit. Everything below must be set up **once in App Store Connect by a human** and is
+**stable across versions** — per the product decision, screenshots and metadata do not change for
+~2 months, so they only need doing when they actually change, not per release:
 
 - Store **metadata**: name, subtitle, description, keywords, promotional text, support/marketing URLs.
 - **Screenshots** and app previews for every required device class.
@@ -172,20 +202,18 @@ automatable through this pipeline:
   `PrivacyInfo.xcprivacy`; both must agree).
 - **Age rating** questionnaire.
 - **Pricing and availability**.
-- **Export-compliance** beyond the bundled `ITSAppUsesNonExemptEncryption=false` attestation, if
-  the app ever adds non-exempt cryptography.
 - Accepting Apple **agreements** (above).
-- The **final human review** of all of the above. `--submit` can programmatically press "Submit for
-  Review", but doing so with incomplete/incorrect metadata will draw an Apple rejection — so treat
-  the human metadata pass as a hard prerequisite for `--submit`.
 
-## Publish-safety blockers (preconditions for `--submit`)
+The one genuinely per-version field, **"What's New in This Version,"** *is* automated by this
+pipeline via `--whats-new` / the `whats_new` input. Submitting with incomplete/incorrect metadata
+will draw an Apple rejection, so treat the one-time human metadata pass as a prerequisite for
+`--submit`.
 
-`--submit` is deliberately double-gated (`--submit --ack-blockers`, and the workflow re-checks
-`ack_publish_blockers`) because a public submission is irreversible and exposes real users. Before
-setting those flags, clear the full publish-safety audit — summarized in
-`KT/hushh-one-publish-safety-audit.md` (~17 items; that file may live outside this branch). The
-non-negotiable ones:
+## Publish-safety blockers (preconditions for `submit_for_review`)
+
+A public submission is irreversible and exposes real users. Before submitting, clear the full
+publish-safety audit — summarized in `KT/hushh-one-publish-safety-audit.md` (~17 items; that file may
+live outside this branch). The non-negotiable ones:
 
 1. **`PrivacyInfo.xcprivacy` reconciliation.** `hushh-webapp/ios/App/App/PrivacyInfo.xcprivacy` in
    this branch is a best-effort declaration (collected data types, tracking=false, required-reason
@@ -196,48 +224,31 @@ non-negotiable ones:
 3. Everything else enumerated in the audit.
 
 Prepare-only mode (the default) requires none of this — it is safe to run repeatedly to stage a
-build for review.
+build, set its release notes, and attach it for review.
 
 ## Verify (don't stop at "workflow green")
 
-1. Read the run's **job summary**: SHA, version `1.3.5`, resolved build number, backend
-   `PRODUCTION (hushh-pda)`, and mode.
+1. Read the run's **job summary**: SHA, version `1.3.6`, resolved build number, backend
+   `UAT (hushh-pda-uat)`, and mode.
 2. **First run after any signing/secret change:** dispatch with `--dry-run` to prove web build,
    cap sync, SPM resolve, **archive, and signing** all succeed before any upload.
-3. For a real prepare-only run: confirm in App Store Connect that version `1.3.5` shows the new
-   build attached, release type **Manual**, state still editable (not submitted).
-4. On device (optional): a TestFlight copy of the same archive boots against the production backend.
-
-## Verification status of this pipeline (honest boundary)
-
-What has been verified statically and offline in this branch:
-
-- The dispatcher parses (`node --check`), its `--help` and arg-gating work, and `--submit` without
-  `--ack-blockers` **fails fast** (exit 1).
-- `submit-appstore-version.py` compiles and its offline `--self-test` passes (JWT mint/verify +
-  argument parsing, no network, no real key).
-- `resolve-ios-build-number.py`, the ExportOptions plist, `AppRelease.entitlements`, and the
-  `PrivacyInfo.xcprivacy` pbxproj wiring all lint clean.
-- The workflow reuses the exact governance gates and the proven archive/export/upload path from the
-  green TestFlight pipeline, adding only the production project, WIF auth, the production entitlement
-  override, and the version/submit layer.
-
-What has **not** been executed here, and why:
-
-- A **live archive/upload/submission** cannot run on this machine (no non-iCloud macOS build host
-  wired for CI locally) and must run on the `macos-15` runner with the operator's secrets in place.
-- **No public App Store submission has been performed.** `--submit` is off by default and was never
-  fired. The final review submission — and all the human ASC steps above — remain the operator's
-  explicit, gated actions.
+3. For a real prepare-only run: confirm in App Store Connect that version `1.3.6` shows the new
+   build attached, "What's New" populated, release type **Manual**, state still editable (not
+   submitted).
+4. For a submit run: confirm the review submission appears in ASC and its state moves to
+   `WAITING_FOR_REVIEW` / `IN_REVIEW`.
+5. On device (optional): a TestFlight copy of the same archive boots against the **UAT** backend.
 
 ## Troubleshooting
 
 | Symptom | Cause / fix |
 | --- | --- |
-| `Missing GCP secret …` | Secret absent in `hushh-pda`, or the deploy SA lacks `secretAccessor`. See setup. |
-| `resolves to non-production host` | `BACKEND_URL` points at UAT/localhost. Fix the production secret. |
-| `requires App Manager` / authz error | ASC API key role too low — regenerate as **App Manager**. |
+| `Missing GCP secret …` | Secret absent in `hushh-pda-uat`, or the `GCP_SA_KEY_UAT` SA lacks `secretAccessor`. See setup. |
+| `must ship the UAT backend, but … resolves to '<host>'` | `BACKEND_URL` in `hushh-pda-uat` points at a non-UAT host. Fix the secret. |
+| `Cloud signing permission error` / `No signing certificate "iOS Distribution"` | ASC API key role too low — regenerate as **Admin** (App Manager cannot mint cloud distribution assets). |
+| `Invalid Pre-Release Train … is closed` / `must contain a higher version` | The marketing version is approved/closed. Bump `MARKETING_VERSION` (App target Debug+Release), land on `main`, re-release. A `--dry-run` will NOT catch this. |
+| `This field is required` on Add for Review | Empty "What's New". Re-run with `--whats-new "…"`; the pipeline now sets it automatically. |
 | Export/upload agreement error | Accept the Apple Program License Agreement in App Store Connect. |
-| Duplicate build number rejected | Check `resolve-ios-build-number.py` stderr in the archive log artifact. |
+| Duplicate build number rejected | The ASC builds API lags a just-uploaded build; re-run so the resolver sees the sibling and picks N+1. |
 | Build stuck `PROCESSING` past the timeout | Apple-side processing delay; re-run prepare-only once the build shows in ASC. |
-| `submit_for_review=true requires ack_publish_blockers=true` | Intentional gate. Clear the blockers, then pass both. |
+| dSYM "Upload Symbols Failed" (Firebase/Google frameworks) | Non-fatal warnings; they do not fail the upload. |

--- a/scripts/ci/submit-appstore-version.py
+++ b/scripts/ci/submit-appstore-version.py
@@ -12,10 +12,13 @@ Two modes:
 * **default (prepare-only, fully automatable, safe)** -- resolve the app for the
   bundle id, ensure an editable App Store version exists for the marketing
   version with ``releaseType = MANUAL`` (so an approved app never auto-releases
-  to the public without a human pressing "Release"), wait for the uploaded build
-  to finish processing, and attach that build to the version. This performs every
-  automatable step *up to but not including* the irreversible "submit for review"
-  action, then stops.
+  to the public without a human pressing "Release"), set the required
+  "What's New in This Version" release notes (``--whats-new``) on every
+  localization, wait for the uploaded build to finish processing, and attach that
+  build to the version. This performs every automatable step *up to but not
+  including* the irreversible "submit for review" action, then stops. Setting
+  whatsNew here is what lets a later one-click submit clear Apple's
+  "What's New in This Version - This field is required" gate.
 
 * ``--submit`` (opt-in, gated, IRREVERSIBLE) -- additionally create a review
   submission, add the version to it, and mark it submitted. This is the action
@@ -64,6 +67,11 @@ EDITABLE_VERSION_STATES = {
 BUILD_STATE_VALID = "VALID"
 BUILD_STATE_PROCESSING = "PROCESSING"
 BUILD_TERMINAL_BAD = {"FAILED", "INVALID"}
+# AppStoreVersionLocalization.whatsNew is capped at 4000 characters by Apple.
+WHATS_NEW_MAX = 4000
+# A review submission that has not been submitted yet can still take items /
+# be submitted; anything past this is already with Apple and must not be reused.
+REVIEW_SUBMISSION_OPEN_STATE = "READY_FOR_REVIEW"
 
 
 def log(message: str) -> None:
@@ -337,55 +345,182 @@ def attach_build(token: str, version_id: str, build_id: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# "What's New in This Version" (required metadata; empty value blocks review)
+# --------------------------------------------------------------------------- #
+def _clamp_whats_new(text: str) -> str:
+    """Trim to Apple's 4000-char limit (pure; unit-tested by --self-test)."""
+    text = text.strip()
+    if len(text) <= WHATS_NEW_MAX:
+        return text
+    log(
+        f"whatsNew is {len(text)} chars; truncating to Apple's "
+        f"{WHATS_NEW_MAX}-char limit"
+    )
+    return text[:WHATS_NEW_MAX]
+
+
+def set_whats_new(token: str, version_id: str, whats_new: str) -> int:
+    """Set whatsNew on every localization of the version.
+
+    "What's New in This Version" is required by Apple for each new version (the
+    first version uses the app description instead). An empty whatsNew is exactly
+    what makes App Store Connect reject "Add for Review" with
+    "What's New in This Version - This field is required", so populating it is the
+    load-bearing step that lets a one-click submit go through. Returns the number
+    of localizations updated.
+    """
+    whats_new = _clamp_whats_new(whats_new)
+    url = (
+        f"{ASC_API_ROOT}/v1/appStoreVersions/{version_id}"
+        "/appStoreVersionLocalizations"
+    )
+    locs = asc_get(url, token).get("data") or []
+    if not locs:
+        # A freshly created version can start with no localizations; create the
+        # primary en-US one so the required field is present.
+        log("no appStoreVersionLocalizations found; creating en-US")
+        created = asc_post(
+            f"{ASC_API_ROOT}/v1/appStoreVersionLocalizations",
+            token,
+            {
+                "data": {
+                    "type": "appStoreVersionLocalizations",
+                    "attributes": {"locale": "en-US", "whatsNew": whats_new},
+                    "relationships": {
+                        "appStoreVersion": {
+                            "data": {
+                                "type": "appStoreVersions",
+                                "id": version_id,
+                            }
+                        }
+                    },
+                }
+            },
+        ).get("data")
+        if created:
+            log(f"created localization {created['id']} (en-US) with whatsNew")
+            return 1
+        return 0
+
+    updated = 0
+    for loc in locs:
+        loc_id = loc["id"]
+        locale = (loc.get("attributes") or {}).get("locale")
+        asc_patch(
+            f"{ASC_API_ROOT}/v1/appStoreVersionLocalizations/{loc_id}",
+            token,
+            {
+                "data": {
+                    "type": "appStoreVersionLocalizations",
+                    "id": loc_id,
+                    "attributes": {"whatsNew": whats_new},
+                }
+            },
+        )
+        updated += 1
+        log(f"set whatsNew on localization {loc_id} ({locale})")
+    return updated
+
+
+# --------------------------------------------------------------------------- #
 # Gated public submission (IRREVERSIBLE)
 # --------------------------------------------------------------------------- #
+def find_open_review_submission(
+    token: str, app_id: str, platform: str
+) -> dict | None:
+    """Return an existing not-yet-submitted review submission, if any.
+
+    Apple allows only one open review submission per app at a time; a prior
+    attempt (including a click on 'Add for Review' in the ASC UI) can leave one
+    in ``READY_FOR_REVIEW``. Reusing it avoids a 409 on create.
+    """
+    query = urllib.parse.urlencode(
+        {
+            "filter[app]": app_id,
+            "filter[state]": REVIEW_SUBMISSION_OPEN_STATE,
+            "limit": "20",
+        }
+    )
+    url = f"{ASC_API_ROOT}/v1/reviewSubmissions?{query}"
+    data = asc_get(url, token).get("data") or []
+    for submission in data:
+        if (submission.get("attributes") or {}).get("platform") == platform:
+            return submission
+    return data[0] if data else None
+
+
+def review_submission_has_version(
+    token: str, submission_id: str, version_id: str
+) -> bool:
+    """True if the version is already an item on the submission (avoid a dup)."""
+    url = (
+        f"{ASC_API_ROOT}/v1/reviewSubmissions/{submission_id}/items"
+        "?include=appStoreVersion&limit=50"
+    )
+    for item in asc_get(url, token).get("data") or []:
+        rel = ((item.get("relationships") or {}).get("appStoreVersion") or {}).get(
+            "data"
+        ) or {}
+        if rel.get("id") == version_id:
+            return True
+    return False
+
+
 def submit_for_review(
     token: str, app_id: str, version_id: str, platform: str
 ) -> str:
-    """Create + submit a review submission. IRREVERSIBLE public-release action."""
-    log("creating review submission (IRREVERSIBLE public App Store submission)")
-    submission = asc_post(
-        f"{ASC_API_ROOT}/v1/reviewSubmissions",
-        token,
-        {
-            "data": {
-                "type": "reviewSubmissions",
-                "attributes": {"platform": platform},
-                "relationships": {
-                    "app": {"data": {"type": "apps", "id": app_id}}
-                },
-            }
-        },
-    ).get("data")
-    if not submission:
-        die("review submission creation returned no data")
-    submission_id = submission["id"]
-    log(f"review submission id = {submission_id}")
+    """Create/reuse + submit a review submission. IRREVERSIBLE public release."""
+    submission = find_open_review_submission(token, app_id, platform)
+    if submission is not None:
+        submission_id = submission["id"]
+        log(f"reusing existing open review submission {submission_id}")
+    else:
+        log("creating review submission (IRREVERSIBLE public App Store submission)")
+        submission = asc_post(
+            f"{ASC_API_ROOT}/v1/reviewSubmissions",
+            token,
+            {
+                "data": {
+                    "type": "reviewSubmissions",
+                    "attributes": {"platform": platform},
+                    "relationships": {
+                        "app": {"data": {"type": "apps", "id": app_id}}
+                    },
+                }
+            },
+        ).get("data")
+        if not submission:
+            die("review submission creation returned no data")
+        submission_id = submission["id"]
+        log(f"review submission id = {submission_id}")
 
-    log("adding App Store version to review submission")
-    asc_post(
-        f"{ASC_API_ROOT}/v1/reviewSubmissionItems",
-        token,
-        {
-            "data": {
-                "type": "reviewSubmissionItems",
-                "relationships": {
-                    "reviewSubmission": {
-                        "data": {
-                            "type": "reviewSubmissions",
-                            "id": submission_id,
-                        }
+    if review_submission_has_version(token, submission_id, version_id):
+        log("App Store version already attached to the review submission")
+    else:
+        log("adding App Store version to review submission")
+        asc_post(
+            f"{ASC_API_ROOT}/v1/reviewSubmissionItems",
+            token,
+            {
+                "data": {
+                    "type": "reviewSubmissionItems",
+                    "relationships": {
+                        "reviewSubmission": {
+                            "data": {
+                                "type": "reviewSubmissions",
+                                "id": submission_id,
+                            }
+                        },
+                        "appStoreVersion": {
+                            "data": {
+                                "type": "appStoreVersions",
+                                "id": version_id,
+                            }
+                        },
                     },
-                    "appStoreVersion": {
-                        "data": {
-                            "type": "appStoreVersions",
-                            "id": version_id,
-                        }
-                    },
-                },
-            }
-        },
-    )
+                }
+            },
+        )
 
     log("marking review submission as submitted")
     asc_patch(
@@ -444,6 +579,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=os.environ.get("IOS_ASC_RELEASE_TYPE", "MANUAL"),
         choices=["MANUAL", "AFTER_APPROVAL", "SCHEDULED"],
         help="App Store release type (default MANUAL: never auto-release).",
+    )
+    parser.add_argument(
+        "--whats-new",
+        default=os.environ.get("IOS_WHATS_NEW"),
+        help=(
+            "'What's New in This Version' release notes, set on every "
+            "localization. Required by Apple for each new version; leaving it "
+            "empty is what blocks 'Add for Review'. Truncated to 4000 chars."
+        ),
     )
     parser.add_argument(
         "--wait-timeout",
@@ -512,16 +656,28 @@ def run_self_test() -> int:
         os.unlink(p8_path)
 
     # Argument parsing must accept the documented shape without a real key.
-    parse_args(
+    ns = parse_args(
         [
             "--p8-path", "/dev/null",
             "--key-id", "K",
             "--issuer-id", "I",
             "--marketing-version", "1.3.5",
             "--build-number", "57",
+            "--whats-new", "Bug fixes and improvements.",
+            "--submit",
         ]
     )
-    log("self-test OK: JWT mint/verify + arg parsing succeeded (offline)")
+    assert ns.whats_new == "Bug fixes and improvements.", "whats-new not parsed"
+    assert ns.submit is True, "submit flag not parsed"
+
+    # whatsNew clamping is pure and load-bearing (empty/overlong values are what
+    # break a one-click submit), so exercise it offline.
+    assert _clamp_whats_new("  hi  ") == "hi", "clamp should strip"
+    long_note = "x" * (WHATS_NEW_MAX + 50)
+    clamped = _clamp_whats_new(long_note)
+    assert len(clamped) == WHATS_NEW_MAX, "clamp should cap at WHATS_NEW_MAX"
+
+    log("self-test OK: JWT mint/verify + arg parsing + whatsNew clamp (offline)")
     return 0
 
 
@@ -557,6 +713,15 @@ def main(argv: list[str]) -> int:
         token, app_id, marketing_version, args.platform, args.release_type
     )
     version_id = version["id"]
+
+    # Populate the required "What's New in This Version" field before anything
+    # else so a prepare-only run still leaves the version submittable, and a
+    # one-click submit does not trip Apple's "This field is required" gate.
+    if args.whats_new and args.whats_new.strip():
+        count = set_whats_new(token, version_id, args.whats_new)
+        log(f"whatsNew set on {count} localization(s)")
+    else:
+        log("no --whats-new provided; leaving existing release notes untouched")
 
     build = wait_for_build(
         token,

--- a/scripts/release/dispatch-ios-appstore.mjs
+++ b/scripts/release/dispatch-ios-appstore.mjs
@@ -8,26 +8,31 @@
  * explicit confirmation, dispatches the workflow with `gh workflow run`, then
  * streams the run with `gh run watch`.
  *
- * The Apple-facing work (build → sign with production entitlements → archive →
- * upload to App Store Connect → prepare the App Store version) all runs on the
- * GitHub macOS runner, because GCP has no macOS instances and local builds hang
- * inside iCloud Drive. This script is the thin, auditable dispatcher.
+ * The Apple-facing work (build the UAT-backed app → sign with production APNs
+ * entitlements → archive → upload to App Store Connect → set What's New →
+ * attach the build → optionally submit for review) all runs on the GitHub macOS
+ * runner, because GCP has no macOS instances and local builds hang inside iCloud
+ * Drive. This script is the thin, auditable dispatcher.
+ *
+ * BACKEND: the public App Store build ships the SAME UAT backend + UAT Firebase
+ * (hushh-pda-uat) as TestFlight — the latest frontend+backend that is live on
+ * UAT. It is NOT built against a separate production backend.
  *
  * SAFETY / IRREVERSIBILITY
  *   By default this prepares the release up to — but NOT including — the final,
- *   irreversible "Submit for App Store Review" action. Submitting for public
- *   review requires BOTH flags together:
- *       --submit --ack-blockers
- *   which map to the workflow's `submit_for_review=true` + `ack_publish_blockers=true`.
- *   The workflow itself re-checks that both are set. Never pass --submit from an
- *   automated context; it publishes to real users and cannot be undone.
+ *   irreversible "Submit for App Store Review" action. One-click submission maps
+ *   to the workflow's `submit_for_review=true`. On this CLI path it additionally
+ *   requires a local `--ack-blockers` acknowledgement so a public submit is never
+ *   fired by accident or from an automated context; it publishes to real users
+ *   and cannot be undone. Clear the publish-safety blockers first.
  *
  * Usage:
  *   node scripts/release/dispatch-ios-appstore.mjs                 # prepare-only, SHA=origin/main
  *   node scripts/release/dispatch-ios-appstore.mjs --sha <sha>     # pin an explicit green SHA
  *   node scripts/release/dispatch-ios-appstore.mjs --dry-run       # archive+sign only, no upload
+ *   node scripts/release/dispatch-ios-appstore.mjs --whats-new "..."  # App Store release notes for this version
  *   node scripts/release/dispatch-ios-appstore.mjs --notes "..."   # annotate the run summary
- *   node scripts/release/dispatch-ios-appstore.mjs --submit --ack-blockers   # IRREVERSIBLE public submit
+ *   node scripts/release/dispatch-ios-appstore.mjs --submit --ack-blockers   # IRREVERSIBLE one-click public submit
  *   node scripts/release/dispatch-ios-appstore.mjs --yes           # skip the interactive confirm
  *   node scripts/release/dispatch-ios-appstore.mjs --no-watch      # dispatch and return immediately
  */
@@ -58,6 +63,7 @@ function parseArgs(argv) {
     dryRun: false,
     submit: false,
     ackBlockers: false,
+    whatsNew: "",
     notes: "",
     yes: false,
     watch: true,
@@ -77,6 +83,9 @@ function parseArgs(argv) {
       case "--ack-blockers":
         opts.ackBlockers = true;
         break;
+      case "--whats-new":
+        opts.whatsNew = argv[++i] ?? "";
+        break;
       case "--notes":
         opts.notes = argv[++i] ?? "";
         break;
@@ -91,7 +100,7 @@ function parseArgs(argv) {
       case "-h":
         console.log(
           "Usage: node scripts/release/dispatch-ios-appstore.mjs " +
-            "[--sha <sha>] [--dry-run] [--submit --ack-blockers] [--notes <text>] [--yes] [--no-watch]",
+            "[--sha <sha>] [--dry-run] [--whats-new <text>] [--submit --ack-blockers] [--notes <text>] [--yes] [--no-watch]",
         );
         process.exit(0);
         break;
@@ -191,12 +200,15 @@ async function main() {
 
   console.log("\nProduction iOS App Store release");
   console.log("────────────────────────────────");
-  console.log(`  Workflow : ${WORKFLOW}`);
-  console.log(`  Ref      : ${REF}`);
-  console.log(`  SHA      : ${sha}`);
-  console.log(`  Backend  : PRODUCTION (hushh-pda / api.hushh.ai)`);
-  console.log(`  Mode     : ${mode}`);
-  if (opts.notes) console.log(`  Notes    : ${opts.notes}`);
+  console.log(`  Workflow  : ${WORKFLOW}`);
+  console.log(`  Ref       : ${REF}`);
+  console.log(`  SHA       : ${sha}`);
+  console.log(`  Backend   : UAT (hushh-pda-uat) — same as TestFlight`);
+  console.log(`  Mode      : ${mode}`);
+  if (!opts.dryRun) {
+    console.log(`  What's New : ${opts.whatsNew || "(workflow default)"}`);
+  }
+  if (opts.notes) console.log(`  Notes     : ${opts.notes}`);
   console.log("");
 
   if (!opts.yes) {
@@ -213,9 +225,12 @@ async function main() {
 
   const ghArgs = ["workflow", "run", WORKFLOW, "--ref", REF, "-f", `sha=${sha}`];
   if (opts.dryRun) ghArgs.push("-f", "dry_run=true");
+  if (opts.whatsNew) ghArgs.push("-f", `whats_new=${opts.whatsNew}`);
   if (opts.notes) ghArgs.push("-f", `notes=${opts.notes}`);
+  // --ack-blockers is a local CLI safety gate (checked above); the workflow no
+  // longer takes an ack input — one-click submit is the single submit_for_review flag.
   if (opts.submit) {
-    ghArgs.push("-f", "submit_for_review=true", "-f", "ack_publish_blockers=true");
+    ghArgs.push("-f", "submit_for_review=true");
   }
 
   console.log(`\n$ gh ${ghArgs.join(" ")}\n`);


### PR DESCRIPTION
## What & why

The public **App Store** release pipeline now ships the **same UAT backend + UAT Firebase (`hushh-pda-uat`)** as TestFlight — the latest frontend+backend that is live on UAT — instead of a separate production backend. Per the product decision, the store binary should be exactly what was tested on UAT/TestFlight. The archived binary is **identical** to the TestFlight build; only the App Store version + submission layer differs.

The build **keeps the production APNs entitlement** (`App/AppRelease.entitlements`, `aps-environment=production`) because push on *any* store binary routes through Apple's production APNs — so the **UAT Firebase project must hold a production APNs key** for push to deliver on the released app.

It also adds **true one-click straight-to-review**: the required *"What's New in This Version"* localization is now auto-populated (an empty field is what was blocking ASC "Add for Review"), and the review submission is reused/created robustly. A single `submit_for_review` toggle drives the irreversible public submit.

## Changes

- **`.github/workflows/release-ios-appstore.yml`** — auth via `GCP_SA_KEY_UAT`, project `hushh-pda-uat`, UAT backend guard; keeps `environment: production` + production actor gate (public submission is a production surface). Sets What's New, attaches the build, opt-in submit. Removes the `ack_publish_blockers` input; adds `whats_new`. Removes WIF (`GCP_WORKLOAD_IDENTITY_PROVIDER`/`GCP_DEPLOY_SERVICE_ACCOUNT`).
- **`scripts/ci/submit-appstore-version.py`** — `set_whats_new()` (POST/PATCH `AppStoreVersionLocalization.whatsNew`), open-submission reuse + item dedupe, `--whats-new` (default `IOS_WHATS_NEW`).
- **`scripts/release/dispatch-ios-appstore.mjs`** — UAT backend framing, `--whats-new`, `--submit` maps to `submit_for_review=true`; local `--ack-blockers` gate retained so a script can't fire a public submit by accident.
- **Docs** — runbook (`docs/guides/mobile/release-ios-appstore.md`), skill (`.claude/skills/release-ios-appstore/SKILL.md`), and `deploy/README.md` + `deploy/app_store_deployment.md` reconciled to: UAT backend + Firebase (`hushh-pda-uat`), SA-key auth, Xcode 26.3, version 1.3.6, **Admin** ASC role, `whats_new`; production-backend/WIF/App-Manager/1.3.5 references removed.

## Safety

- Default is **prepare-only** (upload → set What's New → attach → stop before review). Public submission is **irreversible** and opt-in via the single `submit_for_review` toggle (GitHub UI) / `--submit --ack-blockers` (CLI).
- Publish-safety blockers (led by `PrivacyInfo.xcprivacy` reconciliation) documented as preconditions for `submit_for_review` — see `KT/hushh-one-publish-safety-audit.md`.
- No secrets touched; all live in GCP Secret Manager (`hushh-pda-uat`); the only GitHub secret is the pre-existing `GCP_SA_KEY_UAT`.

## Verification

- `release-ios-appstore.yml` validates as YAML; `submit-appstore-version.py` compiles; `dispatch-ios-appstore.mjs` passes `node --check`.
- Recommended first run after merge: dispatch with `dry_run=true` to prove web build → cap sync → SPM resolve → **archive + signing** before any upload.