### PR TITLE
feat(skills): mirror release-ios-appstore governed skill for Codex

### DIFF
--- a/.codex/evals/cases/release-ios-appstore.json
+++ b/.codex/evals/cases/release-ios-appstore.json
@@ -1,0 +1,37 @@
+{
+  "skill_name": "release-ios-appstore",
+  "trigger": {
+    "positive": [
+      {
+        "prompt": "release the Hushh One iOS app to the public App Store from the latest green main",
+        "top_k": 3
+      },
+      {
+        "prompt": "submit the iOS build for public App Store review and set the What's New notes",
+        "top_k": 3
+      },
+      {
+        "prompt": "cut a prod iOS App Store build, upload to App Store Connect, and attach the processed build",
+        "top_k": 3
+      },
+      {
+        "prompt": "verify the App Store Connect version and submission state after a release run",
+        "top_k": 3
+      }
+    ],
+    "negative": [
+      {
+        "prompt": "run a scoped backend-only UAT deploy and capture Cloud Run revision evidence",
+        "owner": "uat-scoped-deploy"
+      },
+      {
+        "prompt": "fix the Capacitor iOS native plugin bridge and app entitlements build error",
+        "owner": "mobile-native"
+      },
+      {
+        "prompt": "review whether the release PR is safe to merge and check the blocker gates",
+        "owner": "pr-governance-review"
+      }
+    ]
+  }
+}

--- a/.codex/skills/release-ios-appstore/SKILL.md
+++ b/.codex/skills/release-ios-appstore/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: release-ios-appstore
+description: Use when releasing, submitting, or verifying a public Hussh One iOS App Store build cut from green main — Apple-managed signing with an Admin ASC API key, a UAT-backend/UAT-Firebase binary, per-version "What's New" and build attach via the ASC API, and the two-gate dispatch path (prepare-only default, opt-in irreversible public submit).
+---
+
+# Hussh Release iOS to App Store Skill
+
+## Purpose and Trigger
+
+- Primary scope: `release-ios-appstore-scope`
+- Trigger on releasing, submitting, or verifying a public iOS App Store build from a green `main` SHA.
+- Avoid overlap with `uat-scoped-deploy`, `mobile-native`, and broad `repo-operations` intake.
+
+## Coverage and Ownership
+
+- Role: `spoke`
+- Owner family: `repo-operations`
+
+Owned repo surfaces:
+
+1. `.github/workflows/release-ios-appstore.yml`
+2. `scripts/release/dispatch-ios-appstore.mjs`
+
+Non-owned surfaces:
+
+1. `mobile-native`
+2. `uat-scoped-deploy`
+3. `security-audit`
+4. `repo-operations`
+
+## Do Use
+
+1. Cutting a public App Store build from the latest green `main` (prepare-only by default).
+2. Setting per-version "What's New", attaching the processed build, and resolving the build number.
+3. Verifying an App Store Connect upload/version/submission state after a "Release iOS to App Store" run.
+
+## Do Not Use
+
+1. TestFlight-only distribution — use the `ship-ios-testflight` sibling (same UAT-backed binary).
+2. Merging code to `main`; this ships what is already on `main` and never merges.
+3. Production Cloud Run or scoped UAT deploys — route to `uat-scoped-deploy`.
+4. Publish-safety clearance or consent-boundary decisions — route to `security-audit`.
+
+## Read First
+
+1. `.github/workflows/release-ios-appstore.yml`
+2. `docs/guides/mobile/release-ios-appstore.md`
+3. `scripts/release/dispatch-ios-appstore.mjs`
+4. `scripts/ci/submit-appstore-version.py`
+5. `scripts/ci/resolve-ios-build-number.py`
+6. `deploy/app_store_deployment.md`
+7. `docs/reference/operations/branch-governance.md`
+8. `.codex/skills/release-ios-appstore/references/release-proof.md`
+
+## Workflow
+
+1. Confirm the `gh` actor is in `config/ci-governance.json` -> `production.manual_dispatch_users`, else STOP (the run is rejected by `scripts/ci/assert-governed-actor.py` with `--surface production`).
+2. Pick SHA = user-provided else latest `origin/main`; it must be an ancestor of `origin/main`.
+3. Require "Main Post-Merge Smoke Gate" = success on that exact SHA (the workflow re-checks via `scripts/ci/require-deploy-sha-on-main.sh` and refuses otherwise).
+4. First run after any signing/secret change, dispatch a dry run (`make ios-prod-release-dry`): archive + sign, no upload. A dry run does NOT catch a closed marketing-version train.
+5. GATE 1 (every dispatch): restate workflow, `--ref main`, short SHA, mode, backend = UAT (`hushh-pda-uat`), bundle `com.hushh.app`; get an explicit yes, then `make ios-prod-release ARGS="--sha <sha> --yes --whats-new '<notes>'"` (prepare-only default; no `--submit`).
+6. If a real upload fails with "train ... is closed", bump `MARKETING_VERSION` in `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj` (Debug+Release), land it on `main`, re-release; the resolver only bumps the build number.
+7. GATE 2 (public submission only): irreversible and publishes to real users; requires a fresh explicit yes and every publish-safety blocker cleared, then `--submit --ack-blockers` (workflow input `submit_for_review=true`). Never dispatch submit from automation or on assumption.
+8. Verify from the ASC API and the run Job summary — uploaded, processed, "What's New" set, build attached, submitted-or-prepared — before reporting done. Never print, paste, or read the ASC `.p8` / Key / Issuer secrets.
+
+## Handoff Rules
+
+1. If the request is broad or ambiguous, route it back to `repo-operations`.
+2. Route iOS native/Capacitor build, entitlement, or plist issues to `mobile-native`.
+3. Route UAT/prod Cloud Run and web deploy scope to `uat-scoped-deploy`.
+4. Route publish-safety, consent, or secret-boundary findings to `security-audit`.
+
+## Required Checks
+
+```bash
+gh run list --workflow release-ios-appstore.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url
+gh workflow view "Release iOS to App Store" --ref main
+python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py
+```

--- a/.codex/skills/release-ios-appstore/references/release-proof.md
+++ b/.codex/skills/release-ios-appstore/references/release-proof.md
@@ -1,0 +1,119 @@
+# Release iOS to App Store — Evidence & Anti-Rationalization Contract
+
+Durable detail for the `release-ios-appstore` spoke. The compact kernel (SKILL.md) stays lean;
+this reference holds the proof standard, the two-gate rules, and the non-obvious failure modes.
+Read alongside `docs/guides/mobile/release-ios-appstore.md` (the full runbook).
+
+## What this pipeline actually ships
+
+- One dispatch of the **"Release iOS to App Store"** workflow
+  (`.github/workflows/release-ios-appstore.yml`, `runs-on: macos-15`, Xcode 26.3, Node 22) takes a
+  green `main` SHA all the way to the public App Store: web build -> Capacitor sync -> archive ->
+  Apple-managed sign -> export/upload to App Store Connect -> set per-version "What's New" ->
+  attach the processed build -> (opt-in) submit for public review.
+- **Backend is UAT, on purpose.** The public binary is built against the **UAT backend + UAT
+  Firebase (`hushh-pda-uat`)** — the same latest frontend+backend that is live on UAT and
+  TestFlight. There is no separate production backend for the store binary. It still archives with
+  **production APNs** entitlements (correct for any store binary), so the UAT Firebase project must
+  hold a production APNs key for push to deliver. This is a deliberate decision, not a leak — state
+  it plainly in every report so nobody assumes a prod backend.
+- **Bundle** `com.hushh.app`; App Store Connect app id `6757718917`; team `WVDK9JW99C`;
+  marketing version comes from `MARKETING_VERSION` in
+  `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj` (App target, Debug + Release).
+
+## Two gates — never collapse them into one
+
+- **Gate 1 (every dispatch).** Stop and get an explicit "yes" before dispatching. Restate the
+  workflow name, `--ref main`, the short SHA, the mode (dry-run / prepare-only / submit), the
+  backend (UAT `hushh-pda-uat`), and the bundle. The dispatcher
+  `scripts/release/dispatch-ios-appstore.mjs` also prints this and prompts.
+- **Gate 2 (public submission only).** `submit_for_review=true` is **IRREVERSIBLE** — it publishes
+  to real users. It maps to `--submit --ack-blockers` on the CLI (a local safety gate the
+  dispatcher enforces), and it requires: a separate explicit user instruction, and every
+  publish-safety blocker cleared first (see the publish-safety audit note below). Never pass
+  `--submit` / set `submit_for_review=true` from an automated or background context, or on
+  assumption. The default and near-always-correct mode is **prepare-only**.
+
+## Green-main-only
+
+The build is allowed only from a `main` SHA where **"Main Post-Merge Smoke Gate"** = `success`.
+The workflow re-checks with `scripts/ci/require-deploy-sha-on-main.sh` and refuses otherwise; fail
+fast locally too. This skill does **not** merge — if the work is not on `main`, tell the user to
+merge (and run the web deploy) first, then release. It ships what is already on `main`.
+
+## Identity / governance
+
+The actor must be in `config/ci-governance.json` -> `production.manual_dispatch_users`. If not,
+`scripts/ci/assert-governed-actor.py --surface production` rejects the dispatch. Confirm before
+Gate 1. Do not weaken branch protection and do not accept Apple Program License Agreements or enter
+the Apple ID password — those are the user's to perform.
+
+## Secrets boundary (hard)
+
+The ASC API key (`.p8`, **Admin** role) + Key ID + Issuer ID, and the native
+`GoogleService-Info.plist`, live only in **GCP Secret Manager** (`hushh-pda-uat`), added by the
+user. The workflow authenticates with the `GCP_SA_KEY_UAT` GitHub secret (same as TestFlight) and
+fails fast with a runbook pointer if any of `APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` /
+`_ISSUER_ID` / `IOS_GOOGLESERVICE_INFO_PLIST_B64` is missing. Never print, paste,
+`gcloud secrets versions access`, or ask the user to paste these into chat. If one is missing,
+point to the runbook — do not work around it.
+
+## Non-obvious failure modes (each has bitten a real run)
+
+1. **Closed marketing-version train.** App Store Connect rejects an upload whose
+   `CFBundleShortVersionString` (= `MARKETING_VERSION`) equals a version already approved/closed:
+   "Invalid Pre-Release Train ... is closed for new build submissions" / "must contain a higher
+   version than the previously approved version". The build-number resolver
+   (`scripts/ci/resolve-ios-build-number.py`) only bumps `CFBundleVersion` (the build number), not
+   the marketing version. Fix: bump `MARKETING_VERSION` (both App-target configs) to the next
+   patch, land on `main`, re-release. A `--dry-run` will NOT catch this — dry-run skips the
+   upload/ASC-validation leg.
+2. **ASC key role too low.** Archive creates a dev asset and export creates a distribution asset,
+   both via `-allowProvisioningUpdates`. The API key must be **Admin** (App Manager is not enough
+   for the managed distribution certificate). Symptom: a cloud-signing permission error at export.
+3. **Shared build-number pool.** TestFlight and App Store share one `CFBundleVersion` pool, and the
+   ASC builds API lags, so back-to-back runs can collide on a build number. The resolver takes
+   `max(ASC history, pbxproj) + 1`; if two dispatches race, re-run once ASC has caught up.
+4. **dSYM "Upload Symbols Failed"** for Firebase/Google frameworks is **non-fatal** — it does not
+   fail the build or the upload. Do not treat it as a failure.
+5. **Unaccepted Program License Agreement** silently blocks upload/processing — a user-only fix.
+
+## Proof standard (report honestly)
+
+"Workflow green" is not "in App Store Connect", and a prepare-only run is **not** "submitted for
+review". Before calling a release done, capture:
+
+- SHA released (short) and that "Main Post-Merge Smoke Gate" was `success` on that exact SHA.
+- Run URL + final status; mode (dry-run / prepare-only / submitted).
+- Version + resolved build number (e.g. `1.3.6 (60)`).
+- ASC state from the API or Job summary: uploaded / processing / "What's New" set / build attached
+  to the version / review submission created — or, for prepare-only, explicitly "attached, NOT
+  submitted for review"; for dry-run, "not uploaded".
+- On-device note: the build boots against the **UAT** backend (`hushh-pda-uat`, asserted during
+  prep) — the same backend as TestFlight.
+
+Keep merge, smoke, dispatch, upload, and (if any) submission as separate evidence. Never call
+queued or processing work "done".
+
+## Anti-rationalization
+
+- "The user said release, so I'll just submit" — no. Release defaults to prepare-only; public
+  submission is a distinct Gate 2 with its own explicit yes.
+- "Dry-run passed, so the upload is safe" — no. Dry-run does not exercise upload or the
+  marketing-version-train check.
+- "I'll set the secret to unblock the run" — no. Secrets are user-owned in GCP Secret Manager;
+  point to the runbook.
+- "Green run means it's on the store" — no. Confirm the ASC version/build/submission state.
+- "It's the prod release, so it must hit a prod backend" — no. This binary is intentionally
+  UAT-backed; say so.
+
+## Sibling & handoffs
+
+- TestFlight distribution (same UAT-backed binary, no review): the `ship-ios-testflight` skill.
+- iOS native/Capacitor/entitlement/plist issues: `mobile-native`.
+- UAT/prod Cloud Run + web deploy scope: `uat-scoped-deploy`.
+- Publish-safety, consent, or secret-boundary findings: `security-audit`.
+- Broad or ambiguous intake: back to `repo-operations`.
+
+The publish-safety blockers that must clear before Gate 2 live in the uncommitted KT audit
+(KT/hushh-one-publish-safety-audit.md) — a working doc, not a repo artifact; confirm with the user.

--- a/.codex/skills/release-ios-appstore/skill.json
+++ b/.codex/skills/release-ios-appstore/skill.json
@@ -1,0 +1,67 @@
+{
+  "id": "release-ios-appstore",
+  "role": "spoke",
+  "owner_family": "repo-operations",
+  "primary_scope": "release-ios-appstore-scope",
+  "description": "Use when releasing, submitting, or verifying a public Hussh One iOS App Store build cut from green main — Apple-managed signing with an Admin ASC API key, a UAT-backend/UAT-Firebase binary, per-version \"What's New\" and build attach via the ASC API, and the two-gate dispatch path (prepare-only default, opt-in irreversible public submit).",
+  "owned_paths": [
+    ".github/workflows/release-ios-appstore.yml",
+    "scripts/release/dispatch-ios-appstore.mjs"
+  ],
+  "non_owned_paths": [
+    "mobile-native",
+    "uat-scoped-deploy",
+    "security-audit",
+    "repo-operations"
+  ],
+  "task_types": [
+    "release-readiness"
+  ],
+  "required_reads": [
+    ".github/workflows/release-ios-appstore.yml",
+    "docs/guides/mobile/release-ios-appstore.md",
+    "scripts/release/dispatch-ios-appstore.mjs",
+    "scripts/ci/submit-appstore-version.py",
+    "scripts/ci/resolve-ios-build-number.py",
+    "deploy/app_store_deployment.md",
+    "docs/reference/operations/branch-governance.md",
+    ".codex/skills/release-ios-appstore/references/release-proof.md"
+  ],
+  "required_commands": [
+    "gh run list --workflow release-ios-appstore.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url",
+    "gh workflow view \"Release iOS to App Store\" --ref main",
+    "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+  ],
+  "verification_bundles": [
+    {
+      "id": "release-ios-appstore",
+      "commands": [
+        "gh run list --workflow release-ios-appstore.yml --limit 5 --json databaseId,status,conclusion,headSha,event,url",
+        "gh workflow view \"Release iOS to App Store\" --ref main",
+        "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+      ],
+      "tests": [
+        "python3 .codex/skills/codex-skill-authoring/scripts/skill_lint.py"
+      ]
+    }
+  ],
+  "handoff_targets": [
+    "repo-operations",
+    "mobile-native",
+    "uat-scoped-deploy",
+    "security-audit"
+  ],
+  "adjacent_skills": [
+    "mobile-native",
+    "uat-scoped-deploy",
+    "security-audit",
+    "repo-operations"
+  ],
+  "risk_tags": [
+    "public-submission-irreversibility",
+    "version-train-closed",
+    "release-secret-exposure",
+    "uat-backend-in-store-binary",
+    "build-number-collision"
+  ]
+}

--- a/.codex/skills/repo-context/references/ownership-map.md
+++ b/.codex/skills/repo-context/references/ownership-map.md
@@ -64,6 +64,7 @@ Use this reference after the initial scan to choose the correct owner skill firs
 
 1. `github-contribution-governance`
 2. `uat-scoped-deploy`
+3. `release-ios-appstore`
 
 ## Canonical workflow packs
 


### PR DESCRIPTION
## What

Adds the **Codex** governed-skill counterpart to the existing **Claude** `.claude/skills/release-ios-appstore` skill, so both agent surfaces share one release contract for the public iOS App Store pipeline (`.github/workflows/release-ios-appstore.yml` + `scripts/release/dispatch-ios-appstore.mjs`).

## Files

- `.codex/skills/release-ios-appstore/SKILL.md` — 8-section compact kernel (79 lines, ≤85 spoke budget).
- `.codex/skills/release-ios-appstore/skill.json` — 14-key manifest; `repo-operations` spoke; reuses the existing `release-readiness` task type (**no new workflow pack**).
- `.codex/skills/release-ios-appstore/references/release-proof.md` — evidence + anti-rationalization contract and the five non-obvious failure modes.
- `.codex/evals/cases/release-ios-appstore.json` — 4 positive / 3 negative trigger cases.
- `.codex/skills/repo-context/references/ownership-map.md` — register the spoke under `repo-operations`.

## Contract encoded

Two-gate dispatch (prepare-only default, opt-in **irreversible** public submit), green-`main`-only, governed-actor gate, `MARKETING_VERSION`-train bump, and the secrets boundary (ASC `.p8` / Key / Issuer stay in GCP Secret Manager — never printed).

## Governance gates (all green locally)

- `skill_lint.py` — 47 skills / 47 manifests / 39 packs / 22 surfaces
- `compact_kernel_smoke.py`, `truth_first_smoke.py`
- `skill_fleet_audit.py` (Python 3.11+) — 47 pass rows
- `trigger_evals.py` — 0 errors / 0 warnings, rank-1 94%

Docs-only skill metadata under `.codex/`; no runtime/pipeline code changes.