### PR TITLE
feat(runtime): add Meta Muse Spark 1.1 as a BYOA runtime provider

### DIFF
--- a/consent-protocol/hushh_mcp/runtime_providers/factory.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/factory.py
@@ -289,6 +289,12 @@ def _build(
         from .openai_transport import GROK_BASE_URL, OpenAITransport
 
         return OpenAITransport(api_key=api_key, base_url=GROK_BASE_URL, provider="grok")
+    if provider == "musespark":
+        from .openai_transport import MUSE_SPARK_BASE_URL, OpenAITransport
+
+        return OpenAITransport(
+            api_key=api_key, base_url=MUSE_SPARK_BASE_URL, provider="musespark"
+        )
     # normalize_provider already rejects unknown providers, so this is defensive.
     raise ValueError(f"Unsupported runtime provider: {provider!r}")
 

--- a/consent-protocol/hushh_mcp/runtime_providers/openai_transport.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/openai_transport.py
@@ -1,8 +1,11 @@
 """Native OpenAI-compatible transport adapter.
 
-Serves both OpenAI (native realtime) and Grok/x.ai, which speaks the OpenAI
-wire format on its own host. Grok is configured via ``base_url`` so there is
-one code path for both.
+Serves OpenAI (native realtime) plus every provider that speaks the OpenAI wire
+format on its own host: Grok/x.ai and Meta's Muse Spark. Each is configured via
+``base_url`` so there is one code path for all of them.
+
+Adding an OpenAI-compatible provider is a base-URL constant here, a dispatch
+branch in factory.py, and a registry entry — never a new transport.
 """
 
 from __future__ import annotations
@@ -15,6 +18,9 @@ from .normalized import NormalizedChunk, NormalizedFunctionCall, NormalizedRespo
 from .translate import NeutralRequest, NeutralTool
 
 GROK_BASE_URL = "https://api.x.ai/v1"
+# Meta's Model API (public preview). Ships as a deliberately OpenAI-compatible
+# surface, so it needs the base URL and nothing else.
+MUSE_SPARK_BASE_URL = "https://api.meta.ai/v1"
 
 
 def _messages(request: NeutralRequest) -> list[dict[str, Any]]:

--- a/consent-protocol/hushh_mcp/runtime_providers/registry.py
+++ b/consent-protocol/hushh_mcp/runtime_providers/registry.py
@@ -14,7 +14,7 @@ from typing import Literal
 
 from hushh_mcp.constants import GEMINI_MODEL
 
-ProviderId = Literal["gemini", "anthropic", "openai", "grok"]
+ProviderId = Literal["gemini", "anthropic", "openai", "grok", "musespark"]
 
 _PROVIDER_ALIASES: dict[str, ProviderId] = {
     "gemini": "gemini",
@@ -28,6 +28,15 @@ _PROVIDER_ALIASES: dict[str, ProviderId] = {
     "grok": "grok",
     "xai": "grok",
     "x.ai": "grok",
+    # Meta's Muse Spark, served by the Meta Model API. "meta" and "metaai" are
+    # accepted because that is what a person calls it; the canonical id names the
+    # model family rather than the vendor, matching how grok/x.ai resolves.
+    "musespark": "musespark",
+    "muse-spark": "musespark",
+    "muse": "musespark",
+    "meta": "musespark",
+    "metaai": "musespark",
+    "meta_ai": "musespark",
 }
 
 
@@ -90,6 +99,16 @@ _MODELS: tuple[ModelEntry, ...] = (
         aliases=("grok-default", "grok"),
     ),
     ModelEntry(provider="grok", model="grok-4-fast"),
+    # Muse Spark -- OpenAI-compatible wire format on Meta's own host; the Model
+    # API is in public preview. Structured output and parallel tool calling are
+    # documented, so function calling is on. Prompt caching and native realtime
+    # are NOT documented for this surface and stay off until measured against a
+    # live key rather than inferred from the wire format it borrows.
+    ModelEntry(
+        provider="musespark",
+        model="muse-spark-1.1",
+        aliases=("musespark-default", "muse-spark", "muse"),
+    ),
 )
 
 _DEFAULT_MODEL_BY_PROVIDER: dict[ProviderId, ModelEntry] = {}

--- a/consent-protocol/tests/services/test_runtime_providers.py
+++ b/consent-protocol/tests/services/test_runtime_providers.py
@@ -110,11 +110,11 @@ def test_is_known_provider_and_supported_set():
     assert is_known_provider("grok") is True
     assert is_known_provider("cohere") is False
     providers = supported_providers()
-    assert set(providers) == {"gemini", "anthropic", "openai", "grok"}
+    assert set(providers) == {"gemini", "anthropic", "openai", "grok", "musespark"}
 
 
 def test_default_model_per_provider_is_stable():
-    for provider in ("gemini", "anthropic", "openai", "grok"):
+    for provider in ("gemini", "anthropic", "openai", "grok", "musespark"):
         assert default_model_for_provider(provider)
 
 
@@ -132,6 +132,27 @@ def test_resolve_model_entry_empty_model_uses_default():
     entry = resolve_model_entry("gemini", "")
     assert entry.provider == "gemini"
     assert entry.model == default_model_for_provider("gemini")
+
+
+def test_muse_spark_resolves_from_the_names_a_person_actually_uses():
+    # The vendor and the model family are different words, and a caller may
+    # reach for either. Both resolve; a space-separated form does not, which
+    # matches every other alias in the registry rather than inventing a rule
+    # only this provider follows.
+    for alias in ("musespark", "muse-spark", "muse", "meta", "metaai", "MUSE"):
+        assert normalize_provider(alias) == "musespark"
+    assert default_model_for_provider("meta") == "muse-spark-1.1"
+
+
+def test_muse_spark_claims_only_capabilities_meta_documents():
+    # Structured output and parallel tool calling are documented for the Meta
+    # Model API. Prompt caching and native realtime are not, and borrowing the
+    # OpenAI wire format is not evidence of either — asserting them here would
+    # let the voice layer pick a transport the provider may not serve.
+    entry = resolve_model_entry("musespark", "muse-spark-1.1")
+    assert entry.supports_function_calling is True
+    assert entry.supports_prompt_caching is False
+    assert entry.supports_native_realtime is False
 
 
 def test_only_gemini_live_model_advertises_native_realtime():
@@ -255,6 +276,26 @@ def test_build_managed_non_gemini_runtime_client_requires_key():
 def test_factory_rejects_unknown_provider():
     with pytest.raises(ValueError, match="Unsupported runtime provider"):
         build_runtime_client("mistral", "key")
+
+
+def test_factory_sends_muse_spark_to_metas_host_not_openais(monkeypatch):
+    # Muse Spark reuses the OpenAI transport because it speaks that wire format.
+    # The base_url is therefore the ONLY thing separating it from OpenAI, and
+    # getting it wrong would post the user's Meta key to api.openai.com — a
+    # credential leak to a third party that no test above would catch.
+    captured: list[dict[str, Any]] = []
+
+    def fake_async_openai(**kwargs):
+        captured.append(kwargs)
+        return types.SimpleNamespace(kind="openai-compatible")
+
+    monkeypatch.setattr("openai.AsyncOpenAI", fake_async_openai)
+
+    build_runtime_client("meta", "user-supplied-meta-key")
+
+    assert len(captured) == 1
+    assert captured[0]["base_url"] == "https://api.meta.ai/v1"
+    assert captured[0]["api_key"] == "user-supplied-meta-key"
 
 
 def test_factory_gemini_uses_byok_and_managed_adc_clients(monkeypatch):


### PR DESCRIPTION
Adds Meta's Muse Spark 1.1 to the runtime provider registry, so it joins Gemini, Anthropic, OpenAI and Grok as a brain Agent One can run on.

## Why this was small

Meta shipped Muse Spark as a deliberately OpenAI-compatible surface. That makes it structurally identical to how Grok already works here — Grok speaks the OpenAI wire format on its own host and is configured purely by `base_url`. So this is a base-URL constant, a dispatch branch, and a registry entry. **No new transport.**

Documented capabilities are structured output and parallel tool calling, and it generalises to MCP servers natively, which fits the MCP-first posture rather than needing an adapter.

## Capability flags are deliberately conservative

Function calling is on because Meta documents it. **Prompt caching and native realtime are off**, because borrowing another vendor's wire format is not evidence of serving that vendor's realtime API — and `registry.py` already warns never to infer realtime from the provider. If those turn out to be supported, that is a measurement against a live key, not an assumption.

## The test that matters

Muse Spark reuses the OpenAI transport, so `base_url` is the **only** thing separating it from OpenAI. Getting it wrong would POST a user's Meta key to `api.openai.com` — a credential leak to a third party that no other test here would catch.

`test_factory_sends_muse_spark_to_metas_host_not_openais` asserts the transport receives Meta's host. It was verified by sabotage: changing the constant to OpenAI's host fails exactly that test and nothing else.

## Verified

- Full protocol lane green: ruff, mypy (92 source files), bandit, **420 tests**
- `tests/services/test_runtime_providers.py`: 41 passed (3 new)

One note for reviewers: that test file is **not** in the backend CI manifest, which is a deliberately small allowlist. These run locally and in the full suite, but not in the pull-request gate — so the green tick on this PR does not by itself cover them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMQerNkJv8zitj1bCVbXK9)_