### PR TITLE
fix(one): let users pass Add people step without adding anyone

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -330,8 +330,8 @@ describe("OneLocationOnboardingFlow", () => {
     });
   });
 
-  it("requires at least one selected contact before Continue is enabled", () => {
-    renderFlow({
+  it("lets the user continue without selecting anyone and sends no requests", () => {
+    const props = renderFlow({
       people: [people[1]!],
       connections: [],
     });
@@ -340,14 +340,44 @@ describe("OneLocationOnboardingFlow", () => {
     expect(screen.getByRole("button", { name: "Go back" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Skip" })).toBeTruthy();
     const continueButton = screen.getByRole("button", { name: "Continue" });
-    expect(continueButton).toBeDisabled();
+    expect(continueButton).toBeEnabled();
     expect(
-      screen.getByText("Select at least one person to continue"),
+      screen.getByText("Add anyone you'd like — or just continue"),
     ).toBeTruthy();
 
+    fireEvent.click(continueButton);
+    expect(props.onSendConnectionRequests).not.toHaveBeenCalled();
+    expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
+  });
+
+  it("keeps Continue enabled and counts people as they are selected", () => {
+    renderFlow({
+      people: [people[1]!],
+      connections: [],
+    });
+    openPeopleScreen();
+
+    const continueButton = screen.getByRole("button", { name: "Continue" });
+    expect(continueButton).toBeEnabled();
+
     fireEvent.click(screen.getByRole("button", { name: "Add New Person" }));
-    expect(continueButton).not.toBeDisabled();
+    expect(continueButton).toBeEnabled();
     expect(screen.getByText("1 selected")).toBeTruthy();
+  });
+
+  it("advances the optional people step on Skip without ending onboarding", () => {
+    const props = renderFlow({
+      people: [people[1]!],
+      connections: [],
+    });
+    openPeopleScreen();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip" }));
+
+    expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
+    expect(props.onSkip).not.toHaveBeenCalled();
+    expect(props.onComplete).not.toHaveBeenCalled();
+    expect(props.onSendConnectionRequests).not.toHaveBeenCalled();
   });
 
   it("sends deliberate requests, shows selected people, and auto-completes after four seconds", async () => {
@@ -459,6 +489,6 @@ describe("OneLocationOnboardingFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh people" }));
 
     expect(props.onRetryPeople).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
   });
 });

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -961,7 +961,7 @@ function PeopleScreen({
     );
   };
 
-  const canContinue = !loading && selectedIds.length > 0;
+  const canContinue = !loading;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-white dark:bg-[#14171d]">
@@ -1081,7 +1081,7 @@ function PeopleScreen({
         >
           {selectedIds.length > 0
             ? `${selectedIds.length} selected`
-            : "Select at least one person to continue"}
+            : "Add anyone you'd like — or just continue"}
         </p>
         <PrimaryButton
           onClick={() => onContinue(selectedIds)}
@@ -1381,7 +1381,6 @@ export function OneLocationOnboardingFlow({
   };
 
   const handlePeopleContinue = (selectedIds: string[]) => {
-    if (selectedIds.length === 0) return;
     setSelectedPeopleIds(selectedIds);
     const selectedPeople = people.filter((person) =>
       selectedIds.includes(person.userId),
@@ -1435,6 +1434,14 @@ export function OneLocationOnboardingFlow({
       });
   };
 
+  // People is an optional step: "Skip" advances into the flow without adding
+  // anyone (or without changing an existing selection) instead of tearing down
+  // onboarding. It reuses the Continue path, so no requests are sent for an
+  // empty/unchanged selection and all prior onboarding data is preserved.
+  const handlePeopleSkip = () => {
+    handlePeopleContinue(selectedPeopleIds);
+  };
+
   return (
     <main
       className="fixed inset-0 z-[540] flex h-dvh min-h-[100svh] w-full items-stretch justify-center overflow-hidden bg-[#eef3f8] text-[#171d28] dark:bg-[#070a0f] dark:text-[#f4f7fb]"
@@ -1479,7 +1486,7 @@ export function OneLocationOnboardingFlow({
             initialSelectedIds={selectedPeopleIds}
             onRetry={onRetryPeople}
             onBack={() => setScreen("features")}
-            onSkip={() => void runSkip()}
+            onSkip={handlePeopleSkip}
             leaving={leaving}
             onSelectionChange={setSelectedPeopleIds}
             onContinue={handlePeopleContinue}


### PR DESCRIPTION
## Problem

On one.hushh.ai, the One onboarding **Add people** step trapped users who did not want to add anyone:

- **Continue** was gated on selecting ≥1 person (disabled with "Select at least one person to continue").
- The only escape — the top-right **Skip** — tore down the *entire* onboarding, so users perceived it as discarding their earlier progress (including the home address they'd just saved).

Reported from the field by a user who wanted to move past the step without inviting anyone.

## Fix (frontend only)

`components/one-location/onboarding/one-location-onboarding-flow.tsx`:

1. **Ungate Continue** — `canContinue = !loading` (enabled as soon as recommendations finish loading, regardless of selection).
2. **Remove the hidden early-return** in `handlePeopleContinue` so a zero-selection Continue actually advances. The existing `if (requestIds.length === 0) return;` already means **no connection-request API is called** when nobody new is selected — so this is client-only; there is no backend/contract change.
3. **Reword** the footer helper copy to optional tone ("Add anyone you'd like — or just continue").
4. **Make the people-step Skip non-destructive** — it now advances into the flow via the same Continue path (`handlePeopleSkip`) instead of ending onboarding. Welcome / Features / Circle keep their existing global-exit Skip.

Advancing with zero selected lands on the circle screen and completes normally; the saved home address (persisted independently on the Features step) and all prior onboarding state are preserved.

> Note: this onboarding takeover has no platform gate, so the copy/behavior change ships to desktop web as well as iOS — intended; flag for QA.

## Tests

`__tests__/components/one-location-onboarding-flow.test.tsx`:
- Replaced the gate-locking spec with: Continue enabled + advances with zero selected + sends no requests.
- New: live selection counter keeps Continue enabled.
- New: people-step Skip advances to the circle without calling the global `onSkip`/`onComplete` or sending requests.
- Flipped the empty-recommendation-list spec to expect Continue **enabled**.

## Local gates (all green)

- `tsc --noEmit` ✓
- `eslint` (changed files) ✓
- `vitest` onboarding + agent-page suites — 64/64 ✓
- `verify:surface-map` ✓
- `verify:capacitor:static` ✓