### PR TITLE
fix(onboarding): reserve Agent Bar clearance on One setup scroll roots

### DIFF
--- a/hushh-webapp/app/providers.tsx
+++ b/hushh-webapp/app/providers.tsx
@@ -56,6 +56,7 @@ import { getKaiChromeState } from "@/lib/navigation/kai-chrome-state";
 import {
   ROUTES,
   isFoundationPublicRoute,
+  isOneSetupSurfaceRoute,
   isRiaRoute,
 } from "@/lib/navigation/routes";
 import { useAuth } from "@/hooks/use-auth";
@@ -228,9 +229,11 @@ function AppShellFrame({ children }: ProvidersProps) {
           ? "0px"
           : isRiaRoute(pathname)
             ? "calc(var(--onboarding-agent-bar-clearance) + 1.5rem)"
-            : hideGlobalChrome || isPublicStandaloneRoute
+            : isOneSetupSurfaceRoute(pathname)
               ? "calc(var(--onboarding-agent-bar-clearance) + 1.5rem)"
-              : "var(--bottom-chrome-stack-height)",
+              : hideGlobalChrome || isPublicStandaloneRoute
+                ? "calc(var(--onboarding-agent-bar-clearance) + 1.5rem)"
+                : "var(--bottom-chrome-stack-height)",
       }) as CSSProperties,
     [
       chromeState.hideCommandBar,


### PR DESCRIPTION
## What
On **One setup** surface routes (`/one/setup` hub, connections, per-capability incl. Gmail/Gemini, and the finance/kai wizard) the command bar is hidden, so `--app-scroll-bottom-pad` collapsed to the bare bottom inset (~0). The fixed onboarding **Agent Bar** then overlapped the `SetupCompletionFooter` **finish button** on mobile web — with no scroll space to reach it.

Reported via Discord (Kushal / NOUS): *"during onboarding steps the agent bar button was overlapping over the finish button… it should have a little scroll space so that I can view the button… this is web version through the mobile."*

## Fix
Add an `isOneSetupSurfaceRoute(pathname)` branch to the `--app-scroll-bottom-pad` token in `app/providers.tsx`, resolving to the same `calc(var(--onboarding-agent-bar-clearance) + 1.5rem)` clearance already used for the RIA and public-standalone routes that render the same fixed bar.

## Why this shape
- The footer and scroll root are **contractually required** to derive clearance from this token (`setup-completion-footer.contract.test.ts` forbids hardcoding the bar clearance in the footer). So the fix belongs at the token, not the component.
- Brings setup routes to **parity with RIA onboarding** (already shipped consuming this token).
- **Desktop web unchanged:** the footer keeps its fixed `sm:pb-8`; the scroll-root delta is bottom padding only (no content moves). Non-setup routes are untouched (new branch is route-scoped).

## Gates (local, on rebased branch)
- `providers-bottom-clearance` + `setup-completion-footer` + 3 other token contract tests: **13/13 pass**
- `tsc --noEmit`: **0 errors**
- `eslint app/providers.tsx`: clean

Skips Issue 2 (debate UAT-vs-prod) per direction.