### PR TITLE
feat(ria): restore Debate config as a Picks sub-view

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4178,6 +4178,7 @@
           "ria.picks.open_category_top_picks",
           "ria.picks.open_source_kai",
           "ria.picks.open_source_my",
+          "ria.picks.open_view_debate",
           "route.ria_picks"
         ],
         "delegate_agent_ids": [],
@@ -4341,21 +4342,21 @@
   "schema_version": "hushh.runtime_topology_index.v1",
   "source_sha256": {
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
-    "action_gateway": "2e25991c576b00e05b242b6e107f2c665a7b846ab80e53161ce474b6c87095c0",
+    "action_gateway": "ec8e4dae0987de143e456d0f70a489b5083a7c85028a46a7ced57d868ada8bc2",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
     "cache_manifest": "ebd1c1e5f5fdae7c64cac31ba378f3c8e587a11816fb2a114f032c3f2fa7dea0",
     "data_plane": "0a8cd55eee9579c9fbc8c4d20499b118dd048789ee281d8640bc1e0842bc4f04",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
-    "route_index": "84b06798ab53d7cc9c89f18464965db18d109e789f926f293d21dc6bbca4c274",
+    "route_index": "2826d42fba01cbca263a49c3ff66797dc107c9679a1375d102ea9183be71bc82",
     "route_layout": "079e52f558cf36f1f446c10d456523237a04359b0ff81f22a2e98117120130ac",
-    "surface_map": "899502fe9e9e39f9bce4fcad859973836f9b45bffa0f4074dbaaed261c29c79b",
+    "surface_map": "0c8771e80be59087448c14f1afef3e9fb7259746413ebc32357addfebfaf2516",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
   "summary": {
     "a2a_scope_gated_agents": 5,
-    "actions": 115,
+    "actions": 116,
     "agents": 18,
     "aliases": 3,
     "decision_required": 2,

--- a/contracts/kai/kai-action-gateway.vnext.json
+++ b/contracts/kai/kai-action-gateway.vnext.json
@@ -8159,6 +8159,112 @@
       }
     },
     {
+      "action_id": "ria.picks.open_view_debate",
+      "surface_id": "ria_picks",
+      "label": "Show Debate Config",
+      "aliases": [
+        "show debate config",
+        "open debate",
+        "show debate rules"
+      ],
+      "search_keywords": [
+        "debate",
+        "config",
+        "conviction",
+        "screening"
+      ],
+      "meaning": "Opens the read-only debate config sub-view of Picks — the screening rules and conviction bands Kai's investor debate runs on.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/picks?view=debate"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/ria/picks?view=debate"
+      },
+      "control_ids": [
+        "ria_picks_view_debate"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/picks?view=debate"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.picks.open_view_debate",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.picks.open_view_debate",
+            "label": "Show Debate Config",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/ria/picks?view=debate",
+              "screen": "ria_picks"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "ria.picks.start_edit_package",
       "surface_id": "ria_picks",
       "label": "Edit Advisor Package",

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -4952,6 +4952,7 @@
         "ria.picks.open_category_top_picks",
         "ria.picks.open_source_kai",
         "ria.picks.open_source_my",
+        "ria.picks.open_view_debate",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -691,4 +691,34 @@ describe("top shell breadcrumbs", () => {
       ],
     });
   });
+
+  it("deepens Picks into Debate config for the ?view=debate sub-view", () => {
+    const debateView = new URLSearchParams("view=debate");
+
+    // Debate config lives one level below Picks, so Back returns to Picks and
+    // the trail carries a fourth "Debate" crumb.
+    expect(resolveTopShellBreadcrumb("/ria/picks", debateView)).toEqual({
+      backHref: "/ria/picks",
+      width: "content",
+      align: "center",
+      items: [
+        { label: "One", href: "/one" },
+        { label: "RIA", href: "/ria" },
+        { label: "Picks", href: "/ria/picks" },
+        { label: "Debate" },
+      ],
+    });
+
+    // Without the view param, bare Picks is untouched: three crumbs, Back to RIA.
+    expect(resolveTopShellBreadcrumb("/ria/picks")).toEqual({
+      backHref: "/ria",
+      width: "content",
+      align: "center",
+      items: [
+        { label: "One", href: "/one" },
+        { label: "RIA", href: "/ria" },
+        { label: "Picks" },
+      ],
+    });
+  });
 });

--- a/hushh-webapp/app/ria/page.tsx
+++ b/hushh-webapp/app/ria/page.tsx
@@ -183,9 +183,11 @@ export default function RiaHomePage() {
         actionId: "route.ria_clients",
       },
       {
+        // Not a member of RIA_ROUTE_TABS (home/clients/picks) — Connect is a
+        // route jump, so it's a button, not a phantom entry in the tablist.
         id: "ria_route_tab_connect",
         label: "Connect",
-        type: "tab",
+        type: "button",
         actionId: "route.ria_marketplace_connect",
       },
       {

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -10,6 +10,7 @@ import {
   FileSpreadsheet,
   Loader2,
   Medal,
+  MessagesSquare,
   PencilLine,
   Plus,
   Save,
@@ -1354,6 +1355,10 @@ export default function RiaPicksPage() {
 
   const sourceParam = searchParams?.get("source");
   const categoryParam = searchParams?.get("category");
+  // Debate config is a read-only sub-view of Picks (?view=debate), not a
+  // standalone route — it deep-links, inherits the vault guard + BYOK package,
+  // and never trips the route-inventory / native-parity ship gates.
+  const isDebateView = (searchParams?.get("view") || "").trim() === "debate";
 
   useEffect(() => {
     if (sourceParam === "kai" || sourceParam === "my") {
@@ -1372,13 +1377,22 @@ export default function RiaPicksPage() {
   }, [categoryParam]);
 
   const updatePicksRouteState = useCallback(
-    (next: { source?: PicksSource; category?: PicksCategory }) => {
+    (next: {
+      source?: PicksSource;
+      category?: PicksCategory;
+      view?: "debate" | null;
+    }) => {
       const params = new URLSearchParams(searchParams?.toString() || "");
       if (next.source) {
         params.set("source", next.source);
       }
       if (next.category) {
         params.set("category", next.category);
+      }
+      if (next.view === "debate") {
+        params.set("view", "debate");
+      } else if (next.view === null) {
+        params.delete("view");
       }
       const query = params.toString();
       router.replace(query ? `${ROUTES.RIA_PICKS}?${query}` : ROUTES.RIA_PICKS, {
@@ -1586,6 +1600,7 @@ export default function RiaPicksPage() {
       { value: "top-picks", label: "Top picks" },
       { value: "avoid", label: "Avoid" },
       { value: "screening", label: "Screening" },
+      { value: "debate", label: RIA_COPY.debate.eyebrow },
     ],
     []
   );
@@ -2146,22 +2161,29 @@ export default function RiaPicksPage() {
           id: "ria_picks_category_top_picks",
           label: "Top picks",
           type: "tab",
-          state: category === "top-picks" ? "active" : "available",
+          state: !isDebateView && category === "top-picks" ? "active" : "available",
           actionId: "ria.picks.open_category_top_picks",
         },
         {
           id: "ria_picks_category_avoid",
           label: "Avoid",
           type: "tab",
-          state: category === "avoid" ? "active" : "available",
+          state: !isDebateView && category === "avoid" ? "active" : "available",
           actionId: "ria.picks.open_category_avoid",
         },
         {
           id: "ria_picks_category_screening",
           label: "Screening",
           type: "tab",
-          state: category === "screening" ? "active" : "available",
+          state: !isDebateView && category === "screening" ? "active" : "available",
           actionId: "ria.picks.open_category_screening",
+        },
+        {
+          id: "ria_picks_view_debate",
+          label: RIA_COPY.debate.eyebrow,
+          type: "tab",
+          state: isDebateView ? "active" : "available",
+          actionId: "ria.picks.open_view_debate",
         },
         {
           id: "ria_picks_upload_csv",
@@ -2205,8 +2227,8 @@ export default function RiaPicksPage() {
           actionId: "ria.picks.save_package",
         },
       ],
-      activeTab: `${source}:${category}`,
-      activeFilters: [sourceTitle, category],
+      activeTab: isDebateView ? `${source}:debate` : `${source}:${category}`,
+      activeFilters: [sourceTitle, isDebateView ? "debate" : category],
       visibleModules: ["Source tabs", "Category tabs", "Advisor package actions"],
       busyOperations: [
         ...(submitting ? ["ria_picks_uploading"] : []),
@@ -2216,6 +2238,7 @@ export default function RiaPicksPage() {
       screenMetadata: {
         source,
         category,
+        view: isDebateView ? "debate" : "picks",
         editing,
         upload_open: uploadOpen,
         has_unsaved_changes: hasUnsavedChanges,
@@ -2229,6 +2252,7 @@ export default function RiaPicksPage() {
       category,
       editing,
       hasUnsavedChanges,
+      isDebateView,
       isVaultUnlocked,
       kaiRows.length,
       myTopPicks.length,
@@ -2279,16 +2303,23 @@ export default function RiaPicksPage() {
     >
       <AppPageHeaderRegion>
         <PageHeader
-          eyebrow={RIA_COPY.picks.eyebrow}
-          title={RIA_COPY.picks.title}
-          description={RIA_COPY.picks.description}
-          icon={FileSpreadsheet}
+          eyebrow={isDebateView ? RIA_COPY.debate.eyebrow : RIA_COPY.picks.eyebrow}
+          title={isDebateView ? RIA_COPY.debate.title : RIA_COPY.picks.title}
+          description={
+            isDebateView ? RIA_COPY.debate.description : RIA_COPY.picks.description
+          }
+          icon={isDebateView ? MessagesSquare : FileSpreadsheet}
           accent="ria"
         />
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
-        <div className="flex flex-col gap-6">
+        {/* Debate is a read-only config preview — swiping should scroll it, not
+            hop to the adjacent RIA tab, so the pane opts out of route-swipe. */}
+        <div
+          className="flex flex-col gap-6"
+          {...(isDebateView ? { "data-no-route-swipe": "" } : {})}
+        >
           <div data-testid="ria-picks-primary">
             <SettingsSegmentedTabs
               value={source}
@@ -2304,16 +2335,93 @@ export default function RiaPicksPage() {
           </div>
 
           <SettingsSegmentedTabs
-            value={category}
+            value={isDebateView ? "debate" : category}
             onValueChange={(value) => {
+              if (value === "debate") {
+                updatePicksRouteState({ view: "debate" });
+                return;
+              }
               const nextCategory = value as PicksCategory;
               setCategory(nextCategory);
-              updatePicksRouteState({ category: nextCategory });
+              updatePicksRouteState({ category: nextCategory, view: null });
             }}
             options={categoryOptions}
-            mobileColumns={3}
+            mobileColumns={2}
           />
 
+          {isDebateView ? (
+            iamUnavailable ? (
+              <RiaCompatibilityState
+                title="Waiting on IAM schema"
+                description="Debate config needs the IAM tables."
+              />
+            ) : (
+              <div className="space-y-4" data-testid="ria-debate-config">
+                <SurfaceCard>
+                  <SurfaceCardContent className="p-4 sm:p-5">
+                    <p className="text-sm font-semibold text-foreground">
+                      {RIA_COPY.debate.banner.title}
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      {RIA_COPY.debate.banner.description}
+                    </p>
+                  </SurfaceCardContent>
+                </SurfaceCard>
+
+                {source === "kai" && screeningLoading ? (
+                  <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading debate config...
+                  </div>
+                ) : null}
+
+                <div className="space-y-6">
+                  {screeningViewRows.map((section) => (
+                    <SurfaceCard key={section.section}>
+                      <SurfaceCardContent className="p-4">
+                        <h3 className="mb-3 text-sm font-semibold text-foreground">
+                          {section.label}
+                        </h3>
+                        {section.rows.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">
+                            No rules yet for this section.
+                          </p>
+                        ) : (
+                          <div className="space-y-2">
+                            {section.rows.map((rule, index) => (
+                              <div
+                                key={`${section.section}-${index}`}
+                                className="border-b border-border/20 pb-2 last:border-0 last:pb-0"
+                              >
+                                <p className="text-sm font-medium text-foreground">
+                                  {rule.title}
+                                </p>
+                                {shouldRenderScreeningDetail(rule) ? (
+                                  <p className="text-xs leading-5 text-muted-foreground">
+                                    {rule.detail}
+                                  </p>
+                                ) : null}
+                                {shouldRenderScreeningValue(rule) ? (
+                                  <p className="mt-1 text-xs font-medium text-primary">
+                                    {rule.value_text}
+                                  </p>
+                                ) : null}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </SurfaceCardContent>
+                    </SurfaceCard>
+                  ))}
+                </div>
+
+                <p className="px-1 text-xs leading-5 text-muted-foreground">
+                  {RIA_COPY.debate.disclaimer}
+                </p>
+              </div>
+            )
+          ) : (
+            <>
           {showMyListActionRail ? (
             <SurfaceCard>
               <SurfaceCardContent className="space-y-2 p-3 sm:p-4">
@@ -2676,6 +2784,8 @@ export default function RiaPicksPage() {
               ) : null}
             </div>
           ) : null}
+          </>
+          )}
         </div>
       </AppPageContentRegion>
     </AppPageShell>

--- a/hushh-webapp/app/ria/picks/page.voice-action-contract.json
+++ b/hushh-webapp/app/ria/picks/page.voice-action-contract.json
@@ -302,6 +302,54 @@
       "speaker_persona": "kai"
     },
     {
+      "action_id": "ria.picks.open_view_debate",
+      "label": "Show Debate Config",
+      "meaning": "Opens the read-only debate config sub-view of Picks — the screening rules and conviction bands Kai's investor debate runs on.",
+      "aliases": [
+        "show debate config",
+        "open debate",
+        "show debate rules"
+      ],
+      "search_keywords": [
+        "debate",
+        "config",
+        "conviction",
+        "screening"
+      ],
+      "reachability": {
+        "routes": [
+          "/ria/picks?view=debate"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "ria"
+        ]
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/ria/picks?view=debate"
+      },
+      "control_ids": [
+        "ria_picks_view_debate"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "speaker_persona": "kai"
+    },
+    {
       "action_id": "ria.picks.start_edit_package",
       "label": "Edit Advisor Package",
       "meaning": "Represents opening the editable advisor package draft. Voice can explain it, but editing stays manual.",

--- a/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
+++ b/hushh-webapp/contracts/kai/kai-action-gateway.vnext.json
@@ -8159,6 +8159,112 @@
       }
     },
     {
+      "action_id": "ria.picks.open_view_debate",
+      "surface_id": "ria_picks",
+      "label": "Show Debate Config",
+      "aliases": [
+        "show debate config",
+        "open debate",
+        "show debate rules"
+      ],
+      "search_keywords": [
+        "debate",
+        "config",
+        "conviction",
+        "screening"
+      ],
+      "meaning": "Opens the read-only debate config sub-view of Picks — the screening rules and conviction bands Kai's investor debate runs on.",
+      "speaker_persona": "kai",
+      "delegate_agent_id": null,
+      "reachability": {
+        "routes": [
+          "/ria/picks?view=debate"
+        ],
+        "screens": [
+          "ria_picks"
+        ],
+        "hidden_navigable": false,
+        "navigation_prerequisites": [],
+        "active_personas": [
+          "ria"
+        ],
+        "requires_persona_switch_confirmation": false
+      },
+      "guard_ids": [
+        "auth_signed_in",
+        "ria_persona_available"
+      ],
+      "risk_level": "low",
+      "execution_policy": "allow_direct",
+      "activation_policy": "none",
+      "execution_target": {
+        "status": "wired",
+        "path": "route",
+        "target": "/ria/picks?view=debate"
+      },
+      "control_ids": [
+        "ria_picks_view_debate"
+      ],
+      "state_exposure": [],
+      "docs_references": [
+        "docs/reference/kai/kai-action-gateway-vnext.md",
+        "hushh-webapp/app/ria/picks/page.tsx"
+      ],
+      "workflow": null,
+      "external_callback": null,
+      "expected_effects": {
+        "state_changes": [
+          "current route becomes /ria/picks?view=debate"
+        ],
+        "backend_effects": []
+      },
+      "trigger": {
+        "primary": "voice",
+        "supported": [
+          "voice",
+          "tap",
+          "keyboard",
+          "programmatic"
+        ]
+      },
+      "goal": {
+        "goal_id": "goal.ria.picks.open_view_debate",
+        "required_inputs": [],
+        "input_resolvers": [],
+        "slot_schema": {},
+        "workflow_steps": [
+          {
+            "type": "action",
+            "action_id": "ria.picks.open_view_debate",
+            "label": "Show Debate Config",
+            "failure_behavior": "stop",
+            "settlement_target": {
+              "route": "/ria/picks?view=debate",
+              "screen": "ria_picks"
+            }
+          }
+        ],
+        "progress_contract": {
+          "mode": "none",
+          "milestone_events": []
+        },
+        "cancellation_contract": {
+          "cancellable": false,
+          "cancel_action_id": null
+        },
+        "result_contract": {
+          "summary_mode": "action_result"
+        },
+        "entrypoint_support": [
+          "voice",
+          "chat",
+          "typed_search",
+          "command_bar",
+          "ui"
+        ]
+      }
+    },
+    {
       "action_id": "ria.picks.start_edit_package",
       "surface_id": "ria_picks",
       "label": "Edit Advisor Package",

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -4952,6 +4952,7 @@
         "ria.picks.open_category_top_picks",
         "ria.picks.open_source_kai",
         "ria.picks.open_source_my",
+        "ria.picks.open_view_debate",
         "route.ria_picks"
       ],
       "action_coverage": "inherited",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -7421,6 +7421,7 @@
         "ria.picks.open_category_top_picks",
         "ria.picks.open_source_kai",
         "ria.picks.open_source_my",
+        "ria.picks.open_view_debate",
         "ria.picks.save_package",
         "ria.picks.start_edit_package",
         "ria.picks.upload_csv_replace_top_picks",
@@ -7740,5 +7741,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "4314c9f9db9ec14ab6e7580c12adb0d168a90d11bf838dfd701714747fd418f4"
+  "content_sha256": "9aa162ccdda9fe47517a01d98acae958ea179b583c9f5b94513f45230ea3e143"
 }

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -427,6 +427,28 @@ function resolveTopShellBreadcrumbInner(
     };
   }
 
+  // Debate config is a read-only sub-view of Picks (/ria/picks?view=debate):
+  // it deepens one level below Picks, so back returns to Picks, not RIA home.
+  // Checked before the generic riaSubroutes loop, which would otherwise match
+  // the query-stripped /ria/picks pathname and flatten it to a 3-crumb Picks.
+  if (
+    (pathname === ROUTES.RIA_PICKS ||
+      pathname.startsWith(`${ROUTES.RIA_PICKS}/`)) &&
+    searchParams?.get("view") === "debate"
+  ) {
+    return {
+      backHref: ROUTES.RIA_PICKS,
+      width: "content",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "RIA", href: ROUTES.RIA_HOME },
+        { label: "Picks", href: ROUTES.RIA_PICKS },
+        { label: "Debate" },
+      ],
+    };
+  }
+
   // RIA subtabs (level 3): back returns to the RIA home (level 2).
   const riaSubroutes: Array<[string, string]> = [
     [ROUTES.RIA_PICKS, "Picks"],

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -122,6 +122,19 @@ export const RIA_COPY = {
     unlockRail: "Unlock the vault to edit or publish.",
   },
 
+  debate: {
+    eyebrow: "Debate",
+    title: "Debate config",
+    description: "The rules Kai's investor debate runs on.",
+    banner: {
+      title: "This is your debate config",
+      description:
+        "Kai's multi-agent debate scores every name against these screening rules and conviction bands.",
+    },
+    disclaimer:
+      "Agent Kai is an educational and informational tool and is not investment advice. Always consult a licensed financial professional before making investment decisions.",
+  },
+
   connect: {
     eyebrow: "SEBI-registered network",
     title: "Connect",


### PR DESCRIPTION
## Why
Kushal (NOUS) flagged that the RIA **Picks** debate-config surface was reachable before but had dropped off. This restores it — as a deep-linkable sub-view, **without adding a route**.

## What
- **Debate config is back at `/ria/picks?view=debate`** — a 4th category tab on Picks plus a read-only pane that reuses the existing screening rows (investable requirements, automatic-avoid triggers, the-math conviction bands) with an educational not-advice disclaimer.
- **Query-param sub-view by design** (not a new route): it inherits the Picks vault guard + BYOK package, and keeps `native-route-inventory.json` and `app-route-layout.contract.json` **byte-identical** — so native-parity ship gates don't trip.
- **Breadcrumb** deepens Picks → Debate (Back returns to Picks). The pane opts out of route-swipe via `data-no-route-swipe` (honored by `top-shell-route-swipe`).
- **RIA-home Connect** entry demoted from a phantom tablist tab to a button (it's a route jump, not one of home/clients/picks).
- **One new voice action** `ria.picks.open_view_debate`; regenerated the Kai action gateway, route orchestration index, and surface map (deltas are this action only).

Scoped to the current unified bottom nav — the old RIA pill-bar component was already removed on main and is **not** reintroduced here.

## Gates (run in a clean worktree off this branch's base)
- `verify:voice-gateway` ✅ · `verify:route-orchestration-index` ✅ · `verify:surface-map` ✅ · `verify:capacitor:static` ✅
- Tripwires (`native-route-inventory.json`, `app-route-layout.contract.json`) **unchanged** ✅
- New breadcrumb sub-view test passes; Picks page suite green ✅
- Lint clean on changed files ✅

### Pre-existing baseline (reproduced with this slice stashed — not introduced here)
- `typecheck`: 6 errors in `one-location/location-immersive-map.tsx` + `profile/avatar-capture.ts` — missing `@capacitor/google-maps` / `@capacitor/camera` type decls (local stale node_modules; CI fresh-install resolves them).
- `top-shell-breadcrumbs.test.ts`: `/one/profile/regulatory` returns null — fails identically on pristine `main`.

`verify:capacitor:reports` is runtime-derived (CI Android route observations) and not locally satisfiable.