### PR TITLE
feat(mcp): support OAuth client credentials in npm bridge

### DIFF
--- a/.github/workflows/publish-hushh-mcp.yml
+++ b/.github/workflows/publish-hushh-mcp.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       dist_tag:
-        description: "npm dist-tag to publish (beta only; latest promotion is a separate authenticated dist-tag action)"
+        description: "npm dist-tag to publish after package verification"
         required: true
-        default: beta
+        default: latest
         type: choice
         options:
           - beta
+          - latest
 
 permissions:
   contents: read
@@ -70,7 +71,7 @@ jobs:
       - name: Publish package
         working-directory: ${{ env.PACKAGE_DIR }}
         # OIDC is selected by npm automatically. Do not add NODE_AUTH_TOKEN.
-        run: npm publish --tag beta --provenance
+        run: npm publish --tag "${{ inputs.dist_tag }}" --provenance
 
       - name: Verify exact published package from a clean npm cache
         shell: bash

--- a/consent-protocol/mcp_modules/developer_context.py
+++ b/consent-protocol/mcp_modules/developer_context.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
 from contextvars import ContextVar, Token
 from urllib.parse import urlparse
+
+import httpx
 
 from hushh_mcp.services.developer_registry_service import (
     DEFAULT_PUBLIC_TOOL_GROUPS,
@@ -23,10 +27,72 @@ _current_developer_token: ContextVar[str | None] = ContextVar(
     "hushh_mcp_developer_token",
     default=None,
 )
+_oauth_token_lock = threading.Lock()
+_oauth_access_token: tuple[str, float] | None = None
+_OAUTH_TOKEN_REFRESH_SKEW_SECONDS = 60.0
+_OAUTH_TOKEN_REQUEST_TIMEOUT_SECONDS = 10.0
 
 
 def _configured_token() -> str:
-    return str(os.getenv("HUSHH_DEVELOPER_TOKEN", "")).strip()
+    developer_token = str(os.getenv("HUSHH_DEVELOPER_TOKEN", "")).strip()
+    return developer_token or _client_credentials_access_token()
+
+
+def _client_credentials_access_token() -> str:
+    """Return one in-memory OAuth client-credentials token for this bridge.
+
+    Client credentials are accepted only for operations-provisioned developer
+    apps by the remote OAuth service.  This connector caches the returned
+    bearer token only in process memory and renews it before expiry.  It never
+    persists or logs the client secret, access token, or token response.
+    """
+    global _oauth_access_token
+
+    client_id = str(os.getenv("HUSHH_OAUTH_CLIENT_ID", "")).strip()
+    client_secret = str(os.getenv("HUSHH_OAUTH_CLIENT_SECRET", "")).strip()
+    if not client_id or not client_secret:
+        return ""
+
+    now = time.monotonic()
+    cached = _oauth_access_token
+    if cached is not None and cached[1] > now:
+        return cached[0]
+
+    with _oauth_token_lock:
+        now = time.monotonic()
+        cached = _oauth_access_token
+        if cached is not None and cached[1] > now:
+            return cached[0]
+
+        configured_url = str(os.getenv("HUSHH_OAUTH_TOKEN_URL", "")).strip()
+        api_origin = str(os.getenv("CONSENT_API_URL", "")).strip().rstrip("/")
+        token_url = configured_url or f"{api_origin}/oauth/token"
+        if not token_url or urlparse(token_url).scheme not in {"http", "https"}:
+            return ""
+        try:
+            response = httpx.post(
+                token_url,
+                data={"grant_type": "client_credentials", "scope": "mcp:tools"},
+                auth=(client_id, client_secret),
+                timeout=_OAUTH_TOKEN_REQUEST_TIMEOUT_SECONDS,
+            )
+            if response.status_code != 200:
+                return ""
+            payload = response.json()
+        except (httpx.HTTPError, ValueError):
+            return ""
+
+        access_token = str(payload.get("access_token") or "").strip()
+        token_type = str(payload.get("token_type") or "").strip().lower()
+        if not access_token or token_type != "bearer":  # noqa: S105 - OAuth token type
+            return ""
+        try:
+            expires_in = max(1, int(payload.get("expires_in") or 0))
+        except (TypeError, ValueError):
+            return ""
+        refresh_after = now + max(1.0, expires_in - _OAUTH_TOKEN_REFRESH_SKEW_SECONDS)
+        _oauth_access_token = (access_token, refresh_after)
+        return access_token
 
 
 def _delegates_auth_to_remote_api() -> bool:

--- a/consent-protocol/mcp_modules/tools/public_tools_v3.py
+++ b/consent-protocol/mcp_modules/tools/public_tools_v3.py
@@ -259,7 +259,10 @@ async def handle_search_user_scopes(args: dict) -> ToolResult:
             "AUTHENTICATION_REQUIRED",
             "Developer bearer authentication is required.",
             recoverable=True,
-            next_action="Configure HUSHH_DEVELOPER_TOKEN in the connector environment.",
+            next_action=(
+                "Configure HUSHH_DEVELOPER_TOKEN or approved OAuth client credentials "
+                "in the connector environment."
+            ),
         )
     try:
         async with httpx.AsyncClient(timeout=BACKEND_REQUEST_TIMEOUT) as client:
@@ -320,7 +323,10 @@ async def handle_request_consent(args: dict) -> ToolResult:
             "AUTHENTICATION_REQUIRED",
             "Developer bearer authentication is required.",
             recoverable=True,
-            next_action="Configure HUSHH_DEVELOPER_TOKEN in the connector environment.",
+            next_action=(
+                "Configure HUSHH_DEVELOPER_TOKEN or approved OAuth client credentials "
+                "in the connector environment."
+            ),
         )
 
     scope = str(args.get("scope") or "").strip()
@@ -430,7 +436,10 @@ async def handle_check_consent_status(args: dict) -> ToolResult:
             "AUTHENTICATION_REQUIRED",
             "Developer bearer authentication is required.",
             recoverable=True,
-            next_action="Configure HUSHH_DEVELOPER_TOKEN in the connector environment.",
+            next_action=(
+                "Configure HUSHH_DEVELOPER_TOKEN or approved OAuth client credentials "
+                "in the connector environment."
+            ),
         )
     request_ref = str(args.get("request_ref") or "").strip()
     try:
@@ -480,7 +489,10 @@ async def handle_get_encrypted_scoped_export(args: dict) -> ToolResult:
             "AUTHENTICATION_REQUIRED",
             "Developer bearer authentication is required.",
             recoverable=True,
-            next_action="Configure HUSHH_DEVELOPER_TOKEN in the connector environment.",
+            next_action=(
+                "Configure HUSHH_DEVELOPER_TOKEN or approved OAuth client credentials "
+                "in the connector environment."
+            ),
         )
     expected_scope = str(args.get("expected_scope") or "").strip()
     try:

--- a/consent-protocol/tests/test_mcp_client_credentials_bridge.py
+++ b/consent-protocol/tests/test_mcp_client_credentials_bridge.py
@@ -1,0 +1,80 @@
+"""In-memory OAuth client-credentials coverage for the local stdio bridge."""
+
+from __future__ import annotations
+
+import time
+
+from mcp_modules import developer_context
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _reset_oauth_cache() -> None:
+    developer_context._oauth_access_token = None  # type: ignore[attr-defined]
+
+
+def test_client_credentials_exchange_uses_post_basic_auth_and_reuses_memory_token(monkeypatch):
+    _reset_oauth_cache()
+    monkeypatch.delenv("HUSHH_DEVELOPER_TOKEN", raising=False)
+    monkeypatch.setenv("HUSHH_OAUTH_CLIENT_ID", "hco_test_client")
+    monkeypatch.setenv("HUSHH_OAUTH_CLIENT_SECRET", "test-secret")
+    monkeypatch.setenv("CONSENT_API_URL", "https://api.example.test")
+    calls: list[dict] = []
+
+    def fake_post(url, **kwargs):
+        calls.append({"url": url, **kwargs})
+        return _Response(
+            {"access_token": "hdo_at_test", "token_type": "Bearer", "expires_in": 3600}
+        )
+
+    monkeypatch.setattr(developer_context.httpx, "post", fake_post)
+
+    assert developer_context.get_developer_api_headers() == {"Authorization": "Bearer hdo_at_test"}
+    assert developer_context.get_developer_api_headers() == {"Authorization": "Bearer hdo_at_test"}
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://api.example.test/oauth/token"
+    assert calls[0]["data"] == {"grant_type": "client_credentials", "scope": "mcp:tools"}
+    assert calls[0]["auth"] == ("hco_test_client", "test-secret")
+
+
+def test_client_credentials_renews_before_expiry_without_persisting_token(monkeypatch):
+    _reset_oauth_cache()
+    monkeypatch.delenv("HUSHH_DEVELOPER_TOKEN", raising=False)
+    monkeypatch.setenv("HUSHH_OAUTH_CLIENT_ID", "hco_test_client")
+    monkeypatch.setenv("HUSHH_OAUTH_CLIENT_SECRET", "test-secret")
+    monkeypatch.setenv("HUSHH_OAUTH_TOKEN_URL", "https://oauth.example.test/token")
+    developer_context._oauth_access_token = ("expired", time.monotonic() - 1)  # type: ignore[attr-defined]
+
+    def fake_post(_url, **_kwargs):
+        return _Response(
+            {"access_token": "hdo_at_renewed", "token_type": "Bearer", "expires_in": 3600}
+        )
+
+    monkeypatch.setattr(developer_context.httpx, "post", fake_post)
+
+    assert developer_context.get_developer_api_headers() == {
+        "Authorization": "Bearer hdo_at_renewed"
+    }
+
+
+def test_developer_token_remains_the_preferred_compatibility_credential(monkeypatch):
+    _reset_oauth_cache()
+    monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "hdt_compatibility")
+    monkeypatch.setenv("HUSHH_OAUTH_CLIENT_ID", "hco_test_client")
+    monkeypatch.setenv("HUSHH_OAUTH_CLIENT_SECRET", "test-secret")
+
+    def unexpected_post(*_args, **_kwargs):
+        raise AssertionError("OAuth exchange should not run when a bearer token is configured.")
+
+    monkeypatch.setattr(developer_context.httpx, "post", unexpected_post)
+    assert developer_context.get_developer_api_headers() == {
+        "Authorization": "Bearer hdt_compatibility"
+    }

--- a/hushh-webapp/lib/developers/public-docs.json
+++ b/hushh-webapp/lib/developers/public-docs.json
@@ -5,6 +5,9 @@
   "tokenEnvVar": "HUSHH_DEVELOPER_TOKEN",
   "mcpProtocolRevision": "2025-11-25",
   "authentication": {
+    "clientIdEnvVar": "HUSHH_OAUTH_CLIENT_ID",
+    "clientSecretEnvVar": "HUSHH_OAUTH_CLIENT_SECRET",
+    "tokenUrlEnvVar": "HUSHH_OAUTH_TOKEN_URL",
     "discoveryUrl": "https://api.uat.hushh.ai/.well-known/oauth-authorization-server",
     "authorizationEndpoint": "https://api.uat.hushh.ai/oauth/authorize",
     "tokenEndpoint": "https://api.uat.hushh.ai/oauth/token",
@@ -79,6 +82,13 @@
       "whenToUse": "your host expects a local stdio process but supports generic mcpServers JSON.",
       "secretNote": "Keep {{TOKEN_ENV_VAR}} local. This should match the same endpoint and token you use for remote MCP.",
       "template": "{\n  \"mcpServers\": {\n    \"hushh-consent\": {\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"{{PACKAGE_NAME}}\"],\n      \"env\": {\n        \"CONSENT_API_URL\": \"{{API_ORIGIN}}\",\n        \"{{TOKEN_ENV_VAR}}\": \"<developer-token>\"\n      }\n    }\n  }\n}"
+    },
+    {
+      "id": "npm-bridge-client-credentials",
+      "title": "npm bridge with OAuth client credentials",
+      "whenToUse": "your operations-provisioned partner connector needs a local stdio process and has an approved Hussh OAuth client ID and secret.",
+      "secretNote": "Keep the client secret only in the host secret store. Configure either a developer token or OAuth client credentials, never both. The bridge obtains and renews an in-memory Bearer token; it never writes credentials into config output, disk, logs, or MCP results.",
+      "template": "{\n  \"mcpServers\": {\n    \"hushh-consent\": {\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"{{PACKAGE_NAME}}\"],\n      \"env\": {\n        \"CONSENT_API_URL\": \"{{API_ORIGIN}}\",\n        \"{{OAUTH_CLIENT_ID_ENV_VAR}}\": \"<operations-provisioned-client-id>\",\n        \"{{OAUTH_CLIENT_SECRET_ENV_VAR}}\": \"<operations-provisioned-client-secret>\"\n      }\n    }\n  }\n}"
     },
     {
       "id": "claude-remote",

--- a/packages/hushh-mcp/CHANGELOG.md
+++ b/packages/hushh-mcp/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.4.1 - 2026-07-30
+
+- Added an explicit npm bridge configuration for operations-provisioned OAuth
+  client credentials. The bridge obtains and renews its short-lived Bearer
+  token in memory; client credentials never appear in MCP results or generated
+  remote configuration.
+- Made the header-only POST MCP migration explicit for users upgrading from
+  the published 0.1.3 package.
+
 ## 0.4.0 - 2026-07-20
 
 - Published one generated five-tool v0.4 catalog for bearer, PKCE, client

--- a/packages/hushh-mcp/README.md
+++ b/packages/hushh-mcp/README.md
@@ -53,7 +53,7 @@ npx -y @hushh/mcp --help
 
 The same `/mcp/` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
 
-Self-serve applications may use a developer token or OAuth authorization code with S256 PKCE and rotating refresh tokens. Discover OAuth metadata at `https://api.uat.hushh.ai/.well-known/oauth-authorization-server`, request `mcp:tools`, and send the resulting credential only as `Authorization: Bearer <access-token>`. Query-string tokens are rejected. OAuth client credentials are reserved for operations-provisioned partner integrations and never grant vault or personal-information authority.
+Self-serve applications may use a developer token or OAuth authorization code with S256 PKCE and rotating refresh tokens. Discover OAuth metadata at `https://api.uat.hushh.ai/.well-known/oauth-authorization-server`, request `mcp:tools`, and send the resulting credential only as `Authorization: Bearer <access-token>`. Query-string tokens are rejected. OAuth client credentials are reserved for operations-provisioned partner integrations and never grant vault or personal-information authority. The npm bridge exchanges `HUSHH_OAUTH_CLIENT_ID` and `HUSHH_OAUTH_CLIENT_SECRET` locally at the token endpoint, retains the resulting Bearer token only in process memory, and renews it before expiry.
 
 Every tool uses shallow, fully described JSON Schema. Successful calls return `structuredContent` as the canonical result and `content[0].text` as its compatibility mirror. Execution errors return `isError: true` with safe JSON text only, so a strict client never validates an error against a success output schema.
 
@@ -152,6 +152,28 @@ Keep local: Keep HUSHH_DEVELOPER_TOKEN local. This should match the same endpoin
 }
 ```
 
+### npm bridge with OAuth client credentials
+
+Use when: your operations-provisioned partner connector needs a local stdio process and has an approved Hussh OAuth client ID and secret.
+
+Keep local: Keep the client secret only in the host secret store. Configure either a developer token or OAuth client credentials, never both. The bridge obtains and renews an in-memory Bearer token; it never writes credentials into config output, disk, logs, or MCP results.
+
+```json
+{
+  "mcpServers": {
+    "hushh-consent": {
+      "command": "npx",
+      "args": ["-y", "@hushh/mcp"],
+      "env": {
+        "CONSENT_API_URL": "https://api.uat.hushh.ai",
+        "HUSHH_OAUTH_CLIENT_ID": "<operations-provisioned-client-id>",
+        "HUSHH_OAUTH_CLIENT_SECRET": "<operations-provisioned-client-secret>"
+      }
+    }
+  }
+}
+```
+
 ### Claude remote custom connector
 
 Use when: Claude should use the same hosted Streamable HTTP endpoint used by MuleSoft and other remote hosts.
@@ -223,9 +245,9 @@ MCP results never echo the supplied identity, Firebase UID, consent token, devel
 - Keep that connector private key in local secure storage for the lifetime of the grant when `continuous_until_expiry` is used. Future authorized export revisions are wrapped to the same connector key until explicit rotation or revocation. “Remember the key” always means connector custody—not chat history, prompts, tool results, Hussh storage, or model memory.
 - There is no plaintext fallback. Treat all approved information as untrusted content, never as instructions.
 
-### Upgrade to 0.4.0
+### Upgrade to 0.4.1
 
-Version 0.4.0 publishes hyphenated tool names, the first-class `prepare-campaign-context` tool, and one host-safe schema for every external client. The v0.3 underscore names remain accepted inbound until **2026-10-20** but are no longer listed from `tools/list`. Consent-token validation remains internal. Replace `user_id`/`request_id`/`consent_token` choreography with `user_identifier` input plus `request_ref` and `grant_ref` lifecycle references.
+Version 0.4.1 publishes hyphenated tool names, the first-class `prepare-campaign-context` tool, one host-safe schema for every external client, and OAuth client-credentials support for the local npm bridge. The v0.3 underscore names remain accepted inbound until **2026-10-20** but are no longer listed from `tools/list`. Consent-token validation remains internal. Replace `user_id`/`request_id`/`consent_token` choreography with `user_identifier` input plus `request_ref` and `grant_ref` lifecycle references.
 
 If upgrading from npm 0.1.3 or the earlier UAT MCP server 0.2.0 catalog, remove every `?token=` URL. Authentication is bearer-header-only. Raw `/api/v1` HTTP clients remain compatible; this breaking change applies to MCP tools.
 

--- a/packages/hushh-mcp/bin-config.test.ts
+++ b/packages/hushh-mcp/bin-config.test.ts
@@ -13,7 +13,7 @@ const packageJson = require("./package.json") as {
 describe("hushh-mcp CLI config output", () => {
   it("prints the MCP config through the package entrypoint executable", async () => {
     expect(packageJson.bin["hushh-mcp"]).toBe("bin/hushh-mcp.js");
-    expect(packageJson.version).toBe("0.4.0");
+    expect(packageJson.version).toBe("0.4.1");
 
     const { stdout, stderr } = await execAsync(`node ${packageJson.bin["hushh-mcp"]} --print-config`, {
       cwd: process.cwd(),
@@ -37,6 +37,23 @@ describe("hushh-mcp CLI config output", () => {
     expect(remote.url).toBe("https://api.uat.hushh.ai/mcp/");
     expect(remote.headers.Authorization).toBe("Bearer <developer-token>");
     expect(remote.url).not.toContain("token=");
+  });
+
+  it("prints operations-provisioned OAuth client-credentials bridge config", async () => {
+    const { stdout, stderr } = await execAsync(
+      `node ${packageJson.bin["hushh-mcp"]} --print-client-credentials-config`,
+      { cwd: process.cwd() },
+    );
+
+    expect(stderr).toBe("");
+    const config = JSON.parse(stdout);
+    const bridge = config.mcpServers["hushh-consent"];
+    expect(bridge.env.CONSENT_API_URL).toBe("https://api.uat.hushh.ai");
+    expect(bridge.env.HUSHH_OAUTH_CLIENT_ID).toBe("<operations-provisioned-client-id>");
+    expect(bridge.env.HUSHH_OAUTH_CLIENT_SECRET).toBe(
+      "<operations-provisioned-client-secret>",
+    );
+    expect(stdout).not.toContain("HUSHH_DEVELOPER_TOKEN");
   });
 
   it("prints the complete core-plus-campaign static gateway manifest", async () => {

--- a/packages/hushh-mcp/bin/hushh-mcp.js
+++ b/packages/hushh-mcp/bin/hushh-mcp.js
@@ -31,6 +31,7 @@ function printUsage() {
   console.log("  hushh-mcp --print-config");
   console.log("  hushh-mcp --print-codex-toml");
   console.log("  hushh-mcp --print-remote-config");
+  console.log("  hushh-mcp --print-client-credentials-config");
   console.log("  hushh-mcp --print-gateway-manifest");
   console.log("  hushh-mcp --print-agentforce-manifest");
   console.log("  hushh-mcp --print-salesforce-agentexchange-handoff");
@@ -44,6 +45,9 @@ function printUsage() {
   console.log("  HUSHH_MCP_PYTHON        Optional base Python interpreter for bootstrap");
   console.log("  CONSENT_API_URL         Backend origin for stdio bridge consent API calls");
   console.log("  HUSHH_DEVELOPER_TOKEN   Self-serve developer token used by stdio MCP");
+  console.log("  HUSHH_OAUTH_CLIENT_ID   Operations-provisioned OAuth client ID for stdio MCP");
+  console.log("  HUSHH_OAUTH_CLIENT_SECRET  Matching OAuth client secret; never combine with developer token");
+  console.log("  HUSHH_OAUTH_TOKEN_URL   Optional OAuth token endpoint override");
   console.log("  HUSHH_MCP_SKIP_BOOTSTRAP  Set to 1 to skip venv creation and pip install");
 }
 
@@ -87,6 +91,28 @@ function printRemoteConfig() {
             url: promotedRemoteUrl,
             headers: {
               Authorization: "Bearer <developer-token>",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function printClientCredentialsConfig() {
+  console.log(
+    JSON.stringify(
+      {
+        mcpServers: {
+          "hushh-consent": {
+            command: "npx",
+            args: ["-y", "@hushh/mcp"],
+            env: {
+              CONSENT_API_URL: promotedApiOrigin,
+              HUSHH_OAUTH_CLIENT_ID: "<operations-provisioned-client-id>",
+              HUSHH_OAUTH_CLIENT_SECRET: "<operations-provisioned-client-secret>",
             },
           },
         },
@@ -350,6 +376,19 @@ function buildEnv(runtimeDir) {
   return merged;
 }
 
+function validateAuthConfiguration(env) {
+  const developerToken = String(env.HUSHH_DEVELOPER_TOKEN || "").trim();
+  const clientId = String(env.HUSHH_OAUTH_CLIENT_ID || "").trim();
+  const clientSecret = String(env.HUSHH_OAUTH_CLIENT_SECRET || "").trim();
+
+  if (developerToken && (clientId || clientSecret)) {
+    fatal("Configure either HUSHH_DEVELOPER_TOKEN or OAuth client credentials, never both.");
+  }
+  if (Boolean(clientId) !== Boolean(clientSecret)) {
+    fatal("OAuth client-credentials mode requires both HUSHH_OAUTH_CLIENT_ID and HUSHH_OAUTH_CLIENT_SECRET.");
+  }
+}
+
 if (args.includes("--help") || args.includes("-h")) {
   printUsage();
   process.exit(0);
@@ -367,6 +406,11 @@ if (args.includes("--print-codex-toml")) {
 
 if (args.includes("--print-remote-config")) {
   printRemoteConfig();
+  process.exit(0);
+}
+
+if (args.includes("--print-client-credentials-config")) {
+  printClientCredentialsConfig();
   process.exit(0);
 }
 
@@ -423,6 +467,7 @@ const runtimeDir = resolveRuntimeDir();
 const python = ensureBootstrap(runtimeDir);
 const serverPath = path.join(runtimeDir, "mcp_server.py");
 const childEnv = buildEnv(runtimeDir);
+validateAuthConfiguration(childEnv);
 
 const child = spawn(python.command, [...python.args, serverPath], {
   cwd: runtimeDir,

--- a/packages/hushh-mcp/package-lock.json
+++ b/packages/hushh-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hushh/mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hushh/mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "bin": {
         "hushh-mcp": "bin/hushh-mcp.js"

--- a/packages/hushh-mcp/package.json
+++ b/packages/hushh-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hushh/mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Launch-friendly npm wrapper for the Hussh Consent MCP server",
   "license": "Apache-2.0",
   "repository": {
@@ -38,6 +38,7 @@
     "print-config": "node ./bin/hushh-mcp.js --print-config",
     "print-codex-toml": "node ./bin/hushh-mcp.js --print-codex-toml",
     "print-remote-config": "node ./bin/hushh-mcp.js --print-remote-config",
+    "print-client-credentials-config": "node ./bin/hushh-mcp.js --print-client-credentials-config",
     "print-gateway-manifest": "node ./bin/hushh-mcp.js --print-gateway-manifest",
     "print-agentforce-manifest": "node ./bin/hushh-mcp.js --print-agentforce-manifest",
     "print-mulesoft-exchange-manifest": "node ./bin/hushh-mcp.js --print-mulesoft-exchange-manifest",

--- a/packages/hushh-mcp/public-docs.json
+++ b/packages/hushh-mcp/public-docs.json
@@ -5,6 +5,9 @@
   "tokenEnvVar": "HUSHH_DEVELOPER_TOKEN",
   "mcpProtocolRevision": "2025-11-25",
   "authentication": {
+    "clientIdEnvVar": "HUSHH_OAUTH_CLIENT_ID",
+    "clientSecretEnvVar": "HUSHH_OAUTH_CLIENT_SECRET",
+    "tokenUrlEnvVar": "HUSHH_OAUTH_TOKEN_URL",
     "discoveryUrl": "https://api.uat.hushh.ai/.well-known/oauth-authorization-server",
     "authorizationEndpoint": "https://api.uat.hushh.ai/oauth/authorize",
     "tokenEndpoint": "https://api.uat.hushh.ai/oauth/token",
@@ -79,6 +82,13 @@
       "whenToUse": "your host expects a local stdio process but supports generic mcpServers JSON.",
       "secretNote": "Keep {{TOKEN_ENV_VAR}} local. This should match the same endpoint and token you use for remote MCP.",
       "template": "{\n  \"mcpServers\": {\n    \"hushh-consent\": {\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"{{PACKAGE_NAME}}\"],\n      \"env\": {\n        \"CONSENT_API_URL\": \"{{API_ORIGIN}}\",\n        \"{{TOKEN_ENV_VAR}}\": \"<developer-token>\"\n      }\n    }\n  }\n}"
+    },
+    {
+      "id": "npm-bridge-client-credentials",
+      "title": "npm bridge with OAuth client credentials",
+      "whenToUse": "your operations-provisioned partner connector needs a local stdio process and has an approved Hussh OAuth client ID and secret.",
+      "secretNote": "Keep the client secret only in the host secret store. Configure either a developer token or OAuth client credentials, never both. The bridge obtains and renews an in-memory Bearer token; it never writes credentials into config output, disk, logs, or MCP results.",
+      "template": "{\n  \"mcpServers\": {\n    \"hushh-consent\": {\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"{{PACKAGE_NAME}}\"],\n      \"env\": {\n        \"CONSENT_API_URL\": \"{{API_ORIGIN}}\",\n        \"{{OAUTH_CLIENT_ID_ENV_VAR}}\": \"<operations-provisioned-client-id>\",\n        \"{{OAUTH_CLIENT_SECRET_ENV_VAR}}\": \"<operations-provisioned-client-secret>\"\n      }\n    }\n  }\n}"
     },
     {
       "id": "claude-remote",

--- a/packages/hushh-mcp/scripts/render-readme.mjs
+++ b/packages/hushh-mcp/scripts/render-readme.mjs
@@ -37,7 +37,9 @@ function renderTemplate(template) {
     .replaceAll("{{PACKAGE_NAME}}", contract.packageName)
     .replaceAll("{{API_ORIGIN}}", contract.promotedEnvironment.apiOrigin)
     .replaceAll("{{REMOTE_URL}}", contract.promotedEnvironment.remoteUrlTemplate)
-    .replaceAll("{{TOKEN_ENV_VAR}}", contract.tokenEnvVar);
+    .replaceAll("{{TOKEN_ENV_VAR}}", contract.tokenEnvVar)
+    .replaceAll("{{OAUTH_CLIENT_ID_ENV_VAR}}", contract.authentication.clientIdEnvVar)
+    .replaceAll("{{OAUTH_CLIENT_SECRET_ENV_VAR}}", contract.authentication.clientSecretEnvVar);
 }
 
 function renderHostExample(example) {
@@ -121,7 +123,7 @@ npx -y ${contract.packageName} --help
 
 The same \`/mcp/\` endpoint publishes one generated v0.4 five-tool catalog to Codex, Claude, Agentforce, and the npm bridge. Bearer authentication remains first-class. OAuth PKCE and client credentials authenticate the same developer-app identity; they do not select a different consent product, endpoint, or lifecycle.
 
-Self-serve applications may use a developer token or OAuth authorization code with S256 PKCE and rotating refresh tokens. Discover OAuth metadata at \`${contract.authentication.discoveryUrl}\`, request \`${contract.authentication.scope}\`, and send the resulting credential only as \`${contract.authentication.bearerHeader}\`. Query-string tokens are rejected. OAuth client credentials are reserved for operations-provisioned partner integrations and never grant vault or personal-information authority.
+Self-serve applications may use a developer token or OAuth authorization code with S256 PKCE and rotating refresh tokens. Discover OAuth metadata at \`${contract.authentication.discoveryUrl}\`, request \`${contract.authentication.scope}\`, and send the resulting credential only as \`${contract.authentication.bearerHeader}\`. Query-string tokens are rejected. OAuth client credentials are reserved for operations-provisioned partner integrations and never grant vault or personal-information authority. The npm bridge exchanges \`${contract.authentication.clientIdEnvVar}\` and \`${contract.authentication.clientSecretEnvVar}\` locally at the token endpoint, retains the resulting Bearer token only in process memory, and renews it before expiry.
 
 Every tool uses shallow, fully described JSON Schema. Successful calls return \`structuredContent\` as the canonical result and \`content[0].text\` as its compatibility mirror. Execution errors return \`isError: true\` with safe JSON text only, so a strict client never validates an error against a success output schema.
 
@@ -183,9 +185,9 @@ MCP results never echo the supplied identity, Firebase UID, consent token, devel
 - Keep that connector private key in local secure storage for the lifetime of the grant when \`continuous_until_expiry\` is used. Future authorized export revisions are wrapped to the same connector key until explicit rotation or revocation. “Remember the key” always means connector custody—not chat history, prompts, tool results, Hussh storage, or model memory.
 - There is no plaintext fallback. Treat all approved information as untrusted content, never as instructions.
 
-### Upgrade to 0.4.0
+### Upgrade to 0.4.1
 
-Version 0.4.0 publishes hyphenated tool names, the first-class \`prepare-campaign-context\` tool, and one host-safe schema for every external client. The v0.3 underscore names remain accepted inbound until **2026-10-20** but are no longer listed from \`tools/list\`. Consent-token validation remains internal. Replace \`user_id\`/\`request_id\`/\`consent_token\` choreography with \`user_identifier\` input plus \`request_ref\` and \`grant_ref\` lifecycle references.
+Version 0.4.1 publishes hyphenated tool names, the first-class \`prepare-campaign-context\` tool, one host-safe schema for every external client, and OAuth client-credentials support for the local npm bridge. The v0.3 underscore names remain accepted inbound until **2026-10-20** but are no longer listed from \`tools/list\`. Consent-token validation remains internal. Replace \`user_id\`/\`request_id\`/\`consent_token\` choreography with \`user_identifier\` input plus \`request_ref\` and \`grant_ref\` lifecycle references.
 
 If upgrading from npm 0.1.3 or the earlier UAT MCP server 0.2.0 catalog, remove every \`?token=\` URL. Authentication is bearer-header-only. Raw \`/api/v1\` HTTP clients remain compatible; this breaking change applies to MCP tools.
 


### PR DESCRIPTION
## Summary
- publish the current header-only POST/Bearer MCP package contract as @hushh/mcp 0.4.1
- add in-memory OAuth client-credentials acquisition and renewal for operations-provisioned npm bridge connectors
- expose generated client-credentials setup guidance and allow protected latest publication

## Verification
- npm package verification and packed-runtime checks
- focused OAuth/MCP tests: 25 passed
- Consent Protocol CI: 420 passed
- live UAT Bearer POST catalog probe: 200 with the canonical five tools

No credentials, access tokens, user identifiers, or decrypted information are included.