### PR TITLE
fix(mcp): use uv runtime for package release verification

### DIFF
--- a/.github/workflows/publish-hushh-mcp.yml
+++ b/.github/workflows/publish-hushh-mcp.yml
@@ -54,6 +54,11 @@ jobs:
 
       - name: Verify release artifact
         working-directory: ${{ env.PACKAGE_DIR }}
+        env:
+          # Gateway manifest generation imports the canonical Python MCP
+          # contract. Use the dependency-complete uv environment rather than
+          # the runner's bare system Python.
+          HUSHH_MCP_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
         run: npm run verify:package
 
       - name: Guard against duplicate npm version


### PR DESCRIPTION
## Summary
- run package release verification with the consent protocol’s synced uv Python
- prevent canonical gateway-contract generation from importing through the dependency-free runner Python

## Verification
- `HUSHH_MCP_PYTHON="$PWD/consent-protocol/.venv/bin/python" TESTING=true APP_SIGNING_KEY=… VAULT_DATA_KEY=… npm --prefix packages/hushh-mcp run verify:package`

No credentials or protected information are included.