### PR TITLE
fix(mcp): keep release prepack on uv runtime

### DIFF
--- a/.github/workflows/publish-hushh-mcp.yml
+++ b/.github/workflows/publish-hushh-mcp.yml
@@ -22,6 +22,9 @@ jobs:
     environment: npm-publish
     env:
       PACKAGE_DIR: packages/hushh-mcp
+      # Both release verification and npm's prepack lifecycle generate the
+      # canonical gateway contract. They must use the synced Python runtime.
+      HUSHH_MCP_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
 
     steps:
       - name: Assert main-only release dispatch
@@ -54,11 +57,6 @@ jobs:
 
       - name: Verify release artifact
         working-directory: ${{ env.PACKAGE_DIR }}
-        env:
-          # Gateway manifest generation imports the canonical Python MCP
-          # contract. Use the dependency-complete uv environment rather than
-          # the runner's bare system Python.
-          HUSHH_MCP_PYTHON: ${{ github.workspace }}/consent-protocol/.venv/bin/python
         run: npm run verify:package
 
       - name: Guard against duplicate npm version


### PR DESCRIPTION
## Summary
- make the synced consent-protocol uv Python available to both release verification and npm prepack
- prevent gateway-manifest generation from falling back to the runner Python during publish

## Verification
- `HUSHH_MCP_PYTHON="$PWD/consent-protocol/.venv/bin/python" TESTING=true APP_SIGNING_KEY=… VAULT_DATA_KEY=… npm --prefix packages/hushh-mcp run verify:package`

No credentials or protected information are included.