### PR TITLE
feat(connect): request granular data scopes on connect via ZK pipeline

### DIFF
--- a/consent-protocol/api/routes/one/connections.py
+++ b/consent-protocol/api/routes/one/connections.py
@@ -25,10 +25,26 @@ class CreateRequestBody(BaseModel):
     addressee_user_id: str | None = None
     query: str | None = None
     message: str | None = None
+    # Optional granular data-scope request bundled with the connection request.
+    # The requester publishes an on-device X25519 public key so the addressee can
+    # ZK-wrap each granted scope to it (reuses the proven consent export path).
+    requested_scopes: list[str] | None = None
+    requester_public_key: str | None = None
+    requester_key_id: str | None = None
 
 
 class LinkCircleInviteBody(BaseModel):
     peer_user_id: str
+
+
+class AcceptRequestBody(BaseModel):
+    # Optional per-scope decision applied at accept time. Scopes the addressee
+    # left OUT of `granted_scopes` (or listed in `denied_scopes`) are recorded as
+    # denied; the rest are minted as pending scope requests for later resolution
+    # in the consent center. Omit both to accept the connection with every
+    # requested scope queued.
+    granted_scopes: list[str] | None = None
+    denied_scopes: list[str] | None = None
 
 
 @router.get("/connections/directory")
@@ -63,6 +79,29 @@ def list_connection_requests(
         raise _handle(exc) from exc
 
 
+@router.get("/connections/requestable-scopes")
+def list_requestable_scopes(firebase_uid: str = Depends(require_firebase_auth)):
+    # Global, presence-safe catalog for the Connect scope picker. Auth-gated but
+    # user-agnostic: it reflects no specific user's holdings, so it cannot leak
+    # whether the person being connected with has any given data.
+    try:
+        return _service().list_requestable_scopes()
+    except Exception as exc:  # noqa: BLE001
+        raise _handle(exc) from exc
+
+
+@router.get("/connections/received-exports")
+def list_received_exports(firebase_uid: str = Depends(require_firebase_auth)):
+    # Scope exports other users sealed to THIS user's Connect requester key.
+    # The payload carries only ciphertext + the X25519-wrapped export key; the
+    # server never holds the plaintext, and only the addressee's on-device
+    # private key can unwrap it (zero-knowledge).
+    try:
+        return {"items": _service().list_received_scope_exports(firebase_uid)}
+    except Exception as exc:  # noqa: BLE001
+        raise _handle(exc) from exc
+
+
 @router.post("/connections/requests")
 def create_connection_request(
     body: CreateRequestBody,
@@ -75,6 +114,9 @@ def create_connection_request(
                 addressee_user_id=body.addressee_user_id,
                 query=body.query,
                 message=body.message,
+                requested_scopes=body.requested_scopes,
+                requester_public_key=body.requester_public_key,
+                requester_key_id=body.requester_key_id,
             )
         }
     except Exception as exc:  # noqa: BLE001
@@ -97,10 +139,18 @@ def link_circle_invite(
 @router.post("/connections/requests/{request_id}/accept")
 def accept_connection_request(
     request_id: str = Path(...),
+    body: AcceptRequestBody | None = None,
     firebase_uid: str = Depends(require_firebase_auth),
 ):
     try:
-        return {"result": _service().accept_request(firebase_uid, request_id)}
+        return {
+            "result": _service().accept_request(
+                firebase_uid,
+                request_id,
+                granted_scopes=(body.granted_scopes if body else None),
+                denied_scopes=(body.denied_scopes if body else None),
+            )
+        }
     except Exception as exc:  # noqa: BLE001
         raise _handle(exc) from exc
 

--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -9,13 +9,118 @@ discovery directory `list_directory_candidates`, read-only.
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Callable
 
 from db.db_client import get_db
 from hushh_mcp.services.feed_service import FeedService
 
 logger = logging.getLogger(__name__)
+
+# Connect scope-request fan-out constants. A granted P2P scope reuses the proven
+# consent export path: the requester publishes an on-device X25519 public key and
+# the addressee's `handleApprove` wraps each granted scope's export key back to it
+# (X25519 ECDH -> SHA-256 -> AES-256-GCM). The backend only ever relays ciphertext.
+_CONNECTOR_WRAPPING_ALG = "X25519-AES256-GCM"
+_CONNECTION_REQUEST_SOURCE = "connection"
+_CONNECTION_ACTOR_TYPE = "connection"
+# Pending scope-request events live for 14 days (parity with the consent/KYC
+# request window). The narrower grant TTL is applied later by the approve path.
+_CONNECTION_REQUEST_TTL_MS = 14 * 24 * 60 * 60 * 1000
+
+# Domains never offered in the P2P Connect scope picker: advisor (`ria`) and, for
+# v1, precise `location` (shared through the live-location grant flow, not durable
+# `attr.location.*`). Internal-only slugs are excluded separately via
+# `INTERNAL_ONLY_DOMAIN_SLUGS`. The catalog is fully static + global so the picker
+# never reveals whether the addressee actually holds any of these scopes.
+_P2P_EXCLUDED_SCOPE_DOMAINS = frozenset({"ria", "location"})
+# Domains whose data is treated as high-sensitivity in the picker (drives the
+# per-scope caution affordance in the UX).
+_HIGH_SENSITIVITY_DOMAINS = frozenset({"financial", "health"})
+
+
+def _scope_domain(scope: str) -> str:
+    """Top-level PKM domain of an ``attr.<domain>.<branch>.*`` scope ("" if n/a)."""
+    parts = str(scope or "").strip().split(".")
+    return parts[1] if len(parts) > 1 and parts[0] == "attr" else ""
+
+
+def _is_p2p_requestable_scope(scope: str) -> bool:
+    """Whether a person may ask another person to share ``scope``.
+
+    Most-restrictive-wins: it must be an externally requestable semantic branch
+    (``attr.<domain>.<branch>.*``), never a capability/agent scope (including
+    ``cap.one.invoke``), and never in an internal-only or excluded domain.
+    """
+    from hushh_mcp.constants import ConsentScope
+    from hushh_mcp.services.domain_contracts import INTERNAL_ONLY_DOMAIN_SLUGS
+
+    normalized = str(scope or "").strip()
+    if not ConsentScope.is_external_requestable_scope(normalized):
+        return False
+    # `is_external_requestable_scope` also returns True for cap.one.invoke; the
+    # P2P picker never offers capability/agent scopes, only durable attr.* data.
+    if normalized == ConsentScope.CAP_ONE_INVOKE.value:
+        return False
+    if normalized.startswith(("agent.", "cap.")):
+        return False
+    domain = _scope_domain(normalized)
+    if not domain:
+        return False
+    if domain in INTERNAL_ONLY_DOMAIN_SLUGS or domain in _P2P_EXCLUDED_SCOPE_DOMAINS:
+        return False
+    return True
+
+
+def build_requestable_scope_catalog() -> dict[str, Any]:
+    """Global, presence-safe catalog of scopes one person may request from another.
+
+    Derived from the curated ``CANONICAL_BUNDLES`` (which enumerate real, valid
+    ``attr.<domain>.<branch>.*`` scopes), filtered to the P2P-shareable set. This is
+    intentionally NOT the developer ``/user-scopes/{id}`` discovery endpoint — that
+    reflects a *specific user's* holdings and would leak "does B have financial
+    data?" before consent. This catalog reflects no user's data at all.
+    """
+    from hushh_mcp.consent.scope_bundles import CANONICAL_BUNDLES
+    from hushh_mcp.consent.scope_helpers import get_scope_display_metadata
+
+    bundles: list[dict[str, Any]] = []
+    flat: dict[str, None] = {}  # first-seen order, de-duped across bundles
+    for bundle in CANONICAL_BUNDLES.values():
+        allowed = [s for s in bundle.scopes if _is_p2p_requestable_scope(s)]
+        if not allowed:
+            continue  # e.g. kyc_workflow (agent.* scopes) drops out entirely
+        bundles.append(
+            {
+                "id": bundle.bundle_key,
+                "label": bundle.label,
+                "description": bundle.description,
+                "icon_name": bundle.icon_name,
+                "color_hex": bundle.color_hex,
+                "scopes": allowed,
+            }
+        )
+        for scope in allowed:
+            flat.setdefault(scope, None)
+
+    scopes: list[dict[str, Any]] = []
+    for scope in sorted(flat):
+        meta = get_scope_display_metadata(scope)
+        scopes.append(
+            {
+                "scope": scope,
+                "label": meta.get("label"),
+                "description": meta.get("description"),
+                "icon_name": meta.get("icon_name"),
+                "color_hex": meta.get("color_hex"),
+                "sensitivity": (
+                    "high" if _scope_domain(scope) in _HIGH_SENSITIVITY_DOMAINS else "low"
+                ),
+            }
+        )
+    return {"bundles": bundles, "scopes": scopes}
 
 
 class ConnectionsError(RuntimeError):
@@ -88,6 +193,9 @@ class ConnectionsService:
         addressee_user_id: str | None = None,
         query: str | None = None,
         message: str | None = None,
+        requested_scopes: list[str] | None = None,
+        requester_public_key: str | None = None,
+        requester_key_id: str | None = None,
     ) -> dict[str, Any]:
         requester_user_id = (requester_user_id or "").strip()
         if not requester_user_id:
@@ -115,10 +223,13 @@ class ConnectionsService:
                 "CONNECTION_NO_SELF", "You cannot connect with yourself.", status_code=422
             )
 
-        # Idempotent: if a pending request already exists (either direction), return it.
+        # Idempotent: if a pending request already exists (either direction), return
+        # it. On a same-direction re-ask carrying new scope info, merge the new
+        # scopes / refreshed requester key into the existing request instead of
+        # dropping them (the picker may have been reopened to ask for more).
         existing = self._execute_one(
             """
-            SELECT id, requester_user_id, addressee_user_id, status, message
+            SELECT id, requester_user_id, addressee_user_id, status, message, metadata
             FROM connection_requests
             WHERE status = 'pending'
               AND (
@@ -130,23 +241,57 @@ class ConnectionsService:
             {"a": requester_user_id, "b": target},
         )
         if existing:
+            merged_meta = self._parse_request_metadata(existing.get("metadata"))
+            incoming_meta = self._build_scope_request_metadata(
+                requested_scopes=requested_scopes,
+                requester_public_key=requester_public_key,
+                requester_key_id=requester_key_id,
+            )
+            same_direction = (
+                str(existing.get("requester_user_id")) == requester_user_id
+                and str(existing.get("addressee_user_id")) == target
+            )
+            if same_direction and incoming_meta:
+                merged_meta = self._merge_scope_request_metadata(
+                    existing.get("metadata"), incoming_meta
+                )
+                self._execute_one(
+                    """
+                    UPDATE connection_requests
+                    SET metadata = CAST(:metadata AS JSONB), updated_at = NOW()
+                    WHERE id = :id
+                    RETURNING id
+                    """,
+                    {"id": existing.get("id"), "metadata": json.dumps(merged_meta)},
+                )
             return {
                 "id": existing.get("id"),
                 "requesterUserId": existing.get("requester_user_id"),
                 "addresseeUserId": existing.get("addressee_user_id"),
                 "status": existing.get("status") or "pending",
                 "message": existing.get("message"),
+                "requestedScopes": merged_meta.get("requested_scopes", []),
             }
 
+        request_metadata = self._build_scope_request_metadata(
+            requested_scopes=requested_scopes,
+            requester_public_key=requester_public_key,
+            requester_key_id=requester_key_id,
+        )
         row = self._execute_one(
             """
             INSERT INTO connection_requests (
-              requester_user_id, addressee_user_id, status, message, created_at, updated_at
+              requester_user_id, addressee_user_id, status, message, metadata, created_at, updated_at
             )
-            VALUES (:requester, :addressee, 'pending', :message, NOW(), NOW())
+            VALUES (:requester, :addressee, 'pending', :message, CAST(:metadata AS JSONB), NOW(), NOW())
             RETURNING id
             """,
-            {"requester": requester_user_id, "addressee": target, "message": message},
+            {
+                "requester": requester_user_id,
+                "addressee": target,
+                "message": message,
+                "metadata": json.dumps(request_metadata),
+            },
         )
         # Best-effort: nudge the addressee's client so the new request appears
         # without a manual "refresh consents". Only on a genuinely NEW insert
@@ -159,12 +304,323 @@ class ConnectionsService:
             "addresseeUserId": target,
             "status": "pending",
             "message": message,
+            "requestedScopes": request_metadata.get("requested_scopes", []),
         }
 
     # ---- Helpers ----
     @staticmethod
+    def _build_scope_request_metadata(
+        *,
+        requested_scopes: list[str] | None,
+        requester_public_key: str | None,
+        requester_key_id: str | None,
+    ) -> dict[str, Any]:
+        """Normalize the optional bundled scope-request into request metadata.
+
+        Persisted on ``connection_requests.metadata`` (JSONB). Empty when the
+        connection carries no scope ask, so plain connects keep the default
+        ``{}`` shape. Scopes are de-duped, order-preserved, and blank-stripped.
+        The requester's on-device X25519 public key travels here so the
+        addressee can ZK-wrap each granted scope back to the requester.
+        """
+        metadata: dict[str, Any] = {}
+        scopes: list[str] = []
+        for scope in requested_scopes or []:
+            cleaned = str(scope or "").strip()
+            if cleaned and cleaned not in scopes:
+                scopes.append(cleaned)
+        if scopes:
+            metadata["requested_scopes"] = scopes
+        public_key = str(requester_public_key or "").strip()
+        if public_key:
+            metadata["requester_public_key"] = public_key
+        key_id = str(requester_key_id or "").strip()
+        if key_id:
+            metadata["requester_key_id"] = key_id
+        return metadata
+
+    @staticmethod
     def _canonical_pair(x: str, y: str) -> tuple[str, str]:
         return (x, y) if x < y else (y, x)
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    @staticmethod
+    def _parse_request_metadata(value: Any) -> dict[str, Any]:
+        """Coerce a ``connection_requests.metadata`` cell into a dict.
+
+        The driver may hand back an already-parsed dict (JSONB) or a raw JSON
+        string depending on the path; normalize both, and never raise.
+        """
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, str) and value.strip():
+            try:
+                parsed = json.loads(value)
+            except (ValueError, TypeError):
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
+    @staticmethod
+    def _merge_scope_request_metadata(existing: Any, incoming: dict[str, Any]) -> dict[str, Any]:
+        """Merge a fresh scope ask into an existing request's metadata.
+
+        Union the requested scopes (order-preserved, de-duped) and let the newest
+        requester key win (the device may have rotated its on-device keypair).
+        """
+        base = ConnectionsService._parse_request_metadata(existing)
+        merged = dict(base)
+        scopes: list[str] = []
+        for scope in list(base.get("requested_scopes") or []) + list(
+            incoming.get("requested_scopes") or []
+        ):
+            cleaned = str(scope or "").strip()
+            if cleaned and cleaned not in scopes:
+                scopes.append(cleaned)
+        if scopes:
+            merged["requested_scopes"] = scopes
+        if incoming.get("requester_public_key"):
+            merged["requester_public_key"] = incoming["requester_public_key"]
+        if incoming.get("requester_key_id"):
+            merged["requester_key_id"] = incoming["requester_key_id"]
+        return merged
+
+    def _lookup_display_name(self, user_id: str) -> str | None:
+        row = self._execute_one(
+            """
+            SELECT display_name FROM actor_identity_cache
+            WHERE user_id = :user_id
+            LIMIT 1
+            """,
+            {"user_id": (user_id or "").strip()},
+        )
+        name = (row or {}).get("display_name")
+        return str(name).strip() if name else None
+
+    def _record_scope_decision(
+        self, *, request_id: str, granted: list[str], denied: list[str]
+    ) -> None:
+        """Persist the accept-time grant/deny snapshot onto the request row.
+
+        Non-fatal audit/render convenience -- the consent events are the source
+        of truth, so a failure here never blocks the accept.
+        """
+        request_id = (request_id or "").strip()
+        if not request_id:
+            return
+        try:
+            self._execute_one(
+                """
+                UPDATE connection_requests
+                SET metadata = jsonb_set(
+                      COALESCE(metadata, '{}'::jsonb),
+                      '{scope_decision}',
+                      CAST(:decision AS JSONB),
+                      true
+                    ),
+                    updated_at = NOW()
+                WHERE id = :id
+                RETURNING id
+                """,
+                {
+                    "id": request_id,
+                    "decision": json.dumps({"granted": granted, "denied": denied}),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "connections.scope_decision_record_failed request=%s error=%s",
+                request_id,
+                exc,
+            )
+
+    def _insert_consent_request_events(
+        self,
+        *,
+        owner_user_id: str,
+        requester_user_id: str,
+        connection_request_id: str,
+        connection_id: str,
+        requester_public_key: str,
+        requester_key_id: str | None,
+        requester_label: str | None,
+        scopes: list[str],
+    ) -> list[str]:
+        """Mint one pending REQUESTED consent event per granted scope.
+
+        Each event carries the requester's on-device X25519 public key in its
+        metadata so that when the owner approves the scope in the consent center,
+        the client's ``handleApprove`` ZK-wraps that scope's export key back to
+        the requester (backend never sees plaintext). Reuses the same
+        ``consent_audit`` event-sourcing path as KYC/RIA consent. Best-effort per
+        scope: the connection is already formed by the time this runs, so a
+        single failed insert is logged rather than rolling back the accept.
+        """
+        if not scopes or not requester_public_key:
+            return []
+        from hushh_mcp.consent.export_envelope import scope_handle_for_machine_scope
+        from hushh_mcp.consent.scope_helpers import get_scope_description
+
+        issued_at = self._now_ms()
+        expires_at = issued_at + _CONNECTION_REQUEST_TTL_MS
+        single = len(scopes) == 1
+        label = (requester_label or "").strip() or "A connection"
+        bundle_label = f"{label} requested {len(scopes)} data {'scope' if single else 'scopes'}"
+        requested: list[str] = []
+        for index, scope in enumerate(scopes):
+            request_id = connection_request_id if single else f"{connection_request_id}:{index}"
+            token_id = f"evt_conn_req_{connection_request_id}_{index}"
+            metadata = {
+                "request_source": _CONNECTION_REQUEST_SOURCE,
+                "requester_actor_type": _CONNECTION_ACTOR_TYPE,
+                # Synthetic, non-empty developer id: downstream consent readers key
+                # telemetry off developer_app_id, but a P2P share has no real dev
+                # app. Prefixed so it can never collide with a marketplace app id.
+                "developer_app_id": f"connection:{requester_user_id}",
+                "scope_handle": scope_handle_for_machine_scope(owner_user_id, scope),
+                "connector_public_key": requester_public_key,
+                "connector_key_id": requester_key_id,
+                "connector_wrapping_alg": _CONNECTOR_WRAPPING_ALG,
+                "requester_label": label,
+                "requester_entity_id": requester_user_id,
+                "bundle_id": connection_request_id,
+                "bundle_label": bundle_label,
+                "bundle_scope_count": len(scopes),
+                "connection_request_id": connection_request_id,
+                "connection_id": connection_id or None,
+                "reason": f"{label} requested access through a Connect scope request.",
+            }
+            metadata = {k: v for k, v in metadata.items() if v is not None}
+            try:
+                self._execute_one(
+                    """
+                    INSERT INTO consent_audit (
+                      token_id, user_id, agent_id, scope, action, request_id,
+                      scope_description, issued_at, expires_at, poll_timeout_at,
+                      metadata
+                    )
+                    VALUES (
+                      :token_id, :user_id, :agent_id, :scope, 'REQUESTED',
+                      :request_id, :scope_description, :issued_at, :expires_at,
+                      :poll_timeout_at, CAST(:metadata AS JSONB)
+                    )
+                    RETURNING id
+                    """,
+                    {
+                        "token_id": token_id,
+                        "user_id": owner_user_id,
+                        "agent_id": requester_user_id,
+                        "scope": scope,
+                        "request_id": request_id,
+                        "scope_description": get_scope_description(scope),
+                        "issued_at": issued_at,
+                        "expires_at": expires_at,
+                        "poll_timeout_at": expires_at,
+                        "metadata": json.dumps(metadata),
+                    },
+                )
+                requested.append(scope)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "connections.scope_request_failed scope=%s request=%s error=%s",
+                    scope,
+                    connection_request_id,
+                    exc,
+                )
+        return requested
+
+    def _cascade_revoke_scope_grants(self, user_a: str, user_b: str) -> int:
+        """Revoke every active Connect scope grant / pending ask between a pair.
+
+        Called on disconnect: for each direction (owner, reader), resolve the
+        latest consent event per scope and, when that latest state is still
+        pending (REQUESTED) or actively granted (CONSENT_GRANTED and unexpired),
+        append a REVOKED event. Mirrors the RIA disconnect cascade. Scanning by
+        (human owner uid, human reader uid) naturally targets only P2P shares --
+        marketplace/RIA grants carry a developer/app id in agent_id, not a raw
+        user id. Idempotent (a re-run finds the latest state already REVOKED) and
+        best-effort (a failed revoke is logged, never fatal to the disconnect).
+        """
+        user_a = (user_a or "").strip()
+        user_b = (user_b or "").strip()
+        if not user_a or not user_b:
+            return 0
+        from hushh_mcp.consent.scope_helpers import get_scope_description
+
+        revoked = 0
+        now_ms = self._now_ms()
+        for owner, reader in ((user_a, user_b), (user_b, user_a)):
+            rows = self._execute_many(
+                """
+                SELECT scope, action, expires_at, issued_at, request_id
+                FROM consent_audit
+                WHERE user_id = :owner AND agent_id = :reader
+                ORDER BY issued_at DESC
+                """,
+                {"owner": owner, "reader": reader},
+            )
+            latest: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                scope_key = str(row.get("scope") or "").strip()
+                if not scope_key or scope_key in latest:
+                    continue
+                latest[scope_key] = row
+            for scope_key, row in latest.items():
+                action = str(row.get("action") or "").strip().upper()
+                if action not in {"REQUESTED", "CONSENT_GRANTED"}:
+                    continue
+                if action == "CONSENT_GRANTED":
+                    expires_at = row.get("expires_at")
+                    if expires_at is not None:
+                        try:
+                            if int(expires_at) <= now_ms:
+                                continue
+                        except (TypeError, ValueError):
+                            pass
+                token_id = f"evt_conn_revoke_{now_ms}_{revoked}"
+                try:
+                    self._execute_one(
+                        """
+                        INSERT INTO consent_audit (
+                          token_id, user_id, agent_id, scope, action, request_id,
+                          scope_description, issued_at, metadata
+                        )
+                        VALUES (
+                          :token_id, :owner, :reader, :scope, 'REVOKED',
+                          :request_id, :scope_description, :issued_at,
+                          CAST(:metadata AS JSONB)
+                        )
+                        RETURNING id
+                        """,
+                        {
+                            "token_id": token_id,
+                            "owner": owner,
+                            "reader": reader,
+                            "scope": scope_key,
+                            "request_id": row.get("request_id"),
+                            "scope_description": get_scope_description(scope_key),
+                            "issued_at": now_ms,
+                            "metadata": json.dumps(
+                                {
+                                    "request_source": _CONNECTION_REQUEST_SOURCE,
+                                    "revoke_origin": "connection_disconnect",
+                                }
+                            ),
+                        },
+                    )
+                    revoked += 1
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "connections.scope_revoke_failed scope=%s owner=%s reader=%s error=%s",
+                        scope_key,
+                        owner,
+                        reader,
+                        exc,
+                    )
+        return revoked
 
     def _notify_new_request(self, addressee_user_id: str, requester_user_id: str) -> None:
         """Fire the (best-effort) addressee nudge. Never raises."""
@@ -182,7 +638,7 @@ class ConnectionsService:
     def _load_request(self, request_id: str) -> dict[str, Any]:
         row = self._execute_one(
             """
-            SELECT id, requester_user_id, addressee_user_id, status
+            SELECT id, requester_user_id, addressee_user_id, status, metadata
             FROM connection_requests
             WHERE id = :id
             LIMIT 1
@@ -209,7 +665,14 @@ class ConnectionsService:
             {"owner": owner, "trusted": trusted},
         )
 
-    def accept_request(self, user_id: str, request_id: str) -> dict[str, Any]:
+    def accept_request(
+        self,
+        user_id: str,
+        request_id: str,
+        *,
+        granted_scopes: list[str] | None = None,
+        denied_scopes: list[str] | None = None,
+    ) -> dict[str, Any]:
         user_id = (user_id or "").strip()
         req = self._load_request(request_id)
         if str(req.get("addressee_user_id")) != user_id:
@@ -260,10 +723,58 @@ class ConnectionsService:
             event_type="connection_accepted",
             metadata={"counterpart_user_id": user_id},
         )
+
+        # ---- Connect scope-request fan-out (optional) ----
+        # If the requester bundled a granular data-scope ask (and published an
+        # on-device public key), mint one pending REQUESTED consent event per
+        # non-denied scope. The addressee resolves each through the EXISTING
+        # consent center: approving ZK-wraps that scope to the requester's key,
+        # denying records CONSENT_DENIED. No crypto happens here.
+        metadata = self._parse_request_metadata(req.get("metadata"))
+        requested_scopes = [
+            str(s).strip() for s in (metadata.get("requested_scopes") or []) if str(s).strip()
+        ]
+        granted_requested: list[str] = []
+        denied_final: list[str] = []
+        if requested_scopes:
+            requested_set = set(requested_scopes)
+            denied_set = {
+                str(s).strip() for s in (denied_scopes or []) if str(s).strip() in requested_set
+            }
+            if granted_scopes is not None:
+                allowed = {
+                    str(s).strip() for s in granted_scopes if str(s).strip() in requested_set
+                }
+            else:
+                # No explicit decision at accept time -> treat every requested
+                # scope (minus any denied) as approved-to-request.
+                allowed = requested_set
+            to_request = [s for s in requested_scopes if s in allowed and s not in denied_set]
+            denied_final = [s for s in requested_scopes if s not in to_request]
+            requester_public_key = str(metadata.get("requester_public_key") or "").strip()
+            if to_request and requester_public_key:
+                granted_requested = self._insert_consent_request_events(
+                    owner_user_id=user_id,
+                    requester_user_id=requester,
+                    connection_request_id=str(req.get("id") or ""),
+                    connection_id=str((conn or {}).get("id") or ""),
+                    requester_public_key=requester_public_key,
+                    requester_key_id=(str(metadata.get("requester_key_id") or "").strip() or None),
+                    requester_label=self._lookup_display_name(requester),
+                    scopes=to_request,
+                )
+            # Snapshot the decision on the request row (audit + requester view).
+            self._record_scope_decision(
+                request_id=str(req.get("id") or ""),
+                granted=granted_requested,
+                denied=denied_final,
+            )
         return {
             "status": "accepted",
             "requestId": req.get("id"),
             "connectionId": (conn or {}).get("id"),
+            "requestedScopes": granted_requested,
+            "deniedScopes": denied_final,
         }
 
     def link_circle_invite(self, user_id: str, *, peer_user_id: str) -> dict[str, Any]:
@@ -359,6 +870,15 @@ class ConnectionsService:
         return {"status": "cancelled", "requestId": req.get("id")}
 
     # ---- Reads ----
+    def list_requestable_scopes(self) -> dict[str, Any]:
+        """Global, presence-safe scope catalog for the Connect scope picker.
+
+        Returns the same static catalog for every caller — it reflects no user's
+        holdings, so surfacing it to a requester never leaks whether the person
+        they are connecting with actually has any of these scopes.
+        """
+        return build_requestable_scope_catalog()
+
     def list_requests(self, user_id: str, *, direction: str) -> list[dict[str, Any]]:
         user_id = (user_id or "").strip()
         if direction == "incoming":
@@ -395,6 +915,107 @@ class ConnectionsService:
             }
             for r in rows
         ]
+
+    def list_received_scope_exports(self, user_id: str) -> list[dict[str, Any]]:
+        """Return every scope export sealed to this user as a Connect requester.
+
+        When an owner approves a scope this user asked for through a Connect
+        scope request, the owner's device wraps that scope's export key to this
+        user's on-device X25519 public key and the backend stores only the
+        ciphertext (zero-knowledge). Those packages are addressed by the
+        synthetic ``app_id = connection:{requester_user_id}``, so one indexed
+        lookup by app id returns exactly what this user can decrypt -- the
+        server never holds the plaintext or the unwrapped export key.
+
+        The returned shape mirrors the KYC scoped-export package
+        (``encrypted_data``/``iv``/``tag`` + snake_case ``wrapped_key_bundle`` +
+        a reconstructed ``export_envelope``) so the client can rebuild the exact
+        authenticated-envelope AAD and decrypt with the proven pipeline. Only
+        authenticated v2 envelopes carrying a wrapped key bundle are surfaced;
+        anything else is undecryptable noise and is skipped.
+        """
+        user_id = (user_id or "").strip()
+        if not user_id:
+            return []
+        app_id = f"connection:{user_id}"
+        # `now()` keeps the expiry check a clean timestamptz > timestamptz
+        # comparison (no bound value to type-cast); the only interpolated value
+        # is the parameterized :app_id, so no f-string SQL / bandit B608 risk.
+        rows = self._execute_many(
+            """
+            SELECT ce.user_id AS granter_user_id,
+                   ce.encrypted_data, ce.iv, ce.tag,
+                   ce.wrapped_key_bundle, ce.scope, ce.scope_handle,
+                   ce.grant_id, ce.export_revision, ce.export_generated_at,
+                   ce.expires_at, ce.envelope_version, ce.export_id,
+                   ce.envelope_aad, ce.envelope_aad_sha256,
+                   ce.ciphertext_sha256, ce.ciphertext_bytes,
+                   a.display_name AS granter_display_name
+            FROM consent_exports ce
+            LEFT JOIN actor_identity_cache a ON a.user_id = ce.user_id
+            WHERE ce.app_id = :app_id
+              AND ce.envelope_version = 2
+              AND ce.expires_at > now()
+            ORDER BY ce.export_generated_at DESC NULLS LAST
+            """,
+            {"app_id": app_id},
+        )
+        exports: list[dict[str, Any]] = []
+        for r in rows:
+            bundle = self._parse_request_metadata(r.get("wrapped_key_bundle"))
+            if not bundle.get("wrapped_export_key"):
+                # Legacy / non-strict row: without a wrapped key bundle the
+                # requester can never decrypt, so surfacing it is pure noise.
+                continue
+            aad = self._parse_request_metadata(r.get("envelope_aad"))
+            exports.append(
+                {
+                    "granter_user_id": str(r.get("granter_user_id") or "") or None,
+                    "granter_display_name": r.get("granter_display_name"),
+                    "scope": str(r.get("scope") or "") or None,
+                    "scope_handle": str(r.get("scope_handle") or "") or None,
+                    "grant_id": str(r.get("grant_id") or "") or None,
+                    "export_revision": self._coerce_int(r.get("export_revision")),
+                    "export_generated_at": self._iso_or_none(r.get("export_generated_at")),
+                    "expires_at": self._iso_or_none(r.get("expires_at")),
+                    "encrypted_data": r.get("encrypted_data"),
+                    "iv": r.get("iv"),
+                    "tag": r.get("tag"),
+                    "wrapped_key_bundle": bundle,
+                    # Reconstruct the exact v2 envelope submission the owner
+                    # canonicalized as key-wrap AAD. Integer fields are coerced to
+                    # plain ints so the JSON the client re-canonicalizes is
+                    # byte-identical to the wrap-time bytes (GCM auth is exact).
+                    "export_envelope": {
+                        "version": self._coerce_int(r.get("envelope_version")),
+                        "export_id": str(r.get("export_id") or "") or None,
+                        "aad": aad,
+                        "aad_sha256": str(r.get("envelope_aad_sha256") or "") or None,
+                        "ciphertext_sha256": str(r.get("ciphertext_sha256") or "") or None,
+                        "ciphertext_bytes": self._coerce_int(r.get("ciphertext_bytes")),
+                    },
+                }
+            )
+        return exports
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        """Best-effort int coercion (BIGINT/INTEGER may arrive as int/Decimal/str)."""
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _iso_or_none(value: Any) -> str | None:
+        """Render a timestamp column as an ISO-8601 string (datetime or passthrough)."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
 
     def search_directory(
         self, user_id: str, *, query: str | None = None, page: int = 1, limit: int = 20
@@ -544,6 +1165,12 @@ class ConnectionsService:
             """,
             {"id": (connection_id or "").strip()},
         )
+        # Step 4: Cascade-revoke every active Connect scope grant / pending scope
+        # request between the pair, in BOTH directions. Disconnecting must stop
+        # future reads of anything shared through this connection. Idempotent and
+        # best-effort, so it runs on every call (even a retry after the row was
+        # already flipped) to guarantee no grant outlives the connection.
+        self._cascade_revoke_scope_grants(str(user_a or ""), str(user_b or ""))
         if conn:
             FeedService().record_event(
                 user_id=user_a,

--- a/consent-protocol/tests/test_connections_scope_catalog.py
+++ b/consent-protocol/tests/test_connections_scope_catalog.py
@@ -1,0 +1,90 @@
+"""Presence-safety invariants for the Connect scope-request catalog.
+
+``build_requestable_scope_catalog()`` powers the picker shown when one person
+asks another to share data. It is deliberately GLOBAL and static: it must
+reflect no specific user's holdings, or surfacing it would leak "does this
+person have financial data?" before any consent is given. These tests lock that
+property, plus the P2P filter (no agent/capability scopes, no advisor `ria` or
+precise `location` domains) and the high-sensitivity tiering that drives the
+per-scope caution affordance in the UX. The function is pure and synchronous, so
+no database or event loop is involved.
+"""
+
+import inspect
+
+from hushh_mcp.services.connections_service import (
+    _HIGH_SENSITIVITY_DOMAINS,
+    _is_p2p_requestable_scope,
+    _scope_domain,
+    build_requestable_scope_catalog,
+)
+
+_BUNDLE_KEYS = {"id", "label", "description", "icon_name", "color_hex", "scopes"}
+_SCOPE_KEYS = {"scope", "label", "description", "icon_name", "color_hex", "sensitivity"}
+
+
+def test_catalog_is_non_empty_and_well_shaped():
+    catalog = build_requestable_scope_catalog()
+    assert set(catalog) == {"bundles", "scopes"}
+    # The financial + health + lifestyle bundles survive the P2P filter.
+    assert catalog["bundles"], "at least one bundle must survive the P2P filter"
+    assert catalog["scopes"], "flat scope list must be populated"
+    for bundle in catalog["bundles"]:
+        assert set(bundle) == _BUNDLE_KEYS
+        assert bundle["scopes"], "empty bundles are dropped, never emitted"
+    for scope in catalog["scopes"]:
+        assert set(scope) == _SCOPE_KEYS
+
+
+def test_every_emitted_scope_is_p2p_requestable_attr_data():
+    catalog = build_requestable_scope_catalog()
+    flat = [s["scope"] for s in catalog["scopes"]]
+    # Bundle membership never smuggles a scope past the flat filter.
+    for bundle in catalog["bundles"]:
+        for scope in bundle["scopes"]:
+            assert scope in flat, scope
+    for scope in flat:
+        assert scope.startswith("attr."), scope
+        assert _is_p2p_requestable_scope(scope), scope
+
+
+def test_no_agent_capability_or_excluded_domain_scope_leaks():
+    catalog = build_requestable_scope_catalog()
+    flat = [s["scope"] for s in catalog["scopes"]]
+    # The KYC bundle is pure agent.* scopes, so it must vanish entirely.
+    assert "kyc_workflow" not in {b["id"] for b in catalog["bundles"]}
+    for scope in flat:
+        assert not scope.startswith(("agent.", "cap.")), scope
+        assert _scope_domain(scope) not in {"ria", "location"}, scope
+    assert "cap.one.invoke" not in flat
+
+
+def test_reflects_no_user_state_and_is_deterministic():
+    # No parameter is accepted, and repeated calls are structurally identical:
+    # the catalog cannot encode whose holdings it is — that is the whole point.
+    assert len(inspect.signature(build_requestable_scope_catalog).parameters) == 0
+    assert build_requestable_scope_catalog() == build_requestable_scope_catalog()
+
+
+def test_scopes_are_sorted_and_deduped():
+    catalog = build_requestable_scope_catalog()
+    flat = [s["scope"] for s in catalog["scopes"]]
+    assert flat == sorted(flat)
+    assert len(flat) == len(set(flat))
+    # attr.financial.portfolio.* appears in three bundles yet exactly once flat.
+    assert flat.count("attr.financial.portfolio.*") == 1
+
+
+def test_sensitivity_tiering_matches_domain():
+    catalog = build_requestable_scope_catalog()
+    by_scope = {s["scope"]: s["sensitivity"] for s in catalog["scopes"]}
+    # Financial and health are the high-caution domains.
+    assert by_scope["attr.financial.portfolio.*"] == "high"
+    assert by_scope["attr.health.fitness.*"] == "high"
+    # Lifestyle preferences are ordinary-sensitivity.
+    assert by_scope["attr.food.preferences.*"] == "low"
+    for scope, tier in by_scope.items():
+        expected = "high" if _scope_domain(scope) in _HIGH_SENSITIVITY_DOMAINS else "low"
+        assert tier == expected, scope
+    # Both tiers are represented (guards against a filter collapsing one away).
+    assert set(by_scope.values()) == {"high", "low"}

--- a/hushh-webapp/__tests__/connect/requester-key.test.ts
+++ b/hushh-webapp/__tests__/connect/requester-key.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+//
+// This suite exercises the real WebCrypto X25519 + AES-GCM round-trip through
+// the production owner-side producers (`export-encrypt.ts`) and the requester's
+// unwrap seam (`requester-key.ts`). It must run under the Node environment, not
+// jsdom: `crypto.subtle` here is Node's webcrypto, which validates its
+// `ArrayBuffer` arguments against Node's realm. Under jsdom, `new Uint8Array()`
+// yields a jsdom-realm ArrayBuffer that Node's webcrypto rejects with
+// "2nd argument is not instance of ArrayBuffer" — which is exactly why the rest
+// of the suite mocks `export-encrypt`. Running in Node keeps one realm end to
+// end, so we test the actual crypto instead of a mock.
+import { describe, expect, it } from "vitest";
+
+import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
+import {
+  encryptForExport,
+  generateExportKey,
+  wrapExportKeyForConnector,
+} from "@/lib/vault/export-encrypt";
+import {
+  CONNECT_REQUESTER_WRAPPING_ALG,
+  decryptConnectScopedExportWithPrivateKey,
+  type ConnectScopedExportEnvelope,
+} from "@/lib/connect/requester-key";
+
+const X25519 = { name: "X25519" } as unknown as AlgorithmIdentifier;
+
+/** Generate a Connect requester keypair (as `ensureConnectRequesterKey` does),
+ * returning the private CryptoKey plus the raw base64 public key the owner side
+ * wraps to. Keeps the test pure — no IndexedDB (unavailable under jsdom). */
+async function makeRequesterKeypair(): Promise<{
+  privateKey: CryptoKey;
+  publicKey: string;
+}> {
+  const pair = (await crypto.subtle.generateKey(X25519, true, [
+    "deriveBits",
+  ])) as CryptoKeyPair;
+  const publicKey = bytesToBase64(
+    new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey)),
+  );
+  return { privateKey: pair.privateKey, publicKey };
+}
+
+/** Produce the exact envelope the data-owner's `handleApprove` emits for one
+ * granted scope: export key wrapped to the requester's public key, plus the
+ * scope value encrypted under that export key. Both halves carry AAD. */
+async function ownerSealScope(params: {
+  requesterPublicKey: string;
+  connectorKeyId: string;
+  plaintext: string;
+  keyAad: string;
+  dataAad: string;
+}): Promise<ConnectScopedExportEnvelope> {
+  const exportKeyHex = await generateExportKey();
+  const data = await encryptForExport(params.plaintext, exportKeyHex, {
+    additionalData: params.dataAad,
+  });
+  const wrapped = await wrapExportKeyForConnector({
+    exportKeyHex,
+    connectorPublicKey: params.requesterPublicKey,
+    connectorKeyId: params.connectorKeyId,
+    additionalData: params.keyAad,
+  });
+  return {
+    wrappingAlg: wrapped.wrappingAlg,
+    connectorKeyId: wrapped.connectorKeyId,
+    wrappedExportKey: wrapped.wrappedExportKey,
+    wrappedKeyIv: wrapped.wrappedKeyIv,
+    wrappedKeyTag: wrapped.wrappedKeyTag,
+    senderPublicKey: wrapped.senderPublicKey,
+    keyAdditionalData: params.keyAad,
+    ciphertext: data.ciphertext,
+    iv: data.iv,
+    tag: data.tag,
+    dataAdditionalData: params.dataAad,
+  };
+}
+
+describe("connect requester-key ZK round-trip", () => {
+  const connectorKeyId = "connect-req-abc123def456ghijk789";
+  const keyAad = `hushh-one-connect-wrapped-key-v1|attr.financial.portfolio.net_worth|${connectorKeyId}`;
+  const dataAad = `hushh-one-connect-scoped-export-v1|attr.financial.portfolio.net_worth|${connectorKeyId}`;
+
+  it("recovers a scope value the owner sealed to the requester's public key", async () => {
+    const requester = await makeRequesterKeypair();
+    const payload = JSON.stringify({
+      scope: "attr.financial.portfolio.net_worth",
+      value: "1,00,00,000",
+      currency: "INR",
+    });
+
+    const envelope = await ownerSealScope({
+      requesterPublicKey: requester.publicKey,
+      connectorKeyId,
+      plaintext: payload,
+      keyAad,
+      dataAad,
+    });
+
+    const recovered = await decryptConnectScopedExportWithPrivateKey(
+      requester.privateKey,
+      envelope,
+    );
+
+    expect(JSON.parse(recovered)).toEqual({
+      scope: "attr.financial.portfolio.net_worth",
+      value: "1,00,00,000",
+      currency: "INR",
+    });
+    expect(envelope.wrappingAlg).toBe(CONNECT_REQUESTER_WRAPPING_ALG);
+  });
+
+  it("cannot be decrypted by a different requester key (sealed for someone else)", async () => {
+    const requester = await makeRequesterKeypair();
+    const attacker = await makeRequesterKeypair();
+    const envelope = await ownerSealScope({
+      requesterPublicKey: requester.publicKey,
+      connectorKeyId,
+      plaintext: "secret",
+      keyAad,
+      dataAad,
+    });
+
+    await expect(
+      decryptConnectScopedExportWithPrivateKey(attacker.privateKey, envelope),
+    ).rejects.toThrow();
+  });
+
+  it("rejects a tampered wrapped export key (AEAD integrity)", async () => {
+    const requester = await makeRequesterKeypair();
+    const envelope = await ownerSealScope({
+      requesterPublicKey: requester.publicKey,
+      connectorKeyId,
+      plaintext: "secret",
+      keyAad,
+      dataAad,
+    });
+    // Flip a byte in the wrapped key ciphertext. Decode -> mutate a real byte
+    // -> re-encode, so the change always lands on ciphertext. (A naive edit of
+    // the final base64 char can hit only padding bits and be a no-op, making
+    // the tamper — and this integrity assertion — silently flaky.)
+    const rawWrapped = base64ToBytes(envelope.wrappedExportKey);
+    rawWrapped[0] ^= 0xff;
+    const tampered: ConnectScopedExportEnvelope = {
+      ...envelope,
+      wrappedExportKey: bytesToBase64(rawWrapped),
+    };
+
+    await expect(
+      decryptConnectScopedExportWithPrivateKey(requester.privateKey, tampered),
+    ).rejects.toThrow();
+  });
+
+  it("rejects when the data AAD does not match what the owner bound", async () => {
+    const requester = await makeRequesterKeypair();
+    const envelope = await ownerSealScope({
+      requesterPublicKey: requester.publicKey,
+      connectorKeyId,
+      plaintext: "secret",
+      keyAad,
+      dataAad,
+    });
+    const wrongAad: ConnectScopedExportEnvelope = {
+      ...envelope,
+      dataAdditionalData: `${dataAad}|tampered`,
+    };
+
+    await expect(
+      decryptConnectScopedExportWithPrivateKey(requester.privateKey, wrongAad),
+    ).rejects.toThrow();
+  });
+
+  it("rejects an unsupported wrapping algorithm", async () => {
+    const requester = await makeRequesterKeypair();
+    const envelope = await ownerSealScope({
+      requesterPublicKey: requester.publicKey,
+      connectorKeyId,
+      plaintext: "secret",
+      keyAad,
+      dataAad,
+    });
+
+    await expect(
+      decryptConnectScopedExportWithPrivateKey(requester.privateKey, {
+        ...envelope,
+        wrappingAlg: "RSA-OAEP",
+      }),
+    ).rejects.toThrow(/Unsupported wrapping algorithm/);
+  });
+});

--- a/hushh-webapp/__tests__/connections/connections-service.test.ts
+++ b/hushh-webapp/__tests__/connections/connections-service.test.ts
@@ -1,0 +1,243 @@
+// Locks down the wire→envelope mapping in `ConnectionsService.listReceivedExports`.
+//
+// The requester never re-derives the AAD from scratch — it recomputes the two
+// canonical strings the data-owner bound at wrap time and hands them to the
+// on-device AES-GCM unwrap. If either string drifts from what the owner used,
+// GCM auth fails and every received scope becomes silently un-openable. So the
+// contract under test is byte-exact:
+//   • keyAdditionalData  === canonicalConsentExportJson(export_envelope)   (full v2 submission)
+//   • dataAdditionalData === canonicalConsentExportAad(export_envelope.aad) (AAD object alone)
+// plus: canonicalization is key-order independent, integers stay integers,
+// and rows missing any unwrap input are dropped rather than surfaced broken.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  canonicalConsentExportAad,
+  canonicalConsentExportJson,
+  type ConsentExportAadV2,
+} from "@/lib/consent/export-envelope-v2";
+
+const mocks = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: { apiFetch: mocks.apiFetch },
+}));
+
+// Imported after the mock is registered so the service binds to the mocked fetch.
+import { ConnectionsService } from "@/lib/services/connections-service";
+
+function fakeResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+// A well-formed AAD object with keys deliberately NOT in sorted order, so the
+// test proves canonicalization sorts rather than passing the wire order through.
+const AAD: ConsentExportAadV2 = {
+  version: 2,
+  scope_handle: "sh_abc",
+  app_id: "connection:me-user",
+  grant_id: "grant-1",
+  export_id: "exp-1",
+  revision: 3,
+  machine_scope: "attr.financial.portfolio.net_worth",
+  recipient_key_fingerprint: "sha256:deadbeef",
+  payload_algorithm: "AES-256-GCM",
+  expires_at_ms: 1893456000000,
+};
+
+// The full v2 submission the backend echoes back in `export_envelope`, again
+// with scrambled key order.
+const EXPORT_ENVELOPE = {
+  ciphertext_bytes: 42,
+  version: 2,
+  aad: AAD,
+  export_id: "exp-1",
+  aad_sha256: "sha256:aaa",
+  ciphertext_sha256: "sha256:ccc",
+};
+
+function validRawRow() {
+  return {
+    granter_user_id: "granter-1",
+    granter_display_name: "Ada Lovelace",
+    scope: "attr.financial.portfolio.net_worth",
+    scope_handle: "sh_abc",
+    grant_id: "grant-1",
+    export_revision: 3,
+    export_generated_at: "2026-07-30T10:00:00Z",
+    expires_at: "2026-12-31T00:00:00Z",
+    encrypted_data: "ZW5jcnlwdGVk",
+    iv: "aXY=",
+    tag: "dGFn",
+    wrapped_key_bundle: {
+      wrapped_export_key: "d3JhcHBlZA==",
+      wrapped_key_iv: "d2tpdg==",
+      wrapped_key_tag: "d2t0YWc=",
+      sender_public_key: "c3Br",
+      wrapping_alg: "X25519-AES-256-GCM",
+      connector_key_id: "connect-req-abc123",
+    },
+    export_envelope: EXPORT_ENVELOPE,
+  };
+}
+
+describe("ConnectionsService.listReceivedExports", () => {
+  beforeEach(() => {
+    mocks.apiFetch.mockReset();
+  });
+
+  it("maps a wire row to a decryption-ready envelope with byte-exact AAD", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [validRawRow()] }));
+
+    const [item] = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+
+    // camelCase display mapping.
+    expect(item.granterUserId).toBe("granter-1");
+    expect(item.granterDisplayName).toBe("Ada Lovelace");
+    expect(item.scope).toBe("attr.financial.portfolio.net_worth");
+    expect(item.grantId).toBe("grant-1");
+    expect(item.exportRevision).toBe(3);
+
+    // Envelope carries the raw crypto material straight through.
+    expect(item.envelope.wrappedExportKey).toBe("d3JhcHBlZA==");
+    expect(item.envelope.senderPublicKey).toBe("c3Br");
+    expect(item.envelope.wrappingAlg).toBe("X25519-AES-256-GCM");
+    expect(item.envelope.connectorKeyId).toBe("connect-req-abc123");
+    expect(item.envelope.ciphertext).toBe("ZW5jcnlwdGVk");
+
+    // THE contract: both AAD strings match the canonicalizers exactly.
+    expect(item.envelope.keyAdditionalData).toBe(
+      canonicalConsentExportJson(EXPORT_ENVELOPE),
+    );
+    expect(item.envelope.dataAdditionalData).toBe(
+      canonicalConsentExportAad(AAD),
+    );
+  });
+
+  it("canonicalizes (sorts keys) rather than echoing wire byte order", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [validRawRow()] }));
+
+    const [item] = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+
+    // The wire objects have scrambled key order; a naive JSON.stringify of them
+    // would NOT equal the bound AAD. Canonicalization must have reordered.
+    expect(item.envelope.keyAdditionalData).not.toBe(
+      JSON.stringify(EXPORT_ENVELOPE),
+    );
+    expect(item.envelope.dataAdditionalData).not.toBe(JSON.stringify(AAD));
+    // And the canonical form is stably sorted (app_id precedes version).
+    expect(item.envelope.dataAdditionalData.indexOf('"app_id"')).toBeLessThan(
+      item.envelope.dataAdditionalData.indexOf('"version"'),
+    );
+  });
+
+  it("keeps integer fields as JSON numbers (GCM auth is type-sensitive)", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [validRawRow()] }));
+
+    const [item] = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+
+    // Numbers, not quoted strings — a stringified int would break the owner's tag.
+    expect(item.envelope.dataAdditionalData).toContain('"version":2');
+    expect(item.envelope.dataAdditionalData).toContain('"expires_at_ms":1893456000000');
+    expect(item.envelope.dataAdditionalData).toContain('"revision":3');
+    expect(item.envelope.keyAdditionalData).toContain('"ciphertext_bytes":42');
+  });
+
+  it.each([
+    ["wrapped_export_key", (r: ReturnType<typeof validRawRow>) => { r.wrapped_key_bundle.wrapped_export_key = ""; }],
+    ["wrapped_key_iv", (r: ReturnType<typeof validRawRow>) => { r.wrapped_key_bundle.wrapped_key_iv = ""; }],
+    ["wrapped_key_tag", (r: ReturnType<typeof validRawRow>) => { r.wrapped_key_bundle.wrapped_key_tag = ""; }],
+    ["sender_public_key", (r: ReturnType<typeof validRawRow>) => { r.wrapped_key_bundle.sender_public_key = ""; }],
+    ["encrypted_data", (r: ReturnType<typeof validRawRow>) => { r.encrypted_data = ""; }],
+    ["iv", (r: ReturnType<typeof validRawRow>) => { r.iv = ""; }],
+    ["tag", (r: ReturnType<typeof validRawRow>) => { r.tag = ""; }],
+  ])("drops a row missing %s (undecryptable)", async (_label, mutate) => {
+    const row = validRawRow();
+    mutate(row);
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [row] }));
+
+    const result = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+    expect(result).toHaveLength(0);
+  });
+
+  it("drops a row whose envelope has no aad", async () => {
+    const row = validRawRow() as Record<string, unknown>;
+    row.export_envelope = { ...EXPORT_ENVELOPE, aad: null };
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [row] }));
+
+    const result = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps decryptable rows and drops undecryptable ones in a mixed batch", async () => {
+    const good = validRawRow();
+    const bad = validRawRow();
+    bad.wrapped_key_bundle.wrapped_export_key = "";
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [good, bad] }));
+
+    const result = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+    expect(result).toHaveLength(1);
+    expect(result[0].grantId).toBe("grant-1");
+  });
+
+  it("returns an empty list when the API omits items", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({}));
+    const result = await ConnectionsService.listReceivedExports({ idToken: "tok" });
+    expect(result).toEqual([]);
+  });
+
+  it("sends the bearer token to the received-exports endpoint", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ items: [] }));
+    await ConnectionsService.listReceivedExports({ idToken: "tok-xyz" });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith(
+      "/api/one/connections/received-exports",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer tok-xyz" }),
+      }),
+    );
+  });
+
+  it("throws the server error message on a non-ok response", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({ error: "nope" }, false));
+    await expect(
+      ConnectionsService.listReceivedExports({ idToken: "tok" }),
+    ).rejects.toThrow("nope");
+  });
+});
+
+describe("ConnectionsService.listRequestableScopes", () => {
+  beforeEach(() => {
+    mocks.apiFetch.mockReset();
+  });
+
+  it("passes through bundles and scopes from the catalog", async () => {
+    mocks.apiFetch.mockResolvedValue(
+      fakeResponse({
+        bundles: [
+          { id: "finance", label: "Finance", description: "", icon_name: null, color_hex: null, scopes: ["a", "b"] },
+        ],
+        scopes: [
+          { scope: "a", label: "Net worth", description: null, icon_name: null, color_hex: null, sensitivity: "high" },
+        ],
+      }),
+    );
+
+    const catalog = await ConnectionsService.listRequestableScopes({ idToken: "tok" });
+    expect(catalog.bundles).toHaveLength(1);
+    expect(catalog.bundles[0].scopes).toEqual(["a", "b"]);
+    expect(catalog.scopes[0].scope).toBe("a");
+    expect(catalog.scopes[0].sensitivity).toBe("high");
+  });
+
+  it("defaults missing arrays to empty (presence-safe fallback)", async () => {
+    mocks.apiFetch.mockResolvedValue(fakeResponse({}));
+    const catalog = await ConnectionsService.listRequestableScopes({ idToken: "tok" });
+    expect(catalog).toEqual({ bundles: [], scopes: [] });
+  });
+});

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -25,6 +25,9 @@ import {
   type DirectoryPerson,
 } from "@/lib/services/connections-service";
 import { relationshipCta } from "@/lib/connections/relationship-label";
+import { ensureConnectRequesterKey } from "@/lib/connect/requester-key";
+import { ConnectScopeRequestDialog } from "@/components/connect/connect-scope-request-dialog";
+import { ConnectReceivedExports } from "@/components/connect/connect-received-exports";
 
 export default function ConnectPageClient() {
   const { user } = useRequireAuth();
@@ -39,6 +42,8 @@ export default function ConnectPageClient() {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
+  // Person whose scope-request picker is open (null = closed).
+  const [pickerPerson, setPickerPerson] = useState<DirectoryPerson | null>(null);
 
   const loadConnections = useCallback(async (): Promise<ConnectionSummaryEntry[]> => {
     if (!user) return [];
@@ -84,7 +89,7 @@ export default function ConnectPageClient() {
   }, [user, debouncedQuery]);
 
   const handleConnect = useCallback(
-    async (person: DirectoryPerson) => {
+    (person: DirectoryPerson) => {
       if (!user) return;
       const cta = relationshipCta(person.relationship);
       if (cta.action === "respond") {
@@ -92,23 +97,56 @@ export default function ConnectPageClient() {
         return;
       }
       if (cta.action !== "connect") return;
+      // Open the scope picker; the actual send happens on confirm so the user can
+      // bundle a granular data-scope ask (or connect with none).
+      setPickerPerson(person);
+    },
+    [router, user],
+  );
+
+  const sendConnectRequest = useCallback(
+    async (person: DirectoryPerson, requestedScopes: string[]) => {
+      if (!user) return;
       try {
         setBusyId(person.userId);
         const idToken = await user.getIdToken();
-        await ConnectionsService.sendRequest({ idToken, addresseeUserId: person.userId });
+        // Only publish an on-device X25519 lock when we're actually asking for
+        // data — a plain connect needs no key. The addressee's approval wraps
+        // each granted scope's export key to this public key (zero-knowledge).
+        const keyFields =
+          requestedScopes.length > 0
+            ? await (async () => {
+                const key = await ensureConnectRequesterKey(user.uid);
+                return {
+                  requestedScopes,
+                  requesterPublicKey: key.publicKey,
+                  requesterKeyId: key.keyId,
+                };
+              })()
+            : {};
+        await ConnectionsService.sendRequest({
+          idToken,
+          addresseeUserId: person.userId,
+          ...keyFields,
+        });
         setPeople((prev) =>
           prev.map((p) =>
             p.userId === person.userId ? { ...p, relationship: "pending_outgoing" } : p,
           ),
         );
-        toast.success("Connection request sent");
+        setPickerPerson(null);
+        toast.success(
+          requestedScopes.length > 0
+            ? "Connection + data request sent"
+            : "Connection request sent",
+        );
       } catch (sendError) {
         toast.error(sendError instanceof Error ? sendError.message : "Failed to send request");
       } finally {
         setBusyId(null);
       }
     },
-    [router, user],
+    [user],
   );
 
   const handleRemove = useCallback(
@@ -250,6 +288,13 @@ export default function ConnectPageClient() {
             )}
           </SettingsGroup>
 
+          {user ? (
+            <ConnectReceivedExports
+              userId={user.uid}
+              getIdToken={async () => (user ? user.getIdToken() : undefined)}
+            />
+          ) : null}
+
           <div className="space-y-4">
             <div className="relative w-full">
               <span className="absolute inset-y-0 left-0 flex items-center pl-4 pointer-events-none text-muted-foreground/80">
@@ -314,6 +359,21 @@ export default function ConnectPageClient() {
           </div>
         </SurfaceStack>
       </AppPageContentRegion>
+
+      <ConnectScopeRequestDialog
+        open={pickerPerson !== null}
+        onOpenChange={(open) => {
+          if (!open) setPickerPerson(null);
+        }}
+        personName={
+          pickerPerson?.displayName || pickerPerson?.email || "this person"
+        }
+        getIdToken={async () => (user ? user.getIdToken() : undefined)}
+        busy={pickerPerson ? busyId === pickerPerson.userId : false}
+        onConfirm={async (scopes) => {
+          if (pickerPerson) await sendConnectRequest(pickerPerson, scopes);
+        }}
+      />
     </AppPageShell>
   );
 }

--- a/hushh-webapp/components/connect/connect-received-exports.tsx
+++ b/hushh-webapp/components/connect/connect-received-exports.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Inbox, Loader2, ShieldCheck } from "lucide-react";
+
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/lib/morphy-ux/button";
+import {
+  ConnectionsService,
+  type ReceivedScopeExport,
+} from "@/lib/services/connections-service";
+import { decryptConnectScopedExport } from "@/lib/connect/requester-key";
+
+export interface ConnectReceivedExportsProps {
+  /** Current user id (the requester whose on-device key can unwrap these). */
+  userId: string;
+  /** Firebase ID token loader (retrieval is auth-gated). */
+  getIdToken: () => Promise<string | undefined>;
+}
+
+/** Best-effort pretty-print: decrypted scope payloads are JSON, but fall back to
+ * the raw string so a non-JSON payload still renders instead of throwing. */
+function prettyPrint(plaintext: string): string {
+  try {
+    return JSON.stringify(JSON.parse(plaintext), null, 2);
+  } catch {
+    return plaintext;
+  }
+}
+
+/** Turn a machine scope like `vault.read.finance.transactions` into a readable
+ * fallback label when the catalog has no friendlier name. */
+function humanizeScope(scope: string): string {
+  const tail = scope.split(/[.:]/).filter(Boolean).pop() || scope;
+  return tail
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * "Shared with you" — scopes other people granted to THIS device through the
+ * Connect zero-knowledge pipeline. The list arrives as ciphertext + a key
+ * wrapped to this device's X25519 public key; nothing is decrypted until the
+ * user taps "View", and decryption happens entirely on-device. The section
+ * renders only when at least one decryptable export exists, so it stays out of
+ * the way for users who have received nothing.
+ */
+export function ConnectReceivedExports({
+  userId,
+  getIdToken,
+}: ConnectReceivedExportsProps) {
+  const [items, setItems] = useState<ReceivedScopeExport[]>([]);
+  const [scopeLabels, setScopeLabels] = useState<Map<string, string>>(new Map());
+  const [loaded, setLoaded] = useState(false);
+
+  // Reveal state keyed by grant id (stable per export).
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [revealBusy, setRevealBusy] = useState(false);
+  const [revealError, setRevealError] = useState<string | null>(null);
+  const [revealText, setRevealText] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const idToken = await getIdToken();
+        if (!idToken) return;
+        // Received exports are the point of this section; the scope catalog is a
+        // best-effort label source, so a catalog failure must not hide exports.
+        const [received, catalog] = await Promise.all([
+          ConnectionsService.listReceivedExports({ idToken }),
+          ConnectionsService.listRequestableScopes({ idToken }).catch(() => ({
+            bundles: [],
+            scopes: [],
+          })),
+        ]);
+        if (cancelled) return;
+        setItems(received);
+        setScopeLabels(
+          new Map(
+            catalog.scopes
+              .filter((s) => s.label)
+              .map((s) => [s.scope, s.label as string]),
+          ),
+        );
+      } catch {
+        /* non-fatal: the section simply stays hidden if retrieval fails */
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, getIdToken]);
+
+  const openExport = useMemo(
+    () => items.find((it) => (it.grantId || it.scope) === openKey) || null,
+    [items, openKey],
+  );
+
+  const scopeLabelFor = useCallback(
+    (export_: ReceivedScopeExport): string => {
+      const scope = export_.scope || "";
+      return scopeLabels.get(scope) || (scope ? humanizeScope(scope) : "Shared data");
+    },
+    [scopeLabels],
+  );
+
+  const handleReveal = useCallback(
+    async (export_: ReceivedScopeExport) => {
+      const key = export_.grantId || export_.scope || "";
+      setOpenKey(key);
+      setRevealText(null);
+      setRevealError(null);
+      setRevealBusy(true);
+      try {
+        const plaintext = await decryptConnectScopedExport({
+          userId,
+          envelope: export_.envelope,
+        });
+        setRevealText(prettyPrint(plaintext));
+      } catch (error) {
+        setRevealError(
+          error instanceof Error ? error.message : "Couldn't decrypt on this device.",
+        );
+      } finally {
+        setRevealBusy(false);
+      }
+    },
+    [userId],
+  );
+
+  // Stay invisible until we know there is something decryptable to show.
+  if (!loaded || items.length === 0) return null;
+
+  return (
+    <>
+      <SettingsGroup
+        title={`Shared with you (${items.length})`}
+        description="Data people granted to this device. Encrypted end-to-end — only you can open it here."
+        separatorInset
+      >
+        {items.map((export_) => {
+          const key = export_.grantId || export_.scope || "";
+          const granter = export_.granterDisplayName || export_.granterUserId || "Someone";
+          return (
+            <SettingsRow
+              key={key}
+              icon={Inbox}
+              iconTone="green"
+              title={granter}
+              description={scopeLabelFor(export_)}
+              density="compact"
+              trailing={
+                <Button
+                  type="button"
+                  variant="none"
+                  effect="fill"
+                  size="sm"
+                  disabled={revealBusy && openKey === key}
+                  onClick={() => void handleReveal(export_)}
+                >
+                  {revealBusy && openKey === key ? "Opening…" : "View"}
+                </Button>
+              }
+            />
+          );
+        })}
+      </SettingsGroup>
+
+      <Dialog
+        open={openKey !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setOpenKey(null);
+            setRevealText(null);
+            setRevealError(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg gap-0 overflow-hidden p-0">
+          <DialogHeader className="px-5 pt-5 pb-3 text-left">
+            <DialogTitle className="flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-emerald-500" />
+              {openExport ? scopeLabelFor(openExport) : "Shared data"}
+            </DialogTitle>
+            <DialogDescription>
+              {openExport
+                ? `Shared by ${openExport.granterDisplayName || openExport.granterUserId || "someone"}. Decrypted on your device — never on our servers.`
+                : "Decrypted on your device."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="px-5 pb-5">
+            {revealBusy ? (
+              <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Decrypting…
+              </div>
+            ) : revealError ? (
+              <p className="py-6 text-sm text-destructive">{revealError}</p>
+            ) : revealText ? (
+              <ScrollArea className="max-h-[52vh] rounded-md border border-border/60 bg-muted/30">
+                <pre className="whitespace-pre-wrap break-words p-4 text-xs leading-relaxed text-foreground">
+                  {revealText}
+                </pre>
+              </ScrollArea>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/hushh-webapp/components/connect/connect-scope-request-dialog.tsx
+++ b/hushh-webapp/components/connect/connect-scope-request-dialog.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, ShieldCheck } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/lib/morphy-ux/button";
+import {
+  ConnectionsService,
+  type RequestableScope,
+  type RequestableScopeBundle,
+} from "@/lib/services/connections-service";
+
+export interface ConnectScopeRequestDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Display name of the person being connected with (for the title). */
+  personName: string;
+  /** Firebase ID token loader (catalog fetch is auth-gated). */
+  getIdToken: () => Promise<string | undefined>;
+  /** Called with the chosen scopes (possibly empty = plain connect). The caller
+   * owns key generation + the actual send; this dialog only collects intent. */
+  onConfirm: (scopes: string[]) => Promise<void> | void;
+  /** True while the caller's send is in flight. */
+  busy?: boolean;
+}
+
+/**
+ * Bottom-anchored picker shown when a user taps "Connect". It lets the requester
+ * bundle a granular data-scope ask with the connection request. Selecting scopes
+ * is entirely optional — sending with none is a plain connect. Each scope the
+ * addressee later grants flows through the zero-knowledge export pipeline, so the
+ * catalog here is global and presence-safe (it never reveals what the other
+ * person actually holds).
+ */
+export function ConnectScopeRequestDialog({
+  open,
+  onOpenChange,
+  personName,
+  getIdToken,
+  onConfirm,
+  busy = false,
+}: ConnectScopeRequestDialogProps) {
+  const [bundles, setBundles] = useState<RequestableScopeBundle[]>([]);
+  const [scopes, setScopes] = useState<RequestableScope[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Lazy-load the catalog the first time the dialog opens; keep it cached across
+  // reopens within the same mount.
+  useEffect(() => {
+    if (!open || loaded || loading) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        setLoading(true);
+        setLoadError(null);
+        const idToken = await getIdToken();
+        if (!idToken) throw new Error("Not signed in");
+        const catalog = await ConnectionsService.listRequestableScopes({ idToken });
+        if (cancelled) return;
+        setBundles(catalog.bundles);
+        setScopes(catalog.scopes);
+        setLoaded(true);
+      } catch (error) {
+        if (!cancelled) {
+          setLoadError(
+            error instanceof Error ? error.message : "Couldn't load data options",
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, loaded, loading, getIdToken]);
+
+  // Reset the selection whenever the dialog is dismissed so the next person
+  // starts clean.
+  useEffect(() => {
+    if (!open) setSelected(new Set());
+  }, [open]);
+
+  const scopeByKey = useMemo(
+    () => new Map(scopes.map((s) => [s.scope, s])),
+    [scopes],
+  );
+
+  const toggleScope = useCallback((scope: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) next.delete(scope);
+      else next.add(scope);
+      return next;
+    });
+  }, []);
+
+  const bundleState = useCallback(
+    (bundle: RequestableScopeBundle): "all" | "some" | "none" => {
+      const inCatalog = bundle.scopes.filter((s) => scopeByKey.has(s));
+      if (inCatalog.length === 0) return "none";
+      const chosen = inCatalog.filter((s) => selected.has(s)).length;
+      if (chosen === 0) return "none";
+      if (chosen === inCatalog.length) return "all";
+      return "some";
+    },
+    [scopeByKey, selected],
+  );
+
+  const toggleBundle = useCallback(
+    (bundle: RequestableScopeBundle) => {
+      const inCatalog = bundle.scopes.filter((s) => scopeByKey.has(s));
+      setSelected((prev) => {
+        const next = new Set(prev);
+        const allOn = inCatalog.every((s) => next.has(s));
+        for (const s of inCatalog) {
+          if (allOn) next.delete(s);
+          else next.add(s);
+        }
+        return next;
+      });
+    },
+    [scopeByKey],
+  );
+
+  const count = selected.size;
+
+  const handleConfirm = useCallback(async () => {
+    await onConfirm(Array.from(selected));
+  }, [onConfirm, selected]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
+        <DialogHeader className="px-5 pt-5 pb-3 text-left">
+          <DialogTitle>Connect with {personName}</DialogTitle>
+          <DialogDescription>
+            Optionally ask to see some of their data. They choose what to share —
+            each grant is end-to-end encrypted to your device.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[52vh] px-5">
+          <div className="space-y-4 pb-2">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading data options…
+              </div>
+            ) : loadError ? (
+              <p className="py-6 text-sm text-muted-foreground">
+                {loadError}. You can still connect without requesting data.
+              </p>
+            ) : (
+              <>
+                {bundles.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Quick bundles
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {bundles.map((bundle) => {
+                        const state = bundleState(bundle);
+                        return (
+                          <button
+                            key={bundle.id}
+                            type="button"
+                            onClick={() => toggleBundle(bundle)}
+                            aria-pressed={state !== "none"}
+                            className={[
+                              "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+                              state === "all"
+                                ? "border-primary bg-primary text-primary-foreground"
+                                : state === "some"
+                                  ? "border-primary/60 bg-primary/10 text-foreground"
+                                  : "border-input bg-background text-muted-foreground hover:text-foreground",
+                            ].join(" ")}
+                          >
+                            {bundle.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {scopes.length > 0 && (
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Individual data
+                    </p>
+                    <ul className="divide-y divide-border/60">
+                      {scopes.map((scope) => {
+                        const checked = selected.has(scope.scope);
+                        return (
+                          <li key={scope.scope}>
+                            <label className="flex cursor-pointer items-start gap-3 py-2.5">
+                              <Checkbox
+                                checked={checked}
+                                onCheckedChange={() => toggleScope(scope.scope)}
+                                className="mt-0.5"
+                                aria-label={scope.label || scope.scope}
+                              />
+                              <span className="min-w-0 flex-1">
+                                <span className="flex items-center gap-2">
+                                  <span className="truncate text-sm font-medium text-foreground">
+                                    {scope.label || scope.scope}
+                                  </span>
+                                  {scope.sensitivity === "high" && (
+                                    <Badge
+                                      variant="outline"
+                                      className="shrink-0 gap-1 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                                    >
+                                      <ShieldCheck className="h-3 w-3" />
+                                      Sensitive
+                                    </Badge>
+                                  )}
+                                </span>
+                                {scope.description && (
+                                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                                    {scope.description}
+                                  </span>
+                                )}
+                              </span>
+                            </label>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </ScrollArea>
+
+        <DialogFooter className="flex-row items-center justify-between gap-2 border-t border-border/60 px-5 py-3">
+          <span className="text-xs text-muted-foreground">
+            {count === 0
+              ? "No data requested"
+              : `${count} scope${count === 1 ? "" : "s"} requested`}
+          </span>
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="sm"
+            disabled={busy}
+            onClick={() => void handleConfirm()}
+          >
+            {busy
+              ? "Sending…"
+              : count === 0
+                ? "Connect"
+                : "Send request"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hushh-webapp/lib/connect/requester-key.ts
+++ b/hushh-webapp/lib/connect/requester-key.ts
@@ -1,0 +1,284 @@
+// lib/connect/requester-key.ts
+
+/**
+ * On-device X25519 requester key for Connect + granular scope requests.
+ *
+ * When a person clicks "Connect" and also asks for data scopes, this device
+ * publishes a raw X25519 public "lock". The private half never leaves the
+ * device (IndexedDB). If the addressee grants a scope, their `handleApprove`
+ * wraps that scope's export key to this public key via the proven consent
+ * export path (X25519 ECDH -> SHA-256 -> AES-256-GCM, see
+ * `lib/vault/export-encrypt.ts`), so the server only ever relays ciphertext.
+ *
+ * This mirrors `lib/one-marketplace/encryption.ts` (recipient-key blueprint)
+ * but uses X25519 raw/pkcs8 keys to stay wire-compatible with the export
+ * pipeline, and is kept in a Connect-scoped IndexedDB store so its keys never
+ * collide with One Location / Marketplace / KYC connector keys.
+ *
+ * Zero-knowledge is preserved end to end: the backend never sees a plaintext
+ * scope value or a plaintext export key.
+ */
+import { base64ToBytes, bytesToBase64 } from "@/lib/vault/base64";
+import { decryptExport } from "@/lib/vault/export-encrypt";
+
+export const CONNECT_REQUESTER_WRAPPING_ALG = "X25519-AES256-GCM" as const;
+
+const DB_NAME = "hushh-one-connect-requester-keys";
+const STORE_NAME = "requesterKeys";
+const DB_VERSION = 1;
+
+/**
+ * A scope export delivered to the requester: the export key wrapped to this
+ * device's public key (X25519 -> AES-GCM), plus the scope data encrypted under
+ * that export key (AES-GCM). Composed from the owner-side producers
+ * `wrapExportKeyForConnector` (key half) and `encryptForExport` (data half).
+ */
+export type ConnectScopedExportEnvelope = {
+  wrappingAlg?: string;
+  connectorKeyId?: string;
+  // Wrapped export key (X25519 ECDH -> SHA-256 -> AES-256-GCM).
+  wrappedExportKey: string;
+  wrappedKeyIv: string;
+  wrappedKeyTag: string;
+  senderPublicKey: string;
+  keyAdditionalData?: string;
+  // Scope data encrypted under the export key (AES-256-GCM).
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  dataAdditionalData?: string;
+};
+
+export type ConnectRequesterKeyHandle = {
+  keyId: string;
+  publicKey: string;
+  wrappingAlg: typeof CONNECT_REQUESTER_WRAPPING_ALG;
+};
+
+type StoredRequesterKey = {
+  userId: string;
+  keyId: string;
+  publicKey: string; // base64 raw X25519 public key
+  privateKey: CryptoKey; // non-serialized; structured-cloned into IndexedDB
+  createdAt: string;
+};
+
+function requireCrypto(): Crypto {
+  if (typeof globalThis.crypto === "undefined" || !globalThis.crypto.subtle) {
+    throw new Error("Connect requester keys require Web Crypto.");
+  }
+  return globalThis.crypto;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(
+    await requireCrypto().subtle.digest("SHA-256", toArrayBuffer(bytes)),
+  );
+  return bytesToHex(digest);
+}
+
+function openKeyDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === "undefined") {
+    throw new Error("Connect key storage is unavailable on this device.");
+  }
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "userId" });
+      }
+    };
+    request.onerror = () => reject(request.error || new Error("Unable to open key storage."));
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function readStoredKey(userId: string): Promise<StoredRequesterKey | null> {
+  const db = await openKeyDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const request = tx.objectStore(STORE_NAME).get(userId);
+    request.onerror = () => reject(request.error || new Error("Unable to read key."));
+    request.onsuccess = () => resolve((request.result as StoredRequesterKey | undefined) || null);
+    tx.oncomplete = () => db.close();
+  });
+}
+
+async function writeStoredKey(record: StoredRequesterKey): Promise<void> {
+  const db = await openKeyDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    tx.objectStore(STORE_NAME).put(record);
+    tx.onerror = () => reject(tx.error || new Error("Unable to store key."));
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+  });
+}
+
+/**
+ * Return this device's Connect requester key, generating and persisting a fresh
+ * X25519 keypair on first use. Only the raw base64 public key ever leaves the
+ * device (sent as `requester_public_key` with the connection request); the
+ * private key stays in IndexedDB. Idempotent per user.
+ */
+export async function ensureConnectRequesterKey(
+  userId: string,
+): Promise<ConnectRequesterKeyHandle> {
+  const existing = await readStoredKey(userId).catch(() => null);
+  if (existing) {
+    return {
+      keyId: existing.keyId,
+      publicKey: existing.publicKey,
+      wrappingAlg: CONNECT_REQUESTER_WRAPPING_ALG,
+    };
+  }
+
+  const cryptoObj = requireCrypto();
+  const algorithm = { name: "X25519" } as unknown as AlgorithmIdentifier;
+  const pair = (await cryptoObj.subtle.generateKey(algorithm, true, [
+    "deriveBits",
+  ])) as CryptoKeyPair;
+  const publicKeyBytes = new Uint8Array(
+    await cryptoObj.subtle.exportKey("raw", pair.publicKey),
+  );
+  const publicKey = bytesToBase64(publicKeyBytes);
+  const keyId = `connect-req-${(await sha256Hex(publicKeyBytes)).slice(0, 20)}`;
+  await writeStoredKey({
+    userId,
+    keyId,
+    publicKey,
+    privateKey: pair.privateKey,
+    createdAt: new Date().toISOString(),
+  });
+  return { keyId, publicKey, wrappingAlg: CONNECT_REQUESTER_WRAPPING_ALG };
+}
+
+/**
+ * Unwrap an export key that was wrapped to this device's public key. Symmetric
+ * with `deriveWrappingKey`/`wrapExportKeyForConnector` in
+ * `lib/vault/export-encrypt.ts`: import the sender's ephemeral public key,
+ * derive the shared secret, hash to an AES-GCM key, and decrypt.
+ */
+async function unwrapExportKeyWithPrivateKey(
+  privateKey: CryptoKey,
+  bundle: {
+    wrappedExportKey: string;
+    wrappedKeyIv: string;
+    wrappedKeyTag: string;
+    senderPublicKey: string;
+    additionalData?: string;
+  },
+): Promise<string> {
+  const algorithm = { name: "X25519" } as unknown as AlgorithmIdentifier;
+  const senderPublicKey = await crypto.subtle.importKey(
+    "raw",
+    toArrayBuffer(base64ToBytes(bundle.senderPublicKey)),
+    algorithm,
+    false,
+    [],
+  );
+  const sharedSecret = await crypto.subtle.deriveBits(
+    { name: "X25519", public: senderPublicKey } as unknown as AlgorithmIdentifier,
+    privateKey,
+    256,
+  );
+  const derivedBytes = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", sharedSecret),
+  );
+  const wrappingKey = await crypto.subtle.importKey(
+    "raw",
+    toArrayBuffer(derivedBytes),
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"],
+  );
+  const ciphertext = base64ToBytes(bundle.wrappedExportKey);
+  const tag = base64ToBytes(bundle.wrappedKeyTag);
+  const sealed = new Uint8Array(ciphertext.length + tag.length);
+  sealed.set(ciphertext);
+  sealed.set(tag, ciphertext.length);
+  const exportKeyBytes = new Uint8Array(
+    await crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: toArrayBuffer(base64ToBytes(bundle.wrappedKeyIv)),
+        ...(bundle.additionalData
+          ? { additionalData: new TextEncoder().encode(bundle.additionalData) }
+          : {}),
+      },
+      wrappingKey,
+      toArrayBuffer(sealed),
+    ),
+  );
+  return bytesToHex(exportKeyBytes);
+}
+
+/**
+ * Decrypt a scoped export given this device's private key. Split out from the
+ * IndexedDB-backed path so the crypto round-trip is testable without device
+ * storage (mirrors `decryptEnvelopeWithPrivateKey` in the marketplace module).
+ */
+export async function decryptConnectScopedExportWithPrivateKey(
+  privateKey: CryptoKey,
+  envelope: ConnectScopedExportEnvelope,
+): Promise<string> {
+  if (
+    envelope.wrappingAlg &&
+    envelope.wrappingAlg !== CONNECT_REQUESTER_WRAPPING_ALG
+  ) {
+    throw new Error(`Unsupported wrapping algorithm: ${envelope.wrappingAlg}`);
+  }
+  const exportKeyHex = await unwrapExportKeyWithPrivateKey(privateKey, {
+    wrappedExportKey: envelope.wrappedExportKey,
+    wrappedKeyIv: envelope.wrappedKeyIv,
+    wrappedKeyTag: envelope.wrappedKeyTag,
+    senderPublicKey: envelope.senderPublicKey,
+    additionalData: envelope.keyAdditionalData,
+  });
+  return decryptExport(
+    envelope.ciphertext,
+    envelope.iv,
+    envelope.tag,
+    exportKeyHex,
+    envelope.dataAdditionalData
+      ? { additionalData: envelope.dataAdditionalData }
+      : undefined,
+  );
+}
+
+/**
+ * Decrypt a scoped export delivered to this device using the on-device private
+ * key. Throws if this device holds no requester key, or if the export was
+ * sealed for a different key (e.g. a different browser/device).
+ */
+export async function decryptConnectScopedExport(params: {
+  userId: string;
+  envelope: ConnectScopedExportEnvelope;
+}): Promise<string> {
+  const stored = await readStoredKey(params.userId);
+  if (!stored) {
+    throw new Error("Requester key unavailable on this device.");
+  }
+  if (
+    params.envelope.connectorKeyId &&
+    params.envelope.connectorKeyId !== stored.keyId
+  ) {
+    throw new Error("Scoped export was sealed for a different requester key.");
+  }
+  return decryptConnectScopedExportWithPrivateKey(stored.privateKey, params.envelope);
+}

--- a/hushh-webapp/lib/services/connections-service.ts
+++ b/hushh-webapp/lib/services/connections-service.ts
@@ -1,4 +1,10 @@
 import { ApiService } from "@/lib/services/api-service";
+import {
+  canonicalConsentExportAad,
+  canonicalConsentExportJson,
+  type ConsentExportAadV2,
+} from "@/lib/consent/export-envelope-v2";
+import type { ConnectScopedExportEnvelope } from "@/lib/connect/requester-key";
 
 export type ConnectionRelationship =
   | "none"
@@ -36,6 +42,82 @@ export interface ConnectionRequest {
   message: string | null;
   counterpartUserId: string;
   counterpartDisplayName: string | null;
+}
+
+/** A curated bundle of related scopes the requester can ask for in one tap. */
+export interface RequestableScopeBundle {
+  id: string;
+  label: string;
+  description: string;
+  icon_name: string | null;
+  color_hex: string | null;
+  scopes: string[];
+}
+
+/** A single requestable data scope with display metadata + sensitivity tier. */
+export interface RequestableScope {
+  scope: string;
+  label: string | null;
+  description: string | null;
+  icon_name: string | null;
+  color_hex: string | null;
+  sensitivity: "high" | "low";
+}
+
+/** Global, presence-safe catalog powering the Connect scope picker. It reflects
+ * no specific user's holdings, so surfacing it cannot leak whether the person
+ * being connected with has any given data. */
+export interface RequestableScopeCatalog {
+  bundles: RequestableScopeBundle[];
+  scopes: RequestableScope[];
+}
+
+/** Raw wire shape of one received scope export (mirrors the backend's
+ * `list_received_scope_exports` dict). Kept internal; callers get the mapped,
+ * decryption-ready {@link ReceivedScopeExport}. */
+interface RawReceivedScopeExport {
+  granter_user_id: string | null;
+  granter_display_name: string | null;
+  scope: string | null;
+  scope_handle: string | null;
+  grant_id: string | null;
+  export_revision: number | null;
+  export_generated_at: string | null;
+  expires_at: string | null;
+  encrypted_data: string | null;
+  iv: string | null;
+  tag: string | null;
+  wrapped_key_bundle: {
+    wrapped_export_key?: string | null;
+    wrapped_key_iv?: string | null;
+    wrapped_key_tag?: string | null;
+    sender_public_key?: string | null;
+    wrapping_alg?: string | null;
+    connector_key_id?: string | null;
+  } | null;
+  export_envelope: {
+    version: number | null;
+    export_id: string | null;
+    aad: ConsentExportAadV2 | null;
+    aad_sha256: string | null;
+    ciphertext_sha256: string | null;
+    ciphertext_bytes: number | null;
+  } | null;
+}
+
+/** A scope another user sealed to this device via the Connect ZK pipeline,
+ * carrying display metadata plus a ready-to-decrypt {@link ConnectScopedExportEnvelope}
+ * (both AAD strings are pre-computed to match the owner's wrap-time bytes). */
+export interface ReceivedScopeExport {
+  granterUserId: string | null;
+  granterDisplayName: string | null;
+  scope: string | null;
+  scopeHandle: string | null;
+  grantId: string | null;
+  exportRevision: number | null;
+  exportGeneratedAt: string | null;
+  expiresAt: string | null;
+  envelope: ConnectScopedExportEnvelope;
 }
 
 function authHeaders(idToken: string): HeadersInit {
@@ -89,23 +171,135 @@ export class ConnectionsService {
     return payload.items ?? [];
   }
 
+  /** Global catalog of scopes/bundles the requester may ask for. Presence-safe:
+   * it does not reflect the addressee's actual holdings. */
+  static async listRequestableScopes(opts: {
+    idToken: string;
+  }): Promise<RequestableScopeCatalog> {
+    const response = await ApiService.apiFetch(
+      "/api/one/connections/requestable-scopes",
+      { method: "GET", headers: authHeaders(opts.idToken) },
+    );
+    const payload = await jsonOrThrow<RequestableScopeCatalog>(response);
+    return { bundles: payload.bundles ?? [], scopes: payload.scopes ?? [] };
+  }
+
+  /** List scope exports other users sealed to THIS user's Connect requester key.
+   * Each item is returned decryption-ready: the owner wrapped the export key with
+   * the full v2 envelope submission as AAD and encrypted the payload with the AAD
+   * object alone, so we recompute both here byte-for-byte. Rows missing the
+   * wrapped key or the authenticated AAD are undecryptable and dropped. Nothing
+   * here is plaintext — decryption happens on-device via the stored private key. */
+  static async listReceivedExports(opts: {
+    idToken: string;
+  }): Promise<ReceivedScopeExport[]> {
+    const response = await ApiService.apiFetch(
+      "/api/one/connections/received-exports",
+      { method: "GET", headers: authHeaders(opts.idToken) },
+    );
+    const payload = await jsonOrThrow<{ items: RawReceivedScopeExport[] }>(response);
+    const items = payload.items ?? [];
+    const mapped: ReceivedScopeExport[] = [];
+    for (const raw of items) {
+      const bundle = raw.wrapped_key_bundle;
+      const env = raw.export_envelope;
+      // Every field below is required to unwrap + decrypt; a missing one means
+      // the row can never be opened on this device, so skip it silently.
+      if (
+        !bundle?.wrapped_export_key ||
+        !bundle.wrapped_key_iv ||
+        !bundle.wrapped_key_tag ||
+        !bundle.sender_public_key ||
+        !raw.encrypted_data ||
+        !raw.iv ||
+        !raw.tag ||
+        !env?.aad
+      ) {
+        continue;
+      }
+      const envelope: ConnectScopedExportEnvelope = {
+        wrappingAlg: bundle.wrapping_alg ?? undefined,
+        connectorKeyId: bundle.connector_key_id ?? undefined,
+        wrappedExportKey: bundle.wrapped_export_key,
+        wrappedKeyIv: bundle.wrapped_key_iv,
+        wrappedKeyTag: bundle.wrapped_key_tag,
+        senderPublicKey: bundle.sender_public_key,
+        // Key-wrap AAD = canonical JSON of the FULL v2 envelope submission.
+        keyAdditionalData: canonicalConsentExportJson(env),
+        ciphertext: raw.encrypted_data,
+        iv: raw.iv,
+        tag: raw.tag,
+        // Data-encrypt AAD = canonical JSON of the AAD object alone.
+        dataAdditionalData: canonicalConsentExportAad(env.aad),
+      };
+      mapped.push({
+        granterUserId: raw.granter_user_id ?? null,
+        granterDisplayName: raw.granter_display_name ?? null,
+        scope: raw.scope ?? null,
+        scopeHandle: raw.scope_handle ?? null,
+        grantId: raw.grant_id ?? null,
+        exportRevision: raw.export_revision ?? null,
+        exportGeneratedAt: raw.export_generated_at ?? null,
+        expiresAt: raw.expires_at ?? null,
+        envelope,
+      });
+    }
+    return mapped;
+  }
+
+  /** Send a connection request, optionally bundling a granular scope ask. When
+   * `requestedScopes` is present the caller also publishes its on-device X25519
+   * public key so the addressee can ZK-wrap each granted scope to it. */
   static async sendRequest(opts: {
     idToken: string;
     addresseeUserId: string;
     message?: string;
+    requestedScopes?: string[];
+    requesterPublicKey?: string;
+    requesterKeyId?: string;
   }): Promise<void> {
+    const body: Record<string, unknown> = {
+      addressee_user_id: opts.addresseeUserId,
+      message: opts.message,
+    };
+    if (opts.requestedScopes && opts.requestedScopes.length > 0) {
+      body.requested_scopes = opts.requestedScopes;
+      if (opts.requesterPublicKey) body.requester_public_key = opts.requesterPublicKey;
+      if (opts.requesterKeyId) body.requester_key_id = opts.requesterKeyId;
+    }
     const response = await ApiService.apiFetch("/api/one/connections/requests", {
       method: "POST",
       headers: authHeaders(opts.idToken),
-      body: JSON.stringify({ addressee_user_id: opts.addresseeUserId, message: opts.message }),
+      body: JSON.stringify(body),
     });
     await jsonOrThrow<unknown>(response);
   }
 
-  static async accept(opts: { idToken: string; requestId: string }): Promise<void> {
+  /** Accept a connection request. Pass `grantedScopes`/`deniedScopes` to apply a
+   * per-scope decision at accept time; omit both to queue every requested scope
+   * for later per-scope resolution in the consent center. */
+  static async accept(opts: {
+    idToken: string;
+    requestId: string;
+    grantedScopes?: string[];
+    deniedScopes?: string[];
+  }): Promise<void> {
+    const hasDecision =
+      opts.grantedScopes !== undefined || opts.deniedScopes !== undefined;
     const response = await ApiService.apiFetch(
       `/api/one/connections/requests/${encodeURIComponent(opts.requestId)}/accept`,
-      { method: "POST", headers: authHeaders(opts.idToken) },
+      {
+        method: "POST",
+        headers: authHeaders(opts.idToken),
+        ...(hasDecision
+          ? {
+              body: JSON.stringify({
+                granted_scopes: opts.grantedScopes ?? null,
+                denied_scopes: opts.deniedScopes ?? null,
+              }),
+            }
+          : {}),
+      },
     );
     await jsonOrThrow<unknown>(response);
   }


### PR DESCRIPTION
## What & why

Extend the **Connect** tab so a connection request can bundle a **granular data-scope ask**. The addressee grants or denies **each scope individually**; every granted scope is sealed to the requester's on-device X25519 key through the existing **zero-knowledge** export pipeline (hybrid X25519-AES-256-GCM envelope). The backend stores only ciphertext and never holds the plaintext or the unwrapped export key.

This is an in-place extension of `/one/connect` — no new page, no schema change.

## Backend (`consent-protocol`)

- **Presence-safe scope catalog** — `build_requestable_scope_catalog()` is global, pure, zero-arg. It emits only P2P-shareable `attr.*` scopes (agent/capability/`ria`/precise-`location` scopes filtered out), so surfacing the picker can't leak whether the other person holds any given data. The pure-`agent.*` KYC bundle vanishes entirely.
- **Scope-request metadata** persists on the existing `connection_requests.metadata` JSONB column — **no migration**.
- **Accept-time per-scope grant/deny fan-out** ZK-wraps each *granted* scope's export key to the requester's published public key; denied scopes never leave the owner.
- **Received-exports reader** keyed by the synthetic `connection:{user}` app id, reconstructing the byte-exact envelope for on-device unwrap.
- **Route**: `requestable-scopes` + `received-exports` endpoints, and granted/denied scope fields on request create/accept.

## Frontend (`hushh-webapp`)

- Connect **scope-request picker dialog** + **received-data surface**.
- Requester **X25519 key management** (on-device; public key only leaves the device).
- **Byte-exact AAD reconstruction** for on-device unwrap: key-wrap AAD = full v2 submission; data AAD = the `aad` object alone. Integers stay integers or GCM auth fails.

## The crypto contract (why the tests are strict)

The requester never re-derives AAD from scratch — it recomputes the two canonical strings the owner bound at wrap time. If either drifts, GCM auth fails and received scopes become silently un-openable. Tests lock:
- `keyAdditionalData === canonicalConsentExportJson(export_envelope)`
- `dataAdditionalData === canonicalConsentExportAad(aad)`
- key-order-independent canonicalization, integer preservation, and row-drop on any missing unwrap input.

## Tests

- **Backend**: presence-safety invariants for the catalog (no agent/cap/ria/location leak; deterministic; sorted+deduped; sensitivity tiering).
- **Frontend**: wire→envelope AAD contract (scrambled key order) + requester-key round-trip.

## Ship plan

Static gates → merge → **UAT (verify ZK round-trip)** → **production (only if UAT round-trip is proven green)**.
