### PR TITLE
fix(mcp): source release token from protected environment

### DIFF
--- a/.github/workflows/publish-hushh-mcp.yml
+++ b/.github/workflows/publish-hushh-mcp.yml
@@ -73,7 +73,10 @@ jobs:
 
       - name: Publish package
         working-directory: ${{ env.PACKAGE_DIR }}
-        # OIDC is selected by npm automatically. Do not add NODE_AUTH_TOKEN.
+        # The granular npm token is held only in the protected npm-publish
+        # environment. OIDC remains available for provenance generation.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag "${{ inputs.dist_tag }}" --provenance
 
       - name: Verify exact published package from a clean npm cache


### PR DESCRIPTION
## Summary
- source the npm publishing credential only from the protected `npm-publish` environment
- keep provenance generation enabled while avoiding a repository or workspace secret

## Verification
- package docs, gateway parity, tests, packed runtime, and `npm pack --dry-run` passed

No credential value is included in source or this pull request.