### PR TITLE
test(ria): harden debate sub-view coverage + resilient screening states

### DIFF
--- a/hushh-webapp/__tests__/app/ria/picks-page-debate.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page-debate.test.tsx
@@ -1,0 +1,602 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Page-level coverage of the Debate config sub-view (?view=debate). This reuses
+// the picks-page.test.tsx harness verbatim, but swaps the fixed useSearchParams
+// mock for a hoisted-mutable `searchParams` (set per test) plus a hoisted
+// `iamNotReady` flag so we can exercise the debate render branch, its routing,
+// and the additive unlock / error-retry / loading states.
+const mocks = vi.hoisted(() => {
+  return {
+    replace: vi.fn(),
+    searchParams: new URLSearchParams(),
+    iamNotReady: false,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+    },
+    useAuth: vi.fn(),
+    useVault: vi.fn(),
+    usePersonaState: vi.fn(),
+    useStaleResource: vi.fn(),
+    refresh: vi.fn(),
+    tickerUniverse: {
+      preloadTickerUniverse: vi.fn(),
+      searchTickerUniverseRemote: vi.fn(),
+    },
+    riaService: {
+      listPicks: vi.fn(),
+      savePickPackage: vi.fn(),
+      importPickCsv: vi.fn(),
+      getRenaissanceUniverse: vi.fn(),
+      getRenaissanceAvoid: vi.fn(),
+      getRenaissanceScreening: vi.fn(),
+    },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+  useSearchParams: () => mocks.searchParams,
+  usePathname: () => "/ria/picks",
+}));
+
+vi.mock("sonner", () => ({
+  toast: mocks.toast,
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: mocks.useVault,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: mocks.usePersonaState,
+}));
+
+vi.mock("@/lib/cache/use-stale-resource", () => ({
+  useStaleResource: mocks.useStaleResource,
+}));
+
+vi.mock("@/components/app-ui/app-page-shell", () => ({
+  AppPageShell: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AppPageHeaderRegion: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AppPageContentRegion: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/app-ui/page-sections", () => ({
+  PageHeader: ({
+    title,
+    description,
+    actions,
+  }: {
+    title?: React.ReactNode;
+    description?: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <section>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      <div>{actions}</div>
+    </section>
+  ),
+  SectionHeader: ({
+    title,
+    description,
+    actions,
+  }: {
+    title?: React.ReactNode;
+    description?: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      <div>{actions}</div>
+    </section>
+  ),
+}));
+
+vi.mock("@/components/app-ui/data-table", () => ({
+  DataTable: ({
+    data,
+    searchPlaceholder,
+  }: {
+    data: Array<Record<string, unknown>>;
+    searchPlaceholder?: string;
+  }) => (
+    <div data-testid="mock-data-table">
+      <span>{searchPlaceholder}</span>
+      <span>{data.length}</span>
+      {data.map((row, index) => (
+        <div key={index}>
+          {String(row.ticker || row.title || row.company_name || index)}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/app-ui/surfaces", () => ({
+  SurfaceCard: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  SurfaceCardContent: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  SurfaceInset: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/profile/settings-ui", () => ({
+  SettingsSegmentedTabs: ({
+    value,
+    onValueChange,
+    options,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    options: Array<{ value: string; label: string }>;
+  }) => (
+    <div>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          aria-pressed={option.value === value}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaCompatibilityState: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description: string;
+  }) => (
+    <div>
+      <span>{title}</span>
+      <span>{description}</span>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/app-ui/command-fields", () => ({
+  CommandPickerField: ({
+    value,
+    placeholder,
+    options = [],
+    onSelect,
+  }: {
+    value: string;
+    placeholder: string;
+    options?: Array<{ value: string; label: string }>;
+    onSelect: (option: { value: string; label: string } | null) => void;
+  }) => (
+    <select
+      aria-label={placeholder}
+      value={value}
+      onChange={(event) => {
+        const nextValue = event.target.value;
+        const option = options.find((item) => item.value === nextValue) || null;
+        onSelect(option);
+      }}
+    >
+      <option value="">{placeholder}</option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  PopupTextEditorField: ({
+    value,
+    placeholder,
+    onSave,
+  }: {
+    value: string;
+    placeholder: string;
+    onSave: (value: string) => void;
+  }) => (
+    <textarea
+      value={value}
+      placeholder={placeholder}
+      onChange={(event) => onSave(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: ({
+    value,
+    onChange,
+    placeholder,
+    type,
+    accept,
+  }: {
+    value?: string;
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    type?: string;
+    accept?: string;
+  }) => (
+    <input
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      type={type}
+      accept={accept}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    placeholder?: string;
+  }) => (
+    <textarea value={value} onChange={onChange} placeholder={placeholder} />
+  ),
+}));
+
+vi.mock("@/lib/morphy-ux/button", async () => {
+  const ReactModule = await import("react");
+  return {
+    Button: ({
+      children,
+      onClick,
+      disabled,
+      asChild = false,
+    }: {
+      children: React.ReactNode;
+      onClick?: () => void;
+      disabled?: boolean;
+      asChild?: boolean;
+    }) => {
+      if (asChild && ReactModule.isValidElement(children)) {
+        return ReactModule.cloneElement(children, {
+          onClick,
+          "data-disabled": disabled ? "true" : undefined,
+        });
+      }
+      return (
+        <button type="button" onClick={onClick} disabled={disabled}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <span />;
+  return {
+    Check: Icon,
+    ChevronsUpDown: Icon,
+    Crown: Icon,
+    Download: Icon,
+    FileSpreadsheet: Icon,
+    FilePenLine: Icon,
+    Loader2: Icon,
+    Medal: Icon,
+    MessagesSquare: Icon,
+    PencilLine: Icon,
+    Plus: Icon,
+    SearchIcon: Icon,
+    Save: Icon,
+    Star: Icon,
+    Trophy: Icon,
+    Trash2: Icon,
+    Upload: Icon,
+    X: Icon,
+    XIcon: Icon,
+  };
+});
+
+vi.mock("@/lib/navigation/routes", () => ({
+  ROUTES: {
+    RIA_ONBOARDING: "/ria/onboarding",
+    RIA_PICKS: "/ria/picks",
+  },
+}));
+
+vi.mock("@/lib/kai/ticker-universe-cache", () => ({
+  preloadTickerUniverse: mocks.tickerUniverse.preloadTickerUniverse,
+  searchTickerUniverseRemote: mocks.tickerUniverse.searchTickerUniverseRemote,
+}));
+
+vi.mock("@/lib/services/ria-service", () => ({
+  isIAMSchemaNotReadyError: () => mocks.iamNotReady,
+  RiaService: mocks.riaService,
+}));
+
+import RiaPicksPage from "@/app/ria/picks/page";
+
+function buildResource(overrides?: Record<string, unknown>) {
+  return {
+    data: {
+      package: {
+        top_picks: [],
+        avoid_rows: [],
+        screening_sections: [
+          { section: "investable_requirements", rows: [] },
+          { section: "automatic_avoid_triggers", rows: [] },
+          { section: "the_math", rows: [] },
+        ],
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: mocks.refresh,
+    ...overrides,
+  };
+}
+
+describe("RiaPicksPage — Debate config sub-view", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.searchParams = new URLSearchParams();
+    mocks.iamNotReady = false;
+    mocks.useAuth.mockReturnValue({
+      user: {
+        uid: "ria-user-1",
+        getIdToken: vi.fn().mockResolvedValue("token-123"),
+      },
+    });
+    mocks.usePersonaState.mockReturnValue({
+      riaCapability: "ready",
+      loading: false,
+      refreshing: false,
+    });
+    mocks.useVault.mockReturnValue({
+      vaultKey: "vault-key-1",
+      vaultOwnerToken: "vault-owner-token-1",
+      isVaultUnlocked: true,
+    });
+    mocks.useStaleResource.mockReturnValue(buildResource());
+    mocks.riaService.getRenaissanceUniverse.mockResolvedValue({
+      items: [
+        {
+          ticker: "NVDA",
+          company_name: "NVIDIA",
+          sector: "Semis",
+          tier: "ACE",
+          investment_thesis: "Compounding AI infrastructure demand",
+          fcf_billions: 29,
+        },
+      ],
+      total: 1,
+    });
+    mocks.riaService.getRenaissanceAvoid.mockResolvedValue({ items: [] });
+    mocks.riaService.getRenaissanceScreening.mockResolvedValue({ items: [] });
+    mocks.tickerUniverse.preloadTickerUniverse.mockResolvedValue([]);
+    mocks.tickerUniverse.searchTickerUniverseRemote.mockResolvedValue([]);
+  });
+
+  it("renders the debate config pane when view=debate", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate");
+
+    render(<RiaPicksPage />);
+
+    expect(await screen.findByTestId("ria-debate-config")).toBeTruthy();
+    expect(screen.getByText("This is your debate config")).toBeTruthy();
+    // PageHeader swaps its title to the debate copy.
+    expect(
+      screen.getByRole("heading", { name: "Debate config" }),
+    ).toBeTruthy();
+    // The educational-not-advice disclaimer is always present in debate view.
+    expect(
+      screen.getByText(/is not investment advice/i),
+    ).toBeTruthy();
+  });
+
+  it("renders the default picks view when view is absent", async () => {
+    render(<RiaPicksPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Stock universe" }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("ria-debate-config")).toBeNull();
+    expect(screen.queryByText("This is your debate config")).toBeNull();
+  });
+
+  it("falls back to the default picks view for an unknown view value", async () => {
+    mocks.searchParams = new URLSearchParams("view=garbage");
+
+    render(<RiaPicksPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Stock universe" }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("ria-debate-config")).toBeNull();
+  });
+
+  it("treats the view match as case-sensitive (view=Debate is not debate)", async () => {
+    mocks.searchParams = new URLSearchParams("view=Debate");
+
+    render(<RiaPicksPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Stock universe" }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("ria-debate-config")).toBeNull();
+  });
+
+  it("renders the three screening section headers in debate view", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate");
+
+    render(<RiaPicksPage />);
+
+    expect(await screen.findByText("Investable requirements")).toBeTruthy();
+    expect(screen.getByText("Automatic avoid triggers")).toBeTruthy();
+    expect(screen.getByText("The math")).toBeTruthy();
+    // Empty Kai config renders the per-section empty state, not a crash.
+    expect(
+      screen.getAllByText("No rules yet for this section."),
+    ).toHaveLength(3);
+  });
+
+  it("shows the IAM-schema compatibility state instead of debate content when IAM is not ready", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate");
+    mocks.iamNotReady = true;
+    mocks.useStaleResource.mockReturnValue(
+      buildResource({ error: "iam schema not ready", data: undefined }),
+    );
+
+    render(<RiaPicksPage />);
+
+    expect(await screen.findByText("Waiting on IAM schema")).toBeTruthy();
+    expect(screen.queryByTestId("ria-debate-config")).toBeNull();
+  });
+
+  it("routes into debate when the Debate tab is selected", async () => {
+    render(<RiaPicksPage />);
+
+    await screen.findByRole("heading", { name: "Stock universe" });
+    fireEvent.click(screen.getByRole("button", { name: /^debate$/i }));
+
+    expect(mocks.replace).toHaveBeenCalled();
+    const call = mocks.replace.mock.calls.at(-1);
+    expect(String(call?.[0])).toMatch(/view=debate/);
+  });
+
+  it("clears the debate view when a non-debate tab is selected", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate");
+
+    render(<RiaPicksPage />);
+
+    await screen.findByTestId("ria-debate-config");
+    fireEvent.click(screen.getByRole("button", { name: /^top picks$/i }));
+
+    expect(mocks.replace).toHaveBeenCalled();
+    const call = mocks.replace.mock.calls.at(-1);
+    expect(String(call?.[0])).toMatch(/category=top-picks/);
+    expect(String(call?.[0])).not.toMatch(/view=debate/);
+  });
+
+  // --- Additive robustness fixes (previously all collapsed to "No rules yet") ---
+
+  it("shows the unlock notice (not a false-empty config) for a locked My-list vault", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate&source=my");
+    mocks.useVault.mockReturnValue({
+      vaultKey: null,
+      vaultOwnerToken: null,
+      isVaultUnlocked: false,
+    });
+    mocks.useStaleResource.mockReturnValue(
+      buildResource({
+        data: {
+          package: {
+            top_picks: [],
+            avoid_rows: [],
+            screening_sections: [],
+          },
+          metadata: {
+            has_package: true,
+            storage_source: "pkm",
+            package_revision: 3,
+            top_pick_count: 0,
+            avoid_count: 0,
+            screening_row_count: 0,
+            active_share_count: 0,
+          },
+        },
+      }),
+    );
+
+    render(<RiaPicksPage />);
+
+    expect(await screen.findByTestId("ria-debate-unlock")).toBeTruthy();
+    expect(screen.getByText("Unlock required")).toBeTruthy();
+    expect(screen.queryByText("No rules yet for this section.")).toBeNull();
+  });
+
+  it("surfaces an error with retry when the Kai screening fetch fails, and recovers on retry", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate");
+    mocks.riaService.getRenaissanceScreening
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue({
+        items: [
+          {
+            section: "investable_requirements",
+            rule_index: 0,
+            title: "Positive free cash flow",
+            detail: "The business must convert demand into free cash flow.",
+            value_text: "> 0",
+          },
+        ],
+      });
+
+    render(<RiaPicksPage />);
+
+    expect(await screen.findByTestId("ria-debate-error")).toBeTruthy();
+    expect(screen.getByText("Debate config unavailable")).toBeTruthy();
+    // The false-empty state must not be shown while the fetch is in error.
+    expect(screen.queryByText("No rules yet for this section.")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(await screen.findByText("Positive free cash flow")).toBeTruthy();
+    expect(screen.queryByTestId("ria-debate-error")).toBeNull();
+  });
+
+  it("shows a single loading state (not spinner + empty sections) while Kai screening loads", async () => {
+    mocks.searchParams = new URLSearchParams("view=debate");
+    // Never-resolving fetch keeps the debate view in its loading state.
+    mocks.riaService.getRenaissanceScreening.mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    render(<RiaPicksPage />);
+
+    expect(await screen.findByTestId("ria-debate-loading")).toBeTruthy();
+    // Sections must be mutually exclusive with the spinner.
+    expect(screen.queryByText("Investable requirements")).toBeNull();
+    expect(screen.queryByText("No rules yet for this section.")).toBeNull();
+  });
+
+  it("does not render debate content for the default picks view even after data loads", async () => {
+    render(<RiaPicksPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Stock universe" }),
+      ).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("ria-debate-config")).toBeNull();
+    expect(screen.queryByTestId("ria-debate-loading")).toBeNull();
+    expect(screen.queryByTestId("ria-debate-error")).toBeNull();
+    expect(screen.queryByTestId("ria-debate-unlock")).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -707,4 +707,29 @@ describe("top shell breadcrumbs", () => {
       ],
     });
   });
+
+  it("keeps bare Picks for unknown or wrong-case view values", () => {
+    const barePicks = {
+      backHref: "/ria",
+      width: "content" as const,
+      align: "center" as const,
+      items: [
+        { label: "One", href: "/one" },
+        { label: "RIA", href: "/ria" },
+        { label: "Picks" },
+      ],
+    };
+
+    // An unrecognized view value must not deepen into the Debate crumb; it stays
+    // a plain three-crumb Picks with Back to RIA.
+    expect(
+      resolveTopShellBreadcrumb("/ria/picks", new URLSearchParams("view=garbage")),
+    ).toEqual(barePicks);
+
+    // The Picks debate match is case-sensitive (view === "debate"), so a
+    // capitalized value is treated as unknown rather than the debate sub-view.
+    expect(
+      resolveTopShellBreadcrumb("/ria/picks", new URLSearchParams("view=Debate")),
+    ).toEqual(barePicks);
+  });
 });

--- a/hushh-webapp/__tests__/voice/ria-picks-debate-action-contract.test.ts
+++ b/hushh-webapp/__tests__/voice/ria-picks-debate-action-contract.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression guard for the Debate config sub-view voice action. The debate view
+// is a query-param sub-view of Picks (?view=debate), and its voice action is the
+// only contract surface that makes it discoverable via One/Kai. If the action is
+// dropped or its target drifts, the debate view silently stops being voice- and
+// search-reachable even though the route still renders — this test fails loudly
+// before that regression can ship.
+const contractPath = resolve(
+  process.cwd(),
+  "app/ria/picks/page.voice-action-contract.json",
+);
+
+interface VoiceAction {
+  action_id: string;
+  execution_policy?: string;
+  risk_level?: string;
+  guard_ids?: string[];
+  control_ids?: string[];
+  aliases?: string[];
+  search_keywords?: string[];
+  reachability?: { routes?: string[]; active_personas?: string[] };
+  execution_target?: { status?: string; path?: string; target?: string };
+}
+
+describe("RIA Picks debate voice action contract", () => {
+  const contract = JSON.parse(readFileSync(contractPath, "utf8")) as {
+    surface_id: string;
+    actions: VoiceAction[];
+  };
+  const actions = new Map(
+    contract.actions.map((action) => [action.action_id, action]),
+  );
+  const debate = actions.get("ria.picks.open_view_debate");
+
+  it("belongs to the ria_picks surface", () => {
+    expect(contract.surface_id).toBe("ria_picks");
+  });
+
+  it("declares the debate sub-view action", () => {
+    expect(debate).toBeDefined();
+  });
+
+  it("routes the debate action to the ?view=debate sub-view", () => {
+    expect(debate?.execution_target).toMatchObject({
+      status: "wired",
+      path: "route",
+      target: "/ria/picks?view=debate",
+    });
+    expect(debate?.reachability?.routes).toContain("/ria/picks?view=debate");
+  });
+
+  it("is a low-risk, directly executable navigation", () => {
+    expect(debate?.execution_policy).toBe("allow_direct");
+    expect(debate?.risk_level).toBe("low");
+  });
+
+  it("is guarded by auth + the RIA persona", () => {
+    expect(debate?.guard_ids).toEqual(
+      expect.arrayContaining(["auth_signed_in", "ria_persona_available"]),
+    );
+    expect(debate?.reachability?.active_personas).toContain("ria");
+  });
+
+  it("binds the debate route tab control", () => {
+    expect(debate?.control_ids).toContain("ria_picks_view_debate");
+  });
+
+  it("is discoverable by debate-oriented aliases and keywords", () => {
+    const haystack = [
+      ...(debate?.aliases ?? []),
+      ...(debate?.search_keywords ?? []),
+    ]
+      .join(" ")
+      .toLowerCase();
+    expect(haystack).toContain("debate");
+  });
+
+  it("keeps debate as the only view-based sub-view action (no duplicates)", () => {
+    const viewActions = contract.actions.filter((action) =>
+      (action.execution_target?.target ?? "").includes("view=debate"),
+    );
+    expect(viewActions).toHaveLength(1);
+  });
+});

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -1352,6 +1352,11 @@ export default function RiaPicksPage() {
   const [avoidLoading, setAvoidLoading] = useState(false);
   const [screeningRows, setScreeningRows] = useState<RiaScreeningRow[]>([]);
   const [screeningLoading, setScreeningLoading] = useState(false);
+  // Debate config surfaces Kai's screening fetch; without an explicit error +
+  // retry state a failed load silently collapses into the "No rules yet" empty
+  // state (indistinguishable from a genuinely empty config). Additive only.
+  const [screeningError, setScreeningError] = useState(false);
+  const [screeningReloadToken, setScreeningReloadToken] = useState(0);
 
   const sourceParam = searchParams?.get("source");
   const categoryParam = searchParams?.get("category");
@@ -1574,10 +1579,16 @@ export default function RiaPicksPage() {
     let cancelled = false;
     void (async () => {
       setScreeningLoading(true);
+      setScreeningError(false);
       try {
         const idToken = await user.getIdToken();
         const data = await RiaService.getRenaissanceScreening(idToken);
         if (!cancelled) setScreeningRows(data.items);
+      } catch {
+        // A failed screening fetch previously escaped as an unhandled rejection
+        // and left the debate view silently empty. Surface it so the debate
+        // branch can render an explicit error + retry affordance.
+        if (!cancelled) setScreeningError(true);
       } finally {
         if (!cancelled) setScreeningLoading(false);
       }
@@ -1585,7 +1596,7 @@ export default function RiaPicksPage() {
     return () => {
       cancelled = true;
     };
-  }, [screeningRows.length, user]);
+  }, [screeningRows.length, user, screeningReloadToken]);
 
   const sourceOptions = useMemo(
     () => [
@@ -2368,52 +2379,108 @@ export default function RiaPicksPage() {
                   </SurfaceCardContent>
                 </SurfaceCard>
 
-                {source === "kai" && screeningLoading ? (
-                  <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+                {source === "my" && myListRequiresUnlock ? (
+                  // Locked My-list vault: without this the debate view rendered
+                  // "No rules yet" cards (false-empty), hiding that the config
+                  // exists but is locked. Mirrors the picks unlock notice.
+                  <SurfaceCard>
+                    <SurfaceCardContent
+                      className="p-4 sm:p-5"
+                      data-testid="ria-debate-unlock"
+                    >
+                      <p className="text-sm font-medium text-foreground">
+                        Unlock required
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                        This advisor package is now stored in your PKM. Unlock the
+                        vault to view the debate config.
+                      </p>
+                    </SurfaceCardContent>
+                  </SurfaceCard>
+                ) : source === "kai" && screeningError ? (
+                  // A failed Kai screening fetch used to collapse into the empty
+                  // state. Show it explicitly with a retry that re-arms the loader.
+                  <SurfaceCard>
+                    <SurfaceCardContent
+                      className="space-y-3 p-4 sm:p-5"
+                      data-testid="ria-debate-error"
+                    >
+                      <div>
+                        <p className="text-sm font-medium text-foreground">
+                          Debate config unavailable
+                        </p>
+                        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                          The debate screening rules failed to load. Check your
+                          connection and try again.
+                        </p>
+                      </div>
+                      <Button
+                        variant="none"
+                        effect="fade"
+                        size="sm"
+                        onClick={() => {
+                          setScreeningError(false);
+                          setScreeningReloadToken((token) => token + 1);
+                        }}
+                        className="justify-center"
+                      >
+                        Try again
+                      </Button>
+                    </SurfaceCardContent>
+                  </SurfaceCard>
+                ) : (source === "kai" && screeningLoading) ||
+                  (source === "my" && picksResource.loading) ? (
+                  // Spinner is mutually exclusive with the section list so the
+                  // two never render together, and My-list no longer flashes empty
+                  // while its package is still loading.
+                  <div
+                    className="flex items-center gap-2 py-8 text-sm text-muted-foreground"
+                    data-testid="ria-debate-loading"
+                  >
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Loading debate config...
                   </div>
-                ) : null}
-
-                <div className="space-y-6">
-                  {screeningViewRows.map((section) => (
-                    <SurfaceCard key={section.section}>
-                      <SurfaceCardContent className="p-4">
-                        <h3 className="mb-3 text-sm font-semibold text-foreground">
-                          {section.label}
-                        </h3>
-                        {section.rows.length === 0 ? (
-                          <p className="text-sm text-muted-foreground">
-                            No rules yet for this section.
-                          </p>
-                        ) : (
-                          <div className="space-y-2">
-                            {section.rows.map((rule, index) => (
-                              <div
-                                key={`${section.section}-${index}`}
-                                className="border-b border-border/20 pb-2 last:border-0 last:pb-0"
-                              >
-                                <p className="text-sm font-medium text-foreground">
-                                  {rule.title}
-                                </p>
-                                {shouldRenderScreeningDetail(rule) ? (
-                                  <p className="text-xs leading-5 text-muted-foreground">
-                                    {rule.detail}
+                ) : (
+                  <div className="space-y-6">
+                    {screeningViewRows.map((section) => (
+                      <SurfaceCard key={section.section}>
+                        <SurfaceCardContent className="p-4">
+                          <h3 className="mb-3 text-sm font-semibold text-foreground">
+                            {section.label}
+                          </h3>
+                          {section.rows.length === 0 ? (
+                            <p className="text-sm text-muted-foreground">
+                              No rules yet for this section.
+                            </p>
+                          ) : (
+                            <div className="space-y-2">
+                              {section.rows.map((rule, index) => (
+                                <div
+                                  key={`${section.section}-${index}`}
+                                  className="border-b border-border/20 pb-2 last:border-0 last:pb-0"
+                                >
+                                  <p className="text-sm font-medium text-foreground">
+                                    {rule.title}
                                   </p>
-                                ) : null}
-                                {shouldRenderScreeningValue(rule) ? (
-                                  <p className="mt-1 text-xs font-medium text-primary">
-                                    {rule.value_text}
-                                  </p>
-                                ) : null}
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </SurfaceCardContent>
-                    </SurfaceCard>
-                  ))}
-                </div>
+                                  {shouldRenderScreeningDetail(rule) ? (
+                                    <p className="text-xs leading-5 text-muted-foreground">
+                                      {rule.detail}
+                                    </p>
+                                  ) : null}
+                                  {shouldRenderScreeningValue(rule) ? (
+                                    <p className="mt-1 text-xs font-medium text-primary">
+                                      {rule.value_text}
+                                    </p>
+                                  ) : null}
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </SurfaceCardContent>
+                      </SurfaceCard>
+                    ))}
+                  </div>
+                )}
 
                 <p className="px-1 text-xs leading-5 text-muted-foreground">
                   {RIA_COPY.debate.disclaimer}


### PR DESCRIPTION
## Summary
Adds automated regression coverage for the **RIA Debate config** sub-view (`/ria/picks?view=debate`) and makes its Kai screening fetch resilient. Previously a failed or in-flight screening load silently collapsed into the misleading "No rules yet" empty state; this adds explicit error/loading/unlock affordances.

Debate itself already shipped and is verified on UAT + prod — this slice is **test-only + additive runtime hardening**.

## Changes
- **`__tests__/app/ria/picks-page-debate.test.tsx`** (new, 12 tests): debate pane rendering; view-param gating (absent / garbage / wrong-case); screening section headers + empty states; IAM-unavailable state; tab navigation; locked my-list unlock gate; screening error → retry → recovery; loading state.
- **`__tests__/voice/ria-picks-debate-action-contract.test.ts`** (new, 8 tests): regression guard that `ria.picks.open_view_debate` stays wired to `/ria/picks?view=debate` with correct policy, guards, and control binding.
- **`__tests__/utils/top-shell-breadcrumbs.test.ts`**: bare Picks breadcrumb for unknown / wrong-case `view` values.
- **`app/ria/picks/page.tsx`**: additive `screeningError`/`screeningReloadToken` state; catch failed screening fetches → explicit error card + "Try again"; unlock notice for locked my-list; loading spinner made mutually exclusive with the section list. **Happy path unchanged.**

## Safety
- No schema, API, or migration changes. Fully backward compatible and reversible.
- Green locally: eslint (`--max-warnings=0`), 52 tests (debate suite + picks regression), `verify:voice-gateway`, `verify:surface-map`. Typecheck adds zero new errors (only pre-existing capacitor native-plugin baseline errors remain, untouched).