### PR TITLE
fix(kai): durable coarse-checkpoint store for cross-instance debate resume

### DIFF
--- a/consent-protocol/api/routes/kai/run_manager.py
+++ b/consent-protocol/api/routes/kai/run_manager.py
@@ -7,6 +7,7 @@ disconnect/reconnect without losing an ongoing debate.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import uuid
@@ -91,11 +92,38 @@ class KaiAnalyzeRunManager:
         self,
         *,
         retention_seconds: int = 6 * 60 * 60,
+        on_checkpoint: Optional[Callable[["AnalyzeRunRecord", str], Any]] = None,
     ) -> None:
         self._retention_seconds = max(60, retention_seconds)
         self._runs_by_id: dict[str, AnalyzeRunRecord] = {}
         self._active_by_session: dict[tuple[str, str], str] = {}
         self._lock = asyncio.Lock()
+        # Optional coarse-checkpoint sink. Called with (run, phase) where phase
+        # is "start" or "terminal". Kept deliberately generic so this manager
+        # never imports a storage backend; the stream layer supplies a
+        # flag-gated, best-effort persister. May be sync or async.
+        self._on_checkpoint = on_checkpoint
+
+    async def _emit_checkpoint(self, run: "AnalyzeRunRecord", phase: str) -> None:
+        """Fire the optional checkpoint sink. Best-effort — never raises.
+
+        The sink is itself expected to be best-effort, but we defend the run's
+        hot path here too so a misbehaving sink can never interrupt streaming.
+        """
+        callback = self._on_checkpoint
+        if callback is None:
+            return
+        try:
+            result = callback(run, phase)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # pragma: no cover - checkpoint is best-effort
+            logger.debug(
+                "[KaiRun] checkpoint sink failed for %s (%s)",
+                run.run_id,
+                phase,
+                exc_info=True,
+            )
 
     async def _append_frame(self, run: AnalyzeRunRecord, frame: RunFrame) -> dict[str, Any] | None:
         try:
@@ -116,10 +144,12 @@ class KaiAnalyzeRunManager:
             frame["data"] = json.dumps(envelope)
 
         just_completed = False
+        is_terminal = False
         async with run.condition:
             run.events.append(frame)
             run.updated_at = _now_iso()
             if envelope and bool(envelope.get("terminal")):
+                is_terminal = True
                 event_name = str(envelope.get("event") or "")
                 run.terminal_event = event_name or run.terminal_event
                 payload = envelope.get("payload")
@@ -146,6 +176,10 @@ class KaiAnalyzeRunManager:
                 actor_label="Kai",
                 metadata={"ticker": run.ticker},
             )
+        if is_terminal:
+            # Coarse terminal checkpoint (fires once per run, on any terminal
+            # event) so a cross-instance reconnect can replay the final frame.
+            await self._emit_checkpoint(run, "terminal")
         return envelope if isinstance(envelope, dict) else None
 
     async def _append_synthetic_terminal(
@@ -296,7 +330,12 @@ class KaiAnalyzeRunManager:
             run.worker_task = asyncio.create_task(self._run_worker(run, generator_factory))
             self._runs_by_id[run_id] = run
             self._active_by_session[session_key] = run_id
-            return "started", run
+
+        # Persist the coarse "start" checkpoint outside the manager lock so the
+        # durable-store write never serializes concurrent run starts. The run is
+        # already fully registered above, so this cannot race a reconnect.
+        await self._emit_checkpoint(run, "start")
+        return "started", run
 
     async def get_active(
         self,

--- a/consent-protocol/api/routes/kai/stream.py
+++ b/consent-protocol/api/routes/kai/stream.py
@@ -19,6 +19,7 @@ from typing import Annotated, Any, AsyncGenerator, Callable, Dict, Optional
 from fastapi import APIRouter, Header, HTTPException, Path, Query, Request
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
+from starlette.concurrency import run_in_threadpool
 
 from api.middlewares.observability import get_request_id
 from api.routes.kai._streaming import (
@@ -38,6 +39,7 @@ from hushh_mcp.operons.kai.llm import (
     stream_gemini_response,
     synthesize_debate_recommendation_card,
 )
+from hushh_mcp.services import kai_analyze_run_store
 from hushh_mcp.services.consent_db import ConsentDBService
 from hushh_mcp.services.personal_knowledge_model_service import get_pkm_service
 from hushh_mcp.services.renaissance_service import get_renaissance_service
@@ -48,7 +50,66 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Kai Streaming"])
 _TICKER_SYMBOL_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,5}$")
-_RUN_MANAGER = KaiAnalyzeRunManager()
+
+
+def _durable_run_store_enabled() -> bool:
+    """Feature flag for the coarse-checkpoint durable analyze-run store.
+
+    Default OFF. With the flag unset no checkpoints are written and no
+    read-through occurs on 404, so run behavior is byte-for-byte the existing
+    in-memory path. Flip ``KAI_ANALYZE_DURABLE_RUN_STORE`` to enable
+    cross-instance terminal replay.
+    """
+    raw = str(os.getenv("KAI_ANALYZE_DURABLE_RUN_STORE", "false")).strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+async def _persist_run_checkpoint(run: Any, phase: str) -> None:
+    """Coarse-checkpoint sink wired into :class:`KaiAnalyzeRunManager`.
+
+    Best-effort and flag-gated: a no-op unless the durable store is enabled. The
+    store is synchronous, so writes run off the event loop via a threadpool. Any
+    failure is swallowed here (and again in the store) so a checkpoint can never
+    perturb the live stream.
+    """
+    if not _durable_run_store_enabled():
+        return
+    try:
+        if phase == "start":
+            await run_in_threadpool(
+                kai_analyze_run_store.save_start_checkpoint,
+                run_id=run.run_id,
+                user_id=run.user_id,
+                debate_session_id=run.debate_session_id,
+                ticker=run.ticker,
+                risk_profile=run.risk_profile,
+                started_at=run.started_at,
+                updated_at=run.updated_at,
+            )
+        elif phase == "terminal":
+            await run_in_threadpool(
+                kai_analyze_run_store.save_terminal_checkpoint,
+                run_id=run.run_id,
+                user_id=run.user_id,
+                status=run.status,
+                terminal_event=run.terminal_event,
+                terminal_payload=run.terminal_payload,
+                debate_session_id=run.debate_session_id,
+                ticker=run.ticker,
+                risk_profile=run.risk_profile,
+                completed_at=run.completed_at or run.updated_at,
+                updated_at=run.updated_at,
+            )
+    except Exception:  # pragma: no cover - best-effort mirror
+        logger.debug(
+            "[KaiStream] durable checkpoint persist failed for %s (%s)",
+            getattr(run, "run_id", "?"),
+            phase,
+            exc_info=True,
+        )
+
+
+_RUN_MANAGER = KaiAnalyzeRunManager(on_checkpoint=_persist_run_checkpoint)
 
 # ---------------------------------------------------------------------------
 # Input bounds (CWE-400 — Uncontrolled Resource Consumption)
@@ -2497,6 +2558,70 @@ def _parse_cursor(cursor: Optional[int]) -> int:
     return parsed
 
 
+async def _maybe_durable_terminal_replay(
+    *,
+    run_id: str,
+    user_id: str,
+) -> Optional[EventSourceResponse]:
+    """Cross-instance terminal replay for a run this instance never created.
+
+    On Cloud Run the in-memory ``_RUN_MANAGER`` is per-instance, so a reconnect
+    can land on an instance with no record of ``run_id`` and 404. When the
+    durable store is enabled we look up the run's coarse terminal checkpoint and,
+    if the run already finished, replay its single terminal SSE frame (e.g. the
+    DecisionCard) so the client completes instead of stalling.
+
+    Returns ``None`` when the flag is OFF, the store is unreachable, the run is
+    unknown/unowned, or the run has no terminal checkpoint yet (still running on
+    another instance). The caller then falls back to its existing 404, which the
+    web client already handles via the inline-stream fallback (#4737). Ownership
+    is enforced inside the store query (``user_id`` filter), and the callers here
+    have already validated the vault-owner token for ``user_id``.
+    """
+    if not _durable_run_store_enabled():
+        return None
+
+    checkpoint = await run_in_threadpool(
+        kai_analyze_run_store.load_terminal_checkpoint,
+        run_id=run_id,
+        user_id=user_id,
+    )
+    if not checkpoint:
+        return None
+
+    terminal_event = checkpoint.get("terminal_event")
+    if not terminal_event:
+        return None
+
+    payload = checkpoint.get("terminal_payload")
+    if not isinstance(payload, dict):
+        payload = {}
+    payload.setdefault("run_id", run_id)
+
+    # Match the canonical terminal envelope produced on the live path
+    # (KaiAnalyzeRunManager._append_synthetic_terminal) so a replayed frame is
+    # indistinguishable from a same-instance terminal frame to the client.
+    envelope = {
+        "schema_version": "1.0",
+        "stream_id": f"run_{run_id}",
+        "stream_kind": "stock_analyze",
+        "seq": 1,
+        "event": terminal_event,
+        "terminal": True,
+        "payload": payload,
+    }
+
+    async def _single_terminal() -> AsyncGenerator[dict, None]:
+        yield {"event": terminal_event, "id": "1", "data": json.dumps(envelope)}
+
+    logger.info(
+        "stream.durable_terminal_replay run_id=%s event=%s",
+        run_id,
+        terminal_event,
+    )
+    return _create_sse_response(_single_terminal())
+
+
 def _stream_factory(
     ticker: str,
     user_id: str,
@@ -2601,6 +2726,15 @@ async def analyze_stream_post(
     if body.run_id:
         run = await _RUN_MANAGER.get_run(body.run_id)
         if run is None:
+            # Cross-instance miss: if the durable store has this run's terminal
+            # checkpoint, replay it instead of 404ing. Falls through to the
+            # existing 404 (web inline-fallback #4737) when unavailable/unfinished.
+            replay = await _maybe_durable_terminal_replay(
+                run_id=body.run_id,
+                user_id=body.user_id,
+            )
+            if replay is not None:
+                return replay
             raise HTTPException(
                 status_code=404,
                 detail={
@@ -2739,6 +2873,12 @@ async def analyze_run_stream(
     await _require_vault_owner_token(user_id=user_id, authorization=authorization)
     run = await _RUN_MANAGER.get_run(run_id)
     if run is None or run.user_id != user_id:
+        # Cross-instance miss: replay the durable terminal checkpoint when the
+        # store has it (ownership enforced by the store query). Falls through to
+        # the existing 404 (web inline-fallback #4737) when unavailable/unfinished.
+        replay = await _maybe_durable_terminal_replay(run_id=run_id, user_id=user_id)
+        if replay is not None:
+            return replay
         raise HTTPException(
             status_code=404,
             detail={

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 124,
+  "expected_migration_version": 125,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 124,
+  "expected_migration_version": 125,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1079,6 +1079,20 @@
       "event_type",
       "created_at",
       "metadata"
+    ],
+    "kai_analyze_runs": [
+      "run_id",
+      "user_id",
+      "debate_session_id",
+      "ticker",
+      "risk_profile",
+      "status",
+      "terminal_event",
+      "terminal_payload",
+      "started_at",
+      "completed_at",
+      "created_at",
+      "updated_at"
     ]
   }
 }

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 124,
+  "expected_migration_version": 125,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1079,6 +1079,20 @@
       "event_type",
       "created_at",
       "metadata"
+    ],
+    "kai_analyze_runs": [
+      "run_id",
+      "user_id",
+      "debate_session_id",
+      "ticker",
+      "risk_profile",
+      "status",
+      "terminal_event",
+      "terminal_payload",
+      "started_at",
+      "completed_at",
+      "created_at",
+      "updated_at"
     ]
   }
 }

--- a/consent-protocol/db/migrations/125_kai_analyze_run_store.sql
+++ b/consent-protocol/db/migrations/125_kai_analyze_run_store.sql
@@ -1,0 +1,46 @@
+-- 125_kai_analyze_run_store.sql
+--
+-- Durable, cross-instance run store for Kai/RIA "debate" analyze streams.
+--
+-- Background: KaiAnalyzeRunManager (api/routes/kai/run_manager.py) is an
+-- in-memory, per-process singleton. On Cloud Run (multiple instances) a
+-- reconnect to GET /analyze/run/{run_id}/stream can land on an instance that
+-- never created the run and 404s (ANALYZE_RUN_NOT_FOUND). This table is a
+-- COARSE checkpoint mirror (start + terminal only, ~2 writes/run) read ONLY on
+-- the 404 miss path so a cross-instance reconnect can still receive the final
+-- DecisionCard. It intentionally does NOT store per-token frames (that would
+-- re-introduce the pool fanout pinned by DB_SQLALCHEMY_MAX_OVERFLOW=0 in #4736).
+--
+-- Idempotent + REPLAY-safe: the release pipeline re-executes every manifest
+-- migration on each deploy (db/migrate.py --migration-mode replay), so this
+-- file uses only IF NOT EXISTS guards and no trigger functions (updated_at is
+-- maintained by the application layer). No consent token is ever persisted.
+
+CREATE TABLE IF NOT EXISTS kai_analyze_runs (
+    run_id             TEXT PRIMARY KEY,
+    user_id            TEXT NOT NULL,
+    debate_session_id  TEXT,
+    ticker             TEXT,
+    risk_profile       TEXT,
+    status             TEXT NOT NULL DEFAULT 'running',
+    terminal_event     TEXT,
+    terminal_payload   JSONB,
+    started_at         TIMESTAMPTZ,
+    completed_at       TIMESTAMPTZ,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Ownership / active-run lookups are keyed on the user (the run_id read path is
+-- already served by the primary key).
+CREATE INDEX IF NOT EXISTS idx_kai_analyze_runs_user_session
+    ON kai_analyze_runs (user_id, debate_session_id);
+
+-- Supports time-based retention pruning of terminal rows without a full scan.
+CREATE INDEX IF NOT EXISTS idx_kai_analyze_runs_updated_at
+    ON kai_analyze_runs (updated_at);
+
+COMMENT ON TABLE kai_analyze_runs IS
+    'Coarse-checkpoint durable mirror of in-memory Kai analyze runs; read-through on cross-instance 404 only. Flag-gated by KAI_ANALYZE_DURABLE_RUN_STORE.';
+COMMENT ON COLUMN kai_analyze_runs.terminal_payload IS
+    'Final terminal event payload (e.g. DecisionCard) used to replay a single terminal SSE frame on cross-instance reconnect.';

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -102,7 +102,8 @@
     "121_trusted_devices.sql",
     "122_trusted_device_repair.sql",
     "123_pkm_device_sync.sql",
-    "124_trusted_device_vault_handoff.sql"
+    "124_trusted_device_vault_handoff.sql",
+    "125_kai_analyze_run_store.sql"
   ],
   "groups": {
     "iam": [

--- a/consent-protocol/hushh_mcp/services/kai_analyze_run_store.py
+++ b/consent-protocol/hushh_mcp/services/kai_analyze_run_store.py
@@ -1,0 +1,197 @@
+"""Durable coarse-checkpoint store for Kai/RIA analyze ("debate") runs.
+
+Why this exists
+---------------
+``KaiAnalyzeRunManager`` (``api/routes/kai/run_manager.py``) keeps run state in
+an in-memory, per-process dict. On Cloud Run the backend fans across multiple
+instances, so a client that reconnects to ``GET /analyze/run/{run_id}/stream``
+can land on an instance that never created the run and receive HTTP 404
+``ANALYZE_RUN_NOT_FOUND``. This module is a *coarse* mirror of run state in
+Postgres (table ``kai_analyze_runs``, migration 125) that the stream routes read
+**only on the 404 miss path** so a cross-instance reconnect can still receive
+the run's final terminal frame (e.g. the DecisionCard).
+
+Design guardrails (do not soften without re-reading the parity + fanout notes)
+------------------------------------------------------------------------------
+* **Coarse only.** We persist at most two checkpoints per run — ``start`` and
+  ``terminal``. We never persist per-token frames: that would re-introduce the
+  connection fanout that #4736 pinned away (``DB_SQLALCHEMY_MAX_OVERFLOW=0``).
+* **Best-effort.** Every function swallows its own errors and returns a falsy
+  value. A store outage must never break the live SSE hot path — the run still
+  streams from memory on the instance that owns it.
+* **Flag-gated by the caller.** This module does not read the feature flag; the
+  stream layer only calls it when ``KAI_ANALYZE_DURABLE_RUN_STORE`` is enabled,
+  so with the flag OFF (the default) there are zero reads and zero writes and
+  production behavior is byte-for-byte unchanged.
+* **No secrets.** The consent token is never written here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_TABLE = "kai_analyze_runs"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_json(value: Any) -> Optional[Dict[str, Any]]:
+    """Return a dict from a JSON column value.
+
+    Postgres JSONB round-trips as a ``dict``; the offline SQLite engine stores
+    JSON as TEXT and returns a ``str``. Anything else (or malformed JSON) yields
+    ``None`` so callers can fall back cleanly.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def save_start_checkpoint(
+    *,
+    run_id: str,
+    user_id: str,
+    debate_session_id: Optional[str] = None,
+    ticker: Optional[str] = None,
+    risk_profile: Optional[str] = None,
+    started_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> bool:
+    """Persist the coarse ``start`` checkpoint (status='running').
+
+    Best-effort: returns ``True`` on write, ``False`` on any failure. Uses
+    ``upsert(on_conflict=run_id)`` so a retry or a late terminal write both
+    converge on one row.
+    """
+    try:
+        from db.db_client import get_db
+
+        now = updated_at or started_at or _now_iso()
+        row: Dict[str, Any] = {
+            "run_id": run_id,
+            "user_id": user_id,
+            "debate_session_id": debate_session_id,
+            "ticker": ticker,
+            "risk_profile": risk_profile,
+            "status": "running",
+            "started_at": started_at or now,
+            "updated_at": now,
+            "created_at": now,
+        }
+        get_db().table(_TABLE).upsert(row, on_conflict="run_id").execute()
+        return True
+    except Exception:  # pragma: no cover - best-effort mirror
+        logger.debug("[KaiRunStore] start checkpoint failed for %s", run_id, exc_info=True)
+        return False
+
+
+def save_terminal_checkpoint(
+    *,
+    run_id: str,
+    user_id: str,
+    status: str,
+    terminal_event: Optional[str],
+    terminal_payload: Optional[Dict[str, Any]],
+    debate_session_id: Optional[str] = None,
+    ticker: Optional[str] = None,
+    risk_profile: Optional[str] = None,
+    completed_at: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> bool:
+    """Persist the coarse terminal checkpoint.
+
+    Best-effort: returns ``True`` on write, ``False`` on any failure. Uses
+    ``upsert(on_conflict=run_id)`` so it self-heals into a complete row even when
+    the ``start`` checkpoint was never written (e.g. the flag was flipped on
+    mid-run). Identity columns are only included when provided so a conflict
+    update never clobbers a good start value with ``None``.
+    """
+    try:
+        from db.db_client import get_db
+
+        now = updated_at or completed_at or _now_iso()
+        row: Dict[str, Any] = {
+            "run_id": run_id,
+            "user_id": user_id,
+            "status": status or "completed",
+            "terminal_event": terminal_event,
+            "terminal_payload": terminal_payload,
+            "completed_at": completed_at,
+            "updated_at": now,
+            "created_at": now,
+        }
+        if debate_session_id is not None:
+            row["debate_session_id"] = debate_session_id
+        if ticker is not None:
+            row["ticker"] = ticker
+        if risk_profile is not None:
+            row["risk_profile"] = risk_profile
+        get_db().table(_TABLE).upsert(row, on_conflict="run_id").execute()
+        return True
+    except Exception:  # pragma: no cover - best-effort mirror
+        logger.debug("[KaiRunStore] terminal checkpoint failed for %s", run_id, exc_info=True)
+        return False
+
+
+def load_terminal_checkpoint(
+    *,
+    run_id: str,
+    user_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the terminal checkpoint for a completed run owned by ``user_id``.
+
+    Returns ``None`` when the store is unreachable, the run is unknown, the
+    caller does not own it, or the run has no terminal event yet (still running,
+    or the terminal checkpoint was never written). Ownership is enforced in the
+    query (``user_id`` filter) so a mismatch simply yields no row.
+    """
+    try:
+        from db.db_client import get_db
+
+        result = (
+            get_db()
+            .table(_TABLE)
+            .select("*")
+            .eq("run_id", run_id)
+            .eq("user_id", user_id)
+            .limit(1)
+            .execute()
+        )
+        rows = result.data or []
+        if not rows:
+            return None
+
+        row = rows[0]
+        terminal_event = row.get("terminal_event")
+        if not terminal_event:
+            return None
+
+        payload = _coerce_json(row.get("terminal_payload")) or {}
+        payload.setdefault("run_id", run_id)
+        return {
+            "run_id": run_id,
+            "user_id": row.get("user_id"),
+            "status": row.get("status"),
+            "terminal_event": terminal_event,
+            "terminal_payload": payload,
+            "ticker": row.get("ticker"),
+            "debate_session_id": row.get("debate_session_id"),
+        }
+    except Exception:  # pragma: no cover - best-effort read-through
+        logger.debug("[KaiRunStore] terminal load failed for %s", run_id, exc_info=True)
+        return None

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -31,3 +31,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_kai_analyze_run_store.py

--- a/consent-protocol/tests/test_kai_analyze_run_store.py
+++ b/consent-protocol/tests/test_kai_analyze_run_store.py
@@ -1,0 +1,275 @@
+"""Tests for the durable coarse-checkpoint Kai/RIA analyze ("debate") run store.
+
+Two concerns are covered:
+
+1. **Governance lockstep** — migration 125 is registered in the release manifest
+   and the schema contracts, and the migration is purely additive / REPLAY-safe.
+2. **Cross-instance resume** — the whole point of the store: a checkpoint written
+   by one process must be readable by a *different* engine pointed at the same
+   database, proving a Cloud Run reconnect on a foreign instance can replay the
+   terminal frame. We exercise this against the offline SQLite engine (which is
+   the same ``db.db_client`` code path prod uses, minus Postgres), using a fresh
+   engine for the read to simulate the second instance.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION_NAME = "125_kai_analyze_run_store.sql"
+MIGRATION = ROOT / "db" / "migrations" / MIGRATION_NAME
+CONTRACTS = ROOT / "db" / "contracts"
+
+# The table is a production-fanout mitigation. It lives in the integrated/core
+# contracts; dev_minimum is an intentional subset and does not require it.
+_TABLE_COLUMNS = {
+    "run_id",
+    "user_id",
+    "debate_session_id",
+    "ticker",
+    "risk_profile",
+    "status",
+    "terminal_event",
+    "terminal_payload",
+    "started_at",
+    "completed_at",
+    "created_at",
+    "updated_at",
+}
+
+
+def _json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def _release_versions(manifest: dict) -> list[int]:
+    return [
+        int(name.split("_", 1)[0]) for name in manifest["ordered_migrations"] if name[:3].isdigit()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Governance lockstep
+# ---------------------------------------------------------------------------
+
+
+def test_run_store_is_registered_in_release_manifest_and_contracts() -> None:
+    manifest = _json(ROOT / "db" / "release_migration_manifest.json")
+    release_versions = _release_versions(manifest)
+
+    assert MIGRATION.exists()
+    assert MIGRATION_NAME in manifest["ordered_migrations"]
+    # Appending the migration must not duplicate an entry, and it must be the new
+    # release ceiling so every contract's expected version lands on it.
+    assert len(manifest["ordered_migrations"]) == len(set(manifest["ordered_migrations"]))
+    assert max(release_versions) == 125
+
+    for contract_name in (
+        "dev_minimum_schema.json",
+        "uat_integrated_schema.json",
+        "prod_core_schema.json",
+    ):
+        contract = _json(CONTRACTS / contract_name)
+        assert contract["expected_migration_version"] == max(release_versions), contract_name
+
+    # The table is required only by the integrated + core contracts (dev_minimum
+    # is a deliberate subset — see the 10-table gap between it and prod_core).
+    for contract_name in ("uat_integrated_schema.json", "prod_core_schema.json"):
+        required_tables = _json(CONTRACTS / contract_name)["required_tables"]
+        assert "kai_analyze_runs" in required_tables, contract_name
+        assert set(required_tables["kai_analyze_runs"]) == _TABLE_COLUMNS, contract_name
+
+
+def test_run_store_migration_is_additive_and_replay_safe() -> None:
+    sql = MIGRATION.read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS kai_analyze_runs" in sql
+    for column in _TABLE_COLUMNS:
+        assert column in sql, column
+    # Coarse mirror only — the terminal frame is a JSON blob, no per-token columns.
+    assert "terminal_payload" in sql
+    # Indexes must be replay-safe too.
+    assert "CREATE INDEX IF NOT EXISTS idx_kai_analyze_runs_user_session" in sql
+    assert "CREATE INDEX IF NOT EXISTS idx_kai_analyze_runs_updated_at" in sql
+    # Never destructive: the release pipeline re-runs this on every deploy.
+    assert "DROP TABLE" not in sql
+    assert "DROP COLUMN" not in sql
+    # The consent token must never be persisted to this mirror.
+    assert "consent_token" not in sql.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cross-instance resume (offline SQLite, same db_client code path)
+# ---------------------------------------------------------------------------
+
+# SQLite-compatible mirror of the migration-125 shape. The offline schema file
+# does not know about kai_analyze_runs, so the "first instance" creates it.
+_SQLITE_DDL = """
+CREATE TABLE IF NOT EXISTS kai_analyze_runs (
+    run_id             TEXT PRIMARY KEY,
+    user_id            TEXT NOT NULL,
+    debate_session_id  TEXT,
+    ticker             TEXT,
+    risk_profile       TEXT,
+    status             TEXT NOT NULL DEFAULT 'running',
+    terminal_event     TEXT,
+    terminal_payload   TEXT,
+    started_at         TEXT,
+    completed_at       TEXT,
+    created_at         TEXT,
+    updated_at         TEXT
+)
+"""
+
+
+@pytest.fixture()
+def offline_db(tmp_path, monkeypatch):
+    """Boot the offline SQLite engine on a real file shared across engines."""
+    db_file = tmp_path / "kai-run-store.db"
+    monkeypatch.setenv("DB_OFFLINE", "1")
+    monkeypatch.setenv("OFFLINE_DB_PATH", str(db_file))
+
+    import db.connection as connection
+    import db.db_client as db_client
+    import db.offline_db as offline_db_mod
+
+    importlib.reload(offline_db_mod)
+    db_client._engine = None
+    db_client._db_client = None
+    connection._pool = None
+
+    # "First instance": create the table the migration would have created.
+    from db.db_client import get_db
+
+    get_db().execute_raw(_SQLITE_DDL)
+
+    yield
+
+    if db_client._engine is not None:
+        db_client._engine.dispose()
+    db_client._engine = None
+    db_client._db_client = None
+    connection._pool = None
+
+
+def _simulate_fresh_instance() -> None:
+    """Dispose the current engine and force a new one on the same file.
+
+    This is the crux of the cross-instance test: the read must go through a
+    genuinely separate SQLAlchemy engine (a stand-in for a different Cloud Run
+    instance), not the connection that wrote the row.
+    """
+    import db.connection as connection
+    import db.db_client as db_client
+
+    if db_client._engine is not None:
+        db_client._engine.dispose()
+    db_client._engine = None
+    db_client._db_client = None
+    connection._pool = None
+
+
+def test_terminal_checkpoint_round_trips_to_a_fresh_instance(offline_db) -> None:
+    from hushh_mcp.services.kai_analyze_run_store import (
+        load_terminal_checkpoint,
+        save_start_checkpoint,
+        save_terminal_checkpoint,
+    )
+
+    # Instance A: run starts, then completes with a terminal DecisionCard frame.
+    assert save_start_checkpoint(
+        run_id="run-1",
+        user_id="user-1",
+        debate_session_id="sess-1",
+        ticker="AAPL",
+        risk_profile="balanced",
+    )
+    payload = {"decision": "BUY", "confidence": 0.82, "run_id": "run-1"}
+    assert save_terminal_checkpoint(
+        run_id="run-1",
+        user_id="user-1",
+        status="completed",
+        terminal_event="decision_card",
+        terminal_payload=payload,
+    )
+
+    # Instance B: a different engine on the same DB reads the terminal frame.
+    _simulate_fresh_instance()
+    loaded = load_terminal_checkpoint(run_id="run-1", user_id="user-1")
+
+    assert loaded is not None
+    assert loaded["status"] == "completed"
+    assert loaded["terminal_event"] == "decision_card"
+    assert loaded["terminal_payload"]["decision"] == "BUY"
+    assert loaded["terminal_payload"]["confidence"] == 0.82
+    # Identity columns from the start checkpoint survive the terminal upsert.
+    assert loaded["ticker"] == "AAPL"
+    assert loaded["debate_session_id"] == "sess-1"
+
+
+def test_terminal_checkpoint_self_heals_without_a_prior_start(offline_db) -> None:
+    # Flag flipped mid-run: only the terminal write happens. The upsert must
+    # still produce a complete, loadable row.
+    from hushh_mcp.services.kai_analyze_run_store import (
+        load_terminal_checkpoint,
+        save_terminal_checkpoint,
+    )
+
+    assert save_terminal_checkpoint(
+        run_id="run-2",
+        user_id="user-1",
+        status="completed",
+        terminal_event="decision_card",
+        terminal_payload={"decision": "HOLD"},
+        ticker="MSFT",
+        debate_session_id="sess-2",
+    )
+
+    _simulate_fresh_instance()
+    loaded = load_terminal_checkpoint(run_id="run-2", user_id="user-1")
+    assert loaded is not None
+    assert loaded["terminal_payload"]["decision"] == "HOLD"
+    assert loaded["ticker"] == "MSFT"
+
+
+def test_load_is_none_for_unknown_run(offline_db) -> None:
+    from hushh_mcp.services.kai_analyze_run_store import load_terminal_checkpoint
+
+    assert load_terminal_checkpoint(run_id="does-not-exist", user_id="user-1") is None
+
+
+def test_load_is_none_for_a_run_still_running(offline_db) -> None:
+    # A start checkpoint with no terminal frame must not be replayable.
+    from hushh_mcp.services.kai_analyze_run_store import (
+        load_terminal_checkpoint,
+        save_start_checkpoint,
+    )
+
+    assert save_start_checkpoint(run_id="run-3", user_id="user-1")
+    _simulate_fresh_instance()
+    assert load_terminal_checkpoint(run_id="run-3", user_id="user-1") is None
+
+
+def test_load_enforces_ownership(offline_db) -> None:
+    # A different user must never be able to read another user's terminal frame.
+    from hushh_mcp.services.kai_analyze_run_store import (
+        load_terminal_checkpoint,
+        save_terminal_checkpoint,
+    )
+
+    assert save_terminal_checkpoint(
+        run_id="run-4",
+        user_id="owner",
+        status="completed",
+        terminal_event="decision_card",
+        terminal_payload={"decision": "SELL"},
+    )
+
+    _simulate_fresh_instance()
+    assert load_terminal_checkpoint(run_id="run-4", user_id="intruder") is None
+    assert load_terminal_checkpoint(run_id="run-4", user_id="owner") is not None

--- a/consent-protocol/tests/test_pkm_device_sync_migration.py
+++ b/consent-protocol/tests/test_pkm_device_sync_migration.py
@@ -30,5 +30,5 @@ def test_schema_contracts_require_the_sync_delete_function() -> None:
         "prod_core_schema.json",
     ):
         contract = json.loads((ROOT / "db/contracts" / contract_name).read_text())
-        assert contract["expected_migration_version"] == 124
+        assert contract["expected_migration_version"] == 125
         assert "delete_pkm_domain_v3" in contract["required_functions"]

--- a/consent-protocol/tests/test_trusted_device_migration.py
+++ b/consent-protocol/tests/test_trusted_device_migration.py
@@ -10,7 +10,7 @@ def test_trusted_device_migration_is_release_ordered_and_metadata_only() -> None
     manifest = json.loads(
         (ROOT / "db" / "release_migration_manifest.json").read_text(encoding="utf-8")
     )
-    assert manifest["ordered_migrations"][-1] == "124_trusted_device_vault_handoff.sql"
+    assert "124_trusted_device_vault_handoff.sql" in manifest["ordered_migrations"]
     assert "122_trusted_device_repair.sql" in manifest["groups"]["iam"]
 
     sql = (ROOT / "db" / "migrations" / "121_trusted_devices.sql").read_text(encoding="utf-8")
@@ -89,6 +89,6 @@ def test_trusted_device_migration_is_release_ordered_and_metadata_only() -> None
         contract = json.loads(
             (ROOT / "db" / "contracts" / contract_name).read_text(encoding="utf-8")
         )
-        assert contract["expected_migration_version"] == 124
+        assert contract["expected_migration_version"] == 125
         for table, columns in expected_columns.items():
             assert set(contract["required_tables"][table]) == columns

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -213,6 +213,12 @@ steps:
         append_optional_env "ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED" "${_ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED}"
         append_optional_env "APP_REVIEW_MODE" "${_APP_REVIEW_MODE}"
         append_optional_env "HUSHH_PROD_PHONE_TEST_ENABLED" "${_HUSHH_PROD_PHONE_TEST_ENABLED}"
+        # Cross-instance durable Kai/RIA "debate" run store (migration 125).
+        # Empty default => var not deployed => app treats it as "false" => the
+        # coarse-checkpoint store is dormant and prod behavior is unchanged. Flip
+        # the _KAI_ANALYZE_DURABLE_RUN_STORE substitution to "true" (per-env) to
+        # enable read-through replay of terminal frames on a cross-instance 404.
+        append_optional_env "KAI_ANALYZE_DURABLE_RUN_STORE" "${_KAI_ANALYZE_DURABLE_RUN_STORE}"
 
         # Join with '|' (not ',') so env VALUES may themselves contain commas.
         # Paired with gcloud's alternate-delimiter syntax on --set-env-vars below.
@@ -350,6 +356,9 @@ substitutions:
   _ONE_EMAIL_KYC_STRICT_CLIENT_ZK_ENABLED: "true"
   _APP_REVIEW_MODE: ""
   _HUSHH_PROD_PHONE_TEST_ENABLED: ""
+  # Dormant by default (empty => not deployed => app default "false"). Set to
+  # "true" per-environment to enable the durable Kai analyze run store.
+  _KAI_ANALYZE_DURABLE_RUN_STORE: ""
   _CLOUD_RUN_NO_TRAFFIC: "false"
   _CONSENT_API_PUBLIC_ORIGIN: ""
   _DB_POOL_MIN_SIZE: "1"


### PR DESCRIPTION
## Summary

RIA **debate** resume works on UAT but 404s on prod. Root cause: `KaiAnalyzeRunManager` (`api/routes/kai/run_manager.py`) is a **per-process in-memory singleton**. On Cloud Run a reconnect can land on an instance that never created the run, so it returns `ANALYZE_RUN_NOT_FOUND` (session affinity is best-effort and lost on scale-down / cold-start / revision change). This was partially masked by the frontend inline-fallback in #4737; this PR addresses the server-side durability gap.

Adds a **Postgres-backed durable run store** that mirrors only **coarse checkpoints** (2 writes/run: `start` + `terminal`) — never per-token frames — so it cannot starve the pool pinned at `DB_SQLALCHEMY_MAX_OVERFLOW=0` (#4736). On a 404 miss the stream reads through to the store and, if the run already finished, replays its single terminal SSE frame (e.g. the DecisionCard) so the client completes instead of stalling; otherwise it falls through to the existing 404.

## What changed
- **New store** `hushh_mcp/services/kai_analyze_run_store.py` — `save_start_checkpoint` / `save_terminal_checkpoint` / `load_terminal_checkpoint`, all best-effort.
- **`run_manager.py`** — optional `on_checkpoint` sink (default `None`), fired once at start and once on any terminal frame; wrapped so a misbehaving sink can never interrupt streaming.
- **`stream.py`** — flag-gated persister + `_maybe_durable_terminal_replay` wired at both 404 sites.
- **Migration `125_kai_analyze_run_store.sql`** — additive, REPLAY-safe (`CREATE TABLE/INDEX IF NOT EXISTS`).
- **Manifest + contracts** — migration registered; `expected_migration_version` bumped 124→125 across dev/uat/prod contracts; `kai_analyze_runs` added to uat/prod contracts (dev_minimum is an intentional subset).
- **Tests** — new cross-instance round-trip suite + governance lockstep; added to the CI backend manifest.

## Safety / blast radius
- **Flag-gated `KAI_ANALYZE_DURABLE_RUN_STORE`, default OFF.** With the flag off no checkpoints are written and no read-through occurs → behavior is **byte-for-byte** the existing in-memory path. Prod deploys with the flag unset (empty substitution in `backend.cloudbuild.yaml`), so this ships **dormant**.
- **Best-effort everywhere** — the sink and every store call are wrapped; a store failure can never perturb the live stream.
- **No per-token writes** → pool-safe under the `MAX_OVERFLOW=0` pin.
- **Ownership** enforced by `user_id` on the read; **consent token is never persisted**.
- Migration is idempotent → safe under the prod inline `replay` migration mode.

## Testing
- `ruff check .` — pass
- `bandit -ll` — no issues
- Full CI manifest (`run-test-ci.sh`) — **427 passed** incl. the new 7-test suite
- `db_migration_release_guard.py` for all 3 contracts — `violations: []`, version lockstep 125

## Rollout plan
1. Merge → UAT (flag can be flipped ON on UAT to verify true multi-instance resume).
2. Prod receives the **dormant** code + migration 125 (applied inline). Prod behavior unchanged until the flag is deliberately flipped.