### PR TITLE
feat(kai): add Market home entry point to Analysis & Debate

### DIFF
--- a/hushh-webapp/__tests__/components/kai-market-preview-movers.test.ts
+++ b/hushh-webapp/__tests__/components/kai-market-preview-movers.test.ts
@@ -69,6 +69,19 @@ describe("market route overlays", () => {
     expect(source).not.toContain('actionHref={buildKaiMarketRoute("analysis")}');
   });
 
+  it("gives Market home a discoverable entry into the Analysis workspace", () => {
+    const source = readFileSync(
+      join(process.cwd(), "components/kai/views/kai-market-preview-view.tsx"),
+      "utf8",
+    );
+
+    // A tappable card on the default Finance landing routes users into the
+    // live debate / recommendation surface, which is otherwise reachable only
+    // via the top-shell tab or a direct URL.
+    expect(source).toContain('data-testid="kai-analysis-entry"');
+    expect(source).toContain('openOneMarketHref(buildKaiMarketRoute("analysis"))');
+  });
+
   it("does not mount a hidden notification sheet on route load", () => {
     const source = readFileSync(
       join(process.cwd(), "components/kai/views/kai-market-preview-view.tsx"),

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -5,12 +5,14 @@ import { usePathname, useSearchParams } from "next/navigation";
 import {
   Activity,
   AlertTriangle,
+  ArrowRight,
   ChartColumnIncreasing,
   Cpu,
   LineChart,
   Loader2,
   Newspaper,
   Percent,
+  Sparkles,
   TrendingDown,
   TrendingUp,
   type LucideIcon,
@@ -2316,6 +2318,36 @@ export function KaiMarketPreviewView() {
 
           {hasPayload ? (
             <>
+              <section className="mx-auto mt-9 w-full max-w-[1080px] px-[var(--one-gutter)]">
+                <button
+                  type="button"
+                  data-testid="kai-analysis-entry"
+                  onClick={() =>
+                    openOneMarketHref(buildKaiMarketRoute("analysis"))
+                  }
+                  className="group flex w-full items-center gap-3.5 rounded-[var(--app-card-radius-compact)] bg-[color:var(--one-card)] p-4 text-left shadow-[var(--app-card-shadow-standard)] transition-transform active:scale-[0.995]"
+                >
+                  <span className="grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-[color:var(--one-indigo-t)] text-[color:var(--one-indigo)]">
+                    <Sparkles className="h-5 w-5" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-2">
+                      <span className="text-[15px] font-semibold text-foreground">
+                        Analysis &amp; Debate
+                      </span>
+                      <span className="rounded-full bg-[color:var(--one-indigo-t)] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-[color:var(--one-indigo)]">
+                        New
+                      </span>
+                    </span>
+                    <span className="mt-0.5 block truncate text-[13px] text-muted-foreground">
+                      Watch Kai&apos;s analysts debate a stock and get a clear
+                      recommendation.
+                    </span>
+                  </span>
+                  <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                </button>
+              </section>
+
               <section className="mx-auto mt-9 w-full max-w-[1080px] px-[var(--one-gutter)]">
                 <RiaPicksList
                   rows={riaPickRows}


### PR DESCRIPTION
## What

Adds a discoverable navigation entry point to the Kai **Analysis & Debate** workspace.

The Analysis surface (live analyst debate + clear recommendation, at `/one/kai?tab=analysis`) already exists and works, but it was only reachable via the Finance top-shell tab or a direct URL. Ordinary users had no obvious way in. This adds a tappable **"Analysis & Debate"** card as the first section of the Market home body (the default Finance landing every user hits).

## How

- New additive `<section>` in `kai-market-preview-view.tsx`, rendered inside the existing `hasPayload` block, before the picks list.
- Routes via the existing in-file helper `openOneMarketHref(buildKaiMarketRoute("analysis"))` — the same proven internal-nav path used by mover ticker clicks (`requestInternalAppNavigation`, `scroll:false`).
- Uses existing design tokens (`--one-card`, `--one-indigo(-t)`, `--app-card-radius-compact`, `--app-card-shadow-standard`) and lucide `Sparkles`/`ArrowRight`.

## Safety

- **Purely additive.** No existing behavior removed or changed. Desktop web unchanged.
- Does **not** touch the debate panel component (separate in-flight work).
- Deliberately uses `onClick`/`openOneMarketHref` rather than `actionHref={buildKaiMarketRoute("analysis")}`, so the existing movers-test guard that forbids that exact string on the Market-news header still holds.

## Tests / gates

- Added a positive regression test in `kai-market-preview-movers.test.ts` asserting the entry card + nav call are present.
- Green locally: movers 10/10, navbar-bottom-nav 7/7, top-shell/home-shell nav-contract suites 52/52, eslint clean, tsc type-clean for the changed files.