### PR TITLE
chore(governance): grant Damria production deploy access

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -128,7 +128,8 @@
     ],
     "manual_dispatch_users": [
       "kushaltrivedi5",
-      "ankitkumarsingh1702"
+      "ankitkumarsingh1702",
+      "DamriaNeelesh"
     ],
     "owner_environment": "production"
   }

--- a/docs/reference/operations/branch-governance.md
+++ b/docs/reference/operations/branch-governance.md
@@ -179,16 +179,19 @@ outside it, and the boundaries are enforced, not informal:
 |---|---|---|---|
 | Merge cohort | `allowed-maintainers-to-approve` team | bypass review + queue, edit pipeline | `main.review_bypass_users` / `merge_queue_bypass_users` / `protected_pipeline_edit_users` |
 | UAT deploy cohort | same as merge cohort | dispatch UAT deploy of a green `main` SHA | `uat.manual_dispatch_users` (held == merge cohort) |
-| Production deploy cohort | `kushaltrivedi5`, `ankitkumarsingh1702` | dispatch production deploy | `production.manual_dispatch_users` |
+| Production deploy cohort | approved production operators | dispatch production deploy | `production.manual_dispatch_users` |
 
 Invariants enforced in CI by `verify-deployment-environment-governance.py`:
 
 - **UAT == merge cohort.** Anyone trusted to land code on `main` may validate it
   in the UAT sandbox — no more, no less. The two lists are held equal and any
   independent drift fails the check.
-- **Production == approved dispatch cohort.** `production.manual_dispatch_users`
-  must be exactly `["kushaltrivedi5", "ankitkumarsingh1702"]`; any independent
-  widening or narrowing fails the check.
+- **Production == explicitly approved dispatch cohort.**
+  `production.manual_dispatch_users` must be non-empty, unique, and a strict
+  subset of the UAT maintainer cohort. Its membership is intentionally owned by
+  the reviewed JSON policy; the verifier rejects an empty, out-of-cohort, or
+  full-maintainer production roster but does not duplicate the roster in code
+  or prose.
 - **Deploy identity variables are present.** Each deployment environment must
   contain every name declared in its `required_environment_variables` policy.
   These are GitHub environment variables consumed through `vars.*`, not
@@ -304,7 +307,7 @@ The production workflow uses one active GitHub environment name:
 
 | Environment | Intended use |
 |---|---|
-| `production` | Governed production deploy lane for `kushaltrivedi5` and `ankitkumarsingh1702` |
+| `production` | Governed production deploy lane for the operators named in `production.manual_dispatch_users` |
 
 The UAT workflow uses one active GitHub environment name:
 

--- a/scripts/ci/repo-governance-check.sh
+++ b/scripts/ci/repo-governance-check.sh
@@ -13,6 +13,7 @@ python3 scripts/ci/verify-protected-pipeline-edits.py --self-test
 python3 scripts/ci/verify-pr-base-policy.py --self-test
 python3 scripts/ci/verify-branch-governance-doc-consistency.py
 python3 scripts/ci/verify-branch-governance-doc-consistency.py --self-test
+python3 scripts/ci/test_verify_deployment_environment_governance.py
 python3 scripts/ci/test_resolve_deploy_scope.py
 python3 scripts/ci/test_resolve_uat_verification_plan.py
 python3 scripts/ci/test_change_aware_verification_wiring.py

--- a/scripts/ci/test_verify_deployment_environment_governance.py
+++ b/scripts/ci/test_verify_deployment_environment_governance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from unittest.mock import patch
 
 
 def _module():
@@ -25,7 +26,7 @@ def _policy() -> dict:
         },
         "uat": {
             "environment": "uat",
-            "manual_dispatch_users": ["maintainer"],
+            "manual_dispatch_users": ["maintainer", "uat-only-operator"],
             "required_environment_variables": [
                 "GCP_WORKLOAD_IDENTITY_PROVIDER",
                 "GCP_DEPLOY_SERVICE_ACCOUNT",
@@ -33,7 +34,7 @@ def _policy() -> dict:
         },
         "production": {
             "owner_environment": "production",
-            "manual_dispatch_users": ["kushaltrivedi5", "ankitkumarsingh1702"],
+            "manual_dispatch_users": ["maintainer"],
             "required_environment_variables": [
                 "GCP_WORKLOAD_IDENTITY_PROVIDER",
                 "GCP_DEPLOY_SERVICE_ACCOUNT",
@@ -53,7 +54,7 @@ def _environment_payload() -> dict:
     }
 
 
-def test_required_environment_variables_are_enforced(monkeypatch) -> None:
+def test_required_environment_variables_are_enforced() -> None:
     module = _module()
 
     def fake_gh_json(path: str) -> dict:
@@ -66,12 +67,11 @@ def test_required_environment_variables_are_enforced(monkeypatch) -> None:
             }
         return _environment_payload()
 
-    monkeypatch.setattr(module, "_gh_json", fake_gh_json)
+    with patch.object(module, "_gh_json", fake_gh_json):
+        assert module._assert_surface("production", "owner/repo", _policy()) == []
 
-    assert module._assert_surface("production", "owner/repo", _policy()) == []
 
-
-def test_missing_environment_variable_fails_verification(monkeypatch) -> None:
+def test_missing_environment_variable_fails_verification() -> None:
     module = _module()
 
     def fake_gh_json(path: str) -> dict:
@@ -79,11 +79,114 @@ def test_missing_environment_variable_fails_verification(monkeypatch) -> None:
             return {"variables": [{"name": "GCP_WORKLOAD_IDENTITY_PROVIDER"}]}
         return _environment_payload()
 
-    monkeypatch.setattr(module, "_gh_json", fake_gh_json)
-
-    errors = module._assert_surface("production", "owner/repo", _policy())
+    with patch.object(module, "_gh_json", fake_gh_json):
+        errors = module._assert_surface("production", "owner/repo", _policy())
 
     assert errors == [
         "production is missing required environment variables: "
         "['GCP_DEPLOY_SERVICE_ACCOUNT']"
     ]
+
+
+def test_empty_production_dispatch_cohort_fails_verification() -> None:
+    module = _module()
+    policy = _policy()
+    policy["production"]["manual_dispatch_users"] = []
+
+    def fake_gh_json(path: str) -> dict:
+        if path.endswith("/variables"):
+            return {
+                "variables": [
+                    {"name": "GCP_WORKLOAD_IDENTITY_PROVIDER"},
+                    {"name": "GCP_DEPLOY_SERVICE_ACCOUNT"},
+                ]
+            }
+        return _environment_payload()
+
+    with patch.object(module, "_gh_json", fake_gh_json):
+        assert module._assert_surface("production", "owner/repo", policy) == [
+            "production manual dispatch policy must name at least one user"
+        ]
+
+
+def test_production_dispatch_cohort_must_be_within_uat_cohort() -> None:
+    module = _module()
+    policy = _policy()
+    policy["production"]["manual_dispatch_users"] = ["unapproved-operator"]
+
+    def fake_gh_json(path: str) -> dict:
+        if path.endswith("/variables"):
+            return {
+                "variables": [
+                    {"name": "GCP_WORKLOAD_IDENTITY_PROVIDER"},
+                    {"name": "GCP_DEPLOY_SERVICE_ACCOUNT"},
+                ]
+            }
+        return _environment_payload()
+
+    with patch.object(module, "_gh_json", fake_gh_json):
+        assert module._assert_surface("production", "owner/repo", policy) == [
+            "production manual dispatch users must be a subset of the UAT "
+            "maintainer cohort: ['unapproved-operator']"
+        ]
+
+
+def test_duplicate_production_dispatch_user_fails_verification() -> None:
+    module = _module()
+    policy = _policy()
+    policy["production"]["manual_dispatch_users"] = ["maintainer", "maintainer"]
+
+    def fake_gh_json(path: str) -> dict:
+        if path.endswith("/variables"):
+            return {
+                "variables": [
+                    {"name": "GCP_WORKLOAD_IDENTITY_PROVIDER"},
+                    {"name": "GCP_DEPLOY_SERVICE_ACCOUNT"},
+                ]
+            }
+        return _environment_payload()
+
+    with patch.object(module, "_gh_json", fake_gh_json):
+        assert module._assert_surface("production", "owner/repo", policy) == [
+            "production manual dispatch policy must not contain duplicate users"
+        ]
+
+
+def test_production_dispatch_cohort_must_be_strictly_smaller_than_uat() -> None:
+    module = _module()
+    policy = _policy()
+    policy["production"]["manual_dispatch_users"] = policy["uat"]["manual_dispatch_users"]
+
+    def fake_gh_json(path: str) -> dict:
+        if path.endswith("/variables"):
+            return {
+                "variables": [
+                    {"name": "GCP_WORKLOAD_IDENTITY_PROVIDER"},
+                    {"name": "GCP_DEPLOY_SERVICE_ACCOUNT"},
+                ]
+            }
+        return _environment_payload()
+
+    with patch.object(module, "_gh_json", fake_gh_json):
+        assert module._assert_surface("production", "owner/repo", policy) == [
+            "production manual dispatch users must be a strict subset of the UAT "
+            "maintainer cohort"
+        ]
+
+
+def main() -> None:
+    tests = (
+        test_required_environment_variables_are_enforced,
+        test_missing_environment_variable_fails_verification,
+        test_empty_production_dispatch_cohort_fails_verification,
+        test_production_dispatch_cohort_must_be_within_uat_cohort,
+        test_duplicate_production_dispatch_user_fails_verification,
+        test_production_dispatch_cohort_must_be_strictly_smaller_than_uat,
+    )
+    for test in tests:
+        test()
+        print(f"ok {test.__name__}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/verify-deployment-environment-governance.py
+++ b/scripts/ci/verify-deployment-environment-governance.py
@@ -12,7 +12,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 POLICY_PATH = REPO_ROOT / "config" / "ci-governance.json"
 DEFAULT_REPO = "hushh-labs/hushh-research"
-PRODUCTION_MANUAL_DISPATCH_USERS = ["kushaltrivedi5", "ankitkumarsingh1702"]
 
 
 def _gh_json(*args: str) -> dict:
@@ -74,11 +73,23 @@ def _assert_surface(surface: str, repo: str, policy: dict) -> list[str]:
         )
 
     allowed_users = surface_policy.get("manual_dispatch_users") or []
-    if surface == "production" and allowed_users != PRODUCTION_MANUAL_DISPATCH_USERS:
-        errors.append(
-            "production manual dispatch policy drifted: "
-            f"expected {PRODUCTION_MANUAL_DISPATCH_USERS}, got {allowed_users}"
-        )
+    if surface == "production":
+        if not allowed_users:
+            errors.append("production manual dispatch policy must name at least one user")
+        if len(allowed_users) != len(set(allowed_users)):
+            errors.append("production manual dispatch policy must not contain duplicate users")
+        uat_cohort = set(policy.get("uat", {}).get("manual_dispatch_users") or [])
+        out_of_cohort = sorted(set(allowed_users) - uat_cohort)
+        if out_of_cohort:
+            errors.append(
+                "production manual dispatch users must be a subset of the UAT "
+                f"maintainer cohort: {out_of_cohort}"
+            )
+        if set(allowed_users) == uat_cohort:
+            errors.append(
+                "production manual dispatch users must be a strict subset of the UAT "
+                "maintainer cohort"
+            )
 
     # UAT dispatch authority must equal the merge cohort (main.review_bypass_users).
     # Invariant: anyone trusted to land code on `main` is trusted to validate that


### PR DESCRIPTION
Purpose: grant @DamriaNeelesh governed production workflow-dispatch authority. Existing GitHub repository-admin and GCP production-Owner access are unchanged.

Scope:
- Add @DamriaNeelesh to the production manual-dispatch allowlist.
- Keep the allowlist authoritative only in config/ci-governance.json.
- Enforce that production dispatchers are non-empty, unique, and a strict subset of the UAT maintainer cohort.
- Document the policy and execute six self-contained verifier regressions in the required Governance CI lane.

Verification:
- Six governance verifier regression cases pass locally.
- Python syntax check and Damria production-actor assertion pass.
- Live production environment governance and docs governance verification pass.

No application code or shared-worktree changes are included.