### PR TITLE
fix(pkm): retry transient runtime-secret vault writes so managed-Gemini save is reliable

### DIFF
--- a/hushh-webapp/__tests__/lib/personal-knowledge-model/runtime-secret-retry.test.ts
+++ b/hushh-webapp/__tests__/lib/personal-knowledge-model/runtime-secret-retry.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  classifyRuntimeSecretStoreError,
+  computeRuntimeSecretRetryDelayMs,
+  runRuntimeSecretCommitWithRetry,
+  RuntimeSecretCommitError,
+  RUNTIME_SECRET_MAX_ATTEMPTS,
+  RUNTIME_SECRET_RETRY_BASE_MS,
+  RUNTIME_SECRET_RETRY_MAX_DELAY_MS,
+  type RuntimeSecretCommitHooks,
+} from "@/lib/personal-knowledge-model/runtime-secret-retry";
+
+type Result = { success: boolean; conflict?: boolean; message?: string };
+
+/**
+ * Build a runner harness with fully controllable hooks. `now` advances by a
+ * fixed step on every read so tests can exercise the deadline without real time.
+ */
+function makeHooks(overrides: Partial<RuntimeSecretCommitHooks<Result>> = {}) {
+  const pause = vi.fn(async (_ms: number) => undefined);
+  let clock = 0;
+  const now = vi.fn(() => {
+    const value = clock;
+    clock += 1;
+    return value;
+  });
+  const rebuildAfterConflict = vi.fn(async () => undefined);
+  const random = vi.fn(() => 0); // deterministic: zero jitter unless overridden
+  const hooks: RuntimeSecretCommitHooks<Result> = {
+    send: vi.fn(async () => ({ success: true })),
+    rebuildAfterConflict,
+    pause,
+    now,
+    random,
+    ...overrides,
+  };
+  return { hooks, pause, rebuildAfterConflict, random, setClock: (fn: () => number) => (hooks.now = fn) };
+}
+
+describe("classifyRuntimeSecretStoreError", () => {
+  it("treats configured 5xx/429/408/425 store-domain failures as transient", () => {
+    for (const status of [408, 425, 429, 500, 502, 503, 504]) {
+      const error = new Error(`Failed to store domain data: ${status} - upstream hiccup`);
+      expect(classifyRuntimeSecretStoreError(error)).toBe("transient");
+    }
+  });
+
+  it("treats 4xx client failures and conflicts as fatal (not replayable)", () => {
+    for (const status of [400, 401, 403, 404, 409, 422]) {
+      const error = new Error(`Failed to store domain data: ${status} - nope`);
+      expect(classifyRuntimeSecretStoreError(error)).toBe("fatal");
+    }
+  });
+
+  it("treats network/abort/timeout fingerprints as transient", () => {
+    const abort = new Error("The operation was aborted");
+    abort.name = "AbortError";
+    expect(classifyRuntimeSecretStoreError(abort)).toBe("transient");
+
+    const timeout = new Error("timed out");
+    timeout.name = "TimeoutError";
+    expect(classifyRuntimeSecretStoreError(timeout)).toBe("transient");
+
+    expect(classifyRuntimeSecretStoreError(new TypeError("Failed to fetch"))).toBe(
+      "transient",
+    );
+    expect(classifyRuntimeSecretStoreError(new Error("NetworkError when attempting to fetch"))).toBe(
+      "transient",
+    );
+    expect(classifyRuntimeSecretStoreError(new Error("socket hang up"))).toBe("transient");
+    expect(classifyRuntimeSecretStoreError("Load failed")).toBe("transient");
+  });
+
+  it("defaults precondition/unknown errors to fatal", () => {
+    expect(classifyRuntimeSecretStoreError(new Error("Invalid PKM credential reference."))).toBe(
+      "fatal",
+    );
+    expect(classifyRuntimeSecretStoreError(new Error("Runtime secret is required."))).toBe("fatal");
+    expect(classifyRuntimeSecretStoreError(undefined)).toBe("fatal");
+    expect(classifyRuntimeSecretStoreError({ weird: true })).toBe("fatal");
+  });
+});
+
+describe("computeRuntimeSecretRetryDelayMs", () => {
+  it("applies full jitter within the exponential ceiling", () => {
+    // random=1 yields the ceiling; random=0 yields 0.
+    expect(
+      computeRuntimeSecretRetryDelayMs(0, { baseMs: 300, maxMs: 2000, random: () => 1 }),
+    ).toBe(300);
+    expect(
+      computeRuntimeSecretRetryDelayMs(1, { baseMs: 300, maxMs: 2000, random: () => 1 }),
+    ).toBe(600);
+    expect(
+      computeRuntimeSecretRetryDelayMs(2, { baseMs: 300, maxMs: 2000, random: () => 1 }),
+    ).toBe(1200);
+    expect(
+      computeRuntimeSecretRetryDelayMs(0, { baseMs: 300, maxMs: 2000, random: () => 0 }),
+    ).toBe(0);
+  });
+
+  it("never exceeds maxMs even for large attempt indices", () => {
+    const delay = computeRuntimeSecretRetryDelayMs(10, {
+      baseMs: 300,
+      maxMs: 2000,
+      random: () => 1,
+    });
+    expect(delay).toBe(2000);
+  });
+
+  it("clamps negative/fractional indices to a safe floor", () => {
+    expect(
+      computeRuntimeSecretRetryDelayMs(-5, { baseMs: 300, maxMs: 2000, random: () => 1 }),
+    ).toBe(300);
+  });
+
+  it("defaults to the module base/max constants", () => {
+    const delay = computeRuntimeSecretRetryDelayMs(0, { random: () => 1 });
+    expect(delay).toBe(RUNTIME_SECRET_RETRY_BASE_MS);
+    expect(delay).toBeLessThanOrEqual(RUNTIME_SECRET_RETRY_MAX_DELAY_MS);
+  });
+});
+
+describe("runRuntimeSecretCommitWithRetry", () => {
+  it("returns immediately on first success without pausing or rebuilding", async () => {
+    const { hooks, pause, rebuildAfterConflict } = makeHooks({
+      send: vi.fn(async () => ({ success: true, message: "ok" })),
+    });
+    const result = await runRuntimeSecretCommitWithRetry(hooks);
+    expect(result).toEqual({ success: true, message: "ok" });
+    expect(hooks.send).toHaveBeenCalledTimes(1);
+    expect(pause).not.toHaveBeenCalled();
+    expect(rebuildAfterConflict).not.toHaveBeenCalled();
+  });
+
+  // THE regression test: a transient infra fault must be replayed with the
+  // IDENTICAL request (no rebuild) and then succeed — exactly the path that was
+  // missing when the "Your choice could not be saved" toast fired.
+  it("replays the identical request after a transient throw, then succeeds", async () => {
+    const send = vi
+      .fn<[], Promise<Result>>()
+      .mockRejectedValueOnce(new Error("Failed to store domain data: 503 - overloaded"))
+      .mockResolvedValueOnce({ success: true });
+    const { hooks, pause, rebuildAfterConflict } = makeHooks({ send });
+
+    const result = await runRuntimeSecretCommitWithRetry(hooks);
+
+    expect(result.success).toBe(true);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(pause).toHaveBeenCalledTimes(1); // backed off once
+    expect(rebuildAfterConflict).not.toHaveBeenCalled(); // transient => NO rebuild
+  });
+
+  it("gives up after exhausting attempts on persistent transient faults", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("Failed to store domain data: 500 - still broken");
+    });
+    const { hooks, pause } = makeHooks({ send, now: () => 0 });
+
+    await expect(runRuntimeSecretCommitWithRetry(hooks)).rejects.toThrow(
+      /Failed to store domain data: 500/,
+    );
+    expect(send).toHaveBeenCalledTimes(RUNTIME_SECRET_MAX_ATTEMPTS);
+    expect(pause).toHaveBeenCalledTimes(RUNTIME_SECRET_MAX_ATTEMPTS - 1);
+  });
+
+  it("fails fast on a fatal throw (no retry, no pause)", async () => {
+    const fatal = new Error("Failed to store domain data: 400 - bad request");
+    const send = vi.fn(async () => {
+      throw fatal;
+    });
+    const { hooks, pause } = makeHooks({ send });
+
+    await expect(runRuntimeSecretCommitWithRetry(hooks)).rejects.toBe(fatal);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds after a genuine conflict and then succeeds without backoff", async () => {
+    const send = vi
+      .fn<[], Promise<Result>>()
+      .mockResolvedValueOnce({ success: false, conflict: true, message: "version conflict" })
+      .mockResolvedValueOnce({ success: true });
+    const { hooks, pause, rebuildAfterConflict } = makeHooks({ send });
+
+    const result = await runRuntimeSecretCommitWithRetry(hooks);
+
+    expect(result.success).toBe(true);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(rebuildAfterConflict).toHaveBeenCalledTimes(1); // conflict => rebuild
+    expect(pause).not.toHaveBeenCalled(); // conflict => no backoff
+  });
+
+  it("throws a conflict RuntimeSecretCommitError once rebuilds are exhausted", async () => {
+    const send = vi.fn(async () => ({
+      success: false,
+      conflict: true,
+      message: "still conflicting",
+    }));
+    const { hooks, rebuildAfterConflict } = makeHooks({ send });
+
+    await expect(runRuntimeSecretCommitWithRetry(hooks)).rejects.toMatchObject({
+      name: "RuntimeSecretCommitError",
+      reason: "conflict",
+    });
+    expect(send).toHaveBeenCalledTimes(RUNTIME_SECRET_MAX_ATTEMPTS);
+    expect(rebuildAfterConflict).toHaveBeenCalledTimes(RUNTIME_SECRET_MAX_ATTEMPTS - 1);
+  });
+
+  it("throws a rejected RuntimeSecretCommitError on success:false without conflict", async () => {
+    const send = vi.fn(async () => ({ success: false, message: "hard no" }));
+    const { hooks, pause, rebuildAfterConflict } = makeHooks({ send });
+
+    const error = await runRuntimeSecretCommitWithRetry(hooks).catch((e) => e);
+    expect(error).toBeInstanceOf(RuntimeSecretCommitError);
+    expect(error.reason).toBe("rejected");
+    expect(send).toHaveBeenCalledTimes(1); // definite rejection, no retry
+    expect(pause).not.toHaveBeenCalled();
+    expect(rebuildAfterConflict).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying transient faults once the wall-clock deadline is exceeded", async () => {
+    const send = vi.fn(async () => {
+      throw new Error("Failed to store domain data: 503 - overloaded");
+    });
+    // now() jumps past the deadline immediately after the first failure.
+    let calls = 0;
+    const now = vi.fn(() => {
+      calls += 1;
+      return calls === 1 ? 0 : 999_999;
+    });
+    const { hooks, pause } = makeHooks({ send, now });
+
+    await expect(runRuntimeSecretCommitWithRetry(hooks)).rejects.toThrow(
+      /Failed to store domain data: 503/,
+    );
+    expect(send).toHaveBeenCalledTimes(1); // deadline blocked any replay
+    expect(pause).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
@@ -267,44 +267,45 @@ export function GeminiRuntimeSettingsCard({
           source: "connections_gemini_api_key",
         },
       });
-      await Promise.all([
-        PersonalKnowledgeModelService.storeRuntimeSecret({
-          userId,
-          vaultKey,
-          vaultOwnerToken,
-          credentialRef: GEMINI_RUNTIME_TRANSPORT_REF,
-          secret: transport,
-          confirmation: {
-            confirmedByUser: true,
-            surface: "web",
-            source: "connections_gemini_transport",
-          },
-        }),
-        PersonalKnowledgeModelService.storeRuntimeSecret({
-          userId,
-          vaultKey,
-          vaultOwnerToken,
-          credentialRef: GEMINI_VERTEX_PROJECT_REF,
-          secret: "",
-          confirmation: {
-            confirmedByUser: true,
-            surface: "web",
-            source: "connections_gemini_vertex_project",
-          },
-        }),
-        PersonalKnowledgeModelService.storeRuntimeSecret({
-          userId,
-          vaultKey,
-          vaultOwnerToken,
-          credentialRef: GEMINI_VERTEX_LOCATION_REF,
-          secret: "",
-          confirmation: {
-            confirmedByUser: true,
-            surface: "web",
-            source: "connections_gemini_vertex_location",
-          },
-        }),
-      ]);
+      // Write sequentially: these credentials share one encrypted vault domain,
+      // so a Promise.all would race read-modify-writes against each other and
+      // self-induce version conflicts.
+      await PersonalKnowledgeModelService.storeRuntimeSecret({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+        credentialRef: GEMINI_RUNTIME_TRANSPORT_REF,
+        secret: transport,
+        confirmation: {
+          confirmedByUser: true,
+          surface: "web",
+          source: "connections_gemini_transport",
+        },
+      });
+      await PersonalKnowledgeModelService.storeRuntimeSecret({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+        credentialRef: GEMINI_VERTEX_PROJECT_REF,
+        secret: "",
+        confirmation: {
+          confirmedByUser: true,
+          surface: "web",
+          source: "connections_gemini_vertex_project",
+        },
+      });
+      await PersonalKnowledgeModelService.storeRuntimeSecret({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+        credentialRef: GEMINI_VERTEX_LOCATION_REF,
+        secret: "",
+        confirmation: {
+          confirmedByUser: true,
+          surface: "web",
+          source: "connections_gemini_vertex_location",
+        },
+      });
       await persistMode("byok");
       setDraftKey("");
       invalidateCredentialValidation();
@@ -340,41 +341,41 @@ export function GeminiRuntimeSettingsCard({
           source: "connections_gemini_api_key_remove",
         },
       });
-      await Promise.all([
-        PersonalKnowledgeModelService.removeRuntimeSecret({
-          userId,
-          vaultKey,
-          vaultOwnerToken,
-          credentialRef: GEMINI_RUNTIME_TRANSPORT_REF,
-          confirmation: {
-            confirmedByUser: true,
-            surface: "web",
-            source: "connections_gemini_transport_remove",
-          },
-        }),
-        PersonalKnowledgeModelService.removeRuntimeSecret({
-          userId,
-          vaultKey,
-          vaultOwnerToken,
-          credentialRef: GEMINI_VERTEX_PROJECT_REF,
-          confirmation: {
-            confirmedByUser: true,
-            surface: "web",
-            source: "connections_gemini_vertex_project_remove",
-          },
-        }),
-        PersonalKnowledgeModelService.removeRuntimeSecret({
-          userId,
-          vaultKey,
-          vaultOwnerToken,
-          credentialRef: GEMINI_VERTEX_LOCATION_REF,
-          confirmation: {
-            confirmedByUser: true,
-            surface: "web",
-            source: "connections_gemini_vertex_location_remove",
-          },
-        }),
-      ]);
+      // Remove sequentially for the same reason as saveByok: these credentials
+      // share one encrypted vault domain and must not race each other.
+      await PersonalKnowledgeModelService.removeRuntimeSecret({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+        credentialRef: GEMINI_RUNTIME_TRANSPORT_REF,
+        confirmation: {
+          confirmedByUser: true,
+          surface: "web",
+          source: "connections_gemini_transport_remove",
+        },
+      });
+      await PersonalKnowledgeModelService.removeRuntimeSecret({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+        credentialRef: GEMINI_VERTEX_PROJECT_REF,
+        confirmation: {
+          confirmedByUser: true,
+          surface: "web",
+          source: "connections_gemini_vertex_project_remove",
+        },
+      });
+      await PersonalKnowledgeModelService.removeRuntimeSecret({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+        credentialRef: GEMINI_VERTEX_LOCATION_REF,
+        confirmation: {
+          confirmedByUser: true,
+          surface: "web",
+          source: "connections_gemini_vertex_location_remove",
+        },
+      });
       await persistMode("hushh_managed_vertex");
       selectionRevisionRef.current += 1;
       setMode("hushh_managed_vertex");

--- a/hushh-webapp/lib/personal-knowledge-model/runtime-secret-retry.ts
+++ b/hushh-webapp/lib/personal-knowledge-model/runtime-secret-retry.ts
@@ -1,0 +1,277 @@
+/**
+ * Bounded, idempotent retry policy for encrypted runtime-secret vault writes.
+ *
+ * Saving a runtime secret (`PersonalKnowledgeModelService.storeRuntimeSecret` /
+ * `removeRuntimeSecret`) is a read → modify → encrypt → commit round trip
+ * against the owner's encrypted PKM vault. Two independent failure modes can
+ * otherwise surface to the user as the toast "Your choice could not be saved.
+ * Please try again.":
+ *
+ *   1. **Transient infrastructure faults** — an HTTP 5xx / 429 / 408 or a
+ *      network blip on the `store-domain` POST. These make `storeDomainData`
+ *      THROW. The correct response is to *replay the identical request*: the
+ *      server derives its commit id deterministically from the mutation plan id,
+ *      so re-sending the exact same built artifacts (same plan id + same
+ *      ciphertext) is an idempotent replay, never a double write.
+ *
+ *   2. **A genuine version conflict** — a concurrent writer advanced the
+ *      domain's content revision. `storeDomainData` RETURNS
+ *      `{ success: false, conflict: true }` (it does not throw). The correct
+ *      response is to *rebuild*: re-read the domain fresh, re-apply the leaf
+ *      mutation, and mint a brand-new mutation plan (new plan id + bumped
+ *      manifest version) before committing again.
+ *
+ * This module is intentionally pure and dependency-free so it is exhaustively
+ * unit-testable. All I/O — sending, rebuilding, sleeping, the clock, and
+ * randomness — is injected through `hooks`.
+ */
+
+/** Total commit attempts (1 initial send + 3 retries). */
+export const RUNTIME_SECRET_MAX_ATTEMPTS = 4;
+/** Wall-clock budget across all attempts, in milliseconds. */
+export const RUNTIME_SECRET_RETRY_DEADLINE_MS = 8000;
+/** Base delay for the exponential backoff, in milliseconds. */
+export const RUNTIME_SECRET_RETRY_BASE_MS = 300;
+/** Upper bound on any single backoff delay, in milliseconds. */
+export const RUNTIME_SECRET_RETRY_MAX_DELAY_MS = 2000;
+
+/**
+ * HTTP statuses that are safe to replay identically. 5xx are server-side
+ * hiccups; 429/408/425 are throttling / timeout signals. A deterministic commit
+ * id makes replaying any of these idempotent.
+ */
+const TRANSIENT_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+/**
+ * Network-layer failure fingerprints. `fetch` surfaces these as `TypeError`s or
+ * `AbortError`s whose messages vary by runtime, so we match on substrings.
+ */
+const TRANSIENT_NETWORK_PATTERN =
+  /(failed to fetch|networkerror|network error|load failed|connection|timed out|timeout|econnreset|econnrefused|etimedout|socket hang up|fetch failed)/i;
+
+export type RuntimeSecretStoreErrorClass = "transient" | "fatal";
+
+/**
+ * Decide whether a thrown store error is worth an identical replay.
+ *
+ * Transient (replayable): configured 5xx/429/408/425 statuses parsed from a
+ * `storeDomainData` throw, plus network/abort/timeout fingerprints.
+ *
+ * Fatal (fail fast): everything else — 4xx client errors (400/401/403/404/422),
+ * our own precondition messages ("Invalid PKM credential reference.", etc.), and
+ * any unrecognised error. Defaulting unknown errors to fatal keeps a genuine
+ * bug from being masked behind three silent retries.
+ */
+export function classifyRuntimeSecretStoreError(
+  error: unknown,
+): RuntimeSecretStoreErrorClass {
+  const status = extractStoreDomainStatus(error);
+  if (status !== null) {
+    return TRANSIENT_HTTP_STATUSES.has(status) ? "transient" : "fatal";
+  }
+
+  if (error instanceof Error) {
+    if (error.name === "AbortError" || error.name === "TimeoutError") {
+      return "transient";
+    }
+    if (error instanceof TypeError && /fetch/i.test(error.message)) {
+      return "transient";
+    }
+    if (TRANSIENT_NETWORK_PATTERN.test(error.message)) {
+      return "transient";
+    }
+    return "fatal";
+  }
+
+  if (typeof error === "string" && TRANSIENT_NETWORK_PATTERN.test(error)) {
+    return "transient";
+  }
+
+  return "fatal";
+}
+
+/**
+ * Pull the HTTP status out of a `storeDomainData` throw, whose message is
+ * `Failed to store domain data: <status> - <body>`. Returns null when the error
+ * is not a store-domain HTTP failure (e.g. a network error or a precondition).
+ */
+function extractStoreDomainStatus(error: unknown): number | null {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
+  const match = message.match(/Failed to store domain data:\s*(\d{3})/i);
+  if (!match || !match[1]) {
+    return null;
+  }
+  const status = Number.parseInt(match[1], 10);
+  return Number.isFinite(status) ? status : null;
+}
+
+/**
+ * Full-jitter exponential backoff. Returns a value uniformly random in
+ * `[0, min(maxMs, baseMs * 2 ** attemptIndex))`, which spreads concurrent
+ * retriers and avoids a synchronised thundering herd against the vault API.
+ *
+ * @param attemptIndex Zero-based index of the retry (0 = first retry).
+ */
+export function computeRuntimeSecretRetryDelayMs(
+  attemptIndex: number,
+  options: { baseMs?: number; maxMs?: number; random?: () => number } = {},
+): number {
+  const baseMs = options.baseMs ?? RUNTIME_SECRET_RETRY_BASE_MS;
+  const maxMs = options.maxMs ?? RUNTIME_SECRET_RETRY_MAX_DELAY_MS;
+  const random = options.random ?? Math.random;
+  const safeIndex = Math.max(0, Math.floor(attemptIndex));
+  const exponential = baseMs * 2 ** safeIndex;
+  const ceiling = Math.min(maxMs, exponential);
+  return Math.max(0, Math.round(random() * ceiling));
+}
+
+export type RuntimeSecretCommitFailureReason = "conflict" | "rejected";
+
+/**
+ * Thrown when a commit fails for a reason that is NOT an identical-replay
+ * candidate: an unresolved version conflict after exhausting rebuilds, or a
+ * definite server rejection (`success: false` without `conflict`).
+ */
+export class RuntimeSecretCommitError extends Error {
+  readonly reason: RuntimeSecretCommitFailureReason;
+  readonly attempts: number;
+  readonly result?: RuntimeSecretCommitResult;
+
+  constructor(
+    message: string,
+    details: {
+      reason: RuntimeSecretCommitFailureReason;
+      attempts: number;
+      result?: RuntimeSecretCommitResult;
+    },
+  ) {
+    super(message);
+    this.name = "RuntimeSecretCommitError";
+    this.reason = details.reason;
+    this.attempts = details.attempts;
+    this.result = details.result;
+  }
+}
+
+/** Minimal result contract the runner needs to steer the retry loop. */
+export interface RuntimeSecretCommitResult {
+  success: boolean;
+  conflict?: boolean;
+  message?: string;
+}
+
+export interface RuntimeSecretCommitHooks<T extends RuntimeSecretCommitResult> {
+  /** Commit the currently-built artifacts. Called once per attempt. */
+  send: () => Promise<T>;
+  /**
+   * React to a genuine version conflict: re-read fresh, re-apply the mutation,
+   * and rebuild the commit with a new plan id. Invoked between attempts only
+   * when `send` returned `{ conflict: true }`.
+   */
+  rebuildAfterConflict: (previousResult: T) => Promise<void>;
+  /** Sleep helper (injected so tests need no real timers). */
+  pause: (ms: number) => Promise<void>;
+  /** Monotonic-ish clock in milliseconds (injected for deterministic tests). */
+  now: () => number;
+  /** Randomness for jitter (defaults to `Math.random`). */
+  random?: () => number;
+}
+
+export interface RuntimeSecretCommitOptions {
+  maxAttempts?: number;
+  deadlineMs?: number;
+  baseMs?: number;
+  maxDelayMs?: number;
+}
+
+/**
+ * Drive a runtime-secret commit to a definitive outcome.
+ *
+ * Loop, per attempt:
+ *   - `send()`.
+ *     - `success` → return the result.
+ *     - `conflict` → rebuild (no backoff — the world changed, it is not
+ *       overloaded) and retry, or throw `RuntimeSecretCommitError` once
+ *       rebuilds are exhausted.
+ *     - `success: false` without `conflict` → throw `RuntimeSecretCommitError`
+ *       immediately (a definite rejection, never replayable).
+ *   - `send()` throws:
+ *     - fatal → rethrow as-is (callers already handle these).
+ *     - transient, budget remaining → back off with jitter and replay the
+ *       *identical* built artifacts (idempotent via the deterministic commit id).
+ *     - transient, budget exhausted → rethrow the last error.
+ *
+ * The method therefore always resolves to a successful result or throws — it
+ * never returns `{ success: false }`, which is what closes the latent
+ * "false success" toast at every call site.
+ */
+export async function runRuntimeSecretCommitWithRetry<
+  T extends RuntimeSecretCommitResult,
+>(
+  hooks: RuntimeSecretCommitHooks<T>,
+  options: RuntimeSecretCommitOptions = {},
+): Promise<T> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? RUNTIME_SECRET_MAX_ATTEMPTS);
+  const deadlineMs = options.deadlineMs ?? RUNTIME_SECRET_RETRY_DEADLINE_MS;
+  const baseMs = options.baseMs ?? RUNTIME_SECRET_RETRY_BASE_MS;
+  const maxDelayMs = options.maxDelayMs ?? RUNTIME_SECRET_RETRY_MAX_DELAY_MS;
+  const random = hooks.random ?? Math.random;
+  const startedAt = hooks.now();
+
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    try {
+      const result = await hooks.send();
+      if (result.success) {
+        return result;
+      }
+      if (result.conflict === true) {
+        if (attempt >= maxAttempts) {
+          throw new RuntimeSecretCommitError(
+            result.message ||
+              "This change collided with another update. Please try again.",
+            { reason: "conflict", attempts: attempt, result },
+          );
+        }
+        await hooks.rebuildAfterConflict(result);
+        // No backoff: a conflict means the vault moved on, not that it is busy.
+        continue;
+      }
+      // success === false with no conflict: a definite, non-retryable rejection.
+      throw new RuntimeSecretCommitError(
+        result.message || "Your change could not be saved.",
+        { reason: "rejected", attempts: attempt, result },
+      );
+    } catch (error) {
+      if (error instanceof RuntimeSecretCommitError) {
+        throw error;
+      }
+      if (classifyRuntimeSecretStoreError(error) === "fatal") {
+        throw error;
+      }
+      if (attempt >= maxAttempts) {
+        throw error;
+      }
+      const remaining = deadlineMs - (hooks.now() - startedAt);
+      if (remaining <= 0) {
+        throw error;
+      }
+      const delay = Math.min(
+        computeRuntimeSecretRetryDelayMs(attempt - 1, {
+          baseMs,
+          maxMs: maxDelayMs,
+          random,
+        }),
+        remaining,
+      );
+      await hooks.pause(delay);
+      // Replay the identical built artifacts on the next iteration.
+    }
+  }
+}

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -43,6 +43,9 @@ import {
   type PkmMutationPlanV2,
   type PkmUserConfirmation,
 } from "@/lib/personal-knowledge-model/mutation-plan";
+import {
+  runRuntimeSecretCommitWithRetry,
+} from "@/lib/personal-knowledge-model/runtime-secret-retry";
 
 // ==================== Types ====================
 
@@ -3803,25 +3806,28 @@ export class PersonalKnowledgeModelService {
       throw new Error("Runtime secret is required.");
     }
 
+    const applyMutation = (base: Record<string, unknown>): Record<string, unknown> => {
+      const next = this.isPlainObject(base) ? this.cloneRecord(base) : {};
+      this.setValueAtNestedPath(next, parsed.keys, secret);
+      return next;
+    };
+
     const existingData = await this.loadDomainData({
       userId: params.userId,
       domain: parsed.domain,
       vaultKey: params.vaultKey,
       vaultOwnerToken: params.vaultOwnerToken,
     }).catch(() => null);
-    const domainData = this.isPlainObject(existingData)
-      ? this.cloneRecord(existingData)
-      : {};
-    this.setValueAtNestedPath(domainData, parsed.keys, secret);
 
-    return this.storeRuntimeSecretsDomain({
+    return this.commitRuntimeSecretsDomainWithRetry({
       userId: params.userId,
       vaultKey: params.vaultKey,
       vaultOwnerToken: params.vaultOwnerToken,
       domain: parsed.domain,
-      domainData,
       scopePath: parsed.keys[0] || "llm",
       confirmation: params.confirmation,
+      initialDomainData: applyMutation(this.isPlainObject(existingData) ? existingData : {}),
+      applyMutation,
     });
   }
 
@@ -3837,29 +3843,42 @@ export class PersonalKnowledgeModelService {
       throw new Error("Invalid PKM credential reference.");
     }
 
+    const applyMutation = (base: Record<string, unknown>): Record<string, unknown> => {
+      const next = this.isPlainObject(base) ? this.cloneRecord(base) : {};
+      this.deleteValueAtNestedPath(next, parsed.keys);
+      return next;
+    };
+
     const existingData = await this.loadDomainData({
       userId: params.userId,
       domain: parsed.domain,
       vaultKey: params.vaultKey,
       vaultOwnerToken: params.vaultOwnerToken,
     }).catch(() => null);
-    const domainData = this.isPlainObject(existingData)
-      ? this.cloneRecord(existingData)
-      : {};
-    this.deleteValueAtNestedPath(domainData, parsed.keys);
 
-    return this.storeRuntimeSecretsDomain({
+    return this.commitRuntimeSecretsDomainWithRetry({
       userId: params.userId,
       vaultKey: params.vaultKey,
       vaultOwnerToken: params.vaultOwnerToken,
       domain: parsed.domain,
-      domainData,
       scopePath: parsed.keys[0] || "llm",
       confirmation: params.confirmation,
+      initialDomainData: applyMutation(this.isPlainObject(existingData) ? existingData : {}),
+      applyMutation,
     });
   }
 
-  private static async storeRuntimeSecretsDomain(params: {
+  /**
+   * Build the exact `storeDomainData` payload for a runtime-secret commit:
+   * read the manifest (force a fresh read after a conflict), encrypt the domain,
+   * derive the summary/structure/manifest artifacts, and mint the mutation plan.
+   *
+   * Because the mutation plan id is random per build, each call yields a fresh
+   * server commit id. Callers must therefore build ONCE for a given attempt and
+   * reuse the returned payload for any transient replay; only a genuine conflict
+   * should trigger a rebuild.
+   */
+  private static async buildRuntimeSecretsCommit(params: {
     userId: string;
     vaultKey: string;
     vaultOwnerToken: string;
@@ -3867,11 +3886,13 @@ export class PersonalKnowledgeModelService {
     domainData: Record<string, unknown>;
     scopePath: string;
     confirmation: PkmUserConfirmation;
-  }): Promise<StoreDomainDataResult> {
+    forceManifestReload?: boolean;
+  }): Promise<Parameters<typeof PersonalKnowledgeModelService.storeDomainData>[0]> {
     const previousManifest = await this.getDomainManifest(
       params.userId,
       params.domain,
-      params.vaultOwnerToken
+      params.vaultOwnerToken,
+      params.forceManifestReload === true
     ).catch(() => null);
     const encryptedBlob = await this.encryptDomainForStorage({
       vaultKey: params.vaultKey,
@@ -3893,7 +3914,7 @@ export class PersonalKnowledgeModelService {
       confirmation: params.confirmation,
     });
 
-    return this.storeDomainData({
+    return {
       userId: params.userId,
       domain: params.domain,
       encryptedBlob,
@@ -3903,6 +3924,69 @@ export class PersonalKnowledgeModelService {
       mutationPlan,
       domainData: params.domainData,
       vaultOwnerToken: params.vaultOwnerToken,
+    };
+  }
+
+  /**
+   * Commit a runtime-secret domain mutation with a bounded, idempotent retry.
+   *
+   * Transient throws (5xx/429/408/network) replay the identical built artifacts
+   * — the deterministic commit id makes this a safe server-side replay. A
+   * genuine version conflict re-reads the domain fresh (cache-busted), re-applies
+   * the leaf mutation, and rebuilds with a new plan id. The call resolves to a
+   * successful result or throws; it never returns `{ success: false }`.
+   */
+  private static async commitRuntimeSecretsDomainWithRetry(params: {
+    userId: string;
+    vaultKey: string;
+    vaultOwnerToken: string;
+    domain: string;
+    scopePath: string;
+    confirmation: PkmUserConfirmation;
+    initialDomainData: Record<string, unknown>;
+    applyMutation: (base: Record<string, unknown>) => Record<string, unknown>;
+  }): Promise<StoreDomainDataResult> {
+    let built = await this.buildRuntimeSecretsCommit({
+      userId: params.userId,
+      vaultKey: params.vaultKey,
+      vaultOwnerToken: params.vaultOwnerToken,
+      domain: params.domain,
+      domainData: params.initialDomainData,
+      scopePath: params.scopePath,
+      confirmation: params.confirmation,
+    });
+
+    return runRuntimeSecretCommitWithRetry<StoreDomainDataResult>({
+      send: () => this.storeDomainData(built),
+      rebuildAfterConflict: async () => {
+        // A genuine version conflict: another writer advanced this domain. Drop
+        // the cached copies, re-read the domain fresh, re-apply the leaf, and
+        // rebuild with a new plan id + bumped manifest version.
+        const cache = CacheService.getInstance();
+        cache.invalidate(CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB(params.userId, params.domain));
+        cache.invalidate(CACHE_KEYS.DOMAIN_DATA(params.userId, params.domain));
+        const freshData = await this.loadDomainData({
+          userId: params.userId,
+          domain: params.domain,
+          vaultKey: params.vaultKey,
+          vaultOwnerToken: params.vaultOwnerToken,
+        }).catch(() => null);
+        const domainData = params.applyMutation(
+          this.isPlainObject(freshData) ? freshData : {}
+        );
+        built = await this.buildRuntimeSecretsCommit({
+          userId: params.userId,
+          vaultKey: params.vaultKey,
+          vaultOwnerToken: params.vaultOwnerToken,
+          domain: params.domain,
+          domainData,
+          scopePath: params.scopePath,
+          confirmation: params.confirmation,
+          forceManifestReload: true,
+        });
+      },
+      pause: (ms) => this.pause(ms),
+      now: () => Date.now(),
     });
   }
 


### PR DESCRIPTION
## Problem

A user reported (Discord) that when setting up **One → Connections** and choosing **"Hushh managed Gemini"**, they *occasionally* get the toast:

> Your choice could not be saved. Please try again.

The choice is healthy — retrying usually works — which is the signature of a transient fault with no client retry.

## Root cause

Saving a runtime secret is a **read → modify → encrypt → commit** round trip against the encrypted PKM vault. The client had **no retry** on that path:

- Any transient HTTP **5xx / 429 / 408** or network blip on the `store-domain` POST makes `storeDomainData` **throw**.
- That throw bubbles straight to the `selectManaged` handler's `catch`, which fires the error toast.
- The managed path writes a **single mode leaf**, so a *transient fault* — not a version conflict — is the dominant failure mode here.

Two latent issues compounded it:
1. Methods could return `{ success: false }` on a 409 without any caller distinguishing it from success (false-success risk).
2. The BYOK save/remove path fired three writes to the **same** vault domain via `Promise.all`, racing read-modify-writes and self-inducing version conflicts.

## Fix

- **New `lib/personal-knowledge-model/runtime-secret-retry.ts`** — a pure, dependency-free, fully injectable retry policy:
  - **Transient** faults (5xx/429/408/network) replay the **identical** built artifacts. The server derives its commit id deterministically from the mutation plan id, so an identical replay is an **idempotent** server-side replay — never a double write.
  - **Genuine version conflict** (`409 → { success: false, conflict: true }`) instead cache-busts, re-reads the domain fresh, re-applies the leaf mutation, and rebuilds with a **new** plan id + bumped manifest version.
  - Full-jitter exponential backoff; **4 attempts** within an **8s** wall-clock budget; unknown errors default to **fatal** (fail fast, never mask a real bug behind silent retries).
- **Service** (`personal-knowledge-model-service.ts`) — split the write path into `buildRuntimeSecretsCommit` (build once) and `commitRuntimeSecretsDomainWithRetry` (drive the loop). These now **always resolve to a success or throw** — they never return `{ success: false }`, closing the false-success at every call site (all callers already use try/catch, so no call-site changes).
- **Gemini card** (`gemini-runtime-settings-card.tsx`) — serialized the BYOK save/remove writes (they share one vault domain and must not race).

## Tests

- `__tests__/lib/personal-knowledge-model/runtime-secret-retry.test.ts` — **16 unit tests**:
  - `classifyRuntimeSecretStoreError`: transient statuses/network fingerprints vs fatal 4xx/precondition/unknown.
  - `computeRuntimeSecretRetryDelayMs`: full-jitter bounds, exponential ceiling, cap, index clamping (deterministic via injected `random`).
  - `runRuntimeSecretCommitWithRetry`: happy path, **transient-throw-then-succeed (the test that reproduces and would have caught this bug)**, transient exhaustion, fatal fail-fast, conflict-rebuild-then-succeed, conflict exhaustion, definite-rejection, and deadline cutoff.
- Existing `gemini-runtime-settings-card` and `runtime-secret-settings-card` component tests remain green.

## Verification

- `vitest run` on the new + related suites: **28 passed**.
- `tsc --noEmit`: no new errors (only pre-existing baseline errors in untouched `@capacitor/*`-dependent files).
- `eslint` on all changed files: clean (exit 0).

## Risk / rollback

Low. Change is additive on the client write path; server contract unchanged; replay is idempotent by construction. Rollback = revert this PR.
