### PR TITLE
fix(connect): resolve infinite "Loading data options" in scope dialog

### DIFF
--- a/hushh-webapp/__tests__/components/connect-scope-request-dialog.test.tsx
+++ b/hushh-webapp/__tests__/components/connect-scope-request-dialog.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectScopeRequestDialog } from "@/components/connect/connect-scope-request-dialog";
+import {
+  ConnectionsService,
+  type RequestableScopeCatalog,
+} from "@/lib/services/connections-service";
+
+function sampleCatalog(): RequestableScopeCatalog {
+  return {
+    bundles: [],
+    scopes: [
+      {
+        scope: "email",
+        label: "Email",
+        description: "Your email address",
+        icon_name: null,
+        color_hex: null,
+        sensitivity: "low",
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ConnectScopeRequestDialog catalog loading", () => {
+  // Regression for the infinite "Loading data options…" spinner: the load
+  // effect used to list `loading` (and the inline `getIdToken` closure) in its
+  // dependency array, so `setLoading(true)` re-ran the effect, its cleanup
+  // cancelled the in-flight fetch, and `loading` was never cleared. The dialog
+  // stayed on the spinner forever even with a perfectly healthy backend. Note
+  // `getIdToken` is a fresh closure on every render here, exactly as the real
+  // caller passes it.
+  it("clears the spinner and renders scopes once the catalog loads", async () => {
+    const spy = vi
+      .spyOn(ConnectionsService, "listRequestableScopes")
+      .mockResolvedValue(sampleCatalog());
+
+    render(
+      <ConnectScopeRequestDialog
+        open
+        onOpenChange={() => {}}
+        personName="Akshat Kumar"
+        getIdToken={() => Promise.resolve("test-token")}
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Email")).toBeInTheDocument();
+    expect(screen.queryByText(/Loading data options/i)).toBeNull();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a recoverable error without retry-storming on failure", async () => {
+    const spy = vi
+      .spyOn(ConnectionsService, "listRequestableScopes")
+      .mockRejectedValue(new Error("catalog unavailable"));
+
+    render(
+      <ConnectScopeRequestDialog
+        open
+        onOpenChange={() => {}}
+        personName="Akshat Kumar"
+        getIdToken={() => Promise.resolve("test-token")}
+        onConfirm={() => {}}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/You can still connect without requesting data/i),
+    ).toBeInTheDocument();
+    // A single failed attempt must not loop.
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/components/connect/connect-scope-request-dialog.tsx
+++ b/hushh-webapp/components/connect/connect-scope-request-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, ShieldCheck } from "lucide-react";
 
 import {
@@ -58,16 +58,27 @@ export function ConnectScopeRequestDialog({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
+  // The caller hands us a fresh `getIdToken` closure on every render, so keep a
+  // stable ref to the latest one. Putting `getIdToken` in the effect deps below
+  // would re-run the effect mid-flight and cancel its own catalog fetch.
+  const getIdTokenRef = useRef(getIdToken);
+  getIdTokenRef.current = getIdToken;
+  // Whether a catalog load has already been started for the current open. This
+  // is what lets `setLoading(true)` fire without re-entering (and cancelling)
+  // the in-flight request — the classic cause of a spinner that never resolves.
+  const loadStartedRef = useRef(false);
+
   // Lazy-load the catalog the first time the dialog opens; keep it cached across
   // reopens within the same mount.
   useEffect(() => {
-    if (!open || loaded || loading) return;
+    if (!open || loaded || loadStartedRef.current) return;
+    loadStartedRef.current = true;
     let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
     void (async () => {
       try {
-        setLoading(true);
-        setLoadError(null);
-        const idToken = await getIdToken();
+        const idToken = await getIdTokenRef.current();
         if (!idToken) throw new Error("Not signed in");
         const catalog = await ConnectionsService.listRequestableScopes({ idToken });
         if (cancelled) return;
@@ -86,8 +97,11 @@ export function ConnectScopeRequestDialog({
     })();
     return () => {
       cancelled = true;
+      // Let a later open — or React's dev StrictMode remount — retry if this
+      // attempt was torn down before it settled.
+      loadStartedRef.current = false;
     };
-  }, [open, loaded, loading, getIdToken]);
+  }, [open, loaded]);
 
   // Reset the selection whenever the dialog is dismissed so the next person
   // starts clean.


### PR DESCRIPTION
## Problem

Opening the Connect scope picker (tap **Connect with <person>** on `/one/connect`) hangs forever on **"Loading data options…"**. Reproduced manually on UAT. The backend catalog endpoint (`/api/one/connections/requestable-scopes`) is healthy — this is a pure frontend effect bug.

## Root cause

`ConnectScopeRequestDialog`'s catalog-load effect had deps `[open, loaded, loading, getIdToken]`:

1. Effect runs on open → `setLoading(true)`.
2. `loading` is in the deps → the state change **re-runs the effect**. React first fires the cleanup (`cancelled = true`) on the in-flight run, then the re-run early-returns because `loading` is now `true`.
3. The cancelled first run's `await` resolves but `if (cancelled) return` skips `setLoaded(true)`, and `finally { if (!cancelled) setLoading(false) }` is skipped too.
4. `loading` is stuck `true` forever → **infinite spinner**, every time.

The inline `getIdToken` closure (new identity each render) guaranteed the re-run too. There was no component test for the dialog, so this shipped.

## Fix

- Depend only on `[open, loaded]`.
- Hold the token loader in a ref (`getIdTokenRef`) so its changing identity can't re-trigger the effect.
- Guard re-entry with `loadStartedRef` so `setLoading(true)` can never cancel its own request; reset it in cleanup so a later open (or dev StrictMode remount) can retry.
- Hoist `setLoading(true)`/`setLoadError(null)` to run synchronously when the load starts.

Behavior preserved: catalog cached across reopens, error state on failure ("…You can still connect without requesting data."), no retry-storm on failure.

## Tests

New `__tests__/components/connect-scope-request-dialog.test.tsx`:
- **Verified it fails on the old effect** (DOM stuck on "Loading data options…", `findByText("Email")` times out) and **passes on the fix**.
- Covers the success path (spinner clears, scopes render, single fetch) and the failure path (recoverable error, no retry loop).

`eslint` clean (no `exhaustive-deps` suppression needed); `tsc` clean for the changed files.