### PR TITLE
feat(connect): recipient can modify the requested-scope list before accepting

### DIFF
--- a/consent-protocol/hushh_mcp/services/connections_service.py
+++ b/consent-protocol/hushh_mcp/services/connections_service.py
@@ -1080,7 +1080,7 @@ class ConnectionsService:
         rows = self._execute_many(
             f"""
             SELECT cr.id, cr.requester_user_id, cr.addressee_user_id, cr.status,
-                   cr.message, cr.created_at,
+                   cr.message, cr.created_at, cr.metadata,
                    {counterpart_col} AS counterpart_user_id,
                    a.display_name AS counterpart_display_name
             FROM connection_requests cr
@@ -1090,19 +1090,30 @@ class ConnectionsService:
             """,  # nosec B608
             {"user_id": user_id},
         )
-        return [
-            {
-                "id": str(r.get("id") or ""),
-                "requesterUserId": str(r.get("requester_user_id") or ""),
-                "addresseeUserId": str(r.get("addressee_user_id") or ""),
-                "status": str(r.get("status") or ""),
-                "message": r.get("message"),
-                "createdAt": r.get("created_at"),
-                "counterpartUserId": str(r.get("counterpart_user_id") or ""),
-                "counterpartDisplayName": r.get("counterpart_display_name"),
-            }
-            for r in rows
-        ]
+        requests: list[dict[str, Any]] = []
+        for r in rows:
+            # Surface the requester's bundled data ask so the addressee can review
+            # (and later modify) it before accepting. These are the requester's own
+            # scope keys -- not the addressee's holdings -- so echoing them back is
+            # presence-safe and leaks nothing about what either party actually has.
+            metadata = self._parse_request_metadata(r.get("metadata"))
+            requested_scopes = [
+                str(s).strip() for s in (metadata.get("requested_scopes") or []) if str(s).strip()
+            ]
+            requests.append(
+                {
+                    "id": str(r.get("id") or ""),
+                    "requesterUserId": str(r.get("requester_user_id") or ""),
+                    "addresseeUserId": str(r.get("addressee_user_id") or ""),
+                    "status": str(r.get("status") or ""),
+                    "message": r.get("message"),
+                    "createdAt": r.get("created_at"),
+                    "counterpartUserId": str(r.get("counterpart_user_id") or ""),
+                    "counterpartDisplayName": r.get("counterpart_display_name"),
+                    "requestedScopes": requested_scopes,
+                }
+            )
+        return requests
 
     def list_received_scope_exports(self, user_id: str) -> list[dict[str, Any]]:
         """Return every scope export sealed to this user as a Connect requester.

--- a/consent-protocol/hushh_mcp/services/consent_center_service.py
+++ b/consent-protocol/hushh_mcp/services/consent_center_service.py
@@ -1463,6 +1463,9 @@ class ConsentCenterService:
                 "counterpart_id": r.get("counterpartUserId"),
                 "counterpart_label": r.get("counterpartDisplayName") or "Someone",
                 "reason": r.get("message") or "wants to connect with you",
+                # Bundled data ask (if any) so the recipient can review + modify the
+                # list before accepting. Empty list = a plain connect with no scopes.
+                "requested_scopes": r.get("requestedScopes") or [],
             }
             for r in (rows or [])
         ]

--- a/consent-protocol/tests/services/test_connections_service.py
+++ b/consent-protocol/tests/services/test_connections_service.py
@@ -186,6 +186,58 @@ def test_accept_rejected_when_not_addressee():
     assert exc.value.status_code == 403
 
 
+def test_list_requests_incoming_surfaces_requested_scopes():
+    """The incoming read path must parse metadata and echo the requester's bundled
+    data ask as ``requestedScopes`` so the addressee can review/modify it. Covers
+    both metadata shapes the driver may return (parsed dict + raw JSON string)."""
+    svc = _svc()
+    rows = [
+        {
+            "id": "req-dict",
+            "requester_user_id": "ria-1",
+            "addressee_user_id": "user-a",
+            "status": "pending",
+            "message": "pick for you",
+            "counterpart_user_id": "ria-1",
+            "counterpart_display_name": "Ada RIA",
+            # JSONB path: driver already parsed the cell into a dict.
+            "metadata": {"requested_scopes": ["vault.read.finance", " vault.read.portfolio "]},
+        },
+        {
+            "id": "req-str",
+            "requester_user_id": "ria-2",
+            "addressee_user_id": "user-a",
+            "status": "pending",
+            "message": None,
+            "counterpart_user_id": "ria-2",
+            "counterpart_display_name": None,
+            # Raw JSON-string path.
+            "metadata": '{"requested_scopes": ["vault.read.identity"]}',
+        },
+        {
+            "id": "req-plain",
+            "requester_user_id": "friend-1",
+            "addressee_user_id": "user-a",
+            "status": "pending",
+            "message": None,
+            "counterpart_user_id": "friend-1",
+            "counterpart_display_name": None,
+            "metadata": None,  # plain connect, no ask
+        },
+    ]
+    with patch("hushh_mcp.services.connections_service.get_db", _db_returning(rows)):
+        out = svc.list_requests("user-a", direction="incoming")
+
+    by_id = {r["id"]: r for r in out}
+    # Whitespace is stripped and order preserved.
+    assert by_id["req-dict"]["requestedScopes"] == [
+        "vault.read.finance",
+        "vault.read.portfolio",
+    ]
+    assert by_id["req-str"]["requestedScopes"] == ["vault.read.identity"]
+    assert by_id["req-plain"]["requestedScopes"] == []
+
+
 def test_cancel_rejected_when_not_requester():
     svc = _svc()
     db = _RecordingDB(

--- a/consent-protocol/tests/services/test_consent_center_connection_requests.py
+++ b/consent-protocol/tests/services/test_consent_center_connection_requests.py
@@ -17,3 +17,42 @@ def test_consents_pending_count_includes_incoming_connection_requests():
         count = asyncio.run(svc._incoming_connection_request_count("user-a"))
     assert count == 2
     fake_conn.list_requests.assert_called_once_with("user-a", direction="incoming")
+
+
+def test_incoming_entries_surface_requested_scopes_for_modify_flow():
+    """A connection request that bundles a data ask must forward those scopes to
+    the recipient so the consent center can offer "modify the list" (grant a
+    subset). A plain connect with no ask must degrade to an empty list."""
+    svc = ConsentCenterService.__new__(ConsentCenterService)
+
+    fake_conn = MagicMock()
+    fake_conn.list_requests.return_value = [
+        {
+            "id": "req-scoped",
+            "counterpartUserId": "ria-1",
+            "counterpartDisplayName": "Ada RIA",
+            "message": "sharing a pick",
+            "requestedScopes": ["vault.read.finance", "vault.read.portfolio"],
+        },
+        {
+            "id": "req-plain",
+            "counterpartUserId": "friend-1",
+            # no requestedScopes key at all → plain connect
+        },
+    ]
+
+    with patch(
+        "hushh_mcp.services.consent_center_service.ConnectionsService",
+        return_value=fake_conn,
+    ):
+        entries = asyncio.run(svc._incoming_connection_request_entries("user-a"))
+
+    by_id = {e["id"]: e for e in entries}
+    assert by_id["req-scoped"]["requested_scopes"] == [
+        "vault.read.finance",
+        "vault.read.portfolio",
+    ]
+    assert by_id["req-scoped"]["kind"] == "connection_request"
+    # Plain connect: field is present and empty so the UI simply hides "Choose data".
+    assert by_id["req-plain"]["requested_scopes"] == []
+    fake_conn.list_requests.assert_called_once_with("user-a", direction="incoming")

--- a/hushh-webapp/components/connect/connect-scope-review-dialog.tsx
+++ b/hushh-webapp/components/connect/connect-scope-review-dialog.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, ShieldCheck } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/lib/morphy-ux/button";
+import { humanizeConsentScope } from "@/lib/consent/consent-display";
+import {
+  ConnectionsService,
+  type RequestableScope,
+} from "@/lib/services/connections-service";
+
+export interface ConnectScopeReviewDecision {
+  /** Scopes the recipient chose to grant (checked). */
+  grantedScopes: string[];
+  /** Requested scopes the recipient chose not to grant (unchecked). */
+  deniedScopes: string[];
+}
+
+export interface ConnectScopeReviewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Display name of the person who sent the request (for the title). */
+  personName: string;
+  /** The scope keys the requester asked for. The recipient may grant any subset. */
+  requestedScopes: string[];
+  /** Firebase ID token loader (label catalog fetch is auth-gated). */
+  getIdToken: () => Promise<string | undefined>;
+  /** Called with the recipient's per-scope decision. The caller owns the accept
+   * call + optimistic list update; this dialog only collects intent. */
+  onConfirm: (decision: ConnectScopeReviewDecision) => Promise<void> | void;
+  /** True while the caller's accept is in flight. */
+  busy?: boolean;
+}
+
+/**
+ * Recipient-side counterpart to {@link ConnectScopeRequestDialog}. When someone
+ * receives a connection request that bundles a data ask (e.g. an RIA requesting
+ * pick-related scopes), this lets them MODIFY the list — grant a subset instead
+ * of the all-or-nothing Accept. Every scope starts checked, matching today's
+ * "Accept = grant all" default; unchecking one records it as denied. Confirming
+ * accepts the connection and mints a pending, zero-knowledge scope request only
+ * for the checked scopes.
+ */
+export function ConnectScopeReviewDialog({
+  open,
+  onOpenChange,
+  personName,
+  requestedScopes,
+  getIdToken,
+  onConfirm,
+  busy = false,
+}: ConnectScopeReviewDialogProps) {
+  const [catalog, setCatalog] = useState<Map<string, RequestableScope>>(
+    new Map(),
+  );
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  // Selection starts with every requested scope checked (parity with the current
+  // accept-all default); the recipient unchecks to narrow the grant.
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  // Normalize + de-dupe the requested list once per set of props.
+  const scopeKeys = useMemo(() => {
+    const seen = new Set<string>();
+    const keys: string[] = [];
+    for (const raw of requestedScopes) {
+      const key = String(raw || "").trim();
+      if (key && !seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+    return keys;
+  }, [requestedScopes]);
+
+  // Re-seed the selection whenever the dialog opens (or the request changes) so
+  // each review starts from "share everything".
+  useEffect(() => {
+    if (open) setSelected(new Set(scopeKeys));
+  }, [open, scopeKeys]);
+
+  // Lazily fetch the global label catalog the first time the dialog opens; it is
+  // presence-safe and reused across reopens within the same mount.
+  useEffect(() => {
+    if (!open || loaded || loading) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        setLoading(true);
+        const idToken = await getIdToken();
+        if (!idToken) throw new Error("Not signed in");
+        const result = await ConnectionsService.listRequestableScopes({ idToken });
+        if (cancelled) return;
+        setCatalog(new Map(result.scopes.map((s) => [s.scope, s])));
+        setLoaded(true);
+      } catch {
+        // Non-fatal: fall back to humanized scope keys so review still works.
+        if (!cancelled) setLoaded(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, loaded, loading, getIdToken]);
+
+  const toggleScope = useCallback((scope: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) next.delete(scope);
+      else next.add(scope);
+      return next;
+    });
+  }, []);
+
+  const grantedCount = selected.size;
+  const total = scopeKeys.length;
+
+  const handleConfirm = useCallback(async () => {
+    const grantedScopes = scopeKeys.filter((s) => selected.has(s));
+    const deniedScopes = scopeKeys.filter((s) => !selected.has(s));
+    await onConfirm({ grantedScopes, deniedScopes });
+  }, [onConfirm, scopeKeys, selected]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
+        <DialogHeader className="px-5 pt-5 pb-3 text-left">
+          <DialogTitle>Choose what to share with {personName}</DialogTitle>
+          <DialogDescription>
+            They asked to see the data below. Pick only what you want to share —
+            each grant is end-to-end encrypted to their device, and you can
+            change your mind anytime.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[52vh] px-5">
+          <div className="space-y-1 pb-2">
+            {loading && !loaded ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading request…
+              </div>
+            ) : scopeKeys.length === 0 ? (
+              <p className="py-6 text-sm text-muted-foreground">
+                No specific data was requested.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border/60">
+                {scopeKeys.map((key) => {
+                  const meta = catalog.get(key);
+                  const label = meta?.label || humanizeConsentScope(key);
+                  const checked = selected.has(key);
+                  return (
+                    <li key={key}>
+                      <label className="flex cursor-pointer items-start gap-3 py-2.5">
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={() => toggleScope(key)}
+                          className="mt-0.5"
+                          aria-label={label}
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-2">
+                            <span className="truncate text-sm font-medium text-foreground">
+                              {label}
+                            </span>
+                            {meta?.sensitivity === "high" && (
+                              <Badge
+                                variant="outline"
+                                className="shrink-0 gap-1 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                              >
+                                <ShieldCheck className="h-3 w-3" />
+                                Sensitive
+                              </Badge>
+                            )}
+                          </span>
+                          {meta?.description && (
+                            <span className="mt-0.5 block text-xs text-muted-foreground">
+                              {meta.description}
+                            </span>
+                          )}
+                        </span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </ScrollArea>
+
+        <DialogFooter className="flex-row items-center justify-between gap-2 border-t border-border/60 px-5 py-3">
+          <span className="text-xs text-muted-foreground">
+            {total === 0
+              ? "Connect only"
+              : grantedCount === 0
+                ? "Sharing nothing"
+                : `Sharing ${grantedCount} of ${total}`}
+          </span>
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="sm"
+            disabled={busy}
+            onClick={() => void handleConfirm()}
+          >
+            {busy ? "Accepting…" : "Accept"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -83,6 +83,10 @@ import {
 } from "@/lib/consent/consent-sheet-route";
 import { isConnectionRequestEntry } from "@/components/consent/connection-request-entry";
 import { ConnectionsService } from "@/lib/services/connections-service";
+import {
+  ConnectScopeReviewDialog,
+  type ConnectScopeReviewDecision,
+} from "@/components/connect/connect-scope-review-dialog";
 
 import {
   CONSENT_CENTER_PAGE_SIZE,
@@ -895,6 +899,7 @@ function ConsentEntryDetail({
   actor,
   entry,
   onApprove,
+  onModify,
   onDeny,
   onRevoke,
   onRevokeScope,
@@ -905,6 +910,7 @@ function ConsentEntryDetail({
   actor: ConsentCenterActor;
   entry: ConsentCenterEntry | null;
   onApprove: (entry: ConsentCenterEntry, durationHours?: number) => void;
+  onModify: (entry: ConsentCenterEntry) => void;
   onDeny: (entry: ConsentCenterEntry) => void;
   onRevoke: (entry: ConsentCenterEntry) => void;
   onRevokeScope: (scope: string) => void;
@@ -1026,6 +1032,10 @@ function ConsentEntryDetail({
       : entry.status === "pending");
   const isConnectionDecision =
     isPendingDecision && isConnectionRequestEntry(entry);
+  // A connection ask can bundle data scopes (e.g. an RIA pick). When present,
+  // the recipient can modify the list (grant a subset) instead of accept-all.
+  const hasRequestedScopes =
+    isConnectionDecision && (entry.requested_scopes?.length ?? 0) > 0;
   const isMarketplaceDecision =
     isPendingDecision && isMarketplaceConsent(entry.metadata, entry.scope);
   const durationOptions =
@@ -1162,6 +1172,19 @@ function ConsentEntryDetail({
               </Select>
             </div>
           ) : null}
+          {isConnectionDecision && hasRequestedScopes ? (
+            <Button
+              variant="none"
+              effect="fade"
+              size="sm"
+              className="min-h-11"
+              disabled={requestBusy}
+              onClick={() => onModify(entry)}
+              data-voice-control-id="consent_choose_data"
+            >
+              Choose data
+            </Button>
+          ) : null}
           <Button
             variant="blue-gradient"
             effect="fill"
@@ -1183,7 +1206,9 @@ function ConsentEntryDetail({
                 ? "Accepting..."
                 : "Allowing..."
               : isConnectionDecision
-                ? "Accept"
+                ? hasRequestedScopes
+                  ? "Accept all"
+                  : "Accept"
                 : "Allow"}
           </Button>
           <Button
@@ -1528,6 +1553,11 @@ export function ConsentCenterPage() {
   const [locallyRevokedScopes, setLocallyRevokedScopes] = useState<Set<string>>(
     () => new Set(),
   );
+  // Recipient "modify the list" flow: the connection request whose bundled data
+  // scopes the user is reviewing (null = dialog closed), plus its in-flight flag.
+  const [scopeReviewEntry, setScopeReviewEntry] =
+    useState<ConsentCenterEntry | null>(null);
+  const [scopeReviewBusy, setScopeReviewBusy] = useState(false);
 
   useEffect(() => {
     if (routeQuery !== searchValue) {
@@ -1717,6 +1747,35 @@ export function ConsentCenterPage() {
       isMarketplaceEntry,
       user,
     ],
+  );
+  // Accept a connection request while modifying the bundled data list: grant the
+  // chosen subset and record the rest as denied. Mirrors approveEntry's cache
+  // sync + completion event so every consent surface refreshes identically.
+  const acceptConnectionWithScopes = useCallback(
+    async (entry: ConsentCenterEntry, decision: ConnectScopeReviewDecision) => {
+      if (!user) return;
+      setScopeReviewBusy(true);
+      try {
+        const idToken = await user.getIdToken();
+        await ConnectionsService.accept({
+          idToken,
+          requestId: entry.request_id || entry.id,
+          grantedScopes: decision.grantedScopes,
+          deniedScopes: decision.deniedScopes,
+        });
+        CacheSyncService.onConsentMutated(user.uid);
+        window.dispatchEvent(new CustomEvent(CONSENT_ACTION_COMPLETE_EVENT));
+        setScopeReviewEntry(null);
+      } catch (error) {
+        console.error(
+          "[ConsentCenter] Couldn't accept the connection request with a modified scope list:",
+          error,
+        );
+      } finally {
+        setScopeReviewBusy(false);
+      }
+    },
+    [user],
   );
   const denyEntry = useCallback(
     (entry: ConsentCenterEntry) => {
@@ -2908,6 +2967,12 @@ export function ConsentCenterPage() {
               closeDetailPanel();
               approveEntry(entry, durationHours);
             }}
+            onModify={(entry) => {
+              // Keep the entry around and open the scope-review dialog; the panel
+              // closes so the dialog owns focus while the user picks scopes.
+              closeDetailPanel();
+              setScopeReviewEntry(entry);
+            }}
             onDeny={(entry) => {
               closeDetailPanel();
               denyEntry(entry);
@@ -2923,6 +2988,24 @@ export function ConsentCenterPage() {
           />
         )}
       </SettingsDetailPanel>
+
+      <ConnectScopeReviewDialog
+        open={Boolean(scopeReviewEntry)}
+        onOpenChange={(open) => {
+          if (!open && !scopeReviewBusy) setScopeReviewEntry(null);
+        }}
+        personName={
+          scopeReviewEntry ? resolveCounterpartLabel(scopeReviewEntry) : ""
+        }
+        requestedScopes={scopeReviewEntry?.requested_scopes ?? []}
+        getIdToken={idTokenLoader}
+        busy={scopeReviewBusy}
+        onConfirm={(decision) => {
+          if (scopeReviewEntry) {
+            void acceptConnectionWithScopes(scopeReviewEntry, decision);
+          }
+        }}
+      />
     </AppPageShell>
   );
 }

--- a/hushh-webapp/lib/services/consent-center-service.ts
+++ b/hushh-webapp/lib/services/consent-center-service.ts
@@ -102,6 +102,10 @@ export interface ConsentCenterEntry {
   is_scope_upgrade?: boolean | null;
   existing_granted_scopes?: string[] | null;
   additional_access_summary?: string | null;
+  /** For `connection_request` entries: the data scopes the requester bundled with
+   * the connection ask. Present so the recipient can review and modify the list
+   * (grant a subset) before accepting. Empty/absent = a plain connect. */
+  requested_scopes?: string[] | null;
   technical_identity?: {
     user_id?: string | null;
   } | null;


### PR DESCRIPTION
## What & why

Third part of the Connect data-scope user story, built as an **additive** feature on top of the already-shipped request/share flow:

> *"If the user has received a connection request that bundles reserved scopes (e.g. an RIA sharing a pick), they get to **modify the list**."*

Today an incoming connection request that carries a data ask is **all-or-nothing** — Accept grants every requested scope, Decline grants none. This PR lets the **recipient grant a subset**: a `Choose data` action on scoped requests opens a review dialog where every scope is pre-checked (parity with today's accept-all default); the recipient unchecks anything they don't want to share and accepts a **partial grant**.

## How

- **Backend read path** — `list_requests` now surfaces `requestedScopes` parsed from request metadata (handles both JSONB dict and raw JSON-string forms); consent-center incoming entries carry `requested_scopes` through to the UI.
- **Accept path (already supported)** — `accept_request(..., granted_scopes, denied_scopes)` computes the allowed subset and mints one pending, **zero-knowledge** `REQUESTED` consent event per non-denied scope, wrapped to the requester's public key. This PR wires the client to pass the recipient's decision.
- **Frontend** — new `ConnectScopeReviewDialog` collects the per-scope decision; `consent-center-page` shows `Choose data` only on requests that actually carry scopes and calls `ConnectionsService.accept({ grantedScopes, deniedScopes })`.

## Backward compatibility

Strictly additive. Plain connect requests (no requested scopes) keep the existing Accept/Decline flow unchanged — the new control is hidden when `requested_scopes` is empty/absent. No changes to already-healthy UAT/prod behavior.

## Tests & gates

- New regression tests: scope passthrough for dict **and** JSON-string metadata; incoming entries surface `requested_scopes` for the modify flow, degrade to `[]` for plain connects.
- BE: ruff check + format clean, bandit clean, 26 tests pass.
- FE: `tsc --noEmit` clean, eslint clean on all touched files.