### PR TITLE
fix(connect): give each requestable scope a distinct label

### DIFF
--- a/consent-protocol/hushh_mcp/consent/scope_generator.py
+++ b/consent-protocol/hushh_mcp/consent/scope_generator.py
@@ -1111,7 +1111,10 @@ class DynamicScopeGenerator:
         Returns:
             Dict with display_name, domain, attribute, is_wildcard, icon_name, color_hex, description
         """
-        from hushh_mcp.services.domain_contracts import get_canonical_domain_metadata
+        from hushh_mcp.services.domain_contracts import (
+            get_canonical_domain_metadata,
+            get_canonical_subintent_metadata,
+        )
 
         domain, attribute_key, is_wildcard = self.parse_scope(scope)
 
@@ -1133,13 +1136,36 @@ class DynamicScopeGenerator:
         domain_display = metadata.display_name if metadata else domain.title()
         domain_description = metadata.description if metadata else None
 
-        if is_wildcard:
+        if attribute_key:
+            # A branch scope such as ``attr.financial.profile.*``. It grants one
+            # branch of a domain, NOT the whole domain, so its label must stay
+            # distinct from both the domain-wide wildcard and its sibling
+            # branches. Prefer the branch's authored subintent metadata (name,
+            # description, icon, colour); fall back to a composed label for
+            # domains that register no subintents (health, lifestyle, ...).
+            #
+            # Historically ``is_wildcard`` was checked first, so every
+            # branch-level wildcard collapsed to "All {domain} Data" — five
+            # financial and three health scopes rendered as two identical rows
+            # in the Connect scope picker. Checking ``attribute_key`` first keeps
+            # each branch legible.
+            subintent = get_canonical_subintent_metadata(f"{domain}.{attribute_key}")
+            if subintent:
+                display_name = subintent.display_name
+                description = subintent.description
+                icon_name = subintent.icon_name
+                color_hex = subintent.color_hex
+            else:
+                attr_display = attribute_key.replace("_", " ").title()
+                display_name = f"{domain_display} — {attr_display}"
+                if is_wildcard:
+                    description = f"All {attr_display.lower()} data within {domain_display}"
+                else:
+                    description = f"{attr_display} within {domain_display}"
+        elif is_wildcard:
+            # True domain-level wildcard (``attr.<domain>.*``): the whole domain.
             display_name = f"All {domain_display} Data"
             description = domain_description
-        elif attribute_key:
-            attr_display = attribute_key.replace("_", " ").title()
-            display_name = f"{domain_display} — {attr_display}"
-            description = f"{attr_display} within {domain_display}"
         else:
             display_name = domain_display
             description = domain_description

--- a/consent-protocol/hushh_mcp/services/domain_contracts.py
+++ b/consent-protocol/hushh_mcp/services/domain_contracts.py
@@ -359,6 +359,23 @@ def get_canonical_domain_metadata(domain_key: str) -> DomainContractEntry | None
     return None
 
 
+def get_canonical_subintent_metadata(domain_key: str) -> DomainSubintentEntry | None:
+    """Return authored metadata for a canonical subintent branch, if registered.
+
+    ``domain_key`` is the fully-qualified branch key (e.g. ``financial.profile``).
+    Only financial subintents are registered today; every other branch returns
+    None so callers compose a display label from the parent domain + branch name.
+    Kept parallel to :func:`get_canonical_domain_metadata` so scope-display code
+    can prefer a branch's authored name/description/icon over a generic one.
+    """
+
+    key = normalize_domain_key(domain_key)
+    for entry in FINANCIAL_SUBINTENT_REGISTRY:
+        if entry.domain_key == key:
+            return entry
+    return None
+
+
 def canonical_domain_metadata_map() -> dict[str, dict[str, str]]:
     return {
         entry.domain_key: {

--- a/consent-protocol/tests/test_connections_scope_catalog.py
+++ b/consent-protocol/tests/test_connections_scope_catalog.py
@@ -88,3 +88,41 @@ def test_sensitivity_tiering_matches_domain():
         assert tier == expected, scope
     # Both tiers are represented (guards against a filter collapsing one away).
     assert set(by_scope.values()) == {"high", "low"}
+
+
+def test_every_flat_scope_label_is_unique():
+    # Regression: five financial branches all read "All Financial Data" and
+    # three health branches all read "All Health & Wellness Data", so the picker
+    # showed eight rows that looked identical. Distinct backend scopes must map
+    # to distinct human labels or the user cannot tell what they are granting.
+    catalog = build_requestable_scope_catalog()
+    labels = [s["label"] for s in catalog["scopes"]]
+    duplicates = sorted({label for label in labels if labels.count(label) > 1})
+    assert len(labels) == len(set(labels)), f"duplicate scope labels in catalog: {duplicates}"
+
+
+def test_no_collapsed_domain_wildcard_labels_leak_onto_branches():
+    # The catalog is built from branch scopes only (attr.<domain>.<branch>.*),
+    # never bare domain wildcards, so the domain-wide "All … Data" labels must
+    # not appear. Their presence would mean a branch collapsed back to the
+    # domain label — the exact defect this fix removes.
+    catalog = build_requestable_scope_catalog()
+    labels = {s["label"] for s in catalog["scopes"]}
+    assert "All Financial Data" not in labels
+    assert "All Health & Wellness Data" not in labels
+
+
+def test_every_flat_scope_has_a_nonempty_label_and_description():
+    # A blank label or description would render an empty, unexplained row.
+    catalog = build_requestable_scope_catalog()
+    for scope in catalog["scopes"]:
+        assert scope["label"], scope["scope"]
+        assert scope["description"], scope["scope"]
+        # The label must not just echo the raw scope string back at the user.
+        assert scope["label"] != scope["scope"], scope["scope"]
+
+
+def test_bundle_labels_are_unique():
+    catalog = build_requestable_scope_catalog()
+    labels = [b["label"] for b in catalog["bundles"]]
+    assert len(labels) == len(set(labels)), f"duplicate bundle labels: {labels}"

--- a/consent-protocol/tests/test_scope_generator_pure_helpers.py
+++ b/consent-protocol/tests/test_scope_generator_pure_helpers.py
@@ -403,3 +403,117 @@ class TestMatchesWildcard:
     )
     def test_cross_domain_wildcard_never_matches(self, scope, wildcard):
         assert GEN.matches_wildcard(scope, wildcard) is False
+
+
+# ===========================================================================
+# get_scope_display_info
+# ===========================================================================
+
+
+class TestGetScopeDisplayInfo:
+    """Guards the Connect scope-picker labels.
+
+    Regression: branch-level wildcards (``attr.financial.profile.*``) used to
+    collapse to "All Financial Data" because ``is_wildcard`` was checked before
+    ``attribute_key``. Five financial and three health scopes then rendered as
+    two identical rows in the requestable-scope catalog. These tests lock in
+    that every branch keeps a distinct, legible label while the true
+    domain-level wildcard still reads "All {domain} Data", and that the scope's
+    machine identity (domain / attribute / is_wildcard) is preserved untouched.
+    """
+
+    # --- Domain-level wildcard stays "All {domain} Data" ---
+
+    def test_domain_wildcard_is_all_domain_data(self):
+        info = GEN.get_scope_display_info("attr.financial.*")
+        assert info["display_name"] == "All Financial Data"
+        assert info["domain"] == "financial"
+        assert info["attribute"] is None
+        assert info["is_wildcard"] is True
+
+    def test_health_domain_wildcard_is_all_domain_data(self):
+        info = GEN.get_scope_display_info("attr.health.*")
+        assert info["display_name"] == "All Health & Wellness Data"
+        assert info["attribute"] is None
+
+    # --- Branch wildcards no longer collapse to the domain label ---
+
+    def test_financial_profile_branch_is_not_domain_label(self):
+        info = GEN.get_scope_display_info("attr.financial.profile.*")
+        assert info["display_name"] == "Financial Profile"
+        assert info["display_name"] != "All Financial Data"
+        assert info["domain"] == "financial"
+        assert info["attribute"] == "profile"
+        assert info["is_wildcard"] is True
+
+    def test_financial_documents_branch_is_distinct(self):
+        info = GEN.get_scope_display_info("attr.financial.documents.*")
+        assert info["display_name"] == "Financial Documents"
+        assert info["display_name"] != "All Financial Data"
+        assert info["attribute"] == "documents"
+
+    def test_health_branch_is_not_domain_label(self):
+        info = GEN.get_scope_display_info("attr.health.fitness.*")
+        assert "Fitness" in info["display_name"]
+        assert info["display_name"] != "All Health & Wellness Data"
+        assert info["domain"] == "health"
+        assert info["attribute"] == "fitness"
+
+    # --- Sibling branches are mutually distinct (label + description) ---
+
+    def test_financial_sibling_branches_have_distinct_labels(self):
+        branches = [
+            "attr.financial.portfolio.*",
+            "attr.financial.profile.*",
+            "attr.financial.documents.*",
+            "attr.financial.analysis_history.*",
+            "attr.financial.decisions.*",
+        ]
+        labels = [GEN.get_scope_display_info(s)["display_name"] for s in branches]
+        assert len(set(labels)) == len(labels), f"collapsed labels: {labels}"
+
+    def test_health_sibling_branches_have_distinct_labels(self):
+        branches = [
+            "attr.health.fitness.*",
+            "attr.health.metrics.*",
+            "attr.health.wellness_preferences.*",
+        ]
+        labels = [GEN.get_scope_display_info(s)["display_name"] for s in branches]
+        assert len(set(labels)) == len(labels), f"collapsed labels: {labels}"
+
+    def test_domain_wildcard_and_branch_wildcard_differ(self):
+        domain = GEN.get_scope_display_info("attr.financial.*")["display_name"]
+        branch = GEN.get_scope_display_info("attr.financial.profile.*")["display_name"]
+        assert domain != branch
+
+    # --- Authored subintent metadata is applied to financial branches ---
+
+    def test_financial_branch_uses_authored_subintent_metadata(self):
+        info = GEN.get_scope_display_info("attr.financial.profile.*")
+        # authored FINANCIAL_SUBINTENT_REGISTRY entries carry icon + colour
+        assert info["icon_name"] is not None
+        assert info["color_hex"] is not None
+        assert info["description"]
+
+    # --- Underscored branch keys survive normalisation ---
+
+    def test_underscored_branch_key_preserved(self):
+        info = GEN.get_scope_display_info("attr.financial.analysis_history.*")
+        assert info["attribute"] == "analysis_history"
+        assert info["display_name"] != "All Financial Data"
+
+    # --- Composed fallback for domains with no authored subintents ---
+
+    def test_composed_fallback_label_for_unregistered_branch(self):
+        info = GEN.get_scope_display_info("attr.health.metrics.*")
+        # health registers no subintents, so the label is composed from the
+        # domain display name and the humanised attribute key.
+        assert info["display_name"] == "Health & Wellness — Metrics"
+
+    # --- Non-attr scope identity is preserved ---
+
+    def test_non_attr_scope_returns_scope_as_label(self):
+        info = GEN.get_scope_display_info("vault.owner")
+        assert info["display_name"] == "vault.owner"
+        assert info["domain"] is None
+        assert info["is_wildcard"] is False


### PR DESCRIPTION
## Problem
The Connect scope-request picker (`/one/connect` → "Connect with <person>") rendered eight look-alike rows:
- **5×** distinct financial branch scopes all read **"All Financial Data"** (Sensitive)
- **3×** distinct health branch scopes all read **"All Health & Wellness Data"**

Distinct backend scopes collapsed to identical human labels, so a user could not tell what they were actually granting. (Follow-up to the connect infinite-spinner fix, PR #4753.)

## Root cause
`DynamicScopeGenerator.get_scope_display_info()` checked `is_wildcard` **before** `attribute_key`. A branch-level wildcard like `attr.financial.profile.*` is *both* a wildcard *and* has an attribute key, so it matched the `is_wildcard` branch first and collapsed to the domain-wide `"All {domain} Data"` label instead of naming its branch.

## Fix (presentational only)
- Reorder `get_scope_display_info()` to check `attribute_key` first.
- Branch scopes prefer **authored subintent metadata** (name / description / icon / colour) via a new `get_canonical_subintent_metadata()` + `FINANCIAL_SUBINTENT_REGISTRY`, and fall back to a composed `"{Domain} — {Branch}"` label for domains with no registered subintents (health, lifestyle, …).
- The true domain-level wildcard `attr.<domain>.*` still reads `"All {domain} Data"`.
- **Backend scope strings are untouched** — selection and submission still key on the raw `scope`. This changes labels only.

### Resulting catalog (all 12 rows now distinct)
| scope | label |
|---|---|
| attr.financial.portfolio.* | Financial Portfolio |
| attr.financial.profile.* | Financial Profile |
| attr.financial.documents.* | Financial Documents |
| attr.financial.analysis_history.* | Financial Analysis History |
| attr.financial.decisions.* | Financial — Decisions |
| attr.health.fitness.* | Health & Wellness — Fitness |
| attr.health.metrics.* | Health & Wellness — Metrics |
| attr.health.wellness_preferences.* | Health & Wellness — Wellness Preferences |
| attr.food.preferences.* | Food & Dining — Preferences |
| attr.entertainment.preferences.* | Entertainment — Preferences |
| attr.shopping.preferences.* | Shopping — Preferences |
| attr.travel.preferences.* | Travel — Preferences |

## Tests
- **`TestGetScopeDisplayInfo`** (generator level): domain wildcard stays "All … Data"; branch wildcards no longer collapse to the domain label; sibling branches are mutually distinct; authored subintent metadata applied; underscored branch keys preserved; scope identity (domain / attribute / is_wildcard) untouched.
- **Catalog level**: every flat scope label is unique; the collapsed domain labels never leak onto branches; every row has a non-empty label + description; bundle labels unique.
- Verified as genuine regression guards: reverting the source fix fails 10 of the new tests with the exact `"All Financial Data" ×5 / "All Health & Wellness Data" ×3` duplication; **97 passed** with the fix in place.

## Verification pending
UAT deploy + Chrome check of the live dialog (blocked on the vault-unlock gate, per the connect verification gotcha).

_(Supersedes #4755, which lacked a DCO sign-off.)_