### PR TITLE
ci(uat): make PKM evaluator advisory

### DIFF
--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -385,6 +385,58 @@ jobs:
         continue-on-error: true
         run: bash scripts/ci/cloudrun-retention.sh "${{ env.BACKEND_SERVICE }}" "${{ env.GCP_REGION }}" "${{ env.BACKEND_REVISION_RETENTION }}"
 
+      # The structure evaluator exercises the backend candidate image. Keep it
+      # before the frontend build so an advisory model-quality warning is
+      # available as early as possible, without turning a model variance into a
+      # deployment or rollback authority.
+      - name: Resolve backend candidate revision
+        id: backend-candidate-state
+        if: steps.scope.outputs.deploy_backend == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          backend_revision="$(gcloud run services describe "${{ env.BACKEND_SERVICE }}" \
+            --project="${{ env.GCP_PROJECT_ID }}" \
+            --region="${{ env.GCP_REGION }}" \
+            --format='value(status.latestCreatedRevisionName)')"
+          echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify backend candidate runtime identity
+        if: steps.scope.outputs.deploy_backend == 'true'
+        run: >-
+          bash scripts/ci/assert-cloud-run-runtime-identity.sh
+          "${{ env.GCP_PROJECT_ID }}"
+          "${{ env.GCP_REGION }}"
+          "${{ steps.backend-candidate-state.outputs.backend_revision }}"
+          "${{ env.RUNTIME_SERVICE_ACCOUNT }}"
+
+      - name: Verify candidate PKM evaluator in Cloud Run
+        id: verify-candidate-pkm-evaluator
+        if: steps.scope.outputs.deploy_backend == 'true' && steps.verification-plan.outputs.pkm_evaluator_runs != '0'
+        shell: bash
+        env:
+          BACKEND_REVISION: ${{ steps.backend-candidate-state.outputs.backend_revision }}
+        run: |
+          set -euo pipefail
+          if ./scripts/ci/run-candidate-pkm-structure-agent-eval.sh; then
+            echo "outcome=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "outcome=failure" >> "$GITHUB_OUTPUT"
+            echo "Candidate PKM evaluator failed; continuing with its advisory warning." >&2
+          fi
+
+      - name: Record candidate PKM evaluator warning
+        if: always() && steps.scope.outputs.deploy_backend == 'true' && steps.verification-plan.outputs.pkm_evaluator_runs != '0' && steps.verify-candidate-pkm-evaluator.outputs.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::warning title=Candidate PKM evaluator warning::The synthetic structure-agent evaluator failed. This is advisory; runtime identity, provenance, parity, schema, semantic, reviewer, and passkey gates remain blocking."
+          {
+            echo "## ⚠ Candidate PKM evaluator warning"
+            echo ""
+            echo "The synthetic structure-agent evaluator failed for this backend candidate. The result is recorded for remediation but does not authorize rollback by itself."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Deploy frontend using Cloud Build
         id: deploy-frontend
         if: steps.scope.outputs.deploy_frontend == 'true'
@@ -423,23 +475,6 @@ jobs:
 
           echo "backend_revision=${backend_revision}" >> "$GITHUB_OUTPUT"
           echo "frontend_revision=${frontend_revision}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify backend candidate runtime identity
-        if: steps.scope.outputs.deploy_backend == 'true'
-        run: >-
-          bash scripts/ci/assert-cloud-run-runtime-identity.sh
-          "${{ env.GCP_PROJECT_ID }}"
-          "${{ env.GCP_REGION }}"
-          "${{ steps.candidate-state.outputs.backend_revision }}"
-          "${{ env.RUNTIME_SERVICE_ACCOUNT }}"
-
-      - name: Verify candidate PKM evaluator in Cloud Run
-        id: verify-candidate-pkm-evaluator
-        if: steps.scope.outputs.deploy_backend == 'true' && steps.verification-plan.outputs.pkm_evaluator_runs != '0'
-        shell: bash
-        env:
-          BACKEND_REVISION: ${{ steps.candidate-state.outputs.backend_revision }}
-        run: ./scripts/ci/run-candidate-pkm-structure-agent-eval.sh
 
       - name: Promote deployed revisions to UAT traffic
         shell: bash
@@ -728,6 +763,7 @@ jobs:
           REVIEWER_BYOK_REQUIRED: ${{ steps.verification-plan.outputs.run_reviewer_byok }}
           PASSKEY_ASSOCIATIONS_OUTCOME: ${{ steps.verify-passkey-associations.outcome }}
           PKM_EVALUATOR_RUNS: ${{ steps.verification-plan.outputs.pkm_evaluator_runs }}
+          PKM_EVALUATOR_OUTCOME: ${{ steps.verify-candidate-pkm-evaluator.outputs.outcome }}
           VERIFICATION_PLAN_REASON: ${{ steps.verification-plan.outputs.reason }}
         run: |
           set -euo pipefail
@@ -926,6 +962,12 @@ jobs:
                   "required": passkey_associations_required,
                   "outcome": os.environ.get("PASSKEY_ASSOCIATIONS_OUTCOME", ""),
                   "success": passkey_associations_success,
+              },
+              "candidate_pkm_evaluator": {
+                  "required": int(os.environ.get("PKM_EVALUATOR_RUNS") or "0") != 0,
+                  "outcome": os.environ.get("PKM_EVALUATOR_OUTCOME", ""),
+                  "advisory": True,
+                  "warning": os.environ.get("PKM_EVALUATOR_OUTCOME") == "failure",
               },
               "verification_plan": {
                   "reason": os.environ.get("VERIFICATION_PLAN_REASON", ""),
@@ -1139,6 +1181,7 @@ jobs:
             echo "- Verification plan: \`${{ steps.verification-plan.outputs.reason }}\`"
             echo "- Verification lanes: \`${{ steps.verification-plan.outputs.lanes }}\`"
             echo "- PKM evaluator runs: \`${{ steps.verification-plan.outputs.pkm_evaluator_runs }}\`"
+            echo "- Candidate PKM evaluator outcome (advisory): \`${{ steps.verify-candidate-pkm-evaluator.outputs.outcome }}\`"
             echo "- PKM upgrade gate required: \`${{ steps.verification-plan.outputs.run_pkm_upgrade_gate }}\`"
             echo "- Reviewer BYOK required: \`${{ steps.verification-plan.outputs.run_reviewer_byok }}\`"
             echo "- Backend deployed SHA before run: \`${{ steps.predeploy-state.outputs.backend_sha || 'unknown' }}\`"

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -144,6 +144,13 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     assert "resolve-uat-verification-plan.py" in workflow
     assert "outputs.pkm_evaluator_runs != '0'" in workflow
     assert "outputs.run_pkm_upgrade_gate" in workflow
+    assert "Record candidate PKM evaluator warning" in workflow
+    assert "Candidate PKM evaluator warning" in workflow
+    assert 'echo "outcome=failure" >> "$GITHUB_OUTPUT"' in workflow
+    assert "steps.verify-candidate-pkm-evaluator.outputs.outcome == 'failure'" in workflow
+    assert workflow.index("Verify candidate PKM evaluator in Cloud Run") < workflow.index(
+        "Deploy frontend using Cloud Build"
+    )
     assert workflow.index("Verify candidate PKM evaluator in Cloud Run") < workflow.index(
         "Promote deployed revisions to UAT traffic"
     )

--- a/consent-protocol/tests/test_pkm_v7_recovery_migration.py
+++ b/consent-protocol/tests/test_pkm_v7_recovery_migration.py
@@ -148,6 +148,12 @@ def test_uat_deploy_runs_protected_pkm_gate_and_reviewer_byok_rehearsal():
     assert "Candidate PKM evaluator warning" in workflow
     assert 'echo "outcome=failure" >> "$GITHUB_OUTPUT"' in workflow
     assert "steps.verify-candidate-pkm-evaluator.outputs.outcome == 'failure'" in workflow
+    evaluator_start = workflow.index("- name: Verify candidate PKM evaluator in Cloud Run")
+    evaluator_end = workflow.index("- name: Record candidate PKM evaluator warning")
+    evaluator_step = workflow[evaluator_start:evaluator_end]
+    assert "if ./scripts/ci/run-candidate-pkm-structure-agent-eval.sh; then" in evaluator_step
+    assert "continue-on-error" not in evaluator_step
+    assert "exit 1" not in evaluator_step
     assert workflow.index("Verify candidate PKM evaluator in Cloud Run") < workflow.index(
         "Deploy frontend using Cloud Build"
     )

--- a/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
+++ b/consent-protocol/tests/test_uat_deploy_no_traffic_contract.py
@@ -202,8 +202,13 @@ def test_production_health_gates_only_probe_after_successful_promotion() -> None
 
 
 def test_nonproduction_rollback_targets_are_traffic_bearing_revisions() -> None:
-    for path in (".github/workflows/deploy-uat.yml", ".github/workflows/deploy-dev.yml"):
+    for path, expected_created_revision_lookups in (
+        (".github/workflows/deploy-uat.yml", 3),
+        (".github/workflows/deploy-dev.yml", 2),
+    ):
         workflow = _read(path)
         assert workflow.count("status.latestReadyRevisionName") == 0
-        assert workflow.count("status.latestCreatedRevisionName") == 2
+        assert (
+            workflow.count("status.latestCreatedRevisionName") == expected_created_revision_lookups
+        )
         assert workflow.count("status.traffic[0].revisionName") >= 6

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,10 +41,13 @@ The same selector produces the `uat-verification-plan` artifact with the
 required/skipped lane reasons; do not reproduce its path policy in another
 workflow or deploy script.
 For a PKM upgrade release, the hosted structure evaluator uses the
-coverage-balanced `release_chain_24` phase and stops immediately on
-zero-tolerance infrastructure, schema, or domain failures. The 60- and
-120-prompt matrices remain available for offline research and deep rehearsal;
-they are not repeated in the UAT release critical path.
+coverage-balanced `release_chain_24` phase immediately after the backend
+candidate is built and before the frontend build begins. Its model-quality
+result is recorded as a release warning, not a traffic or rollback authority;
+runtime identity, provenance, parity, schema, semantic, reviewer, and passkey
+gates remain blocking. The 60- and 120-prompt matrices remain available for
+offline research and deep rehearsal; they are not repeated in the UAT release
+critical path.
 
 ### Backend Deployment
 


### PR DESCRIPTION
## Summary
- run the synthetic PKM evaluator after the backend candidate and before the frontend build
- capture evaluator failures as explicit UAT warnings without affecting traffic promotion or rollback
- preserve blocking identity, provenance, parity, schema, semantic, reviewer, and passkey gates

## Verification
- ./bin/hushh codex pre-pr
- focused UAT deployment contract tests
- docs verification