### PR TITLE
fix(location): synchronize Location controls

### DIFF
--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -168,6 +168,14 @@ or an active Nearby presence. Pausing stops new foreground/background private
 updates, clears the local self preview, and explicitly checks out active Nearby
 presence before the UI may report `Location paused`.
 
+`Auto-share my location` is a durable user-scoped preference, independent from
+Pause. It controls continuous foreground/background updates only for private
+grants the owner already approved; it never creates a grant or auto-approves a
+request. Turning Auto-share off leaves consent and expiry intact and makes new
+shares publish only the location the owner explicitly confirms. Pause
+temporarily suppresses Auto-share without erasing that preference, so both
+settings remain stable across tab changes and route remounts.
+
 Pause does not revoke private grants. Their authored expiry remains intact and
 recipients may retain the last encrypted point they already received. Resuming
 requires a fresh usable foreground fix. Nearby visibility remains a separate
@@ -175,6 +183,11 @@ explicit consent: turning the header on never checks its confirmation box or
 creates presence. A successful Nearby check-in clears Pause and updates the
 shared control state; checkout removes only Nearby activity unless the user
 chooses the global Pause control.
+
+While Pause is active, Saved Locations must fail closed before asking the
+device location provider for a new point. A capture already in flight is
+discarded if Pause becomes active. Existing encrypted saved places remain
+readable, repairable, and removable while the vault is unlocked.
 
 `Location limited` means a channel is enabled but current permission or fix
 accuracy is not sufficient for Nearby admission. It must not be presented as a

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -2,7 +2,7 @@
 
 Status: v1 implementation contract
 Owner: One + IAM/consent governance
-Last updated: 2026-07-30
+Last updated: 2026-07-31
 
 ## Visual Map
 
@@ -158,6 +158,28 @@ Capability scopes:
 - `cap.location.nearby.publish`
 - `cap.location.nearby.discover`
 - `cap.location.nearby.revoke`
+
+## Unified Location Control Contract
+
+The Location Agent header switch and Settings `Pause my location` control one
+user-scoped device preference. The header is on when at least one location
+channel is active: the owner's live preview, an active private grant publisher,
+or an active Nearby presence. Pausing stops new foreground/background private
+updates, clears the local self preview, and explicitly checks out active Nearby
+presence before the UI may report `Location paused`.
+
+Pause does not revoke private grants. Their authored expiry remains intact and
+recipients may retain the last encrypted point they already received. Resuming
+requires a fresh usable foreground fix. Nearby visibility remains a separate
+explicit consent: turning the header on never checks its confirmation box or
+creates presence. A successful Nearby check-in clears Pause and updates the
+shared control state; checkout removes only Nearby activity unless the user
+chooses the global Pause control.
+
+`Location limited` means a channel is enabled but current permission or fix
+accuracy is not sufficient for Nearby admission. It must not be presented as a
+successful precise check-in; Nearby continues to require a fresh fix no worse
+than 100 metres.
 
 ## Nearby Check-In Contract
 

--- a/docs/reference/architecture/one-location-agent.md
+++ b/docs/reference/architecture/one-location-agent.md
@@ -96,6 +96,11 @@ live-location grants:
 - reverse geocoding may send the captured point through the authenticated Maps
   proxy to obtain display copy and an ISO country code, but the Maps service
   does not persist the point or result
+- one physical place may have only one saved category; a candidate within 25
+  metres of any existing Home, Work, or Other place is rejected with a reminder
+  to remove the existing place first. The encrypted persistence mutation
+  rechecks this invariant against the latest PKM state after write conflicts,
+  while existing legacy duplicates are preserved for explicit owner cleanup
 - before saving, the owner may replace the captured place from the same
   onboarding prompt; authenticated Maps autocomplete and place details replace
   the display address and coordinates together in memory, while raw coordinates

--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -206,8 +206,14 @@ vi.mock("sonner", () => ({
 
 import { LocationImmersiveMap } from "@/components/one-location/location-immersive-map";
 import { beginNearbyPrivateReturn } from "@/lib/one-location/nearby-private-navigation";
+import {
+  forgetOneLocationControlPreference,
+  readOneLocationControlState,
+  updateOneLocationControlState,
+} from "@/lib/one-location/location-control-state";
 
 beforeEach(() => {
+  forgetOneLocationControlPreference("test-user");
   window.sessionStorage.clear();
   window.history.replaceState({}, "", "/one/location/map");
   experienceHarness.demoMode = true;
@@ -244,6 +250,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  forgetOneLocationControlPreference("test-user");
   cleanup();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -401,6 +408,10 @@ describe("LocationImmersiveMap demo experience", () => {
     experienceHarness.demoMode = false;
     experienceHarness.nearbyAvailable = true;
     experienceHarness.query = "";
+    updateOneLocationControlState("test-user", (current) => ({
+      ...current,
+      paused: true,
+    }));
 
     render(<LocationImmersiveMap />);
     fireEvent.click(
@@ -424,6 +435,14 @@ describe("LocationImmersiveMap demo experience", () => {
     );
 
     fireEvent.click(screen.getByTestId("publish-nearby-state"));
+
+    expect(readOneLocationControlState("test-user")).toEqual(
+      expect.objectContaining({
+        paused: false,
+        nearbyPresenceActive: true,
+        nearbyCheckedInAt: "2026-07-31T00:00:00.000Z",
+      }),
+    );
 
     const nearbyRoster = await screen.findByTestId(
       "one-location-map-nearby-people",

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -964,6 +964,72 @@ describe("OneLocationAgentPage", () => {
     );
   });
 
+  it("does not claim Location is paused when Nearby checkout fails", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockGetNearbyPresence.mockResolvedValue({
+      presence: {
+        status: "active",
+        audience: "all_opted_in",
+        radiusMeters: 500,
+        allowConnectionRequests: true,
+        consentVersion: "one-location-nearby-presence-v1",
+        checkedInAt: "2026-07-31T00:00:00.000Z",
+        expiresAt: "2026-07-31T01:00:00.000Z",
+        placeLabel: "Event venue",
+      },
+      attendees: [],
+    });
+    mockCheckoutNearby.mockRejectedValue(new Error("checkout unavailable"));
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Turn location off" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Settings$/i }));
+    const pauseSwitch = await screen.findByRole("switch", {
+      name: "Pause my location",
+    });
+    fireEvent.click(pauseSwitch);
+
+    await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalled());
+    expect(pauseSwitch).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("keeps Pause enabled when resuming cannot capture a fresh point", async () => {
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Turn location off" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Turn location off" }),
+    );
+    await waitFor(() => expect(screen.getByText("Location paused")).toBeTruthy());
+
+    mockCaptureCurrentPosition.mockClear();
+    mockCaptureCurrentPosition.mockRejectedValue(
+      new Error("fresh location unavailable"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Settings$/i }));
+    const pauseSwitch = await screen.findByRole("switch", {
+      name: "Pause my location",
+    });
+    fireEvent.click(pauseSwitch);
+
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalled());
+    expect(pauseSwitch).toHaveAttribute("aria-checked", "true");
+  });
+
   it("shows a limited status when the captured point is too approximate for Nearby", async () => {
     mockGetState.mockResolvedValue({
       ...locationState(),

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -35,6 +35,8 @@ const {
   mockCreateCircleInvite,
   mockGetActivity,
   mockGetState,
+  mockGetNearbyPresence,
+  mockCheckoutNearby,
   mockSyncCurrentUser,
   mockSyncOneLocationContactSignals,
   mockSearchConnectionDirectory,
@@ -73,6 +75,8 @@ const {
   mockCreateCircleInvite: vi.fn(),
   mockGetActivity: vi.fn(),
   mockGetState: vi.fn(),
+  mockGetNearbyPresence: vi.fn(),
+  mockCheckoutNearby: vi.fn(),
   mockSyncCurrentUser: vi.fn(),
   mockSyncOneLocationContactSignals: vi.fn(),
   mockSearchConnectionDirectory: vi.fn(),
@@ -199,6 +203,8 @@ vi.mock("@/lib/one-location/service", () => ({
     openAppSettings: mockOpenAppSettings,
     getActivity: mockGetActivity,
     getState: mockGetState,
+    getNearbyPresence: mockGetNearbyPresence,
+    checkoutNearby: mockCheckoutNearby,
     createGrant: mockCreateGrant,
     storeEnvelope: mockStoreEnvelope,
     captureCurrentPosition: mockCaptureCurrentPosition,
@@ -607,6 +613,9 @@ describe("OneLocationAgentPage", () => {
     // snapshot cannot leak into the next test's initial render.
     const { CacheService } = await import("@/lib/services/cache-service");
     CacheService.getInstance().clear();
+    const { forgetOneLocationControlPreference } =
+      await import("@/lib/one-location/location-control-state");
+    forgetOneLocationControlPreference("user_a");
     mockSearchParams.toString = () => "";
     mockSearchParamsGet.mockReturnValue(null);
     mockUseRequireAuth.mockReturnValue({
@@ -752,6 +761,14 @@ describe("OneLocationAgentPage", () => {
       publicUrl: "/one/location/request/invite_1",
     });
     mockGetState.mockResolvedValue(locationState());
+    mockGetNearbyPresence.mockResolvedValue({
+      presence: null,
+      attendees: [],
+    });
+    mockCheckoutNearby.mockResolvedValue({
+      presence: null,
+      attendees: [],
+    });
     mockGetActivity.mockResolvedValue(locationActivity());
     mockSyncCurrentUser.mockResolvedValue({
       user_id: "user_a",
@@ -840,6 +857,10 @@ describe("OneLocationAgentPage", () => {
   });
 
   it("keeps the heading and location toggle inline as the only header action", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
     render(<OneLocationAgentPage />);
     await skipLocationEntryFlow();
 
@@ -891,8 +912,81 @@ describe("OneLocationAgentPage", () => {
         screen.getByRole("switch", { name: "Turn location on" }),
       ).toHaveAttribute("aria-checked", "false"),
     );
-    expect(screen.getByText("Location off")).toBeTruthy();
+    expect(screen.getByText("Location paused")).toBeTruthy();
     expect(mockRevokeGrant).not.toHaveBeenCalled();
+  });
+
+  it("keeps the header, Pause setting, and active Nearby presence synchronized", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockGetNearbyPresence.mockResolvedValue({
+      presence: {
+        status: "active",
+        audience: "all_opted_in",
+        radiusMeters: 500,
+        allowConnectionRequests: true,
+        consentVersion: "one-location-nearby-presence-v1",
+        checkedInAt: "2026-07-31T00:00:00.000Z",
+        expiresAt: "2026-07-31T01:00:00.000Z",
+        placeLabel: "Event venue",
+      },
+      attendees: [],
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Turn location off" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Settings$/i }));
+    const pauseSwitch = await screen.findByRole("switch", {
+      name: "Pause my location",
+    });
+    expect(pauseSwitch).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(pauseSwitch);
+    await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(pauseSwitch).toHaveAttribute("aria-checked", "true"),
+    );
+
+    mockCaptureCurrentPosition.mockClear();
+    fireEvent.click(pauseSwitch);
+    await waitFor(() => expect(mockCaptureCurrentPosition).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(pauseSwitch).toHaveAttribute("aria-checked", "false"),
+    );
+  });
+
+  it("shows a limited status when the captured point is too approximate for Nearby", async () => {
+    mockGetState.mockResolvedValue({
+      ...locationState(),
+      ownerGrants: [],
+    });
+    mockCaptureCurrentPosition.mockResolvedValue({
+      latitude: 28.6139,
+      longitude: 77.209,
+      accuracyM: 240,
+      capturedAt: "2026-07-31T00:00:00.000Z",
+      sourcePlatform: "web",
+    });
+
+    render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+
+    fireEvent.click(screen.getByRole("switch", { name: "Turn location on" }));
+    await waitFor(() =>
+      expect(screen.getByText("Location limited")).toBeTruthy(),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Turn location off" }),
+    ).toHaveAttribute("aria-checked", "true");
   });
 
   it("renders a focused, validated share flow with a 15-minute default", async () => {

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -233,6 +233,7 @@ vi.mock("@/lib/one-location/service", () => ({
 }));
 
 vi.mock("@/lib/one-location/saved-locations", () => ({
+  DuplicateSavedLocationError: class extends Error {},
   addSavedLocation: mockAddSavedLocation,
   loadSavedLocations: mockLoadSavedLocations,
 }));

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -948,13 +948,21 @@ describe("OneLocationAgentPage", () => {
     const pauseSwitch = await screen.findByRole("switch", {
       name: "Pause my location",
     });
+    const autoShareSwitch = screen.getByRole("switch", {
+      name: "Auto-share my location",
+    });
     expect(pauseSwitch).toHaveAttribute("aria-checked", "false");
+    expect(autoShareSwitch).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(autoShareSwitch);
+    expect(autoShareSwitch).toHaveAttribute("aria-checked", "false");
 
     fireEvent.click(pauseSwitch);
     await waitFor(() => expect(mockCheckoutNearby).toHaveBeenCalled());
     await waitFor(() =>
       expect(pauseSwitch).toHaveAttribute("aria-checked", "true"),
     );
+    expect(autoShareSwitch).toHaveAttribute("aria-checked", "false");
 
     mockCaptureCurrentPosition.mockClear();
     fireEvent.click(pauseSwitch);
@@ -962,6 +970,7 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() =>
       expect(pauseSwitch).toHaveAttribute("aria-checked", "false"),
     );
+    expect(autoShareSwitch).toHaveAttribute("aria-checked", "false");
   });
 
   it("does not claim Location is paused when Nearby checkout fails", async () => {

--- a/hushh-webapp/__tests__/lib/one-location/saved-locations-persistence.integration.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-locations-persistence.integration.test.ts
@@ -169,4 +169,36 @@ describe("saved-place onboarding to Settings persistence", () => {
       segmentIds: undefined,
     });
   });
+
+  it("keeps one encrypted record when another category targets the same place", async () => {
+    await addSavedLocation({
+      context: CONTEXT,
+      input: {
+        category: "home",
+        latitude: 12.9763,
+        longitude: 77.5929,
+        address: "Kasturba Road, Bengaluru",
+      },
+    });
+
+    await expect(
+      addSavedLocation({
+        context: CONTEXT,
+        input: {
+          category: "work",
+          latitude: 12.9764,
+          longitude: 77.593,
+          address: "Kasturba Road, Bengaluru",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "duplicate_saved_location",
+      existingCategory: "home",
+    });
+
+    CacheService.getInstance().clear();
+    expect(await loadSavedLocations(CONTEXT)).toEqual([
+      expect.objectContaining({ category: "home" }),
+    ]);
+  });
 });

--- a/hushh-webapp/__tests__/lib/one-location/saved-locations.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-locations.test.ts
@@ -23,9 +23,12 @@ vi.mock("@/lib/services/pkm-write-coordinator", () => ({
 import {
   addSavedLocation,
   defaultLabelForCategory,
+  DuplicateSavedLocationError,
+  findDuplicateSavedLocation,
   loadSavedLocations,
   LOCATION_PKM_DOMAIN,
   removeSavedLocation,
+  SAVED_LOCATION_DUPLICATE_RADIUS_METERS,
   sortSavedLocationsForDisplay,
   updateSavedLocationAddress,
 } from "@/lib/one-location/saved-locations";
@@ -158,11 +161,13 @@ describe("encrypted saved-locations PKM store", () => {
       input: { category: "home", latitude: 2, longitude: 2 },
     });
 
-    expect(locations.filter((location) => location.category === "home")).toHaveLength(1);
+    expect(
+      locations.filter((location) => location.category === "home"),
+    ).toHaveLength(1);
     expect(locations[0]?.latitude).toBe(2);
   });
 
-  it("keeps distinct Other places and de-duplicates a matching one", async () => {
+  it("keeps distinct Other places and rejects a repeated physical place", async () => {
     await addSavedLocation({
       context: CONTEXT,
       input: {
@@ -181,21 +186,315 @@ describe("encrypted saved-locations PKM store", () => {
         longitude: 20,
       },
     });
-    const locations = await addSavedLocation({
+    await addSavedLocation({
       context: CONTEXT,
       input: {
         category: "other",
         label: "Gym",
-        latitude: 10,
-        longitude: 10,
+        latitude: 30,
+        longitude: 30,
       },
     });
+    await expect(
+      addSavedLocation({
+        context: CONTEXT,
+        input: {
+          category: "other",
+          label: "Library",
+          latitude: 10,
+          longitude: 10,
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "DuplicateSavedLocationError",
+      code: "duplicate_saved_location",
+      existingCategory: "other",
+      existingLabel: "Gym (Other)",
+    });
 
-    expect(locations.filter((location) => location.category === "other")).toHaveLength(2);
+    const locations = await loadSavedLocations(CONTEXT);
+    expect(
+      locations.filter((location) => location.category === "other"),
+    ).toHaveLength(3);
     expect(locations.map((location) => location.label).sort()).toEqual([
       "Cafe",
       "Gym",
+      "Gym",
     ]);
+  });
+
+  it("rejects the same physical place across Home, Work, and Other", async () => {
+    await addSavedLocation({
+      context: CONTEXT,
+      input: {
+        category: "home",
+        latitude: 12.9763,
+        longitude: 77.5929,
+      },
+    });
+
+    await expect(
+      addSavedLocation({
+        context: CONTEXT,
+        input: {
+          category: "work",
+          latitude: 12.9764,
+          longitude: 77.593,
+        },
+      }),
+    ).rejects.toThrow(
+      "This place is already saved as Home. Choose a different place or remove it first.",
+    );
+    await expect(
+      addSavedLocation({
+        context: CONTEXT,
+        input: {
+          category: "other",
+          label: "Parents",
+          latitude: 12.9763,
+          longitude: 77.5929,
+        },
+      }),
+    ).rejects.toBeInstanceOf(DuplicateSavedLocationError);
+
+    expect(await loadSavedLocations(CONTEXT)).toEqual([
+      expect.objectContaining({ category: "home" }),
+    ]);
+  });
+
+  it("allows distinct places beyond the duplicate radius", async () => {
+    await addSavedLocation({
+      context: CONTEXT,
+      input: {
+        category: "home",
+        latitude: 0,
+        longitude: 0,
+        address: "Same display address",
+      },
+    });
+    const locations = await addSavedLocation({
+      context: CONTEXT,
+      input: {
+        category: "work",
+        latitude: 0.0003,
+        longitude: 0,
+        address: "Same display address",
+      },
+    });
+
+    expect(locations.map((location) => location.category).sort()).toEqual([
+      "home",
+      "work",
+    ]);
+  });
+
+  it("uses the physical-distance threshold at its boundary", () => {
+    const existing = [
+      {
+        id: "home",
+        category: "home" as const,
+        label: "Home",
+        latitude: 0,
+        longitude: 0,
+        savedAt: "2026-07-31T00:00:00.000Z",
+      },
+    ];
+    const latitudeDegreesPerMetre = 180 / (Math.PI * 6_371_000);
+
+    expect(
+      findDuplicateSavedLocation(existing, {
+        latitude:
+          (SAVED_LOCATION_DUPLICATE_RADIUS_METERS - 0.01) *
+          latitudeDegreesPerMetre,
+        longitude: 0,
+      }),
+    ).toBe(existing[0]);
+    expect(
+      findDuplicateSavedLocation(existing, {
+        latitude:
+          (SAVED_LOCATION_DUPLICATE_RADIUS_METERS + 0.01) *
+          latitudeDegreesPerMetre,
+        longitude: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("recognizes the same place across the antimeridian", () => {
+    const existing = [
+      {
+        id: "home",
+        category: "home" as const,
+        label: "Home",
+        latitude: 0,
+        longitude: 179.99995,
+        savedAt: "2026-07-31T00:00:00.000Z",
+      },
+    ];
+
+    expect(
+      findDuplicateSavedLocation(existing, {
+        latitude: 0,
+        longitude: -179.99995,
+      }),
+    ).toBe(existing[0]);
+  });
+
+  it("does not rewrite an existing record when the same category is resaved", async () => {
+    await addSavedLocation({
+      context: CONTEXT,
+      input: {
+        category: "home",
+        latitude: 12.9763,
+        longitude: 77.5929,
+        address: "Original address",
+      },
+    });
+    const before = await loadSavedLocations(CONTEXT);
+
+    await expect(
+      addSavedLocation({
+        context: CONTEXT,
+        input: {
+          category: "home",
+          latitude: 12.9763,
+          longitude: 77.5929,
+          address: "Replacement address",
+        },
+      }),
+    ).rejects.toMatchObject({ code: "duplicate_saved_location" });
+
+    expect(await loadSavedLocations(CONTEXT)).toEqual(before);
+  });
+
+  it("reports a deterministic category for legacy duplicate records", () => {
+    const samePoint = { latitude: 12.9763, longitude: 77.5929 };
+    const legacyDuplicates = [
+      {
+        id: "other-gym",
+        category: "other" as const,
+        label: "Gym",
+        ...samePoint,
+        savedAt: "2026-07-31T00:00:00.000Z",
+      },
+      {
+        id: "work",
+        category: "work" as const,
+        label: "Work",
+        ...samePoint,
+        savedAt: "2026-07-31T00:00:00.000Z",
+      },
+      {
+        id: "home",
+        category: "home" as const,
+        label: "Home",
+        ...samePoint,
+        savedAt: "2026-07-31T00:00:00.000Z",
+      },
+    ];
+
+    expect(findDuplicateSavedLocation(legacyDuplicates, samePoint)?.category).toBe(
+      "home",
+    );
+    expect(legacyDuplicates.map((location) => location.category)).toEqual([
+      "other",
+      "work",
+      "home",
+    ]);
+  });
+
+  it("rechecks the latest encrypted state after a concurrent write", async () => {
+    const concurrentlySavedHome = {
+      id: "home",
+      category: "home" as const,
+      label: "Home",
+      latitude: 12.9763,
+      longitude: 77.5929,
+      savedAt: "2026-07-31T00:00:00.000Z",
+    };
+    pkm.saveMergedDomain.mockImplementationOnce(
+      async (rawParams: Record<string, unknown>) => {
+        const build = rawParams.build as (context: {
+          currentDomainData: Record<string, unknown>;
+          currentManifest: null;
+        }) => Record<string, unknown>;
+        await build({ currentDomainData: {}, currentManifest: null });
+        const currentDomainData = {
+          saved_places: {
+            schema_version: 1,
+            locations: [concurrentlySavedHome],
+            updated_at: "2026-07-31T00:00:00.000Z",
+          },
+        };
+        const plan = await build({ currentDomainData, currentManifest: null });
+        pkm.domainData = plan.domainData as Record<string, unknown>;
+        return {
+          success: true,
+          saveState: "saved",
+          fullBlob: { [LOCATION_PKM_DOMAIN]: pkm.domainData },
+        };
+      },
+    );
+
+    await expect(
+      addSavedLocation({
+        context: CONTEXT,
+        input: {
+          category: "work",
+          latitude: 12.9763,
+          longitude: 77.5929,
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "duplicate_saved_location",
+      existingCategory: "home",
+    });
+    expect(await loadSavedLocations(CONTEXT)).toEqual([concurrentlySavedHome]);
+  });
+
+  it("uses the final retry when a concurrent duplicate is removed", async () => {
+    const concurrentlyRemovedHome = {
+      id: "home",
+      category: "home" as const,
+      label: "Home",
+      latitude: 12.9763,
+      longitude: 77.5929,
+      savedAt: "2026-07-31T00:00:00.000Z",
+    };
+    pkm.saveMergedDomain.mockImplementationOnce(
+      async (rawParams: Record<string, unknown>) => {
+        const build = rawParams.build as (context: {
+          currentDomainData: Record<string, unknown>;
+          currentManifest: null;
+        }) => Record<string, unknown>;
+        await build({
+          currentDomainData: {
+            saved_places: {
+              schema_version: 1,
+              locations: [concurrentlyRemovedHome],
+              updated_at: "2026-07-31T00:00:00.000Z",
+            },
+          },
+          currentManifest: null,
+        });
+        const plan = await build({ currentDomainData: {}, currentManifest: null });
+        pkm.domainData = plan.domainData as Record<string, unknown>;
+        return {
+          success: true,
+          saveState: "saved",
+          fullBlob: { [LOCATION_PKM_DOMAIN]: pkm.domainData },
+        };
+      },
+    );
+
+    const locations = await addSavedLocation({
+      context: CONTEXT,
+      input: {
+        category: "work",
+        latitude: 12.9763,
+        longitude: 77.5929,
+      },
+    });
+    expect(locations).toEqual([expect.objectContaining({ category: "work" })]);
   });
 
   it("rejects invalid coordinates before any PKM write", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1800,6 +1800,13 @@ export function OneLocationAgentPageContent({
       readLocationWorkspaceMemory(auth.userId),
     );
   const locationControl = useOneLocationControlState(auth.userId);
+  const automaticPrivatePublishingAllowedRef = useRef(
+    !locationControl.paused && locationControl.autoShareEnabled,
+  );
+  useEffect(() => {
+    automaticPrivatePublishingAllowedRef.current =
+      !locationControl.paused && locationControl.autoShareEnabled;
+  }, [locationControl.autoShareEnabled, locationControl.paused]);
   const nearbyCheckInAvailable = isOneLocationNearbyCheckInAvailable();
   useEffect(() => {
     setLocationWorkspace(readLocationWorkspaceMemory(auth.userId));
@@ -1849,6 +1856,8 @@ export function OneLocationAgentPageContent({
   );
   const activateMyLocation = useCallback(
     (point: PlainLocationPoint) => {
+      automaticPrivatePublishingAllowedRef.current =
+        locationControl.autoShareEnabled;
       updateLocationWorkspace((current) => ({
         ...current,
         myLocationPoint: point,
@@ -1859,7 +1868,7 @@ export function OneLocationAgentPageContent({
         selfPreviewEnabled: true,
       }));
     },
-    [auth.userId, updateLocationWorkspace],
+    [auth.userId, locationControl.autoShareEnabled, updateLocationWorkspace],
   );
   const clearMyLocationPreview = useCallback(() => {
     updateLocationWorkspace((current) => ({
@@ -2072,7 +2081,7 @@ export function OneLocationAgentPageContent({
     !locationControl.paused &&
     (locationControl.selfPreviewEnabled ||
       locationControl.nearbyPresenceActive ||
-      activeOwnerGrants.length > 0);
+      (locationControl.autoShareEnabled && activeOwnerGrants.length > 0));
   const locationAccuracyLimited =
     locationEnabled &&
     (permission?.state !== "granted" ||
@@ -3597,6 +3606,7 @@ export function OneLocationAgentPageContent({
   useEffect(() => {
     if (!vaultOwnerToken || !activeOwnerGrants.length) return;
     if (locationControl.paused) return;
+    if (!locationControl.autoShareEnabled) return;
     if (busy && busy !== "load") return;
     if (
       permission?.state === "denied" ||
@@ -3608,6 +3618,7 @@ export function OneLocationAgentPageContent({
 
     const publishActiveGrants = async () => {
       if (livePublishInFlightRef.current) return;
+      if (!automaticPrivatePublishingAllowedRef.current) return;
       if (
         typeof document !== "undefined" &&
         document.visibilityState === "hidden"
@@ -3616,7 +3627,9 @@ export function OneLocationAgentPageContent({
       livePublishInFlightRef.current = true;
       try {
         const point = await OneLocationService.captureCurrentPosition();
+        if (!automaticPrivatePublishingAllowedRef.current) return;
         for (const grant of activeOwnerGrants) {
+          if (!automaticPrivatePublishingAllowedRef.current) return;
           const recipient = recipientForGrant(grant);
           if (!recipient?.keyId || !recipient.publicKeyJwk) continue;
           await publishEnvelopeWithRetry(
@@ -3646,6 +3659,7 @@ export function OneLocationAgentPageContent({
   }, [
     activeOwnerGrants,
     busy,
+    locationControl.autoShareEnabled,
     locationControl.paused,
     permission?.state,
     publishEnvelopeWithRetry,
@@ -3666,6 +3680,7 @@ export function OneLocationAgentPageContent({
     if (typeof window === "undefined") return;
     if (!vaultOwnerToken || !activeOwnerGrants.length) return;
     if (locationControl.paused) return;
+    if (!locationControl.autoShareEnabled) return;
     if (
       permission?.state === "denied" ||
       permission?.state === "restricted" ||
@@ -3680,6 +3695,7 @@ export function OneLocationAgentPageContent({
 
     const publishMovement = async (point: PlainLocationPoint) => {
       if (cancelled) return;
+      if (!automaticPrivatePublishingAllowedRef.current) return;
       if (
         typeof document !== "undefined" &&
         document.visibilityState === "hidden"
@@ -3715,6 +3731,7 @@ export function OneLocationAgentPageContent({
       livePublishInFlightRef.current = true;
       try {
         for (const grant of activeOwnerGrants) {
+          if (!automaticPrivatePublishingAllowedRef.current) return;
           const recipient = recipientForGrant(grant);
           if (!recipient?.keyId || !recipient.publicKeyJwk) continue;
           const driven = await drivePointForGrant(grant, point);
@@ -3763,6 +3780,7 @@ export function OneLocationAgentPageContent({
     };
   }, [
     activeOwnerGrants,
+    locationControl.autoShareEnabled,
     locationControl.paused,
     permission?.state,
     publishEnvelopeWithRetry,
@@ -3784,7 +3802,9 @@ export function OneLocationAgentPageContent({
       !shouldStreamSelfPreview({
         streaming:
           locationControl.selfPreviewEnabled && !locationControl.paused,
-        activeGrantCount: activeOwnerGrants.length,
+        activeGrantCount: locationControl.autoShareEnabled
+          ? activeOwnerGrants.length
+          : 0,
         permissionState: permission?.state,
       })
     ) {
@@ -3845,6 +3865,7 @@ export function OneLocationAgentPageContent({
       }
     };
   }, [
+    locationControl.autoShareEnabled,
     locationControl.paused,
     locationControl.selfPreviewEnabled,
     activeOwnerGrants.length,
@@ -3899,7 +3920,10 @@ export function OneLocationAgentPageContent({
       minIntervalMs: LIVE_LOCATION_MIN_PUBLISH_INTERVAL_MS,
     });
     void syncBackgroundShare({
-      enabled: backgroundShareEnabled && !locationControl.paused,
+      enabled:
+        backgroundShareEnabled &&
+        locationControl.autoShareEnabled &&
+        !locationControl.paused,
       session,
     });
     return () => {
@@ -3908,6 +3932,7 @@ export function OneLocationAgentPageContent({
   }, [
     backgroundShareEnabled,
     activeOwnerGrants,
+    locationControl.autoShareEnabled,
     locationControl.paused,
     recipients,
     vaultOwnerToken,
@@ -5376,6 +5401,7 @@ export function OneLocationAgentPageContent({
     }
 
     setBusy("selfLocation");
+    automaticPrivatePublishingAllowedRef.current = false;
     try {
       if (nearbyCheckInAvailable && vaultOwnerToken) {
         const nearby = await OneLocationService.getNearbyPresence({
@@ -5397,6 +5423,8 @@ export function OneLocationAgentPageContent({
       setMyLocationError(null);
       toast.success("Location updates are paused on this device.");
     } catch {
+      automaticPrivatePublishingAllowedRef.current =
+        locationControl.autoShareEnabled;
       toast.error(
         "Pause did not complete. You may still be visible nearby; please try again.",
       );
@@ -5406,6 +5434,7 @@ export function OneLocationAgentPageContent({
   }, [
     auth.userId,
     clearMyLocationPreview,
+    locationControl.autoShareEnabled,
     nearbyCheckInAvailable,
     vaultOwnerToken,
   ]);
@@ -5413,6 +5442,24 @@ export function OneLocationAgentPageContent({
   const handleResumeMyLocation = useCallback(() => {
     void handleShowMyLiveLocation();
   }, [handleShowMyLiveLocation]);
+
+  const handleAutoShareChange = useCallback(
+    (enabled: boolean) => {
+      automaticPrivatePublishingAllowedRef.current =
+        enabled && !locationControl.paused;
+      updateOneLocationControlState(auth.userId, (current) => ({
+        ...current,
+        autoShareEnabled: enabled,
+      }));
+      if (!enabled) setBackgroundShareEnabled(false);
+      toast.success(
+        enabled
+          ? "Approved shares will receive live updates."
+          : "Approved shares will update only when you explicitly share.",
+      );
+    },
+    [auth.userId, locationControl.paused],
+  );
 
   const markLocationOnboardingSeen = useCallback(() => {
     // Persist only after completion so an interrupted first run can resume next
@@ -6119,6 +6166,7 @@ export function OneLocationAgentPageContent({
     },
     permissionIsPrompt: permission?.state === "prompt",
     locationEnabled,
+    autoShareEnabled: locationControl.autoShareEnabled,
     locationPaused: locationControl.paused,
     locationAccuracyLimited,
     myLocationPoint,
@@ -6159,6 +6207,7 @@ export function OneLocationAgentPageContent({
     onShowMyLocation: () => void handleShowMyLiveLocation(),
     onHideMyLocation: () => void handleHideMyLiveLocation(),
     onResumeMyLocation: handleResumeMyLocation,
+    onAutoShareChange: handleAutoShareChange,
     onRequestPermission: () => void handleRequestLocationPermission(),
     onOpenLocationSettings: () => void handleOpenLocationSettings(),
     onSyncContacts: () => void handleSyncContactSignal(),

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -159,6 +159,12 @@ import {
   writeLocationWorkspaceMemory,
   type LocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
+import { updateOneLocationControlState } from "@/lib/one-location/location-control-state";
+import { useOneLocationControlState } from "@/lib/one-location/use-location-control-state";
+import {
+  isOneLocationNearbyCheckInAvailable,
+  ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS,
+} from "@/lib/one-location/nearby-check-in-availability";
 
 import {
   clearSosIncident,
@@ -1793,6 +1799,8 @@ export function OneLocationAgentPageContent({
     useState<LocationWorkspaceMemory>(() =>
       readLocationWorkspaceMemory(auth.userId),
     );
+  const locationControl = useOneLocationControlState(auth.userId);
+  const nearbyCheckInAvailable = isOneLocationNearbyCheckInAvailable();
   useEffect(() => {
     setLocationWorkspace(readLocationWorkspaceMemory(auth.userId));
   }, [auth.userId]);
@@ -1839,10 +1847,29 @@ export function OneLocationAgentPageContent({
     },
     [updateLocationWorkspace],
   );
+  const activateMyLocation = useCallback(
+    (point: PlainLocationPoint) => {
+      updateLocationWorkspace((current) => ({
+        ...current,
+        myLocationPoint: point,
+      }));
+      updateOneLocationControlState(auth.userId, (current) => ({
+        ...current,
+        paused: false,
+        selfPreviewEnabled: true,
+      }));
+    },
+    [auth.userId, updateLocationWorkspace],
+  );
+  const clearMyLocationPreview = useCallback(() => {
+    updateLocationWorkspace((current) => ({
+      ...current,
+      myLocationPoint: null,
+    }));
+  }, [updateLocationWorkspace]);
   const [myLocationError, setMyLocationError] = useState<string | null>(null);
   // True once the owner taps "Show my location" — keeps their own preview
   // streaming live (foreground) even before any share exists.
-  const [selfPreviewStreaming, setSelfPreviewStreaming] = useState(false);
   const decryptedPoints = locationWorkspace.decryptedPoints;
   const setDecryptedPoints = useCallback(
     (next: SetStateAction<Record<string, PlainLocationPoint>>) => {
@@ -2041,6 +2068,70 @@ export function OneLocationAgentPageContent({
       (state?.ownerGrants ?? []).filter((grant) => grant.status === "active"),
     [state?.ownerGrants],
   );
+  const locationEnabled =
+    !locationControl.paused &&
+    (locationControl.selfPreviewEnabled ||
+      locationControl.nearbyPresenceActive ||
+      activeOwnerGrants.length > 0);
+  const locationAccuracyLimited =
+    locationEnabled &&
+    (permission?.state !== "granted" ||
+      permission?.precise === false ||
+      (typeof myLocationPoint?.accuracyM === "number" &&
+        Number.isFinite(myLocationPoint.accuracyM) &&
+        myLocationPoint.accuracyM > ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS));
+
+  useEffect(() => {
+    if (!nearbyCheckInAvailable || !auth.userId || !vaultOwnerToken) {
+      return;
+    }
+    const userId = auth.userId;
+    const ownerToken = vaultOwnerToken;
+    let cancelled = false;
+
+    void OneLocationService.getNearbyPresence({
+      vaultOwnerToken: ownerToken,
+    })
+      .then(async (next) => {
+        if (cancelled) return;
+        if (locationControl.paused && next.presence) {
+          try {
+            const checkedOut = await OneLocationService.checkoutNearby({
+              vaultOwnerToken: ownerToken,
+            });
+            if (cancelled) return;
+            next = checkedOut;
+          } catch {
+            if (cancelled) return;
+            updateOneLocationControlState(userId, (current) => ({
+              ...current,
+              paused: false,
+              nearbyPresenceActive: true,
+              nearbyCheckedInAt: next.presence?.checkedInAt ?? null,
+            }));
+            toast.error(
+              "Nearby checkout did not complete. Location is still on; try pausing again.",
+            );
+            return;
+          }
+        }
+        updateOneLocationControlState(userId, (current) => ({
+          ...current,
+          nearbyPresenceActive: Boolean(next.presence),
+          nearbyCheckedInAt: next.presence?.checkedInAt ?? null,
+        }));
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    auth.userId,
+    locationControl.paused,
+    nearbyCheckInAvailable,
+    vaultOwnerToken,
+  ]);
 
   // The remaining location actions (Alert and Check-In) share the same
   // recipients: connections ready for private sharing.
@@ -2476,6 +2567,9 @@ export function OneLocationAgentPageContent({
             locationServicesEnabled: true,
           },
         );
+        if (shouldCapturePoint) {
+          activateMyLocation(point);
+        }
         return shouldCapturePoint ? { ready: true, point } : { ready: true };
       } catch (error) {
         const nextPermission =
@@ -2495,7 +2589,7 @@ export function OneLocationAgentPageContent({
         return { ready: false };
       }
     },
-    [refreshLocationPermission],
+    [activateMyLocation, refreshLocationPermission],
   );
 
   useEffect(() => {
@@ -3502,6 +3596,7 @@ export function OneLocationAgentPageContent({
 
   useEffect(() => {
     if (!vaultOwnerToken || !activeOwnerGrants.length) return;
+    if (locationControl.paused) return;
     if (busy && busy !== "load") return;
     if (
       permission?.state === "denied" ||
@@ -3551,6 +3646,7 @@ export function OneLocationAgentPageContent({
   }, [
     activeOwnerGrants,
     busy,
+    locationControl.paused,
     permission?.state,
     publishEnvelopeWithRetry,
     recipientForGrant,
@@ -3569,6 +3665,7 @@ export function OneLocationAgentPageContent({
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (!vaultOwnerToken || !activeOwnerGrants.length) return;
+    if (locationControl.paused) return;
     if (
       permission?.state === "denied" ||
       permission?.state === "restricted" ||
@@ -3666,6 +3763,7 @@ export function OneLocationAgentPageContent({
     };
   }, [
     activeOwnerGrants,
+    locationControl.paused,
     permission?.state,
     publishEnvelopeWithRetry,
     recipientForGrant,
@@ -3684,7 +3782,8 @@ export function OneLocationAgentPageContent({
     if (typeof window === "undefined") return;
     if (
       !shouldStreamSelfPreview({
-        streaming: selfPreviewStreaming,
+        streaming:
+          locationControl.selfPreviewEnabled && !locationControl.paused,
         activeGrantCount: activeOwnerGrants.length,
         permissionState: permission?.state,
       })
@@ -3746,7 +3845,8 @@ export function OneLocationAgentPageContent({
       }
     };
   }, [
-    selfPreviewStreaming,
+    locationControl.paused,
+    locationControl.selfPreviewEnabled,
     activeOwnerGrants.length,
     permission?.state,
     setMyLocationPoint,
@@ -3798,11 +3898,20 @@ export function OneLocationAgentPageContent({
       minMoveMeters: LIVE_LOCATION_MIN_MOVE_METERS,
       minIntervalMs: LIVE_LOCATION_MIN_PUBLISH_INTERVAL_MS,
     });
-    void syncBackgroundShare({ enabled: backgroundShareEnabled, session });
+    void syncBackgroundShare({
+      enabled: backgroundShareEnabled && !locationControl.paused,
+      session,
+    });
     return () => {
       void OneLocationService.stopBackgroundShare();
     };
-  }, [backgroundShareEnabled, activeOwnerGrants, recipients, vaultOwnerToken]);
+  }, [
+    backgroundShareEnabled,
+    activeOwnerGrants,
+    locationControl.paused,
+    recipients,
+    vaultOwnerToken,
+  ]);
 
   const handleRevoke = useCallback(
     async (grantId: string) => {
@@ -5245,9 +5354,6 @@ export function OneLocationAgentPageContent({
         setMyLocationError(message);
         return;
       }
-      setMyLocationPoint(result.point);
-      // Keep the preview live from here on (foreground streaming watch below).
-      setSelfPreviewStreaming(true);
       toast.success("Your live location preview is ready.");
     } catch (error) {
       const message = locationServicesErrorMessage(error);
@@ -5256,17 +5362,57 @@ export function OneLocationAgentPageContent({
     } finally {
       setBusy(null);
     }
-  }, [ensureForegroundLocationReady, setMyLocationPoint]);
+  }, [ensureForegroundLocationReady]);
 
-  // LIVE badge toggle-off: stop the self-preview stream and clear the local
-  // preview point. Purely local state; never touches active share grants
-  // (those are revoked from their own grant controls).
-  const handleHideMyLiveLocation = useCallback(() => {
-    setSelfPreviewStreaming(false);
-    setMyLocationPoint(null);
-    setMyLocationError(null);
-    toast.success("Live location preview is off.");
-  }, [setMyLocationPoint]);
+  // One coordinated pause owns every Location entry point. Private grants keep
+  // their consent/expiry contract, but all new foreground/background updates
+  // stop. Nearby presence is a separate authority and must explicitly check
+  // out before the UI may claim that Location is paused.
+  const handleHideMyLiveLocation = useCallback(async () => {
+    if (!auth.userId) return;
+    if (nearbyCheckInAvailable && !vaultOwnerToken) {
+      toast.error("Unlock One before pausing nearby location.");
+      return;
+    }
+
+    setBusy("selfLocation");
+    try {
+      if (nearbyCheckInAvailable && vaultOwnerToken) {
+        const nearby = await OneLocationService.getNearbyPresence({
+          vaultOwnerToken,
+        });
+        if (nearby.presence) {
+          await OneLocationService.checkoutNearby({ vaultOwnerToken });
+        }
+      }
+      updateOneLocationControlState(auth.userId, (current) => ({
+        ...current,
+        paused: true,
+        selfPreviewEnabled: false,
+        nearbyPresenceActive: false,
+        nearbyCheckedInAt: null,
+      }));
+      clearMyLocationPreview();
+      setBackgroundShareEnabled(false);
+      setMyLocationError(null);
+      toast.success("Location updates are paused on this device.");
+    } catch {
+      toast.error(
+        "Pause did not complete. You may still be visible nearby; please try again.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }, [
+    auth.userId,
+    clearMyLocationPreview,
+    nearbyCheckInAvailable,
+    vaultOwnerToken,
+  ]);
+
+  const handleResumeMyLocation = useCallback(() => {
+    void handleShowMyLiveLocation();
+  }, [handleShowMyLiveLocation]);
 
   const markLocationOnboardingSeen = useCallback(() => {
     // Persist only after completion so an interrupted first run can resume next
@@ -5972,6 +6118,9 @@ export function OneLocationAgentPageContent({
       actionLabel: locationReadiness.actionLabel ?? null,
     },
     permissionIsPrompt: permission?.state === "prompt",
+    locationEnabled,
+    locationPaused: locationControl.paused,
+    locationAccuracyLimited,
     myLocationPoint,
     myLocationError,
     recipients: rankedRecipients,
@@ -6008,7 +6157,8 @@ export function OneLocationAgentPageContent({
     toggleShareRecipient: (id) => toggleShareRecipient(id, "section_list"),
     toggleRequestOwner: (id) => toggleRequestOwner(id, "section_list"),
     onShowMyLocation: () => void handleShowMyLiveLocation(),
-    onHideMyLocation: () => handleHideMyLiveLocation(),
+    onHideMyLocation: () => void handleHideMyLiveLocation(),
+    onResumeMyLocation: handleResumeMyLocation,
     onRequestPermission: () => void handleRequestLocationPermission(),
     onOpenLocationSettings: () => void handleOpenLocationSettings(),
     onSyncContacts: () => void handleSyncContactSignal(),

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -58,6 +58,7 @@ import {
 import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
 import {
   addSavedLocation,
+  DuplicateSavedLocationError,
   loadSavedLocations,
   type SavedLocationCategory,
 } from "@/lib/one-location/saved-locations";
@@ -5791,8 +5792,12 @@ export function OneLocationAgentPageContent({
         setSaveLocationModalOpen(false);
         setSaveLocationPoint(null);
         toast.success("Location saved securely.");
-      } catch {
-        toast.error("Could not save this location. Please try again.");
+      } catch (error) {
+        toast.error(
+          error instanceof DuplicateSavedLocationError
+            ? error.message
+            : "Could not save this location. Please try again.",
+        );
       } finally {
         setSaveLocationSaving(false);
       }

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   updateSavedLocationAddress: vi.fn(),
   captureCurrentPosition: vi.fn(),
   reverseGeocode: vi.fn(),
+  toastError: vi.fn(),
 }));
 
 vi.mock("@/lib/firebase/auth-context", () => ({
@@ -26,6 +27,26 @@ vi.mock("@/lib/vault/vault-context", () => ({
 }));
 
 vi.mock("@/lib/one-location/saved-locations", () => ({
+  DuplicateSavedLocationError: class DuplicateSavedLocationError extends Error {},
+  duplicateSavedLocationMessage: (location: {
+    category: string;
+    label: string;
+  }) => {
+    const label =
+      location.category === "other" && location.label !== "Other"
+        ? `${location.label} (Other)`
+        : location.label;
+    return `This place is already saved as ${label}. Choose a different place or remove it first.`;
+  },
+  findDuplicateSavedLocation: (
+    locations: Array<{ latitude: number; longitude: number }>,
+    candidate: { latitude: number; longitude: number },
+  ) =>
+    locations.find(
+      (location) =>
+        location.latitude === candidate.latitude &&
+        location.longitude === candidate.longitude,
+    ) ?? null,
   loadSavedLocations: mocks.loadSavedLocations,
   addSavedLocation: mocks.addSavedLocation,
   removeSavedLocation: mocks.removeSavedLocation,
@@ -45,7 +66,7 @@ vi.mock("@/lib/one-location/service", () => ({
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
-    error: vi.fn(),
+    error: mocks.toastError,
   },
 }));
 
@@ -54,6 +75,7 @@ import {
   forgetOneLocationControlPreference,
   updateOneLocationControlState,
 } from "@/lib/one-location/location-control-state";
+import { DuplicateSavedLocationError } from "@/lib/one-location/saved-locations";
 
 const HOME = {
   id: "home",
@@ -87,6 +109,7 @@ describe("SavedLocationsSection", () => {
       name: null,
       countryCode: "IN",
     });
+    mocks.toastError.mockReset();
   });
 
   afterEach(() => {
@@ -200,8 +223,9 @@ describe("SavedLocationsSection", () => {
   });
 
   it("captures, resolves, and saves a new place through encrypted PKM", async () => {
+    mocks.loadSavedLocations.mockResolvedValueOnce([]);
     render(<SavedLocationsSection />);
-    await screen.findByText("Kasturba Road, Bengaluru");
+    await screen.findByText(/no saved places yet/i);
 
     fireEvent.click(screen.getByRole("button", { name: /add place/i }));
     expect(
@@ -234,6 +258,51 @@ describe("SavedLocationsSection", () => {
         },
       }),
     );
+  });
+
+  it("reminds the owner and blocks a duplicate category before persistence", async () => {
+    render(<SavedLocationsSection />);
+    await screen.findByText("Kasturba Road, Bengaluru");
+
+    fireEvent.click(screen.getByRole("button", { name: /add place/i }));
+    expect(
+      await screen.findByRole("dialog", { name: /save this place/i }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Work" }));
+    fireEvent.click(screen.getByRole("button", { name: /save location/i }));
+
+    expect(mocks.addSavedLocation).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "This place is already saved as Home. Choose a different place or remove it first.",
+    );
+    expect(
+      screen.getByRole("dialog", { name: /save this place/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a duplicate discovered from a newer encrypted state", async () => {
+    mocks.loadSavedLocations.mockResolvedValueOnce([]);
+    mocks.addSavedLocation.mockRejectedValueOnce(
+      new DuplicateSavedLocationError(
+        "This place is already saved as Home. Choose a different place or remove it first.",
+      ),
+    );
+    render(<SavedLocationsSection />);
+    await screen.findByText(/no saved places yet/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /add place/i }));
+    await screen.findByRole("dialog", { name: /save this place/i });
+    fireEvent.click(screen.getByRole("button", { name: "Work" }));
+    fireEvent.click(screen.getByRole("button", { name: /save location/i }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "This place is already saved as Home. Choose a different place or remove it first.",
+      ),
+    );
+    expect(
+      screen.getByRole("dialog", { name: /save this place/i }),
+    ).toBeInTheDocument();
   });
 
   it("removes the encrypted place from Settings", async () => {

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   authUser: { uid: "user-123" } as { uid: string } | null,
@@ -50,6 +50,10 @@ vi.mock("sonner", () => ({
 }));
 
 import { SavedLocationsSection } from "@/components/one-location/saved-locations-section";
+import {
+  forgetOneLocationControlPreference,
+  updateOneLocationControlState,
+} from "@/lib/one-location/location-control-state";
 
 const HOME = {
   id: "home",
@@ -63,6 +67,7 @@ const HOME = {
 
 describe("SavedLocationsSection", () => {
   beforeEach(() => {
+    forgetOneLocationControlPreference("user-123");
     mocks.authUser = { uid: "user-123" };
     mocks.vault.isVaultUnlocked = true;
     mocks.vault.vaultKey = "vault-key";
@@ -82,6 +87,10 @@ describe("SavedLocationsSection", () => {
       name: null,
       countryCode: "IN",
     });
+  });
+
+  afterEach(() => {
+    forgetOneLocationControlPreference("user-123");
   });
 
   it("loads the encrypted saved place into Settings without exposing coordinates", async () => {
@@ -109,6 +118,60 @@ describe("SavedLocationsSection", () => {
     ).toBeInTheDocument();
     expect(mocks.loadSavedLocations).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: /add place/i })).toBeDisabled();
+  });
+
+  it("does not request device location while Location is paused", async () => {
+    updateOneLocationControlState("user-123", (current) => ({
+      ...current,
+      paused: true,
+    }));
+
+    render(<SavedLocationsSection />);
+
+    await screen.findByText("Kasturba Road, Bengaluru");
+    expect(screen.getByRole("button", { name: /add place/i })).toBeDisabled();
+    expect(
+      screen.getByText(/resume location before capturing another saved place/i),
+    ).toBeInTheDocument();
+    expect(mocks.captureCurrentPosition).not.toHaveBeenCalled();
+  });
+
+  it("discards a saved-place capture when Location is paused in flight", async () => {
+    let resolveCapture: (point: {
+      latitude: number;
+      longitude: number;
+      accuracy: number;
+      capturedAt: string;
+    }) => void = () => undefined;
+    mocks.captureCurrentPosition.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveCapture = resolve;
+      }),
+    );
+
+    render(<SavedLocationsSection />);
+    await screen.findByText("Kasturba Road, Bengaluru");
+    fireEvent.click(screen.getByRole("button", { name: /add place/i }));
+    await waitFor(() => expect(mocks.captureCurrentPosition).toHaveBeenCalled());
+
+    await act(async () => {
+      updateOneLocationControlState("user-123", (current) => ({
+        ...current,
+        paused: true,
+      }));
+      resolveCapture({
+        latitude: 12.9763,
+        longitude: 77.5929,
+        accuracy: 8,
+        capturedAt: "2026-07-26T00:00:00.000Z",
+      });
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.queryByRole("dialog", { name: /save this place/i }),
+    ).not.toBeInTheDocument();
+    expect(mocks.reverseGeocode).not.toHaveBeenCalled();
   });
 
   it("does not rehydrate decrypted places when a pending load settles after lock", async () => {

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -30,6 +30,7 @@ import {
   readLocationWorkspaceMemory,
   writeLocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
+import { updateOneLocationControlState } from "@/lib/one-location/location-control-state";
 import {
   DARK_MAP_STYLES,
   getBrowserMapsApiKey,
@@ -381,6 +382,20 @@ export function LocationImmersiveMap() {
     }
     return point;
   }, [auth.userId, captureCurrentLocation]);
+
+  const handleNearbyStateChange = useCallback(
+    (next: OneLocationNearbyPresenceState) => {
+      setNearbyPresenceState(next);
+      if (!auth.userId) return;
+      updateOneLocationControlState(auth.userId, (current) => ({
+        ...current,
+        paused: next.presence ? false : current.paused,
+        nearbyPresenceActive: Boolean(next.presence),
+        nearbyCheckedInAt: next.presence?.checkedInAt ?? null,
+      }));
+    },
+    [auth.userId],
+  );
 
   const focusSelfPoint = useCallback(
     async (
@@ -1643,7 +1658,7 @@ export function LocationImmersiveMap() {
             }
             closeNearbyCheckIn();
           }}
-          onStateChange={setNearbyPresenceState}
+          onStateChange={handleNearbyStateChange}
         />
       ) : null}
     </main>

--- a/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
+++ b/hushh-webapp/components/one-location/nearby-check-in/nearby-check-in-sheet.tsx
@@ -34,6 +34,7 @@ import { relationshipCta } from "@/lib/connections/relationship-label";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
 import { OneLocationService } from "@/lib/one-location/service";
+import { ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS } from "@/lib/one-location/nearby-check-in-availability";
 import type {
   OneLocationNearbyAttendee,
   OneLocationNearbyPlaceSuggestion,
@@ -50,7 +51,6 @@ const DURATIONS = [
   { value: 120 as const, label: "2 hours" },
 ];
 
-const MAX_NEARBY_LOCATION_ACCURACY_METERS = 100;
 const EMPTY_NEARBY_STATE: OneLocationNearbyPresenceState = {
   presence: null,
   attendees: [],
@@ -75,7 +75,7 @@ function hasCheckInAccuracy(point: PlainLocationPoint): boolean {
     typeof point.accuracyM === "number" &&
     Number.isFinite(point.accuracyM) &&
     point.accuracyM >= 0 &&
-    point.accuracyM <= MAX_NEARBY_LOCATION_ACCURACY_METERS
+    point.accuracyM <= ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS
   );
 }
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -155,6 +155,7 @@ export type LocationHubViewModel = {
   };
   permissionIsPrompt: boolean;
   locationEnabled: boolean;
+  autoShareEnabled: boolean;
   locationPaused: boolean;
   locationAccuracyLimited: boolean;
   myLocationPoint: PlainLocationPoint | null;
@@ -199,6 +200,7 @@ export type LocationHubViewModel = {
   onShowMyLocation: () => void;
   onHideMyLocation: () => void;
   onResumeMyLocation: () => void;
+  onAutoShareChange: (enabled: boolean) => void;
   onRequestPermission: () => void;
   onOpenLocationSettings: () => void;
   onSyncContacts: () => void;
@@ -1073,9 +1075,6 @@ function LocationSettingsFlow({
   smsContactCount: number;
   onManageSmsContacts: () => void;
 }) {
-  // Auto-share remains presentation-only; Pause is the shared Location control.
-  const [autoShare, setAutoShare] = useState(false);
-
   return (
     <div>
       <TaskFlowHeader
@@ -1094,14 +1093,15 @@ function LocationSettingsFlow({
               Auto-share my location
             </p>
             <p className="mt-0.5 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
-              On — your circle sees you live, no approval needed. Off — every
-              request needs your approval first.
+              On — approved shares keep receiving live updates. Off — new shares
+              send only the location you explicitly confirm.
             </p>
           </div>
           <LocationToggle
-            checked={autoShare}
-            onChange={setAutoShare}
+            checked={vm.autoShareEnabled}
+            onChange={vm.onAutoShareChange}
             label="Auto-share my location"
+            disabled={BUSY(vm, "selfLocation")}
           />
         </div>
         <div className="flex items-center gap-3.5 py-4">
@@ -1115,7 +1115,7 @@ function LocationSettingsFlow({
             </p>
           </div>
           <LocationToggle
-            checked={!vm.locationEnabled}
+            checked={vm.locationPaused}
             onChange={(next) => {
               if (next) {
                 vm.onHideMyLocation();

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -154,6 +154,9 @@ export type LocationHubViewModel = {
     actionLabel?: string | null;
   };
   permissionIsPrompt: boolean;
+  locationEnabled: boolean;
+  locationPaused: boolean;
+  locationAccuracyLimited: boolean;
   myLocationPoint: PlainLocationPoint | null;
   myLocationError: string | null;
 
@@ -195,6 +198,7 @@ export type LocationHubViewModel = {
   /* actions — wired 1:1 to existing handlers */
   onShowMyLocation: () => void;
   onHideMyLocation: () => void;
+  onResumeMyLocation: () => void;
   onRequestPermission: () => void;
   onOpenLocationSettings: () => void;
   onSyncContacts: () => void;
@@ -318,9 +322,16 @@ const LEGACY_ACTION_TO_FLOW: Readonly<Partial<Record<string, FlowKind>>> = {
 const BUSY = (vm: LocationHubViewModel, key: string) => vm.busy === key;
 
 function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
-  const locationOn = Boolean(vm.myLocationPoint);
+  const locationOn = vm.locationEnabled;
   const toggling = BUSY(vm, "selfLocation");
   const refreshing = BUSY(vm, "load");
+  const statusLabel = vm.locationPaused
+    ? "Location paused"
+    : vm.locationAccuracyLimited
+      ? "Location limited"
+      : locationOn
+        ? "Location on"
+        : "Location off";
 
   const handleLocationChange = (checked: boolean) => {
     if (checked === locationOn) return;
@@ -343,7 +354,7 @@ function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
           className="hidden whitespace-nowrap sm:inline"
           aria-hidden="true"
         >
-          {locationOn ? "Location on" : "Location off"}
+          {statusLabel}
         </span>
         <Switch
           checked={locationOn}
@@ -685,6 +696,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           <InviteFlow vm={vm} onClose={closeFlow} />
         ) : flow === "settings" ? (
           <LocationSettingsFlow
+            vm={vm}
             smsContactCount={vm.smsContactUserIds.length}
             onManageSmsContacts={() => openFlow("sms-contacts")}
           />
@@ -1021,10 +1033,12 @@ function LocationToggle({
   checked,
   onChange,
   label,
+  disabled = false,
 }: {
   checked: boolean;
   onChange: (next: boolean) => void;
   label: string;
+  disabled?: boolean;
 }) {
   return (
     <button
@@ -1032,10 +1046,12 @@ function LocationToggle({
       role="switch"
       aria-checked={checked}
       aria-label={label}
+      disabled={disabled}
       onClick={() => onChange(!checked)}
       className={cn(
         "relative h-[31px] w-[51px] shrink-0 rounded-full transition-colors duration-200",
         checked ? "bg-[#34c759]" : "bg-black/15 dark:bg-white/20",
+        disabled && "cursor-not-allowed opacity-60",
       )}
     >
       <span
@@ -1049,15 +1065,16 @@ function LocationToggle({
 }
 
 function LocationSettingsFlow({
+  vm,
   smsContactCount,
   onManageSmsContacts,
 }: {
+  vm: LocationHubViewModel;
   smsContactCount: number;
   onManageSmsContacts: () => void;
 }) {
-  // Inert local state for now — real auto-share / pause wiring comes later.
+  // Auto-share remains presentation-only; Pause is the shared Location control.
   const [autoShare, setAutoShare] = useState(false);
-  const [paused, setPaused] = useState(false);
 
   return (
     <div>
@@ -1093,13 +1110,21 @@ function LocationSettingsFlow({
               Pause my location
             </p>
             <p className="mt-0.5 text-[13px] leading-[1.45] text-black/50 dark:text-muted-foreground">
-              Go invisible to everyone until you turn this off.
+              Stop new private-share updates and check out from Nearby. Existing
+              shares keep their expiry and may retain your last encrypted point.
             </p>
           </div>
           <LocationToggle
-            checked={paused}
-            onChange={setPaused}
+            checked={!vm.locationEnabled}
+            onChange={(next) => {
+              if (next) {
+                vm.onHideMyLocation();
+                return;
+              }
+              vm.onResumeMyLocation();
+            }}
             label="Pause my location"
+            disabled={BUSY(vm, "selfLocation")}
           />
         </div>
       </div>
@@ -1107,8 +1132,8 @@ function LocationSettingsFlow({
       <div className="mt-4 flex items-start gap-2.5 px-1">
         <Shield className="mt-0.5 h-[15px] w-[15px] shrink-0 text-[color:var(--app-accent)]" />
         <p className="text-[13px] leading-[1.5] text-black/50 dark:text-muted-foreground">
-          Your location is never shared outside your circle. You can revoke
-          access to anyone at any time.
+          Private shares stay in your circle. Nearby Check-In is separate and
+          only starts after you explicitly agree.
         </p>
       </div>
 

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -17,6 +17,9 @@ import { SaveLocationModal } from "@/components/one-location/onboarding/save-loc
 import { useAuth } from "@/lib/firebase/auth-context";
 import {
   addSavedLocation,
+  duplicateSavedLocationMessage,
+  DuplicateSavedLocationError,
+  findDuplicateSavedLocation,
   loadSavedLocations,
   removeSavedLocation,
   sortSavedLocationsForDisplay,
@@ -264,6 +267,15 @@ export function SavedLocationsSection() {
         return;
       }
 
+      const duplicate = findDuplicateSavedLocation(
+        locations,
+        saveLocationPoint,
+      );
+      if (duplicate) {
+        toast.error(duplicateSavedLocationMessage(duplicate));
+        return;
+      }
+
       setSaveLocationSaving(true);
       const session = { userId, vaultKey, vaultOwnerToken };
       try {
@@ -282,9 +294,13 @@ export function SavedLocationsSection() {
         setSaveLocationModalOpen(false);
         setSaveLocationPoint(null);
         toast.success("Location saved securely.");
-      } catch {
+      } catch (error) {
         if (!isCurrentVaultSession(session)) return;
-        toast.error("Could not save this location. Please try again.");
+        toast.error(
+          error instanceof DuplicateSavedLocationError
+            ? error.message
+            : "Could not save this location. Please try again.",
+        );
       } finally {
         if (isCurrentVaultSession(session)) {
           setSaveLocationSaving(false);
@@ -294,6 +310,7 @@ export function SavedLocationsSection() {
     [
       saveLocationAddress,
       saveLocationPoint,
+      locations,
       isCurrentVaultSession,
       userId,
       vaultKey,

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -24,8 +24,10 @@ import {
   type SavedLocationCategory,
   updateSavedLocationAddress,
 } from "@/lib/one-location/saved-locations";
+import { readOneLocationControlState } from "@/lib/one-location/location-control-state";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
+import { useOneLocationControlState } from "@/lib/one-location/use-location-control-state";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 
@@ -55,6 +57,7 @@ export function SavedLocationsSection() {
   const { user } = useAuth();
   const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
   const userId = user?.uid ?? null;
+  const locationControl = useOneLocationControlState(userId);
   const [locations, setLocations] = useState<SavedLocation[]>([]);
   const [loadedUserId, setLoadedUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -72,6 +75,7 @@ export function SavedLocationsSection() {
     useState(false);
   const [saveLocationSaving, setSaveLocationSaving] = useState(false);
   const vaultSessionRef = useRef({ userId, vaultKey, vaultOwnerToken });
+  const captureRequestIdRef = useRef(0);
   vaultSessionRef.current = { userId, vaultKey, vaultOwnerToken };
 
   const hasVaultAccess = Boolean(
@@ -136,6 +140,7 @@ export function SavedLocationsSection() {
 
   useEffect(() => {
     if (hasVaultAccess) return;
+    captureRequestIdRef.current += 1;
     setLocations([]);
     setSaveLocationModalOpen(false);
     setSaveLocationPoint(null);
@@ -148,6 +153,16 @@ export function SavedLocationsSection() {
     setLoading(false);
   }, [hasVaultAccess]);
 
+  useEffect(() => {
+    if (!locationControl.paused) return;
+    captureRequestIdRef.current += 1;
+    setCapturing(false);
+    setSaveLocationModalOpen(false);
+    setSaveLocationPoint(null);
+    setSaveLocationAddress(null);
+    setSaveLocationAddressLoading(false);
+  }, [locationControl.paused]);
+
   const handleAdd = useCallback(async () => {
     if (!userId || !vaultKey || !vaultOwnerToken || capturing) {
       if (!hasVaultAccess) {
@@ -155,12 +170,24 @@ export function SavedLocationsSection() {
       }
       return;
     }
+    if (readOneLocationControlState(userId).paused) {
+      toast.error("Resume Location before adding a saved place.");
+      return;
+    }
 
     setCapturing(true);
+    const captureRequestId = captureRequestIdRef.current + 1;
+    captureRequestIdRef.current = captureRequestId;
     const session = { userId, vaultKey, vaultOwnerToken };
     try {
       const point = await OneLocationService.captureCurrentPosition();
-      if (!isCurrentVaultSession(session)) return;
+      if (
+        captureRequestIdRef.current !== captureRequestId ||
+        !isCurrentVaultSession(session) ||
+        readOneLocationControlState(userId).paused
+      ) {
+        return;
+      }
       setSaveLocationPoint(point);
       setSaveLocationAddress(null);
       setSaveLocationAddressLoading(true);
@@ -172,25 +199,47 @@ export function SavedLocationsSection() {
           lat: point.latitude,
           lng: point.longitude,
         });
-        if (!isCurrentVaultSession(session)) return;
+        if (
+          captureRequestIdRef.current !== captureRequestId ||
+          !isCurrentVaultSession(session) ||
+          readOneLocationControlState(userId).paused
+        ) {
+          return;
+        }
         setSaveLocationAddress(
           (place.formattedAddress || place.name || "").trim() || null,
         );
       } catch {
-        if (!isCurrentVaultSession(session)) return;
+        if (
+          captureRequestIdRef.current !== captureRequestId ||
+          !isCurrentVaultSession(session)
+        ) {
+          return;
+        }
         setSaveLocationAddress(null);
       } finally {
-        if (isCurrentVaultSession(session)) {
+        if (
+          captureRequestIdRef.current === captureRequestId &&
+          isCurrentVaultSession(session)
+        ) {
           setSaveLocationAddressLoading(false);
         }
       }
     } catch {
-      if (!isCurrentVaultSession(session)) return;
+      if (
+        captureRequestIdRef.current !== captureRequestId ||
+        !isCurrentVaultSession(session)
+      ) {
+        return;
+      }
       toast.error(
         "We could not read your current location. Check location permission and try again.",
       );
     } finally {
-      if (isCurrentVaultSession(session)) {
+      if (
+        captureRequestIdRef.current === captureRequestId &&
+        isCurrentVaultSession(session)
+      ) {
         setCapturing(false);
       }
     }
@@ -346,7 +395,7 @@ export function SavedLocationsSection() {
           <button
             type="button"
             onClick={() => void handleAdd()}
-            disabled={!hasVaultAccess || capturing}
+            disabled={!hasVaultAccess || locationControl.paused || capturing}
             className="press-scale inline-flex h-8 items-center gap-1.5 rounded-full bg-[color:var(--app-accent-tint,#e7f0fd)] px-3 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] transition-opacity disabled:cursor-not-allowed disabled:opacity-45"
           >
             {capturing ? (
@@ -468,8 +517,9 @@ export function SavedLocationsSection() {
         </div>
         {hasVaultAccess ? (
           <p className="mt-2 px-1 text-[11px] leading-[1.45] text-black/40 dark:text-muted-foreground">
-            Saved places are encrypted in your vault and shared only when you
-            explicitly approve location access.
+            {locationControl.paused
+              ? "Resume Location before capturing another saved place."
+              : "Saved places are encrypted in your vault and shared only when you explicitly approve location access."}
           </p>
         ) : null}
       </section>

--- a/hushh-webapp/lib/cache/cache-sync-service.ts
+++ b/hushh-webapp/lib/cache/cache-sync-service.ts
@@ -12,6 +12,11 @@ import {
   clearAllLocationWorkspaceMemory,
   clearLocationWorkspaceMemory,
 } from "@/lib/one-location/location-workspace-memory";
+import {
+  clearAllOneLocationControlRuntime,
+  clearOneLocationControlRuntime,
+  forgetOneLocationControlPreference,
+} from "@/lib/one-location/location-control-state";
 import type { PersonalKnowledgeModelMetadata } from "@/lib/services/personal-knowledge-model-service";
 
 type DomainSummaryPatch = Record<string, unknown>;
@@ -542,6 +547,7 @@ export class CacheSyncService {
     // server snapshot after the vault security boundary changes.
     OneLocationStateResource.invalidate(userId);
     clearLocationWorkspaceMemory(userId);
+    clearOneLocationControlRuntime(userId);
     if (typeof options?.hasVault === "boolean") {
       cache.set(
         CACHE_KEYS.VAULT_CHECK(userId),
@@ -732,6 +738,7 @@ export class CacheSyncService {
     if (userId) {
       OneLocationStateResource.invalidate(userId);
       clearLocationWorkspaceMemory(userId);
+      clearOneLocationControlRuntime(userId);
       cache.invalidateUser(userId);
       void import("@/lib/services/connected-systems-resource-service")
         .then(({ ConnectedSystemsResourceService }) =>
@@ -741,10 +748,12 @@ export class CacheSyncService {
       return;
     }
     clearAllLocationWorkspaceMemory();
+    clearAllOneLocationControlRuntime();
     cache.clear();
   }
 
   static onAccountDeleted(userId?: string | null): void {
     this.onAuthSignedOut(userId ?? null);
+    if (userId) forgetOneLocationControlPreference(userId);
   }
 }

--- a/hushh-webapp/lib/one-location/__tests__/location-control-state.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-control-state.test.ts
@@ -27,11 +27,29 @@ describe("One Location control state", () => {
     clearOneLocationControlRuntime(userId);
 
     expect(readOneLocationControlState(userId)).toEqual({
+      autoShareEnabled: true,
       paused: true,
       selfPreviewEnabled: false,
       nearbyPresenceActive: false,
       nearbyCheckedInAt: null,
     });
+  });
+
+  it("keeps both settings preferences across route remounts", () => {
+    updateOneLocationControlState(userId, (current) => ({
+      ...current,
+      autoShareEnabled: false,
+      paused: true,
+    }));
+
+    clearOneLocationControlRuntime(userId);
+
+    expect(readOneLocationControlState(userId)).toEqual(
+      expect.objectContaining({
+        autoShareEnabled: false,
+        paused: true,
+      }),
+    );
   });
 
   it("notifies every mounted surface from one update", () => {

--- a/hushh-webapp/lib/one-location/__tests__/location-control-state.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-control-state.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearOneLocationControlRuntime,
+  forgetOneLocationControlPreference,
+  readOneLocationControlState,
+  subscribeOneLocationControlState,
+  updateOneLocationControlState,
+} from "@/lib/one-location/location-control-state";
+
+const userId = "location-control-user";
+
+afterEach(() => {
+  forgetOneLocationControlPreference(userId);
+});
+
+describe("One Location control state", () => {
+  it("keeps pause durable while runtime activity remains memory-only", () => {
+    updateOneLocationControlState(userId, (current) => ({
+      ...current,
+      paused: true,
+      selfPreviewEnabled: true,
+      nearbyPresenceActive: true,
+      nearbyCheckedInAt: "2026-07-31T00:00:00.000Z",
+    }));
+
+    clearOneLocationControlRuntime(userId);
+
+    expect(readOneLocationControlState(userId)).toEqual({
+      paused: true,
+      selfPreviewEnabled: false,
+      nearbyPresenceActive: false,
+      nearbyCheckedInAt: null,
+    });
+  });
+
+  it("notifies every mounted surface from one update", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeOneLocationControlState(userId, listener);
+
+    updateOneLocationControlState(userId, (current) => ({
+      ...current,
+      paused: false,
+      nearbyPresenceActive: true,
+      nearbyCheckedInAt: "2026-07-31T00:00:00.000Z",
+    }));
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nearbyPresenceActive: true,
+        nearbyCheckedInAt: "2026-07-31T00:00:00.000Z",
+      }),
+    );
+    unsubscribe();
+  });
+
+  it("never retains a nearby timestamp after presence ends", () => {
+    const state = updateOneLocationControlState(userId, (current) => ({
+      ...current,
+      nearbyPresenceActive: false,
+      nearbyCheckedInAt: "stale-value",
+    }));
+
+    expect(state.nearbyCheckedInAt).toBeNull();
+  });
+});

--- a/hushh-webapp/lib/one-location/location-control-state.ts
+++ b/hushh-webapp/lib/one-location/location-control-state.ts
@@ -1,0 +1,149 @@
+/**
+ * Non-coordinate state shared by every One Location control surface.
+ *
+ * The global pause bit is a non-sensitive, user-scoped device preference. The
+ * live activity flags are runtime-only mirrors of independent authorities:
+ * self preview, private grants, and Nearby Check-In presence. Nearby consent
+ * remains explicit and is never inferred from this state.
+ */
+export type OneLocationControlState = {
+  paused: boolean;
+  selfPreviewEnabled: boolean;
+  nearbyPresenceActive: boolean;
+  nearbyCheckedInAt: string | null;
+};
+
+const PAUSED_PREFERENCE_PREFIX = "one_location_updates_paused_v1:";
+const EMPTY_STATE: OneLocationControlState = {
+  paused: false,
+  selfPreviewEnabled: false,
+  nearbyPresenceActive: false,
+  nearbyCheckedInAt: null,
+};
+
+const runtimeByUser = new Map<string, OneLocationControlState>();
+const listenersByUser = new Map<
+  string,
+  Set<(state: OneLocationControlState) => void>
+>();
+
+function cloneState(state: OneLocationControlState): OneLocationControlState {
+  return { ...state };
+}
+
+function preferenceKey(userId: string): string {
+  return `${PAUSED_PREFERENCE_PREFIX}${userId}`;
+}
+
+function readPausedPreference(userId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(preferenceKey(userId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writePausedPreference(userId: string, paused: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (paused) {
+      window.localStorage.setItem(preferenceKey(userId), "1");
+    } else {
+      window.localStorage.removeItem(preferenceKey(userId));
+    }
+  } catch {
+    // A blocked localStorage write only reduces cross-reload continuity. The
+    // current in-memory pause still applies for this session.
+  }
+}
+
+export function readOneLocationControlState(
+  userId: string | null | undefined,
+): OneLocationControlState {
+  if (!userId) return cloneState(EMPTY_STATE);
+  const runtime = runtimeByUser.get(userId);
+  if (runtime) return cloneState(runtime);
+  return {
+    ...EMPTY_STATE,
+    paused: readPausedPreference(userId),
+  };
+}
+
+export function updateOneLocationControlState(
+  userId: string | null | undefined,
+  updater: (current: OneLocationControlState) => OneLocationControlState,
+): OneLocationControlState {
+  if (!userId) return cloneState(EMPTY_STATE);
+  const current = readOneLocationControlState(userId);
+  const updated = updater(current);
+  const paused = Boolean(updated.paused);
+  const nearbyPresenceActive = !paused && Boolean(updated.nearbyPresenceActive);
+  const next: OneLocationControlState = {
+    paused,
+    selfPreviewEnabled: !paused && Boolean(updated.selfPreviewEnabled),
+    nearbyPresenceActive,
+    nearbyCheckedInAt: nearbyPresenceActive ? updated.nearbyCheckedInAt : null,
+  };
+  runtimeByUser.set(userId, next);
+  writePausedPreference(userId, next.paused);
+  for (const listener of listenersByUser.get(userId) ?? []) {
+    listener(cloneState(next));
+  }
+  return cloneState(next);
+}
+
+export function subscribeOneLocationControlState(
+  userId: string,
+  listener: (state: OneLocationControlState) => void,
+): () => void {
+  const listeners =
+    listenersByUser.get(userId) ??
+    new Set<(state: OneLocationControlState) => void>();
+  listeners.add(listener);
+  listenersByUser.set(userId, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) listenersByUser.delete(userId);
+  };
+}
+
+/** Clear volatile activity mirrors while retaining the privacy-safe pause. */
+export function clearOneLocationControlRuntime(
+  userId: string | null | undefined,
+): void {
+  if (!userId) return;
+  runtimeByUser.delete(userId);
+  const next = readOneLocationControlState(userId);
+  for (const listener of listenersByUser.get(userId) ?? []) {
+    listener(cloneState(next));
+  }
+}
+
+export function clearAllOneLocationControlRuntime(): void {
+  const userIds = Array.from(runtimeByUser.keys());
+  runtimeByUser.clear();
+  for (const userId of userIds) {
+    const next = readOneLocationControlState(userId);
+    for (const listener of listenersByUser.get(userId) ?? []) {
+      listener(cloneState(next));
+    }
+  }
+}
+
+export function forgetOneLocationControlPreference(
+  userId: string | null | undefined,
+): void {
+  if (!userId) return;
+  runtimeByUser.delete(userId);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.removeItem(preferenceKey(userId));
+    } catch {
+      // Best-effort account-deletion cleanup for restricted browser storage.
+    }
+  }
+  for (const listener of listenersByUser.get(userId) ?? []) {
+    listener(cloneState(EMPTY_STATE));
+  }
+}

--- a/hushh-webapp/lib/one-location/location-control-state.ts
+++ b/hushh-webapp/lib/one-location/location-control-state.ts
@@ -1,12 +1,13 @@
 /**
  * Non-coordinate state shared by every One Location control surface.
  *
- * The global pause bit is a non-sensitive, user-scoped device preference. The
+ * Pause and Auto-share are non-sensitive, user-scoped device preferences. The
  * live activity flags are runtime-only mirrors of independent authorities:
- * self preview, private grants, and Nearby Check-In presence. Nearby consent
- * remains explicit and is never inferred from this state.
+ * self preview, private grants, and Nearby Check-In presence. No preference
+ * creates consent; Nearby and private-share authority remain explicit.
  */
 export type OneLocationControlState = {
+  autoShareEnabled: boolean;
   paused: boolean;
   selfPreviewEnabled: boolean;
   nearbyPresenceActive: boolean;
@@ -14,7 +15,9 @@ export type OneLocationControlState = {
 };
 
 const PAUSED_PREFERENCE_PREFIX = "one_location_updates_paused_v1:";
+const AUTO_SHARE_PREFERENCE_PREFIX = "one_location_auto_share_v1:";
 const EMPTY_STATE: OneLocationControlState = {
+  autoShareEnabled: true,
   paused: false,
   selfPreviewEnabled: false,
   nearbyPresenceActive: false,
@@ -31,14 +34,18 @@ function cloneState(state: OneLocationControlState): OneLocationControlState {
   return { ...state };
 }
 
-function preferenceKey(userId: string): string {
+function pausedPreferenceKey(userId: string): string {
   return `${PAUSED_PREFERENCE_PREFIX}${userId}`;
+}
+
+function autoSharePreferenceKey(userId: string): string {
+  return `${AUTO_SHARE_PREFERENCE_PREFIX}${userId}`;
 }
 
 function readPausedPreference(userId: string): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem(preferenceKey(userId)) === "1";
+    return window.localStorage.getItem(pausedPreferenceKey(userId)) === "1";
   } catch {
     return false;
   }
@@ -48,13 +55,35 @@ function writePausedPreference(userId: string, paused: boolean): void {
   if (typeof window === "undefined") return;
   try {
     if (paused) {
-      window.localStorage.setItem(preferenceKey(userId), "1");
+      window.localStorage.setItem(pausedPreferenceKey(userId), "1");
     } else {
-      window.localStorage.removeItem(preferenceKey(userId));
+      window.localStorage.removeItem(pausedPreferenceKey(userId));
     }
   } catch {
     // A blocked localStorage write only reduces cross-reload continuity. The
     // current in-memory pause still applies for this session.
+  }
+}
+
+function readAutoSharePreference(userId: string): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(autoSharePreferenceKey(userId)) !== "0";
+  } catch {
+    return true;
+  }
+}
+
+function writeAutoSharePreference(userId: string, enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled) {
+      window.localStorage.removeItem(autoSharePreferenceKey(userId));
+    } else {
+      window.localStorage.setItem(autoSharePreferenceKey(userId), "0");
+    }
+  } catch {
+    // The current in-memory preference remains authoritative for this session.
   }
 }
 
@@ -66,6 +95,7 @@ export function readOneLocationControlState(
   if (runtime) return cloneState(runtime);
   return {
     ...EMPTY_STATE,
+    autoShareEnabled: readAutoSharePreference(userId),
     paused: readPausedPreference(userId),
   };
 }
@@ -80,12 +110,14 @@ export function updateOneLocationControlState(
   const paused = Boolean(updated.paused);
   const nearbyPresenceActive = !paused && Boolean(updated.nearbyPresenceActive);
   const next: OneLocationControlState = {
+    autoShareEnabled: Boolean(updated.autoShareEnabled),
     paused,
     selfPreviewEnabled: !paused && Boolean(updated.selfPreviewEnabled),
     nearbyPresenceActive,
     nearbyCheckedInAt: nearbyPresenceActive ? updated.nearbyCheckedInAt : null,
   };
   runtimeByUser.set(userId, next);
+  writeAutoSharePreference(userId, next.autoShareEnabled);
   writePausedPreference(userId, next.paused);
   for (const listener of listenersByUser.get(userId) ?? []) {
     listener(cloneState(next));
@@ -108,7 +140,7 @@ export function subscribeOneLocationControlState(
   };
 }
 
-/** Clear volatile activity mirrors while retaining the privacy-safe pause. */
+/** Clear volatile activity mirrors while retaining user preferences. */
 export function clearOneLocationControlRuntime(
   userId: string | null | undefined,
 ): void {
@@ -138,7 +170,8 @@ export function forgetOneLocationControlPreference(
   runtimeByUser.delete(userId);
   if (typeof window !== "undefined") {
     try {
-      window.localStorage.removeItem(preferenceKey(userId));
+      window.localStorage.removeItem(pausedPreferenceKey(userId));
+      window.localStorage.removeItem(autoSharePreferenceKey(userId));
     } catch {
       // Best-effort account-deletion cleanup for restricted browser storage.
     }

--- a/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
+++ b/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
@@ -1,5 +1,7 @@
 import { resolveAppEnvironment } from "@/lib/app-env";
 
+export const ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS = 100;
+
 /**
  * Radius-based nearby discovery is a local/UAT simulation until production
  * admission and abuse-prevention controls are available. The backend remains

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -3,6 +3,7 @@
 import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
 import { buildPersonalKnowledgeModelStructureArtifacts } from "@/lib/personal-knowledge-model/manifest";
 import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { haversineMeters } from "@/lib/one-location/marker-interpolation";
 
 export const LOCATION_PKM_DOMAIN = "location";
 
@@ -10,8 +11,15 @@ const SAVED_PLACES_KEY = "saved_places";
 const SAVED_PLACES_SCHEMA_VERSION = 1;
 const MAX_LABEL_LENGTH = 40;
 const MAX_ADDRESS_LENGTH = 300;
+export const SAVED_LOCATION_DUPLICATE_RADIUS_METERS = 25;
 
 export type SavedLocationCategory = "home" | "work" | "other";
+
+const SAVED_LOCATION_CATEGORY_PRIORITY: Record<SavedLocationCategory, number> = {
+  home: 0,
+  work: 1,
+  other: 2,
+};
 
 export type SavedLocation = {
   id: string;
@@ -28,6 +36,19 @@ export type SavedLocationVaultContext = {
   vaultKey: string | null;
   vaultOwnerToken: string | null;
 };
+
+export class DuplicateSavedLocationError extends Error {
+  readonly code = "duplicate_saved_location";
+  readonly existingCategory: SavedLocationCategory;
+  readonly existingLabel: string;
+
+  constructor(existingLocation: SavedLocation) {
+    super(duplicateSavedLocationMessage(existingLocation));
+    this.name = "DuplicateSavedLocationError";
+    this.existingCategory = existingLocation.category;
+    this.existingLabel = duplicateLocationLabel(existingLocation);
+  }
+}
 
 type SavedPlacesEnvelope = {
   schema_version: number;
@@ -178,6 +199,45 @@ export function defaultLabelForCategory(
   return "Other";
 }
 
+function duplicateLocationLabel(location: SavedLocation): string {
+  if (location.category !== "other") {
+    return defaultLabelForCategory(location.category);
+  }
+  const label = cleanText(location.label, MAX_LABEL_LENGTH);
+  return label && label.toLowerCase() !== "other"
+    ? `${label} (Other)`
+    : "Other";
+}
+
+export function duplicateSavedLocationMessage(location: SavedLocation): string {
+  return `This place is already saved as ${duplicateLocationLabel(location)}. Choose a different place or remove it first.`;
+}
+
+/** Find the preferred saved point representing the same physical place. */
+export function findDuplicateSavedLocation(
+  existing: SavedLocation[],
+  candidate: Pick<SavedLocation, "latitude" | "longitude">,
+): SavedLocation | null {
+  return (
+    existing
+      .filter(
+        (location) =>
+          haversineMeters(
+            { lat: location.latitude, lng: location.longitude },
+            { lat: candidate.latitude, lng: candidate.longitude },
+          ) <= SAVED_LOCATION_DUPLICATE_RADIUS_METERS,
+      )
+      .sort((left, right) => {
+        const categoryOrder =
+          SAVED_LOCATION_CATEGORY_PRIORITY[left.category] -
+          SAVED_LOCATION_CATEGORY_PRIORITY[right.category];
+        if (categoryOrder !== 0) return categoryOrder;
+        const labelOrder = left.label.localeCompare(right.label);
+        return labelOrder !== 0 ? labelOrder : left.id.localeCompare(right.id);
+      })[0] ?? null
+  );
+}
+
 /** Read saved places from the encrypted Location PKM domain. */
 export async function loadSavedLocations(
   context: SavedLocationVaultContext,
@@ -206,8 +266,8 @@ export async function loadSavedLocations(
 }
 
 /**
- * Add or replace a saved place in encrypted PKM. Home and Work are singletons;
- * Other places are additive and de-duplicated by label plus nearby coordinates.
+ * Add or replace a saved place in encrypted PKM. Home and Work are singletons,
+ * and one physical place can exist under only one category.
  */
 export async function addSavedLocation(params: {
   context: SavedLocationVaultContext;
@@ -244,10 +304,17 @@ export async function addSavedLocation(params: {
     savedAt: new Date().toISOString(),
   };
 
-  return mutateSavedLocations({
+  let duplicateLocation: SavedLocation | null = null;
+
+  const locations = await mutateSavedLocations({
     context: params.context,
     source: "one_location_saved_place_confirm",
     mutate: (existing) => {
+      const duplicate = findDuplicateSavedLocation(existing, entry);
+      duplicateLocation = duplicate;
+      if (duplicate) {
+        return existing;
+      }
       if (input.category === "home" || input.category === "work") {
         return [
           entry,
@@ -256,18 +323,13 @@ export async function addSavedLocation(params: {
           ),
         ];
       }
-      const withoutDuplicate = existing.filter(
-        (location) =>
-          !(
-            location.category === "other" &&
-            location.label.trim().toLowerCase() === label.toLowerCase() &&
-            Math.abs(location.latitude - entry.latitude) < 1e-4 &&
-            Math.abs(location.longitude - entry.longitude) < 1e-4
-          ),
-      );
-      return [...withoutDuplicate, entry];
+      return [...existing, entry];
     },
   });
+  if (duplicateLocation) {
+    throw new DuplicateSavedLocationError(duplicateLocation);
+  }
+  return locations;
 }
 
 /** Remove a saved place from encrypted PKM. */

--- a/hushh-webapp/lib/one-location/use-location-control-state.ts
+++ b/hushh-webapp/lib/one-location/use-location-control-state.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  readOneLocationControlState,
+  subscribeOneLocationControlState,
+  type OneLocationControlState,
+} from "@/lib/one-location/location-control-state";
+
+export function useOneLocationControlState(
+  userId: string | null | undefined,
+): OneLocationControlState {
+  const [state, setState] = useState<OneLocationControlState>(() =>
+    readOneLocationControlState(userId),
+  );
+
+  useEffect(() => {
+    setState(readOneLocationControlState(userId));
+    if (!userId) return;
+    return subscribeOneLocationControlState(userId, setState);
+  }, [userId]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

- synchronize the Location Agent header switch, Settings Pause, private publishing, and active Nearby presence through one user-scoped controller
- persist Auto-share and Pause across tab changes/remounts while keeping Auto-share independent from Pause and limited to already-approved grants
- make global Pause stop foreground/background publishing, clear self preview, check out Nearby, and block Saved Location GPS capture without revoking grants or deleting saved places
- fail closed on Nearby checkout/resume failures, cancel in-flight automatic/capture work after a privacy toggle, and surface approximate GPS as Location limited
- prevent the same physical place from being saved as Home, Work, or Other more than once, using an inclusive 25 m GPS-jitter tolerance at both the UI and encrypted PKM persistence boundary
- preserve Home/Work singleton moves, distinct Other places, and legacy duplicate records while returning a specific reminder for same-category, cross-category, stale-tab, and concurrent-save conflicts
- clear volatile control state at vault/auth boundaries while retaining user preferences until account deletion

## Verification

- 80 focused One Location tests passed across store, persistence integration, Settings UI, and full page behavior
- duplicate QA covers GPS threshold boundaries, antimeridian coordinates, same/different categories and labels, no-rewrite behavior, deterministic legacy conflicts, and concurrent add/remove retries
- 55 cache-coherence tests passed serially
- 21 analytics tests passed
- TypeScript typecheck passed
- targeted ESLint passed with zero warnings
- design-system, docs, service-boundary, surface-map, and data-model verification passed
- DCO signoff passed for all 4 PR commits
- gitleaks scanned all 4 PR commits with no leaks
- local signed-in route verification requires maintainer-only reviewer credentials; GitHub CI is the authoritative credential-backed run
- the local Windows umbrella harness reached governance checks but hit existing path-separator marker checks; generated/canonical files were left untouched for authoritative Linux CI

## Scope

Only the One Location synchronization and saved-place de-duplication implementation, focused tests, cache/auth lifecycle integration, and canonical architecture documentation are included. Unrelated local onboarding, Settings UI, global CSS, and Check-In-flow edits were excluded.