### PR TITLE
fix(location): balance onboarding layout on mobile

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -126,7 +126,7 @@ describe("OneLocationOnboardingFlow", () => {
     expect(welcomeHotel?.className).toContain("object-contain");
     expect(welcomeHotel?.className).toContain("!w-auto");
     expect(welcomeHotel?.className).toContain("max-w-none");
-    expect(welcomeHotel?.className).toContain("scale-[0.96]");
+    expect(welcomeHotel?.className).toContain("scale-[0.93]");
     expect(screen.getByRole("button", { name: "Skip" })).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Go back" }));
@@ -159,9 +159,16 @@ describe("OneLocationOnboardingFlow", () => {
     expect(featureGrid?.className).toContain("shrink-0");
     const lowerGrid = document.querySelector("[data-one-feature-lower-grid]");
     expect(lowerGrid?.className).toContain("grid-cols-2");
-    expect(
-      document.querySelector("[data-one-feature-cta] button")?.className,
-    ).toContain("h-[58px]");
+    const featureCta = document.querySelector("[data-one-feature-cta]");
+    expect(featureCta?.className).toContain("max-[431px]:mt-auto");
+    expect(featureCta?.querySelector("button")?.className).toContain(
+      "h-[58px]",
+    );
+    const responsiveStyles =
+      featureSurface?.querySelector("style")?.textContent;
+    expect(responsiveStyles).toContain("var(--onboarding-agent-bar-clearance)");
+    expect(responsiveStyles).toContain("aspect-ratio: 1.60 / 1");
+    expect(responsiveStyles).toContain("aspect-ratio: 0.63 / 1");
 
     const cards = document.querySelectorAll("[data-one-use-case-card]");
     expect(cards).toHaveLength(3);

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -79,7 +79,7 @@ const WELCOME_ORBIT_ITEMS = [
     src: "/one-location/onboarding/orbit-office.webp",
     position: "right-[8%] top-[10%]",
     imageClassName:
-      "relative left-1/2 !w-auto max-w-none -translate-x-1/2 scale-[0.96] object-contain",
+      "relative left-1/2 !w-auto max-w-none -translate-x-1/2 scale-[0.93] object-contain",
   },
   {
     src: "/one-location/onboarding/orbit-person-2.webp",
@@ -906,7 +906,7 @@ function FeaturesScreen({
           {status}
         </p>
       </div>
-      <div className="shrink-0 pt-8" data-one-feature-cta>
+      <div className="shrink-0 pt-8 max-[431px]:mt-auto" data-one-feature-cta>
         <PrimaryButton
           onClick={onContinue}
           busy={permissionBusy}
@@ -961,6 +961,21 @@ function FeaturesScreen({
           [data-one-feature-lower-grid] { gap: 8px; }
           [data-one-feature-cta] { padding-top: 8px; }
           [data-one-feature-cta] button { min-height: 46px; height: 46px; }
+        }
+        @media (max-width: 431px) and (min-height: 800px) {
+          [data-one-feature-screen] {
+            padding-bottom: calc(
+              var(--onboarding-agent-bar-clearance) +
+              max(env(safe-area-inset-bottom, 0px), 12px)
+            );
+          }
+        }
+        @media (max-width: 431px) and (min-height: 820px) {
+          [data-one-feature-header] { margin-top: 16px; }
+          [data-one-feature-grid] { margin-top: 26px; gap: 14px; }
+          [data-one-feature-card="share"] { aspect-ratio: 1.60 / 1; }
+          [data-one-feature-card="checkin"],
+          [data-one-feature-card="sms"] { aspect-ratio: 0.63 / 1; }
         }
         @media (max-width: 430px) {
           [data-one-feature-screen] { padding-left: 16px; padding-right: 16px; }


### PR DESCRIPTION
## Summary

- anchor the Location onboarding CTA to the mobile bottom region while preserving the shared Agent Bar and safe-area clearance
- spread tall-phone space across the existing feature composition so 412?915 and 430?932 no longer show a large blank tail
- reduce the welcome-screen hotel artwork from 0.96 to 0.93 scale for better orbit-icon balance
- extend the focused component contract for the responsive behavior

## Impact Map

- Routes touched: /one/location onboarding presentation only
- API/schema/type changes: none
- Runtime DB data-plane changes: none
- Cache keys touched: none
- PKM effects: none
- Mobile parity impacts: responsive web/Capacitor presentation; no plugin or bridge changes
- Trust boundary touched: none
- Caller/proxy/backend pairing: unchanged
- Rollback or safe-failure behavior: revert this single UI commit; compact-height rules remain unchanged
- Docs updated: none; no shared design rule changed

## Verification

- focused onboarding Vitest: 23 passed
- design-system verification passed
- cache verification: 55 passed
- documentation verification passed
- TypeScript typecheck passed
- focused ESLint passed with zero warnings
- browser geometry matrix: 320?568, 351?640, 375?667, 375?812, 390?844, 393?852, 412?915, 430?932, 529?912, 1280?568, 1280?720, and 1920?1080
- all measured viewports: zero shell/document scroll and feature grid finishes before the CTA
- DCO and pre-push freshness checks passed

The full local CI orchestrator reached the secret scan but is not Windows-compatible in this checkout (its inline Python path handling exits with an IndexError); GitHub PR Validation remains the authoritative full gate.


---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)