### PR TITLE
feat(sage): bring Sage, a persistent research agent, to the web app

### DIFF
--- a/consent-protocol/api/routes/kai/__init__.py
+++ b/consent-protocol/api/routes/kai/__init__.py
@@ -32,8 +32,10 @@ from .gmail import router as gmail_router
 from .health import router as health_router
 from .losers import router as losers_router
 from .market_insights import router as market_insights_router
+from .pkm_highlight import router as pkm_highlight_router
 from .plaid import router as plaid_router
 from .portfolio import router as portfolio_router
+from .sage_citations import router as sage_citations_router
 from .stream import router as stream_router
 from .support import router as support_router
 from .voice import router as voice_router
@@ -118,6 +120,15 @@ KAI_ROUTE_CONTRACT_PATHS = [
     "/market/insights/baseline/{user_id}",
     "/market/insights/{user_id}",
     "/stock-preview/{user_id}",
+    "/pkm/highlight-summary",
+    "/pkm/sage-briefing",
+    "/pkm/sage-recap",
+    "/pkm/sage-research",
+    "/pkm/sage-review",
+    "/pkm/sage-thread-synthesis",
+    "/sage/paper-search",
+    "/sage/paper-lineage",
+    "/sage/paper-insight",
 ]
 
 # Include all sub-routers (no prefix since main router has /api/kai)
@@ -127,6 +138,8 @@ kai_router.include_router(agent_realtime_router)
 kai_router.include_router(agent_voice_router)
 kai_router.include_router(chat_router)
 kai_router.include_router(portfolio_router)
+kai_router.include_router(pkm_highlight_router)
+kai_router.include_router(sage_citations_router)
 kai_router.include_router(plaid_router)
 kai_router.include_router(gmail_router)
 kai_router.include_router(consent_router)

--- a/consent-protocol/api/routes/kai/pkm_highlight.py
+++ b/consent-protocol/api/routes/kai/pkm_highlight.py
@@ -1,0 +1,1002 @@
+# consent-protocol/api/routes/kai/pkm_highlight.py
+"""
+One-line, human-readable summaries for the desktop dashboard's Memory
+Highlights card (Beta 1.5's "Today" section).
+
+The PKM auto-capture pipeline stores structured, sometimes near-raw
+fragments (kind/summary/status/observation entries) -- accurate for the
+PKM explorer's audit-trail view, but not something to show verbatim as
+"here's what Hushh remembered about you." This endpoint takes whatever
+raw domain data the caller already has and asks an LLM for exactly one
+warm, specific sentence -- reusing the same genai.Client call shape
+already used by receipt_memory_service.py's readable-summary enrichment.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from api.middleware import require_vault_owner_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_MODEL = "gemini-3.1-flash-lite"
+_TIMEOUT_SECONDS = 8.0
+# summarize_sage_briefing is the heaviest prompt in the "quick" tier -- it
+# reasons across every domain's summary at once, not one domain in
+# isolation, so it regularly ran past the shared 8s budget under real load
+# and silently fell back to generic text (asyncio.TimeoutError stringifies
+# to "", which is why the failure log line showed a blank error message).
+_SAGE_BRIEFING_TIMEOUT_SECONDS = 20.0
+_RESEARCH_TIMEOUT_SECONDS = 25.0
+_MAX_PAYLOAD_CHARS = 4000
+_MAX_QUERY_CHARS = 500
+_ANSWER_CHARS = 4000
+_DEEP_ANSWER_CHARS = 8000
+# Research Threads' answer-length control (deep mode only -- quick Ask Sage
+# stays a fixed short answer). Each tier pairs a char budget with how long a
+# generation actually takes and how much room the model needs to reach it --
+# a bigger cap alone does nothing if the timeout fires or max_output_tokens
+# cuts generation off first.
+_DEEP_LENGTH_ANSWER_CHARS = {"standard": _DEEP_ANSWER_CHARS, "thorough": 14000, "exhaustive": 20000}
+_DEEP_LENGTH_TIMEOUT_SECONDS = {"standard": 35.0, "thorough": 55.0, "exhaustive": 75.0}
+_DEEP_LENGTH_MAX_OUTPUT_TOKENS = {"thorough": 6144, "exhaustive": 9216}
+_DEEP_LENGTH_INSTRUCTIONS = {
+    "standard": (
+        "Write a genuinely thorough answer: cover the actual mechanisms or reasoning involved, "
+        "concrete evidence or examples, and (where relevant) real open questions or caveats -- "
+        "structure it as a few clear markdown paragraphs, with a bulleted list only where it "
+        "actually helps. Not one dense block, and not padded filler either."
+    ),
+    "thorough": (
+        "Write a long, deeply detailed answer (aim for roughly 1200-1800 words) structured as a "
+        "small set of clearly titled chapters -- start with a 1-2 sentence overview, then break the "
+        "rest into 3-5 chapters using markdown `## Chapter Title` headings (a short, specific title "
+        "per chapter, not 'Introduction'/'Conclusion'). Each chapter should cover a distinct real "
+        "mechanism, comparison, or angle -- use a `### ` sub-heading only if a chapter genuinely "
+        "needs a finer split. Never pad with filler or repetition just to hit length; every chapter "
+        "must carry real additional substance."
+    ),
+    "exhaustive": (
+        "Write an exhaustive, comprehensive answer (aim for roughly 2000-2800 words) -- treat this "
+        "like a real reference write-up the user will keep coming back to, not a quick answer. "
+        "Structure it as a sequence of clearly titled chapters: start with a 1-2 sentence overview, "
+        "then break the rest into 5-8 chapters using markdown `## Chapter Title` headings (a short, "
+        "specific title per chapter, e.g. the mechanism/comparison/angle it covers -- never generic "
+        "titles like 'Introduction' or 'Conclusion'). Use a `### ` sub-heading only if a chapter "
+        "genuinely needs a finer split. Cover the actual mechanisms or reasoning in full depth, "
+        "historical or comparative context where relevant, multiple concrete examples or pieces of "
+        "evidence, known edge cases or limitations, and real open research questions -- distributed "
+        "across the chapters, not crammed into one. Never pad with filler, repetition, or restating "
+        "the question just to hit length -- every chapter must carry real additional substance "
+        "grounded in what you actually found."
+    ),
+}
+# The largest an answer can ever be (exhaustive tier) -- conversation-history
+# and thread-synthesis fields must accept up to this, not just the standard
+# tier's 8000, or a long turn 422s every follow-up/synthesis after it.
+_MAX_ANSWER_CHARS_ANY_TIER = _DEEP_LENGTH_ANSWER_CHARS["exhaustive"]
+# Thread synthesis needs more room than the other digest endpoints here --
+# deep-mode answers run up to _MAX_ANSWER_CHARS_ANY_TIER long, and truncating
+# them too hard before synthesis means the model never sees (and so can't
+# credit as "established") whatever fell past the cut.
+_THREAD_SYNTHESIS_TURN_ANSWER_CHARS = 3000
+_THREAD_SYNTHESIS_MAX_PAYLOAD_CHARS = 12000
+
+
+class PkmHighlightSummaryRequest(BaseModel):
+    domain: str = Field(..., max_length=64)
+    display_name: str = Field(..., max_length=128)
+    raw_summary: dict = Field(default_factory=dict)
+    highlights: list[str] = Field(default_factory=list)
+    mode: Literal["brief", "rich"] = "brief"
+
+
+class PkmHighlightSummaryResponse(BaseModel):
+    text: str
+
+
+class SageDomainInput(BaseModel):
+    domain: str = Field(..., max_length=64)
+    display_name: str = Field(..., max_length=128)
+    summary: dict = Field(default_factory=dict)
+    attribute_count: int = 0
+    last_updated: str | None = None
+
+
+class PkmSageBriefingRequest(BaseModel):
+    domains: list[SageDomainInput] = Field(default_factory=list, max_length=12)
+
+
+class SageSuggestedFix(BaseModel):
+    note_text: str
+    from_domain: str
+    from_display_name: str
+    target_domain: str
+    target_display_name: str
+
+
+class PkmSageBriefingResponse(BaseModel):
+    text: str
+    suggested_fix: SageSuggestedFix | None = None
+    suggested_prompts: list[str] = Field(default_factory=list)
+
+
+class SageResearchSource(BaseModel):
+    title: str
+    url: str
+
+
+class SageConversationTurn(BaseModel):
+    query: str = Field(..., max_length=_MAX_QUERY_CHARS)
+    # Must match _MAX_ANSWER_CHARS_ANY_TIER -- Research Threads always ask
+    # with depth="deep" and echo prior turns' raw answers back as
+    # conversation history, so a cap below the largest length tier 422s any
+    # follow-up once an earlier turn's answer runs long (the sibling
+    # SageThreadTurnInput.answer field hit this same bug once already).
+    answer: str = Field(..., max_length=_MAX_ANSWER_CHARS_ANY_TIER)
+
+
+class PkmSageResearchRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=_MAX_QUERY_CHARS)
+    domains: list[SageDomainInput] = Field(default_factory=list, max_length=12)
+    mode: Literal["standard", "challenge"] = "standard"
+    conversation_history: list[SageConversationTurn] = Field(default_factory=list, max_length=6)
+    # "deep" is for persistent Research Threads, where a short chat-style answer
+    # reads as thin -- "quick" (the default) keeps Ask Sage's one-shot answers
+    # fast and conversational, unchanged from before this field existed.
+    depth: Literal["quick", "deep"] = "quick"
+    # Only meaningful when depth="deep" -- the answer-length tier the user
+    # picked for a Research Thread. Ignored in "quick" mode, which always
+    # stays a short conversational answer.
+    length: Literal["standard", "thorough", "exhaustive"] = "standard"
+
+
+class SageKeyTerm(BaseModel):
+    term: str
+    definition: str
+
+
+class SageComparison(BaseModel):
+    label: str
+    value: float
+    unit: str = ""
+
+
+class PkmSageResearchResponse(BaseModel):
+    answer: str
+    sources: list[SageResearchSource] = Field(default_factory=list)
+    # Both grounded in the SAME answer text the model already wrote (parsed out
+    # of a trailing JSON block it's asked to append, deep mode only) -- never a
+    # separate generation pass, so nothing here can introduce facts the prose
+    # answer doesn't already state. Empty whenever the answer has nothing
+    # genuinely non-obvious to define or nothing genuinely comparable to plot.
+    key_terms: list[SageKeyTerm] = Field(default_factory=list)
+    comparisons: list[SageComparison] = Field(default_factory=list)
+    # A well-formed academic-literature search query for this question, or
+    # None when the model judged there's no real paper trail to trace (e.g. a
+    # question about proprietary internal tooling) -- used instead of the raw
+    # user question for paper auto-trace, since a natural-language question
+    # containing a product/tool name matches unrelated papers on OpenAlex's
+    # full-text search far more often than a clean topical query does.
+    paper_search_query: str | None = None
+
+
+class SageRecapDomainInput(BaseModel):
+    domain: str = Field(..., max_length=64)
+    display_name: str = Field(..., max_length=128)
+    previous_summary: dict = Field(default_factory=dict)
+    current_summary: dict = Field(default_factory=dict)
+
+
+class PkmSageRecapRequest(BaseModel):
+    domains: list[SageRecapDomainInput] = Field(default_factory=list, max_length=12)
+
+
+class PkmSageRecapResponse(BaseModel):
+    text: str
+    has_changes: bool
+
+
+class PkmSageReviewRequest(BaseModel):
+    domain: str = Field(..., max_length=64)
+    display_name: str = Field(..., max_length=128)
+    fragments: list[str] = Field(default_factory=list, max_length=200)
+
+
+class PkmSageReviewResponse(BaseModel):
+    document: str
+
+
+class SageThreadTurnInput(BaseModel):
+    query: str = Field(..., max_length=_MAX_QUERY_CHARS)
+    # Must cover the full range a turn's answer can be, including the
+    # "exhaustive" length tier's _MAX_ANSWER_CHARS_ANY_TIER -- a tighter cap
+    # here doesn't truncate, it rejects the whole synthesis request outright
+    # once any turn exceeds it.
+    answer: str = Field(..., max_length=_MAX_ANSWER_CHARS_ANY_TIER)
+
+
+class SageThreadPaperInput(BaseModel):
+    title: str = Field(..., max_length=300)
+    year: int | None = None
+    topic: str | None = Field(default=None, max_length=200)
+    cited_by_count: int = 0
+
+
+class PkmSageThreadSynthesisRequest(BaseModel):
+    title: str = Field(..., max_length=200)
+    turns: list[SageThreadTurnInput] = Field(default_factory=list, max_length=20)
+    traced_papers: list[SageThreadPaperInput] = Field(default_factory=list, max_length=30)
+
+
+class PkmSageThreadSynthesisResponse(BaseModel):
+    summary: str
+    established: list[str] = Field(default_factory=list)
+    open_questions: list[str] = Field(default_factory=list)
+
+
+def _fallback_text(payload: PkmHighlightSummaryRequest) -> str:
+    return f"Hushh has been keeping notes on your {payload.display_name.lower()}."
+
+
+def _recap_fallback_text(payload: PkmSageRecapRequest) -> str:
+    if not payload.domains:
+        return "Nothing new since your last visit."
+    names = [d.display_name for d in payload.domains[:3]]
+    joined = ", ".join(names) if len(names) < 2 else f"{', '.join(names[:-1])} and {names[-1]}"
+    return f"Your {joined} notes have updated since your last visit."
+
+
+def _thread_fallback_summary(payload: PkmSageThreadSynthesisRequest) -> str:
+    turn_count = len(payload.turns)
+    paper_count = len(payload.traced_papers)
+    parts = []
+    if turn_count:
+        parts.append(f"{turn_count} question{'s' if turn_count != 1 else ''} asked")
+    if paper_count:
+        parts.append(f"{paper_count} paper{'s' if paper_count != 1 else ''} traced")
+    detail = " and ".join(parts) if parts else "nothing recorded yet"
+    return f"This thread on \"{payload.title}\" has {detail} so far."
+
+
+def _sage_fallback_text(payload: PkmSageBriefingRequest) -> str:
+    count = len(payload.domains)
+    if count == 0:
+        return "Sage doesn't have enough saved detail yet to make a cross-domain observation."
+    names = [d.display_name.lower() for d in payload.domains[:3]]
+    joined = ", ".join(names) if len(names) < 2 else f"{', '.join(names[:-1])}, and {names[-1]}"
+    return f"Sage is tracking {joined} so far -- a cross-domain read will sharpen as more detail builds up."
+
+
+@router.post("/pkm/highlight-summary", response_model=PkmHighlightSummaryResponse)
+async def summarize_pkm_highlight(
+    payload: PkmHighlightSummaryRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PkmHighlightSummaryResponse:
+    """
+    Turns one PKM domain's raw captured data into a single clean sentence
+    for the dashboard card. Best-effort: falls back to a plain, honest
+    line (never raw field dumps) if the LLM call fails or isn't configured.
+
+    **Authentication**: Requires valid VAULT_OWNER token -- this reads the
+    caller-supplied PKM content, not the vault, but keeps the same gate
+    as every other PKM-adjacent endpoint since the content is personal.
+    """
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        return PkmHighlightSummaryResponse(text=_fallback_text(payload))
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        return PkmHighlightSummaryResponse(text=_fallback_text(payload))
+
+    digest = {
+        "domain": payload.domain,
+        "summary": payload.raw_summary,
+        "highlights": payload.highlights[:10],
+    }
+    digest_json = json.dumps(digest, default=str)[:_MAX_PAYLOAD_CHARS]
+
+    # Stay entirely in a "you/your" voice describing the user -- without this,
+    # the model sometimes drifts into first person about itself ("I have
+    # saved this...", "I'll keep this in mind...", "I look forward to..."),
+    # which reads as a confirmation toast bleeding into what should be an
+    # observational summary, and breaks tone consistency against the other
+    # domain cards rendered right next to it.
+    voice_rule = (
+        "Write entirely about the user in a 'you/your' voice describing what the data shows "
+        "-- never write in first person about yourself as the assistant (no 'I have saved...', "
+        "'I'll remember...', 'I look forward to...', or similar). "
+    )
+
+    if payload.mode == "rich":
+        prompt = (
+            "You write 2-3 warm, specific sentences describing what a personal knowledge "
+            "assistant remembers about its user, based on the JSON payload below. "
+            "Rules: use ONLY facts present in the payload -- never invent numbers, names, "
+            "or events not shown. Ignore internal field names like 'Kind', 'Status', "
+            "'Summary', or entries that look like raw test input rather than real facts. "
+            "Weave the real facts together into a small narrative (what happened, and what "
+            "it might mean going forward) rather than a flat list -- but every claim must "
+            "still trace back to something actually in the payload. " + voice_rule +
+            "Write like a person telling a friend what they noticed, not like a database "
+            "describing its own schema. Return ONLY the sentences, no quotes, no JSON, no "
+            "preamble.\n\n"
+            f"Payload: {digest_json}"
+        )
+    else:
+        prompt = (
+            "You write one short, warm, specific sentence describing what a personal "
+            "knowledge assistant remembers about its user, based on the JSON payload below. "
+            "Rules: use ONLY facts present in the payload -- never invent numbers, names, or "
+            "events. Ignore internal field names like 'Kind', 'Status', 'Summary', or entries "
+            "that look like raw test input rather than real facts. " + voice_rule +
+            "Write like a person telling a friend what they noticed, not like a database "
+            "describing its own schema. Return ONLY the sentence, no quotes, no JSON, no "
+            "preamble.\n\n"
+            f"Payload: {digest_json}"
+        )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(temperature=0.3),
+            ),
+            timeout=_TIMEOUT_SECONDS,
+        )
+        text = (getattr(response, "text", "") or "").strip().strip('"')
+        if not text:
+            return PkmHighlightSummaryResponse(text=_fallback_text(payload))
+        max_chars = 600 if payload.mode == "rich" else 280
+        return PkmHighlightSummaryResponse(text=text[:max_chars])
+    except Exception as exc:
+        logger.warning("[pkm_highlight] summary generation failed: %s", exc)
+        return PkmHighlightSummaryResponse(text=_fallback_text(payload))
+
+
+@router.post("/pkm/sage-briefing", response_model=PkmSageBriefingResponse)
+async def summarize_sage_briefing(
+    payload: PkmSageBriefingRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PkmSageBriefingResponse:
+    """
+    Sage's cross-domain briefing: one Gemini call reasoning across every PKM
+    domain's already-computed summary at once (not per-domain in isolation),
+    looking for one real, specific, non-obvious connection or observation.
+
+    Same trust/fallback shape as summarize_pkm_highlight above, just fed the
+    small per-domain `summary` projections for every domain together instead
+    of one domain's raw_summary + highlights.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as the
+    per-domain highlight endpoint above.
+    """
+    if not payload.domains:
+        return PkmSageBriefingResponse(text=_sage_fallback_text(payload))
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        return PkmSageBriefingResponse(text=_sage_fallback_text(payload))
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        return PkmSageBriefingResponse(text=_sage_fallback_text(payload))
+
+    known_domains = {d.domain for d in payload.domains}
+    display_name_by_domain = {d.domain: d.display_name for d in payload.domains}
+
+    digest = [
+        {
+            "domain": d.domain,
+            "display_name": d.display_name,
+            "summary": d.summary,
+            "attribute_count": d.attribute_count,
+            "last_updated": d.last_updated,
+        }
+        for d in payload.domains
+    ]
+    digest_json = json.dumps(digest, default=str)[:_MAX_PAYLOAD_CHARS]
+
+    prompt = (
+        "You are Sage, a personal second-brain assistant. Below is a JSON list of every "
+        "life domain your user has data in, each with its own small summary. "
+        "Rules: use ONLY facts present in the payload -- never invent numbers, names, dates, "
+        "or events not shown. Ignore internal field names like 'Kind', 'Status', or raw "
+        "test-looking entries. Never give financial, medical, or legal advice -- observe, "
+        "don't prescribe. Two real facts sitting in different domains are NOT automatically "
+        "related -- never claim one informs, aligns with, reflects, or explains another unless "
+        "the payload itself states that link (e.g. a note that explicitly ties them together). "
+        "A shared timeframe, life stage, or topic keyword is not evidence of a real connection.\n\n"
+        "Return ONLY a single JSON object (no markdown fences, no preamble) shaped exactly like:\n"
+        '{"text": "2-3 short sentences making ONE real, specific observation. Prefer a genuine '
+        "cross-domain connection ONLY if the payload actually evidences one; otherwise state one "
+        "honest, specific fact (from the richest domain, or naming two domains separately without "
+        'implying they relate) -- never a per-domain recap, and never a fabricated link.", '
+        '"misfiled": {"found": true or false, "note_text": "the exact saved note/fact text '
+        "that looks like it belongs in a different domain than the one it's currently filed "
+        'under, copied verbatim from the payload", "from_domain": "the domain key it is '
+        'currently under (must be one of the domain keys in the payload)", "target_domain": '
+        '"the domain key it actually belongs under (must ALSO be one of the domain keys in '
+        'the payload, and different from from_domain)"}, '
+        '"suggested_prompts": ["a short first-person question (under 90 characters) the user '
+        "might genuinely want to ask a personal researcher, grounded in a specific real fact "
+        'from the payload", "..." , "..."]}\n'
+        "Only set misfiled.found to true if you can point at a specific real note text that "
+        "clearly belongs to a different domain already present in the payload -- never guess "
+        "or force one. For suggested_prompts, write exactly 3 short questions, each referencing "
+        "a different real fact from a different domain where possible (e.g. a specific dollar "
+        "amount, holding, job title, or preference) -- never generic questions that could apply "
+        "to anyone, and never invent facts not present.\n\n"
+        f"Domains: {digest_json}"
+    )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(
+                    temperature=0.4, response_mime_type="application/json"
+                ),
+            ),
+            timeout=_SAGE_BRIEFING_TIMEOUT_SECONDS,
+        )
+        raw_text = (getattr(response, "text", "") or "").strip()
+        if not raw_text:
+            return PkmSageBriefingResponse(text=_sage_fallback_text(payload))
+
+        parsed = json.loads(raw_text)
+        text = str(parsed.get("text") or "").strip()
+        if not text:
+            return PkmSageBriefingResponse(text=_sage_fallback_text(payload))
+
+        suggested_fix = None
+        misfiled = parsed.get("misfiled") or {}
+        if isinstance(misfiled, dict) and misfiled.get("found"):
+            note_text = str(misfiled.get("note_text") or "").strip()
+            from_domain = str(misfiled.get("from_domain") or "").strip()
+            target_domain = str(misfiled.get("target_domain") or "").strip()
+            if (
+                note_text
+                and from_domain in known_domains
+                and target_domain in known_domains
+                and from_domain != target_domain
+            ):
+                suggested_fix = SageSuggestedFix(
+                    note_text=note_text[:400],
+                    from_domain=from_domain,
+                    from_display_name=display_name_by_domain[from_domain],
+                    target_domain=target_domain,
+                    target_display_name=display_name_by_domain[target_domain],
+                )
+
+        raw_prompts = parsed.get("suggested_prompts") or []
+        suggested_prompts = [
+            str(p).strip()[:200] for p in raw_prompts if isinstance(p, str) and str(p).strip()
+        ][:3]
+
+        return PkmSageBriefingResponse(
+            text=text[:600], suggested_fix=suggested_fix, suggested_prompts=suggested_prompts
+        )
+    except Exception as exc:
+        logger.warning("[pkm_highlight] sage briefing generation failed: %s", exc)
+        return PkmSageBriefingResponse(text=_sage_fallback_text(payload))
+
+
+@router.post("/pkm/sage-recap", response_model=PkmSageRecapResponse)
+async def sage_recap(
+    payload: PkmSageRecapRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PkmSageRecapResponse:
+    """
+    "What's new since last time": the caller has already diffed each
+    domain's readable summary against a snapshot from the user's last
+    visit (stored client-side) and only sends the domains that actually
+    changed, each with its previous_summary and current_summary. This
+    turns that diff into a short, grounded narration -- same trust/
+    fallback shape as the other Sage endpoints above.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as the
+    other Sage endpoints above.
+    """
+    if not payload.domains:
+        return PkmSageRecapResponse(text="Nothing new since your last visit.", has_changes=False)
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        return PkmSageRecapResponse(text=_recap_fallback_text(payload), has_changes=True)
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        return PkmSageRecapResponse(text=_recap_fallback_text(payload), has_changes=True)
+
+    digest = [
+        {
+            "domain": d.domain,
+            "display_name": d.display_name,
+            "previous_summary": d.previous_summary,
+            "current_summary": d.current_summary,
+        }
+        for d in payload.domains
+    ]
+    digest_json = json.dumps(digest, default=str)[:_MAX_PAYLOAD_CHARS]
+
+    prompt = (
+        "You are Sage, a personal second-brain assistant. Below is a JSON list of life domains "
+        "that changed since the user's last visit, each with its previous_summary and "
+        "current_summary. Write 2-3 short sentences narrating what's genuinely new or changed, "
+        "using ONLY facts present in current_summary that actually differ from previous_summary. "
+        "Ignore internal field names like 'Kind', 'Status', or raw test-looking entries. "
+        "If a domain's current_summary doesn't meaningfully differ in substance from its "
+        "previous_summary, don't mention that domain at all. Never invent numbers, names, or "
+        "events not shown. Write like a person catching a friend up on what changed, not a diff "
+        "tool listing fields. Return ONLY the sentences, no quotes, no JSON, no preamble.\n\n"
+        f"Domains: {digest_json}"
+    )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(temperature=0.3),
+            ),
+            timeout=_TIMEOUT_SECONDS,
+        )
+        text = (getattr(response, "text", "") or "").strip().strip('"')
+        if not text:
+            return PkmSageRecapResponse(text=_recap_fallback_text(payload), has_changes=True)
+        return PkmSageRecapResponse(text=text[:600], has_changes=True)
+    except Exception as exc:
+        logger.warning("[pkm_highlight] sage recap generation failed: %s", exc)
+        return PkmSageRecapResponse(text=_recap_fallback_text(payload), has_changes=True)
+
+
+_SAGE_DATA_MARKER = "###SAGE_DATA###"
+
+
+def _parse_deep_extras(raw_text: str) -> tuple[str, list[SageKeyTerm], list[SageComparison], str | None]:
+    """Splits the model's trailing ###SAGE_DATA### JSON block (if present)
+    off the prose answer. Anything that fails to parse cleanly just means an
+    empty extras set -- this is a bonus on top of the real answer, never
+    something worth surfacing an error for."""
+    if _SAGE_DATA_MARKER not in raw_text:
+        return raw_text.strip(), [], [], None
+    prose, _, trailer = raw_text.partition(_SAGE_DATA_MARKER)
+    prose = prose.strip()
+    trailer = trailer.strip().strip("`")
+    if trailer.lower().startswith("json"):
+        trailer = trailer[4:].strip()
+    try:
+        parsed = json.loads(trailer)
+    except Exception:
+        return prose, [], [], None
+    if not isinstance(parsed, dict):
+        return prose, [], [], None
+
+    key_terms: list[SageKeyTerm] = []
+    for item in (parsed.get("key_terms") or [])[:4]:
+        if not isinstance(item, dict):
+            continue
+        term = str(item.get("term") or "").strip()[:80]
+        definition = str(item.get("definition") or "").strip()[:300]
+        if term and definition:
+            key_terms.append(SageKeyTerm(term=term, definition=definition))
+
+    comparisons: list[SageComparison] = []
+    for item in (parsed.get("comparisons") or [])[:5]:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("label") or "").strip()[:60]
+        value = item.get("value")
+        if not label or not isinstance(value, (int, float)):
+            continue
+        comparisons.append(SageComparison(label=label, value=float(value), unit=str(item.get("unit") or "")[:20]))
+
+    paper_search_query = parsed.get("paper_search_query")
+    paper_search_query = str(paper_search_query).strip()[:200] if isinstance(paper_search_query, str) else None
+    paper_search_query = paper_search_query or None
+
+    return prose, key_terms, comparisons, paper_search_query
+
+
+@router.post("/pkm/sage-research", response_model=PkmSageResearchResponse)
+async def sage_research(
+    payload: PkmSageResearchRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PkmSageResearchResponse:
+    """
+    Sage as an actual researcher: answers a real question using Gemini's
+    Google Search grounding (a genuine live web search, not a hallucinated
+    answer) and personalizes the framing using the user's own PKM domain
+    summaries. Every source returned is a real grounding citation from the
+    search the model actually ran.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as the other
+    Sage endpoints above -- the personalization context is personal data.
+    """
+    query = payload.query.strip()
+    if not query:
+        raise HTTPException(status_code=400, detail="Query is required")
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        raise HTTPException(status_code=503, detail="Research isn't available right now.")
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        raise HTTPException(status_code=503, detail="Research isn't available right now.")
+
+    context_digest = json.dumps(
+        [
+            {"display_name": d.display_name, "summary": d.summary}
+            for d in payload.domains
+        ],
+        default=str,
+    )[:_MAX_PAYLOAD_CHARS]
+
+    history_block = ""
+    if payload.conversation_history:
+        turns = payload.conversation_history[-4:]
+        history_lines = [
+            f"User asked: {turn.query}\nYou answered: {turn.answer[:600]}" for turn in turns
+        ]
+        history_block = (
+            "\n\nRecent conversation so far (most recent last -- use this ONLY to understand "
+            "follow-up questions like 'what about X' or 'and for Y'; if the new question stands "
+            "on its own, ignore this and just answer it):\n" + "\n\n".join(history_lines) + "\n"
+        )
+
+    if payload.mode == "challenge":
+        prompt = (
+            "You are Sage, acting as a rigorous adversarial researcher (a 'red team' pass). "
+            "You have live web search available -- use it. Do this in two clearly separated "
+            "stages, using real, current, verifiable information for both:\n\n"
+            "Stage 1 -- Thesis: give the best direct answer, recommendation, or baseline "
+            "position on the user's question, in a few short paragraphs.\n\n"
+            "Stage 2 -- Red-Team Critique: actively argue AGAINST the thesis you just gave. "
+            "Search for and surface real conflicting evidence, known failure modes, edge "
+            "cases, unstated assumptions, or credible alternative positions. Do not soften "
+            "this into a generic disclaimer -- find the strongest real counter-case you can. "
+            "If you genuinely cannot find a credible counter-case after searching, say so "
+            "plainly instead of inventing a weak one.\n\n"
+            "Format the response as markdown with exactly two headings: '## Thesis' and "
+            "'## Red-Team Critique'. Then briefly personalize the framing using ONLY the "
+            "real facts in the JSON context below if genuinely relevant (never force a "
+            "connection, never invent facts not present). Never give financial, medical, or "
+            "legal advice as a recommendation -- inform, don't prescribe. Do not fabricate "
+            "sources or facts."
+            f"{history_block}\n\n"
+            f"User's question: {query}\n\n"
+            f"Personal context (JSON, may be empty): {context_digest}"
+        )
+    elif payload.depth == "deep":
+        length_instruction = _DEEP_LENGTH_INSTRUCTIONS.get(
+            payload.length, _DEEP_LENGTH_INSTRUCTIONS["standard"]
+        )
+        prompt = (
+            "You are Sage, a personal researcher building a persistent research thread with the "
+            "user -- this isn't a quick chat answer, it's a real investigation they will keep "
+            "coming back to and building on, so a thin, generic answer fails them. Answer the "
+            "user's question below thoroughly, using real, current information -- you have live "
+            "web search available, use it. If the question is a follow-up that only makes sense "
+            "given the earlier conversation, use the conversation history below to understand what "
+            "it's actually asking, then answer the follow-up itself -- don't just repeat or "
+            "re-summarize the earlier answer.\n\n"
+            f"{length_instruction} When you cite "
+            "something specific from your search, name it inline (e.g. 'the original Transformer "
+            "paper found...') instead of leaving an uncited claim. Then briefly personalize the "
+            "framing using ONLY the real facts in the JSON context below if genuinely relevant "
+            "(never force a connection, never invent facts not present). Never give financial, "
+            "medical, or legal advice as a recommendation -- inform, don't prescribe. Do not "
+            "fabricate sources or facts.\n\n"
+            "After your full answer, on its own new line, output exactly `###SAGE_DATA###` and "
+            "then, right after it, a single JSON object (no markdown fence, no commentary after "
+            "it) with three fields:\n"
+            '- "key_terms": up to 4 objects {"term": string, "definition": string} -- ONLY for '
+            "genuinely technical or non-obvious terms you actually used above, each definition "
+            "stating ONLY what your answer already established (never new information). Use an "
+            "empty list if every term you used is already plain language.\n"
+            '- "comparisons": up to 5 objects {"label": string, "value": number, "unit": string} '
+            "-- ONLY if your answer already states real, comparable numeric facts worth a quick "
+            "visual (e.g. accuracy percentages, benchmark scores, parameter counts, latency). Every "
+            "item must share the SAME unit -- if your answer has more than one kind of number (e.g. "
+            "both a score and a distance/error metric), pick only the single most illustrative "
+            "same-unit set, don't mix different units in one list. Use an empty list if nothing in "
+            "your answer is genuinely comparable numbers -- never invent or force a number that "
+            "isn't really there.\n"
+            '- "paper_search_query": a short, well-formed academic-literature search string (e.g. '
+            "\"attention mechanism transformer sequence modeling\") ONLY if this question genuinely "
+            "has real academic papers behind it worth tracing. Use `null` if this is about "
+            "proprietary tooling, a specific product, or anything else with no real paper trail --"
+            " never invent a search query just to have one, and never use the user's raw question "
+            "verbatim (it may name things -- like a specific internal tool -- that won't match real "
+            "papers)."
+            f"{history_block}\n\n"
+            f"User's question: {query}\n\n"
+            f"Personal context (JSON, may be empty): {context_digest}"
+        )
+    else:
+        prompt = (
+            "You are Sage, a personal researcher. Answer the user's question below using real, "
+            "current information -- you have live web search available, use it. If the question "
+            "is a follow-up that only makes sense given the earlier conversation, use the "
+            "conversation history below to understand what it's actually asking, then answer "
+            "the follow-up itself -- don't just repeat or re-summarize the earlier answer. "
+            "Then briefly personalize the framing using ONLY the real facts in the JSON context "
+            "if genuinely relevant (never force a connection, never invent facts not present). "
+            "Never give financial, medical, or legal advice as a recommendation -- inform, don't "
+            "prescribe. Keep it focused and readable: a few short paragraphs, not an essay. "
+            "Do not fabricate sources or facts."
+            f"{history_block}\n\n"
+            f"User's question: {query}\n\n"
+            f"Personal context (JSON, may be empty): {context_digest}"
+        )
+
+    generation_kwargs: dict = {
+        "temperature": 0.3,
+        "tools": [genai_types.Tool(google_search=genai_types.GoogleSearch())],
+    }
+    if payload.depth == "deep":
+        timeout_seconds = _DEEP_LENGTH_TIMEOUT_SECONDS.get(payload.length, _DEEP_LENGTH_TIMEOUT_SECONDS["standard"])
+        max_output_tokens = _DEEP_LENGTH_MAX_OUTPUT_TOKENS.get(payload.length)
+        if max_output_tokens:
+            generation_kwargs["max_output_tokens"] = max_output_tokens
+    else:
+        timeout_seconds = _RESEARCH_TIMEOUT_SECONDS
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(**generation_kwargs),
+            ),
+            timeout=timeout_seconds,
+        )
+        answer = (getattr(response, "text", "") or "").strip()
+        if not answer:
+            raise HTTPException(status_code=502, detail="Sage couldn't find an answer just now.")
+
+        key_terms: list[SageKeyTerm] = []
+        comparisons: list[SageComparison] = []
+        paper_search_query: str | None = None
+        if payload.depth == "deep":
+            answer, key_terms, comparisons, paper_search_query = _parse_deep_extras(answer)
+
+        sources: list[SageResearchSource] = []
+        seen_urls: set[str] = set()
+        candidates = getattr(response, "candidates", None) or []
+        grounding_metadata = getattr(candidates[0], "grounding_metadata", None) if candidates else None
+        chunks = getattr(grounding_metadata, "grounding_chunks", None) or []
+        for chunk in chunks:
+            web = getattr(chunk, "web", None)
+            if not web:
+                continue
+            url = str(getattr(web, "uri", "") or "").strip()
+            title = str(getattr(web, "title", "") or "").strip() or url
+            if not url or url in seen_urls:
+                continue
+            seen_urls.add(url)
+            sources.append(SageResearchSource(title=title[:200], url=url))
+            if len(sources) >= 8:
+                break
+
+        answer_cap = (
+            _DEEP_LENGTH_ANSWER_CHARS.get(payload.length, _DEEP_ANSWER_CHARS)
+            if payload.depth == "deep"
+            else _ANSWER_CHARS
+        )
+        return PkmSageResearchResponse(
+            answer=answer[:answer_cap],
+            sources=sources,
+            key_terms=key_terms,
+            comparisons=comparisons,
+            paper_search_query=paper_search_query,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("[pkm_highlight] sage research failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Sage couldn't research that just now.")
+
+
+@router.post("/pkm/sage-review", response_model=PkmSageReviewResponse)
+async def sage_review(
+    payload: PkmSageReviewRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PkmSageReviewResponse:
+    """
+    Sage drafting a structured self-assessment / performance-review document
+    from real, already-saved fragments in one PKM domain (typically
+    "professional") -- the caller has already decrypted the domain client-
+    side and flattened it into plain-text fragments; this endpoint never
+    sees encrypted data, only the fragments it's given.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as the other
+    Sage endpoints above.
+    """
+    display_name = payload.display_name.strip() or payload.domain
+    fragments = [f.strip() for f in payload.fragments if f.strip()][:200]
+    if not fragments:
+        return PkmSageReviewResponse(
+            document=f"Not enough saved {display_name.lower()} history yet to draft a self-assessment."
+        )
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        return PkmSageReviewResponse(document="Review drafting isn't available right now.")
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        return PkmSageReviewResponse(document="Review drafting isn't available right now.")
+
+    fragments_text = "\n".join(f"- {f}" for f in fragments)[:_MAX_PAYLOAD_CHARS]
+
+    prompt = (
+        "You are Sage, drafting a professional self-assessment / performance-review document for "
+        f"the user, based ONLY on real notes they've saved about their {display_name} life domain "
+        "over time (each line below is one real saved fragment, in no particular order). "
+        "Rules: use ONLY facts present in the fragments -- never invent accomplishments, numbers, "
+        "dates, or outcomes not stated. Ignore fragments that look like raw test data, internal "
+        "field names, or aren't real personal facts. Structure the document with clear markdown "
+        "section headings such as Key Updates & Milestones, and Highlights -- only include a Growth "
+        "Areas section if the fragments genuinely support one, never invent generic filler for it. "
+        "If the fragments are sparse, write a short, honest document rather than padding it with "
+        "generic language -- never fabricate volume or achievements. Return the document as "
+        "markdown, no preamble, no meta-commentary about the fragments themselves.\n\n"
+        f"Saved fragments:\n{fragments_text}"
+    )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(temperature=0.3),
+            ),
+            timeout=_RESEARCH_TIMEOUT_SECONDS,
+        )
+        text = (getattr(response, "text", "") or "").strip()
+        if not text:
+            return PkmSageReviewResponse(
+                document=f"Sage couldn't draft a {display_name.lower()} self-assessment just now."
+            )
+        return PkmSageReviewResponse(document=text[:6000])
+    except Exception as exc:
+        logger.warning("[pkm_highlight] sage review generation failed: %s", exc)
+        return PkmSageReviewResponse(
+            document=f"Sage couldn't draft a {display_name.lower()} self-assessment just now."
+        )
+
+
+@router.post("/pkm/sage-thread-synthesis", response_model=PkmSageThreadSynthesisResponse)
+async def sage_thread_synthesis(
+    payload: PkmSageThreadSynthesisRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PkmSageThreadSynthesisResponse:
+    """
+    Sage keeping a running synthesis of one persistent Research Thread: a
+    short summary plus what's been established vs. what's still an open
+    question, reasoning over ONLY the real Q&A turns and traced papers the
+    caller has already accumulated for this thread (never re-fetched here --
+    this endpoint has no access to the encrypted vault, same boundary as
+    every other Sage endpoint). Refreshed on thread creation, every new
+    turn, and whenever the thread's detail view is opened.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as the other
+    Sage endpoints above.
+    """
+    if not payload.turns and not payload.traced_papers:
+        return PkmSageThreadSynthesisResponse(
+            summary=f"Ask something to get \"{payload.title}\" started.",
+            established=[],
+            open_questions=[],
+        )
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        return PkmSageThreadSynthesisResponse(summary=_thread_fallback_summary(payload))
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        return PkmSageThreadSynthesisResponse(summary=_thread_fallback_summary(payload))
+
+    digest = json.dumps(
+        {
+            "title": payload.title,
+            "turns": [
+                {"query": t.query, "answer": t.answer[:_THREAD_SYNTHESIS_TURN_ANSWER_CHARS]}
+                for t in payload.turns[-20:]
+            ],
+            "traced_papers": [
+                {"title": p.title, "year": p.year, "topic": p.topic, "cited_by_count": p.cited_by_count}
+                for p in payload.traced_papers[:30]
+            ],
+        },
+        default=str,
+    )[:_THREAD_SYNTHESIS_MAX_PAYLOAD_CHARS]
+
+    prompt = (
+        "You are Sage, keeping a running synthesis of a user's ongoing research thread. Below is "
+        "the thread's title, every question asked so far with its answer, and every paper they've "
+        "traced. Rules: use ONLY facts present in the turns/papers below -- never invent findings, "
+        "numbers, or sources not shown. Never give financial, medical, or legal advice -- observe, "
+        "don't prescribe.\n\n"
+        "Return ONLY a single JSON object (no markdown fences, no preamble) shaped exactly like:\n"
+        '{"summary": "1-2 short sentences on what this research thread is actually about and how '
+        'far it has gotten", "established": ["a short, specific thing genuinely settled by the '
+        'turns/papers so far", "..."], "open_questions": ["a short, specific thing still '
+        'unresolved or worth investigating next, grounded in what\'s already been asked/traced", '
+        '"..."]}\n'
+        "Return at most 5 established items and 4 open questions -- fewer is fine if the thread is "
+        "thin, never pad with generic filler. If there truly isn't enough here yet, say so plainly "
+        "in summary and return empty lists rather than inventing content.\n\n"
+        f"Thread: {digest}"
+    )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(
+                    temperature=0.3, response_mime_type="application/json"
+                ),
+            ),
+            timeout=_TIMEOUT_SECONDS,
+        )
+        raw_text = (getattr(response, "text", "") or "").strip()
+        if not raw_text:
+            return PkmSageThreadSynthesisResponse(summary=_thread_fallback_summary(payload))
+
+        parsed = json.loads(raw_text)
+        summary = str(parsed.get("summary") or "").strip()
+        if not summary:
+            return PkmSageThreadSynthesisResponse(summary=_thread_fallback_summary(payload))
+
+        established = [
+            str(item).strip()[:300]
+            for item in (parsed.get("established") or [])
+            if isinstance(item, str) and str(item).strip()
+        ][:5]
+        open_questions = [
+            str(item).strip()[:300]
+            for item in (parsed.get("open_questions") or [])
+            if isinstance(item, str) and str(item).strip()
+        ][:4]
+
+        return PkmSageThreadSynthesisResponse(
+            summary=summary[:600], established=established, open_questions=open_questions
+        )
+    except Exception as exc:
+        logger.warning("[pkm_highlight] sage thread synthesis failed: %s", exc)
+        return PkmSageThreadSynthesisResponse(summary=_thread_fallback_summary(payload))

--- a/consent-protocol/api/routes/kai/sage_citations.py
+++ b/consent-protocol/api/routes/kai/sage_citations.py
@@ -1,0 +1,339 @@
+# api/routes/kai/sage_citations.py
+"""
+Sage's citation-lineage explorer: real academic search plus citation-graph
+edges from OpenAlex (free, unauthenticated, no rate-limit wall) -- what a
+paper cites (references) and what cites it (cited_by), the "trace the
+lineage of an idea" half of turning Sage from a second-brain into an
+active researcher.
+
+Semantic Scholar was the original candidate but its unauthenticated tier
+returned HTTP 429 on the very first live call made while building this --
+OpenAlex covers the same graph (via its `cites:` and id filters) with no
+such wall, so it's the one actually wired up.
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from api.middleware import require_vault_owner_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_OPENALEX_BASE = "https://api.openalex.org"
+_TIMEOUT = httpx.Timeout(connect=3.0, read=8.0, write=5.0, pool=3.0)
+_USER_AGENT = "hushh-desktop-sage/1.0 (personal research assistant)"
+_MAX_SEARCH_RESULTS = 6
+_MAX_REFERENCES = 15
+_MAX_CITED_BY = 10
+_MODEL = "gemini-3.1-flash-lite"
+_INSIGHT_TIMEOUT_SECONDS = 8.0
+_WORK_SELECT_FIELDS = "id,title,display_name,publication_year,authorships,cited_by_count,primary_topic"
+_INSIGHT_SELECT_FIELDS = (
+    "id,title,display_name,publication_year,authorships,cited_by_count,"
+    "primary_topic,abstract_inverted_index,referenced_works"
+)
+
+
+class PaperSummary(BaseModel):
+    id: str
+    title: str
+    year: int | None = None
+    authors: list[str] = Field(default_factory=list)
+    cited_by_count: int = 0
+    topic: str | None = None
+
+
+class PaperSearchRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=300)
+
+
+class PaperSearchResponse(BaseModel):
+    results: list[PaperSummary] = Field(default_factory=list)
+
+
+class PaperLineageRequest(BaseModel):
+    work_id: str = Field(..., min_length=1, max_length=64)
+
+
+class PaperLineageResponse(BaseModel):
+    paper: PaperSummary
+    references: list[PaperSummary] = Field(default_factory=list)
+    cited_by: list[PaperSummary] = Field(default_factory=list)
+
+
+class PaperInsightRequest(BaseModel):
+    work_id: str = Field(..., min_length=1, max_length=64)
+
+
+class PaperInsightResponse(BaseModel):
+    insight: str
+    topic: str | None = None
+    has_abstract: bool = False
+
+
+def _short_id(raw: str) -> str:
+    """OpenAlex ids come back as full URLs (https://openalex.org/W123) --
+    normalize to the bare 'W123' form used in filter queries and our own
+    responses."""
+    return raw.rsplit("/", 1)[-1].strip()
+
+
+def _authors_from_work(work: dict) -> list[str]:
+    names: list[str] = []
+    for authorship in (work.get("authorships") or [])[:5]:
+        author = authorship.get("author") or {}
+        name = str(author.get("display_name") or "").strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def _topic_from_work(work: dict) -> str | None:
+    primary_topic = work.get("primary_topic") or {}
+    if not isinstance(primary_topic, dict):
+        return None
+    name = str(primary_topic.get("display_name") or "").strip()
+    return name or None
+
+
+def _summary_from_work(work: dict) -> PaperSummary:
+    return PaperSummary(
+        id=_short_id(str(work.get("id") or "")),
+        title=str(work.get("title") or work.get("display_name") or "Untitled").strip(),
+        year=work.get("publication_year"),
+        authors=_authors_from_work(work),
+        cited_by_count=int(work.get("cited_by_count") or 0),
+        topic=_topic_from_work(work),
+    )
+
+
+def _reconstruct_abstract(inverted_index: dict | None) -> str:
+    """OpenAlex stores abstracts as {word: [positions]} to dodge publisher
+    copyright on full-text redistribution -- this is the real abstract,
+    just word-shuffled; putting it back in order is a one-time O(n log n) sort."""
+    if not isinstance(inverted_index, dict) or not inverted_index:
+        return ""
+    positions: list[tuple[int, str]] = []
+    for word, idxs in inverted_index.items():
+        if not isinstance(idxs, list):
+            continue
+        for idx in idxs:
+            if isinstance(idx, int):
+                positions.append((idx, word))
+    positions.sort(key=lambda p: p[0])
+    return " ".join(word for _, word in positions)[:3000]
+
+
+@router.post("/sage/paper-search", response_model=PaperSearchResponse)
+async def search_papers(
+    payload: PaperSearchRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PaperSearchResponse:
+    """
+    Free-text search over OpenAlex -- returns a short candidate list for the
+    user to pick from rather than trusting the single top hit: relevance-
+    ranked full-text search on a generic title can surface an unrelated
+    paper (confirmed live while building this), so the caller always picks.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same gate as
+    every other Sage endpoint -- this is a proxy the app pays the (small)
+    external-call cost for, not something to leave open.
+    """
+    query = payload.query.strip()
+    if not query:
+        raise HTTPException(status_code=400, detail="Search text is required")
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT, headers={"User-Agent": _USER_AGENT}) as client:
+            res = await client.get(
+                f"{_OPENALEX_BASE}/works",
+                params={
+                    "search": query,
+                    "per-page": _MAX_SEARCH_RESULTS,
+                    "select": _WORK_SELECT_FIELDS,
+                },
+            )
+            res.raise_for_status()
+            data = res.json() or {}
+    except Exception as exc:
+        logger.warning("[sage_citations] paper search failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Couldn't search papers just now.")
+
+    results = [_summary_from_work(w) for w in (data.get("results") or [])]
+    return PaperSearchResponse(results=results)
+
+
+@router.post("/sage/paper-lineage", response_model=PaperLineageResponse)
+async def paper_lineage(
+    payload: PaperLineageRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PaperLineageResponse:
+    """
+    Traces one paper's citation lineage in both directions: what it cites
+    (references) and what cites it (cited_by, sorted by each citing paper's
+    own cited_by_count as a rough "which downstream work is actually core"
+    signal). Three OpenAlex calls total (the work itself, its references
+    batch-fetched by id, and its citing works), all unauthenticated.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as
+    search_papers above.
+    """
+    work_id = payload.work_id.strip()
+    if not work_id:
+        raise HTTPException(status_code=400, detail="A paper id is required")
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT, headers={"User-Agent": _USER_AGENT}) as client:
+            work_res = await client.get(f"{_OPENALEX_BASE}/works/{work_id}")
+            work_res.raise_for_status()
+            work = work_res.json() or {}
+
+            reference_ids = [_short_id(r) for r in (work.get("referenced_works") or [])][:_MAX_REFERENCES]
+            references: list[PaperSummary] = []
+            if reference_ids:
+                ref_res = await client.get(
+                    f"{_OPENALEX_BASE}/works",
+                    params={
+                        "filter": f"openalex_id:{'|'.join(reference_ids)}",
+                        "per-page": len(reference_ids),
+                        "select": _WORK_SELECT_FIELDS,
+                    },
+                )
+                if ref_res.is_success:
+                    references = [_summary_from_work(w) for w in (ref_res.json().get("results") or [])]
+
+            cited_by: list[PaperSummary] = []
+            citing_res = await client.get(
+                f"{_OPENALEX_BASE}/works",
+                params={
+                    "filter": f"cites:{work_id}",
+                    "sort": "cited_by_count:desc",
+                    "per-page": _MAX_CITED_BY,
+                    "select": _WORK_SELECT_FIELDS,
+                },
+            )
+            if citing_res.is_success:
+                cited_by = [_summary_from_work(w) for w in (citing_res.json().get("results") or [])]
+    except httpx.HTTPStatusError as exc:
+        logger.warning("[sage_citations] lineage fetch failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Couldn't trace that paper's citations just now.")
+    except Exception as exc:
+        logger.warning("[sage_citations] lineage fetch failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Couldn't trace that paper's citations just now.")
+
+    return PaperLineageResponse(
+        paper=_summary_from_work(work),
+        references=references,
+        cited_by=cited_by,
+    )
+
+
+@router.post("/sage/paper-insight", response_model=PaperInsightResponse)
+async def paper_insight(
+    payload: PaperInsightRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PaperInsightResponse:
+    """
+    Sage explaining what a traced paper actually is and why its position in
+    the citation lineage matters -- grounded in OpenAlex's real abstract
+    (reconstructed from its word-position index) and primary_topic, not a
+    guess from the title alone. Explicitly told to use ONLY the given
+    abstract/metadata, same anti-fabrication contract as every other Sage
+    endpoint; falls back to an honest, factual, non-LLM line if the
+    abstract is missing or the model call fails.
+
+    **Authentication**: Requires valid VAULT_OWNER token, same as the
+    other citation endpoints above.
+    """
+    work_id = payload.work_id.strip()
+    if not work_id:
+        raise HTTPException(status_code=400, detail="A paper id is required")
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT, headers={"User-Agent": _USER_AGENT}) as client:
+            res = await client.get(
+                f"{_OPENALEX_BASE}/works/{work_id}",
+                params={"select": _INSIGHT_SELECT_FIELDS},
+            )
+            res.raise_for_status()
+            work = res.json() or {}
+    except Exception as exc:
+        logger.warning("[sage_citations] paper-insight fetch failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Couldn't load that paper's details just now.")
+
+    title = str(work.get("title") or work.get("display_name") or "Untitled").strip()
+    year = work.get("publication_year")
+    topic = _topic_from_work(work)
+    cited_by_count = int(work.get("cited_by_count") or 0)
+    reference_count = len(work.get("referenced_works") or [])
+    abstract = _reconstruct_abstract(work.get("abstract_inverted_index"))
+    has_abstract = bool(abstract)
+
+    fallback = (
+        f"{title}{f' ({year})' if year else ''} sits in the "
+        f"{topic.lower() if topic else 'related'} literature, cited by {cited_by_count} "
+        f"other work{'s' if cited_by_count != 1 else ''} so far."
+    )
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except Exception:
+        return PaperInsightResponse(insight=fallback, topic=topic, has_abstract=has_abstract)
+
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
+    if not api_key:
+        return PaperInsightResponse(insight=fallback, topic=topic, has_abstract=has_abstract)
+
+    digest = json.dumps(
+        {
+            "title": title,
+            "year": year,
+            "authors": _authors_from_work(work)[:5],
+            "topic": topic,
+            "cited_by_count": cited_by_count,
+            "reference_count": reference_count,
+            "abstract": abstract or "(no abstract available -- rely only on title/topic/counts)",
+        },
+        default=str,
+    )[:4000]
+
+    prompt = (
+        "You are Sage, a personal researcher explaining one academic paper to someone tracing "
+        "its citation lineage. Below is real metadata for the paper, including its actual "
+        "abstract when available. Write 2-3 short sentences: (1) what the paper's real "
+        "contribution is, using ONLY what the abstract actually states -- never invent findings, "
+        "methods, or results it doesn't mention; if no abstract is given, say only what the "
+        "title/topic honestly support instead of guessing at content. (2) one sentence on how "
+        "significant its position in the citation network is, using the real cited_by_count and "
+        "reference_count given (e.g. widely-cited hub vs. a more niche or recent work). Write "
+        "like a person explaining why this paper matters, not a database dump. Return ONLY the "
+        "sentences, no quotes, no preamble, no markdown.\n\n"
+        f"Paper: {digest}"
+    )
+
+    try:
+        client = genai.Client(api_key=api_key)
+        response = await asyncio.wait_for(
+            client.aio.models.generate_content(
+                model=_MODEL,
+                contents=prompt,
+                config=genai_types.GenerateContentConfig(temperature=0.3),
+            ),
+            timeout=_INSIGHT_TIMEOUT_SECONDS,
+        )
+        text = (getattr(response, "text", "") or "").strip().strip('"')
+        return PaperInsightResponse(
+            insight=text[:500] if text else fallback, topic=topic, has_abstract=has_abstract
+        )
+    except Exception as exc:
+        logger.warning("[sage_citations] paper insight generation failed: %s", exc)
+        return PaperInsightResponse(insight=fallback, topic=topic, has_abstract=has_abstract)

--- a/consent-protocol/hushh_mcp/services/domain_contracts.py
+++ b/consent-protocol/hushh_mcp/services/domain_contracts.py
@@ -149,6 +149,14 @@ CANONICAL_DOMAIN_REGISTRY: tuple[DomainContractEntry, ...] = (
         description="Catch-all fallback for uncategorized preferences",
         status="active_fallback",
     ),
+    DomainContractEntry(
+        domain_key="research",
+        display_name="Research",
+        icon_name="flask-conical",
+        color_hex="#7C3AED",
+        description="Sage's persistent research threads: questions asked, papers traced, and running synthesis",
+        status="active_extension",
+    ),
 )
 
 CANONICAL_DOMAIN_KEYS = tuple(entry.domain_key for entry in CANONICAL_DOMAIN_REGISTRY)

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -3224,30 +3224,33 @@ class PersonalKnowledgeModelService:
             if not domain:
                 return False
 
-            domain_blob_result = await self._execute_query(
+            normalized_segment_ids = {
+                str(segment_id or "").strip().lower()
+                for segment_id in (segment_ids or [])
+                if str(segment_id or "").strip()
+            }
+
+            query = (
                 self.supabase.table("pkm_blobs")
                 .select("segment_id")
                 .eq("user_id", user_id)
                 .eq("domain", domain)
-                .order("segment_id")
             )
+            if normalized_segment_ids:
+                query = query.order("segment_id")
+            else:
+                # Common case: no segment filter, so any single row proves
+                # existence -- no need to pull every segment for the domain.
+                query = query.limit(1)
+
+            domain_blob_result = await self._execute_query(query)
             if domain_blob_result.data:
-                rows = domain_blob_result.data
-                normalized_segment_ids = sorted(
-                    {
-                        str(segment_id or "").strip().lower()
-                        for segment_id in (segment_ids or [])
-                        if str(segment_id or "").strip()
-                    }
-                )
                 if normalized_segment_ids:
-                    rows = [
-                        row
-                        for row in rows
-                        if str(row.get("segment_id") or "root").strip().lower()
+                    return any(
+                        str(row.get("segment_id") or "root").strip().lower()
                         in normalized_segment_ids
-                    ]
-                    return bool(rows)
+                        for row in domain_blob_result.data
+                    )
                 return True
 
             # Legacy fallback: domain exists only in the monolithic blob.

--- a/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
+++ b/consent-protocol/hushh_mcp/services/personal_knowledge_model_service.py
@@ -1596,11 +1596,6 @@ class PersonalKnowledgeModelService:
                 .eq("domain", canonical_domain)
                 .limit(1)
             )
-            manifest_result = await self._execute_query(manifest_query)
-            if not manifest_result.data:
-                return None
-
-            manifest_row = manifest_result.data[0]
             path_query = (
                 self.supabase.table("pkm_manifest_paths")
                 .select("*")
@@ -1608,7 +1603,6 @@ class PersonalKnowledgeModelService:
                 .eq("domain", canonical_domain)
                 .order("json_path")
             )
-            path_rows = await self._execute_query(path_query)
             scope_query = (
                 self.supabase.table("pkm_scope_registry")
                 .select("*")
@@ -1616,7 +1610,23 @@ class PersonalKnowledgeModelService:
                 .eq("domain", canonical_domain)
                 .order("scope_handle")
             )
-            scope_rows = await self._execute_query(scope_query)
+            # None of these three depend on each other's results -- only the
+            # final assembly below does. They used to run one after another
+            # (3 sequential round-trips per domain, per /pkm/metadata call),
+            # which dominated that endpoint's latency for a domain with a lot
+            # of paths (e.g. financial, 695+ distinct paths already this
+            # session). Fetching path/scope rows even when the manifest turns
+            # out not to exist is a wasted query in that rare case, but worth
+            # it for the common case where the domain does exist.
+            manifest_result, path_rows, scope_rows = await asyncio.gather(
+                self._execute_query(manifest_query),
+                self._execute_query(path_query),
+                self._execute_query(scope_query),
+            )
+            if not manifest_result.data:
+                return None
+
+            manifest_row = manifest_result.data[0]
             manifest_row["paths"] = path_rows.data or []
             manifest_row["scope_registry"] = self._normalize_scope_registry_rows(
                 domain=canonical_domain,
@@ -3190,6 +3200,65 @@ class PersonalKnowledgeModelService:
         except Exception as e:
             logger.error("pkm.get_domain_data.error: %s", e)
             return None
+
+    async def domain_data_exists(
+        self,
+        user_id: str,
+        domain: str,
+        segment_ids: list[str] | None = None,
+    ) -> bool:
+        """
+        Cheap existence check for the exact same question get_domain_data
+        answers ("does this domain have a written blob"), without paying to
+        transfer the ciphertext. Callers that only needed a bool (like
+        PkmUpgradeService._build_domain_state, which just did
+        `get_domain_data(...) is not None`) were pulling the full encrypted
+        blob for every domain on every /pkm/metadata call -- fine for small
+        domains, but pushed that endpoint to 15-20s+ once a domain (e.g.
+        financial, research) grew large. Mirrors get_domain_data's exact
+        branches so the answer can never disagree with what a real fetch
+        would find.
+        """
+        try:
+            domain = self._canonicalize_domain_key(domain)
+            if not domain:
+                return False
+
+            domain_blob_result = await self._execute_query(
+                self.supabase.table("pkm_blobs")
+                .select("segment_id")
+                .eq("user_id", user_id)
+                .eq("domain", domain)
+                .order("segment_id")
+            )
+            if domain_blob_result.data:
+                rows = domain_blob_result.data
+                normalized_segment_ids = sorted(
+                    {
+                        str(segment_id or "").strip().lower()
+                        for segment_id in (segment_ids or [])
+                        if str(segment_id or "").strip()
+                    }
+                )
+                if normalized_segment_ids:
+                    rows = [
+                        row
+                        for row in rows
+                        if str(row.get("segment_id") or "root").strip().lower()
+                        in normalized_segment_ids
+                    ]
+                    return bool(rows)
+                return True
+
+            # Legacy fallback: domain exists only in the monolithic blob.
+            index = await self.get_index_v2(user_id)
+            if index is None or domain not in index.available_domains:
+                return False
+            legacy_blob = await self.get_encrypted_data(user_id)
+            return legacy_blob is not None
+        except Exception as e:
+            logger.error("pkm.domain_data_exists.error: %s", e)
+            return False
 
     async def delete_user_data(self, user_id: str) -> bool:
         """

--- a/consent-protocol/hushh_mcp/services/pkm_upgrade_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_upgrade_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -280,6 +281,69 @@ class PkmUpgradeService:
             latest["steps"] = await self._list_steps(latest["run_id"])
         return latest
 
+    async def _build_domain_state(
+        self,
+        user_id: str,
+        domain: str,
+        summary: dict[str, Any],
+    ) -> dict[str, Any]:
+        manifest = await self.pkm_service.get_domain_manifest(user_id, domain) or {}
+        summary_projection = (
+            manifest.get("summary_projection") if isinstance(manifest, dict) else {}
+        )
+        summary_projection = summary_projection if isinstance(summary_projection, dict) else {}
+        summary_domain_version = summary.get("domain_contract_version")
+        manifest_domain_version = manifest.get("domain_contract_version")
+        summary_readable_version = summary.get("readable_summary_version")
+        manifest_readable_version = manifest.get("readable_summary_version")
+        current_domain_version = self._to_int(
+            manifest_domain_version
+            if manifest_domain_version is not None
+            else summary_domain_version,
+            0,
+        )
+        current_readable_version = self._to_int(
+            manifest_readable_version
+            if manifest_readable_version is not None
+            else summary_readable_version,
+            0,
+        )
+        target_domain_version = current_domain_contract_version(domain)
+        target_readable_version = CURRENT_READABLE_SUMMARY_VERSION
+        current_pkm_contract_version = (
+            manifest.get("pkm_contract_version")
+            or summary_projection.get("pkm_contract_version")
+            or summary.get("pkm_contract_version")
+            or "0.0.0"
+        )
+        current_readable_projection_version = (
+            manifest.get("readable_projection_version")
+            or summary_projection.get("readable_projection_version")
+            or summary.get("readable_projection_version")
+            or "0.0.0"
+        )
+        return {
+            "domain": domain,
+            "current_domain_contract_version": current_domain_version,
+            "target_domain_contract_version": target_domain_version,
+            "current_readable_summary_version": current_readable_version,
+            "target_readable_summary_version": target_readable_version,
+            "current_pkm_contract_version": str(current_pkm_contract_version),
+            "target_pkm_contract_version": CURRENT_PKM_CONTRACT_VERSION,
+            "current_readable_projection_version": str(current_readable_projection_version),
+            "target_readable_projection_version": CURRENT_READABLE_PROJECTION_VERSION,
+            "capabilities_applied": self._domain_capabilities(manifest),
+            "blocked_reasons": self._domain_blockers(manifest),
+            "upgraded_at": manifest.get("upgraded_at") or summary.get("upgraded_at"),
+            "needs_upgrade": (
+                current_domain_version < target_domain_version
+                or current_readable_version < target_readable_version
+                or str(current_pkm_contract_version) != CURRENT_PKM_CONTRACT_VERSION
+                or str(current_readable_projection_version)
+                != CURRENT_READABLE_PROJECTION_VERSION
+            ),
+        }
+
     async def build_status(self, user_id: str) -> dict[str, Any]:
         index = await self.pkm_service.get_index_v2(user_id)
         available_domains = list(index.available_domains) if index else []
@@ -307,72 +371,27 @@ class PkmUpgradeService:
             getattr(index, "model_version", None),
             max(CURRENT_PKM_MODEL_VERSION - 1, 1),
         )
-        domain_states: list[dict[str, Any]] = []
         domain_summaries = index.domain_summaries if index else {}
-        for domain in sorted(available_domains):
-            summary = (
-                domain_summaries.get(domain)
-                if isinstance(domain_summaries.get(domain), dict)
-                else {}
+        # Each domain's manifest fetch is independent of every other domain's
+        # -- this used to be a sequential for-loop doing one awaited DB round
+        # trip per domain, which is what made build_status (embedded in
+        # /pkm/metadata and hit on every single write's ensureWritableVersion
+        # check) take roughly N-domains x per-call latency. Fetching them
+        # concurrently turns that sum into a max.
+        domain_states = list(
+            await asyncio.gather(
+                *(
+                    self._build_domain_state(
+                        user_id,
+                        domain,
+                        domain_summaries.get(domain)
+                        if isinstance(domain_summaries.get(domain), dict)
+                        else {},
+                    )
+                    for domain in sorted(available_domains)
+                )
             )
-            manifest = await self.pkm_service.get_domain_manifest(user_id, domain) or {}
-            summary_projection = (
-                manifest.get("summary_projection") if isinstance(manifest, dict) else {}
-            )
-            summary_projection = summary_projection if isinstance(summary_projection, dict) else {}
-            summary_domain_version = summary.get("domain_contract_version")
-            manifest_domain_version = manifest.get("domain_contract_version")
-            summary_readable_version = summary.get("readable_summary_version")
-            manifest_readable_version = manifest.get("readable_summary_version")
-            current_domain_version = self._to_int(
-                manifest_domain_version
-                if manifest_domain_version is not None
-                else summary_domain_version,
-                0,
-            )
-            current_readable_version = self._to_int(
-                manifest_readable_version
-                if manifest_readable_version is not None
-                else summary_readable_version,
-                0,
-            )
-            target_domain_version = current_domain_contract_version(domain)
-            target_readable_version = CURRENT_READABLE_SUMMARY_VERSION
-            current_pkm_contract_version = (
-                manifest.get("pkm_contract_version")
-                or summary_projection.get("pkm_contract_version")
-                or summary.get("pkm_contract_version")
-                or "0.0.0"
-            )
-            current_readable_projection_version = (
-                manifest.get("readable_projection_version")
-                or summary_projection.get("readable_projection_version")
-                or summary.get("readable_projection_version")
-                or "0.0.0"
-            )
-            domain_states.append(
-                {
-                    "domain": domain,
-                    "current_domain_contract_version": current_domain_version,
-                    "target_domain_contract_version": target_domain_version,
-                    "current_readable_summary_version": current_readable_version,
-                    "target_readable_summary_version": target_readable_version,
-                    "current_pkm_contract_version": str(current_pkm_contract_version),
-                    "target_pkm_contract_version": CURRENT_PKM_CONTRACT_VERSION,
-                    "current_readable_projection_version": str(current_readable_projection_version),
-                    "target_readable_projection_version": CURRENT_READABLE_PROJECTION_VERSION,
-                    "capabilities_applied": self._domain_capabilities(manifest),
-                    "blocked_reasons": self._domain_blockers(manifest),
-                    "upgraded_at": manifest.get("upgraded_at") or summary.get("upgraded_at"),
-                    "needs_upgrade": (
-                        current_domain_version < target_domain_version
-                        or current_readable_version < target_readable_version
-                        or str(current_pkm_contract_version) != CURRENT_PKM_CONTRACT_VERSION
-                        or str(current_readable_projection_version)
-                        != CURRENT_READABLE_PROJECTION_VERSION
-                    ),
-                }
-            )
+        )
 
         stale_domains = [domain for domain in domain_states if domain["needs_upgrade"]]
         latest_run = await self._get_latest_run(user_id)

--- a/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-dashboard-page.test.tsx
@@ -44,11 +44,14 @@ describe("OneDashboardPage", () => {
         .getByRole("link", { name: "Open Connected Systems" })
         .getAttribute("href"),
     ).toBe(ROUTES.CONNECTED_SYSTEMS);
+    expect(
+      screen.getByRole("link", { name: "Open Sage" }).getAttribute("href"),
+    ).toBe(ROUTES.SAGE);
     expect(screen.getAllByText("Setup needed")).toHaveLength(3);
     expect(screen.getAllByText("Ready")).toHaveLength(3);
     expect(screen.getByText("2 pending")).toBeTruthy();
     expect(screen.getByText("Gmail receipts and saved knowledge.")).toBeTruthy();
-    expect(container.querySelectorAll(".morphy-ripple-host").length).toBe(7);
+    expect(container.querySelectorAll(".morphy-ripple-host").length).toBe(8);
     expect(screen.queryByRole("link", { name: "Open One Agent" })).toBeNull();
   });
 

--- a/hushh-webapp/app/globals.css
+++ b/hushh-webapp/app/globals.css
@@ -2219,6 +2219,22 @@ body:has([data-one-market-surface="true"]) .bar-glass-top {
   animation: stage-pulse 1.5s ease-in-out infinite;
 }
 
+/* Indeterminate progress sweep -- for long-running single-call research
+   requests (Sage deep-mode / exhaustive length can legitimately run past a
+   minute) where no real step-by-step progress exists to report. */
+@keyframes sage-progress-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(300%);
+  }
+}
+
+.animate-sage-progress-sweep {
+  animation: sage-progress-sweep 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
 /* Ensure spinner utilities always rotate in runtime (vault/auth/load states). */
 @keyframes hushh-spin-fallback {
   to {

--- a/hushh-webapp/app/one/page.tsx
+++ b/hushh-webapp/app/one/page.tsx
@@ -8,12 +8,14 @@ import { NativeRouteMarker } from "@/components/app-ui/native-route-marker";
 import { OneDashboardPage } from "@/components/dashboard/one-dashboard-page";
 import { useConsentPendingSummaryCount } from "@/lib/consent/use-consent-pending-summary-count";
 import { useAuth } from "@/lib/firebase/auth-context";
+import { useVault } from "@/lib/vault/vault-context";
 import { ROUTES } from "@/lib/navigation/routes";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 
 export default function OneHomePage() {
   const router = useRouter();
   const { user, loading } = useAuth();
+  const { vaultOwnerToken } = useVault();
   const pendingConsents = useConsentPendingSummaryCount();
   const [oneSetupResolved, setOneSetupResolved] = useState<boolean | null>(
     null,
@@ -69,6 +71,8 @@ export default function OneHomePage() {
         displayName={user.displayName || user.email}
         pendingConsents={pendingConsents}
         oneSetupResolved={oneSetupResolved}
+        userId={user.uid}
+        vaultOwnerToken={vaultOwnerToken}
       />
     </>
   );

--- a/hushh-webapp/app/one/sage/ask/page.tsx
+++ b/hushh-webapp/app/one/sage/ask/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Search } from "lucide-react";
+
+import { AppPageContentRegion, AppPageHeaderRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AskSagePanel } from "@/components/sage/ask-sage-panel";
+import { useAuth } from "@/hooks/use-auth";
+import { useSageDomains } from "@/hooks/use-sage-domains";
+
+export default function SageAskPage() {
+  const { user } = useAuth();
+  const { domains, loading } = useSageDomains();
+  const searchParams = useSearchParams();
+  const initialQuery = searchParams.get("q") || undefined;
+  const autoAsk = searchParams.get("auto") === "1";
+
+  return (
+    <AppPageShell
+      as="main"
+      width="standard"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      nativeTest={{
+        routeId: "/one/sage/ask",
+        marker: "native-route-sage-ask",
+        authState: user ? "authenticated" : "pending",
+        dataState: "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          eyebrow="One / Sage"
+          title="Ask Sage"
+          description="A real question, researched live and personalized against what Sage knows about you -- ask a follow-up any time."
+          icon={Search}
+          accent="violet"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        {loading ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <AskSagePanel domains={domains} initialQuery={initialQuery} autoAsk={autoAsk} />
+        )}
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/app/one/sage/citations/page.tsx
+++ b/hushh-webapp/app/one/sage/citations/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { GitBranch } from "lucide-react";
+
+import { AppPageContentRegion, AppPageHeaderRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { CitationLineagePanel } from "@/components/sage/citation-lineage-panel";
+import { useAuth } from "@/hooks/use-auth";
+
+export default function SageCitationsPage() {
+  const { user } = useAuth();
+
+  return (
+    <AppPageShell
+      as="main"
+      width="expanded"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      nativeTest={{
+        routeId: "/one/sage/citations",
+        marker: "native-route-sage-citations",
+        authState: user ? "authenticated" : "pending",
+        dataState: "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          eyebrow="One / Sage"
+          title="Citation lineage"
+          description="Trace a paper's real citation graph -- what it builds on, and what builds on it."
+          icon={GitBranch}
+          accent="violet"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        <CitationLineagePanel />
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/app/one/sage/notes/page.tsx
+++ b/hushh-webapp/app/one/sage/notes/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { BookOpen } from "lucide-react";
+
+import { AppPageContentRegion, AppPageHeaderRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { NotesArchivePanel } from "@/components/sage/notes-archive-panel";
+import { useAuth } from "@/hooks/use-auth";
+
+export default function SageNotesPage() {
+  const { user } = useAuth();
+
+  return (
+    <AppPageShell
+      as="main"
+      width="standard"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      nativeTest={{
+        routeId: "/one/sage/notes",
+        marker: "native-route-sage-notes",
+        authState: user ? "authenticated" : "pending",
+        dataState: "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          eyebrow="One / Sage"
+          title="Notes archive"
+          description="Every raw note Kai has captured in your own words, across every domain, searchable in one place."
+          icon={BookOpen}
+          accent="violet"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        <NotesArchivePanel />
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/app/one/sage/page.tsx
+++ b/hushh-webapp/app/one/sage/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+
+import { AppPageContentRegion, AppPageHeaderRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { SagePanel } from "@/components/sage/sage-panel";
+import { useAuth } from "@/hooks/use-auth";
+
+export default function SagePage() {
+  const { user } = useAuth();
+
+  return (
+    <AppPageShell
+      as="main"
+      width="standard"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      nativeTest={{
+        routeId: "/one/sage",
+        marker: "native-route-sage",
+        authState: user ? "authenticated" : "pending",
+        dataState: "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          eyebrow="One / Sage"
+          title="Sage"
+          description="Your personal researcher and second brain -- reads across everything Hushh knows about you and surfaces what actually connects."
+          icon={Sparkles}
+          accent="violet"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        <SagePanel />
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/app/one/sage/review/page.tsx
+++ b/hushh-webapp/app/one/sage/review/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { FileText } from "lucide-react";
+
+import { AppPageContentRegion, AppPageHeaderRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SelfReviewPanel } from "@/components/sage/self-review-panel";
+import { useAuth } from "@/hooks/use-auth";
+import { useSageDomains } from "@/hooks/use-sage-domains";
+
+export default function SageReviewPage() {
+  const { user } = useAuth();
+  const { domains, loading } = useSageDomains();
+
+  return (
+    <AppPageShell
+      as="main"
+      width="standard"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      nativeTest={{
+        routeId: "/one/sage/review",
+        marker: "native-route-sage-review",
+        authState: user ? "authenticated" : "pending",
+        dataState: "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          eyebrow="One / Sage"
+          title="Self-assessment"
+          description="Sage drafts a structured self-assessment from your real accumulated history -- only what you've actually told Kai, nothing invented."
+          icon={FileText}
+          accent="violet"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        {loading ? <Skeleton className="h-64 w-full" /> : <SelfReviewPanel domains={domains} />}
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/app/one/sage/threads/page.tsx
+++ b/hushh-webapp/app/one/sage/threads/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { FlaskConical } from "lucide-react";
+
+import { AppPageContentRegion, AppPageHeaderRegion, AppPageShell } from "@/components/app-ui/app-page-shell";
+import { PageHeader } from "@/components/app-ui/page-sections";
+import { ResearchThreadsPanel } from "@/components/sage/research-threads-panel";
+import { useAuth } from "@/hooks/use-auth";
+
+export default function SageThreadsPage() {
+  const { user } = useAuth();
+
+  return (
+    <AppPageShell
+      as="main"
+      width="expanded"
+      className="pb-[calc(var(--app-bottom-fixed-ui,96px)+1.25rem)] sm:pb-10 md:pb-8"
+      nativeTest={{
+        routeId: "/one/sage/threads",
+        marker: "native-route-sage-threads",
+        authState: user ? "authenticated" : "pending",
+        dataState: "loaded",
+      }}
+    >
+      <AppPageHeaderRegion>
+        <PageHeader
+          eyebrow="One / Sage"
+          title="Research threads"
+          description="An ongoing investigation Sage keeps working on with you -- questions asked, papers traced, and what's still open."
+          icon={FlaskConical}
+          accent="violet"
+        />
+      </AppPageHeaderRegion>
+      <AppPageContentRegion>
+        <ResearchThreadsPanel />
+      </AppPageContentRegion>
+    </AppPageShell>
+  );
+}

--- a/hushh-webapp/components/dashboard/agent-card.tsx
+++ b/hushh-webapp/components/dashboard/agent-card.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+import { ArrowRight, type LucideIcon } from "lucide-react";
+
+import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
+import { cn } from "@/lib/utils";
+
+export type AgentCardTone = "finance" | "sage";
+
+const ACCENT_BAR_CLASS_BY_TONE: Record<AgentCardTone, string> = {
+  finance: "bg-gradient-to-r from-emerald-500 to-teal-400",
+  sage: "bg-gradient-to-r from-violet-500 to-purple-400",
+};
+
+const ICON_CLASS_BY_TONE: Record<AgentCardTone, string> = {
+  finance: "bg-emerald-500/12 text-emerald-700 dark:text-emerald-300",
+  sage: "bg-violet-500/12 text-violet-700 dark:text-violet-300",
+};
+
+const BORDER_CLASS_BY_TONE: Record<AgentCardTone, string> = {
+  finance:
+    "border-emerald-500/24 hover:border-emerald-500/50 dark:border-emerald-400/20 dark:hover:border-emerald-300/44",
+  sage:
+    "border-violet-500/24 hover:border-violet-500/50 dark:border-violet-400/20 dark:hover:border-violet-300/44",
+};
+
+const METRIC_TONE_CLASS: Record<AgentCardTone, string> = {
+  finance: "text-emerald-700 dark:text-emerald-300",
+  sage: "text-violet-700 dark:text-violet-300",
+};
+
+const META_DOT_CLASS_BY_TONE: Record<AgentCardTone, string> = {
+  finance: "bg-emerald-500",
+  sage: "bg-violet-500",
+};
+
+/**
+ * A "quiet background agent" summary tile for the dashboard's Today
+ * section: a live metric, a one-line insight, and when it last checked --
+ * as opposed to ModeTile, which just links to a static workflow. Carries
+ * a top accent bar and tone-colored metric so it reads as a live widget,
+ * not another static launcher tile.
+ */
+export function AgentCard({
+  icon: Icon,
+  tone,
+  title,
+  metricLabel,
+  metric,
+  insight,
+  meta,
+  href,
+  loading = false,
+}: {
+  icon: LucideIcon;
+  tone: AgentCardTone;
+  title: string;
+  metricLabel?: string;
+  metric?: string | null;
+  insight: string;
+  meta?: string | null;
+  href: string;
+  loading?: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-label={`Open ${title}`}
+      className={cn(
+        "group relative isolate flex min-h-[9.5rem] flex-col gap-2.5 overflow-hidden rounded-xl border bg-card/85 p-4 text-left shadow-[0_1px_2px_rgba(15,23,42,0.06)] transition-[background-color,border-color,box-shadow,transform] duration-200 hover:-translate-y-[1px] hover:bg-card hover:shadow-[0_18px_36px_-24px_rgba(15,23,42,0.5)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        BORDER_CLASS_BY_TONE[tone],
+      )}
+    >
+      <span
+        className={cn("absolute inset-x-0 top-0 h-[3px]", ACCENT_BAR_CLASS_BY_TONE[tone])}
+        aria-hidden
+      />
+      <MaterialRipple variant="link" effect="glass" className="rounded-xl" />
+      <span className="flex items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+              ICON_CLASS_BY_TONE[tone],
+            )}
+          >
+            <Icon className="h-4 w-4" aria-hidden />
+          </span>
+          <span className="truncate text-[15px] font-semibold leading-5 text-foreground">
+            {title}
+          </span>
+        </span>
+        <ArrowRight
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-foreground"
+          aria-hidden
+        />
+      </span>
+
+      {metric ? (
+        <span className="flex items-baseline gap-1.5">
+          <span
+            className={cn(
+              "text-[1.7rem] font-semibold leading-8 tabular-nums",
+              METRIC_TONE_CLASS[tone],
+            )}
+          >
+            {metric}
+          </span>
+          {metricLabel ? (
+            <span className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground/70">
+              {metricLabel}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+
+      <span className="line-clamp-2 text-sm leading-5 text-muted-foreground">
+        {loading ? "Checking…" : insight}
+      </span>
+
+      {meta ? (
+        <span className="mt-auto flex items-center gap-1.5 text-xs text-muted-foreground/80">
+          <span
+            className={cn("h-1.5 w-1.5 shrink-0 rounded-full", META_DOT_CLASS_BY_TONE[tone])}
+            aria-hidden
+          />
+          {meta}
+        </span>
+      ) : null}
+    </Link>
+  );
+}

--- a/hushh-webapp/components/dashboard/one-dashboard-page.tsx
+++ b/hushh-webapp/components/dashboard/one-dashboard-page.tsx
@@ -23,6 +23,7 @@ import {
 import { PageHeader, SectionHeader } from "@/components/app-ui/page-sections";
 import { SurfaceStack } from "@/components/app-ui/surfaces";
 import { Badge } from "@/components/ui/badge";
+import { TodaySection } from "@/components/dashboard/today-section";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
 import { ROUTES } from "@/lib/navigation/routes";
@@ -285,10 +286,14 @@ export function OneDashboardPage({
   displayName,
   pendingConsents = 0,
   oneSetupResolved = null,
+  userId = null,
+  vaultOwnerToken = null,
 }: {
   displayName?: string | null;
   pendingConsents?: number;
   oneSetupResolved?: boolean | null;
+  userId?: string | null;
+  vaultOwnerToken?: string | null;
 }) {
   const firstName =
     String(displayName || "")
@@ -331,6 +336,7 @@ export function OneDashboardPage({
 
       <AppPageContentRegion>
         <SurfaceStack compact className="gap-4">
+          <TodaySection userId={userId} vaultOwnerToken={vaultOwnerToken} />
           <ModeSection
             title="Workflows"
             description="Finance, email, location, and connected systems."

--- a/hushh-webapp/components/dashboard/today-section.tsx
+++ b/hushh-webapp/components/dashboard/today-section.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+import { AgentCard } from "@/components/dashboard/agent-card";
+import { SectionHeader } from "@/components/app-ui/page-sections";
+import { ApiService } from "@/lib/services/api-service";
+import { AppBackgroundTaskService } from "@/lib/services/app-background-task-service";
+import { PersonalKnowledgeModelService } from "@/lib/services/personal-knowledge-model-service";
+import { ROUTES } from "@/lib/navigation/routes";
+
+function sageFixSeenKey(userId: string): string {
+  return `sage_fix_seen_v1_${userId}`;
+}
+
+// Sage's "active" surface: rather than re-announcing the same passive take
+// every time the dashboard loads, only push a bell notification when the
+// specific suggested fix is new (or has changed) since the last time this
+// user saw one -- avoids repeat-notifying for the same unresolved item on
+// every /one visit.
+function notifyIfNewSageFix(params: {
+  userId: string;
+  fix: { note_text?: string; from_display_name?: string; target_domain?: string; target_display_name?: string } | null | undefined;
+}): void {
+  if (typeof window === "undefined") return;
+  const key = sageFixSeenKey(params.userId);
+  const fix = params.fix;
+  const signature = fix?.note_text && fix?.target_domain ? `${fix.target_domain}::${fix.note_text}` : "";
+
+  let lastSeen: string | null = null;
+  try {
+    lastSeen = window.localStorage.getItem(key);
+  } catch {
+    lastSeen = null;
+  }
+
+  if (signature && signature !== lastSeen) {
+    const taskId = AppBackgroundTaskService.startTask({
+      userId: params.userId,
+      kind: "sage_fix",
+      title: "Sage found something to fix",
+      description: `"${fix?.note_text}" looks filed under ${fix?.from_display_name}, not ${fix?.target_display_name}.`,
+      routeHref: ROUTES.SAGE,
+      visibility: "primary",
+    });
+    AppBackgroundTaskService.completeTask(taskId);
+  }
+
+  try {
+    if (signature) {
+      window.localStorage.setItem(key, signature);
+    } else {
+      window.localStorage.removeItem(key);
+    }
+  } catch {
+    // Best-effort only -- a missed write just means this fix may re-notify once more.
+  }
+}
+
+type CardState = {
+  loading: boolean;
+  metric: string | null;
+  insight: string;
+  meta: string | null;
+};
+
+const SAGE_IDLE: CardState = {
+  loading: true,
+  metric: null,
+  insight: "Reading across everything Hushh knows about you…",
+  meta: null,
+};
+
+function useSageCard(userId: string | null, vaultOwnerToken: string | null): CardState {
+  const [state, setState] = useState<CardState>(SAGE_IDLE);
+
+  useEffect(() => {
+    if (!userId || !vaultOwnerToken) {
+      setState((prev) => ({ ...prev, loading: false }));
+      return;
+    }
+
+    let cancelled = false;
+
+    async function run() {
+      try {
+        const metadata = await PersonalKnowledgeModelService.getMetadata(
+          userId as string,
+          false,
+          vaultOwnerToken as string,
+        );
+        if (cancelled) return;
+
+        if (metadata.domains.length === 0) {
+          setState({
+            loading: false,
+            metric: null,
+            insight: "Sage is still getting to know you.",
+            meta: null,
+          });
+          return;
+        }
+
+        const briefingResponse = await ApiService.summarizeSageBriefing({
+          vaultOwnerToken: vaultOwnerToken as string,
+          domains: metadata.domains.map((d) => ({
+            domain: d.key,
+            displayName: d.displayName,
+            summary: d.summary,
+            attributeCount: d.attributeCount,
+            lastUpdated: d.readableUpdatedAt || d.lastUpdated,
+          })),
+        });
+        if (cancelled) return;
+
+        const briefingData = briefingResponse.ok ? await briefingResponse.json() : null;
+        notifyIfNewSageFix({ userId: userId as string, fix: briefingData?.suggested_fix });
+        setState({
+          loading: false,
+          metric: String(metadata.totalAttributes),
+          insight: briefingData?.text || "Not enough saved detail yet for a cross-domain read.",
+          meta: `${metadata.domains.length} area${metadata.domains.length === 1 ? "" : "s"} of your life`,
+        });
+      } catch {
+        if (!cancelled) {
+          setState({
+            loading: false,
+            metric: null,
+            insight: "Couldn't load Sage right now.",
+            meta: null,
+          });
+        }
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, vaultOwnerToken]);
+
+  return state;
+}
+
+/**
+ * "Today" board: Sage surfaced as a glanceable, quiet background-agent card,
+ * above the static Workflows/Memory/Access tile grid -- the web counterpart
+ * to desktop's Today section (Market Watch isn't part of this port; it's a
+ * desktop/Electron-only surface).
+ */
+export function TodaySection({
+  userId,
+  vaultOwnerToken,
+}: {
+  userId: string | null;
+  vaultOwnerToken: string | null;
+}) {
+  const sage = useSageCard(userId, vaultOwnerToken);
+
+  return (
+    <section
+      aria-labelledby="one-section-today"
+      className="space-y-3 rounded-2xl border border-emerald-500/14 bg-gradient-to-b from-emerald-500/[0.05] to-transparent p-3 dark:border-emerald-400/12 dark:from-emerald-400/[0.04] sm:p-4"
+    >
+      <SectionHeader
+        id="one-section-today"
+        title="Today"
+        description="What Hushh has been keeping an eye on for you."
+        icon={Sparkles}
+        accent="emerald"
+        className="px-0"
+        testId="one-today-section"
+      />
+      <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-3">
+        <AgentCard
+          icon={Sparkles}
+          tone="sage"
+          title="Sage"
+          metricLabel="Saved details"
+          metric={sage.metric}
+          insight={sage.insight}
+          meta={sage.meta}
+          href={ROUTES.SAGE}
+          loading={sage.loading}
+        />
+      </div>
+    </section>
+  );
+}

--- a/hushh-webapp/components/sage/add-note-panel.tsx
+++ b/hushh-webapp/components/sage/add-note-panel.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { NotebookPen } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { addNoteEntity, buildSageNoteSummaryPatch } from "@/lib/sage/add-note-entity";
+import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+/**
+ * A direct, real write into any domain -- same addNoteEntity +
+ * buildSageNoteSummaryPatch + PkmWriteCoordinator path already proven by
+ * Sage's other save actions tonight, just exposed as its own small tool
+ * instead of being wedged into Ask Sage or the misfiled-note fix. Useful
+ * for quickly adding real texture to a thin domain (e.g. for a demo)
+ * without needing Kai chat.
+ */
+export function AddNotePanel({
+  domains,
+  onSaved,
+}: {
+  domains: DomainSummary[];
+  onSaved?: () => void;
+}) {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  const [domainKey, setDomainKey] = useState(domains[0]?.key || "");
+  const [text, setText] = useState("");
+  const [state, setState] = useState<SaveState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveDomainKey = domainKey || domains[0]?.key || "";
+  const domain = domains.find((d) => d.key === effectiveDomainKey);
+
+  async function handleSave() {
+    const trimmed = text.trim();
+    if (!trimmed || !user?.uid || !vaultKey || !vaultOwnerToken || !domain) return;
+    setState("saving");
+    setError(null);
+    try {
+      // Re-fetch live rather than trusting the `domains` prop -- adding two
+      // notes to the same domain back to back (before the parent's onSaved
+      // refresh lands) would otherwise silently overwrite the first note's
+      // highlight line, since readable_highlights is replaced wholesale on
+      // write, not merged server-side.
+      const freshDomains = await PersonalKnowledgeModelService.getMetadata(user.uid, true, vaultOwnerToken)
+        .then((m) => m.domains)
+        .catch(() => domains);
+      const freshDomain = freshDomains.find((d) => d.key === domain.key) || domain;
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: domain.key,
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => ({
+          domainData: addNoteEntity(context.currentDomainData, trimmed, "sage_manual"),
+          summary: {
+            source: "sage_manual",
+            message_excerpt: trimmed.slice(0, 160),
+            ...buildSageNoteSummaryPatch({
+              displayName: freshDomain.displayName,
+              existingHighlights: freshDomain.readableHighlights || [],
+              noteText: trimmed,
+            }),
+          },
+        }),
+      });
+      if (!result.success) {
+        setState("error");
+        setError(result.message || "Couldn't save that just now.");
+        return;
+      }
+      setState("saved");
+      setText("");
+      onSaved?.();
+    } catch (err) {
+      setState("error");
+      setError(err instanceof Error ? err.message : "Couldn't save that just now.");
+    }
+  }
+
+  if (domains.length === 0) return null;
+
+  return (
+    <div className="rounded-2xl border border-violet-500/25 bg-card/85 p-4 shadow-[0_1px_2px_rgba(15,23,42,0.06)] sm:p-5">
+      <div className="flex items-center gap-2 text-sm font-semibold text-violet-700 dark:text-violet-300">
+        <NotebookPen className="h-4 w-4" aria-hidden />
+        Add a note
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Write a real note straight into a domain -- the same safe write path Sage uses everywhere
+        else.
+      </p>
+
+      <div className="mt-3 flex flex-col gap-2">
+        <select
+          value={effectiveDomainKey}
+          onChange={(event) => {
+            setDomainKey(event.target.value);
+            setState("idle");
+          }}
+          className="h-10 w-full rounded-md border border-border/60 bg-card px-3 text-sm text-foreground sm:w-auto"
+        >
+          {domains.map((d) => (
+            <option key={d.key} value={d.key}>
+              {d.displayName}
+            </option>
+          ))}
+        </select>
+        <Textarea
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          placeholder="e.g. Bought running shoes and a winter jacket from REI last week, about $310 total."
+          className="min-h-[3rem] resize-none"
+          rows={2}
+        />
+        <Button onClick={() => void handleSave()} disabled={state === "saving" || !text.trim()} className="sm:w-auto">
+          {state === "saving" ? "Saving…" : "Save note"}
+        </Button>
+      </div>
+
+      {state === "saved" ? (
+        <p className="mt-2 text-sm text-emerald-600 dark:text-emerald-400">Saved to {domain?.displayName}.</p>
+      ) : null}
+      {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/ask-sage-panel.tsx
+++ b/hushh-webapp/components/sage/ask-sage-panel.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ExternalLink, Search, Swords } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { ApiService } from "@/lib/services/api-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { addNoteEntity, buildSageNoteSummaryPatch } from "@/lib/sage/add-note-entity";
+import { SageMarkdown } from "@/components/sage/sage-markdown";
+import { SageLoadingIndicator } from "@/components/sage/sage-loading-indicator";
+import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
+import { cn } from "@/lib/utils";
+
+type ResearchSource = { title: string; url: string };
+
+type ResearchResult = {
+  id: string;
+  query: string;
+  answer: string;
+  sources: ResearchSource[];
+  saveState: "idle" | "saving" | "saved" | "error";
+  challenged: boolean;
+};
+
+const MAX_HISTORY = 5;
+const MAX_CONVERSATION_TURNS = 4;
+
+/**
+ * Sage as an actual researcher: a real question in, a real Gemini call with
+ * live Google Search grounding out, personalized against the user's own PKM
+ * summaries. This is the "active" half of Sage -- the rest of the page is
+ * Sage reading your existing data; this is Sage going and doing new work.
+ */
+export function AskSagePanel({
+  domains,
+  suggestedPrompts = [],
+  initialQuery,
+  autoAsk = false,
+}: {
+  domains: DomainSummary[];
+  suggestedPrompts?: string[];
+  /** Pre-fills the query box (e.g. from a suggested-prompt deep link) --
+   * never auto-submits on its own, the user still hits Ask themselves. */
+  initialQuery?: string;
+  /** Asks `initialQuery` automatically on mount -- for the home page's own
+   * quick-ask box, where the user already typed a real question and
+   * submitted it, vs. a suggested-prompt chip, which only pre-fills. */
+  autoAsk?: boolean;
+}) {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  const [query, setQuery] = useState(initialQuery || "");
+  const [asking, setAsking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [results, setResults] = useState<ResearchResult[]>([]);
+  const [saveDomain, setSaveDomain] = useState<string>(domains[0]?.key || "");
+  const [challengeMode, setChallengeMode] = useState(false);
+  const autoAsked = useRef(false);
+
+  const effectiveSaveDomain = saveDomain || domains[0]?.key || "";
+
+  async function handleAsk(overrideQuery?: string) {
+    const trimmed = (overrideQuery ?? query).trim();
+    if (!trimmed || !vaultOwnerToken || asking) return;
+    setAsking(true);
+    setError(null);
+    try {
+      const conversationHistory = results
+        .slice(0, MAX_CONVERSATION_TURNS)
+        .slice()
+        .reverse()
+        .map((r) => ({ query: r.query, answer: r.answer }));
+      const response = await ApiService.askSage({
+        vaultOwnerToken,
+        query: trimmed,
+        mode: challengeMode ? "challenge" : "standard",
+        domains: domains.map((d) => ({
+          domain: d.key,
+          displayName: d.displayName,
+          summary: d.summary,
+          attributeCount: d.attributeCount,
+        })),
+        conversationHistory,
+      });
+      if (!response.ok) {
+        const detail = await response.json().catch(() => null);
+        throw new Error(detail?.detail || "Sage couldn't research that just now.");
+      }
+      const data = await response.json();
+      setResults((prev) =>
+        [
+          {
+            id: `${Date.now()}`,
+            query: trimmed,
+            answer: String(data.answer || ""),
+            sources: Array.isArray(data.sources) ? data.sources : [],
+            saveState: "idle" as const,
+            challenged: challengeMode,
+          },
+          ...prev,
+        ].slice(0, MAX_HISTORY),
+      );
+      setQuery("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sage couldn't research that just now.");
+    } finally {
+      setAsking(false);
+    }
+  }
+
+  // Fires the pre-filled query automatically once the vault token is ready
+  // (it isn't necessarily available on the very first render) -- guarded by
+  // a ref so a later vaultOwnerToken change (e.g. a refresh) never re-asks.
+  useEffect(() => {
+    if (!autoAsk || !initialQuery?.trim() || !vaultOwnerToken || autoAsked.current) return;
+    autoAsked.current = true;
+    void handleAsk(initialQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoAsk, initialQuery, vaultOwnerToken]);
+
+  async function handleSave(resultId: string) {
+    const result = results.find((r) => r.id === resultId);
+    if (!result || !user?.uid || !vaultKey || !vaultOwnerToken || !effectiveSaveDomain) return;
+
+    setResults((prev) => prev.map((r) => (r.id === resultId ? { ...r, saveState: "saving" } : r)));
+    try {
+      const noteText = `Asked Sage: "${result.query}" — ${result.answer}`.slice(0, 1200);
+      // Re-fetch live rather than trusting the `domains` prop (a one-time
+      // page-load snapshot) -- readable_highlights is replaced wholesale on
+      // write, not merged server-side, so saving a second result to the same
+      // domain in one sitting against a stale snapshot silently overwrote the
+      // first save's highlight line.
+      const freshDomains = await PersonalKnowledgeModelService.getMetadata(user.uid, true, vaultOwnerToken)
+        .then((m) => m.domains)
+        .catch(() => domains);
+      const targetDomain = freshDomains.find((d) => d.key === effectiveSaveDomain) || domains.find((d) => d.key === effectiveSaveDomain);
+      const writeResult = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: effectiveSaveDomain,
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => ({
+          domainData: addNoteEntity(context.currentDomainData, noteText, "sage_research"),
+          summary: {
+            source: "sage_research",
+            message_excerpt: noteText.slice(0, 160),
+            ...buildSageNoteSummaryPatch({
+              displayName: targetDomain?.displayName || effectiveSaveDomain,
+              existingHighlights: targetDomain?.readableHighlights || [],
+              noteText,
+            }),
+          },
+        }),
+      });
+      setResults((prev) =>
+        prev.map((r) => (r.id === resultId ? { ...r, saveState: writeResult.success ? "saved" : "error" } : r)),
+      );
+    } catch {
+      setResults((prev) => prev.map((r) => (r.id === resultId ? { ...r, saveState: "error" } : r)));
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-violet-500/25 bg-card/85 p-4 shadow-[0_1px_2px_rgba(15,23,42,0.06)] sm:p-5">
+      <div className="flex items-center gap-2 text-sm font-semibold text-violet-700 dark:text-violet-300">
+        <Search className="h-4 w-4" aria-hidden />
+        Ask Sage
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Ask a real question. Sage researches it live and personalizes the answer against what it
+        knows about you. Ask a follow-up any time -- Sage remembers what you just asked.
+      </p>
+
+      {suggestedPrompts.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {suggestedPrompts.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              onClick={() => {
+                setQuery(prompt);
+                void handleAsk(prompt);
+              }}
+              disabled={asking}
+              className="rounded-full border border-border/60 bg-card px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-violet-500/40 hover:text-foreground disabled:opacity-60"
+            >
+              {prompt}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end">
+        <Textarea
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void handleAsk();
+            }
+          }}
+          placeholder={
+            results.length > 0
+              ? "Ask a follow-up, e.g. what about international equities?"
+              : "e.g. What should I know about rebalancing a portfolio like mine?"
+          }
+          className="min-h-[2.75rem] flex-1 resize-none"
+          rows={2}
+        />
+        <Button onClick={() => void handleAsk()} disabled={asking || !query.trim()} className="sm:w-auto">
+          {asking ? "Researching…" : "Ask"}
+        </Button>
+      </div>
+
+      <SageLoadingIndicator active={asking} expectedSeconds={challengeMode ? 25 : 12} />
+
+      <button
+        type="button"
+        onClick={() => setChallengeMode((prev) => !prev)}
+        className={cn(
+          "mt-2.5 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors",
+          challengeMode
+            ? "border-orange-500/40 bg-orange-500/10 text-orange-700 dark:border-orange-400/40 dark:text-orange-300"
+            : "border-border/60 bg-card text-muted-foreground hover:border-violet-500/40 hover:text-foreground",
+        )}
+        aria-pressed={challengeMode}
+      >
+        <Swords className="h-3 w-3" aria-hidden />
+        Challenge Mode
+      </button>
+      {challengeMode ? (
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          Sage will argue against its own answer and actively search for the strongest real
+          counter-case.
+        </p>
+      ) : null}
+      {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+
+      {results.length > 0 ? (
+        <div className="mt-4 space-y-3">
+          {results.map((result) => (
+            <div
+              key={result.id}
+              className="rounded-xl border border-border/60 bg-background/60 p-3.5 sm:p-4"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-medium text-foreground">{result.query}</p>
+                {result.challenged ? (
+                  <span className="inline-flex items-center gap-1 rounded-full border border-orange-500/30 bg-orange-500/10 px-2 py-0.5 text-[11px] font-medium text-orange-700 dark:border-orange-400/30 dark:text-orange-300">
+                    <Swords className="h-2.5 w-2.5" aria-hidden />
+                    Challenge Mode
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-2 border-t border-border/50 pt-2">
+                <SageMarkdown text={result.answer} />
+              </div>
+
+              {result.sources.length > 0 ? (
+                <div className="mt-2.5 flex flex-wrap gap-1.5 border-t border-border/50 pt-2.5">
+                  {result.sources.map((source) => (
+                    <a
+                      key={source.url}
+                      href={source.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-card px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:border-violet-500/40 hover:text-foreground"
+                    >
+                      {source.title}
+                      <ExternalLink className="h-3 w-3" aria-hidden />
+                    </a>
+                  ))}
+                </div>
+              ) : null}
+
+              {domains.length > 0 ? (
+                <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/50 pt-2.5">
+                  <select
+                    value={effectiveSaveDomain}
+                    onChange={(event) => setSaveDomain(event.target.value)}
+                    className="rounded-md border border-border/60 bg-card px-2 py-1 text-xs text-foreground"
+                    disabled={result.saveState === "saving" || result.saveState === "saved"}
+                  >
+                    {domains.map((d) => (
+                      <option key={d.key} value={d.key}>
+                        {d.displayName}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleSave(result.id)}
+                    disabled={result.saveState === "saving" || result.saveState === "saved"}
+                    className={cn(result.saveState === "saved" && "text-emerald-600 dark:text-emerald-400")}
+                  >
+                    {result.saveState === "saving"
+                      ? "Saving…"
+                      : result.saveState === "saved"
+                        ? "Saved"
+                        : result.saveState === "error"
+                          ? "Retry save"
+                          : "Save to notes"}
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/chaptered-answer.tsx
+++ b/hushh-webapp/components/sage/chaptered-answer.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { SageMarkdown } from "@/components/sage/sage-markdown";
+import { cn } from "@/lib/utils";
+
+type Chapter = { title: string; body: string };
+
+const WORDS_PER_MINUTE = 200;
+// Only a top-level "## " heading counts as a chapter break -- a "### " stays
+// inside the current chapter as a sub-heading (this mirrors what the
+// thorough/exhaustive length-tier prompts in pkm_highlight.py are actually
+// instructed to produce: "## Chapter Title" per chapter, "### " only for a
+// finer split within one).
+const CHAPTER_HEADING_RE = /^##\s+(.*)$/;
+
+function parseChapters(text: string): { intro: string; chapters: Chapter[] } {
+  const lines = text.split("\n");
+  const introLines: string[] = [];
+  const chapters: Chapter[] = [];
+  let current: Chapter | null = null;
+
+  for (const line of lines) {
+    const match = line.match(CHAPTER_HEADING_RE);
+    if (match) {
+      if (current) chapters.push(current);
+      current = { title: (match[1] ?? "").trim(), body: "" };
+    } else if (current) {
+      current.body += `${line}\n`;
+    } else {
+      introLines.push(line);
+    }
+  }
+  if (current) chapters.push(current);
+
+  return { intro: introLines.join("\n").trim(), chapters };
+}
+
+function estimateReadMinutes(text: string): number {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}
+
+/**
+ * Long deep-mode answers (the "thorough"/"exhaustive" length tiers, up to
+ * ~20k characters) read as one intimidating wall of text as plain flowing
+ * markdown. Once the model's own "## " headings give it real chapter
+ * structure, this renders it as a proper chaptered document instead: a
+ * jump-to nav, one chapter open at a time, an estimated read time -- a
+ * reader can scan the shape of the answer before committing to it.
+ *
+ * Answers with fewer than 2 "## " headings (short/standard-tier answers,
+ * or anything the model didn't structure) render as plain flowing
+ * markdown -- chapter chrome would be pure overhead on a few paragraphs.
+ */
+export function ChapteredAnswer({ text }: { text: string }) {
+  const { intro, chapters } = useMemo(() => parseChapters(text), [text]);
+  const [openIndex, setOpenIndex] = useState(0);
+  const [flatView, setFlatView] = useState(false);
+
+  if (chapters.length < 2) {
+    return <SageMarkdown text={text} />;
+  }
+
+  if (flatView) {
+    return (
+      <div className="min-w-0">
+        <div className="mb-1.5 flex justify-end">
+          <button
+            type="button"
+            onClick={() => setFlatView(false)}
+            className="text-[11px] font-medium text-violet-700 hover:underline dark:text-violet-300"
+          >
+            View as chapters
+          </button>
+        </div>
+        <SageMarkdown text={text} />
+      </div>
+    );
+  }
+
+  const totalMinutes = estimateReadMinutes(text);
+
+  return (
+    <div className="min-w-0">
+      {intro ? <SageMarkdown text={intro} /> : null}
+
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          {chapters.length} chapters · ~{totalMinutes} min read
+        </p>
+        <button
+          type="button"
+          onClick={() => setFlatView(true)}
+          className="text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground hover:underline"
+        >
+          View as one page
+        </button>
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {chapters.map((chapter, index) => (
+          <button
+            key={index}
+            type="button"
+            onClick={() => setOpenIndex(index)}
+            className={cn(
+              "rounded-full border px-2.5 py-1 text-left text-xs font-medium transition-colors",
+              openIndex === index
+                ? "border-violet-500/40 bg-violet-500/15 text-violet-700 dark:text-violet-300"
+                : "border-border/60 bg-card text-muted-foreground hover:border-violet-500/40 hover:text-foreground",
+            )}
+          >
+            {index + 1}. {chapter.title}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-2.5 space-y-1.5">
+        {chapters.map((chapter, index) => {
+          const isOpen = openIndex === index;
+          return (
+            <div key={index} className="overflow-hidden rounded-lg border border-border/50">
+              <button
+                type="button"
+                onClick={() => setOpenIndex((current) => (current === index ? -1 : index))}
+                className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-foreground"
+                aria-expanded={isOpen}
+              >
+                <span className="min-w-0">
+                  {index + 1}. {chapter.title}
+                </span>
+                <ChevronDown
+                  className={cn(
+                    "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200",
+                    isOpen && "rotate-180",
+                  )}
+                  aria-hidden
+                />
+              </button>
+              {isOpen ? (
+                <div className="border-t border-border/50 px-3 py-2.5">
+                  <SageMarkdown text={chapter.body} />
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/citation-lineage-panel.tsx
+++ b/hushh-webapp/components/sage/citation-lineage-panel.tsx
@@ -1,0 +1,788 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUpFromLine,
+  ArrowUpRight,
+  ChevronDown,
+  ChevronRight,
+  FlaskConical,
+  GitBranch,
+  Quote,
+  Search,
+  Sparkles,
+  Tag,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { ApiService } from "@/lib/services/api-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { addNoteEntity, buildSageNoteSummaryPatch } from "@/lib/sage/add-note-entity";
+import {
+  addTracedPaperToThread,
+  buildResearchThreadsSummaryPatch,
+  listResearchThreads,
+} from "@/lib/sage/research-thread-entity";
+import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import { ROUTES } from "@/lib/navigation/routes";
+import { cn } from "@/lib/utils";
+
+const RESEARCH_DOMAIN = "research";
+
+type Paper = {
+  id: string;
+  title: string;
+  year: number | null;
+  authors: string[];
+  citedByCount: number;
+  topic: string | null;
+};
+
+type Lineage = {
+  paper: Paper;
+  references: Paper[];
+  citedBy: Paper[];
+};
+
+function parsePaper(raw: unknown): Paper {
+  const r = (raw || {}) as Record<string, unknown>;
+  return {
+    id: String(r.id || ""),
+    title: String(r.title || "Untitled"),
+    year: typeof r.year === "number" ? r.year : null,
+    authors: Array.isArray(r.authors) ? r.authors.map(String) : [],
+    citedByCount: typeof r.cited_by_count === "number" ? r.cited_by_count : 0,
+    topic: typeof r.topic === "string" && r.topic.trim() ? r.topic.trim() : null,
+  };
+}
+
+function authorLine(authors: string[]): string {
+  if (authors.length === 0) return "";
+  if (authors.length <= 2) return authors.join(" & ");
+  return `${authors[0]} et al.`;
+}
+
+function formatCount(count: number): string {
+  return count.toLocaleString();
+}
+
+const EXAMPLE_QUERIES = ["Attention Is All You Need", "AlphaFold protein structure", "CRISPR-Cas9"];
+
+/** A citation-count pill, reused everywhere a paper's weight needs to read at a glance. */
+function CitationChip({ count }: { count: number }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-700 dark:text-violet-300">
+      <Quote className="h-2.5 w-2.5" aria-hidden />
+      {formatCount(count)}
+    </span>
+  );
+}
+
+/**
+ * A field/topic pill from OpenAlex's own classifier -- real structured
+ * data (primary_topic), not an LLM guess, so it's styled as a plain
+ * outline chip to visually read as "informational" next to the filled
+ * (and AI-synthesized) chips around it.
+ */
+function TopicChip({ topic }: { topic: string | null }) {
+  if (!topic) return null;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-border/60 px-2 py-0.5 text-xs text-muted-foreground">
+      <Tag className="h-2.5 w-2.5" aria-hidden />
+      {topic}
+    </span>
+  );
+}
+
+/** A thin proportional bar showing how a paper's citation count ranks against the rest of its list. */
+function WeightBar({ count, max }: { count: number; max: number }) {
+  const pct = max > 0 ? Math.max(4, Math.round((count / max) * 100)) : 0;
+  return (
+    <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-violet-500/10">
+      <div className="h-full rounded-full bg-violet-500/50" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}
+
+function SectionHeader({
+  icon: Icon,
+  label,
+  count,
+  sub,
+}: {
+  icon: LucideIcon;
+  label: string;
+  count: number;
+  sub: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-base font-semibold text-foreground">
+        <Icon className="h-4 w-4 text-violet-600 dark:text-violet-400" aria-hidden />
+        {label}
+        {count > 0 ? <span className="text-sm font-normal text-muted-foreground">({count})</span> : null}
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">{sub}</p>
+    </div>
+  );
+}
+
+/** How many levels deep a node can expand in place before the only option left is re-rooting the whole tree. */
+const MAX_EXPAND_DEPTH = 2;
+
+/**
+ * One paper in the lineage spine. Expands in place to reveal its own
+ * references (if it's on the "builds on" side) or its own citing works
+ * (if it's on the "built on by" side) -- nested indefinitely deeper in the
+ * SAME direction it was found in, so the tree never doubles back on
+ * itself. Bounded by MAX_EXPAND_DEPTH; past that, "Trace from here" is the
+ * only way further -- it re-roots the whole panel on this paper instead.
+ */
+function LineageNode({
+  paper,
+  direction,
+  depth,
+  rank,
+  siblingMax,
+  vaultOwnerToken,
+  onRetrace,
+}: {
+  paper: Paper;
+  direction: "back" | "forward";
+  depth: number;
+  rank: number;
+  siblingMax: number;
+  vaultOwnerToken: string | null;
+  onRetrace: (paper: Paper) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [children, setChildren] = useState<Paper[] | null>(null);
+
+  async function toggleExpand() {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    setExpanded(true);
+    if (children !== null || !vaultOwnerToken || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await ApiService.getSagePaperLineage({ vaultOwnerToken, workId: paper.id });
+      if (!response.ok) throw new Error("Couldn't load this paper's lineage.");
+      const data = await response.json();
+      const raw = direction === "back" ? data.references : data.cited_by;
+      const list: Paper[] = Array.isArray(raw) ? raw.map(parsePaper) : [];
+      setChildren(direction === "back" ? list.slice().sort((a, b) => b.citedByCount - a.citedByCount) : list);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't load this paper's lineage.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const canExpandInPlace = depth < MAX_EXPAND_DEPTH;
+  const childMax = children && children.length > 0 ? Math.max(1, ...children.map((p) => p.citedByCount)) : 1;
+
+  return (
+    <div className="relative">
+      <span
+        className="absolute -left-[1.6rem] top-4 h-2 w-2 rounded-full bg-violet-500/60"
+        aria-hidden
+      />
+      <div className="flex w-full items-start gap-2 rounded-lg border border-border/50 bg-background/60 p-3.5">
+        <span className="mt-0.5 shrink-0 text-xs font-medium text-muted-foreground/70">#{rank}</span>
+        <div className="min-w-0 flex-1 text-left">
+          <p className="text-base leading-snug text-foreground">{paper.title}</p>
+          <p className="mt-1 flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+            {[paper.year, authorLine(paper.authors)].filter(Boolean).join(" · ")}
+            <CitationChip count={paper.citedByCount} />
+            <TopicChip topic={paper.topic} />
+          </p>
+          <WeightBar count={paper.citedByCount} max={siblingMax} />
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {canExpandInPlace ? (
+            <button
+              type="button"
+              onClick={() => void toggleExpand()}
+              className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-violet-500/10 hover:text-foreground"
+              aria-label={expanded ? "Collapse" : "Expand"}
+              aria-expanded={expanded}
+            >
+              <ChevronDown className={cn("h-4 w-4 transition-transform", expanded && "rotate-180")} aria-hidden />
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => onRetrace(paper)}
+            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-violet-500/10 hover:text-foreground"
+            aria-label="Trace from here"
+            title="Trace from here"
+          >
+            <ArrowUpRight className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      {expanded ? (
+        <div className="relative ml-3 mt-2.5 space-y-2.5 border-l-2 border-violet-500/15 pl-6">
+          {loading ? <Skeleton className="h-16 w-full" /> : null}
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {!loading && !error && children && children.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {direction === "back" ? "No further references found." : "Nothing else cites this yet."}
+            </p>
+          ) : null}
+          {!loading && !error && children
+            ? children.map((child, index) => (
+                <LineageNode
+                  key={child.id}
+                  paper={child}
+                  direction={direction}
+                  depth={depth + 1}
+                  rank={index + 1}
+                  siblingMax={childMax}
+                  vaultOwnerToken={vaultOwnerToken}
+                  onRetrace={onRetrace}
+                />
+              ))
+            : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Sage tracing a real paper's citation lineage in both directions --
+ * "Citation Lineage & Tree Traversal" from the researcher-agent vision,
+ * built against OpenAlex (free, unauthenticated) rather than Semantic
+ * Scholar (which 429'd on the very first live call while building this).
+ * Rendered as a vertical spine (references above, the traced paper as the
+ * anchor, citing works below) where every node expands IN PLACE via
+ * LineageNode -- clicking a reference nests its own references underneath
+ * it instead of replacing the screen, so you don't lose your place. This
+ * is deliberately a CSS/SVG-free tree (no force-directed graph dependency
+ * exists in this app) rather than a pannable node-link canvas.
+ */
+export function CitationLineagePanel() {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  const searchParams = useSearchParams();
+  const threadId = searchParams.get("threadId");
+  const deepLinkWorkId = searchParams.get("workId");
+  const deepLinkTitle = searchParams.get("title");
+  const deepLinkOpened = useRef(false);
+
+  const [domains, setDomains] = useState<DomainSummary[]>([]);
+  const [saveDomain, setSaveDomain] = useState<string>("");
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [addToThreadState, setAddToThreadState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [candidates, setCandidates] = useState<Paper[]>([]);
+
+  const [trail, setTrail] = useState<Paper[]>([]);
+  const [lineage, setLineage] = useState<Lineage | null>(null);
+  const [loadingLineage, setLoadingLineage] = useState(false);
+  const [lineageError, setLineageError] = useState<string | null>(null);
+  const [insight, setInsight] = useState<{ loading: boolean; text: string | null }>({
+    loading: false,
+    text: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      if (!user?.uid || !vaultOwnerToken) return;
+      try {
+        const metadata = await PersonalKnowledgeModelService.getMetadata(user.uid, false, vaultOwnerToken);
+        if (!cancelled) {
+          setDomains(metadata.domains);
+          setSaveDomain(metadata.domains[0]?.key || "");
+        }
+      } catch {
+        // Non-critical -- saving to notes is a secondary action here.
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, vaultOwnerToken]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const workId = lineage?.paper.id;
+    if (!workId || !vaultOwnerToken) {
+      setInsight({ loading: false, text: null });
+      return;
+    }
+    setInsight({ loading: true, text: null });
+    void (async () => {
+      try {
+        const response = await ApiService.getSagePaperInsight({ vaultOwnerToken, workId });
+        const data = response.ok ? await response.json() : null;
+        if (!cancelled) setInsight({ loading: false, text: data?.insight || null });
+      } catch {
+        if (!cancelled) setInsight({ loading: false, text: null });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [lineage?.paper.id, vaultOwnerToken]);
+
+  async function handleSearch() {
+    const trimmed = query.trim();
+    if (!trimmed || !vaultOwnerToken || searching) return;
+    setSearching(true);
+    setSearchError(null);
+    try {
+      const response = await ApiService.searchSagePapers({ vaultOwnerToken, query: trimmed });
+      if (!response.ok) throw new Error("Search failed just now.");
+      const data = await response.json();
+      const results = Array.isArray(data.results) ? data.results.map(parsePaper) : [];
+      setCandidates(results);
+      if (results.length === 0) setSearchError("No papers matched that search.");
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : "Search failed just now.");
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function openPaper(paper: Paper) {
+    if (!vaultOwnerToken || loadingLineage) return;
+    setLoadingLineage(true);
+    setLineageError(null);
+    setCandidates([]);
+    setSaveState("idle");
+    setAddToThreadState("idle");
+    try {
+      const response = await ApiService.getSagePaperLineage({ vaultOwnerToken, workId: paper.id });
+      if (!response.ok) throw new Error("Couldn't trace that paper's citations just now.");
+      const data = await response.json();
+      const references: Paper[] = Array.isArray(data.references) ? data.references.map(parsePaper) : [];
+      const citedBy: Paper[] = Array.isArray(data.cited_by) ? data.cited_by.map(parsePaper) : [];
+      setLineage({
+        paper: parsePaper(data.paper),
+        // Most-cited (most foundational) reference first -- same "what actually
+        // matters here" ordering OpenAlex already gives us for citedBy.
+        references: references.slice().sort((a, b) => b.citedByCount - a.citedByCount),
+        citedBy,
+      });
+      setTrail((prev) => {
+        const existingIndex = prev.findIndex((p) => p.id === paper.id);
+        if (existingIndex >= 0) return prev.slice(0, existingIndex + 1);
+        return [...prev, paper];
+      });
+    } catch (err) {
+      setLineageError(err instanceof Error ? err.message : "Couldn't trace that paper's citations just now.");
+    } finally {
+      setLoadingLineage(false);
+    }
+  }
+
+  useEffect(() => {
+    if (deepLinkOpened.current || !deepLinkWorkId || !vaultOwnerToken) return;
+    deepLinkOpened.current = true;
+    void openPaper({
+      id: deepLinkWorkId,
+      title: deepLinkTitle || "Untitled",
+      year: null,
+      authors: [],
+      citedByCount: 0,
+      topic: null,
+    });
+    // openPaper is stable across renders in practice (redefined each render but
+    // reads only current state/props); this should fire once per deep link.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deepLinkWorkId, vaultOwnerToken]);
+
+  async function handleSaveToNotes() {
+    if (!lineage || !user?.uid || !vaultKey || !vaultOwnerToken || !saveDomain) return;
+    setSaveState("saving");
+    try {
+      const { paper } = lineage;
+      const noteText = `Sage citation trace: "${paper.title}"${paper.year ? ` (${paper.year})` : ""}${
+        authorLine(paper.authors) ? ` by ${authorLine(paper.authors)}` : ""
+      } -- cites ${lineage.references.length} works, cited by ${paper.citedByCount}.`;
+      // Re-fetch live rather than trusting the `domains` prop -- see the
+      // matching comment in ask-sage-panel.tsx's handleSave for why a stale
+      // snapshot here silently overwrites an earlier save's highlight line.
+      const freshDomains = await PersonalKnowledgeModelService.getMetadata(user.uid, true, vaultOwnerToken)
+        .then((m) => m.domains)
+        .catch(() => domains);
+      const targetDomain = freshDomains.find((d) => d.key === saveDomain) || domains.find((d) => d.key === saveDomain);
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: saveDomain,
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => ({
+          domainData: addNoteEntity(context.currentDomainData, noteText, "sage_citation"),
+          summary: {
+            source: "sage_citation",
+            message_excerpt: noteText.slice(0, 160),
+            ...buildSageNoteSummaryPatch({
+              displayName: targetDomain?.displayName || saveDomain,
+              existingHighlights: targetDomain?.readableHighlights || [],
+              noteText,
+            }),
+          },
+        }),
+      });
+      setSaveState(result.success ? "saved" : "error");
+    } catch {
+      setSaveState("error");
+    }
+  }
+
+  async function handleAddToThread() {
+    if (!lineage || !threadId || !user?.uid || !vaultKey || !vaultOwnerToken) return;
+    setAddToThreadState("saving");
+    try {
+      const { paper } = lineage;
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: RESEARCH_DOMAIN,
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => {
+          const updated = addTracedPaperToThread(context.currentDomainData, threadId, {
+            id: paper.id,
+            title: paper.title,
+            year: paper.year,
+            topic: paper.topic,
+            citedByCount: paper.citedByCount,
+          });
+          const threadsAfter = listResearchThreads(updated);
+          return {
+            domainData: updated,
+            mergeDecision: { merge_mode: "replace_domain" },
+            summary: { source: "sage_citation_thread", ...buildResearchThreadsSummaryPatch(threadsAfter) },
+          };
+        },
+      });
+      setAddToThreadState(result.success ? "saved" : "error");
+    } catch {
+      setAddToThreadState("error");
+    }
+  }
+
+  function resetSearch() {
+    setLineage(null);
+    setTrail([]);
+    setCandidates([]);
+    setSearchError(null);
+    setLineageError(null);
+  }
+
+  return (
+    <div className="space-y-4">
+      {threadId ? (
+        <Link
+          href={ROUTES.SAGE_THREADS}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+          Back to research thread
+        </Link>
+      ) : null}
+
+      <div className="rounded-2xl border border-violet-500/25 bg-card/85 p-5 shadow-[0_1px_2px_rgba(15,23,42,0.06)] sm:p-6">
+        <div className="flex items-center gap-2 text-base font-semibold text-violet-700 dark:text-violet-300">
+          <GitBranch className="h-5 w-5" aria-hidden />
+          Trace a paper
+        </div>
+        <p className="mt-1.5 text-base text-muted-foreground">
+          Search a paper by title, then see what it builds on and what builds on it -- real citation
+          data, not a summary.
+        </p>
+        <div className="mt-4 flex flex-col gap-2.5 sm:flex-row">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void handleSearch();
+              }
+            }}
+            placeholder="e.g. Attention Is All You Need"
+            className="h-12 flex-1 text-base"
+          />
+          <Button
+            onClick={() => void handleSearch()}
+            disabled={searching || !query.trim()}
+            className="h-12 px-6 text-base sm:w-auto"
+          >
+            <Search className="mr-1.5 h-4 w-4" aria-hidden />
+            {searching ? "Searching…" : "Search"}
+          </Button>
+        </div>
+        {searchError ? <p className="mt-2.5 text-sm text-destructive">{searchError}</p> : null}
+
+        {candidates.length === 0 && !lineage && !loadingLineage ? (
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <span className="text-sm text-muted-foreground">Try:</span>
+            {EXAMPLE_QUERIES.map((example) => (
+              <button
+                key={example}
+                type="button"
+                onClick={() => {
+                  setQuery(example);
+                  void handleSearch();
+                }}
+                className="rounded-full border border-border/60 bg-background/60 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:border-violet-500/40 hover:text-foreground"
+              >
+                {example}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {candidates.length > 0 ? (
+          <div className="mt-4 space-y-2.5">
+            {candidates.map((paper) => (
+              <button
+                key={paper.id}
+                type="button"
+                onClick={() => void openPaper(paper)}
+                className="flex w-full items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/60 p-4 text-left transition-colors hover:border-violet-500/40"
+              >
+                <div className="min-w-0">
+                  <p className="text-base font-medium leading-snug text-foreground">{paper.title}</p>
+                  <p className="mt-1.5 flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+                    {[paper.year, authorLine(paper.authors)].filter(Boolean).join(" · ")}
+                    <CitationChip count={paper.citedByCount} />
+                    <TopicChip topic={paper.topic} />
+                  </p>
+                </div>
+                <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {trail.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          {trail.map((paper, index) => {
+            const isCurrent = index === trail.length - 1;
+            return (
+              <span key={paper.id} className="flex items-center gap-2">
+                {index > 0 ? <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" aria-hidden /> : null}
+                {isCurrent ? (
+                  <span className="max-w-[18rem] truncate rounded-full bg-violet-500/15 px-3 py-1.5 font-medium text-violet-700 dark:text-violet-300">
+                    {paper.title}
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => void openPaper(paper)}
+                    className="max-w-[18rem] truncate rounded-full border border-border/60 bg-card px-3 py-1.5 text-muted-foreground hover:border-violet-500/40 hover:text-foreground"
+                  >
+                    {paper.title}
+                  </button>
+                )}
+              </span>
+            );
+          })}
+          <button
+            type="button"
+            onClick={resetSearch}
+            className="ml-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            New search
+          </button>
+        </div>
+      ) : null}
+
+      {loadingLineage ? (
+        <div className="space-y-2.5 border-l-2 border-violet-500/10 pl-6">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : null}
+      {loadingLineage ? (
+        <div className="rounded-2xl border border-border/60 bg-card/85 p-5 sm:p-6">
+          <Skeleton className="h-6 w-3/4" />
+          <Skeleton className="mt-3 h-4 w-1/2" />
+        </div>
+      ) : null}
+      {loadingLineage ? (
+        <div className="space-y-2.5 border-l-2 border-violet-500/10 pl-6">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : null}
+
+      {lineageError ? <p className="text-sm text-destructive">{lineageError}</p> : null}
+
+      {lineage && !loadingLineage ? (
+        <>
+          <SectionHeader
+            icon={ArrowDownToLine}
+            label="Builds on"
+            count={lineage.references.length}
+            sub="What this paper cites, most-foundational first"
+          />
+          {lineage.references.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No references found.</p>
+          ) : (
+            <div className="space-y-2.5 border-l-2 border-violet-500/20 pl-6">
+              {(() => {
+                const max = Math.max(1, ...lineage.references.map((p) => p.citedByCount));
+                return lineage.references.map((paper, index) => (
+                  <LineageNode
+                    key={paper.id}
+                    paper={paper}
+                    direction="back"
+                    depth={0}
+                    rank={index + 1}
+                    siblingMax={max}
+                    vaultOwnerToken={vaultOwnerToken}
+                    onRetrace={(p) => void openPaper(p)}
+                  />
+                ));
+              })()}
+            </div>
+          )}
+
+          <div className="flex justify-center">
+            <div className="h-6 w-0.5 bg-gradient-to-b from-violet-500/20 to-violet-500/40" aria-hidden />
+          </div>
+
+          <div className="relative overflow-hidden rounded-2xl border border-violet-500/25 bg-gradient-to-br from-violet-500/[0.07] to-transparent p-5 dark:border-violet-400/25 dark:from-violet-400/[0.06] sm:p-6">
+            <span className="text-xs font-medium uppercase tracking-wide text-violet-700/80 dark:text-violet-300/80">
+              Currently tracing
+            </span>
+            <p className="mt-1.5 text-xl font-semibold leading-snug text-foreground">
+              {lineage.paper.title}
+            </p>
+            <div className="mt-2.5 flex flex-wrap items-center gap-2 text-base text-muted-foreground">
+              {[lineage.paper.year, authorLine(lineage.paper.authors)].filter(Boolean).join(" · ")}
+              <CitationChip count={lineage.paper.citedByCount} />
+              <TopicChip topic={lineage.paper.topic} />
+            </div>
+
+            <div className="mt-3.5 flex items-start gap-2 border-t border-violet-500/15 pt-3.5 dark:border-violet-400/15">
+              <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-violet-600 dark:text-violet-400" aria-hidden />
+              {insight.loading ? (
+                <div className="flex-1 space-y-1.5 pt-0.5">
+                  <Skeleton className="h-3.5 w-full" />
+                  <Skeleton className="h-3.5 w-4/5" />
+                </div>
+              ) : insight.text ? (
+                <p className="text-sm leading-6 text-foreground">{insight.text}</p>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Sage couldn&apos;t read this one just now.
+                </p>
+              )}
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-2.5">
+              {domains.length > 0 ? (
+                <>
+                  <select
+                    value={saveDomain}
+                    onChange={(event) => setSaveDomain(event.target.value)}
+                    className="h-10 rounded-md border border-border/60 bg-card px-3 text-sm text-foreground"
+                    disabled={saveState === "saving" || saveState === "saved"}
+                  >
+                    {domains.map((d) => (
+                      <option key={d.key} value={d.key}>
+                        {d.displayName}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    variant="outline"
+                    onClick={() => void handleSaveToNotes()}
+                    disabled={saveState === "saving" || saveState === "saved"}
+                    className="h-10"
+                  >
+                    {saveState === "saving"
+                      ? "Saving…"
+                      : saveState === "saved"
+                        ? "Saved"
+                        : saveState === "error"
+                          ? "Retry save"
+                          : "Save to notes"}
+                  </Button>
+                </>
+              ) : null}
+              {threadId ? (
+                <Button
+                  variant="outline"
+                  onClick={() => void handleAddToThread()}
+                  disabled={addToThreadState === "saving" || addToThreadState === "saved"}
+                  className="h-10"
+                >
+                  <FlaskConical className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                  {addToThreadState === "saving"
+                    ? "Adding…"
+                    : addToThreadState === "saved"
+                      ? "Added to thread"
+                      : addToThreadState === "error"
+                        ? "Retry add"
+                        : "Add to research thread"}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex justify-center">
+            <div className="h-6 w-0.5 bg-gradient-to-b from-violet-500/40 to-violet-500/20" aria-hidden />
+          </div>
+
+          <SectionHeader
+            icon={ArrowUpFromLine}
+            label="Built on by"
+            count={lineage.citedBy.length}
+            sub="What cites this paper, most-cited first"
+          />
+          {lineage.citedBy.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No citing works found.</p>
+          ) : (
+            <div className="space-y-2.5 border-l-2 border-violet-500/20 pl-6">
+              {(() => {
+                const max = Math.max(1, ...lineage.citedBy.map((p) => p.citedByCount));
+                return lineage.citedBy.map((paper, index) => (
+                  <LineageNode
+                    key={paper.id}
+                    paper={paper}
+                    direction="forward"
+                    depth={0}
+                    rank={index + 1}
+                    siblingMax={max}
+                    vaultOwnerToken={vaultOwnerToken}
+                    onRetrace={(p) => void openPaper(p)}
+                  />
+                ));
+              })()}
+            </div>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/citation-lineage-panel.tsx
+++ b/hushh-webapp/components/sage/citation-lineage-panel.tsx
@@ -34,7 +34,6 @@ import {
   listResearchThreads,
 } from "@/lib/sage/research-thread-entity";
 import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
-import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
 import { ROUTES } from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 

--- a/hushh-webapp/components/sage/health-radar-card.tsx
+++ b/hushh-webapp/components/sage/health-radar-card.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from "recharts";
+
+import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
+import { cn } from "@/lib/utils";
+
+export type HealthRadarAxis = { subject: string; value: number };
+
+const healthRadarChartConfig = {
+  value: {
+    label: "Score",
+    color: "rgb(139 92 246)", // violet-500, Sage's accent everywhere else
+  },
+} satisfies ChartConfig;
+
+/**
+ * A prominent radar + score-bar card -- the same shape as Kai's "Portfolio
+ * Intelligence & Health" (radar left, big score + Critical/Stable/Optimal
+ * gradient bar right), generalized so any Sage surface with a genuine set
+ * of real, already-computed 0-100 axis values can use it. Never computes
+ * anything itself -- callers own what the axes actually measure and must
+ * make sure every value is real, derived data, not invented.
+ */
+export function HealthRadarCard({
+  icon: Icon,
+  title,
+  axes,
+  overall,
+  scaleLabels,
+}: {
+  icon: LucideIcon;
+  title: string;
+  axes: HealthRadarAxis[];
+  overall: number;
+  /** [low, mid, high] labels under the gradient bar, e.g. ["Early", "Developing", "Well-established"]. */
+  scaleLabels: [string, string, string];
+}) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-violet-500/20 dark:border-violet-400/20">
+      <div className="flex items-center gap-2 border-b border-violet-500/10 bg-violet-500/[0.04] px-5 py-3 dark:border-violet-400/10 dark:bg-violet-400/[0.03]">
+        <Icon className="h-4 w-4 text-violet-700 dark:text-violet-300" aria-hidden />
+        <span className="text-sm font-semibold text-violet-700 dark:text-violet-300">{title}</span>
+      </div>
+      <div className="grid grid-cols-1 divide-y divide-border/10 md:grid-cols-2 md:divide-x md:divide-y-0">
+        <div className="flex items-center justify-center p-5">
+          <ChartContainer config={healthRadarChartConfig} className="h-[220px] w-full max-w-[280px]">
+            <RadarChart cx="50%" cy="50%" outerRadius="75%" data={axes}>
+              <PolarGrid stroke="var(--border)" strokeOpacity={0.3} />
+              <PolarAngleAxis
+                dataKey="subject"
+                tick={{ fill: "var(--muted-foreground)", fontSize: 10, fontWeight: 600 }}
+              />
+              <Radar dataKey="value" stroke="var(--color-value)" fill="var(--color-value)" fillOpacity={0.45} />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    formatter={(value, _name, item) => {
+                      const payload = item?.payload as { subject?: string } | undefined;
+                      return (
+                        <div className="flex min-w-[7rem] items-center justify-between gap-3">
+                          <span className="text-muted-foreground">{payload?.subject}</span>
+                          <span className="font-semibold text-foreground">{Number(value).toFixed(0)}%</span>
+                        </div>
+                      );
+                    }}
+                  />
+                }
+              />
+            </RadarChart>
+          </ChartContainer>
+        </div>
+        <div className="flex flex-col justify-center gap-4 p-5">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Overall</p>
+            <div className="mt-1 flex items-baseline gap-1.5">
+              <span className="text-3xl font-semibold text-foreground">{overall}</span>
+              <span className="text-lg font-semibold text-muted-foreground/50">%</span>
+              <span className="ml-1.5 text-sm text-muted-foreground">
+                {overall < 40 ? scaleLabels[0] : overall < 70 ? scaleLabels[1] : scaleLabels[2]}
+              </span>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <div className="h-2.5 w-full overflow-hidden rounded-full bg-muted/40">
+              <div
+                className={cn(
+                  "h-full rounded-full transition-all duration-700 ease-out",
+                  overall < 40
+                    ? "bg-gradient-to-r from-red-600 to-red-400"
+                    : overall < 70
+                      ? "bg-gradient-to-r from-amber-500 to-amber-300"
+                      : "bg-gradient-to-r from-emerald-600 to-emerald-400",
+                )}
+                style={{ width: `${overall}%` }}
+              />
+            </div>
+            <div className="flex justify-between px-0.5">
+              <span className="text-[9px] font-bold uppercase tracking-wide text-red-500/70">{scaleLabels[0]}</span>
+              <span className="text-[9px] font-bold uppercase tracking-wide text-amber-500/70">{scaleLabels[1]}</span>
+              <span className="text-[9px] font-bold uppercase tracking-wide text-emerald-500/70">
+                {scaleLabels[2]}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/notes-archive-panel.tsx
+++ b/hushh-webapp/components/sage/notes-archive-panel.tsx
@@ -136,6 +136,9 @@ export function NotesArchivePanel() {
         vaultOwnerToken,
         build: (context) => {
           const archived = archiveMatchingNoteEntity(context.currentDomainData, note.text, "Removed by user");
+          if (!archived.matched) {
+            throw new Error("Couldn't find that note to remove.");
+          }
           return {
             domainData: archived.domainData,
             summary: {

--- a/hushh-webapp/components/sage/notes-archive-panel.tsx
+++ b/hushh-webapp/components/sage/notes-archive-panel.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  BadgeCheck,
+  BookOpen,
+  Briefcase,
+  Landmark,
+  Plane,
+  Search,
+  ShoppingBag,
+  X,
+} from "lucide-react";
+
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AddNotePanel } from "@/components/sage/add-note-panel";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import {
+  PersonalKnowledgeModelService,
+  type DomainSummary,
+} from "@/lib/services/personal-knowledge-model-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { archiveMatchingNoteEntity, buildArchivedNoteSummaryPatch } from "@/lib/sage/add-note-entity";
+
+const DOMAIN_ICON: Record<string, typeof Landmark> = {
+  financial: Landmark,
+  professional: Briefcase,
+  shopping: ShoppingBag,
+  travel: Plane,
+  kyc_connector: BadgeCheck,
+};
+
+const NOTE_PREFIX = /^saved from your note:\s*/i;
+
+type NoteEntry = {
+  id: string;
+  domainKey: string;
+  domainDisplayName: string;
+  text: string;
+  updatedAt: string | null;
+};
+
+function extractNotes(domain: DomainSummary): NoteEntry[] {
+  const highlights = Array.isArray(domain.readableHighlights) ? domain.readableHighlights : [];
+  const notes: NoteEntry[] = [];
+  highlights.forEach((line, index) => {
+    if (!NOTE_PREFIX.test(line)) return;
+    const text = line.replace(NOTE_PREFIX, "").trim();
+    if (!text) return;
+    notes.push({
+      id: `${domain.key}_${index}`,
+      domainKey: domain.key,
+      domainDisplayName: domain.displayName,
+      text,
+      updatedAt: domain.readableUpdatedAt || domain.lastUpdated,
+    });
+  });
+  return notes;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+/**
+ * Sage's "searchable personal archive": every raw note Kai/One has ever
+ * captured verbatim ("Saved from your note: ..."), across every domain,
+ * in one place with a plain-text filter -- no new capture mechanism,
+ * this is real data that already exists per-domain, just never surfaced
+ * together before.
+ */
+export function NotesArchivePanel() {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  const [loading, setLoading] = useState(true);
+  const [domains, setDomains] = useState<DomainSummary[]>([]);
+  const [notes, setNotes] = useState<NoteEntry[]>([]);
+  const [query, setQuery] = useState("");
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  // forceRefresh=true bypasses the metadata cache -- required right after a
+  // write, since a stale-ok read here can hand back the pre-write snapshot
+  // (the same race sage-panel.tsx's refreshDomains() already had to guard
+  // against after handleApplyFix). The plain mount-time call below stays
+  // stale-ok since nothing has changed yet from this component's view.
+  async function refresh(forceRefresh = false) {
+    if (!user?.uid || !vaultOwnerToken) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const metadata = await PersonalKnowledgeModelService.getMetadata(user.uid, forceRefresh, vaultOwnerToken);
+      setDomains(metadata.domains);
+      const all = metadata.domains.flatMap(extractNotes).sort((a, b) => {
+        const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+        const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+        return bTime - aTime;
+      });
+      setNotes(all);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    // Only re-run when the user/token actually changes -- refresh() is also
+    // called directly from AddNotePanel's onSaved below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, vaultOwnerToken]);
+
+  // Archives the underlying entity (never deletes) and strips it from
+  // readable_highlights, the same two-write shape sage-panel.tsx already
+  // uses for its source-side "fix" archive -- reusing that plumbing rather
+  // than inventing a second one. Removes it from local state immediately on
+  // success (rather than relying solely on the follow-up refresh) so the
+  // click always reads as having done something even if that refresh is
+  // slow.
+  async function handleRemoveNote(note: NoteEntry) {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+    setRemovingId(note.id);
+    setRemoveError(null);
+    try {
+      const domain = domains.find((d) => d.key === note.domainKey);
+      const result = await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: note.domainKey,
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => {
+          const archived = archiveMatchingNoteEntity(context.currentDomainData, note.text, "Removed by user");
+          return {
+            domainData: archived.domainData,
+            summary: {
+              source: "sage_note_remove",
+              ...buildArchivedNoteSummaryPatch({
+                existingHighlights: domain?.readableHighlights || [],
+                noteText: note.text,
+              }),
+            },
+          };
+        },
+      });
+      if (!result.success) {
+        setRemoveError(result.message || "Couldn't remove that note just now.");
+        return;
+      }
+      setNotes((prev) => prev.filter((n) => n.id !== note.id));
+      void refresh(true);
+    } catch (err) {
+      setRemoveError(err instanceof Error ? err.message : "Couldn't remove that note just now.");
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
+  const filtered = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return notes;
+    return notes.filter(
+      (note) =>
+        note.text.toLowerCase().includes(trimmed) ||
+        note.domainDisplayName.toLowerCase().includes(trimmed),
+    );
+  }, [notes, query]);
+
+  return (
+    <div className="space-y-4">
+      <AddNotePanel domains={domains} onSaved={() => void refresh(true)} />
+      {removeError ? <p className="text-sm text-destructive">{removeError}</p> : null}
+
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : notes.length === 0 ? (
+        <Empty className="border-violet-500/20 bg-violet-500/[0.03] dark:border-violet-400/20 dark:bg-violet-400/[0.03]">
+          <EmptyHeader>
+            <EmptyMedia variant="icon" className="bg-violet-500/10 text-violet-700 dark:text-violet-300">
+              <BookOpen className="size-6" aria-hidden />
+            </EmptyMedia>
+            <EmptyTitle>No raw notes yet</EmptyTitle>
+            <EmptyDescription>
+              When you tell Kai something in your own words -- or add one above -- the exact
+              wording gets saved here too, not just the cleaned-up summary.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search your notes…"
+              className="pl-9"
+            />
+          </div>
+
+          {filtered.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">No notes match &ldquo;{query}&rdquo;.</p>
+          ) : (
+            <div className="space-y-2.5">
+              {filtered.map((note) => {
+                const Icon = DOMAIN_ICON[note.domainKey] || BookOpen;
+                return (
+                  <div
+                    key={note.id}
+                    className="group relative flex items-start gap-3 rounded-xl border border-border/60 bg-card/85 p-4 shadow-[0_1px_2px_rgba(15,23,42,0.06)]"
+                  >
+                    <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 text-violet-700 dark:text-violet-300">
+                      <Icon className="h-4 w-4" aria-hidden />
+                    </span>
+                    <div className="min-w-0 flex-1 pr-6">
+                      <p className="text-sm leading-5 text-foreground">&ldquo;{note.text}&rdquo;</p>
+                      <p className="mt-1.5 text-xs text-muted-foreground/80">
+                        {note.domainDisplayName}
+                        {formatDate(note.updatedAt) ? ` · ${formatDate(note.updatedAt)}` : ""}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => void handleRemoveNote(note)}
+                      disabled={removingId === note.id}
+                      className="absolute right-2 top-2 rounded-md p-1 text-muted-foreground/50 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100 disabled:opacity-100"
+                      aria-label="Remove this note"
+                      title="Remove this note"
+                    >
+                      <X className="h-3.5 w-3.5" aria-hidden />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/research-threads-panel.tsx
+++ b/hushh-webapp/components/sage/research-threads-panel.tsx
@@ -1,0 +1,1421 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Bar, BarChart, CartesianGrid, LabelList, XAxis, YAxis } from "recharts";
+import {
+  ArrowLeft,
+  Archive,
+  CheckCircle2,
+  CircleHelp,
+  Download,
+  ExternalLink,
+  FlaskConical,
+  Gauge,
+  GitBranch,
+  Link2,
+  MessageSquare,
+  Quote,
+  Sparkles,
+  Tag,
+  User,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ChartContainer, ChartTooltip, ChartTooltipContent, type ChartConfig } from "@/components/ui/chart";
+import { HealthRadarCard, type HealthRadarAxis } from "@/components/sage/health-radar-card";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { ApiService } from "@/lib/services/api-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
+import {
+  addTracedPaperToThread,
+  appendThreadTurn,
+  archiveResearchThread,
+  buildResearchThreadsSummaryPatch,
+  createResearchThread,
+  listResearchThreads,
+  removeTracedPaperFromThread,
+  updateThreadSynthesis,
+  type ResearchThreadComparison,
+  type ResearchThreadEntity,
+  type ResearchThreadKeyTerm,
+  type ResearchThreadPaper,
+  type ResearchThreadSource,
+  type ResearchThreadTurn,
+} from "@/lib/sage/research-thread-entity";
+import { ChapteredAnswer } from "@/components/sage/chaptered-answer";
+import { SageLoadingIndicator } from "@/components/sage/sage-loading-indicator";
+import { buildSageCitationsRoute } from "@/lib/navigation/routes";
+import { cn } from "@/lib/utils";
+
+const RESEARCH_DOMAIN = "research";
+
+type View = { mode: "list" } | { mode: "detail"; threadId: string };
+
+type AnswerLength = "standard" | "thorough" | "exhaustive";
+
+const ANSWER_LENGTH_OPTIONS: Array<{ value: AnswerLength; label: string; hint: string }> = [
+  { value: "standard", label: "Standard", hint: "A few thorough paragraphs (~8k characters)" },
+  { value: "thorough", label: "Thorough", hint: "Sectioned, in-depth answer (~14k characters)" },
+  { value: "exhaustive", label: "Exhaustive", hint: "Full reference write-up (~20k characters)" },
+];
+
+// Roughly matches the backend's per-tier timeout (_DEEP_LENGTH_TIMEOUT_SECONDS
+// in pkm_highlight.py), scaled down a bit from the worst case to reflect a
+// typical call -- used only to pace SageLoadingIndicator's status cycling
+// and its "still working" reassurance, never shown as a literal countdown.
+const ANSWER_LENGTH_EXPECTED_SECONDS: Record<AnswerLength, number> = {
+  standard: 20,
+  thorough: 35,
+  exhaustive: 50,
+};
+
+/**
+ * Only 3 real backend tiers exist (each maps to its own prompt instruction,
+ * generation token budget, and timeout server-side) -- a continuous slider
+ * would imply finer control than actually exists, so this is a segmented
+ * toggle instead.
+ */
+function AnswerLengthControl({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: AnswerLength;
+  onChange: (value: AnswerLength) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-muted-foreground">Answer length</span>
+      <div className="flex items-center gap-0.5 rounded-full border border-border/60 bg-card p-0.5">
+        {ANSWER_LENGTH_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            disabled={disabled}
+            aria-pressed={value === option.value}
+            title={option.hint}
+            className={cn(
+              "rounded-full px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-60",
+              value === option.value
+                ? "bg-violet-500/15 text-violet-700 dark:text-violet-300"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * How resolved a thread's synthesis is, at a glance -- a real proportion of
+ * the actual established/open-question counts already on the synthesis,
+ * not a separately invented "alignment score".
+ */
+function SynthesisRatioBar({ established, open }: { established: number; open: number }) {
+  const total = established + open;
+  if (total === 0) return null;
+  const establishedPct = Math.round((established / total) * 100);
+  return (
+    <div className="mt-3 flex items-center gap-2.5 text-xs text-muted-foreground">
+      <span className="shrink-0 text-emerald-700 dark:text-emerald-400">{established} established</span>
+      <div className="flex h-1.5 flex-1 overflow-hidden rounded-full bg-muted/40">
+        <div className="h-full bg-emerald-500/70" style={{ width: `${establishedPct}%` }} />
+        <div className="h-full bg-amber-500/70" style={{ width: `${100 - establishedPct}%` }} />
+      </div>
+      <span className="shrink-0 text-amber-700 dark:text-amber-400">{open} open</span>
+    </div>
+  );
+}
+
+function formatRelativeTime(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return null;
+  const days = Math.max(0, Math.round((Date.now() - then) / 86_400_000));
+  if (days < 1) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  return `${Math.round(days / 30)}mo ago`;
+}
+
+function CitationChip({ count }: { count: number }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-700 dark:text-violet-300">
+      <Quote className="h-2.5 w-2.5" aria-hidden />
+      {count.toLocaleString()}
+    </span>
+  );
+}
+
+function TopicChip({ topic }: { topic: string | null }) {
+  if (!topic) return null;
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-border/60 px-2 py-0.5 text-xs text-muted-foreground">
+      <Tag className="h-2.5 w-2.5" aria-hidden />
+      {topic}
+    </span>
+  );
+}
+
+/**
+ * Click-to-reveal definitions for terms an answer actually used -- each
+ * definition is grounded in that same answer (see _parse_deep_extras on the
+ * backend), never a fresh lookup, so this can't introduce new claims.
+ */
+function KeyTermChips({ items }: { items: ResearchThreadKeyTerm[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="mt-2.5 flex flex-wrap items-center gap-1.5 border-t border-violet-500/10 pt-2.5">
+      {items.map((item, index) => (
+        <Popover key={index}>
+          <PopoverTrigger className="inline-flex items-center gap-1 rounded-full border border-violet-500/30 bg-violet-500/[0.06] px-2 py-0.5 text-xs font-medium text-violet-700 transition-colors hover:border-violet-500/50 dark:text-violet-300">
+            {item.term}
+          </PopoverTrigger>
+          <PopoverContent className="w-64 text-sm">
+            <p className="font-medium text-foreground">{item.term}</p>
+            <p className="mt-1 text-muted-foreground">{item.definition}</p>
+          </PopoverContent>
+        </Popover>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The per-turn KeyTermChips above only show up buried inside whichever
+ * message bubble first defined a term -- easy to miss once a thread has a
+ * few turns. This aggregates every term across the whole thread (first
+ * definition wins on a duplicate, case-insensitively) into one always-
+ * visible glossary near the top, same click-to-reveal chip UI, just once
+ * per thread instead of scattered per-message.
+ */
+function computeThreadGlossary(turns: ResearchThreadTurn[]): ResearchThreadKeyTerm[] {
+  const seen = new Set<string>();
+  const glossary: ResearchThreadKeyTerm[] = [];
+  for (const turn of turns) {
+    for (const item of turn.keyTerms) {
+      const key = item.term.trim().toLowerCase();
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      glossary.push(item);
+    }
+  }
+  return glossary;
+}
+
+function ThreadGlossary({ turns }: { turns: ResearchThreadTurn[] }) {
+  const glossary = useMemo(() => computeThreadGlossary(turns), [turns]);
+  if (glossary.length === 0) return null;
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card/85 p-4">
+      <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
+        <Tag className="h-4 w-4 text-violet-700 dark:text-violet-300" aria-hidden />
+        Glossary
+      </span>
+      <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+        {glossary.map((item, index) => (
+          <Popover key={index}>
+            <PopoverTrigger className="inline-flex items-center gap-1 rounded-full border border-violet-500/30 bg-violet-500/[0.06] px-2.5 py-1 text-xs font-medium text-violet-700 transition-colors hover:border-violet-500/50 dark:text-violet-300">
+              {item.term}
+            </PopoverTrigger>
+            <PopoverContent className="w-64 text-sm">
+              <p className="font-medium text-foreground">{item.term}</p>
+              <p className="mt-1 text-muted-foreground">{item.definition}</p>
+            </PopoverContent>
+          </Popover>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Serializes a thread to portable Markdown -- title, synthesis, every turn
+ * with its sources, traced papers, and the glossary. Privacy-first personal
+ * data shouldn't be a one-way door: making it trivial to take your own
+ * research out of the app (no server round-trip, this is just the same
+ * data already loaded, restructured as text) is the honest counterpart to
+ * the BYOK/E2E-encryption pitch the rest of Sage is built on.
+ */
+function buildThreadMarkdown(thread: ResearchThreadEntity): string {
+  const lines: string[] = [`# ${thread.title}`, ""];
+
+  if (thread.synthesis) {
+    lines.push("## What we know so far", "", thread.synthesis.summary, "");
+    if (thread.synthesis.established.length > 0) {
+      lines.push("### Established", "", ...thread.synthesis.established.map((item) => `- ${item}`), "");
+    }
+    if (thread.synthesis.openQuestions.length > 0) {
+      lines.push("### Open questions", "", ...thread.synthesis.openQuestions.map((item) => `- ${item}`), "");
+    }
+  }
+
+  const glossary = computeThreadGlossary(thread.turns);
+  if (glossary.length > 0) {
+    lines.push("## Glossary", "");
+    for (const item of glossary) lines.push(`- **${item.term}**: ${item.definition}`);
+    lines.push("");
+  }
+
+  if (thread.turns.length > 0) {
+    lines.push("## Questions & answers", "");
+    thread.turns.forEach((turn, index) => {
+      lines.push(`### ${index + 1}. ${turn.query}`, "", turn.answer, "");
+      if (turn.sources.length > 0) {
+        lines.push(...turn.sources.map((s) => `- [${s.title}](${s.url})`), "");
+      }
+    });
+  }
+
+  if (thread.tracedPapers.length > 0) {
+    lines.push("## Traced papers", "");
+    for (const paper of thread.tracedPapers) {
+      const year = paper.year ? ` (${paper.year})` : "";
+      lines.push(`- ${paper.title}${year} -- cited by ${paper.citedByCount}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function downloadThreadMarkdown(thread: ResearchThreadEntity): void {
+  const markdown = buildThreadMarkdown(thread);
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const filename = `${thread.title.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 60) || "research-thread"}.md`;
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+type RelatedThread = {
+  thread: ResearchThreadEntity;
+  sharedTerms: string[];
+  sharedPaperTitles: string[];
+};
+
+function collectTermMap(thread: ResearchThreadEntity): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const turn of thread.turns) {
+    for (const item of turn.keyTerms) {
+      const key = item.term.trim().toLowerCase();
+      if (key && !map.has(key)) map.set(key, item.term.trim());
+    }
+  }
+  return map;
+}
+
+/**
+ * Surfaces OTHER active threads that overlap with this one -- by shared key
+ * terms or shared traced papers -- turning a flat list of separate
+ * investigations into something closer to an actual personal knowledge
+ * graph. Pure client-side computation over threads already loaded (no new
+ * backend call, no LLM judgment call about "relatedness" to get wrong).
+ */
+function computeRelatedThreads(thread: ResearchThreadEntity, allThreads: ResearchThreadEntity[]): RelatedThread[] {
+  const ownTermMap = collectTermMap(thread);
+  const ownPaperIds = new Set(thread.tracedPapers.map((p) => p.id));
+
+  const related: RelatedThread[] = [];
+  for (const other of allThreads) {
+    if (other.entityId === thread.entityId || other.status !== "active") continue;
+    const otherTermMap = collectTermMap(other);
+    const sharedTerms = [...otherTermMap.keys()]
+      .filter((key) => ownTermMap.has(key))
+      .map((key) => ownTermMap.get(key) as string);
+    const sharedPapers = other.tracedPapers.filter((p) => ownPaperIds.has(p.id));
+    if (sharedTerms.length === 0 && sharedPapers.length === 0) continue;
+    related.push({ thread: other, sharedTerms, sharedPaperTitles: sharedPapers.map((p) => p.title) });
+  }
+  return related.sort(
+    (a, b) =>
+      b.sharedTerms.length + b.sharedPaperTitles.length - (a.sharedTerms.length + a.sharedPaperTitles.length),
+  );
+}
+
+function RelatedThreadsCard({
+  related,
+  onOpenThread,
+}: {
+  related: RelatedThread[];
+  onOpenThread: (threadId: string) => void;
+}) {
+  if (related.length === 0) return null;
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card/85 p-4">
+      <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
+        <Link2 className="h-4 w-4 text-violet-700 dark:text-violet-300" aria-hidden />
+        Related threads
+      </span>
+      <div className="mt-2.5 space-y-2">
+        {related.slice(0, 4).map((r) => (
+          <button
+            key={r.thread.entityId}
+            type="button"
+            onClick={() => onOpenThread(r.thread.entityId)}
+            className="flex w-full flex-col gap-1 rounded-lg border border-border/50 bg-background/60 p-2.5 text-left transition-colors hover:border-violet-500/40"
+          >
+            <span className="text-sm font-medium text-foreground">{r.thread.title}</span>
+            <span className="text-xs text-muted-foreground">
+              {[
+                r.sharedTerms.length > 0 ? `shares "${r.sharedTerms.slice(0, 2).join('", "')}"` : null,
+                r.sharedPaperTitles.length > 0
+                  ? `${r.sharedPaperTitles.length} shared paper${r.sharedPaperTitles.length === 1 ? "" : "s"}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const sageComparisonChartConfig = {
+  value: {
+    label: "Value",
+    color: "rgb(139 92 246)", // violet-500, matching Sage's accent everywhere else in this panel
+  },
+} satisfies ChartConfig;
+
+function compactChartLabel(value: string, max = 18): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+/**
+ * One real bar chart (recharts, via the same ChartContainer/ChartTooltip
+ * wrapper the Kai dashboard views use) for a single same-unit group of
+ * comparable numbers -- not a full-size dashboard panel, sized to just fit
+ * its handful of rows since it sits inline in a chat bubble.
+ */
+function SageComparisonChart({ unit, items }: { unit: string; items: ResearchThreadComparison[] }) {
+  const data = items.map((item) => ({ name: item.label, value: item.value }));
+  const height = Math.max(56, items.length * 34);
+  return (
+    <ChartContainer config={sageComparisonChartConfig} className="w-full" style={{ height }}>
+      <BarChart accessibilityLayer data={data} layout="vertical" margin={{ left: 4, right: 44, top: 4, bottom: 4 }}>
+        <CartesianGrid horizontal={false} strokeDasharray="3 3" strokeOpacity={0.35} />
+        <XAxis type="number" hide />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={108}
+          tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+          tickFormatter={(value) => compactChartLabel(String(value))}
+          axisLine={false}
+          tickLine={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={
+            <ChartTooltipContent
+              hideLabel
+              formatter={(value, _name, item) => {
+                const payload = item?.payload as { name?: string } | undefined;
+                return (
+                  <div className="flex min-w-[8rem] flex-col gap-0.5">
+                    <span className="text-[11px] font-semibold text-foreground">{payload?.name}</span>
+                    <span className="text-sm font-semibold text-foreground">
+                      {Number(value).toLocaleString()}
+                      {unit ? ` ${unit}` : ""}
+                    </span>
+                  </div>
+                );
+              }}
+            />
+          }
+        />
+        <Bar dataKey="value" fill="var(--color-value)" radius={[0, 4, 4, 0]} barSize={14}>
+          <LabelList
+            dataKey="value"
+            position="right"
+            fontSize={10}
+            fill="var(--foreground)"
+            formatter={(val: number) => `${val.toLocaleString()}${unit ? ` ${unit}` : ""}`}
+          />
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+/**
+ * Real numbers an answer already stated, charted -- grouped by unit rather
+ * than one shared chart: the prompt asks the model for a single same-unit
+ * set, but if it ever slips in two kinds of number (e.g. a score and a
+ * distance metric), plotting them on one shared axis would make one look
+ * negligible for no real reason. Only rendered when the model actually
+ * found something genuinely comparable.
+ */
+function ComparisonBars({ items }: { items: ResearchThreadComparison[] }) {
+  if (items.length === 0) return null;
+  const groups = new Map<string, ResearchThreadComparison[]>();
+  for (const item of items) {
+    const key = item.unit || "";
+    const existing = groups.get(key);
+    if (existing) existing.push(item);
+    else groups.set(key, [item]);
+  }
+  return (
+    <div className="mt-2.5 space-y-3 border-t border-violet-500/10 pt-2.5">
+      {Array.from(groups.entries()).map(([unit, groupItems]) => (
+        <SageComparisonChart key={unit || "unitless"} unit={unit} items={groupItems} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A profile of how mature THIS INVESTIGATION is, not the topic itself --
+ * there's no universal rubric for scoring an arbitrary research subject
+ * (unlike Kai's portfolio health, which scores a fixed financial domain),
+ * so this deliberately scores the thread's own research process instead,
+ * using only real, already-present data:
+ *  - Depth: how many questions have been asked
+ *  - Evidence: how many real web sources were found across all turns
+ *  - Grounding: what fraction of turns actually returned live search sources
+ *    (vs. answered from the model's own knowledge)
+ *  - Consensus: established vs. open-question ratio from the synthesis
+ *  - Breadth: how many distinct key terms have come up
+ *  - Currency: how recent the traced papers are, on average
+ * Every axis is a straight count/ratio over data already on the thread --
+ * nothing here is invented or separately generated.
+ */
+function computeResearchHealth(thread: ResearchThreadEntity): { axes: HealthRadarAxis[]; overall: number } {
+  const turnCount = thread.turns.length;
+  const totalSources = thread.turns.reduce((sum, t) => sum + t.sources.length, 0);
+  const turnsWithSources = thread.turns.filter((t) => t.sources.length > 0).length;
+  const uniqueTerms = new Set(thread.turns.flatMap((t) => t.keyTerms.map((k) => k.term.trim().toLowerCase())));
+  const establishedCount = thread.synthesis?.established.length ?? 0;
+  const openCount = thread.synthesis?.openQuestions.length ?? 0;
+  const consensusTotal = establishedCount + openCount;
+
+  const currentYear = new Date().getFullYear();
+  const papersWithYear = thread.tracedPapers.filter((p) => typeof p.year === "number");
+  const currency =
+    papersWithYear.length === 0
+      ? 0
+      : papersWithYear.reduce((sum, p) => {
+          const age = currentYear - (p.year as number);
+          return sum + Math.max(0, Math.min(100, 100 - age * 10));
+        }, 0) / papersWithYear.length;
+
+  const axes: HealthRadarAxis[] = [
+    { subject: "Depth", value: Math.min(100, turnCount * 25) },
+    { subject: "Evidence", value: Math.min(100, totalSources * 12.5) },
+    { subject: "Grounding", value: turnCount === 0 ? 0 : Math.round((turnsWithSources / turnCount) * 100) },
+    { subject: "Consensus", value: consensusTotal === 0 ? 0 : Math.round((establishedCount / consensusTotal) * 100) },
+    { subject: "Breadth", value: Math.min(100, uniqueTerms.size * 12.5) },
+    { subject: "Currency", value: Math.round(currency) },
+  ];
+  const overall = Math.round(axes.reduce((sum, axis) => sum + axis.value, 0) / axes.length);
+  return { axes, overall };
+}
+
+function ResearchHealthPanel({ thread }: { thread: ResearchThreadEntity }) {
+  const { axes, overall } = useMemo(() => computeResearchHealth(thread), [thread]);
+  return (
+    <HealthRadarCard
+      icon={Gauge}
+      title="Investigation health"
+      axes={axes}
+      overall={overall}
+      scaleLabels={["Early", "Developing", "Well-established"]}
+    />
+  );
+}
+
+function askDomains(domains: DomainSummary[]) {
+  return domains.map((d) => ({
+    domain: d.key,
+    displayName: d.displayName,
+    summary: d.summary,
+    attributeCount: d.attributeCount,
+  }));
+}
+
+/**
+ * Owns its own query/loading/error state so typing here never re-renders
+ * the (potentially large, markdown-heavy) thread list above it -- keeping
+ * this input's state in the parent caused every keystroke to re-render
+ * every thread card, which visibly flickered.
+ */
+function NewThreadBox({
+  personalDomains,
+  vaultOwnerToken,
+  onCreate,
+}: {
+  personalDomains: DomainSummary[];
+  vaultOwnerToken: string | null;
+  onCreate: (
+    query: string,
+    answer: string,
+    sources: ResearchThreadSource[],
+    keyTerms: ResearchThreadKeyTerm[],
+    comparisons: ResearchThreadComparison[],
+    paperSearchQuery: string | null,
+  ) => Promise<void>;
+}) {
+  const [query, setQuery] = useState("");
+  const [length, setLength] = useState<AnswerLength>("standard");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCreate() {
+    const trimmed = query.trim();
+    if (!trimmed || !vaultOwnerToken || creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const response = await ApiService.askSage({
+        vaultOwnerToken,
+        query: trimmed,
+        mode: "standard",
+        depth: "deep",
+        length,
+        domains: askDomains(personalDomains),
+      });
+      if (!response.ok) throw new Error("Sage couldn't research that just now.");
+      const data = await response.json();
+      const answer = String(data.answer || "");
+      const sources: ResearchThreadSource[] = Array.isArray(data.sources) ? data.sources : [];
+      const keyTerms: ResearchThreadKeyTerm[] = Array.isArray(data.key_terms) ? data.key_terms : [];
+      const comparisons: ResearchThreadComparison[] = Array.isArray(data.comparisons) ? data.comparisons : [];
+      const paperSearchQuery: string | null = typeof data.paper_search_query === "string" ? data.paper_search_query : null;
+      await onCreate(trimmed, answer, sources, keyTerms, comparisons, paperSearchQuery);
+      setQuery("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't start that thread just now.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-violet-500/25 bg-card/85 p-5 shadow-[0_1px_2px_rgba(15,23,42,0.06)] sm:p-6">
+      <div className="flex items-center gap-2 text-base font-semibold text-violet-700 dark:text-violet-300">
+        <FlaskConical className="h-5 w-5" aria-hidden />
+        Start a new research thread
+      </div>
+      <p className="mt-1.5 text-sm text-muted-foreground">
+        Ask a real question. Sage will keep working on it with you across visits -- not just one
+        answer, an ongoing investigation.
+      </p>
+      <div className="mt-4 flex flex-col gap-2.5 sm:flex-row">
+        <Textarea
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void handleCreate();
+            }
+          }}
+          placeholder="e.g. Are transformers better than RNNs for long-context tasks?"
+          className="min-h-[2.75rem] flex-1 resize-none"
+          rows={2}
+        />
+        <Button onClick={() => void handleCreate()} disabled={creating || !query.trim()}>
+          {creating ? "Starting…" : "Start thread"}
+        </Button>
+      </div>
+      <div className="mt-2.5">
+        <AnswerLengthControl value={length} onChange={setLength} disabled={creating} />
+      </div>
+      <SageLoadingIndicator active={creating} expectedSeconds={ANSWER_LENGTH_EXPECTED_SECONDS[length]} />
+      {error ? <p className="mt-2.5 text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
+/**
+ * Same isolation as NewThreadBox above, for the same reason: typing a
+ * follow-up must not re-render the turn history / synthesis block sitting
+ * next to it.
+ */
+function FollowUpAskBox({
+  thread,
+  personalDomains,
+  vaultOwnerToken,
+  onAnswered,
+}: {
+  thread: ResearchThreadEntity;
+  personalDomains: DomainSummary[];
+  vaultOwnerToken: string | null;
+  onAnswered: (
+    query: string,
+    answer: string,
+    sources: ResearchThreadSource[],
+    keyTerms: ResearchThreadKeyTerm[],
+    comparisons: ResearchThreadComparison[],
+    paperSearchQuery: string | null,
+  ) => Promise<void>;
+}) {
+  const [query, setQuery] = useState("");
+  const [length, setLength] = useState<AnswerLength>("standard");
+  const [asking, setAsking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleAsk() {
+    const trimmed = query.trim();
+    if (!trimmed || !vaultOwnerToken || asking) return;
+    setAsking(true);
+    setError(null);
+    try {
+      const conversationHistory = thread.turns.slice(-4).map((t) => ({ query: t.query, answer: t.answer }));
+      const response = await ApiService.askSage({
+        vaultOwnerToken,
+        query: trimmed,
+        mode: "standard",
+        depth: "deep",
+        length,
+        domains: askDomains(personalDomains),
+        conversationHistory,
+      });
+      if (!response.ok) throw new Error("Sage couldn't research that just now.");
+      const data = await response.json();
+      const answer = String(data.answer || "");
+      const sources: ResearchThreadSource[] = Array.isArray(data.sources) ? data.sources : [];
+      const keyTerms: ResearchThreadKeyTerm[] = Array.isArray(data.key_terms) ? data.key_terms : [];
+      const comparisons: ResearchThreadComparison[] = Array.isArray(data.comparisons) ? data.comparisons : [];
+      const paperSearchQuery: string | null = typeof data.paper_search_query === "string" ? data.paper_search_query : null;
+      await onAnswered(trimmed, answer, sources, keyTerms, comparisons, paperSearchQuery);
+      setQuery("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sage couldn't research that just now.");
+    } finally {
+      setAsking(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card/85 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <Textarea
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void handleAsk();
+            }
+          }}
+          placeholder="Ask a follow-up…"
+          className="min-h-[2.75rem] flex-1 resize-none"
+          rows={2}
+        />
+        <Button onClick={() => void handleAsk()} disabled={asking || !query.trim()}>
+          {asking ? "Researching…" : "Ask"}
+        </Button>
+      </div>
+      <div className="mt-2">
+        <AnswerLengthControl value={length} onChange={setLength} disabled={asking} />
+      </div>
+      <SageLoadingIndicator active={asking} expectedSeconds={ANSWER_LENGTH_EXPECTED_SECONDS[length]} />
+      {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
+/**
+ * Sage as a persistent researcher instead of a one-shot chat: a named,
+ * ongoing investigation that survives across visits, accumulating real
+ * Q&A turns and traced papers, with a running synthesis of what's
+ * established vs. still open. Stored in its own `research` PKM domain
+ * (a new domain key -- the domain system is fully dynamic, no backend
+ * schema change needed; confirmed live before building this) via the same
+ * PkmWriteCoordinator.saveMergedDomain path every other Sage write uses.
+ *
+ * Every build() below returns `mergeDecision: { merge_mode: "replace_domain" }`.
+ * Without it, saveMergedDomain's default "create_entity" mode re-derives the
+ * write by heuristically extracting a single entity out of `domainData` and
+ * splicing it into a separately-fetched base blob -- a heuristic built for
+ * flat entity shapes like notes, not this domain's nested
+ * turns/tracedPapers/synthesis structure. It silently discarded every new
+ * thread while still reporting success, since our build() already does a
+ * correct, complete read-modify-write against context.currentDomainData --
+ * replace_domain tells the coordinator to persist that result verbatim.
+ */
+export function ResearchThreadsPanel() {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+
+  const [loading, setLoading] = useState(true);
+  const [threads, setThreads] = useState<ResearchThreadEntity[]>([]);
+  const [personalDomains, setPersonalDomains] = useState<DomainSummary[]>([]);
+  const [view, setView] = useState<View>({ mode: "list" });
+  const [synthesisLoading, setSynthesisLoading] = useState(false);
+
+  /**
+   * Always called right after a write (create/append/synthesis/archive).
+   * forceRefresh is required here: the cache invalidation that a write
+   * triggers (CacheSyncService.onPkmDomainStored) goes through a
+   * fire-and-forget dynamic import that isn't awaited by the write path,
+   * so a stale-first read immediately after a write can race it and
+   * return pre-write data -- e.g. a just-created thread not yet in
+   * `threads`, making the detail view think it doesn't exist.
+   */
+  async function refreshThreads(): Promise<ResearchThreadEntity[]> {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return [];
+    const snapshot = await PkmDomainResourceService.getStaleFirst({
+      userId: user.uid,
+      domain: RESEARCH_DOMAIN,
+      vaultKey,
+      vaultOwnerToken,
+      forceRefresh: true,
+    });
+    const parsed = listResearchThreads(snapshot?.data || {});
+    setThreads(parsed);
+    return parsed;
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      if (!user?.uid || !vaultKey || !vaultOwnerToken) {
+        if (!cancelled) setLoading(false);
+        return;
+      }
+      try {
+        const [snapshot, metadata] = await Promise.all([
+          PkmDomainResourceService.getStaleFirst({
+            userId: user.uid,
+            domain: RESEARCH_DOMAIN,
+            vaultKey,
+            vaultOwnerToken,
+          }),
+          PersonalKnowledgeModelService.getMetadata(user.uid, false, vaultOwnerToken),
+        ]);
+        if (!cancelled) {
+          setThreads(listResearchThreads(snapshot?.data || {}));
+          setPersonalDomains(metadata.domains);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, vaultKey, vaultOwnerToken]);
+
+  /**
+   * Runs whenever the viewed thread's content has changed since its last
+   * synthesis: refreshes the synthesis AND auto-traces papers for the most
+   * recent question, in ONE combined write. These used to be two separate
+   * fire-and-forget writes (triggered right after each other from
+   * handleThreadCreated/handleFollowUpAnswered) and they raced: both read
+   * the same locally-cached pre-write snapshot, so whichever wrote second
+   * hit a version conflict, retried against a cache that hadn't been
+   * invalidated yet, and after exhausting its retries was silently
+   * dropped -- confirmed live (traced papers landed, synthesis didn't).
+   * Combining them into one write removes the race by construction.
+   *
+   * Order inside the write matters too: papers are added BEFORE the
+   * synthesis timestamp is set, so synthesis.generatedAt always lands >=
+   * the paper-add's updated_at bump within this same write -- otherwise
+   * the staleness check below would see its own write as stale and loop.
+   */
+  async function enrichThreadAfterTurn(
+    threadId: string,
+    title: string,
+    turns: ResearchThreadTurn[],
+    tracedPapersBefore: ResearchThreadPaper[],
+    paperSearchQuery: string | null,
+  ) {
+    if (!vaultOwnerToken || !user?.uid || !vaultKey) return;
+    setSynthesisLoading(true);
+    try {
+      // Capped to match PkmSageThreadSynthesisRequest's max_length (turns:20,
+      // traced_papers:30) on the backend -- a long-lived thread (the whole
+      // point of Research Threads) past either limit used to 422 silently
+      // (swallowed by the .catch below), freezing "What we know so far"
+      // forever with no error shown. Most-recent turns kept since synthesis
+      // cares about current state, not the earliest questions asked.
+      const synthesisPromise = ApiService.getSageThreadSynthesis({
+        vaultOwnerToken,
+        title,
+        turns: turns.slice(-20).map((t) => ({ query: t.query, answer: t.answer })),
+        tracedPapers: tracedPapersBefore.slice(-30).map((p) => ({
+          title: p.title,
+          year: p.year,
+          topic: p.topic,
+          citedByCount: p.citedByCount,
+        })),
+      }).catch(() => null);
+      const paperPromise = paperSearchQuery
+        ? ApiService.searchSagePapers({ vaultOwnerToken, query: paperSearchQuery }).catch(() => null)
+        : Promise.resolve(null);
+
+      const [synthesisResponse, paperResponse] = await Promise.all([synthesisPromise, paperPromise]);
+      const synthesisData = synthesisResponse?.ok ? await synthesisResponse.json() : null;
+      const paperData = paperResponse?.ok ? await paperResponse.json() : null;
+      const candidates = (Array.isArray(paperData?.results) ? paperData.results : []).slice(0, 2);
+
+      if (!synthesisData && candidates.length === 0) return;
+
+      await PkmWriteCoordinator.saveMergedDomain({
+        userId: user.uid,
+        domain: RESEARCH_DOMAIN,
+        vaultKey,
+        vaultOwnerToken,
+        build: (context) => {
+          let updated = context.currentDomainData;
+          for (const candidate of candidates) {
+            const id = String(candidate.id || "").trim();
+            if (!id) continue;
+            updated = addTracedPaperToThread(updated, threadId, {
+              id,
+              title: String(candidate.title || "Untitled"),
+              year: typeof candidate.year === "number" ? candidate.year : null,
+              topic: typeof candidate.topic === "string" ? candidate.topic : null,
+              citedByCount: typeof candidate.cited_by_count === "number" ? candidate.cited_by_count : 0,
+            });
+          }
+          if (synthesisData) {
+            updated = updateThreadSynthesis(updated, threadId, {
+              summary: String(synthesisData.summary || ""),
+              established: Array.isArray(synthesisData.established) ? synthesisData.established : [],
+              openQuestions: Array.isArray(synthesisData.open_questions) ? synthesisData.open_questions : [],
+            });
+          }
+          const threadsAfter = listResearchThreads(updated);
+          return {
+            domainData: updated,
+            mergeDecision: { merge_mode: "replace_domain" },
+            summary: { source: "sage_research_thread_enrich", ...buildResearchThreadsSummaryPatch(threadsAfter) },
+          };
+        },
+      });
+      await refreshThreads();
+    } catch {
+      // Best-effort -- the turn itself already saved; revisiting the thread retries this.
+    } finally {
+      setSynthesisLoading(false);
+    }
+  }
+
+  const activeThreadId = view.mode === "detail" ? view.threadId : null;
+  const activeThread = activeThreadId ? threads.find((t) => t.entityId === activeThreadId) : undefined;
+
+  useEffect(() => {
+    if (!activeThreadId || !activeThread) return;
+    if (activeThread.turns.length === 0 && activeThread.tracedPapers.length === 0) return;
+    // Skip the (multi-second) LLM call if the stored synthesis was already
+    // generated at or after the thread's last content change -- updateThreadSynthesis
+    // never touches updatedAt, so this comparison is exact, not a heuristic.
+    // Without it, every visit to an already-synthesized thread re-ran the full
+    // synthesis call for no reason.
+    const synthesisIsCurrent = Boolean(
+      activeThread.synthesis?.generatedAt && activeThread.synthesis.generatedAt >= activeThread.updatedAt,
+    );
+    if (synthesisIsCurrent) return;
+    const lastTurn = activeThread.turns[activeThread.turns.length - 1];
+    void enrichThreadAfterTurn(
+      activeThread.entityId,
+      activeThread.title,
+      activeThread.turns,
+      activeThread.tracedPapers,
+      lastTurn?.paperSearchQuery || null,
+    );
+    // Driven by updatedAt (bumped by any real content change: a new turn, or
+    // a paper added from Citation Lineage) rather than turns.length alone,
+    // so both sources of "this needs re-enrichment" are covered by one check.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeThreadId, activeThread?.updatedAt]);
+
+  async function handleThreadCreated(
+    query: string,
+    answer: string,
+    sources: ResearchThreadSource[],
+    keyTerms: ResearchThreadKeyTerm[],
+    comparisons: ResearchThreadComparison[],
+    paperSearchQuery: string | null,
+  ) {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+    let newThreadId = "";
+    const result = await PkmWriteCoordinator.saveMergedDomain({
+      userId: user.uid,
+      domain: RESEARCH_DOMAIN,
+      vaultKey,
+      vaultOwnerToken,
+      build: (context) => {
+        const created = createResearchThread(context.currentDomainData, query);
+        newThreadId = created.thread.entityId;
+        const withTurn = appendThreadTurn(created.domainData, newThreadId, {
+          query,
+          answer,
+          mode: "standard",
+          sources,
+          keyTerms,
+          comparisons,
+          paperSearchQuery,
+        });
+        const threadsAfter = listResearchThreads(withTurn);
+        return {
+          domainData: withTurn,
+          mergeDecision: { merge_mode: "replace_domain" },
+          summary: {
+            source: "sage_research_thread",
+            message_excerpt: query.slice(0, 160),
+            ...buildResearchThreadsSummaryPatch(threadsAfter),
+          },
+        };
+      },
+    });
+    if (!result.success) throw new Error(result.message || "Couldn't save that thread just now.");
+    await refreshThreads();
+    setView({ mode: "detail", threadId: newThreadId });
+    // Enrichment (synthesis + auto-trace) runs from the staleness effect
+    // above once this thread is the active view -- not triggered here
+    // directly, so it never races a second write.
+  }
+
+  async function handleFollowUpAnswered(
+    thread: ResearchThreadEntity,
+    query: string,
+    answer: string,
+    sources: ResearchThreadSource[],
+    keyTerms: ResearchThreadKeyTerm[],
+    comparisons: ResearchThreadComparison[],
+    paperSearchQuery: string | null,
+  ) {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+    await PkmWriteCoordinator.saveMergedDomain({
+      userId: user.uid,
+      domain: RESEARCH_DOMAIN,
+      vaultKey,
+      vaultOwnerToken,
+      build: (context) => {
+        const updated = appendThreadTurn(context.currentDomainData, thread.entityId, {
+          query,
+          answer,
+          mode: "standard",
+          sources,
+          keyTerms,
+          comparisons,
+          paperSearchQuery,
+        });
+        const threadsAfter = listResearchThreads(updated);
+        return {
+          domainData: updated,
+          mergeDecision: { merge_mode: "replace_domain" },
+          summary: {
+            source: "sage_research_thread",
+            message_excerpt: query.slice(0, 160),
+            ...buildResearchThreadsSummaryPatch(threadsAfter),
+          },
+        };
+      },
+    });
+    // Enrichment runs from the staleness effect above (triggered by this
+    // write's updated_at bump) instead of being called directly here --
+    // same reasoning as handleThreadCreated.
+    await refreshThreads();
+  }
+
+  async function handleArchiveThread(threadId: string) {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+    await PkmWriteCoordinator.saveMergedDomain({
+      userId: user.uid,
+      domain: RESEARCH_DOMAIN,
+      vaultKey,
+      vaultOwnerToken,
+      build: (context) => {
+        const updated = archiveResearchThread(context.currentDomainData, threadId);
+        const threadsAfter = listResearchThreads(updated);
+        return {
+          domainData: updated,
+          mergeDecision: { merge_mode: "replace_domain" },
+          summary: { source: "sage_research_thread_archive", ...buildResearchThreadsSummaryPatch(threadsAfter) },
+        };
+      },
+    });
+    await refreshThreads();
+    setView({ mode: "list" });
+  }
+
+  async function handleRemoveTracedPaper(threadId: string, paperId: string) {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+    await PkmWriteCoordinator.saveMergedDomain({
+      userId: user.uid,
+      domain: RESEARCH_DOMAIN,
+      vaultKey,
+      vaultOwnerToken,
+      build: (context) => {
+        const updated = removeTracedPaperFromThread(context.currentDomainData, threadId, paperId);
+        const threadsAfter = listResearchThreads(updated);
+        return {
+          domainData: updated,
+          mergeDecision: { merge_mode: "replace_domain" },
+          summary: { source: "sage_research_thread_remove_paper", ...buildResearchThreadsSummaryPatch(threadsAfter) },
+        };
+      },
+    });
+    await refreshThreads();
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full" />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Skeleton className="h-28 w-full" />
+          <Skeleton className="h-28 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (view.mode === "detail") {
+    const thread = threads.find((t) => t.entityId === view.threadId);
+    if (!thread) {
+      return (
+        <div className="space-y-4">
+          <button
+            type="button"
+            onClick={() => setView({ mode: "list" })}
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+            All research threads
+          </button>
+          <p className="text-sm text-muted-foreground">That thread couldn&apos;t be found.</p>
+        </div>
+      );
+    }
+
+    const relative = formatRelativeTime(thread.updatedAt);
+    const relatedThreads = computeRelatedThreads(thread, threads);
+
+    return (
+      <div className="space-y-4">
+        <button
+          type="button"
+          onClick={() => setView({ mode: "list" })}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+          All research threads
+        </button>
+
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-violet-500/10 text-violet-700 dark:text-violet-300">
+              <FlaskConical className="h-5 w-5" aria-hidden />
+            </span>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-xl font-semibold leading-snug text-foreground">{thread.title}</p>
+                {thread.status === "active" ? (
+                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+                    Active
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                {relative ? <span>Updated {relative}</span> : null}
+                <span className="inline-flex items-center gap-1">
+                  <MessageSquare className="h-3 w-3" aria-hidden />
+                  {thread.turns.length} question{thread.turns.length === 1 ? "" : "s"}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <GitBranch className="h-3 w-3" aria-hidden />
+                  {thread.tracedPapers.length} paper{thread.tracedPapers.length === 1 ? "" : "s"} traced
+                </span>
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => downloadThreadMarkdown(thread)}
+              className="text-muted-foreground"
+            >
+              <Download className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+              Export
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleArchiveThread(thread.entityId)}
+              className="text-muted-foreground"
+            >
+              <Archive className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+              Archive
+            </Button>
+          </div>
+        </div>
+
+        <RelatedThreadsCard
+          related={relatedThreads}
+          onOpenThread={(threadId) => setView({ mode: "detail", threadId })}
+        />
+
+        {thread.turns.length > 0 ? <ResearchHealthPanel thread={thread} /> : null}
+
+        <div className="relative overflow-hidden rounded-2xl border border-violet-500/20 bg-gradient-to-br from-violet-500/[0.06] to-transparent p-5 dark:border-violet-400/20 dark:from-violet-400/[0.05]">
+          <span className="flex items-center gap-2 text-sm font-semibold text-violet-700 dark:text-violet-300">
+            <Sparkles className="h-4 w-4" aria-hidden />
+            What we know so far
+          </span>
+          {synthesisLoading ? (
+            <div className="mt-3 space-y-1.5">
+              <Skeleton className="h-3.5 w-full" />
+              <Skeleton className="h-3.5 w-4/5" />
+            </div>
+          ) : thread.synthesis ? (
+            <>
+              <p className="mt-2 text-[15px] leading-6 text-foreground">{thread.synthesis.summary}</p>
+              <SynthesisRatioBar
+                established={thread.synthesis.established.length}
+                open={thread.synthesis.openQuestions.length}
+              />
+              {thread.synthesis.established.length > 0 || thread.synthesis.openQuestions.length > 0 ? (
+                <div className="mt-3.5 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {thread.synthesis.established.length > 0 ? (
+                    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/[0.05] p-3 dark:border-emerald-400/20 dark:bg-emerald-400/[0.05]">
+                      <p className="text-xs font-medium uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+                        Established
+                      </p>
+                      <ul className="mt-1.5 space-y-1.5">
+                        {thread.synthesis.established.map((item, index) => (
+                          <li key={index} className="flex items-start gap-2 text-sm text-foreground">
+                            <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden />
+                            {item}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  {thread.synthesis.openQuestions.length > 0 ? (
+                    <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.05] p-3 dark:border-amber-400/20 dark:bg-amber-400/[0.05]">
+                      <p className="text-xs font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                        Open questions
+                      </p>
+                      <ul className="mt-1.5 space-y-1.5">
+                        {thread.synthesis.openQuestions.map((item, index) => (
+                          <li key={index} className="flex items-start gap-2 text-sm text-foreground">
+                            <CircleHelp className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />
+                            {item}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <p className="mt-2 text-sm text-muted-foreground">Ask something below to get this thread started.</p>
+          )}
+        </div>
+
+        {thread.turns.length > 0 ? <ThreadGlossary turns={thread.turns} /> : null}
+
+        <FollowUpAskBox
+          thread={thread}
+          personalDomains={personalDomains}
+          vaultOwnerToken={vaultOwnerToken}
+          onAnswered={(query, answer, sources, keyTerms, comparisons, paperSearchQuery) =>
+            handleFollowUpAnswered(thread, query, answer, sources, keyTerms, comparisons, paperSearchQuery)
+          }
+        />
+
+        {thread.turns.length > 0 ? (
+          <div className="space-y-4">
+            {thread.turns
+              .slice()
+              .reverse()
+              .map((turn, index) => {
+                const turnRelative = formatRelativeTime(turn.createdAt);
+                return (
+                  <div key={index} className="space-y-2.5">
+                    <div className="flex items-start gap-2.5">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                        <User className="h-3.5 w-3.5" aria-hidden />
+                      </span>
+                      <div className="min-w-0 flex-1 rounded-2xl rounded-tl-sm bg-muted/60 px-3.5 py-2.5">
+                        <p className="text-sm text-foreground">{turn.query}</p>
+                      </div>
+                    </div>
+                    <div className="flex items-start gap-2.5">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-violet-500/15 text-violet-700 dark:text-violet-300">
+                        <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                      </span>
+                      <div className="min-w-0 flex-1 rounded-2xl rounded-tl-sm border border-violet-500/15 bg-violet-500/[0.03] px-3.5 py-2.5 dark:border-violet-400/15">
+                        <ChapteredAnswer text={turn.answer} />
+                        <ComparisonBars items={turn.comparisons} />
+                        <KeyTermChips items={turn.keyTerms} />
+                        {turn.sources.length > 0 ? (
+                          <div className="mt-2.5 flex flex-wrap gap-1.5 border-t border-violet-500/10 pt-2.5">
+                            {turn.sources.map((source) => (
+                              <a
+                                key={source.url}
+                                href={source.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-card px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:border-violet-500/40 hover:text-foreground"
+                              >
+                                {source.title}
+                                <ExternalLink className="h-3 w-3" aria-hidden />
+                              </a>
+                            ))}
+                          </div>
+                        ) : null}
+                        {turnRelative ? (
+                          <p className="mt-1.5 text-[11px] text-muted-foreground/70">{turnRelative}</p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        ) : null}
+
+        <div className="rounded-xl border border-border/60 bg-card/85 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-base font-semibold text-foreground">
+              Traced papers <span className="text-sm font-normal text-muted-foreground">({thread.tracedPapers.length})</span>
+            </p>
+            <Link href={buildSageCitationsRoute(thread.entityId)}>
+              <Button size="sm" variant="outline">
+                <GitBranch className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+                Trace a paper
+              </Button>
+            </Link>
+          </div>
+          {thread.tracedPapers.length === 0 ? (
+            <p className="mt-2 text-sm text-muted-foreground">No papers traced yet for this thread.</p>
+          ) : (
+            <div className="mt-3 space-y-3">
+              {thread.tracedPapers.length > 1 ? (
+                <SageComparisonChart
+                  unit="citations"
+                  items={thread.tracedPapers.map((paper) => ({
+                    label: paper.title,
+                    value: paper.citedByCount,
+                    unit: "citations",
+                  }))}
+                />
+              ) : null}
+              {thread.tracedPapers.map((paper) => (
+                <div
+                  key={paper.id}
+                  className="group relative rounded-lg border border-border/50 bg-background/60 p-3 transition-colors hover:border-violet-500/40"
+                >
+                  <button
+                    type="button"
+                    onClick={() => void handleRemoveTracedPaper(thread.entityId, paper.id)}
+                    className="absolute right-2 top-2 rounded-md p-1 text-muted-foreground/50 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
+                    aria-label={`Remove "${paper.title}" from traced papers`}
+                    title="Remove from traced papers"
+                  >
+                    <X className="h-3.5 w-3.5" aria-hidden />
+                  </button>
+                  <Link
+                    href={buildSageCitationsRoute(thread.entityId, { workId: paper.id, title: paper.title })}
+                    className="block pr-6"
+                  >
+                    <p className="text-sm text-foreground">{paper.title}</p>
+                    <p className="mt-1.5 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+                      {paper.year || "Year unknown"}
+                      <CitationChip count={paper.citedByCount} />
+                      <TopicChip topic={paper.topic} />
+                    </p>
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const activeThreads = threads.filter((t) => t.status === "active");
+
+  return (
+    <div className="space-y-4">
+      <NewThreadBox
+        personalDomains={personalDomains}
+        vaultOwnerToken={vaultOwnerToken}
+        onCreate={handleThreadCreated}
+      />
+
+      {activeThreads.length === 0 ? (
+        <Empty className="border-violet-500/20 bg-violet-500/[0.03] dark:border-violet-400/20 dark:bg-violet-400/[0.03]">
+          <EmptyHeader>
+            <EmptyMedia variant="icon" className="bg-violet-500/10 text-violet-700 dark:text-violet-300">
+              <FlaskConical className="size-6" aria-hidden />
+            </EmptyMedia>
+            <EmptyTitle>No research threads yet</EmptyTitle>
+            <EmptyDescription>
+              Ask something above to start Sage&apos;s first ongoing investigation.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {activeThreads.map((thread) => {
+            const relative = formatRelativeTime(thread.updatedAt);
+            return (
+              <button
+                key={thread.entityId}
+                type="button"
+                onClick={() => setView({ mode: "detail", threadId: thread.entityId })}
+                className="flex flex-col gap-3 rounded-xl border border-border/60 bg-card/85 p-4 text-left shadow-[0_1px_2px_rgba(15,23,42,0.06)] transition-colors hover:border-violet-500/40"
+              >
+                <div className="flex items-start gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 text-violet-700 dark:text-violet-300">
+                    <FlaskConical className="h-4 w-4" aria-hidden />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-[15px] font-semibold leading-snug text-foreground">{thread.title}</p>
+                    {relative ? <p className="mt-0.5 text-xs text-muted-foreground/70">Updated {relative}</p> : null}
+                  </div>
+                </div>
+                <p className="line-clamp-2 text-sm text-muted-foreground">
+                  {thread.synthesis?.summary || "Ask something to get started."}
+                </p>
+                <div className="mt-auto flex items-center gap-3 border-t border-border/50 pt-2.5 text-xs text-muted-foreground/80">
+                  <span className="inline-flex items-center gap-1">
+                    <MessageSquare className="h-3 w-3" aria-hidden />
+                    {thread.turns.length} question{thread.turns.length === 1 ? "" : "s"}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <GitBranch className="h-3 w-3" aria-hidden />
+                    {thread.tracedPapers.length} traced
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/sage-loading-indicator.tsx
+++ b/hushh-webapp/components/sage/sage-loading-indicator.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const SAGE_STATUS_MESSAGES = [
+  "Reading your question…",
+  "Searching the web…",
+  "Reading sources…",
+  "Cross-checking facts…",
+  "Structuring the answer…",
+  "Writing a thorough answer…",
+  "Double-checking the details…",
+  "Wrapping up…",
+];
+
+function useCyclingStatus(active: boolean, messages: string[], intervalMs: number): string {
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    if (!active) {
+      setIndex(0);
+      return;
+    }
+    const id = setInterval(() => {
+      setIndex((current) => Math.min(current + 1, messages.length - 1));
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [active, intervalMs, messages.length]);
+  return messages[index] ?? messages[0] ?? "";
+}
+
+function useElapsedSeconds(active: boolean): number {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    if (!active) {
+      setElapsed(0);
+      return;
+    }
+    const startedAt = Date.now();
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return elapsed;
+}
+
+/**
+ * Sage's own research calls can legitimately run 8-75s (deep mode's
+ * "exhaustive" length tier, or challenge mode's two-stage search) -- a
+ * static "Researching…" label over that long reads as stalled. Paces a
+ * cycling status line and an elapsed-time readout against how long the
+ * call is actually expected to take, plus an indeterminate progress sweep
+ * (there's no real step-by-step progress from this single-call endpoint,
+ * so this never claims to be a literal percentage).
+ */
+export function SageLoadingIndicator({
+  active,
+  expectedSeconds = 20,
+}: {
+  active: boolean;
+  /** Roughly how long this call is expected to take -- used only to pace
+   * the status-message cycle and decide when to show the "still working"
+   * reassurance, never rendered as a literal countdown or percentage. */
+  expectedSeconds?: number;
+}) {
+  const statusMessage = useCyclingStatus(
+    active,
+    SAGE_STATUS_MESSAGES,
+    (expectedSeconds * 1000) / SAGE_STATUS_MESSAGES.length,
+  );
+  const elapsedSeconds = useElapsedSeconds(active);
+
+  if (!active) return null;
+
+  const longWait = elapsedSeconds > expectedSeconds;
+
+  return (
+    <div className="mt-2.5 rounded-xl border border-violet-500/20 bg-violet-500/5 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs font-medium text-violet-700 dark:text-violet-300">
+          <span className="inline-flex items-center gap-1" aria-hidden>
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-160ms] motion-reduce:animate-none" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-80ms] motion-reduce:animate-none" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current motion-reduce:animate-none" />
+          </span>
+          <span>{statusMessage}</span>
+        </div>
+        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground" aria-live="polite">
+          {elapsedSeconds}s
+        </span>
+      </div>
+      <div className="relative mt-2.5 h-1 overflow-hidden rounded-full bg-violet-500/10">
+        <div className="absolute inset-y-0 left-0 w-1/3 rounded-full bg-gradient-to-r from-transparent via-violet-500/80 to-transparent animate-sage-progress-sweep motion-reduce:animate-none" />
+      </div>
+      {longWait ? (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Still working -- a genuinely thorough answer just takes longer than a quick one.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/sage-markdown.tsx
+++ b/hushh-webapp/components/sage/sage-markdown.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * Shared markdown renderer for Sage's generated text (research answers,
+ * self-assessment drafts) -- both are real Gemini output with headings,
+ * lists, bold, and occasionally tables, so both need the same treatment.
+ */
+export function SageMarkdown({ text }: { text: string }) {
+  return (
+    <div className="min-w-0 space-y-2 break-words text-[14px] leading-6 text-foreground">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => <h4 className="mt-2 text-sm font-semibold">{children}</h4>,
+          h2: ({ children }) => <h4 className="mt-2 text-sm font-semibold">{children}</h4>,
+          h3: ({ children }) => <h5 className="mt-2 text-sm font-semibold">{children}</h5>,
+          h4: ({ children }) => <h6 className="mt-2 text-sm font-semibold">{children}</h6>,
+          p: ({ children }) => <p className="my-1.5 first:mt-0 last:mb-0">{children}</p>,
+          ul: ({ children }) => <ul className="my-1.5 ml-5 list-disc space-y-1">{children}</ul>,
+          ol: ({ children }) => <ol className="my-1.5 ml-5 list-decimal space-y-1">{children}</ol>,
+          li: ({ children }) => <li className="pl-1">{children}</li>,
+          table: ({ children }) => (
+            <div className="my-2 overflow-x-auto rounded-md border border-border/70">
+              <table className="min-w-full border-collapse text-left text-xs">{children}</table>
+            </div>
+          ),
+          th: ({ children }) => (
+            <th className="border-b border-border/70 bg-muted/60 px-2.5 py-1.5 font-semibold">{children}</th>
+          ),
+          td: ({ children }) => (
+            <td className="border-b border-border/50 px-2.5 py-1.5 align-top last:border-b-0">{children}</td>
+          ),
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/sage-markdown.tsx
+++ b/hushh-webapp/components/sage/sage-markdown.tsx
@@ -14,14 +14,24 @@ export function SageMarkdown({ text }: { text: string }) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          h1: ({ children }) => <h4 className="mt-2 text-sm font-semibold">{children}</h4>,
-          h2: ({ children }) => <h4 className="mt-2 text-sm font-semibold">{children}</h4>,
-          h3: ({ children }) => <h5 className="mt-2 text-sm font-semibold">{children}</h5>,
-          h4: ({ children }) => <h6 className="mt-2 text-sm font-semibold">{children}</h6>,
+          h1: ({ children }) => <h2 className="mt-2 text-sm font-semibold">{children}</h2>,
+          h2: ({ children }) => <h3 className="mt-2 text-sm font-semibold">{children}</h3>,
+          h3: ({ children }) => <h4 className="mt-2 text-sm font-semibold">{children}</h4>,
+          h4: ({ children }) => <h5 className="mt-2 text-sm font-semibold">{children}</h5>,
           p: ({ children }) => <p className="my-1.5 first:mt-0 last:mb-0">{children}</p>,
           ul: ({ children }) => <ul className="my-1.5 ml-5 list-disc space-y-1">{children}</ul>,
           ol: ({ children }) => <ol className="my-1.5 ml-5 list-decimal space-y-1">{children}</ol>,
           li: ({ children }) => <li className="pl-1">{children}</li>,
+          a: ({ children, href }) => (
+            <a
+              href={href || "#"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-primary underline-offset-4 hover:underline"
+            >
+              {children}
+            </a>
+          ),
           table: ({ children }) => (
             <div className="my-2 overflow-x-auto rounded-md border border-border/70">
               <table className="min-w-full border-collapse text-left text-xs">{children}</table>

--- a/hushh-webapp/components/sage/sage-panel.tsx
+++ b/hushh-webapp/components/sage/sage-panel.tsx
@@ -1,0 +1,892 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ArrowRight,
+  BadgeCheck,
+  BookOpen,
+  Briefcase,
+  ChevronRight,
+  FileText,
+  FlaskConical,
+  Gauge,
+  GitBranch,
+  History,
+  Landmark,
+  Plane,
+  Search,
+  ShoppingBag,
+  Sparkles,
+  Wand2,
+} from "lucide-react";
+
+import { SectionHeader } from "@/components/app-ui/page-sections";
+import { Button } from "@/components/ui/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { MaterialRipple } from "@/lib/morphy-ux/material-ripple";
+import { cn } from "@/lib/utils";
+import { ApiService } from "@/lib/services/api-service";
+import {
+  PersonalKnowledgeModelService,
+  type DomainSummary,
+} from "@/lib/services/personal-knowledge-model-service";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import {
+  addNoteEntity,
+  archiveMatchingNoteEntity,
+  buildArchivedNoteSummaryPatch,
+  buildSageNoteSummaryPatch,
+  hasMatchingNote,
+} from "@/lib/sage/add-note-entity";
+import { listResearchThreads, type ResearchThreadEntity } from "@/lib/sage/research-thread-entity";
+import { HealthRadarCard, type HealthRadarAxis } from "@/components/sage/health-radar-card";
+import { ROUTES, buildSageAskRoute } from "@/lib/navigation/routes";
+
+const RESEARCH_DOMAIN = "research";
+const NOTE_PREFIX = /^saved from your note:\s*/i;
+
+const DOMAIN_ICON: Record<string, typeof Landmark> = {
+  financial: Landmark,
+  professional: Briefcase,
+  shopping: ShoppingBag,
+  travel: Plane,
+  kyc_connector: BadgeCheck,
+};
+
+/** Per-domain accent so the knowledge-base grid reads as distinct areas of
+ * your life, not N copies of the same violet card. */
+const DOMAIN_TONE_CLASS: Record<string, string> = {
+  financial: "bg-emerald-500/12 text-emerald-700 dark:text-emerald-300",
+  professional: "bg-sky-500/12 text-sky-700 dark:text-sky-300",
+  shopping: "bg-amber-500/12 text-amber-700 dark:text-amber-300",
+  travel: "bg-teal-500/12 text-teal-700 dark:text-teal-300",
+  kyc_connector: "bg-rose-500/12 text-rose-700 dark:text-rose-300",
+};
+const DOMAIN_TONE_FALLBACK = "bg-violet-500/12 text-violet-700 dark:text-violet-300";
+
+/** How many per-domain AI-summary calls fire at once -- see the effect below. */
+const DOMAIN_TEXT_CONCURRENCY = 2;
+
+type TextState = {
+  loading: boolean;
+  text: string | null;
+};
+
+type SuggestedFix = {
+  noteText: string;
+  fromDomain: string;
+  fromDisplayName: string;
+  targetDomain: string;
+  targetDisplayName: string;
+};
+
+type FixState = "idle" | "fixing" | "fixed" | "error";
+
+function formatRelativeTime(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return null;
+  const days = Math.max(0, Math.round((Date.now() - then) / 86_400_000));
+  if (days < 1) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  return `${Math.round(days / 30)}mo ago`;
+}
+
+/**
+ * How much real, current substance actually lives in one PKM domain --
+ * blends raw richness (attribute count) with recency (when it was last
+ * updated), same "real signal, no invented score" rule as Research
+ * Threads' Investigation Health. Both halves come straight off the
+ * DomainSummary already loaded for this page.
+ */
+/** Attribute count at which a domain is considered maximally "rich" on the
+ * radar. Log-scaled rather than linear so richness keeps discriminating
+ * well past a handful of attributes -- a straight `count * 5` capped at
+ * 100 saturated at just 20 attributes, which meant any reasonably active
+ * account showed every domain pinned at 100% and the radar flattened into
+ * an uninformative regular pentagon. */
+const RICHNESS_SATURATION_ATTRIBUTE_COUNT = 200;
+
+function computeDomainHealth(domain: DomainSummary): number {
+  const richness = Math.min(
+    100,
+    Math.round(
+      (Math.log2(domain.attributeCount + 1) / Math.log2(RICHNESS_SATURATION_ATTRIBUTE_COUNT + 1)) * 100,
+    ),
+  );
+  const updatedAt = domain.readableUpdatedAt || domain.lastUpdated;
+  const updatedTime = updatedAt ? new Date(updatedAt).getTime() : NaN;
+  const days = Number.isFinite(updatedTime) ? Math.max(0, (Date.now() - updatedTime) / 86_400_000) : Infinity;
+  const freshness = !Number.isFinite(days) ? 20 : days <= 7 ? 100 : days <= 30 ? 75 : days <= 90 ? 45 : 20;
+  // Richness-weighted, not a straight average -- an even 50/50 blend means
+  // freshness alone (pinned at 100 for anything touched in the last week)
+  // puts a 50-point floor under every recently-touched domain no matter how
+  // little is actually in it, which is what kept the radar looking "full"
+  // even after richness itself stopped saturating instantly.
+  return Math.round(richness * 0.7 + freshness * 0.3);
+}
+
+function computeKnowledgeHealth(domains: DomainSummary[]): { axes: HealthRadarAxis[]; overall: number } {
+  const axes = domains.map((d) => ({ subject: d.displayName, value: computeDomainHealth(d) }));
+  const overall = axes.length === 0 ? 0 : Math.round(axes.reduce((sum, a) => sum + a.value, 0) / axes.length);
+  return { axes, overall };
+}
+
+/**
+ * A live "agent" tile -- top accent bar, ripple, hover lift, and room for a
+ * real derived metric -- for the tools that carry actual state (a running
+ * thread, a saved note). Mirrors the dashboard's AgentCard so Sage's home
+ * page reads as alive rather than a static launcher grid. `children`
+ * renders outside the Link so tiles that need their own nested links (Ask
+ * Sage's prompt chips) never end up with an <a> inside an <a>.
+ */
+function SageAgentTile({
+  icon: Icon,
+  title,
+  metric,
+  metricLabel,
+  insight,
+  meta,
+  href,
+  loading = false,
+  children,
+}: {
+  icon: typeof Landmark;
+  title: string;
+  metric?: string | null;
+  metricLabel?: string;
+  insight: string;
+  meta?: string | null;
+  href: string;
+  loading?: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="group relative isolate overflow-hidden rounded-xl border border-violet-500/24 bg-card/85 shadow-[0_1px_2px_rgba(15,23,42,0.06)] transition-[border-color,box-shadow] duration-200 hover:border-violet-500/50 hover:shadow-[0_18px_36px_-24px_rgba(15,23,42,0.5)] dark:border-violet-400/20 dark:hover:border-violet-300/44">
+      <span className="absolute inset-x-0 top-0 h-[3px] bg-gradient-to-r from-violet-500 to-purple-400" aria-hidden />
+      <Link href={href} aria-label={`Open ${title}`} className="relative isolate block p-4 sm:p-5">
+        <MaterialRipple variant="link" effect="glass" className="rounded-xl" />
+        <span className="flex items-center justify-between gap-2">
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-500/12 text-violet-700 dark:text-violet-300">
+              <Icon className="h-4 w-4" aria-hidden />
+            </span>
+            <span className="truncate text-[15px] font-semibold leading-5 text-foreground">{title}</span>
+          </span>
+          <ArrowRight
+            className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-foreground"
+            aria-hidden
+          />
+        </span>
+
+        {metric ? (
+          <span className="mt-2.5 flex items-baseline gap-1.5">
+            <span className="text-[1.6rem] font-semibold leading-7 tabular-nums text-violet-700 dark:text-violet-300">
+              {metric}
+            </span>
+            {metricLabel ? (
+              <span className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground/70">
+                {metricLabel}
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+
+        <p className={cn("line-clamp-3 text-sm leading-5 text-muted-foreground", metric ? "mt-2" : "mt-2.5")}>
+          {loading ? "Reading…" : insight}
+        </p>
+      </Link>
+
+      {children ? <div className="px-4 pb-1 sm:px-5">{children}</div> : null}
+
+      {meta ? (
+        <div className="flex items-center gap-1.5 px-4 pb-4 pt-2 text-xs text-muted-foreground/80 sm:px-5">
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-violet-500" aria-hidden />
+          <span className="truncate">{meta}</span>
+        </div>
+      ) : (
+        <div className="pb-4 sm:pb-5" />
+      )}
+    </div>
+  );
+}
+
+/**
+ * A real input right on the home tile -- but Sage never researches inline
+ * here. Submitting navigates to the dedicated Ask Sage page with the query
+ * carried over and auto-asked there (buildSageAskRoute's `autoAsk`), so the
+ * actual research call and its answer only ever happen on that one page,
+ * never duplicated between a home-tile version and the full page.
+ */
+function QuickAskBox() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  function handleSubmit() {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    router.push(buildSageAskRoute(trimmed, true));
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Textarea
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            handleSubmit();
+          }
+        }}
+        placeholder="Ask a real question…"
+        className="min-h-[2.25rem] flex-1 resize-none py-1.5 text-xs"
+        rows={1}
+      />
+      <Button size="sm" onClick={handleSubmit} disabled={!query.trim()}>
+        Ask
+      </Button>
+    </div>
+  );
+}
+
+/** A quiet, compact launcher for tools with no per-visit state to surface --
+ * kept small and low-emphasis on purpose so the three live tiles above (Ask
+ * Sage, Research threads, Notes) read as the primary surface. */
+function SageLinkTile({
+  icon: Icon,
+  title,
+  description,
+  href,
+}: {
+  icon: typeof Landmark;
+  title: string;
+  description: string;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-label={`Open ${title}`}
+      className="group relative isolate flex min-h-[6.75rem] flex-col overflow-hidden rounded-lg border border-border/60 bg-card/85 p-3.5 text-left shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-violet-500/40 hover:shadow-[0_14px_32px_-28px_rgba(15,23,42,0.55)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:border-violet-400/35"
+    >
+      <MaterialRipple variant="link" effect="glass" className="rounded-lg" />
+      <span className="flex items-start justify-between gap-2">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-500/10 text-violet-700 dark:text-violet-300">
+          <Icon className="h-4 w-4" aria-hidden />
+        </span>
+        <ChevronRight
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-foreground"
+          aria-hidden
+        />
+      </span>
+      <span className="mt-2 block text-sm font-semibold leading-5 text-foreground">{title}</span>
+      <span className="mt-1 line-clamp-2 text-xs leading-4 text-muted-foreground">{description}</span>
+    </Link>
+  );
+}
+
+/**
+ * Sage: a fresh reading of the same PKM store Kai/Nav/KYC have been writing
+ * to all along -- one cross-domain "take" (a real connection across life
+ * areas, never a per-domain recap) plus one clean sentence per domain.
+ * Deliberately its own page/layout, not a reskin of the PKM explorer.
+ *
+ * The heavier interactive tools (Ask Sage, Research Threads, Citation
+ * Lineage, Self-assessment, Notes) each live on their own dedicated page --
+ * this page is a hub: a real "how much do I actually know about you"
+ * radar, the cross-domain briefing, and a tile grid linking out. Keeping
+ * every tool inlined here used to mean scrolling past three full
+ * interactive panels just to see the domain summaries.
+ */
+export function SagePanel() {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  const [loadingDomains, setLoadingDomains] = useState(true);
+  const [domains, setDomains] = useState<DomainSummary[]>([]);
+  const [briefing, setBriefing] = useState<TextState>({ loading: true, text: null });
+  const [suggestedFix, setSuggestedFix] = useState<SuggestedFix | null>(null);
+  const [fixState, setFixState] = useState<FixState>("idle");
+  const [fixError, setFixError] = useState<string | null>(null);
+  const [domainText, setDomainText] = useState<Record<string, TextState>>({});
+  const [suggestedPrompts, setSuggestedPrompts] = useState<string[]>([]);
+  const [recap, setRecap] = useState<TextState>({ loading: false, text: null });
+  const recapCheckedRef = useRef(false);
+  const [latestThread, setLatestThread] = useState<ResearchThreadEntity | null>(null);
+
+  const knowledgeHealth = useMemo(() => computeKnowledgeHealth(domains), [domains]);
+  const totalAttributes = useMemo(() => domains.reduce((sum, d) => sum + d.attributeCount, 0), [domains]);
+
+  // The Research Threads tile shows this thread's real synthesis instead of
+  // static marketing copy -- a lightweight decrypt-only read (no LLM call),
+  // same cost class as the domains fetch above, not the slow per-domain
+  // summary calls below.
+  useEffect(() => {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const snapshot = await PkmDomainResourceService.getStaleFirst({
+          userId: user.uid,
+          domain: RESEARCH_DOMAIN,
+          vaultKey,
+          vaultOwnerToken,
+        });
+        const threads = listResearchThreads(snapshot?.data || {}).filter((t) => t.status === "active");
+        if (!cancelled) setLatestThread(threads[0] || null);
+      } catch {
+        if (!cancelled) setLatestThread(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, vaultKey, vaultOwnerToken]);
+
+  // The Notes tile shows the most recent real note instead of static copy --
+  // derived straight from the domain summaries already loaded, no extra
+  // fetch (same raw-note extraction NotesArchivePanel uses).
+  const latestNote = useMemo(() => {
+    let best: { text: string; domainDisplayName: string; updatedAt: string } | null = null;
+    for (const domain of domains) {
+      const highlights = Array.isArray(domain.readableHighlights) ? domain.readableHighlights : [];
+      const updatedAt = domain.readableUpdatedAt || domain.lastUpdated || "";
+      for (const line of highlights) {
+        if (!NOTE_PREFIX.test(line)) continue;
+        const text = line.replace(NOTE_PREFIX, "").trim();
+        if (!text) continue;
+        if (!best || updatedAt > best.updatedAt) {
+          best = { text, domainDisplayName: domain.displayName, updatedAt };
+        }
+      }
+    }
+    return best;
+  }, [domains]);
+
+  async function refreshDomains() {
+    if (!user?.uid || !vaultOwnerToken) return;
+    const metadata = await PersonalKnowledgeModelService.getMetadata(user.uid, true, vaultOwnerToken);
+    setDomains(metadata.domains);
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      if (!user?.uid || !vaultOwnerToken) {
+        if (!cancelled) setLoadingDomains(false);
+        return;
+      }
+      try {
+        const metadata = await PersonalKnowledgeModelService.getMetadata(
+          user.uid,
+          false,
+          vaultOwnerToken,
+        );
+        if (!cancelled) setDomains(metadata.domains);
+      } finally {
+        if (!cancelled) setLoadingDomains(false);
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, vaultOwnerToken]);
+
+  useEffect(() => {
+    if (!vaultOwnerToken || domains.length === 0) return;
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const response = await ApiService.summarizeSageBriefing({
+          vaultOwnerToken,
+          domains: domains.map((d) => ({
+            domain: d.key,
+            displayName: d.displayName,
+            summary: d.summary,
+            attributeCount: d.attributeCount,
+            lastUpdated: d.readableUpdatedAt || d.lastUpdated,
+          })),
+        });
+        const data = response.ok ? await response.json() : null;
+        if (!cancelled) {
+          setBriefing({ loading: false, text: data?.text || null });
+          const fix = data?.suggested_fix;
+          if (fix?.note_text && fix?.from_domain && fix?.target_domain) {
+            setSuggestedFix({
+              noteText: fix.note_text,
+              fromDomain: fix.from_domain,
+              fromDisplayName: fix.from_display_name || fix.from_domain,
+              targetDomain: fix.target_domain,
+              targetDisplayName: fix.target_display_name || fix.target_domain,
+            });
+          }
+          if (Array.isArray(data?.suggested_prompts)) {
+            setSuggestedPrompts(data.suggested_prompts.filter((p: unknown) => typeof p === "string"));
+          }
+        }
+      } catch {
+        if (!cancelled) setBriefing({ loading: false, text: null });
+      }
+    })();
+
+    // Each domain updates its own card the moment ITS call finishes, instead
+    // of every card waiting on Promise.all across every domain -- previously
+    // a fast domain's real summary sat invisible behind the single slowest
+    // one. Also capped to DOMAIN_TEXT_CONCURRENCY at a time: backend logs
+    // showed every one of these landing at ~10.1s in lockstep (the 8s LLM
+    // timeout plus overhead) when all domains fired at once, which reads as
+    // contention under concurrent load, not each call being independently
+    // slow -- fewer in flight at once gives each a real shot at finishing
+    // inside budget instead of timing out to its fallback together.
+    void (async () => {
+      for (let i = 0; i < domains.length; i += DOMAIN_TEXT_CONCURRENCY) {
+        const batch = domains.slice(i, i + DOMAIN_TEXT_CONCURRENCY);
+        await Promise.all(
+          batch.map(async (d) => {
+            try {
+              const response = await ApiService.summarizePkmHighlight({
+                vaultOwnerToken,
+                domain: d.key,
+                displayName: d.displayName,
+                rawSummary: d.summary,
+                highlights: d.readableHighlights || [],
+                mode: "rich",
+              });
+              const data = response.ok ? await response.json() : null;
+              if (!cancelled) {
+                setDomainText((prev) => ({ ...prev, [d.key]: { loading: false, text: data?.text || null } }));
+              }
+            } catch {
+              if (!cancelled) setDomainText((prev) => ({ ...prev, [d.key]: { loading: false, text: null } }));
+            }
+          }),
+        );
+        if (cancelled) return;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [domains, vaultOwnerToken]);
+
+  useEffect(() => {
+    if (recapCheckedRef.current) return;
+    if (!user?.uid || !vaultOwnerToken || domains.length === 0) return;
+    recapCheckedRef.current = true;
+
+    const storageKey = `sage_recap_snapshot_v1_${user.uid}`;
+    type SnapshotEntry = { summary: Record<string, unknown>; updatedAt: string | null };
+    let previousSnapshot: Record<string, SnapshotEntry> | null = null;
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      previousSnapshot = raw ? JSON.parse(raw) : null;
+    } catch {
+      previousSnapshot = null;
+    }
+
+    const currentSnapshot: Record<string, SnapshotEntry> = {};
+    const changed: Array<{
+      domain: string;
+      displayName: string;
+      previousSummary: Record<string, unknown>;
+      currentSummary: Record<string, unknown>;
+    }> = [];
+
+    for (const domain of domains) {
+      const updatedAt = domain.readableUpdatedAt || domain.lastUpdated || null;
+      currentSnapshot[domain.key] = { summary: domain.summary, updatedAt };
+      const previous = previousSnapshot?.[domain.key];
+      if (previous && previous.updatedAt !== updatedAt) {
+        changed.push({
+          domain: domain.key,
+          displayName: domain.displayName,
+          previousSummary: previous.summary,
+          currentSummary: domain.summary,
+        });
+      }
+    }
+
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(currentSnapshot));
+    } catch {
+      // Best-effort only -- losing the snapshot just means the next visit
+      // won't have anything to diff against, not a functional break.
+    }
+
+    if (!previousSnapshot || changed.length === 0) return;
+
+    setRecap({ loading: true, text: null });
+    void (async () => {
+      try {
+        const response = await ApiService.getSageRecap({ vaultOwnerToken, domains: changed });
+        const data = response.ok ? await response.json() : null;
+        setRecap({ loading: false, text: data?.has_changes && data?.text ? data.text : null });
+      } catch {
+        setRecap({ loading: false, text: null });
+      }
+    })();
+  }, [domains, user, vaultOwnerToken]);
+
+  async function handleApplyFix() {
+    if (!suggestedFix || !user?.uid || !vaultKey || !vaultOwnerToken) return;
+    setFixState("fixing");
+    setFixError(null);
+    try {
+      // Check first: if a prior attempt already added this note to the
+      // target domain (e.g. re-clicking after a partial success), don't
+      // add a second duplicate -- just fall through to the source-side
+      // archive below.
+      const targetSnapshot = await PkmDomainResourceService.getStaleFirst({
+        userId: user.uid,
+        domain: suggestedFix.targetDomain,
+        vaultKey,
+        vaultOwnerToken,
+      });
+      const alreadyAdded = hasMatchingNote(targetSnapshot?.data || {}, suggestedFix.noteText);
+
+      if (!alreadyAdded) {
+        const targetDomain = domains.find((d) => d.key === suggestedFix.targetDomain);
+        const result = await PkmWriteCoordinator.saveMergedDomain({
+          userId: user.uid,
+          domain: suggestedFix.targetDomain,
+          vaultKey,
+          vaultOwnerToken,
+          build: (context) => ({
+            domainData: addNoteEntity(context.currentDomainData, suggestedFix.noteText, "sage_fix"),
+            summary: {
+              source: "sage_fix",
+              message_excerpt: suggestedFix.noteText.slice(0, 160),
+              ...buildSageNoteSummaryPatch({
+                displayName: suggestedFix.targetDisplayName,
+                existingHighlights: targetDomain?.readableHighlights || [],
+                noteText: suggestedFix.noteText,
+              }),
+            },
+          }),
+        });
+        if (!result.success) {
+          setFixState("error");
+          setFixError(result.message || "Couldn't save that just now.");
+          return;
+        }
+      }
+
+      // Best-effort: archive the original entry in the source domain so the
+      // fix reads as a real correction, not just a duplicate. Every other
+      // Sage write this session is additive-only (deliberate, given this is
+      // real production data with no automated tests) -- this is the one
+      // exception, scoped to marking (never deleting) the exact matching
+      // entity, attempted only after the Professional-side write already
+      // succeeded.
+      try {
+        const sourceSnapshot = await PkmDomainResourceService.getStaleFirst({
+          userId: user.uid,
+          domain: suggestedFix.fromDomain,
+          vaultKey,
+          vaultOwnerToken,
+        });
+        const archivedReason = `Moved to ${suggestedFix.targetDisplayName}`;
+        const preview = archiveMatchingNoteEntity(sourceSnapshot?.data || {}, suggestedFix.noteText, archivedReason);
+        if (preview.matched) {
+          const sourceDomain = domains.find((d) => d.key === suggestedFix.fromDomain);
+          await PkmWriteCoordinator.saveMergedDomain({
+            userId: user.uid,
+            domain: suggestedFix.fromDomain,
+            vaultKey,
+            vaultOwnerToken,
+            build: (context) => {
+              const archived = archiveMatchingNoteEntity(context.currentDomainData, suggestedFix.noteText, archivedReason);
+              return {
+                domainData: archived.domainData,
+                summary: {
+                  source: "sage_fix_archive",
+                  ...buildArchivedNoteSummaryPatch({
+                    existingHighlights: sourceDomain?.readableHighlights || [],
+                    noteText: suggestedFix.noteText,
+                  }),
+                },
+              };
+            },
+          });
+        }
+      } catch {
+        // Best-effort only -- the Professional-side write already
+        // succeeded; don't surface an error for source-side cleanup.
+      }
+
+      setFixState("fixed");
+      try {
+        window.localStorage.removeItem(`sage_fix_seen_v1_${user.uid}`);
+      } catch {
+        // Best-effort only.
+      }
+      await refreshDomains();
+    } catch (err) {
+      setFixState("error");
+      setFixError(err instanceof Error ? err.message : "Couldn't save that just now.");
+    }
+  }
+
+  if (loadingDomains) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-64 w-full" />
+        <Skeleton className="h-32 w-full" />
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (domains.length === 0) {
+    return (
+      <div className="space-y-4">
+        <Empty className="border-violet-500/20 bg-violet-500/[0.03] dark:border-violet-400/20 dark:bg-violet-400/[0.03]">
+          <EmptyHeader>
+            <EmptyMedia variant="icon" className="bg-violet-500/10 text-violet-700 dark:text-violet-300">
+              <Sparkles className="size-6" aria-hidden />
+            </EmptyMedia>
+            <EmptyTitle>Sage is still getting to know you</EmptyTitle>
+            <EmptyDescription>
+              As Kai and the rest of One save real details about your life, Sage will start reading
+              across them and surfacing what actually connects.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {recap.text ? (
+        <div className="rounded-2xl border border-emerald-500/25 bg-emerald-500/[0.04] p-4 dark:border-emerald-400/25 dark:bg-emerald-400/[0.04] sm:p-5">
+          <span className="flex items-center gap-2 text-sm font-semibold text-emerald-700 dark:text-emerald-300">
+            <History className="h-4 w-4" aria-hidden />
+            What&apos;s new since your last visit
+          </span>
+          <p className="mt-2 text-[15px] leading-6 text-foreground">{recap.text}</p>
+        </div>
+      ) : null}
+
+      <div className="relative overflow-hidden rounded-2xl border border-violet-500/20 bg-gradient-to-br from-violet-500/[0.07] to-transparent p-5 dark:border-violet-400/20 dark:from-violet-400/[0.06]">
+        <span className="absolute inset-x-0 top-0 h-[3px] bg-gradient-to-r from-violet-500 to-purple-400" aria-hidden />
+        <span className="flex items-center gap-2 text-sm font-semibold text-violet-700 dark:text-violet-300">
+          <Sparkles className="h-4 w-4" aria-hidden />
+          Sage&apos;s take
+        </span>
+        <div className="mt-3 flex flex-wrap items-baseline gap-x-5 gap-y-1">
+          <span className="flex items-baseline gap-1.5">
+            <span className="text-[1.7rem] font-semibold leading-8 tabular-nums text-violet-700 dark:text-violet-300">
+              {domains.length}
+            </span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground/70">
+              area{domains.length === 1 ? "" : "s"} of your life
+            </span>
+          </span>
+          <span className="flex items-baseline gap-1.5">
+            <span className="text-[1.7rem] font-semibold leading-8 tabular-nums text-violet-700 dark:text-violet-300">
+              {totalAttributes}
+            </span>
+            <span className="text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground/70">
+              tracked data points
+            </span>
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground/60">
+          {/* This is every distinct field Sage has ever recorded (one portfolio
+              holding alone is several), not a count of individual notes or
+              memories -- worth being upfront about since it reads much larger
+              than "things you'd call a fact." */}
+          Every tracked field across your data, not individual notes -- a single portfolio holding or
+          research answer counts as several.
+        </p>
+        <p className="mt-3 text-[15px] leading-6 text-foreground">
+          {briefing.loading
+            ? "Reading across everything Hushh knows about you…"
+            : briefing.text || "Not enough saved detail yet to make a cross-domain observation."}
+        </p>
+      </div>
+
+      {suggestedFix && fixState !== "fixed" ? (
+        <div className="flex flex-col gap-3 rounded-xl border border-amber-500/25 bg-amber-500/[0.05] p-4 dark:border-amber-400/25 dark:bg-amber-400/[0.05] sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-2.5">
+            <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-amber-500/15 text-amber-700 dark:text-amber-300">
+              <Wand2 className="h-3.5 w-3.5" aria-hidden />
+            </span>
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                This looks filed under {suggestedFix.fromDisplayName}, not {suggestedFix.targetDisplayName}
+              </p>
+              <p className="mt-0.5 text-sm text-muted-foreground">&ldquo;{suggestedFix.noteText}&rdquo;</p>
+              {fixError ? <p className="mt-1 text-sm text-destructive">{fixError}</p> : null}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2 self-end sm:self-auto">
+            <Button variant="ghost" size="sm" onClick={() => setSuggestedFix(null)} disabled={fixState === "fixing"}>
+              Dismiss
+            </Button>
+            <Button size="sm" onClick={() => void handleApplyFix()} disabled={fixState === "fixing"}>
+              {fixState === "fixing" ? "Adding…" : `Add to ${suggestedFix.targetDisplayName}`}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <div>
+        <SectionHeader
+          title="Sage's tools"
+          description="Ask a question, keep a running investigation going, or trace real citations."
+          icon={Sparkles}
+          accent="violet"
+          testId="sage-tools-header"
+        />
+        <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <SageAgentTile
+            icon={Search}
+            title="Ask Sage"
+            insight="A real question, researched live and personalized against what Sage knows about you."
+            href={ROUTES.SAGE_ASK}
+          >
+            <div className="space-y-2">
+              <QuickAskBox />
+              {suggestedPrompts.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {suggestedPrompts.slice(0, 3).map((prompt) => (
+                    <Link
+                      key={prompt}
+                      href={buildSageAskRoute(prompt)}
+                      className="rounded-full border border-border/60 bg-card px-2.5 py-1 text-left text-xs text-muted-foreground transition-colors hover:border-violet-500/40 hover:text-foreground"
+                    >
+                      {prompt}
+                    </Link>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </SageAgentTile>
+
+          <SageAgentTile
+            icon={FlaskConical}
+            title="Research threads"
+            metric={latestThread ? String(latestThread.turns.length) : null}
+            metricLabel={latestThread ? `question${latestThread.turns.length === 1 ? "" : "s"} asked` : undefined}
+            insight={
+              latestThread?.synthesis?.summary ||
+              "A real, ongoing investigation Sage keeps working on with you across visits -- not just one answer."
+            }
+            meta={
+              latestThread
+                ? `From "${latestThread.title}" · ${latestThread.tracedPapers.length} paper${
+                    latestThread.tracedPapers.length === 1 ? "" : "s"
+                  } traced`
+                : null
+            }
+            href={ROUTES.SAGE_THREADS}
+          />
+
+          <SageAgentTile
+            icon={BookOpen}
+            title="Notes"
+            insight={
+              latestNote
+                ? `"${latestNote.text}"`
+                : "Add a note straight into any domain, or search every raw note you've ever given Kai."
+            }
+            meta={latestNote ? `Latest note · ${latestNote.domainDisplayName}` : null}
+            href={ROUTES.SAGE_NOTES}
+          />
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-2.5 sm:grid-cols-3">
+          <SageLinkTile
+            icon={FileText}
+            title="Self-assessment"
+            description="A structured draft from your real accumulated history."
+            href={ROUTES.SAGE_REVIEW}
+          />
+
+          <SageLinkTile
+            icon={GitBranch}
+            title="Trace a paper's citations"
+            description="See what a real paper builds on and what builds on it."
+            href={ROUTES.SAGE_CITATIONS}
+          />
+
+          <SageLinkTile
+            icon={Sparkles}
+            title="Everything Hushh knows"
+            description="Every saved detail, across every domain."
+            href={ROUTES.PKM}
+          />
+        </div>
+      </div>
+
+      <div>
+        <SectionHeader
+          title="Your knowledge base"
+          description="How much Sage actually knows across every part of your life."
+          icon={Gauge}
+          accent="violet"
+          testId="sage-knowledge-header"
+        />
+        <div className="mt-3 space-y-4">
+          <HealthRadarCard
+            icon={Gauge}
+            title="Knowledge coverage"
+            axes={knowledgeHealth.axes}
+            overall={knowledgeHealth.overall}
+            scaleLabels={["Sparse", "Building", "Rich"]}
+          />
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {domains.map((domain) => {
+              const Icon = DOMAIN_ICON[domain.key] || BookOpen;
+              const state = domainText[domain.key];
+              const relative = formatRelativeTime(domain.readableUpdatedAt || domain.lastUpdated);
+              return (
+                <div
+                  key={domain.key}
+                  className="flex flex-col gap-2 rounded-xl border border-border/60 bg-card/85 p-4 shadow-[0_1px_2px_rgba(15,23,42,0.06)] transition-shadow duration-200 hover:shadow-[0_14px_32px_-28px_rgba(15,23,42,0.55)]"
+                >
+                  <span className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+                        DOMAIN_TONE_CLASS[domain.key] || DOMAIN_TONE_FALLBACK,
+                      )}
+                    >
+                      <Icon className="h-4 w-4" aria-hidden />
+                    </span>
+                    <span className="text-[15px] font-semibold text-foreground">{domain.displayName}</span>
+                  </span>
+                  <p className="line-clamp-6 text-sm leading-5 text-muted-foreground">
+                    {/* Real fallback shown immediately, upgraded in place once
+                        Sage's AI summary lands -- no blocking "Reading..." state. */}
+                    {state?.text || `${domain.attributeCount} saved details.`}
+                  </p>
+                  {relative ? (
+                    <span className="text-xs text-muted-foreground/70">Updated {relative}</span>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/sage/self-review-panel.tsx
+++ b/hushh-webapp/components/sage/self-review-panel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { FileText } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { ApiService } from "@/lib/services/api-service";
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
+import { buildPkmMemorySnapshot } from "@/lib/pkm/pkm-memory-cards";
+import { SageMarkdown } from "@/components/sage/sage-markdown";
+
+type DraftState = "idle" | "drafting" | "done" | "error";
+
+/**
+ * Sage drafting a real self-assessment from your own accumulated history in
+ * one domain (usually "professional") -- decrypts that domain client-side,
+ * flattens it into real text fragments (reusing the same walker the PKM
+ * explorer uses), and asks Sage to synthesize a structured document from
+ * ONLY those real fragments. No new capture mechanism, no fabricated
+ * accomplishments -- just what you've already told Kai over time.
+ */
+export function SelfReviewPanel({ domains }: { domains: DomainSummary[] }) {
+  const { user } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
+  // "Professional" is the natural default for a self-assessment, but not if
+  // it's nearly empty while another domain has real substance -- defaulting
+  // to a thin domain would draft a thin document. Only overrides the
+  // professional default when another domain has meaningfully more (2x+).
+  const preferredDomain = useMemo(() => {
+    if (domains.length === 0) return undefined;
+    const professional = domains.find((d) => d.key === "professional");
+    const richest = [...domains].sort((a, b) => b.attributeCount - a.attributeCount)[0];
+    if (professional && richest && richest.attributeCount > professional.attributeCount * 2) {
+      return richest;
+    }
+    return professional || richest;
+  }, [domains]);
+  const [domainKey, setDomainKey] = useState<string>(preferredDomain?.key || "");
+  const [state, setState] = useState<DraftState>("idle");
+  const [document, setDocument] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveDomainKey = domainKey || preferredDomain?.key || "";
+  const domain = domains.find((d) => d.key === effectiveDomainKey);
+
+  async function handleDraft() {
+    if (!user?.uid || !vaultKey || !vaultOwnerToken || !domain) return;
+    setState("drafting");
+    setError(null);
+    try {
+      const snapshot = await PkmDomainResourceService.getStaleFirst({
+        userId: user.uid,
+        domain: domain.key,
+        vaultKey,
+        vaultOwnerToken,
+      });
+      if (!snapshot?.data) {
+        setDocument(`Not enough saved ${domain.displayName.toLowerCase()} history yet to draft a self-assessment.`);
+        setState("done");
+        return;
+      }
+
+      const metadata = await PersonalKnowledgeModelService.getMetadata(user.uid, false, vaultOwnerToken);
+      const memorySnapshot = buildPkmMemorySnapshot({
+        metadata,
+        fullBlob: { [domain.key]: snapshot.data },
+      });
+      const fragments = memorySnapshot.cards
+        .filter((card) => card.domain === domain.key)
+        .map((card) => card.value)
+        .filter(Boolean);
+
+      const response = await ApiService.draftSageReview({
+        vaultOwnerToken,
+        domain: domain.key,
+        displayName: domain.displayName,
+        fragments,
+      });
+      if (!response.ok) {
+        throw new Error("Sage couldn't draft that just now.");
+      }
+      const data = await response.json();
+      setDocument(String(data.document || ""));
+      setState("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sage couldn't draft that just now.");
+      setState("error");
+    }
+  }
+
+  if (domains.length === 0) return null;
+
+  return (
+    <div className="rounded-2xl border border-violet-500/25 bg-card/85 p-4 shadow-[0_1px_2px_rgba(15,23,42,0.06)] sm:p-5">
+      <div className="flex items-center gap-2 text-sm font-semibold text-violet-700 dark:text-violet-300">
+        <FileText className="h-4 w-4" aria-hidden />
+        Draft a self-assessment
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Sage reads your real accumulated history in one domain and drafts a structured document --
+        using only what you've actually told Kai, nothing invented.
+      </p>
+
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <select
+          value={effectiveDomainKey}
+          onChange={(event) => {
+            setDomainKey(event.target.value);
+            setState("idle");
+            setDocument(null);
+          }}
+          className="rounded-md border border-border/60 bg-card px-2.5 py-2 text-sm text-foreground sm:w-auto"
+        >
+          {domains.map((d) => (
+            <option key={d.key} value={d.key}>
+              {d.displayName} ({d.attributeCount})
+            </option>
+          ))}
+        </select>
+        <Button onClick={() => void handleDraft()} disabled={state === "drafting" || !domain} className="sm:w-auto">
+          {state === "drafting" ? "Drafting…" : "Draft my self-assessment"}
+        </Button>
+      </div>
+
+      {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+
+      {document ? (
+        <div className="mt-4 rounded-xl border border-border/60 bg-background/60 p-3.5 sm:p-4">
+          <SageMarkdown text={document} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/hooks/use-sage-domains.ts
+++ b/hushh-webapp/hooks/use-sage-domains.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAuth } from "@/hooks/use-auth";
+import { useVault } from "@/lib/vault/vault-context";
+import { PersonalKnowledgeModelService, type DomainSummary } from "@/lib/services/personal-knowledge-model-service";
+
+/**
+ * Shared by every standalone Sage tool page (Ask Sage, Self-assessment, and
+ * the home page) that needs the same PKM domain list -- each dedicated page
+ * fetches it independently rather than passing it down from the home page,
+ * since a tool page can be opened directly without ever visiting Sage home.
+ */
+export function useSageDomains(): { domains: DomainSummary[]; loading: boolean } {
+  const { user } = useAuth();
+  const { vaultOwnerToken } = useVault();
+  const [domains, setDomains] = useState<DomainSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      if (!user?.uid || !vaultOwnerToken) {
+        if (!cancelled) setLoading(false);
+        return;
+      }
+      try {
+        const metadata = await PersonalKnowledgeModelService.getMetadata(user.uid, false, vaultOwnerToken);
+        if (!cancelled) setDomains(metadata.domains);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, vaultOwnerToken]);
+
+  return { domains, loading };
+}

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -59,6 +59,12 @@ export const ROUTES = {
   KAI_DASHBOARD: "/one/kai/portfolio",
   KAI_ANALYSIS: "/one/kai/analysis",
   KAI_OPTIMIZE: "/one/kai/optimize",
+  SAGE: "/one/sage",
+  SAGE_ASK: "/one/sage/ask",
+  SAGE_NOTES: "/one/sage/notes",
+  SAGE_CITATIONS: "/one/sage/citations",
+  SAGE_THREADS: "/one/sage/threads",
+  SAGE_REVIEW: "/one/sage/review",
 } as const;
 
 function withQuery(pathname: string, entries: Record<string, string | null | undefined>) {
@@ -77,6 +83,34 @@ function withQuery(pathname: string, entries: Record<string, string | null | und
 
 export function buildMarketplaceRiaProfileRoute(riaId?: string | null) {
   return withQuery(ROUTES.MARKETPLACE_RIA_PROFILE, { riaId });
+}
+
+/**
+ * Deep-links Citation Lineage back into a Research Thread. With just
+ * `threadId`, it's a blank search that offers "Add to research thread".
+ * With `paper` too (a paper already traced in that thread), it re-opens
+ * that exact paper's lineage on load instead of showing the search box.
+ */
+export function buildSageCitationsRoute(
+  threadId?: string | null,
+  paper?: { workId?: string | null; title?: string | null } | null,
+) {
+  return withQuery(ROUTES.SAGE_CITATIONS, {
+    threadId,
+    workId: paper?.workId,
+    title: paper?.title,
+  });
+}
+
+/**
+ * Pre-fills the Ask Sage query box. `autoAsk` additionally triggers the
+ * question automatically on load -- for the home page's own quick-ask box,
+ * where the user already typed a real question and hit Ask, vs. a
+ * suggested-prompt chip, which only pre-fills and lets the user confirm
+ * (see AskSagePanel's initialQuery/autoAsk props).
+ */
+export function buildSageAskRoute(query?: string | null, autoAsk?: boolean) {
+  return withQuery(ROUTES.SAGE_ASK, { q: query, auto: autoAsk ? "1" : null });
 }
 
 export function buildPhoneMandateRoute(redirect?: string | null) {

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -240,6 +240,83 @@ export function resolveTopShellBreadcrumb(
     };
   }
 
+  if (pathname === ROUTES.SAGE) {
+    return {
+      backHref: ROUTES.ONE_HOME,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "Sage" },
+      ],
+    };
+  }
+
+  if (pathname === ROUTES.SAGE_ASK) {
+    return {
+      backHref: ROUTES.SAGE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "Sage", href: ROUTES.SAGE },
+        { label: "Ask Sage" },
+      ],
+    };
+  }
+
+  if (pathname === ROUTES.SAGE_REVIEW) {
+    return {
+      backHref: ROUTES.SAGE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "Sage", href: ROUTES.SAGE },
+        { label: "Self-assessment" },
+      ],
+    };
+  }
+
+  if (pathname === ROUTES.SAGE_NOTES) {
+    return {
+      backHref: ROUTES.SAGE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "Sage", href: ROUTES.SAGE },
+        { label: "Notes archive" },
+      ],
+    };
+  }
+
+  if (pathname === ROUTES.SAGE_THREADS) {
+    return {
+      backHref: ROUTES.SAGE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "Sage", href: ROUTES.SAGE },
+        { label: "Research threads" },
+      ],
+    };
+  }
+
+  if (pathname === ROUTES.SAGE_CITATIONS) {
+    return {
+      backHref: ROUTES.SAGE,
+      width: "profile",
+      align: "center",
+      items: [
+        { label: "One", href: ROUTES.ONE_HOME },
+        { label: "Sage", href: ROUTES.SAGE },
+        { label: "Citation lineage" },
+      ],
+    };
+  }
+
   if (pathname === ROUTES.ONE_LOCATION) {
     return {
       backHref: ROUTES.PROFILE,

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -24,6 +24,12 @@ export const ROUTE_ID_VALUES = [
   "one_kyc",
   "one_location",
   "one_location_public_request",
+  "sage_home",
+  "sage_ask",
+  "sage_notes",
+  "sage_citations",
+  "sage_review",
+  "sage_threads",
   "portfolio_shared",
   "ria_home",
   "ria_onboarding",
@@ -92,6 +98,12 @@ export function resolveRouteId(pathname: string): RouteId {
   if (pathname === ROUTES.ONE_KYC) return "one_kyc";
   if (pathname === ROUTES.ONE_LOCATION) return "one_location";
   if (pathname.startsWith("/one/location/request/")) return "one_location_public_request";
+  if (pathname === ROUTES.SAGE) return "sage_home";
+  if (pathname === ROUTES.SAGE_ASK) return "sage_ask";
+  if (pathname === ROUTES.SAGE_NOTES) return "sage_notes";
+  if (pathname === ROUTES.SAGE_CITATIONS) return "sage_citations";
+  if (pathname === ROUTES.SAGE_REVIEW) return "sage_review";
+  if (pathname === ROUTES.SAGE_THREADS) return "sage_threads";
   if (pathname === "/portfolio/shared") return "portfolio_shared";
   if (pathname === ROUTES.RIA_HOME) return "ria_home";
   if (pathname === ROUTES.RIA_ONBOARDING) return "ria_onboarding";

--- a/hushh-webapp/lib/pkm/pkm-domain-resource.ts
+++ b/hushh-webapp/lib/pkm/pkm-domain-resource.ts
@@ -216,7 +216,7 @@ export class PkmDomainResourceService {
             liveRevision: cachedBlobRevision,
             tier: "memory",
           });
-          return await this.refresh(params);
+          return await this.refresh(params, { bypassInflight: params.forceRefresh });
         }
         logRequest("revision_match_hit", {
           userId: params.userId,
@@ -261,7 +261,7 @@ export class PkmDomainResourceService {
               cachedRevision: secure.key.contentRevision,
               liveRevision: cachedBlobRevision,
             });
-            return await this.refresh(params);
+            return await this.refresh(params, { bypassInflight: params.forceRefresh });
           }
           logRequest("revision_match_hit", {
             userId: params.userId,
@@ -284,7 +284,7 @@ export class PkmDomainResourceService {
       domain: params.domain,
       segmentSignature: segmentSignature(params.segmentIds),
     });
-    return await this.refresh(params);
+    return await this.refresh(params, { bypassInflight: params.forceRefresh });
   }
 
   static async prepareDomainWriteContext(
@@ -320,15 +320,30 @@ export class PkmDomainResourceService {
     };
   }
 
+  /**
+   * bypassInflight: without this, a refresh() called right after a write
+   * can silently join an older in-flight refresh() (e.g. one kicked off
+   * on mount) and resolve to its pre-write snapshot instead of fetching
+   * fresh -- the caller thinks it forced a refresh but actually got stale
+   * data. Also threaded down as `forceRefresh` into
+   * PersonalKnowledgeModelService.loadDomainDataWithBlob/getDomainData,
+   * which have their OWN independent cache (CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB)
+   * and inflight dedupe map one layer below this one -- without bypassing
+   * those too, this refresh() can report itself as "network" sourced while
+   * actually still handing back a stale pre-write blob from that deeper
+   * cache. getStaleFirst() sets this whenever the caller passed
+   * forceRefresh: true.
+   */
   static async refresh(
-    params: PkmDomainResourceParams
+    params: PkmDomainResourceParams,
+    options?: { bypassInflight?: boolean }
   ): Promise<PkmDomainResourceSnapshot | null> {
     if (!params.userId || !params.domain || !params.vaultKey) {
       return null;
     }
 
     const inflightKey = `${params.userId}:${params.domain}:${segmentSignature(params.segmentIds)}`;
-    const existing = inflightRefreshes.get(inflightKey);
+    const existing = options?.bypassInflight ? undefined : inflightRefreshes.get(inflightKey);
     if (existing) {
       logRequest("inflight_dedupe_hit", {
         userId: params.userId,
@@ -349,6 +364,7 @@ export class PkmDomainResourceService {
       vaultKey: params.vaultKey,
       vaultOwnerToken: params.vaultOwnerToken || undefined,
       segmentIds: params.segmentIds,
+      forceRefresh: options?.bypassInflight,
     })
       .then(async ({ data, blob }) => {
         if (!data) {

--- a/hushh-webapp/lib/sage/add-note-entity.ts
+++ b/hushh-webapp/lib/sage/add-note-entity.ts
@@ -1,0 +1,208 @@
+/**
+ * Appends a new note entity to a domain's decrypted data under a `notes`
+ * scope, without touching anything else already there. Shared by Sage's
+ * miscategorization-fix action and its "save this research" action -- both
+ * write a plain note into an existing PKM domain via PkmWriteCoordinator.
+ */
+export function addNoteEntity(
+  currentDomainData: Record<string, unknown>,
+  noteText: string,
+  source: string,
+): Record<string, unknown> {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const notesScope =
+    cloned.notes && typeof cloned.notes === "object" && !Array.isArray(cloned.notes)
+      ? (cloned.notes as Record<string, unknown>)
+      : ((cloned.notes = {}) as Record<string, unknown>);
+  const entities =
+    notesScope.entities && typeof notesScope.entities === "object" && !Array.isArray(notesScope.entities)
+      ? (notesScope.entities as Record<string, unknown>)
+      : ((notesScope.entities = {}) as Record<string, unknown>);
+  const entityId = `sage_${source}_${Date.now()}`;
+  const nowIso = new Date().toISOString();
+  entities[entityId] = {
+    entity_id: entityId,
+    observations: [noteText],
+    status: "active",
+    created_at: nowIso,
+    updated_at: nowIso,
+    source,
+  };
+  return cloned;
+}
+
+/**
+ * The domain summary fields (readable_highlights etc.) are what the Notes
+ * Archive, the per-domain Sage card text, and the PKM natural-language
+ * panel actually read -- NOT the raw entity written by addNoteEntity above.
+ * Every write that calls addNoteEntity must also merge this in, or the note
+ * is really saved but invisible everywhere in the app.
+ */
+export function buildSageNoteSummaryPatch(params: {
+  displayName: string;
+  existingHighlights: string[];
+  noteText: string;
+}): Record<string, unknown> {
+  const highlightLine = `Saved from your note: ${params.noteText}`;
+  const highlights = [...params.existingHighlights, highlightLine].slice(-30);
+  return {
+    readable_summary: `Sage added a note to your ${params.displayName} memory.`,
+    readable_highlights: highlights,
+    readable_updated_at: new Date().toISOString(),
+    readable_source_label: "Sage",
+  };
+}
+
+/**
+ * LLM-echoed text (e.g. Gemini's "note_text", meant to be copied verbatim)
+ * is not guaranteed to come back byte-identical to the real stored string --
+ * different dash/quote characters, trailing punctuation, or whitespace are
+ * common even when a model is explicitly told not to alter the text. Exact
+ * equality silently fails in practice, so matching normalizes both sides
+ * and accepts containment either way rather than requiring a perfect match.
+ */
+function normalizeForMatch(value: string): string {
+  return value
+    .normalize("NFKC")
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/[‒–—―]/g, "-")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function isCloseMatch(a: string, b: string): boolean {
+  const na = normalizeForMatch(a);
+  const nb = normalizeForMatch(b);
+  if (!na || !nb) return false;
+  if (na === nb) return true;
+  return na.includes(nb) || nb.includes(na);
+}
+
+/**
+ * Matching is by (fuzzy-normalized) text, not entity id -- there's no id to
+ * match by from the UI side, since notes are surfaced via readable_highlights
+ * strings, not the raw entities. Two notes with identical/near-identical
+ * text are genuinely ambiguous without an id, so this stops at the FIRST
+ * match found (`state.matched`) rather than archiving every matching node in
+ * the tree -- previously, removing one note could silently archive every
+ * other note that happened to share its wording.
+ */
+function archiveMatchingObservationNode(
+  node: unknown,
+  noteText: string,
+  archivedReason: string,
+  nowIso: string,
+  state: { matched: boolean },
+): void {
+  if (state.matched) return;
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      if (state.matched) return;
+      archiveMatchingObservationNode(item, noteText, archivedReason, nowIso, state);
+    }
+    return;
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    if (Array.isArray(obj.observations)) {
+      const hasMatch = obj.observations.some(
+        (entry) => typeof entry === "string" && isCloseMatch(entry, noteText),
+      );
+      if (hasMatch && obj.status !== "archived") {
+        obj.status = "archived";
+        obj.archived_at = nowIso;
+        obj.archived_reason = archivedReason;
+        state.matched = true;
+        return;
+      }
+    }
+    for (const key of Object.keys(obj)) {
+      if (state.matched) return;
+      if (key === "observations") continue;
+      archiveMatchingObservationNode(obj[key], noteText, archivedReason, nowIso, state);
+    }
+  }
+}
+
+/**
+ * Finds the exact entity a misfiled note came from (anywhere in the
+ * domain's arbitrarily-nested JSON, matched by its observation text) and
+ * marks it archived rather than deleting it -- this is a real cross-domain
+ * edit, the one exception to the additive-only rule the rest of Sage's
+ * writes follow, and deliberately non-destructive: the record stays, just
+ * no longer "active", with a note on where it moved to.
+ */
+export function archiveMatchingNoteEntity(
+  currentDomainData: Record<string, unknown>,
+  noteText: string,
+  archivedReason: string,
+): { domainData: Record<string, unknown>; matched: boolean } {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const nowIso = new Date().toISOString();
+  const state = { matched: false };
+  archiveMatchingObservationNode(cloned, noteText, archivedReason, nowIso, state);
+  return { domainData: cloned, matched: state.matched };
+}
+
+function hasMatchingObservationNode(node: unknown, noteText: string): boolean {
+  if (Array.isArray(node)) {
+    return node.some((item) => hasMatchingObservationNode(item, noteText));
+  }
+  if (node && typeof node === "object") {
+    const obj = node as Record<string, unknown>;
+    if (Array.isArray(obj.observations)) {
+      const hasMatch = obj.observations.some(
+        (entry) => typeof entry === "string" && isCloseMatch(entry, noteText),
+      );
+      if (hasMatch) return true;
+    }
+    return Object.keys(obj).some((key) => key !== "observations" && hasMatchingObservationNode(obj[key], noteText));
+  }
+  return false;
+}
+
+/**
+ * Read-only check for whether a note with this exact text already exists
+ * anywhere in the domain -- used to avoid adding a second duplicate entity
+ * if a fix gets applied more than once (e.g. re-clicking after a prior
+ * partial success).
+ */
+export function hasMatchingNote(currentDomainData: Record<string, unknown>, noteText: string): boolean {
+  return hasMatchingObservationNode(currentDomainData, noteText);
+}
+
+const SAVED_FROM_NOTE_PREFIX = /^saved from your note:\s*/i;
+
+/**
+ * Archiving the raw entity (archiveMatchingNoteEntity above) doesn't touch
+ * readable_highlights -- a separate summary-projection field that the
+ * per-domain Sage card, Notes Archive, and PKM natural-language panel
+ * actually read from. Without also stripping the matching line here, a
+ * "moved" note keeps getting described by its old domain forever, even
+ * though the underlying entity is correctly archived.
+ */
+export function buildArchivedNoteSummaryPatch(params: {
+  existingHighlights: string[];
+  noteText: string;
+}): Record<string, unknown> {
+  // Strips only the first matching line, mirroring archiveMatchingNoteEntity
+  // above stopping at the first matching entity -- same "no id to match by"
+  // ambiguity, same "at most one" bound on the blast radius.
+  let removed = false;
+  const remaining = params.existingHighlights.filter((line) => {
+    if (removed) return true;
+    const stripped = line.replace(SAVED_FROM_NOTE_PREFIX, "").trim();
+    const isMatch = isCloseMatch(stripped, params.noteText) || isCloseMatch(line, params.noteText);
+    if (isMatch) {
+      removed = true;
+      return false;
+    }
+    return true;
+  });
+  return {
+    readable_highlights: remaining,
+    readable_updated_at: new Date().toISOString(),
+  };
+}

--- a/hushh-webapp/lib/sage/research-thread-entity.ts
+++ b/hushh-webapp/lib/sage/research-thread-entity.ts
@@ -1,0 +1,345 @@
+/**
+ * Persistent Research Threads: an ongoing investigation (a real question,
+ * the Q&A turns and papers traced while pursuing it, and a running
+ * synthesis of what's established vs. still open) that survives across
+ * sessions -- unlike Ask Sage's per-visit chat or a one-off citation trace.
+ *
+ * Stored in its own `research` PKM domain, under a `threads` scope
+ * (distinct from `add-note-entity.ts`'s `notes` scope: the shape here is
+ * materially richer -- nested turns/papers/synthesis, not a flat
+ * observation string). Raw storage is snake_case to match the rest of the
+ * PKM at-rest convention (e.g. `readable_highlights`); every read goes
+ * through parseThreadEntity so the rest of the app works with a typed,
+ * camelCase shape, same split as `DomainSummary`'s readable_* fields.
+ */
+
+export type ResearchThreadSource = { title: string; url: string };
+
+/** A term used in a turn's answer, defined using ONLY what that same answer
+ * already stated -- not a separate lookup, so it can't introduce new facts. */
+export type ResearchThreadKeyTerm = { term: string; definition: string };
+
+/** A real comparable numeric fact pulled out of a turn's answer, for a
+ * quick inline visual -- never fabricated when the answer has nothing to compare. */
+export type ResearchThreadComparison = { label: string; value: number; unit: string };
+
+export type ResearchThreadTurn = {
+  query: string;
+  answer: string;
+  mode: "standard" | "challenge";
+  sources: ResearchThreadSource[];
+  keyTerms: ResearchThreadKeyTerm[];
+  comparisons: ResearchThreadComparison[];
+  /** A model-curated academic-search query for this turn, or null when the
+   * model judged there's nothing genuinely academic to trace -- e.g. a
+   * question about this app's own internal tooling. Using this (instead of
+   * the raw user question) for paper auto-trace avoids OpenAlex matching
+   * unrelated papers on incidental shared words. */
+  paperSearchQuery: string | null;
+  createdAt: string;
+};
+
+export type ResearchThreadPaper = {
+  id: string;
+  title: string;
+  year: number | null;
+  topic: string | null;
+  citedByCount: number;
+  addedAt: string;
+};
+
+export type ResearchThreadSynthesis = {
+  summary: string;
+  established: string[];
+  openQuestions: string[];
+  generatedAt: string;
+};
+
+export type ResearchThreadEntity = {
+  entityId: string;
+  title: string;
+  status: "active" | "archived";
+  createdAt: string;
+  updatedAt: string;
+  turns: ResearchThreadTurn[];
+  tracedPapers: ResearchThreadPaper[];
+  synthesis: ResearchThreadSynthesis | null;
+};
+
+function toThreadsScope(cloned: Record<string, unknown>): Record<string, unknown> {
+  const scope =
+    cloned.threads && typeof cloned.threads === "object" && !Array.isArray(cloned.threads)
+      ? (cloned.threads as Record<string, unknown>)
+      : ((cloned.threads = {}) as Record<string, unknown>);
+  const entities =
+    scope.entities && typeof scope.entities === "object" && !Array.isArray(scope.entities)
+      ? (scope.entities as Record<string, unknown>)
+      : ((scope.entities = {}) as Record<string, unknown>);
+  return entities;
+}
+
+function parseThreadEntity(raw: unknown): ResearchThreadEntity | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const entityId = String(r.entity_id || "").trim();
+  if (!entityId) return null;
+
+  const turns: ResearchThreadTurn[] = Array.isArray(r.turns)
+    ? r.turns
+        .filter((t): t is Record<string, unknown> => !!t && typeof t === "object")
+        .map((t) => ({
+          query: String(t.query || ""),
+          answer: String(t.answer || ""),
+          mode: t.mode === "challenge" ? "challenge" : "standard",
+          sources: Array.isArray(t.sources)
+            ? t.sources
+                .filter((s): s is Record<string, unknown> => !!s && typeof s === "object")
+                .map((s) => ({ title: String(s.title || ""), url: String(s.url || "") }))
+                .filter((s) => s.url)
+            : [],
+          keyTerms: Array.isArray(t.key_terms)
+            ? t.key_terms
+                .filter((k): k is Record<string, unknown> => !!k && typeof k === "object")
+                .map((k) => ({ term: String(k.term || ""), definition: String(k.definition || "") }))
+                .filter((k) => k.term && k.definition)
+            : [],
+          comparisons: Array.isArray(t.comparisons)
+            ? t.comparisons
+                .filter((c): c is Record<string, unknown> => !!c && typeof c === "object")
+                .map((c) => ({
+                  label: String(c.label || ""),
+                  value: typeof c.value === "number" ? c.value : Number(c.value) || 0,
+                  unit: String(c.unit || ""),
+                }))
+                .filter((c) => c.label)
+            : [],
+          paperSearchQuery:
+            typeof t.paper_search_query === "string" && t.paper_search_query.trim()
+              ? t.paper_search_query.trim()
+              : null,
+          createdAt: String(t.created_at || ""),
+        }))
+    : [];
+
+  const tracedPapers: ResearchThreadPaper[] = Array.isArray(r.traced_papers)
+    ? r.traced_papers
+        .filter((p): p is Record<string, unknown> => !!p && typeof p === "object")
+        .map((p) => ({
+          id: String(p.id || ""),
+          title: String(p.title || "Untitled"),
+          year: typeof p.year === "number" ? p.year : null,
+          topic: typeof p.topic === "string" && p.topic.trim() ? p.topic.trim() : null,
+          citedByCount: typeof p.cited_by_count === "number" ? p.cited_by_count : 0,
+          addedAt: String(p.added_at || ""),
+        }))
+    : [];
+
+  const rawSynthesis = r.synthesis && typeof r.synthesis === "object" ? (r.synthesis as Record<string, unknown>) : null;
+  const synthesis: ResearchThreadSynthesis | null = rawSynthesis
+    ? {
+        summary: String(rawSynthesis.summary || ""),
+        established: Array.isArray(rawSynthesis.established) ? rawSynthesis.established.map(String) : [],
+        openQuestions: Array.isArray(rawSynthesis.open_questions) ? rawSynthesis.open_questions.map(String) : [],
+        generatedAt: String(rawSynthesis.generated_at || ""),
+      }
+    : null;
+
+  return {
+    entityId,
+    title: String(r.title || "Untitled research"),
+    status: r.status === "archived" ? "archived" : "active",
+    createdAt: String(r.created_at || ""),
+    updatedAt: String(r.updated_at || ""),
+    turns,
+    tracedPapers,
+    synthesis,
+  };
+}
+
+/** Every active + archived thread in this domain, most-recently-updated first. */
+export function listResearchThreads(domainData: Record<string, unknown>): ResearchThreadEntity[] {
+  const entities = (domainData?.threads as Record<string, unknown> | undefined)?.entities;
+  if (!entities || typeof entities !== "object") return [];
+  return Object.values(entities)
+    .map(parseThreadEntity)
+    .filter((t): t is ResearchThreadEntity => t !== null)
+    .sort((a, b) => (b.updatedAt || "").localeCompare(a.updatedAt || ""));
+}
+
+export function getResearchThread(domainData: Record<string, unknown>, threadId: string): ResearchThreadEntity | null {
+  const entities = (domainData?.threads as Record<string, unknown> | undefined)?.entities as
+    | Record<string, unknown>
+    | undefined;
+  return parseThreadEntity(entities?.[threadId]);
+}
+
+/** Creates a brand-new thread with no turns/papers yet -- the caller asks the first question separately. */
+export function createResearchThread(
+  currentDomainData: Record<string, unknown>,
+  title: string,
+): { domainData: Record<string, unknown>; thread: ResearchThreadEntity } {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const entities = toThreadsScope(cloned);
+  const entityId = `thread_${Date.now()}`;
+  const nowIso = new Date().toISOString();
+  const raw = {
+    entity_id: entityId,
+    kind: "research_thread",
+    title: title.trim() || "Untitled research",
+    status: "active",
+    created_at: nowIso,
+    updated_at: nowIso,
+    turns: [],
+    traced_papers: [],
+    synthesis: null,
+  };
+  entities[entityId] = raw;
+  const thread = parseThreadEntity(raw);
+  if (!thread) throw new Error("Failed to create research thread");
+  return { domainData: cloned, thread };
+}
+
+export function appendThreadTurn(
+  currentDomainData: Record<string, unknown>,
+  threadId: string,
+  turn: {
+    query: string;
+    answer: string;
+    mode: "standard" | "challenge";
+    sources?: ResearchThreadSource[];
+    keyTerms?: ResearchThreadKeyTerm[];
+    comparisons?: ResearchThreadComparison[];
+    paperSearchQuery?: string | null;
+  },
+): Record<string, unknown> {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const entities = toThreadsScope(cloned);
+  const raw = entities[threadId] as Record<string, unknown> | undefined;
+  if (!raw) return cloned;
+  const nowIso = new Date().toISOString();
+  const turns = Array.isArray(raw.turns) ? raw.turns : [];
+  raw.turns = [
+    ...turns,
+    {
+      query: turn.query,
+      answer: turn.answer,
+      mode: turn.mode,
+      sources: turn.sources || [],
+      key_terms: turn.keyTerms || [],
+      comparisons: turn.comparisons || [],
+      paper_search_query: turn.paperSearchQuery || null,
+      created_at: nowIso,
+    },
+  ];
+  raw.updated_at = nowIso;
+  return cloned;
+}
+
+/** No-op (safe, idempotent) if this exact paper id is already traced in this thread. */
+export function addTracedPaperToThread(
+  currentDomainData: Record<string, unknown>,
+  threadId: string,
+  paper: { id: string; title: string; year: number | null; topic: string | null; citedByCount: number },
+): Record<string, unknown> {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const entities = toThreadsScope(cloned);
+  const raw = entities[threadId] as Record<string, unknown> | undefined;
+  if (!raw) return cloned;
+  const tracedPapers = Array.isArray(raw.traced_papers) ? raw.traced_papers : [];
+  const alreadyTraced = tracedPapers.some(
+    (p) => p && typeof p === "object" && String((p as Record<string, unknown>).id) === paper.id,
+  );
+  if (alreadyTraced) return cloned;
+  const nowIso = new Date().toISOString();
+  raw.traced_papers = [
+    ...tracedPapers,
+    {
+      id: paper.id,
+      title: paper.title,
+      year: paper.year,
+      topic: paper.topic,
+      cited_by_count: paper.citedByCount,
+      added_at: nowIso,
+    },
+  ];
+  raw.updated_at = nowIso;
+  return cloned;
+}
+
+/**
+ * Deliberately does NOT touch updated_at: a manual dismissal shouldn't
+ * re-trigger the synthesis/auto-trace staleness effect using the same
+ * turn's paperSearchQuery, which would likely just re-add the exact paper
+ * the user chose to remove.
+ */
+export function removeTracedPaperFromThread(
+  currentDomainData: Record<string, unknown>,
+  threadId: string,
+  paperId: string,
+): Record<string, unknown> {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const entities = toThreadsScope(cloned);
+  const raw = entities[threadId] as Record<string, unknown> | undefined;
+  if (!raw) return cloned;
+  const tracedPapers = Array.isArray(raw.traced_papers) ? raw.traced_papers : [];
+  raw.traced_papers = tracedPapers.filter(
+    (p) => !(p && typeof p === "object" && String((p as Record<string, unknown>).id) === paperId),
+  );
+  return cloned;
+}
+
+export function updateThreadSynthesis(
+  currentDomainData: Record<string, unknown>,
+  threadId: string,
+  synthesis: { summary: string; established: string[]; openQuestions: string[] },
+): Record<string, unknown> {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const entities = toThreadsScope(cloned);
+  const raw = entities[threadId] as Record<string, unknown> | undefined;
+  if (!raw) return cloned;
+  raw.synthesis = {
+    summary: synthesis.summary,
+    established: synthesis.established,
+    open_questions: synthesis.openQuestions,
+    generated_at: new Date().toISOString(),
+  };
+  return cloned;
+}
+
+export function archiveResearchThread(
+  currentDomainData: Record<string, unknown>,
+  threadId: string,
+): Record<string, unknown> {
+  const cloned = structuredClone(currentDomainData) as Record<string, unknown>;
+  const entities = toThreadsScope(cloned);
+  const raw = entities[threadId] as Record<string, unknown> | undefined;
+  if (!raw) return cloned;
+  raw.status = "archived";
+  raw.updated_at = new Date().toISOString();
+  return cloned;
+}
+
+/**
+ * The `research` domain's readable_summary/readable_highlights -- what
+ * the domain-level card, Notes Archive, and PKM natural-language panel
+ * would read if this domain ever surfaces there. Recomputed from the
+ * CURRENT active-thread list on every mutation, same rule every other
+ * Sage write follows: without this, a thread is really saved but
+ * invisible everywhere outside its own dedicated panel.
+ */
+export function buildResearchThreadsSummaryPatch(threads: ResearchThreadEntity[]): Record<string, unknown> {
+  const active = threads.filter((t) => t.status === "active");
+  const count = active.length;
+  const highlights = active
+    .slice(0, 30)
+    .map((t) => `${t.title}${t.synthesis?.summary ? `: ${t.synthesis.summary}` : " (no synthesis yet)"}`);
+  return {
+    readable_summary:
+      count === 0
+        ? "No active research threads yet."
+        : `You have ${count} active research thread${count === 1 ? "" : "s"}.`,
+    readable_highlights: highlights,
+    readable_updated_at: new Date().toISOString(),
+    readable_source_label: "Sage",
+  };
+}

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -3361,6 +3361,259 @@ export class ApiService {
   }
 
   /**
+   * Turns one PKM domain's raw captured data into a single clean sentence
+   * via an LLM call, for the dashboard's Memory Highlights card -- the raw
+   * PKM explorer data (Kind/Summary/Status fragments) isn't meant to be
+   * shown verbatim as "what Hushh remembered about you."
+   */
+  static async summarizePkmHighlight(data: {
+    vaultOwnerToken: string;
+    domain: string;
+    displayName: string;
+    rawSummary: Record<string, unknown>;
+    highlights: string[];
+    mode?: "brief" | "rich";
+  }): Promise<Response> {
+    return apiFetch(`/api/kai/pkm/highlight-summary`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        domain: data.domain,
+        display_name: data.displayName,
+        raw_summary: data.rawSummary,
+        highlights: data.highlights,
+        mode: data.mode || "brief",
+      }),
+    });
+  }
+
+  /**
+   * Sage's cross-domain briefing: one Gemini call reasoning across every
+   * domain's already-computed summary at once. See summarizePkmHighlight
+   * above for the per-domain equivalent this sits next to.
+   */
+  static async summarizeSageBriefing(data: {
+    vaultOwnerToken: string;
+    domains: Array<{
+      domain: string;
+      displayName: string;
+      summary: Record<string, unknown>;
+      attributeCount: number;
+      lastUpdated: string | null;
+    }>;
+  }): Promise<Response> {
+    return apiFetch(`/api/kai/pkm/sage-briefing`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        domains: data.domains.map((d) => ({
+          domain: d.domain,
+          display_name: d.displayName,
+          summary: d.summary,
+          attribute_count: d.attributeCount,
+          last_updated: d.lastUpdated,
+        })),
+      }),
+    });
+  }
+
+  /**
+   * Ask Sage a real research question: Gemini with live Google Search
+   * grounding, personalized against the caller's own PKM domain summaries.
+   * Returns real cited sources when the model actually searched, none when
+   * it answered from its own knowledge -- never fabricated citations.
+   */
+  static async askSage(data: {
+    vaultOwnerToken: string;
+    query: string;
+    domains: Array<{
+      domain: string;
+      displayName: string;
+      summary: Record<string, unknown>;
+      attributeCount: number;
+    }>;
+    mode?: "standard" | "challenge";
+    conversationHistory?: Array<{ query: string; answer: string }>;
+    /** "deep" asks for a genuinely thorough, source-citing answer -- for
+     * persistent Research Threads, where a quick chat-style answer reads as
+     * thin. Defaults to "quick", the original Ask Sage one-shot behavior. */
+    depth?: "quick" | "deep";
+    /** Only meaningful when depth is "deep" -- how long an answer to ask
+     * for. "standard" is the original deep-mode length; "thorough" and
+     * "exhaustive" ask for progressively longer, section-structured answers
+     * (exhaustive targets 2000-2800 words / ~20k characters). Ignored in
+     * "quick" mode. Defaults to "standard". */
+    length?: "standard" | "thorough" | "exhaustive";
+  }): Promise<Response> {
+    return apiFetch(`/api/kai/pkm/sage-research`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: data.query,
+        mode: data.mode || "standard",
+        depth: data.depth || "quick",
+        length: data.length || "standard",
+        domains: data.domains.map((d) => ({
+          domain: d.domain,
+          display_name: d.displayName,
+          summary: d.summary,
+          attribute_count: d.attributeCount,
+        })),
+        conversation_history: (data.conversationHistory || []).map((turn) => ({
+          query: turn.query,
+          answer: turn.answer,
+        })),
+      }),
+    });
+  }
+
+  /**
+   * "What's new since last time": the caller has already diffed each
+   * domain's readable summary against a snapshot from the user's last
+   * visit and only sends the domains that actually changed.
+   */
+  static async getSageRecap(data: {
+    vaultOwnerToken: string;
+    domains: Array<{
+      domain: string;
+      displayName: string;
+      previousSummary: Record<string, unknown>;
+      currentSummary: Record<string, unknown>;
+    }>;
+  }): Promise<Response> {
+    return apiFetch(`/api/kai/pkm/sage-recap`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        domains: data.domains.map((d) => ({
+          domain: d.domain,
+          display_name: d.displayName,
+          previous_summary: d.previousSummary,
+          current_summary: d.currentSummary,
+        })),
+      }),
+    });
+  }
+
+  /**
+   * Sage drafting a structured self-assessment / performance-review document
+   * from real, already-decrypted fragments of one PKM domain (typically
+   * "professional"). The caller decrypts client-side and flattens to plain
+   * text before calling this -- the backend never sees encrypted data.
+   */
+  static async draftSageReview(data: {
+    vaultOwnerToken: string;
+    domain: string;
+    displayName: string;
+    fragments: string[];
+  }): Promise<Response> {
+    return apiFetch(`/api/kai/pkm/sage-review`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        domain: data.domain,
+        display_name: data.displayName,
+        fragments: data.fragments,
+      }),
+    });
+  }
+
+  /**
+   * Sage keeping a running synthesis of one persistent Research Thread:
+   * a short summary plus what's established vs. still an open question,
+   * reasoning over only the turns/papers the caller has already
+   * accumulated for this thread (never re-fetched server-side).
+   */
+  static async getSageThreadSynthesis(data: {
+    vaultOwnerToken: string;
+    title: string;
+    turns: Array<{ query: string; answer: string }>;
+    tracedPapers: Array<{ title: string; year: number | null; topic: string | null; citedByCount: number }>;
+  }): Promise<Response> {
+    return apiFetch(`/api/kai/pkm/sage-thread-synthesis`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: data.title,
+        turns: data.turns.map((t) => ({ query: t.query, answer: t.answer })),
+        traced_papers: data.tracedPapers.map((p) => ({
+          title: p.title,
+          year: p.year,
+          topic: p.topic,
+          cited_by_count: p.citedByCount,
+        })),
+      }),
+    });
+  }
+
+  /**
+   * Sage's citation-lineage explorer: free-text search over OpenAlex,
+   * returning a short candidate list (never trusting a single top hit --
+   * relevance-ranked search on a generic title can surface an unrelated
+   * paper) for the user to pick from before tracing its lineage.
+   */
+  static async searchSagePapers(data: { vaultOwnerToken: string; query: string }): Promise<Response> {
+    return apiFetch(`/api/kai/sage/paper-search`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: data.query }),
+    });
+  }
+
+  /**
+   * Traces one paper's citation lineage in both directions (what it cites,
+   * what cites it) via OpenAlex, keyed by the OpenAlex work id returned
+   * from searchSagePapers.
+   */
+  static async getSagePaperLineage(data: { vaultOwnerToken: string; workId: string }): Promise<Response> {
+    return apiFetch(`/api/kai/sage/paper-lineage`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ work_id: data.workId }),
+    });
+  }
+
+  /**
+   * Sage explaining what a traced paper actually is and why its position
+   * in the citation network matters -- grounded in OpenAlex's real
+   * abstract and topic classification, not a guess from the title alone.
+   */
+  static async getSagePaperInsight(data: { vaultOwnerToken: string; workId: string }): Promise<Response> {
+    return apiFetch(`/api/kai/sage/paper-insight`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${data.vaultOwnerToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ work_id: data.workId }),
+    });
+  }
+
+  /**
    * Fetch baseline market insights for Kai home without requiring vault access.
    */
   static async getKaiMarketBaselineInsights(data: {

--- a/hushh-webapp/lib/services/personal-knowledge-model-service.ts
+++ b/hushh-webapp/lib/services/personal-knowledge-model-service.ts
@@ -3165,11 +3165,12 @@ export class PersonalKnowledgeModelService {
     userId: string,
     domain: string,
     vaultOwnerToken?: string,
-    segmentIds?: string[]
+    segmentIds?: string[],
+    forceRefresh?: boolean
   ): Promise<EncryptedDomainBlob | null> {
     const cache = CacheService.getInstance();
     const normalizedSegmentIds = this.normalizeSegmentIds(segmentIds);
-    const canUseCache = normalizedSegmentIds.length === 0;
+    const canUseCache = normalizedSegmentIds.length === 0 && !forceRefresh;
     const cacheKey = CACHE_KEYS.ENCRYPTED_DOMAIN_BLOB(userId, domain);
     if (canUseCache) {
       const cached = cache.peek<EncryptedDomainBlob | null>(cacheKey);
@@ -3189,7 +3190,11 @@ export class PersonalKnowledgeModelService {
       Capacitor.isNativePlatform() ? "native" : "web",
       vaultOwnerToken ? "vault_owner" : "anonymous",
     ]);
-    const existingRequest = this.domainDataInflight.get(dedupeKey);
+    // forceRefresh also skips joining an existing in-flight request for this
+    // same key -- otherwise a slow pre-write fetch (e.g. one kicked off on
+    // mount) that's still pending would hand back its pre-write result here,
+    // the same staleness bug the cache check above guards against.
+    const existingRequest = forceRefresh ? undefined : this.domainDataInflight.get(dedupeKey);
     if (existingRequest) {
       return existingRequest;
     }
@@ -3479,6 +3484,7 @@ export class PersonalKnowledgeModelService {
     vaultKey: string;
     vaultOwnerToken?: string;
     segmentIds?: string[];
+    forceRefresh?: boolean;
   }): Promise<{
     data: Record<string, unknown> | null;
     blob: EncryptedDomainBlob | null;
@@ -3487,7 +3493,8 @@ export class PersonalKnowledgeModelService {
       params.userId,
       params.domain,
       params.vaultOwnerToken,
-      params.segmentIds
+      params.segmentIds,
+      params.forceRefresh
     );
     if (!blob) {
       return {


### PR DESCRIPTION
## Summary

Ports Sage from the desktop app (already merged as part of Desktop Beta 1.5, see #4769) onto `hushh-webapp` + `consent-protocol`, so the same agent works cross-platform instead of being desktop-only. Right now the only people who can use Sage are the ones running a desktop build; this makes it available to everyone on the web app.

Sage reads across everything Hushh already knows about a user and works as an ongoing agent, not a one-shot chatbot:

- **Ask Sage** -- live web-grounded research personalized against real PKM data, plus Challenge Mode (thesis + adversarial red-team critique)
- **Research Threads** -- persistent, named investigations with follow-up turns, auto-refreshed synthesis (established vs. open questions), cross-turn glossary, related-thread detection, markdown export, and a Standard/Thorough/Exhaustive answer-length control whose longer answers render as a navigable chaptered document
- **Citation Lineage** -- real OpenAlex citation graph tracing, wired bidirectionally into Research Threads
- **Self-Assessment** -- a structured draft built only from real accumulated history
- **Cross-domain "Sage's take"** -- one grounded observation across domains, plus misfiled-note detection with a one-click fix
- **Notes archive** -- view/remove raw notes across domains
- **Today section** -- a live Sage card on the One dashboard (matching desktop's discovery surface), so it's not direct-URL-only

## What's in this PR

**Backend (`consent-protocol`)**
- Two new route modules: `api/routes/kai/pkm_highlight.py` (highlight/briefing/recap/research/review/thread-synthesis endpoints), `api/routes/kai/sage_citations.py` (OpenAlex paper search/lineage/insight)
- Registered in `api/routes/kai/__init__.py` + `KAI_ROUTE_CONTRACT_PATHS`
- `domain_contracts.py`: new `research` domain registry entry
- `personal_knowledge_model_service.py`: `domain_data_exists()` (cheap existence check instead of fetching a full ciphertext blob just to check presence) + parallelized the 3 sequential `get_domain_manifest` queries
- `pkm_upgrade_service.py`: parallelized `build_status`'s per-domain manifest fetches (was a sequential loop; now `asyncio.gather`)

**Frontend (`hushh-webapp`)**
- New: `app/one/sage/**` (6 routes), `components/sage/**` (11 components), `lib/sage/**` (2 entity modules), `hooks/use-sage-domains.ts`
- Wired into `lib/navigation/routes.ts` + `top-shell-breadcrumbs.ts`, `lib/services/api-service.ts` (10 new client methods), `lib/services/personal-knowledge-model-service.ts` + `lib/pkm/pkm-domain-resource.ts` (a `forceRefresh` plumbing fix for a stale-read-after-write race), `app/globals.css` (progress-sweep animation)
- Dashboard discovery: new `components/dashboard/agent-card.tsx` + `today-section.tsx`, wired into `one-dashboard-page.tsx` / `app/one/page.tsx`. Desktop's Today section also has a Market Watch card; that's intentionally left out here since it depends on an Electron-only IPC bridge with no web equivalent.

All shared-file changes were applied as surgical diffs against `pr-train`'s actual current code (not blind-copied from desktop), with context verified line-by-line before each edit given the branches have diverged since the desktop fork point.

## Testing done

- `npx tsc --noEmit` clean across the full `hushh-webapp` frontend (zero errors)
- AST syntax check on every touched Python file
- Live backend boot against real dev Supabase + Gemini credentials: clean startup, all routes (including the two new ones) import without error, `/api/kai/health` -> 200
- Direct functional test of the Gemini-backed endpoints (`summarize_sage_briefing`, `sage_thread_synthesis`), bypassing HTTP/DB, feeding synthetic-but-realistic payloads and checking the output for fabrication -- both correctly grounded responses only in the facts provided, no invented domains/claims
- Live in-browser testing against real user data: all 6 new Sage routes render; existing Research Threads (created via this same backend previously) list and display correctly, confirming the read path is solid; write path (creating a new thread, saving notes) verified working end-to-end once local DB pool contention (see below) was worked around

## Known non-blocking issue: local dev DB latency

While testing, hit significant latency (SQLAlchemy's default `pool_timeout` of 30s) under concurrent load against the shared dev Supabase project, which caps at 15 session-mode connections. Root cause: `db_client.py`'s SQLAlchemy pool (`pool_size=5, max_overflow=10` by default) plus `db/connection.py`'s separate asyncpg pool (`max_size=10`, hardcoded) can together try to open up to 25 connections from one process alone, against Supabase's 15-connection cap -- pre-existing in this codebase, not introduced by this PR. Worked around locally via a smaller `DB_SQLALCHEMY_POOL_SIZE`/`DB_SQLALCHEMY_MAX_OVERFLOW` in a local-only `.env` (not part of this diff). Not something to fix in this PR; flagging for whoever owns the shared dev Supabase project's connection limits, since Sage's dashboard card adds a couple more concurrent calls to every `/one` page load on top of an already request-heavy page.

## Test plan

- [ ] Pull this branch, run both `consent-protocol` and `hushh-webapp` locally
- [ ] Log in, unlock vault, confirm the "Today" section shows a live Sage card on `/one`
- [ ] Open `/one/sage`, exercise Ask Sage (standard + Challenge Mode)
- [ ] Create a Research Thread, ask a follow-up, confirm synthesis updates
- [ ] Trace a paper via Citation Lineage, add it to a thread
- [ ] Generate a Self-Assessment draft
- [ ] Add and remove a raw note via the Notes archive
