### PR TITLE
fix(one): harden location and phone verification UX

### DIFF
--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -177,6 +177,42 @@ describe("PhoneVerificationFlow country selector", () => {
     });
   });
 
+  it("blocks an Indian number with an extra leading zero before Firebase", async () => {
+    const { startVerification } = renderPhoneVerificationFlow();
+
+    await selectIndiaOnce();
+    fireEvent.change(screen.getByRole("textbox", { name: "Phone number" }), {
+      target: { value: "08004482372" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send verification code" }),
+    );
+
+    await waitFor(() => expect(startVerification).not.toHaveBeenCalled());
+    expect(
+      screen.getByRole("textbox", { name: "Phone number" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("textbox", { name: "One-time code" }),
+    ).toBeNull();
+  });
+
+  it("shows only the masked national number on the OTP screen", async () => {
+    renderPhoneVerificationFlow();
+
+    await selectIndiaOnce();
+    fireEvent.change(screen.getByRole("textbox", { name: "Phone number" }), {
+      target: { value: "8004482372" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send verification code" }),
+    );
+
+    expect(await screen.findByText("•••••• 2372")).toBeTruthy();
+    expect(screen.queryByText(/\+91/)).toBeNull();
+    expect(screen.getByRole("textbox", { name: "One-time code" })).toBeTruthy();
+  });
+
   it("submits both the phone number and six-digit code through their semantic forms", async () => {
     const { startVerification, confirmVerification, onCompleted } =
       renderPhoneVerificationFlow();

--- a/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
+++ b/hushh-webapp/__tests__/components/phone-verification-flow-interaction.test.tsx
@@ -181,20 +181,74 @@ describe("PhoneVerificationFlow country selector", () => {
     const { startVerification } = renderPhoneVerificationFlow();
 
     await selectIndiaOnce();
-    fireEvent.change(screen.getByRole("textbox", { name: "Phone number" }), {
-      target: { value: "08004482372" },
-    });
+    const phoneInput = screen.getByRole("textbox", {
+      name: "Phone number",
+    }) as HTMLInputElement;
+    expect(phoneInput.maxLength).toBe(10);
+
+    fireEvent.change(phoneInput, { target: { value: "0800448237" } });
+    expect(phoneInput.value).toBe("0800448237");
     fireEvent.click(
       screen.getByRole("button", { name: "Send verification code" }),
     );
 
     await waitFor(() => expect(startVerification).not.toHaveBeenCalled());
-    expect(
-      screen.getByRole("textbox", { name: "Phone number" }),
-    ).toBeTruthy();
-    expect(
-      screen.queryByRole("textbox", { name: "One-time code" }),
-    ).toBeNull();
+    expect(phoneInput).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Enter the mobile number without a local leading prefix after +91.",
+    );
+    expect(screen.queryByRole("textbox", { name: "One-time code" })).toBeNull();
+  });
+
+  it("rejects an overlength paste without changing or sending the recipient", async () => {
+    const { startVerification } = renderPhoneVerificationFlow();
+
+    await selectIndiaOnce();
+    const phoneInput = screen.getByRole("textbox", {
+      name: "Phone number",
+    }) as HTMLInputElement;
+    fireEvent.change(phoneInput, { target: { value: "8004482372" } });
+    phoneInput.setSelectionRange(0, phoneInput.value.length);
+    fireEvent.paste(phoneInput, {
+      clipboardData: { getData: () => "800448237299" },
+    });
+
+    expect(phoneInput.value).toBe("8004482372");
+    expect(phoneInput.maxLength).toBe(10);
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Enter no more than 10 digits for India.",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send verification code" }),
+    );
+    await waitFor(() => expect(startVerification).not.toHaveBeenCalled());
+  });
+
+  it("preserves a complete E.164 paste before native maxLength clipping", async () => {
+    const { startVerification } = renderPhoneVerificationFlow();
+    const phoneInput = screen.getByRole("textbox", {
+      name: "Phone number",
+    }) as HTMLInputElement;
+
+    fireEvent.paste(phoneInput, {
+      clipboardData: { getData: () => "+16582101234" },
+    });
+
+    await waitFor(() => expect(phoneInput.value).toBe("6582101234"));
+    const countryInput = screen.getByRole("combobox", {
+      name: "Country code",
+    }) as HTMLInputElement;
+    expect(countryInput.value).toBe("Jamaica (+1)");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send verification code" }),
+    );
+    await waitFor(() => {
+      expect(startVerification).toHaveBeenCalledWith("+16582101234", {
+        resendCode: false,
+      });
+    });
   });
 
   it("shows only the masked national number on the OTP screen", async () => {

--- a/hushh-webapp/__tests__/components/phone-verification-flow.test.ts
+++ b/hushh-webapp/__tests__/components/phone-verification-flow.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   derivePhoneFields,
+  getPhoneNumberValidationError,
+  maskPhoneNumberForOtp,
   resolvePhoneInputChange,
 } from "@/components/auth/phone-verification-flow";
 
@@ -27,7 +29,20 @@ describe("PhoneVerificationFlow phone input normalization", () => {
       localPhoneNumber: "6505550101",
     });
   });
-      it("preserves empty phone input normalization stability", () => {
+
+  it("rejects an Indian trunk prefix before the provider request", () => {
+    expect(getPhoneNumberValidationError("+9108004482372")).toBe(
+      "Enter a valid 10-digit Indian mobile number without the leading 0.",
+    );
+    expect(getPhoneNumberValidationError("+918004482372")).toBeNull();
+  });
+
+  it("masks the OTP destination without exposing the country code", () => {
+    expect(maskPhoneNumberForOtp("+918004482372")).toBe("•••••• 2372");
+    expect(maskPhoneNumberForOtp("+16505550101")).toBe("•••••• 0101");
+  });
+
+  it("preserves empty phone input normalization stability", () => {
     expect(resolvePhoneInputChange("")).toEqual({
       localPhoneNumber: "",
     });

--- a/hushh-webapp/__tests__/components/phone-verification-flow.test.ts
+++ b/hushh-webapp/__tests__/components/phone-verification-flow.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
+import {
+  getCountryCallingCode,
+  getExampleNumber,
+  isSupportedCountry,
+  type CountryCode,
+} from "libphonenumber-js/core";
+import mobileExamples from "libphonenumber-js/examples.mobile.json";
+import mobilePhoneMetadata from "libphonenumber-js/mobile/metadata";
 
 import {
   derivePhoneFields,
+  getMobileNumberLengthRange,
   getPhoneNumberValidationError,
   maskPhoneNumberForOtp,
   resolvePhoneInputChange,
 } from "@/components/auth/phone-verification-flow";
+import { COUNTRY_PHONE_OPTIONS } from "@/lib/constants/country-phone-options";
 
 describe("PhoneVerificationFlow phone input normalization", () => {
   it("preserves a pasted E.164 US test number by splitting country and local digits", () => {
@@ -31,10 +41,67 @@ describe("PhoneVerificationFlow phone input normalization", () => {
   });
 
   it("rejects an Indian trunk prefix before the provider request", () => {
-    expect(getPhoneNumberValidationError("+9108004482372")).toBe(
-      "Enter a valid 10-digit Indian mobile number without the leading 0.",
+    expect(getPhoneNumberValidationError("+9108004482372", "IN")).toBe(
+      "Enter no more than 10 digits for India.",
     );
-    expect(getPhoneNumberValidationError("+918004482372")).toBeNull();
+    expect(getPhoneNumberValidationError("+918004482372", "IN")).toBeNull();
+  });
+
+  it("uses country-specific mobile lengths", () => {
+    expect(getMobileNumberLengthRange("IN")).toEqual({
+      minimum: 10,
+      maximum: 10,
+    });
+    expect(getMobileNumberLengthRange("GB")).toEqual({
+      minimum: 10,
+      maximum: 10,
+    });
+    expect(getMobileNumberLengthRange("DE")).toEqual({
+      minimum: 10,
+      maximum: 11,
+    });
+    expect(getMobileNumberLengthRange("BR")).toEqual({
+      minimum: 10,
+      maximum: 11,
+    });
+  });
+
+  it("preserves alternate national area codes instead of rewriting recipients", () => {
+    expect(derivePhoneFields("+16582101234")).toEqual({
+      countryValue: "JM",
+      localPhoneNumber: "6582101234",
+    });
+    expect(getPhoneNumberValidationError("+16582101234", "JM")).toBeNull();
+  });
+
+  it("accepts canonical mobile examples for every selectable country", () => {
+    const selectableCountries = COUNTRY_PHONE_OPTIONS.filter((option) =>
+      isSupportedCountry(option.value, mobilePhoneMetadata),
+    );
+
+    for (const option of selectableCountries) {
+      const example = getExampleNumber(
+        option.value as CountryCode,
+        mobileExamples,
+        mobilePhoneMetadata,
+      );
+      expect(example, `${option.label} has a mobile example`).toBeTruthy();
+      if (!example) continue;
+
+      expect(
+        getPhoneNumberValidationError(example.number, option.value),
+        `${option.label} ${example.number}`,
+      ).toBeNull();
+      const canonicalDialCode = `+${getCountryCallingCode(
+        option.value as CountryCode,
+        mobilePhoneMetadata,
+      )}`;
+      expect(
+        example.number.slice(canonicalDialCode.length).length,
+      ).toBeLessThanOrEqual(getMobileNumberLengthRange(option.value).maximum);
+    }
+
+    expect(selectableCountries).toHaveLength(243);
   });
 
   it("masks the OTP destination without exposing the country code", () => {

--- a/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
+++ b/hushh-webapp/__tests__/components/top-app-bar.contract.test.ts
@@ -240,6 +240,13 @@ describe("Top app bar responsive contract", () => {
 
   it("keeps onboarding chrome canonical and shell-sized", () => {
     const source = read("components/app-ui/top-app-bar.tsx");
+    const signOutItemStart = source.indexOf(
+      "onClick={() => void handleSignOut()}",
+    );
+    const signOutItemSource = source.slice(
+      signOutItemStart,
+      source.indexOf("</DropdownMenuItem>", signOutItemStart),
+    );
     const deleteItemStart = source.indexOf('variant="destructive"');
     const deleteItemSource = source.slice(
       deleteItemStart,
@@ -254,14 +261,31 @@ describe("Top app bar responsive contract", () => {
       '<ShellActionSurface variant="icon" aria-label="Account actions">',
     );
     expect(source).toContain('variant="destructive"');
+    expect(source).toContain(
+      'className="overflow-hidden rounded-[14px] p-1"',
+    );
+    expect(signOutItemSource).toContain("cursor-pointer");
+    expect(signOutItemSource).toContain("rounded-[10px]");
+    expect(signOutItemSource).toContain(
+      "hover:!bg-[color:var(--app-accent)]",
+    );
+    expect(signOutItemSource).toContain(
+      "hover:!text-[color:var(--app-accent-fg)]",
+    );
+    expect(signOutItemSource).toContain(
+      "hover:[&_svg]:!stroke-[color:var(--app-accent-fg)]",
+    );
     expect(deleteItemSource).toContain("cursor-pointer");
+    expect(deleteItemSource).toContain("rounded-[10px]");
     expect(deleteItemSource).toContain("hover:!bg-red-600");
     expect(deleteItemSource).toContain("hover:!text-white");
+    expect(deleteItemSource).toContain("hover:[&_svg]:!stroke-white");
     expect(deleteItemSource).toContain("hover:[&_svg]:!text-white");
     expect(deleteItemSource).not.toContain(
       "data-[variant=destructive]:focus:bg-popover",
     );
-    expect(source).toContain("focus-visible:ring-accent/70");
+    expect(signOutItemSource).toContain("focus-visible:ring-inset");
+    expect(deleteItemSource).toContain("focus-visible:ring-inset");
     expect(source).not.toContain(
       'className="text-red-600 focus:text-red-600"',
     );

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -228,7 +228,7 @@ import { LiveMap } from "@/components/one-location/live-map";
 import { buildBackgroundShareSession } from "@/lib/one-location/background-share";
 import { syncBackgroundShare } from "@/lib/one-location/background-share-runtime";
 import { BackgroundShareToggle } from "@/app/one/location/background-share-toggle";
-import { liveFreshness } from "@/lib/one-location/freshness";
+import { locationPreviewFreshness } from "@/lib/one-location/freshness";
 import { shouldStreamSelfPreview } from "@/lib/one-location/self-preview";
 import {
   DRIVE_ETA_MIN_RECOMPUTE_INTERVAL_MS,
@@ -832,12 +832,6 @@ function oneLocationErrorMessage(error: unknown, fallback: string): string {
   return isSafeUserFacingMessage(raw) ? raw : fallback;
 }
 
-function isLocationPointStale(point: PlainLocationPoint): boolean {
-  const capturedAt = new Date(point.capturedAt).getTime();
-  if (!Number.isFinite(capturedAt)) return false;
-  return Date.now() - capturedAt > LIVE_LOCATION_STALE_THRESHOLD_MS;
-}
-
 // Great-circle distance in metres between two points (Haversine). Used to decide
 // whether the owner has actually MOVED enough to warrant publishing a fresh
 // encrypted live-location update, so the watch stream doesn't flood the network
@@ -915,29 +909,33 @@ function locationSourceLabel(
 function LocalMapPreview({
   point,
   showNavigation = true,
+  viewportResetKey,
 }: {
   point: PlainLocationPoint;
   // Self-location previews do not need Directions/Start - you are already there.
   showNavigation?: boolean;
+  viewportResetKey?: string | number;
 }) {
   const captured = formatDateTime(point.capturedAt);
-  const isStale = isLocationPointStale(point);
   const accuracy = locationAccuracyLabel(point);
   const directionsUrl = googleMapsDirectionsUrl(point);
-  const freshness = liveFreshness(
-    point.capturedAt,
-    Date.now(),
-    LIVE_LOCATION_STALE_THRESHOLD_MS,
-  );
-  const statusLabel =
-    freshness.state === "live"
+  const freshness = locationPreviewFreshness({
+    capturedAtISO: point.capturedAt,
+    nowMs: Date.now(),
+    staleThresholdMs: LIVE_LOCATION_STALE_THRESHOLD_MS,
+    fixedCheckIn: Boolean(point.checkIn),
+  });
+  const isStale = freshness.state === "paused";
+  const statusLabel = freshness.state === "check_in"
+    ? `Checked in · ${freshness.agoLabel}`
+    : freshness.state === "live"
       ? `Live · ${freshness.agoLabel}`
       : `Paused · last seen ${freshness.agoLabel}`;
 
   return (
     <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
       <div className="relative h-48 max-w-full overflow-hidden bg-[#e5e5ea] sm:h-56 dark:bg-[#111113]">
-        <LiveMap point={point} />
+        <LiveMap point={point} viewportResetKey={viewportResetKey} />
         <div className="pointer-events-none absolute left-3 top-3">
           <span
             className={cn(
@@ -950,7 +948,11 @@ function LocalMapPreview({
             <span
               className={cn(
                 "h-2 w-2 rounded-full",
-                isStale ? "bg-amber-300" : "animate-pulse bg-emerald-300",
+                isStale
+                  ? "bg-amber-300"
+                  : freshness.state === "check_in"
+                    ? "bg-emerald-300"
+                    : "animate-pulse bg-emerald-300",
               )}
               aria-hidden="true"
             />
@@ -1878,6 +1880,7 @@ export function OneLocationAgentPageContent({
     }));
   }, [updateLocationWorkspace]);
   const [myLocationError, setMyLocationError] = useState<string | null>(null);
+  const [mapViewportResetKey, setMapViewportResetKey] = useState(0);
   // True once the owner taps "Show my location" — keeps their own preview
   // streaming live (foreground) even before any share exists.
   const decryptedPoints = locationWorkspace.decryptedPoints;
@@ -5380,6 +5383,7 @@ export function OneLocationAgentPageContent({
         setMyLocationError(message);
         return;
       }
+      setMapViewportResetKey((current) => current + 1);
       toast.success("Your live location preview is ready.");
     } catch (error) {
       const message = locationServicesErrorMessage(error);
@@ -6244,7 +6248,11 @@ export function OneLocationAgentPageContent({
       value ? `Live until ${formatDateTime(value)}` : "Live now",
     expiresCountdownLabel: (value) => expiresCountdownLabel(value) ?? "Active",
     renderMapPreview: (point, showNavigation) => (
-      <LocalMapPreview point={point} showNavigation={showNavigation} />
+      <LocalMapPreview
+        point={point}
+        showNavigation={showNavigation}
+        viewportResetKey={mapViewportResetKey}
+      />
     ),
     mapLocationHref: googleMapsLocationUrl,
     decryptedPoints,
@@ -6529,6 +6537,7 @@ export function OneLocationAgentPageContent({
                       <LocalMapPreview
                         point={myLocationPoint}
                         showNavigation={false}
+                        viewportResetKey={mapViewportResetKey}
                       />
                     </div>
                   ) : null}

--- a/hushh-webapp/components/app-ui/top-app-bar.tsx
+++ b/hushh-webapp/components/app-ui/top-app-bar.tsx
@@ -1310,15 +1310,21 @@ function OnboardingRouteActions() {
             <MoreHorizontal className="h-5 w-5 text-current" />
           </ShellActionSurface>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={() => void handleSignOut()}>
+        <DropdownMenuContent
+          align="end"
+          className="overflow-hidden rounded-[14px] p-1"
+        >
+          <DropdownMenuItem
+            onClick={() => void handleSignOut()}
+            className="cursor-pointer rounded-[10px] hover:!bg-[color:var(--app-accent)] hover:!text-[color:var(--app-accent-fg)] hover:[&_svg]:!stroke-[color:var(--app-accent-fg)] hover:[&_svg]:!text-[color:var(--app-accent-fg)] focus:!bg-[color:var(--app-accent)] focus:!text-[color:var(--app-accent-fg)] focus:[&_svg]:!stroke-[color:var(--app-accent-fg)] focus:[&_svg]:!text-[color:var(--app-accent-fg)] focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
+          >
             <LogOut className="h-4 w-4 text-current" />
             Sign out
           </DropdownMenuItem>
           <DropdownMenuItem
             variant="destructive"
             onClick={() => void requestDeleteAccount()}
-            className="cursor-pointer hover:!bg-red-600 hover:!text-white hover:[&_svg]:!text-white focus:!bg-red-600 focus:!text-white focus:[&_svg]:!text-white focus-visible:ring-2 focus-visible:ring-accent/70"
+            className="cursor-pointer rounded-[10px] hover:!bg-red-600 hover:!text-white hover:[&_svg]:!stroke-white hover:[&_svg]:!text-white focus:!bg-red-600 focus:!text-white focus:[&_svg]:!stroke-white focus:[&_svg]:!text-white focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
           >
             <Trash2 className="h-4 w-4 text-current" />
             Delete account

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -56,9 +56,7 @@ import { cn } from "@/lib/utils";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
-// E.164 defines a 15-digit maximum but no universal national-number minimum.
-// Country metadata below owns completeness and validity (for example, Tokelau
-// has valid numbers shorter than the historical eight-digit app minimum).
+// Country metadata owns national-number length and validity.
 const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
 const E164_MAX_DIGITS = 15;
 const DEFAULT_COUNTRY_VALUE = "US";
@@ -103,12 +101,7 @@ type StartVerificationOutcome =
 
 type ConfirmVerificationOutcome = "verified" | "invalid" | "failed" | "busy";
 
-// Only offer regions for which Google's mobile-number metadata defines an
-// actual numbering plan. Entries such as Antarctica do not own a usable phone
-// plan and must not silently validate as another country that shares a prefix.
-// Normalize NANP entries to the canonical +1 calling code so alternate area
-// codes (for example Jamaica +1 658 and +1 876) remain part of the national
-// number and are never rewritten to the picker's historical area code.
+// Offer metadata-backed plans and keep NANP area codes in the national number.
 const PHONE_COUNTRY_OPTIONS: readonly CountryPhoneOption[] =
   COUNTRY_PHONE_OPTIONS.filter((option) =>
     isSupportedCountry(option.value as CountryCode, mobilePhoneMetadata),
@@ -181,12 +174,6 @@ const mobileNumberLengthCache = new Map<
   { minimum: number; maximum: number }
 >();
 
-/**
- * Returns the supported national mobile-number length range for a country.
- * The metadata is generated from Google's numbering plans by
- * `libphonenumber-js`; the E.164 fallback keeps uncommon/unsupported regions
- * bounded without maintaining a second country table in this app.
- */
 export function getMobileNumberLengthRange(countryValue: string): {
   minimum: number;
   maximum: number;
@@ -205,9 +192,7 @@ export function getMobileNumberLengthRange(countryValue: string): {
   try {
     const metadata = new Metadata(mobilePhoneMetadata);
     metadata.selectNumberingPlan(countryValue as CountryCode);
-    // `type("MOBILE")` is the runtime metadata view used by the package's
-    // own validators. Keeping this access in one helper makes upgrades easy
-    // to verify while preserving every country's variable mobile lengths.
+    // The package exposes this metadata view at runtime but not in its TS API.
     const mobileType = (metadata as MobileAwareMetadata).type("MOBILE");
     const possibleLengths = (mobileType?.possibleLengths() ?? [])
       .filter(
@@ -222,8 +207,7 @@ export function getMobileNumberLengthRange(countryValue: string): {
       };
     }
   } catch {
-    // Defensive fallback for a malformed programmatic country value. Every
-    // visible picker entry has supported metadata.
+    // Invalid programmatic values use the E.164 bound above.
   }
 
   mobileNumberLengthCache.set(cacheKey, range);
@@ -262,11 +246,9 @@ export function derivePhoneFields(phoneNumber?: string | null): {
   if (matchingOption) {
     return {
       countryValue: matchingOption.value,
-      localPhoneNumber:
-        parsedPhone?.nationalNumber ??
-        sanitizeLocalPhoneNumber(
-          normalizedPhone.slice(matchingOption.dialCode.length),
-        ),
+      localPhoneNumber: parsedPhone?.nationalNumber ?? sanitizeLocalPhoneNumber(
+        normalizedPhone.slice(matchingOption.dialCode.length),
+      ),
     };
   }
 
@@ -403,9 +385,7 @@ export function PhoneVerificationFlow({
   );
   const selectedCountryLabel = useMemo(
     () =>
-      getCountryOptionLabel(
-        selectedCountryOption ?? DEFAULT_PHONE_COUNTRY_OPTION,
-      ),
+      getCountryOptionLabel(selectedCountryOption ?? DEFAULT_PHONE_COUNTRY_OPTION),
     [selectedCountryOption],
   );
   const countryInputValue = countryComboboxOpen
@@ -430,8 +410,7 @@ export function PhoneVerificationFlow({
     });
   }, [countryQuery]);
   const activeDialCode = useMemo(
-    () =>
-      selectedCountryOption?.dialCode ?? DEFAULT_PHONE_COUNTRY_OPTION.dialCode,
+    () => selectedCountryOption?.dialCode ?? DEFAULT_PHONE_COUNTRY_OPTION.dialCode,
     [selectedCountryOption],
   );
   const normalizedPhoneInput = useMemo(
@@ -443,31 +422,28 @@ export function PhoneVerificationFlow({
     [selectedCountry],
   );
 
-  const handleCountrySelection = useCallback(
-    (value: string | null) => {
-      if (!value) {
-        return;
-      }
+  const handleCountrySelection = useCallback((value: string | null) => {
+    if (!value) {
+      return;
+    }
 
-      const nextOption = PHONE_COUNTRY_OPTIONS.find(
-        (option) => option.value === value,
-      );
-      if (!nextOption) {
-        return;
-      }
+    const nextOption = PHONE_COUNTRY_OPTIONS.find(
+      (option) => option.value === value,
+    );
+    if (!nextOption) {
+      return;
+    }
 
-      setSelectedCountry(nextOption.value);
-      const maximum = getMobileNumberLengthRange(nextOption.value).maximum;
-      setPhoneNumberError(
-        localPhoneNumber.length > maximum
-          ? `Enter no more than ${maximum} digits for ${nextOption.label}.`
-          : null,
-      );
-      setCountryQuery("");
-      setCountryComboboxOpen(false);
-    },
-    [localPhoneNumber.length],
-  );
+    setSelectedCountry(nextOption.value);
+    const maximum = getMobileNumberLengthRange(nextOption.value).maximum;
+    setPhoneNumberError(
+      localPhoneNumber.length > maximum
+        ? `Enter no more than ${maximum} digits for ${nextOption.label}.`
+        : null,
+    );
+    setCountryQuery("");
+    setCountryComboboxOpen(false);
+  }, [localPhoneNumber.length]);
 
   useLocalOnboardingActionHandler("phone_mandate.select_country", (slots) => {
     const requested = String(
@@ -581,29 +557,25 @@ export function PhoneVerificationFlow({
     { role: "interaction_layer", routeKey: pathname },
   );
 
-  const handlePhoneNumberChange = useCallback(
-    (value: string) => {
-      const nextInput = resolvePhoneInputChange(value);
-      const nextCountry = nextInput.countryValue ?? selectedCountry;
-      const nextOption = getCountryOption(nextCountry);
-      const maximum = getMobileNumberLengthRange(nextCountry).maximum;
-      if (nextInput.localPhoneNumber.length > maximum) {
-        // Never truncate a pasted phone number into a different valid
-        // recipient. Keep the last visible value and require an explicit edit.
-        setPhoneNumberError(
-          `Enter no more than ${maximum} digits for ${nextOption.label}.`,
-        );
-        return;
-      }
-      if (nextInput.countryValue) {
-        setSelectedCountry(nextOption.value);
-        setCountryQuery("");
-      }
-      setLocalPhoneNumber(nextInput.localPhoneNumber);
-      setPhoneNumberError(null);
-    },
-    [selectedCountry],
-  );
+  const handlePhoneNumberChange = useCallback((value: string) => {
+    const nextInput = resolvePhoneInputChange(value);
+    const nextCountry = nextInput.countryValue ?? selectedCountry;
+    const nextOption = getCountryOption(nextCountry);
+    const maximum = getMobileNumberLengthRange(nextCountry).maximum;
+    if (nextInput.localPhoneNumber.length > maximum) {
+      // Reject instead of truncating into a different recipient.
+      setPhoneNumberError(
+        `Enter no more than ${maximum} digits for ${nextOption.label}.`,
+      );
+      return;
+    }
+    if (nextInput.countryValue) {
+      setSelectedCountry(nextOption.value);
+      setCountryQuery("");
+    }
+    setLocalPhoneNumber(nextInput.localPhoneNumber);
+    setPhoneNumberError(null);
+  }, [selectedCountry]);
 
   const handlePhoneNumberPaste = useCallback(
     (event: React.ClipboardEvent<HTMLInputElement>) => {
@@ -612,9 +584,7 @@ export function PhoneVerificationFlow({
       const selectionEnd =
         event.currentTarget.selectionEnd ?? localPhoneNumber.length;
       const nextValue = `${localPhoneNumber.slice(0, selectionStart)}${pastedValue}${localPhoneNumber.slice(selectionEnd)}`;
-      // Own paste normalization before the browser applies maxLength to raw
-      // characters. This preserves full E.164 and formatted numbers while the
-      // shared change handler rejects any overlength national number.
+      // Intercept before maxLength can clip a complete international paste.
       event.preventDefault();
       handlePhoneNumberChange(nextValue);
     },

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -10,6 +10,14 @@ import {
   useState,
 } from "react";
 import type { User } from "firebase/auth";
+import {
+  getCountryCallingCode,
+  isSupportedCountry,
+  Metadata,
+  parsePhoneNumberFromString,
+  type CountryCode,
+} from "libphonenumber-js/core";
+import mobilePhoneMetadata from "libphonenumber-js/mobile/metadata";
 import { Loader2, ShieldCheck } from "lucide-react";
 import { usePathname } from "next/navigation";
 
@@ -48,8 +56,11 @@ import { cn } from "@/lib/utils";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
-const E164_PHONE_PATTERN = /^\+[1-9]\d{7,14}$/;
-const INDIA_MOBILE_PATTERN = /^[6-9]\d{9}$/;
+// E.164 defines a 15-digit maximum but no universal national-number minimum.
+// Country metadata below owns completeness and validity (for example, Tokelau
+// has valid numbers shorter than the historical eight-digit app minimum).
+const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
+const E164_MAX_DIGITS = 15;
 const DEFAULT_COUNTRY_VALUE = "US";
 const FLOW_CONTROL_SHELL_CLASS_NAME =
   "h-[54px] overflow-hidden rounded-[15px] border-black/10 bg-[#f5f5f7]/92 shadow-xs transition-[border-color,box-shadow] focus-within:border-[color:var(--app-accent)] focus-within:ring-4 focus-within:ring-[color:var(--app-accent-ring)] dark:border-white/10 dark:bg-white/[0.08]";
@@ -92,6 +103,27 @@ type StartVerificationOutcome =
 
 type ConfirmVerificationOutcome = "verified" | "invalid" | "failed" | "busy";
 
+// Only offer regions for which Google's mobile-number metadata defines an
+// actual numbering plan. Entries such as Antarctica do not own a usable phone
+// plan and must not silently validate as another country that shares a prefix.
+// Normalize NANP entries to the canonical +1 calling code so alternate area
+// codes (for example Jamaica +1 658 and +1 876) remain part of the national
+// number and are never rewritten to the picker's historical area code.
+const PHONE_COUNTRY_OPTIONS: readonly CountryPhoneOption[] =
+  COUNTRY_PHONE_OPTIONS.filter((option) =>
+    isSupportedCountry(option.value as CountryCode, mobilePhoneMetadata),
+  ).map((option) => ({
+    ...option,
+    dialCode: `+${getCountryCallingCode(
+      option.value as CountryCode,
+      mobilePhoneMetadata,
+    )}`,
+  }));
+const DEFAULT_PHONE_COUNTRY_OPTION =
+  PHONE_COUNTRY_OPTIONS.find(
+    (option) => option.value === DEFAULT_COUNTRY_VALUE,
+  ) ?? PHONE_COUNTRY_OPTIONS[0]!;
+
 function getCountryOptionLabel(option: {
   label: string;
   dialCode: string;
@@ -101,15 +133,15 @@ function getCountryOptionLabel(option: {
 
 function getCountryOption(value: string): CountryPhoneOption {
   return (
-    COUNTRY_PHONE_OPTIONS.find((option) => option.value === value) ??
-    COUNTRY_PHONE_OPTIONS[0]!
+    PHONE_COUNTRY_OPTIONS.find((option) => option.value === value) ??
+    DEFAULT_PHONE_COUNTRY_OPTION
   );
 }
 
 function getCountryOptionForPhoneNumber(
   phoneNumber: string,
 ): CountryPhoneOption | undefined {
-  const matchingOptions = COUNTRY_PHONE_OPTIONS.filter((option) =>
+  const matchingOptions = PHONE_COUNTRY_OPTIONS.filter((option) =>
     phoneNumber.startsWith(option.dialCode),
   ).sort((left, right) => right.dialCode.length - left.dialCode.length);
   const firstMatch = matchingOptions[0];
@@ -133,7 +165,69 @@ function sanitizeDialCode(value: string): string {
 }
 
 function sanitizeLocalPhoneNumber(value: string): string {
-  return value.replace(/\D/g, "").slice(0, 15);
+  return value.replace(/\D/g, "");
+}
+
+type MobileNumberTypeMetadata = {
+  possibleLengths: () => number[];
+};
+
+type MobileAwareMetadata = Metadata & {
+  type: (type: "MOBILE") => MobileNumberTypeMetadata | undefined;
+};
+
+const mobileNumberLengthCache = new Map<
+  string,
+  { minimum: number; maximum: number }
+>();
+
+/**
+ * Returns the supported national mobile-number length range for a country.
+ * The metadata is generated from Google's numbering plans by
+ * `libphonenumber-js`; the E.164 fallback keeps uncommon/unsupported regions
+ * bounded without maintaining a second country table in this app.
+ */
+export function getMobileNumberLengthRange(countryValue: string): {
+  minimum: number;
+  maximum: number;
+} {
+  const dialCode = getCountryOption(countryValue).dialCode;
+  const cacheKey = `${countryValue}:${dialCode}`;
+  const cached = mobileNumberLengthCache.get(cacheKey);
+  if (cached) return cached;
+
+  const fallbackMaximum = Math.max(
+    1,
+    E164_MAX_DIGITS - dialCode.replace(/\D/g, "").length,
+  );
+  let range = { minimum: 1, maximum: fallbackMaximum };
+
+  try {
+    const metadata = new Metadata(mobilePhoneMetadata);
+    metadata.selectNumberingPlan(countryValue as CountryCode);
+    // `type("MOBILE")` is the runtime metadata view used by the package's
+    // own validators. Keeping this access in one helper makes upgrades easy
+    // to verify while preserving every country's variable mobile lengths.
+    const mobileType = (metadata as MobileAwareMetadata).type("MOBILE");
+    const possibleLengths = (mobileType?.possibleLengths() ?? [])
+      .filter(
+        (length) =>
+          Number.isInteger(length) && length > 0 && length <= fallbackMaximum,
+      )
+      .sort((left, right) => left - right);
+    if (possibleLengths.length > 0) {
+      range = {
+        minimum: possibleLengths[0]!,
+        maximum: possibleLengths[possibleLengths.length - 1]!,
+      };
+    }
+  } catch {
+    // Defensive fallback for a malformed programmatic country value. Every
+    // visible picker entry has supported metadata.
+  }
+
+  mobileNumberLengthCache.set(cacheKey, range);
+  return range;
 }
 
 function composePhoneNumber(
@@ -155,14 +249,24 @@ export function derivePhoneFields(phoneNumber?: string | null): {
     };
   }
 
-  const matchingOption = getCountryOptionForPhoneNumber(normalizedPhone);
+  const parsedPhone = parsePhoneNumberFromString(
+    normalizedPhone,
+    mobilePhoneMetadata,
+  );
+  const parsedCountry = parsedPhone?.country;
+  const matchingOption =
+    (parsedCountry
+      ? PHONE_COUNTRY_OPTIONS.find((option) => option.value === parsedCountry)
+      : undefined) ?? getCountryOptionForPhoneNumber(normalizedPhone);
 
   if (matchingOption) {
     return {
       countryValue: matchingOption.value,
-      localPhoneNumber: sanitizeLocalPhoneNumber(
-        normalizedPhone.slice(matchingOption.dialCode.length),
-      ),
+      localPhoneNumber:
+        parsedPhone?.nationalNumber ??
+        sanitizeLocalPhoneNumber(
+          normalizedPhone.slice(matchingOption.dialCode.length),
+        ),
     };
   }
 
@@ -176,6 +280,7 @@ export function derivePhoneFields(phoneNumber?: string | null): {
 
 export function getPhoneNumberValidationError(
   phoneNumber?: string | null,
+  countryValue?: string,
 ): string | null {
   const normalizedPhone = String(phoneNumber ?? "").trim();
   if (!E164_PHONE_PATTERN.test(normalizedPhone)) {
@@ -183,11 +288,31 @@ export function getPhoneNumberValidationError(
   }
 
   const fields = derivePhoneFields(normalizedPhone);
-  if (
-    fields.countryValue === "IN" &&
-    !INDIA_MOBILE_PATTERN.test(fields.localPhoneNumber)
-  ) {
-    return "Enter a valid 10-digit Indian mobile number without the leading 0.";
+  const resolvedCountry = countryValue ?? fields.countryValue;
+  const countryOption = getCountryOption(resolvedCountry);
+  const nationalNumber = normalizedPhone.startsWith(countryOption.dialCode)
+    ? sanitizeLocalPhoneNumber(
+        normalizedPhone.slice(countryOption.dialCode.length),
+      )
+    : fields.localPhoneNumber;
+  const lengthRange = getMobileNumberLengthRange(resolvedCountry);
+
+  if (nationalNumber.length < lengthRange.minimum) {
+    return `Enter a complete mobile number for ${countryOption.label}.`;
+  }
+  if (nationalNumber.length > lengthRange.maximum) {
+    return `Enter no more than ${lengthRange.maximum} digits for ${countryOption.label}.`;
+  }
+
+  const parsedPhone = parsePhoneNumberFromString(
+    normalizedPhone,
+    mobilePhoneMetadata,
+  );
+  if (parsedPhone?.number !== normalizedPhone) {
+    return `Enter the mobile number without a local leading prefix after ${countryOption.dialCode}.`;
+  }
+  if (!parsedPhone?.isValid()) {
+    return `Enter a valid mobile number for ${countryOption.label}.`;
   }
 
   return null;
@@ -237,6 +362,7 @@ export function PhoneVerificationFlow({
   const [countryComboboxOpen, setCountryComboboxOpen] = useState(false);
   const suppressNextCountryFocusOpenRef = useRef(false);
   const [localPhoneNumber, setLocalPhoneNumber] = useState("");
+  const [phoneNumberError, setPhoneNumberError] = useState<string | null>(null);
   const [submittedPhoneNumber, setSubmittedPhoneNumber] = useState(
     currentPhoneNumber || "",
   );
@@ -255,6 +381,7 @@ export function PhoneVerificationFlow({
     const nextFields = derivePhoneFields(currentPhoneNumber);
     setSelectedCountry(nextFields.countryValue);
     setLocalPhoneNumber(nextFields.localPhoneNumber);
+    setPhoneNumberError(null);
     setSubmittedPhoneNumber(currentPhoneNumber || "");
     setCountryQuery("");
     setVerificationCode("");
@@ -271,12 +398,14 @@ export function PhoneVerificationFlow({
   );
   const selectedCountryOption = useMemo(
     () =>
-      COUNTRY_PHONE_OPTIONS.find((option) => option.value === selectedCountry),
+      PHONE_COUNTRY_OPTIONS.find((option) => option.value === selectedCountry),
     [selectedCountry],
   );
   const selectedCountryLabel = useMemo(
     () =>
-      getCountryOptionLabel(selectedCountryOption ?? COUNTRY_PHONE_OPTIONS[0]!),
+      getCountryOptionLabel(
+        selectedCountryOption ?? DEFAULT_PHONE_COUNTRY_OPTION,
+      ),
     [selectedCountryOption],
   );
   const countryInputValue = countryComboboxOpen
@@ -285,10 +414,10 @@ export function PhoneVerificationFlow({
   const filteredCountryOptions = useMemo(() => {
     const normalizedQuery = countryQuery.trim().toLowerCase();
     if (!normalizedQuery) {
-      return COUNTRY_PHONE_OPTIONS;
+      return PHONE_COUNTRY_OPTIONS;
     }
 
-    return COUNTRY_PHONE_OPTIONS.filter((option) => {
+    return PHONE_COUNTRY_OPTIONS.filter((option) => {
       const searchableText = [
         option.label,
         option.dialCode,
@@ -301,30 +430,44 @@ export function PhoneVerificationFlow({
     });
   }, [countryQuery]);
   const activeDialCode = useMemo(
-    () => selectedCountryOption?.dialCode ?? COUNTRY_PHONE_OPTIONS[0]!.dialCode,
+    () =>
+      selectedCountryOption?.dialCode ?? DEFAULT_PHONE_COUNTRY_OPTION.dialCode,
     [selectedCountryOption],
   );
   const normalizedPhoneInput = useMemo(
     () => composePhoneNumber(activeDialCode, localPhoneNumber),
     [activeDialCode, localPhoneNumber],
   );
+  const mobileNumberLengthRange = useMemo(
+    () => getMobileNumberLengthRange(selectedCountry),
+    [selectedCountry],
+  );
 
-  const handleCountrySelection = useCallback((value: string | null) => {
-    if (!value) {
-      return;
-    }
+  const handleCountrySelection = useCallback(
+    (value: string | null) => {
+      if (!value) {
+        return;
+      }
 
-    const nextOption = COUNTRY_PHONE_OPTIONS.find(
-      (option) => option.value === value,
-    );
-    if (!nextOption) {
-      return;
-    }
+      const nextOption = PHONE_COUNTRY_OPTIONS.find(
+        (option) => option.value === value,
+      );
+      if (!nextOption) {
+        return;
+      }
 
-    setSelectedCountry(nextOption.value);
-    setCountryQuery("");
-    setCountryComboboxOpen(false);
-  }, []);
+      setSelectedCountry(nextOption.value);
+      const maximum = getMobileNumberLengthRange(nextOption.value).maximum;
+      setPhoneNumberError(
+        localPhoneNumber.length > maximum
+          ? `Enter no more than ${maximum} digits for ${nextOption.label}.`
+          : null,
+      );
+      setCountryQuery("");
+      setCountryComboboxOpen(false);
+    },
+    [localPhoneNumber.length],
+  );
 
   useLocalOnboardingActionHandler("phone_mandate.select_country", (slots) => {
     const requested = String(
@@ -438,15 +581,45 @@ export function PhoneVerificationFlow({
     { role: "interaction_layer", routeKey: pathname },
   );
 
-  const handlePhoneNumberChange = useCallback((value: string) => {
-    const nextInput = resolvePhoneInputChange(value);
-    if (nextInput.countryValue) {
-      const nextOption = getCountryOption(nextInput.countryValue);
-      setSelectedCountry(nextOption.value);
-      setCountryQuery("");
-    }
-    setLocalPhoneNumber(nextInput.localPhoneNumber);
-  }, []);
+  const handlePhoneNumberChange = useCallback(
+    (value: string) => {
+      const nextInput = resolvePhoneInputChange(value);
+      const nextCountry = nextInput.countryValue ?? selectedCountry;
+      const nextOption = getCountryOption(nextCountry);
+      const maximum = getMobileNumberLengthRange(nextCountry).maximum;
+      if (nextInput.localPhoneNumber.length > maximum) {
+        // Never truncate a pasted phone number into a different valid
+        // recipient. Keep the last visible value and require an explicit edit.
+        setPhoneNumberError(
+          `Enter no more than ${maximum} digits for ${nextOption.label}.`,
+        );
+        return;
+      }
+      if (nextInput.countryValue) {
+        setSelectedCountry(nextOption.value);
+        setCountryQuery("");
+      }
+      setLocalPhoneNumber(nextInput.localPhoneNumber);
+      setPhoneNumberError(null);
+    },
+    [selectedCountry],
+  );
+
+  const handlePhoneNumberPaste = useCallback(
+    (event: React.ClipboardEvent<HTMLInputElement>) => {
+      const pastedValue = event.clipboardData.getData("text");
+      const selectionStart = event.currentTarget.selectionStart ?? 0;
+      const selectionEnd =
+        event.currentTarget.selectionEnd ?? localPhoneNumber.length;
+      const nextValue = `${localPhoneNumber.slice(0, selectionStart)}${pastedValue}${localPhoneNumber.slice(selectionEnd)}`;
+      // Own paste normalization before the browser applies maxLength to raw
+      // characters. This preserves full E.164 and formatted numbers while the
+      // shared change handler rejects any overlength national number.
+      event.preventDefault();
+      handlePhoneNumberChange(nextValue);
+    },
+    [handlePhoneNumberChange, localPhoneNumber],
+  );
 
   const handleStartVerification = useCallback(
     async (
@@ -459,11 +632,23 @@ export function PhoneVerificationFlow({
       const normalizedPhone = (
         phoneNumberOverride ?? normalizedPhoneInput
       ).trim();
-      const validationError = getPhoneNumberValidationError(normalizedPhone);
+      const validationCountry = phoneNumberOverride
+        ? derivePhoneFields(normalizedPhone).countryValue
+        : selectedCountry;
+      if (!phoneNumberOverride && phoneNumberError) {
+        morphyToast.error(phoneNumberError);
+        return "invalid";
+      }
+      const validationError = getPhoneNumberValidationError(
+        normalizedPhone,
+        validationCountry,
+      );
       if (validationError) {
+        setPhoneNumberError(validationError);
         morphyToast.error(validationError);
         return "invalid";
       }
+      setPhoneNumberError(null);
 
       if (currentPhoneNumber && normalizedPhone === currentPhoneNumber) {
         trackEvent("phone_verification_completed", {
@@ -532,6 +717,8 @@ export function PhoneVerificationFlow({
       mode,
       normalizedPhoneInput,
       onCompleted,
+      phoneNumberError,
+      selectedCountry,
       startVerification,
       busy,
     ],
@@ -856,14 +1043,29 @@ export function PhoneVerificationFlow({
                   type="tel"
                   inputMode="tel"
                   autoComplete="tel-national"
+                  maxLength={mobileNumberLengthRange.maximum}
                   value={localPhoneNumber}
+                  aria-invalid={Boolean(phoneNumberError)}
+                  aria-describedby={
+                    phoneNumberError ? "phone-flow-number-error" : undefined
+                  }
                   onChange={(event) =>
                     handlePhoneNumberChange(event.target.value)
                   }
+                  onPaste={handlePhoneNumberPaste}
                   placeholder="6505550101"
                   className={FLOW_CONTROL_CLASS_NAME}
                 />
               </InputGroup>
+              {phoneNumberError ? (
+                <FieldDescription
+                  id="phone-flow-number-error"
+                  role="alert"
+                  className="text-sm font-semibold text-destructive"
+                >
+                  {phoneNumberError}
+                </FieldDescription>
+              ) : null}
             </Field>
           </FieldGroup>
 

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -49,6 +49,7 @@ import { ROUTES } from "@/lib/navigation/routes";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 
 const E164_PHONE_PATTERN = /^\+[1-9]\d{7,14}$/;
+const INDIA_MOBILE_PATTERN = /^[6-9]\d{9}$/;
 const DEFAULT_COUNTRY_VALUE = "US";
 const FLOW_CONTROL_SHELL_CLASS_NAME =
   "h-[54px] overflow-hidden rounded-[15px] border-black/10 bg-[#f5f5f7]/92 shadow-xs transition-[border-color,box-shadow] focus-within:border-[color:var(--app-accent)] focus-within:ring-4 focus-within:ring-[color:var(--app-accent-ring)] dark:border-white/10 dark:bg-white/[0.08]";
@@ -171,6 +172,35 @@ export function derivePhoneFields(phoneNumber?: string | null): {
       normalizedPhone.replace(/^\+\d{1,4}/, ""),
     ),
   };
+}
+
+export function getPhoneNumberValidationError(
+  phoneNumber?: string | null,
+): string | null {
+  const normalizedPhone = String(phoneNumber ?? "").trim();
+  if (!E164_PHONE_PATTERN.test(normalizedPhone)) {
+    return "Enter a valid country code and phone number.";
+  }
+
+  const fields = derivePhoneFields(normalizedPhone);
+  if (
+    fields.countryValue === "IN" &&
+    !INDIA_MOBILE_PATTERN.test(fields.localPhoneNumber)
+  ) {
+    return "Enter a valid 10-digit Indian mobile number without the leading 0.";
+  }
+
+  return null;
+}
+
+export function maskPhoneNumberForOtp(
+  phoneNumber?: string | null,
+): string {
+  const localPhoneNumber = derivePhoneFields(phoneNumber).localPhoneNumber;
+  if (!localPhoneNumber) return "";
+  if (localPhoneNumber.length <= 4) return localPhoneNumber;
+
+  return `${"•".repeat(localPhoneNumber.length - 4)} ${localPhoneNumber.slice(-4)}`;
 }
 
 export function resolvePhoneInputChange(value: string): {
@@ -429,8 +459,9 @@ export function PhoneVerificationFlow({
       const normalizedPhone = (
         phoneNumberOverride ?? normalizedPhoneInput
       ).trim();
-      if (!E164_PHONE_PATTERN.test(normalizedPhone)) {
-        morphyToast.error("Enter a valid country code and phone number.");
+      const validationError = getPhoneNumberValidationError(normalizedPhone);
+      if (validationError) {
+        morphyToast.error(validationError);
         return "invalid";
       }
 
@@ -876,7 +907,7 @@ export function PhoneVerificationFlow({
           <p className="text-center text-sm leading-6 text-muted-foreground">
             Enter the code sent to{" "}
             <span className="font-semibold text-foreground">
-              {maskPhoneNumber(submittedPhoneNumber)}
+              {maskPhoneNumberForOtp(submittedPhoneNumber)}
             </span>
             .
           </p>

--- a/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
@@ -100,6 +100,46 @@ describe("LiveMap", () => {
     mockTheme.current = "light";
   });
 
+  it("restores the marker-centered zoom when an explicit refresh is requested", () => {
+    const markerSetPosition = vi.fn();
+    const mapPanTo = vi.fn();
+    const mapSetZoom = vi.fn();
+    const Marker = vi.fn(function () {
+      return {
+        getPosition: () => ({
+          lat: () => point.latitude,
+          lng: () => point.longitude,
+        }),
+        setPosition: markerSetPosition,
+      };
+    });
+    const Map = vi.fn(function () {
+      return { panTo: mapPanTo, setZoom: mapSetZoom };
+    });
+    // @ts-expect-error test global
+    globalThis.google = { maps: { Map, Marker } };
+    mockStatus.current = "ready";
+
+    const { rerender } = render(
+      <LiveMap point={point} viewportResetKey={0} />,
+    );
+    markerSetPosition.mockClear();
+    mapPanTo.mockClear();
+    mapSetZoom.mockClear();
+
+    rerender(<LiveMap point={point} viewportResetKey={1} />);
+
+    expect(markerSetPosition).toHaveBeenCalledWith({
+      lat: point.latitude,
+      lng: point.longitude,
+    });
+    expect(mapSetZoom).toHaveBeenCalledWith(16);
+    expect(mapPanTo).toHaveBeenCalledWith({
+      lat: point.latitude,
+      lng: point.longitude,
+    });
+  });
+
   it("applies a dark filter to the iframe fallback so it cannot glow white", () => {
     mockStatus.current = "error";
     render(<LiveMap point={point} />);

--- a/hushh-webapp/components/one-location/live-map.tsx
+++ b/hushh-webapp/components/one-location/live-map.tsx
@@ -20,6 +20,7 @@ import { cn } from "@/lib/utils";
 
 // One glide should finish before the next ~5s poll lands.
 const MARKER_ANIMATION_MS = 1200;
+const DEFAULT_PREVIEW_ZOOM = 16;
 
 // In iframe-fallback mode (Maps JS unavailable — e.g. the iOS App:// WebView)
 // every src change reloads the whole embed, a visible flash. So we only recenter
@@ -31,9 +32,15 @@ const IFRAME_RECENTER_METERS = 50;
 export interface LiveMapProps {
   point: PlainLocationPoint;
   className?: string;
+  /**
+   * Bump this only for an explicit user-requested refresh. Background point
+   * updates keep the person's chosen zoom, while a manual refresh restores the
+   * preview camera to the location marker.
+   */
+  viewportResetKey?: string | number;
 }
 
-export function LiveMap({ point, className }: LiveMapProps) {
+export function LiveMap({ point, className, viewportResetKey }: LiveMapProps) {
   const { status } = useGoogleMaps();
   const { resolvedTheme } = useTheme();
   // Follow the APP theme (next-themes class), not the OS scheme, so the map
@@ -43,6 +50,9 @@ export function LiveMap({ point, className }: LiveMapProps) {
   const mapRef = useRef<google.maps.Map | null>(null);
   const markerRef = useRef<google.maps.Marker | null>(null);
   const frameRef = useRef<number | null>(null);
+  const resetPointRef = useRef(point);
+  const lastViewportResetKeyRef = useRef(viewportResetKey);
+  resetPointRef.current = point;
 
   const target: LatLngLiteral = locationLatLng(point);
 
@@ -58,6 +68,14 @@ export function LiveMap({ point, className }: LiveMapProps) {
     );
   }, [point]);
 
+  // The iframe fallback cannot expose a camera API. A user-requested reset
+  // therefore recenters its source point and remounts the iframe below. This is
+  // deliberately separate from background GPS updates so stationary previews
+  // do not flash every few seconds.
+  useEffect(() => {
+    setIframePoint(resetPointRef.current);
+  }, [viewportResetKey]);
+
   // Create the map + marker once the API is ready and the container exists.
   // Google Maps applies colorScheme only at construction, so a theme flip
   // recreates the map (the container div is keyed by scheme below, giving a
@@ -66,7 +84,7 @@ export function LiveMap({ point, className }: LiveMapProps) {
     if (status !== "ready" || !containerRef.current || mapRef.current) return;
     const map = new google.maps.Map(containerRef.current, {
       center: target,
-      zoom: 16,
+      zoom: DEFAULT_PREVIEW_ZOOM,
       disableDefaultUI: true,
       keyboardShortcuts: false,
       // Google Maps attribution, map-data credits, and Terms are provider-owned
@@ -124,12 +142,31 @@ export function LiveMap({ point, className }: LiveMapProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target.lat, target.lng, status]);
 
+  // A fresh reading can have the same coordinates as the previous one. Treat
+  // the explicit reset key—not coordinate movement—as the signal to restore
+  // the original marker-centered camera after the user has panned or zoomed.
+  useEffect(() => {
+    if (status !== "ready") return;
+    if (Object.is(lastViewportResetKeyRef.current, viewportResetKey)) return;
+
+    const map = mapRef.current;
+    const marker = markerRef.current;
+    if (!map || !marker) return;
+
+    lastViewportResetKeyRef.current = viewportResetKey;
+    const resetTarget = locationLatLng(resetPointRef.current);
+    marker.setPosition(resetTarget);
+    map.setZoom(DEFAULT_PREVIEW_ZOOM);
+    map.panTo(resetTarget);
+  }, [status, viewportResetKey]);
+
   // Not ready (loading or error / no key) -> keep today's iframe embed. The
   // keyless embed has no dark mode, so dark theme applies an invert+hue-rotate
   // filter (standard technique) to keep the surface from glowing white.
   if (status !== "ready") {
     return (
       <iframe
+        key={`live-map-iframe:${viewportResetKey ?? "initial"}`}
         title="Live location map preview"
         src={googleMapsLocationEmbedUrl(iframePoint)}
         loading="lazy"

--- a/hushh-webapp/lib/one-location/__tests__/freshness.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/freshness.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { liveFreshness } from "@/lib/one-location/freshness";
+import {
+  liveFreshness,
+  locationPreviewFreshness,
+} from "@/lib/one-location/freshness";
 
 const base = Date.parse("2026-07-09T00:00:00.000Z");
 
@@ -20,5 +23,29 @@ describe("liveFreshness", () => {
     const r = liveFreshness("2026-07-09T00:00:00.000Z", base - 5_000, 60_000);
     expect(r.state).toBe("live");
     expect(r.agoLabel).toBe("0s ago");
+  });
+});
+
+describe("locationPreviewFreshness", () => {
+  it("keeps a fixed Check-In available beyond the live heartbeat threshold", () => {
+    const result = locationPreviewFreshness({
+      capturedAtISO: "2026-07-09T00:00:00.000Z",
+      nowMs: base + 240_000,
+      staleThresholdMs: 60_000,
+      fixedCheckIn: true,
+    });
+
+    expect(result).toEqual({ state: "check_in", agoLabel: "4m ago" });
+  });
+
+  it("still reports a stalled live stream as paused", () => {
+    const result = locationPreviewFreshness({
+      capturedAtISO: "2026-07-09T00:00:00.000Z",
+      nowMs: base + 240_000,
+      staleThresholdMs: 60_000,
+      fixedCheckIn: false,
+    });
+
+    expect(result.state).toBe("paused");
   });
 });

--- a/hushh-webapp/lib/one-location/freshness.ts
+++ b/hushh-webapp/lib/one-location/freshness.ts
@@ -19,3 +19,25 @@ export function liveFreshness(
     agoLabel,
   };
 }
+
+/**
+ * Preview semantics for both continuous live streams and fixed Check-In
+ * snapshots. A Check-In remains a valid place for its grant duration; it does
+ * not become "paused" merely because no tracking heartbeat follows it.
+ */
+export function locationPreviewFreshness(params: {
+  capturedAtISO: string;
+  nowMs: number;
+  staleThresholdMs: number;
+  fixedCheckIn: boolean;
+}): { state: "check_in" | "live" | "paused"; agoLabel: string } {
+  const freshness = liveFreshness(
+    params.capturedAtISO,
+    params.nowMs,
+    params.staleThresholdMs,
+  );
+  return {
+    state: params.fixedCheckIn ? "check_in" : freshness.state,
+    agoLabel: freshness.agoLabel,
+  };
+}

--- a/hushh-webapp/package-lock.json
+++ b/hushh-webapp/package-lock.json
@@ -43,6 +43,7 @@
         "gsap": "^3.15.0",
         "jose": "^6.2.3",
         "jspdf": "^4.2.1",
+        "libphonenumber-js": "^1.13.10",
         "lucide-react": "^0.577.0",
         "next": "^16.2.10",
         "next-themes": "^0.4.6",
@@ -11308,6 +11309,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.10.tgz",
+      "integrity": "sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",

--- a/hushh-webapp/package.json
+++ b/hushh-webapp/package.json
@@ -105,6 +105,7 @@
     "gsap": "^3.15.0",
     "jose": "^6.2.3",
     "jspdf": "^4.2.1",
+    "libphonenumber-js": "^1.13.10",
     "lucide-react": "^0.577.0",
     "next": "^16.2.10",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary

- polish the `/one/setup` account actions menu so Sign out uses the app accent on hover/focus and Delete account uses a clean red surface, with white text/icon strokes and consistent inset radii
- make explicit location-preview refreshes restore the map to the current marker at the default preview zoom, while background location updates continue respecting the user's chosen camera
- keep fixed Check-In locations active for their grant duration instead of incorrectly showing Paused after the live-stream heartbeat threshold
- validate mobile input against metadata-backed numbering plans for all 243 selectable countries, including each country's supported mobile-number length range
- enforce the selected country's maximum directly in the field, reject overlength paste or local trunk prefixes on the same screen, and never silently truncate into a different Firebase recipient
- preserve complete E.164 paste handling, including alternate NANP area codes, while showing only the masked national number on the OTP confirmation screen

Fixes #1921
Fixes #1923

## Verification

- `npm run verify:phone-verification` (22 tests)
- `npx vitest run __tests__/components/top-app-bar.contract.test.ts components/one-location/__tests__/live-map.test.tsx lib/one-location/__tests__/freshness.test.ts __tests__/components/phone-verification-flow.test.ts __tests__/components/phone-verification-flow-interaction.test.tsx __tests__/components/one-location-agent-page.test.tsx` (96 tests on the original PR patch)
- `npm run typecheck`
- focused ESLint with zero warnings for the phone flow and both regression suites
- `npm run verify:design-system`
- `npm run verify:cache` (55 tests on the original PR patch)
- `npm run verify:docs`
- `npm run verify:service-boundary`
- `next build` with the maintainer environment overlay loaded in process memory only
- responsive browser verification at 430x932: India is capped at 10 digits, overlength paste is rejected without mutating or sending the recipient, and the OTP destination renders as `•••••• 2372` without `+91`
- DCO signoff, diff whitespace, secret scan, skill lint, and branch freshness checks

`npm run verify:routes` requires the protected `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`; those values are not available in this isolated worktree and are left to the protected CI/reviewer environment.

## Scope

12 files only: five implementation files, five focused test files, and the two package manifests required for `libphonenumber-js`. No environment, backend, migration, asset, CI, or governance changes.