### PR TITLE
Add recenter controls across One Location maps

### DIFF
--- a/hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx
+++ b/hushh-webapp/__tests__/app/one/location/public-request-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -44,7 +44,13 @@ describe("PublicLocationRequestPageClient", () => {
       expect(mocks.resolvePublicInvite).toHaveBeenCalledWith("public-token"),
     );
 
-    expect(await screen.findByTitle("Public location map")).toBeTruthy();
+    const map = await screen.findByTitle("Public location map");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Recenter public location map" }),
+    );
+
+    expect(screen.getByTitle("Public location map")).not.toBe(map);
+    expect(mocks.resolvePublicInvite).toHaveBeenCalledTimes(1);
     expect(screen.queryByPlaceholderText("Your name")).toBeNull();
     expect(screen.queryByPlaceholderText("Phone number")).toBeNull();
     expect(screen.queryByPlaceholderText("Optional message")).toBeNull();

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -2191,7 +2191,14 @@ describe("OneLocationAgentPage", () => {
     const collapseButton = screen.getByRole("button", {
       name: "Collapse shared location from Trusted A",
     });
+    const recenterButton = screen.getByRole("button", {
+      name: "Recenter map on Trusted A's location",
+    });
+    fireEvent.click(recenterButton);
+    expect(screen.getByTitle("Live location map preview")).not.toBe(mapPreview);
+    expect(mockViewEnvelope).toHaveBeenCalledTimes(viewCallsBeforeCollapse);
     expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
+
     fireEvent.click(collapseButton);
 
     expect(screen.queryByTitle("Live location map preview")).toBeNull();

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -6247,11 +6247,11 @@ export function OneLocationAgentPageContent({
     expiresLabel: (value) =>
       value ? `Live until ${formatDateTime(value)}` : "Live now",
     expiresCountdownLabel: (value) => expiresCountdownLabel(value) ?? "Active",
-    renderMapPreview: (point, showNavigation) => (
+    renderMapPreview: (point, showNavigation, viewportResetKey) => (
       <LocalMapPreview
         point={point}
         showNavigation={showNavigation}
-        viewportResetKey={mapViewportResetKey}
+        viewportResetKey={`${mapViewportResetKey}:${viewportResetKey ?? "default"}`}
       />
     ),
     mapLocationHref: googleMapsLocationUrl,

--- a/hushh-webapp/app/one/location/request/[token]/page-client.tsx
+++ b/hushh-webapp/app/one/location/request/[token]/page-client.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   MapPin,
+  RefreshCw,
   Route,
 } from "lucide-react";
 
@@ -55,7 +56,7 @@ function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
 }
 
 function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
-
+  const [viewportResetKey, setViewportResetKey] = useState(0);
   const capturedAt = formatDateTime(point.capturedAt);
   const accuracy =
     typeof point.accuracyM === "number" && Number.isFinite(point.accuracyM)
@@ -65,6 +66,7 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
     <div className="overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-background">
       <div className="relative h-64 overflow-hidden bg-muted">
         <iframe
+          key={`public-location-map:${viewportResetKey}`}
           title="Public location map"
           src={googleMapsEmbedUrl(point)}
           loading="lazy"
@@ -76,6 +78,17 @@ function PublicLocationMap({ point }: { point: PlainLocationPoint }) {
           <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-300" />
           Public location
         </div>
+        <Button
+          type="button"
+          variant="secondary"
+          size="icon"
+          aria-label="Recenter public location map"
+          title="Recenter map"
+          onClick={() => setViewportResetKey((current) => current + 1)}
+          className="absolute right-3 top-3 z-10 h-11 w-11 rounded-full border border-border/70 bg-background/90 shadow-lg backdrop-blur-xl hover:bg-background sm:h-9 sm:w-9"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        </Button>
       </div>
       <div className="space-y-3 p-3">
         <div className="min-w-0">

--- a/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/live-map.test.tsx
@@ -26,6 +26,7 @@ afterEach(() => {
   // @ts-expect-error test cleanup
   delete globalThis.google;
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("LiveMap", () => {
@@ -104,6 +105,12 @@ describe("LiveMap", () => {
     const markerSetPosition = vi.fn();
     const mapPanTo = vi.fn();
     const mapSetZoom = vi.fn();
+    const cancelAnimationFrame = vi.fn();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 42),
+    );
+    vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrame);
     const Marker = vi.fn(function () {
       return {
         getPosition: () => ({
@@ -126,9 +133,11 @@ describe("LiveMap", () => {
     markerSetPosition.mockClear();
     mapPanTo.mockClear();
     mapSetZoom.mockClear();
+    cancelAnimationFrame.mockClear();
 
     rerender(<LiveMap point={point} viewportResetKey={1} />);
 
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42);
     expect(markerSetPosition).toHaveBeenCalledWith({
       lat: point.latitude,
       lng: point.longitude,

--- a/hushh-webapp/components/one-location/live-map.tsx
+++ b/hushh-webapp/components/one-location/live-map.tsx
@@ -52,7 +52,9 @@ export function LiveMap({ point, className, viewportResetKey }: LiveMapProps) {
   const frameRef = useRef<number | null>(null);
   const resetPointRef = useRef(point);
   const lastViewportResetKeyRef = useRef(viewportResetKey);
-  resetPointRef.current = point;
+  useEffect(() => {
+    resetPointRef.current = point;
+  }, [point]);
 
   const target: LatLngLiteral = locationLatLng(point);
 
@@ -155,6 +157,10 @@ export function LiveMap({ point, className, viewportResetKey }: LiveMapProps) {
 
     lastViewportResetKeyRef.current = viewportResetKey;
     const resetTarget = locationLatLng(resetPointRef.current);
+    if (frameRef.current !== null) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
     marker.setPosition(resetTarget);
     map.setZoom(DEFAULT_PREVIEW_ZOOM);
     map.panTo(resetTarget);

--- a/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
@@ -56,6 +56,45 @@ describe("CheckInFlow nearby private-sharing handoff", () => {
     vi.useRealTimers();
   });
 
+  it("recenters a confirmed check-in without capturing location again", async () => {
+    const onCheckIn = vi
+      .fn<LocationHubViewModel["onCheckIn"]>()
+      .mockResolvedValue({
+        succeededRecipientIds: [],
+        failedRecipientIds: ["user-aarav"],
+      });
+    const vm = viewModel(onCheckIn);
+    vm.renderMapPreview = vi.fn((_point, _showNavigation, resetKey) => (
+      <span data-testid="check-in-map-reset-key">{String(resetKey)}</span>
+    ));
+
+    render(
+      <CheckInFlow vm={vm} entrySource="nearby" onClose={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId("check-in-map-reset-key")).toHaveTextContent(
+      "check-in:0",
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Aarav Mehta/ }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Share encrypted location with 1 person",
+      }),
+    );
+    await waitFor(() => expect(onCheckIn).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Recenter map on the confirmed check-in location",
+      }),
+    );
+
+    expect(screen.getByTestId("check-in-map-reset-key")).toHaveTextContent(
+      "check-in:1",
+    );
+    expect(vm.onShowMyLocation).not.toHaveBeenCalled();
+  });
+
   it("starts with explicit selection and retries only failed recipients", async () => {
     const onCheckIn = vi
       .fn<LocationHubViewModel["onCheckIn"]>()

--- a/hushh-webapp/components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/shared-with-me-card.test.tsx
@@ -7,11 +7,13 @@ describe("SharedWithMeCard", () => {
   it("keeps the live state beside the expiry and exposes an accessible disclosure", () => {
     const onView = vi.fn();
     const onDismiss = vi.fn();
+    const onRecenter = vi.fn();
     const props = {
       name: "Trusted A",
       statusLine: "Live until Jul 28, 11:19 PM",
       onView,
       onDismiss,
+      onRecenter,
       mapHref: "https://www.google.com/maps/search/?api=1&query=1%2C2",
     };
     const { rerender } = render(
@@ -34,6 +36,11 @@ describe("SharedWithMeCard", () => {
     );
     expect(previewRegion).not.toBeNull();
     expect(previewRegion?.hidden).toBe(true);
+    expect(
+      screen.queryByRole("button", {
+        name: "Recenter map on Trusted A's location",
+      }),
+    ).toBeNull();
 
     fireEvent.click(expandButton);
     expect(onView).toHaveBeenCalledTimes(1);
@@ -47,8 +54,15 @@ describe("SharedWithMeCard", () => {
     const collapseButton = screen.getByRole("button", {
       name: "Collapse shared location from Trusted A",
     });
+    const recenterButton = screen.getByRole("button", {
+      name: "Recenter map on Trusted A's location",
+    });
     expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
     expect(collapseButton).not.toBeDisabled();
+    expect(
+      recenterButton.compareDocumentPosition(collapseButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(previewRegion?.hidden).toBe(false);
     expect(
       screen.getByRole("link", {
@@ -56,6 +70,10 @@ describe("SharedWithMeCard", () => {
       }),
     ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+
+    fireEvent.click(recenterButton);
+    expect(onRecenter).toHaveBeenCalledTimes(1);
+    expect(onDismiss).not.toHaveBeenCalled();
 
     fireEvent.click(collapseButton);
     expect(onDismiss).toHaveBeenCalledTimes(1);

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -251,6 +251,7 @@ export function SharedWithMeCard({
   statusLine,
   onView,
   onDismiss,
+  onRecenter,
   mapHref,
   viewBusy,
   previewExpanded,
@@ -261,6 +262,7 @@ export function SharedWithMeCard({
   statusLine: string;
   onView: () => void;
   onDismiss?: () => void;
+  onRecenter?: () => void;
   mapHref?: string;
   viewBusy?: boolean;
   previewExpanded?: boolean;
@@ -294,28 +296,43 @@ export function SharedWithMeCard({
             </StatusPill>
           </div>
         </div>
-        {canTogglePreview ? (
-          <ShellActionSurface
-            variant="icon"
-            aria-label={`${isPreviewExpanded ? "Collapse" : "Expand"} shared location from ${name}`}
-            aria-expanded={isPreviewExpanded}
-            aria-controls={previewRegionId}
-            disabled={viewBusy && !isPreviewExpanded}
-            onClick={togglePreview}
-          >
-            {viewBusy && !isPreviewExpanded ? (
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 transition-transform duration-200",
-                  isPreviewExpanded && "rotate-180",
-                )}
-                aria-hidden="true"
-              />
-            )}
-          </ShellActionSurface>
-        ) : null}
+        <div className="flex shrink-0 items-center gap-1">
+          {isPreviewExpanded && onRecenter ? (
+            <ShellActionSurface
+              variant="icon"
+              className="h-11 w-11 sm:h-9 sm:w-9"
+              aria-label={`Recenter map on ${name}'s location`}
+              aria-controls={previewRegionId}
+              title="Recenter map"
+              onClick={onRecenter}
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            </ShellActionSurface>
+          ) : null}
+          {canTogglePreview ? (
+            <ShellActionSurface
+              variant="icon"
+              className="h-11 w-11 sm:h-9 sm:w-9"
+              aria-label={`${isPreviewExpanded ? "Collapse" : "Expand"} shared location from ${name}`}
+              aria-expanded={isPreviewExpanded}
+              aria-controls={previewRegionId}
+              disabled={viewBusy && !isPreviewExpanded}
+              onClick={togglePreview}
+            >
+              {viewBusy && !isPreviewExpanded ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <ChevronDown
+                  className={cn(
+                    "h-4 w-4 transition-transform duration-200",
+                    isPreviewExpanded && "rotate-180",
+                  )}
+                  aria-hidden="true"
+                />
+              )}
+            </ShellActionSurface>
+          ) : null}
+        </div>
       </div>
       <div id={previewRegionId} hidden={!isPreviewExpanded}>
         {children}

--- a/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/check-in-flow.tsx
@@ -214,6 +214,7 @@ export function CheckInFlow({
   const [confirmedPoint, setConfirmedPoint] =
     useState<PlainLocationPoint | null>(null);
   const [confirmedAt, setConfirmedAt] = useState<string | null>(null);
+  const [mapViewportResetKey, setMapViewportResetKey] = useState(0);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const operationIdRef = useRef<string | null>(null);
   const confirmedRecipientKeysRef = useRef<Record<string, string | null> | null>(
@@ -446,8 +447,17 @@ export function CheckInFlow({
           </div>
           <button
             type="button"
-            onClick={vm.onShowMyLocation}
-            disabled={vm.busy === "selfLocation" || Boolean(confirmedPoint)}
+            onClick={
+              confirmedPoint
+                ? () => setMapViewportResetKey((current) => current + 1)
+                : vm.onShowMyLocation
+            }
+            disabled={vm.busy === "selfLocation"}
+            aria-label={
+              confirmedPoint
+                ? "Recenter map on the confirmed check-in location"
+                : undefined
+            }
             className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-black/[0.14] px-[13px] py-[7px] text-[13px] font-semibold text-[color:var(--app-accent)] disabled:opacity-60 dark:border-white/20 dark:text-[color:var(--app-accent)]"
           >
             <RefreshCw
@@ -456,7 +466,7 @@ export function CheckInFlow({
                 vm.busy === "selfLocation" && "animate-spin",
               )}
             />
-            {confirmedPoint ? "Confirmed" : point ? "Refresh" : "Capture"}
+            {confirmedPoint ? "Recenter" : point ? "Refresh" : "Capture"}
           </button>
         </div>
         {point && !pointIsFresh ? (
@@ -478,7 +488,13 @@ export function CheckInFlow({
           </p>
         ) : null}
         {point ? (
-          <div className="px-3 pb-3">{vm.renderMapPreview(point, false)}</div>
+          <div className="px-3 pb-3">
+            {vm.renderMapPreview(
+              point,
+              false,
+              `check-in:${mapViewportResetKey}`,
+            )}
+          </div>
         ) : null}
       </section>
 

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -259,6 +259,7 @@ export type LocationHubViewModel = {
   renderMapPreview: (
     point: PlainLocationPoint,
     showNavigation?: boolean,
+    viewportResetKey?: string | number,
   ) => ReactNode;
   mapLocationHref: (point: PlainLocationPoint) => string;
   decryptedPoints: Record<string, PlainLocationPoint>;
@@ -911,6 +912,15 @@ function LocationDetailFlow({
   onCollapseGrant: (grantId: string) => void;
   onExpandGrant: (grant: OneLocationGrant) => void;
 }) {
+  const [grantViewportResetKeys, setGrantViewportResetKeys] = useState<
+    Record<string, number>
+  >({});
+  const recenterGrantViewport = useCallback((grantId: string) => {
+    setGrantViewportResetKeys((current) => ({
+      ...current,
+      [grantId]: (current[grantId] ?? 0) + 1,
+    }));
+  }, []);
   const copy = {
     "active-shares": {
       title: "Active shares",
@@ -976,6 +986,9 @@ function LocationDetailFlow({
                   mapHref={point ? vm.mapLocationHref(point) : undefined}
                   onView={() => onExpandGrant(grant)}
                   onDismiss={() => onCollapseGrant(grant.id)}
+                  onRecenter={
+                    point ? () => recenterGrantViewport(grant.id) : undefined
+                  }
                   viewBusy={vm.busy === "view"}
                   message={
                     point?.checkIn?.message ??
@@ -983,7 +996,13 @@ function LocationDetailFlow({
                     undefined
                   }
                 >
-                  {expanded && point ? vm.renderMapPreview(point, false) : null}
+                  {expanded && point
+                    ? vm.renderMapPreview(
+                        point,
+                        false,
+                        `${grant.id}:${grantViewportResetKeys[grant.id] ?? 0}`,
+                      )
+                    : null}
                 </SharedWithMeCard>
               );
             })}


### PR DESCRIPTION
## What changed

- Added a per-person recenter control immediately left of the disclosure chevron in **Shared with me**.
- Restored the primary pin and zoom without collapsing the card or repeating envelope/network work.
- Added side-effect-free recenter behavior to confirmed Check-In and anonymous public location previews.
- Preserved the immersive map's existing Locate control instead of adding a duplicate.
- Cancelled any in-flight marker animation before restoring the latest point at zoom 16.
- Kept mobile controls at 44px touch targets with compact desktop sizing.

## Why

Users can pan or zoom away from the location marker and otherwise have no reliable way to return to the primary pin. Each interactive One Location map now has an appropriate recovery control.

## Validation

- npm run typecheck
- 6 focused Vitest suites, 71 tests passed
- focused ESLint on the changed recenter surfaces
- design-system, service-boundary, docs, DCO, secret scan, and diff checks passed
- final read-only regression review found no PR-blocking issues

## Local pre-PR note

The full local mirror reached repository governance and stopped on existing Windows path-separator assertions in the agent-orchestration checker. No repository files were changed to work around it; GitHub's Linux CI remains the authoritative full mirror.

## Scope

Frontend Location behavior and focused tests only. No backend, database, environment, dependency, authentication, consent, encryption, or deployment changes.

---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)