### PR TITLE
fix(location): restore nearby check-in visibility

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py
@@ -345,6 +345,7 @@ class PostgresNearbyPresenceStore:
             SELECT
               p.owner_user_id,
               p.participant_alias,
+              p.consent_version,
               p.allow_connection_requests,
               p.radius_meters,
               p.anchor_ciphertext,
@@ -425,6 +426,7 @@ class PostgresNearbyPresenceStore:
             SELECT
               p.owner_user_id,
               p.participant_alias,
+              p.consent_version,
               p.allow_connection_requests,
               p.radius_meters,
               p.anchor_ciphertext,

--- a/consent-protocol/tests/services/test_one_location_nearby_presence_service.py
+++ b/consent-protocol/tests/services/test_one_location_nearby_presence_service.py
@@ -668,9 +668,40 @@ def test_postgres_candidates_bind_viewer_version_and_bounded_stable_ranking(
     )
 
     normalized_sql = " ".join(captured["sql"].split()).lower()
+    assert "select p.owner_user_id, p.participant_alias, p.consent_version," in normalized_sql
     assert "p.version = :viewer_version" in normalized_sql
     assert "p.consent_version = :consent_version" in normalized_sql
     assert "p.anchor_cell_token = any(:cell_tokens)" in normalized_sql
     assert "order by random()" not in normalized_sql
     assert "hmac(" in normalized_sql
     assert captured["params"]["limit"] == 240
+
+
+def test_postgres_connection_pair_projects_consent_version(monkeypatch):
+    store = PostgresNearbyPresenceStore()
+    captured = {}
+
+    monkeypatch.setattr(store, "_expire_due", lambda: 0)
+
+    def execute(sql, params=None):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(store, "_execute_many", execute)
+    assert (
+        store.read_connection_pair(
+            viewer_user_id="viewer",
+            participant_alias="00000000-0000-0000-0000-000000000001",
+            consent_version=NEARBY_PRESENCE_CONSENT_VERSION,
+        )
+        == []
+    )
+
+    normalized_sql = " ".join(captured["sql"].split()).lower()
+    assert "select p.owner_user_id, p.participant_alias, p.consent_version," in normalized_sql
+    assert captured["params"] == {
+        "viewer_user_id": "viewer",
+        "participant_alias": "00000000-0000-0000-0000-000000000001",
+        "consent_version": NEARBY_PRESENCE_CONSENT_VERSION,
+    }


### PR DESCRIPTION
## Summary
- return `consent_version` from the Postgres nearby-candidate projection so valid checked-in users are not discarded
- return the same field from the connection-pair projection so Connect remains available
- add regression coverage for both SQL projections

## Root cause
The queries filtered on `p.consent_version` but did not select it. The service revalidates the returned value, so real Postgres rows were treated as missing consent and skipped. Test doubles included the field and masked the adapter mismatch.

## Verification
- `uv run pytest tests/services/test_one_location_nearby_presence_service.py -q` (35 passed)
- nearby route and migration tests (15 passed)
- Ruff check and format check (passed)
- data-model audit (125/125 classified, 0 failures)
- DCO signoff and pre-push protocol lint (passed)

Backend-only hotfix. No migration, schema, frontend, dependency, or environment changes.

---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)