### PR TITLE
fix(location): stabilize onboarding across mobile viewports

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -134,12 +134,13 @@ describe("OneLocationOnboardingFlow", () => {
     expect(props.onSkip).not.toHaveBeenCalled();
   });
 
-  it("keeps the supplied feature cards proportional without an onboarding scroll region", () => {
+  it("keeps the mobile feature screen readable and fitted without page scrolling", () => {
     renderFlow();
     fireEvent.click(screen.getByRole("button", { name: "Get started" }));
 
     const featureShell = screen.getByTestId("one-location-onboarding-features");
     expect(featureShell.className).toContain("max-w-[min(560px,58dvh)]");
+    expect(featureShell.className).toContain("max-[431px]:max-w-none");
     const featureSurface = featureShell.firstElementChild;
     expect(featureSurface?.className).toContain("overflow-hidden");
     expect(featureSurface?.className).toContain("flex-col");
@@ -152,23 +153,31 @@ describe("OneLocationOnboardingFlow", () => {
     const featureScroll = document.querySelector("[data-one-feature-scroll]");
     expect(featureScroll?.className).toContain("overflow-hidden");
     expect(featureScroll?.className).not.toContain("overflow-y-auto");
+    expect(featureScroll?.className).toContain("flex-col");
     expect(featureScroll?.className).toContain("flex-[0_1_auto]");
-    expect(featureScroll?.className).not.toContain("flex-1");
     const featureGrid = document.querySelector("[data-one-feature-grid]");
     expect(featureGrid?.className).toContain("mt-6");
     expect(featureGrid?.className).toContain("shrink-0");
     const lowerGrid = document.querySelector("[data-one-feature-lower-grid]");
     expect(lowerGrid?.className).toContain("grid-cols-2");
     const featureCta = document.querySelector("[data-one-feature-cta]");
-    expect(featureCta?.className).toContain("max-[431px]:mt-auto");
+    expect(featureCta?.className).not.toContain("mt-auto");
     expect(featureCta?.querySelector("button")?.className).toContain(
       "h-[58px]",
     );
     const responsiveStyles =
       featureSurface?.querySelector("style")?.textContent;
-    expect(responsiveStyles).toContain("var(--onboarding-agent-bar-clearance)");
-    expect(responsiveStyles).toContain("aspect-ratio: 1.60 / 1");
-    expect(responsiveStyles).toContain("aspect-ratio: 0.63 / 1");
+    expect(responsiveStyles).not.toContain(
+      "var(--onboarding-agent-bar-clearance)",
+    );
+    expect(responsiveStyles).toContain(
+      "grid-template-rows: minmax(0, 0.82fr) minmax(0, 1fr)",
+    );
+    expect(responsiveStyles).toContain("aspect-ratio: auto");
+    expect(responsiveStyles).toContain(
+      "font-size: clamp(13px, 8.55cqw, 13.5px)",
+    );
+    expect(responsiveStyles).not.toContain("font-size: 7.5px");
 
     const cards = document.querySelectorAll("[data-one-use-case-card]");
     expect(cards).toHaveLength(3);

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -869,7 +869,7 @@ function FeaturesScreen({
         busy={leaving}
       />
       <div
-        className="min-h-0 flex-[0_1_auto] overflow-hidden"
+        className="flex min-h-0 flex-[0_1_auto] flex-col overflow-hidden"
         data-one-feature-scroll
       >
         <header className="mt-3 shrink-0" data-one-feature-header>
@@ -906,7 +906,7 @@ function FeaturesScreen({
           {status}
         </p>
       </div>
-      <div className="shrink-0 pt-8 max-[431px]:mt-auto" data-one-feature-cta>
+      <div className="shrink-0 pt-8" data-one-feature-cta>
         <PrimaryButton
           onClick={onContinue}
           busy={permissionBusy}
@@ -928,6 +928,24 @@ function FeaturesScreen({
         }
         @media (prefers-reduced-motion: reduce) {
           [data-one-onboarding-motion] { animation: none !important; }
+        }
+        @media (max-width: 431px), (min-width: 432px) and (max-height: 920px) {
+          [data-one-feature-scroll] { flex: 1 1 0%; }
+          [data-one-feature-grid] {
+            flex: 1 1 0%;
+            min-height: 0;
+            grid-template-rows: minmax(0, 0.82fr) minmax(0, 1fr);
+          }
+          [data-one-feature-lower-grid] {
+            height: 100%;
+            min-height: 0;
+            align-items: stretch;
+          }
+          [data-one-feature-card] {
+            height: 100%;
+            min-height: 0;
+            aspect-ratio: auto;
+          }
         }
         @media (max-height: 780px) {
           [data-one-feature-screen] {
@@ -962,28 +980,23 @@ function FeaturesScreen({
           [data-one-feature-cta] { padding-top: 8px; }
           [data-one-feature-cta] button { min-height: 46px; height: 46px; }
         }
-        @media (max-width: 431px) and (min-height: 800px) {
-          [data-one-feature-screen] {
-            padding-bottom: calc(
-              var(--onboarding-agent-bar-clearance) +
-              max(env(safe-area-inset-bottom, 0px), 12px)
-            );
-          }
-        }
         @media (max-width: 431px) and (min-height: 820px) {
           [data-one-feature-header] { margin-top: 16px; }
           [data-one-feature-grid] { margin-top: 26px; gap: 14px; }
-          [data-one-feature-card="share"] { aspect-ratio: 1.60 / 1; }
-          [data-one-feature-card="checkin"],
-          [data-one-feature-card="sms"] { aspect-ratio: 0.63 / 1; }
         }
-        @media (max-width: 430px) {
+        @media (max-width: 431px) {
           [data-one-feature-screen] { padding-left: 16px; padding-right: 16px; }
           [data-one-feature-heading] { font-size: 32px; }
           [data-one-feature-subtitle] { font-size: 14px; }
-          [data-one-feature-grid] { gap: 12px; }
-          [data-one-feature-lower-grid] { gap: 12px; }
-          [data-one-feature-card] { border-radius: 22px; }
+          [data-one-feature-grid] {
+            gap: 12px;
+          }
+          [data-one-feature-lower-grid] {
+            gap: 12px;
+          }
+          [data-one-feature-card] {
+            border-radius: 22px;
+          }
         }
         @media (max-width: 380px) {
           [data-one-feature-screen] { padding-left: 14px; padding-right: 14px; }
@@ -1025,7 +1038,7 @@ function FeaturesScreen({
             height: 28px;
             padding-left: 7px;
             padding-right: 7px;
-            font-size: 8px;
+            font-size: 9px;
           }
           [data-one-feature-card="share"] [data-one-feature-status-row] {
             padding-right: 14px;
@@ -1038,15 +1051,15 @@ function FeaturesScreen({
           }
           [data-one-feature-card="share"] [data-one-use-case-tag] {
             padding: 3px 7px;
-            font-size: 9px;
+            font-size: 10px;
           }
           [data-one-feature-card="share"] [data-one-feature-title] {
             margin-top: 6px;
-            font-size: 14px;
+            font-size: 15px;
           }
           [data-one-feature-card="share"] [data-one-feature-body] {
             margin-top: 5px;
-            font-size: 10px;
+            font-size: 11px;
             line-height: 1.25;
           }
           [data-one-feature-card="share"] [data-one-feature-status-row] {
@@ -1059,7 +1072,7 @@ function FeaturesScreen({
             gap: 3px;
             padding-left: 5px;
             padding-right: 5px;
-            font-size: 7.5px;
+            font-size: 9px;
           }
           [data-one-feature-card="share"] [data-one-use-case-alert] > span:first-child {
             width: 12px;
@@ -1095,7 +1108,7 @@ function FeaturesScreen({
             height: 28px;
             padding-left: 7px;
             padding-right: 7px;
-            font-size: 8px;
+            font-size: 9px;
           }
           [data-one-sms-radar-clearance] { width: 81px; height: 81px; }
           [data-one-sms-radar] { width: 60px; height: 60px; }
@@ -1105,24 +1118,24 @@ function FeaturesScreen({
           [data-one-feature-card="checkin"] [data-one-feature-copy],
           [data-one-feature-card="sms"] [data-one-feature-copy] {
             padding-top: 8px;
-            padding-left: 9px;
-            padding-right: 7px;
+            padding-left: 7px;
+            padding-right: 5px;
           }
           [data-one-feature-card="checkin"] [data-one-use-case-tag],
           [data-one-feature-card="sms"] [data-one-use-case-tag] {
             padding: 3px 7px;
-            font-size: 9px;
+            font-size: 10px;
           }
           [data-one-feature-card="checkin"] [data-one-feature-title],
           [data-one-feature-card="sms"] [data-one-feature-title] {
             margin-top: 4px;
-            font-size: 12px;
+            font-size: clamp(13px, 8.55cqw, 13.5px);
             line-height: 1.08;
           }
           [data-one-feature-card="checkin"] [data-one-feature-body],
           [data-one-feature-card="sms"] [data-one-feature-body] {
             margin-top: 3px;
-            font-size: 10px;
+            font-size: 11px;
             line-height: 1.2;
           }
           [data-one-feature-card="checkin"] [data-one-feature-status-row],
@@ -1137,7 +1150,7 @@ function FeaturesScreen({
             gap: 3px;
             padding-left: 4px;
             padding-right: 4px;
-            font-size: 7.5px;
+            font-size: 9px;
           }
           [data-one-feature-card="checkin"] [data-one-use-case-alert] > span:first-child,
           [data-one-feature-card="sms"] [data-one-use-case-alert] > span:first-child {
@@ -1148,9 +1161,9 @@ function FeaturesScreen({
           [data-one-checkin-art] { bottom: 43px; width: 52%; }
           [data-one-sms-radar-clearance] { width: 54px; height: 54px; }
           [data-one-sms-radar] { width: 40px; height: 40px; }
-          [data-one-sms-core] { width: 32px; height: 32px; font-size: 10px; }
+          [data-one-sms-core] { width: 32px; height: 32px; font-size: 13px; }
         }
-        @media (max-width: 430px) and (max-height: 680px) {
+        @media (max-width: 431px) and (max-height: 680px) {
           [data-one-feature-heading] { font-size: 28px; }
           [data-one-feature-subtitle] {
             margin-top: 4px;
@@ -1792,7 +1805,9 @@ export function OneLocationOnboardingFlow({
       <section
         className={cn(
           "flex h-full min-h-0 w-full flex-col overflow-hidden bg-white dark:bg-[#0c1017]",
-          screen === "features" ? "max-w-[min(560px,58dvh)]" : "max-w-[480px]",
+          screen === "features"
+            ? "max-w-[min(560px,58dvh)] max-[431px]:max-w-none"
+            : "max-w-[480px]",
         )}
         data-testid={LOCATION_SCREEN_TEST_IDS[screen]}
       >


### PR DESCRIPTION
## Summary
- make the Location setup feature cards consume the available fullscreen height without page scrolling or clipped content
- remove the hidden Agent Bar clearance and height-coupled phone width that caused the empty footer and inconsistent mobile scaling
- raise narrow-card typography floors, keep both feature headings on two lines, and preserve the existing Back/Skip controls, artwork, and SMS animation
- update the focused onboarding regression contract

## Verification
- `npm test -- --run __tests__/components/one-location-onboarding-flow.test.tsx __tests__/components/one-location-agent-page.test.tsx` (75 passed)
- `npm run typecheck`
- `npm run verify:design-system`
- `npm run verify:docs`
- `npm run verify:cache` (55 passed)
- focused ESLint and `git diff --check`
- Playwright geometry/visual checks at 320x568, 352x635, 390x844, 412x915, and 1440x900, including the visible permission-status state; no document scroll or horizontal card/title overflow

## Environment note
- the signed-in route sweep was attempted but requires the maintainer-only `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE`, which are not available in this local environment

---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)