### PR TITLE
fix(location): reset abandoned private share drafts

### DIFF
--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -46,6 +46,7 @@ const {
   mockRouterPush,
   mockRouterReplace,
   mockRouterBack,
+  mockUseSearchParams,
   mockSearchParamsGet,
   mockSearchParams,
   mockCopyToClipboard,
@@ -86,6 +87,7 @@ const {
   mockRouterPush: vi.fn(),
   mockRouterReplace: vi.fn(),
   mockRouterBack: vi.fn(),
+  mockUseSearchParams: vi.fn(),
   mockSearchParamsGet: vi.fn(),
   mockSearchParams: {
     get: vi.fn(),
@@ -103,7 +105,7 @@ vi.mock("next/navigation", () => ({
     replace: mockRouterReplace,
     back: mockRouterBack,
   }),
-  useSearchParams: () => mockSearchParams,
+  useSearchParams: mockUseSearchParams,
 }));
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -619,6 +621,7 @@ describe("OneLocationAgentPage", () => {
     forgetOneLocationControlPreference("user_a");
     mockSearchParams.toString = () => "";
     mockSearchParamsGet.mockReturnValue(null);
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
     mockUseRequireAuth.mockReturnValue({
       loading: false,
       isAuthenticated: true,
@@ -1148,6 +1151,142 @@ describe("OneLocationAgentPage", () => {
         shareKind: "share",
       }),
     );
+  });
+
+  it("resets every abandoned share field and ignores a late review preflight", async () => {
+    const { rerender } = render(<OneLocationAgentPage />);
+    await skipLocationEntryFlow();
+    await waitFor(() => expect(mockGetState).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: "People" }));
+    fireEvent.change(
+      await screen.findByPlaceholderText("Search trusted people"),
+      { target: { value: "Investor" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Share" }));
+    expect(
+      await screen.findByRole("heading", { name: "Who can see you?" }),
+    ).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search trusted people")).toHaveValue(
+      "",
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /Deselect Investor D for private sharing/i,
+      }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "one_location_recommendation_selected",
+      expect.objectContaining({
+        action: "share",
+        selection_surface: "section_list",
+        selected_count: 1,
+      }),
+      expect.any(Object),
+    );
+
+    const shareParams = new URLSearchParams("action=share");
+    mockUseSearchParams.mockReturnValue(shareParams);
+    rerender(<OneLocationAgentPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search trusted people"), {
+      target: { value: "Trusted" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.click(
+      screen.getByRole("radio", { name: /Approximate area/i }),
+    );
+    fireEvent.click(screen.getByRole("combobox", { name: "Duration" }));
+    fireEvent.click(screen.getByRole("option", { name: "4 hours" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Optional note" }), {
+      target: { value: "Meet me by the entrance" },
+    });
+
+    let resolvePermission:
+      | ((value: {
+          state: "granted";
+          precise: true;
+          background: "foreground-only";
+          locationServicesEnabled: true;
+        }) => void)
+      | null = null;
+    mockGetPermissionState.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePermission = resolve;
+        }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Review share" }));
+
+    const hubParams = new URLSearchParams();
+    mockUseSearchParams.mockReturnValue(hubParams);
+    rerender(<OneLocationAgentPage />);
+    expect(
+      await screen.findByRole("heading", { name: "Location Agent" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "People" }));
+    expect(
+      await screen.findByPlaceholderText("Search trusted people"),
+    ).toHaveValue("Investor");
+    fireEvent.click(screen.getByRole("button", { name: "Now" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
+    expect(
+      await screen.findByRole("heading", { name: "Who can see you?" }),
+    ).toBeTruthy();
+
+    await act(async () => {
+      resolvePermission?.({
+        state: "granted",
+        precise: true,
+        background: "foreground-only",
+        locationServicesEnabled: true,
+      });
+    });
+    expect(
+      screen.getByRole("heading", { name: "Who can see you?" }),
+    ).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search trusted people")).toHaveValue(
+      "",
+    );
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: /Select Trusted B for private sharing/i,
+      }),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Select Trusted B for private sharing/i,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(
+      screen.getByRole("radio", { name: /Precise live location/i }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("radio", { name: /Approximate area/i }),
+    ).toHaveAttribute("aria-checked", "false");
+    expect(
+      screen.getByRole("combobox", { name: "Duration" }).textContent,
+    ).toContain("15 min");
+    expect(
+      screen.getByRole("textbox", { name: "Optional note" }),
+    ).toHaveValue("");
+    expect(screen.getByText("0/140")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Review share" }));
+    expect(
+      await screen.findByRole("heading", { name: "Before you start" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Share location$/i }));
+    expect(
+      await screen.findByRole("heading", { name: "Who can see you?" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+    expect(mockCreateGrant).not.toHaveBeenCalled();
   });
 
   it("opens the canonical Location Settings URL and owns Saved Locations there", async () => {

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -1770,6 +1770,7 @@ export function OneLocationAgentPageContent({
 
   const [shareReviewOpen, setShareReviewOpen] = useState(false);
   const [recipientSearch, setRecipientSearch] = useState("");
+  const [shareRecipientSearch, setShareRecipientSearch] = useState("");
   const [oneNetworkListExpanded, setOneNetworkListExpanded] = useState(false);
   const [selectedRecipientId, setSelectedRecipientId] = useState("");
   const [selectedRequestOwnerId, setSelectedRequestOwnerId] = useState("");
@@ -1931,6 +1932,8 @@ export function OneLocationAgentPageContent({
   const livePublishInFlightRef = useRef(false);
   const liveViewInFlightRef = useRef(false);
   const suppressAutoRecipientSelectionRef = useRef(false);
+  const shareReviewAttemptRef = useRef(0);
+  const shareReviewPendingRef = useRef(false);
   // Continuous movement-driven live tracking (owner side). Holds the active
   // geolocation watch id, the last point we actually published (to measure
   // movement), and the timestamp of that publish (to throttle bursts).
@@ -2001,6 +2004,13 @@ export function OneLocationAgentPageContent({
       recommendationSearchText(recipient).includes(query),
     );
   }, [rankedRecipients, recipientSearch]);
+  const visibleShareRecipients = useMemo(() => {
+    const query = shareRecipientSearch.trim().toLowerCase();
+    if (!query) return rankedRecipients;
+    return rankedRecipients.filter((recipient) =>
+      recommendationSearchText(recipient).includes(query),
+    );
+  }, [rankedRecipients, shareRecipientSearch]);
   const hasMoreVisibleRecipients =
     visibleRecipients.length > ONE_NETWORK_PREVIEW_LIMIT;
   const showExpandedOneNetworkList =
@@ -3066,10 +3076,17 @@ export function OneLocationAgentPageContent({
     };
   }, [auth.userId, activeOwnerGrants]);
 
-  const resetShareComposer = useCallback(() => {
+  const resetShareComposer = useCallback((initialRecipientId?: string) => {
+    const recipientId = initialRecipientId?.trim() || "";
+    shareReviewAttemptRef.current += 1;
+    if (shareReviewPendingRef.current) {
+      shareReviewPendingRef.current = false;
+      setBusy((current) => (current === "share" ? null : current));
+    }
     suppressAutoRecipientSelectionRef.current = true;
-    setSelectedRecipientId("");
-    setSelectedRecipientIds([]);
+    setShareRecipientSearch("");
+    setSelectedRecipientId(recipientId);
+    setSelectedRecipientIds(recipientId ? [recipientId] : []);
     setShareReviewOpen(false);
     setShareDurationHours(ONE_LOCATION_SHARE_DEFAULT_DURATION_HOURS);
     setShareMessage("");
@@ -4548,6 +4565,21 @@ export function OneLocationAgentPageContent({
     [],
   );
 
+  const startShareComposer = useCallback(
+    (initialRecipientId?: string) => {
+      const recipientId = initialRecipientId?.trim() || "";
+      resetShareComposer(recipientId || undefined);
+      if (!recipientId) return;
+      const recipient = recipients.find(
+        (item) => item.userId === recipientId,
+      );
+      if (recipient) {
+        trackRecommendationSelection(recipient, "share", "section_list", 1);
+      }
+    },
+    [recipients, resetShareComposer, trackRecommendationSelection],
+  );
+
   const addShareRecipient = useCallback(
     (
       recipientId: string,
@@ -5305,11 +5337,16 @@ export function OneLocationAgentPageContent({
   );
   const handleOpenShareReview = useCallback(async () => {
     if (!canShare) return;
+    const attemptId = shareReviewAttemptRef.current + 1;
+    shareReviewAttemptRef.current = attemptId;
+    shareReviewPendingRef.current = true;
     setBusy("share");
     const readiness = await ensureForegroundLocationReady({
       capturePoint: false,
       autoOpenSettings: true,
     });
+    if (shareReviewAttemptRef.current !== attemptId) return;
+    shareReviewPendingRef.current = false;
     setBusy(null);
     if (!readiness.ready) return;
     setShareReviewOpen(true);
@@ -6189,6 +6226,7 @@ export function OneLocationAgentPageContent({
     myLocationError,
     recipients: rankedRecipients,
     visibleRecipients,
+    visibleShareRecipients,
     activeOwnerGrants,
     // Received grants stay reachable in their focused detail view. Dismissing
     // a preview never mutates the durable grant or its revocation state.
@@ -6203,6 +6241,7 @@ export function OneLocationAgentPageContent({
       detail: event.detail,
     })),
     recipientSearch,
+    shareRecipientSearch,
     selectedRecipientIds,
     selectedRequestOwnerIds,
     shareDurationHours,
@@ -6213,11 +6252,14 @@ export function OneLocationAgentPageContent({
     publicInviteUrl,
     circleInviteUrl,
     setRecipientSearch,
+    setShareRecipientSearch,
     setShareDurationHours,
     setShareMessage,
     setDurationHours,
     setRequestMessage,
     setShareReviewOpen,
+    resetShareComposer,
+    startShareComposer,
     toggleShareRecipient: (id) => toggleShareRecipient(id, "section_list"),
     toggleRequestOwner: (id) => toggleRequestOwner(id, "section_list"),
     onShowMyLocation: () => void handleShowMyLiveLocation(),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -164,6 +164,7 @@ export type LocationHubViewModel = {
   /* data lists */
   recipients: OneLocationRecipient[];
   visibleRecipients: OneLocationRecipient[];
+  visibleShareRecipients: OneLocationRecipient[];
   activeOwnerGrants: OneLocationGrant[];
   receivedGrants: OneLocationGrant[];
   pendingOwnerRequests: OneLocationAccessRequest[];
@@ -174,6 +175,7 @@ export type LocationHubViewModel = {
 
   /* composer state */
   recipientSearch: string;
+  shareRecipientSearch: string;
   selectedRecipientIds: string[];
   selectedRequestOwnerIds: string[];
   shareDurationHours: string;
@@ -186,11 +188,14 @@ export type LocationHubViewModel = {
 
   /* setters (presentation state owned by page) */
   setRecipientSearch: (v: string) => void;
+  setShareRecipientSearch: (v: string) => void;
   setShareDurationHours: (v: string) => void;
   setShareMessage: (v: string) => void;
   setDurationHours: (v: string) => void;
   setRequestMessage: (v: string) => void;
   setShareReviewOpen: (v: boolean) => void;
+  resetShareComposer: () => void;
+  startShareComposer: (initialRecipientId?: string) => void;
 
   /* selection */
   toggleShareRecipient: (id: string, surface?: string) => void;
@@ -480,9 +485,24 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   }, [pathname, router, searchParams]);
 
   const [shareStep, setShareStep] = useState<"person" | "details">("person");
-  const [locationType, setLocationType] =
+  const [shareLocationType, setShareLocationType] =
+    useState<LocationTypeValue>("precise");
+  const [temporaryLinkLocationType, setTemporaryLinkLocationType] =
     useState<LocationTypeValue>("precise");
   const [reason, setReason] = useState<ReasonValue | null>("Safety check-in");
+  const activeFlowRef = useRef<FlowKind>("none");
+  const resetShareComposer = vm.resetShareComposer;
+  const startShareComposer = vm.startShareComposer;
+  const setShareReviewOpen = vm.setShareReviewOpen;
+
+  const resetShareLocalState = useCallback(() => {
+    setShareStep("person");
+    setShareLocationType("precise");
+  }, []);
+  const resetShareDraft = useCallback(() => {
+    resetShareLocalState();
+    resetShareComposer();
+  }, [resetShareComposer, resetShareLocalState]);
 
   // A location action flow is a focused sub-screen of /one/location.
   // The open flow is mirrored into the URL (`?action=…`) so the SINGLE top-left
@@ -494,8 +514,8 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
   const openFlow = useCallback(
     (next: Exclude<FlowKind, "none">) => {
       setFlow(next);
+      activeFlowRef.current = next;
       pendingFlowRef.current = next;
-      if (next === "share") setShareStep("person");
       const params = new URLSearchParams(searchParams.toString());
       params.delete(FLOW_SOURCE_PARAM);
       params.set(FLOW_ACTION_PARAM, FLOW_TO_ACTION[next]);
@@ -504,9 +524,19 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     [pathname, router, searchParams],
   );
 
+  const openShareFlow = useCallback(
+    (initialRecipientId?: string) => {
+      resetShareLocalState();
+      startShareComposer(initialRecipientId);
+      openFlow("share");
+    },
+    [openFlow, resetShareLocalState, startShareComposer],
+  );
+
   const closeFlow = useCallback(
     (nextTab?: LocationHubTab) => {
       setFlow("none");
+      activeFlowRef.current = "none";
       pendingFlowRef.current = "none";
       setShareStep("person");
       vm.setShareReviewOpen(false);
@@ -530,8 +560,14 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     [pathname, router, searchParams, vm],
   );
 
+  const closeShareFlow = useCallback(() => {
+    resetShareDraft();
+    closeFlow();
+  }, [closeFlow, resetShareDraft]);
+
   const returnToNearbyCheckIn = useCallback(() => {
     setFlow("none");
+    activeFlowRef.current = "none";
     pendingFlowRef.current = "none";
     setShareStep("person");
     vm.setShareReviewOpen(false);
@@ -580,16 +616,26 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       return;
     }
     pendingFlowRef.current = "none";
+    const previousFlow = activeFlowRef.current;
+    if (previousFlow === "share" && desired !== "share") {
+      resetShareDraft();
+    } else if (previousFlow !== "share" && desired === "share") {
+      resetShareDraft();
+    }
+    activeFlowRef.current = desired;
     setFlow((current) => (current === desired ? current : desired));
     if (desired === "none") {
       setShareStep("person");
-      vm.setShareReviewOpen(false);
+      setShareReviewOpen(false);
     }
-    // `vm.setShareReviewOpen` is a stable useState setter; depend on searchParams
-    // only so this runs on every URL change (open/close) without re-firing on
-    // unrelated vm re-renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nearbyCheckInAvailable, pathname, router, searchParams]);
+  }, [
+    nearbyCheckInAvailable,
+    pathname,
+    resetShareDraft,
+    router,
+    searchParams,
+    setShareReviewOpen,
+  ]);
 
   // When a share completes successfully (page bumps shareCompletedTick), close
   // the 3-step share flow and return to the main One Location hub.
@@ -600,8 +646,10 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
       // Closing the flow returns to the hub; the share flow always launches
       // from the "Now" tab, so no explicit tab change is needed.
       setFlow("none");
+      activeFlowRef.current = "none";
       pendingFlowRef.current = "none";
       setShareStep("person");
+      setShareLocationType("precise");
       if (nearbyPrivateCheckIn) {
         router.replace(nearbyCheckInReturnHref, { scroll: false });
         return;
@@ -639,9 +687,9 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             vm={vm}
             step={shareStep}
             setStep={setShareStep}
-            locationType={locationType}
-            setLocationType={setLocationType}
-            onClose={closeFlow}
+            locationType={shareLocationType}
+            setLocationType={setShareLocationType}
+            onClose={closeShareFlow}
           />
         ) : flow === "ask" ? (
           <AskFlow
@@ -706,8 +754,8 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
         ) : (
           <TemporaryLinkFlow
             vm={vm}
-            locationType={locationType}
-            setLocationType={setLocationType}
+            locationType={temporaryLinkLocationType}
+            setLocationType={setTemporaryLinkLocationType}
             onClose={closeFlow}
           />
         )}
@@ -744,7 +792,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
           <LocationHubPanel>
             <NowHub
               vm={vm}
-              onStartShare={() => openFlow("share")}
+              onStartShare={() => openShareFlow()}
               onCheckIn={() =>
                 nearbyCheckInAvailable
                   ? router.push(`${ROUTES.ONE_LOCATION_MAP}?action=check-in`)
@@ -767,7 +815,7 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
               vm={vm}
               onAddConnections={() => router.push(ROUTES.CONNECT)}
               onInvite={() => openFlow("invite")}
-              onStartShare={() => openFlow("share")}
+              onStartShare={openShareFlow}
               onAsk={() => openFlow("ask")}
             />
           </LocationHubPanel>
@@ -1261,7 +1309,7 @@ function PeopleHub({
   vm: LocationHubViewModel;
   onAddConnections: () => void;
   onInvite: () => void;
-  onStartShare: () => void;
+  onStartShare: (initialRecipientId?: string) => void;
   onAsk: () => void;
 }) {
   const hasSearch = vm.recipientSearch.trim().length > 0;
@@ -1397,10 +1445,7 @@ function PeopleHub({
                     </Button>
                   ) : ready ? (
                     <Button
-                      onClick={() => {
-                        vm.toggleShareRecipient(r.userId, "people_hub");
-                        onStartShare();
-                      }}
+                      onClick={() => onStartShare(r.userId)}
                       className="h-9 rounded-full bg-[color:var(--app-accent)] px-5 text-sm font-semibold text-[color:var(--app-accent-fg)] hover:bg-[color:var(--app-accent)]/90"
                     >
                       Share
@@ -1640,7 +1685,7 @@ function ShareFlow({
   setLocationType: (v: LocationTypeValue) => void;
   onClose: () => void;
 }) {
-  const filtered = vm.visibleRecipients;
+  const filtered = vm.visibleShareRecipients;
   const recipientById = new globalThis.Map(
     vm.recipients.map((recipient) => [recipient.userId, recipient]),
   );
@@ -1809,8 +1854,8 @@ function ShareFlow({
         description="Only trusted and location-ready people can receive private live location."
       />
       <PersonSearchInput
-        value={vm.recipientSearch}
-        onChange={vm.setRecipientSearch}
+        value={vm.shareRecipientSearch}
+        onChange={vm.setShareRecipientSearch}
       />
       {filtered.length ? (
         <div className={PEOPLE_LIST_SCROLL_CLASS}>


### PR DESCRIPTION
## Summary
- start every private Share Location session with a clean in-memory draft
- clear stale recipients, private-share search, location type, duration, note, step, and consent review on Cancel or route/browser/native back
- invalidate an in-flight location-readiness check so an abandoned draft cannot reopen the review screen later
- preserve the People/Ask search, temporary-link settings, request drafts, active shares, and People-row recipient shortcut

## Impact map
- **Route:** `/one/location?action=share`
- **API / schema / database / cache:** no changes
- **Consent / crypto:** existing grant creation and encrypted location publishing are unchanged; reset is limited to an unfinished client-side draft
- **Mobile parity:** query-driven browser, app-chrome, and native back transitions use the same reset path
- **Rollback:** revert commit `0f8680273`

## Verification
- `npx vitest run __tests__/components/one-location-agent-page.test.tsx` — 53/53 passed
- `npm run typecheck` — passed
- targeted ESLint for all three changed files — passed with the pre-existing `react-hooks/preserve-manual-memoization` rule disabled; default lint still reports the existing untouched callback warning in `app/one/location/page.tsx`
- `npm run verify:design-system` — passed
- `python .codex/skills/repo-context/scripts/repo_scan.py validate` — passed
- `git diff --check` — passed
- full route verification remains local-maintainer-only because `REVIEWER_UID` and `REVIEWER_VAULT_PASSPHRASE` are not configured in this workstation

---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)