### PR TITLE
feat(agent): add consent-aware governed action recovery

### DIFF
--- a/hushh-webapp/__tests__/components/agent-action-recovery-card.test.tsx
+++ b/hushh-webapp/__tests__/components/agent-action-recovery-card.test.tsx
@@ -1,0 +1,173 @@
+﻿import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentActionRecoveryCard } from "@/components/agent/agent-action-recovery-card";
+import type { AgentActionRecoveryPlan } from "@/lib/agent/agent-action-recovery-plan";
+import { ROUTES } from "@/lib/navigation/routes";
+
+const plan: AgentActionRecoveryPlan = {
+  id: "analysis.start.open_workspace_then_execute",
+  originalActionId: "analysis.start",
+  title: "Start NVDA analysis safely",
+  summary:
+    "Open the Analysis workspace, wait until it is ready, request fresh consent, start the analysis, and verify the resulting effect.",
+  sourceReason: "unavailable",
+  requiresFreshConsent: true,
+  mayAutoExecute: false,
+  policyDecision: {
+    disposition: "propose",
+    reason: "safe_recovery_available",
+    mayAutoRetry: false,
+    requiresFreshConsent: true,
+  },
+  steps: [
+    {
+      id: "open_analysis_workspace",
+      kind: "navigate",
+      label: "Open the Analysis workspace",
+      target: ROUTES.KAI_ANALYSIS,
+    },
+    {
+      id: "wait_for_analysis_workspace",
+      kind: "wait_for_runtime",
+      label: "Wait until the Analysis workspace is ready",
+      condition: "analysis_workspace_ready",
+    },
+    {
+      id: "confirm_analysis_start",
+      kind: "request_consent",
+      label: "Confirm starting an analysis for NVDA",
+      actionId: "analysis.start",
+    },
+    {
+      id: "execute_analysis_start",
+      kind: "execute_action",
+      label: "Start the NVDA analysis",
+      actionId: "analysis.start",
+      slots: {
+        symbol: "NVDA",
+      },
+    },
+    {
+      id: "verify_analysis_started",
+      kind: "verify_effect",
+      label: "Verify that the analysis started",
+      actionId: "analysis.start",
+      acceptedEffectStates: ["started", "completed"],
+    },
+  ],
+};
+
+describe("AgentActionRecoveryCard", () => {
+  it("renders the user-facing recovery proposal", () => {
+    render(
+      <AgentActionRecoveryCard
+        plan={plan}
+        onContinue={() => undefined}
+        onCancel={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Start NVDA analysis safely",
+      }),
+    ).toBeTruthy();
+
+    expect(screen.getByText("Fresh approval required")).toBeTruthy();
+
+    expect(
+      screen.getByText("Open the Analysis workspace"),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByText("Wait until the Analysis workspace is ready"),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByText("Confirm starting an analysis for NVDA"),
+    ).toBeTruthy();
+
+    expect(screen.getByText("Start the NVDA analysis")).toBeTruthy();
+
+    expect(
+      screen.getByText("Verify that the analysis started"),
+    ).toBeTruthy();
+  });
+
+  it("does not expose internal action ids or runtime reasons", () => {
+    render(
+      <AgentActionRecoveryCard
+        plan={plan}
+        onContinue={() => undefined}
+        onCancel={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByText("analysis.start")).toBeNull();
+    expect(screen.queryByText("unavailable")).toBeNull();
+    expect(screen.queryByText("safe_recovery_available")).toBeNull();
+  });
+
+  it("calls the continue handler after user approval", () => {
+    const onContinue = vi.fn();
+
+    render(
+      <AgentActionRecoveryCard
+        plan={plan}
+        onContinue={onContinue}
+        onCancel={() => undefined}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Review and continue",
+      }),
+    );
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the cancel handler", () => {
+    const onCancel = vi.fn();
+
+    render(
+      <AgentActionRecoveryCard
+        plan={plan}
+        onContinue={() => undefined}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Cancel",
+      }),
+    );
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both decisions while continuing", () => {
+    render(
+      <AgentActionRecoveryCard
+        plan={plan}
+        onContinue={() => undefined}
+        onCancel={() => undefined}
+        isContinuing
+      />,
+    );
+
+    const continueButton = screen.getByRole("button", {
+      name: "Review and continue",
+    }) as HTMLButtonElement;
+
+    const cancelButton = screen.getByRole("button", {
+      name: "Cancel",
+    }) as HTMLButtonElement;
+
+    expect(continueButton.disabled).toBe(true);
+    expect(cancelButton.disabled).toBe(true);
+  });
+});

--- a/hushh-webapp/__tests__/services/agent-action-recovery-plan.test.ts
+++ b/hushh-webapp/__tests__/services/agent-action-recovery-plan.test.ts
@@ -1,0 +1,155 @@
+﻿import { describe, expect, it } from "vitest";
+
+import { buildAgentActionRecoveryPlan } from "@/lib/agent/agent-action-recovery-plan";
+import type { AgentActionRuntimeResult } from "@/lib/agent/agent-action-runtime";
+import { ROUTES } from "@/lib/navigation/routes";
+
+function createResult(
+  overrides: Partial<AgentActionRuntimeResult> = {},
+): AgentActionRuntimeResult {
+  return {
+    status: "blocked",
+    effectState: "not_started",
+    actionId: "analysis.start",
+    label: "Start analysis",
+    routeBefore: "/one",
+    resultSummary: "Analysis is not available on the current screen.",
+    reason: "unavailable",
+    ...overrides,
+  };
+}
+
+describe("buildAgentActionRecoveryPlan", () => {
+  it("builds a deterministic analysis recovery proposal", () => {
+    const plan = buildAgentActionRecoveryPlan({
+      result: createResult(),
+      slots: {
+        symbol: "nvda",
+      },
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan).toMatchObject({
+      id: "analysis.start.open_workspace_then_execute",
+      originalActionId: "analysis.start",
+      title: "Start NVDA analysis safely",
+      sourceReason: "unavailable",
+      requiresFreshConsent: true,
+      mayAutoExecute: false,
+      policyDecision: {
+        disposition: "propose",
+        reason: "safe_recovery_available",
+        mayAutoRetry: false,
+        requiresFreshConsent: true,
+      },
+    });
+
+    expect(plan?.steps).toEqual([
+      {
+        id: "open_analysis_workspace",
+        kind: "navigate",
+        label: "Open the Analysis workspace",
+        target: ROUTES.KAI_ANALYSIS,
+      },
+      {
+        id: "wait_for_analysis_workspace",
+        kind: "wait_for_runtime",
+        label: "Wait until the Analysis workspace is ready",
+        condition: "analysis_workspace_ready",
+      },
+      {
+        id: "confirm_analysis_start",
+        kind: "request_consent",
+        label: "Confirm starting an analysis for NVDA",
+        actionId: "analysis.start",
+      },
+      {
+        id: "execute_analysis_start",
+        kind: "execute_action",
+        label: "Start the NVDA analysis",
+        actionId: "analysis.start",
+        slots: {
+          symbol: "NVDA",
+        },
+      },
+      {
+        id: "verify_analysis_started",
+        kind: "verify_effect",
+        label: "Verify that the analysis started",
+        actionId: "analysis.start",
+        acceptedEffectStates: ["started", "completed"],
+      },
+    ]);
+  });
+
+  it("fails closed when the original effect is unknown", () => {
+    expect(
+      buildAgentActionRecoveryPlan({
+        result: createResult({
+          effectState: "unknown",
+        }),
+        slots: {
+          symbol: "NVDA",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not recover when execution already started", () => {
+    expect(
+      buildAgentActionRecoveryPlan({
+        result: createResult({
+          status: "started",
+          effectState: "started",
+        }),
+        slots: {
+          symbol: "NVDA",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not recover a completed action", () => {
+    expect(
+      buildAgentActionRecoveryPlan({
+        result: createResult({
+          status: "succeeded",
+          effectState: "completed",
+        }),
+        slots: {
+          symbol: "NVDA",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not create a plan for another action", () => {
+    expect(
+      buildAgentActionRecoveryPlan({
+        result: createResult({
+          actionId: "connected_system.crm.read",
+        }),
+        slots: {
+          symbol: "NVDA",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("does not create an incomplete plan without a symbol", () => {
+    expect(
+      buildAgentActionRecoveryPlan({
+        result: createResult(),
+      }),
+    ).toBeNull();
+
+    expect(
+      buildAgentActionRecoveryPlan({
+        result: createResult(),
+        slots: {
+          symbol: "   ",
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/services/agent-action-recovery.test.ts
+++ b/hushh-webapp/__tests__/services/agent-action-recovery.test.ts
@@ -1,0 +1,108 @@
+﻿import { describe, expect, it } from "vitest";
+
+import { evaluateAgentActionRecovery } from "@/lib/agent/agent-action-recovery";
+
+describe("evaluateAgentActionRecovery", () => {
+  it("does not recover when the original effect completed", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "completed",
+        hasDeterministicRecovery: true,
+      }),
+    ).toEqual({
+      disposition: "not_needed",
+      reason: "effect_completed",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    });
+  });
+
+  it("fails closed when execution already started", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "started",
+        hasDeterministicRecovery: true,
+      }),
+    ).toEqual({
+      disposition: "stop",
+      reason: "effect_started",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    });
+  });
+
+  it("fails closed when the effect is unknown", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "unknown",
+        hasDeterministicRecovery: true,
+      }),
+    ).toEqual({
+      disposition: "stop",
+      reason: "effect_unknown",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    });
+  });
+
+  it("stops when no deterministic recovery exists", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "not_started",
+        hasDeterministicRecovery: false,
+      }),
+    ).toEqual({
+      disposition: "stop",
+      reason: "no_deterministic_recovery",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    });
+  });
+
+  it("does not propose recovery for irreversible actions", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "not_started",
+        hasDeterministicRecovery: true,
+        risk: "irreversible",
+      }),
+    ).toEqual({
+      disposition: "stop",
+      reason: "irreversible_action",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    });
+  });
+
+  it("proposes deterministic state-changing recovery with fresh consent", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "not_started",
+        hasDeterministicRecovery: true,
+        risk: "state_change",
+        recoveryChangesAction: true,
+      }),
+    ).toEqual({
+      disposition: "propose",
+      reason: "safe_recovery_available",
+      mayAutoRetry: false,
+      requiresFreshConsent: true,
+    });
+  });
+
+  it("can keep existing consent for a same-action read-only recovery", () => {
+    expect(
+      evaluateAgentActionRecovery({
+        effectState: "not_started",
+        hasDeterministicRecovery: true,
+        risk: "read_only",
+        recoveryChangesAction: false,
+      }),
+    ).toEqual({
+      disposition: "propose",
+      reason: "safe_recovery_available",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    });
+  });
+});

--- a/hushh-webapp/__tests__/services/agent-action-runtime.test.ts
+++ b/hushh-webapp/__tests__/services/agent-action-runtime.test.ts
@@ -32,6 +32,7 @@ describe("executeAgentGatewayAction connected systems", () => {
 
     expect(input.router.push).toHaveBeenCalledWith(ROUTES.CONNECTED_SYSTEMS);
     expect(result.status).toBe("started");
+    expect(result.effectState).toBe("started");
     expect(result.screenAfter).toBe("connected_systems");
   });
 
@@ -42,6 +43,20 @@ describe("executeAgentGatewayAction connected systems", () => {
 
     expect(input.router.push).not.toHaveBeenCalled();
     expect(result.status).toBe("blocked");
+    expect(result.effectState).toBe("not_started");
     expect(result.reason).toBe("crm_delete_manual_only");
+  });
+
+  it("records missing actions as provably not started", async () => {
+    const input = baseInput("missing.action");
+
+    const result = await executeAgentGatewayAction(input);
+
+    expect(input.router.push).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "invalid",
+      effectState: "not_started",
+      reason: "missing_action",
+    });
   });
 });

--- a/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
+++ b/hushh-webapp/__tests__/voice/agent-action-runtime.test.ts
@@ -73,6 +73,7 @@ describe("executeAgentGatewayAction", () => {
     expect(router.push).toHaveBeenCalledWith(`${ROUTES.KAI_ANALYSIS}?ticker=NVDA`);
     expect(result).toMatchObject({
       status: "started",
+      effectState: "started",
       actionId: "analysis.start",
       routeAfter: `${ROUTES.KAI_ANALYSIS}?ticker=NVDA`,
       screenAfter: "kai_analysis",

--- a/hushh-webapp/components/agent/agent-action-recovery-card.tsx
+++ b/hushh-webapp/components/agent/agent-action-recovery-card.tsx
@@ -1,0 +1,107 @@
+﻿"use client";
+
+import { useId } from "react";
+import { ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { AgentActionRecoveryPlan } from "@/lib/agent/agent-action-recovery-plan";
+
+type AgentActionRecoveryCardProps = {
+  plan: AgentActionRecoveryPlan;
+  onContinue: () => void;
+  onCancel: () => void;
+  isContinuing?: boolean;
+};
+
+export function AgentActionRecoveryCard({
+  plan,
+  onContinue,
+  onCancel,
+  isContinuing = false,
+}: AgentActionRecoveryCardProps) {
+  const titleId = useId();
+
+  return (
+    <section
+      aria-labelledby={titleId}
+      aria-busy={isContinuing}
+      className="rounded-2xl border border-border/70 bg-card p-4 shadow-sm"
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+          aria-hidden="true"
+        >
+          <ShieldCheck className="size-5" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Recovery review
+          </p>
+
+          <h3
+            id={titleId}
+            className="mt-1 text-base font-semibold text-foreground"
+          >
+            {plan.title}
+          </h3>
+
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {plan.summary}
+          </p>
+        </div>
+      </div>
+
+      {plan.requiresFreshConsent ? (
+        <div className="mt-4 rounded-xl border border-border/70 bg-muted/40 px-3 py-2">
+          <p className="text-sm font-medium text-foreground">
+            Fresh approval required
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            One will not run this recovery until you review and approve it.
+          </p>
+        </div>
+      ) : null}
+
+      <ol
+        aria-label="Recovery steps"
+        className="mt-4 space-y-3"
+      >
+        {plan.steps.map((step, index) => (
+          <li
+            key={step.id}
+            className="flex items-start gap-3 text-sm text-foreground"
+          >
+            <span
+              className="flex size-6 shrink-0 items-center justify-center rounded-full border border-border bg-background text-xs font-medium"
+              aria-hidden="true"
+            >
+              {index + 1}
+            </span>
+
+            <span className="pt-0.5 leading-5">{step.label}</span>
+          </li>
+        ))}
+      </ol>
+
+      <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button
+          variant="outline"
+          onClick={onCancel}
+          disabled={isContinuing}
+        >
+          Cancel
+        </Button>
+
+        <Button
+          onClick={onContinue}
+          isLoading={isContinuing}
+          disabled={isContinuing}
+        >
+          Review and continue
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -33,6 +33,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { Button } from "@/components/ui/button";
+import { AgentActionRecoveryCard } from "@/components/agent/agent-action-recovery-card";
 import { AgentHistorySidebar } from "@/components/agent/agent-history-sidebar";
 import { AgentPkmReviewPanel } from "@/components/agent/agent-pkm-review-panel";
 import { AgentVoiceWaveInput } from "@/components/agent/agent-voice-wave-input";
@@ -46,6 +47,10 @@ import {
   executeAgentGatewayAction,
   type AgentActionRuntimeResult,
 } from "@/lib/agent/agent-action-runtime";
+import {
+  buildAgentActionRecoveryPlan,
+  type AgentActionRecoveryPlan,
+} from "@/lib/agent/agent-action-recovery-plan";
 import {
   addToPKM,
   clearAgentPkmContext,
@@ -93,7 +98,10 @@ import {
   type AgentChatToolEvent,
 } from "@/lib/services/agent-chat-client";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
-import { ROUTES } from "@/lib/navigation/routes";
+import {
+  buildKaiAnalysisPreviewRoute,
+  ROUTES,
+} from "@/lib/navigation/routes";
 import { cn } from "@/lib/utils";
 import { useVault } from "@/lib/vault/vault-context";
 import { deriveVoiceRouteScreen } from "@/lib/voice/route-screen-derivation";
@@ -756,6 +764,8 @@ export function AgentChatWorkspace({
   const [activeFrontendToolCount, setActiveFrontendToolCount] = useState(0);
   const [activePkmToolCount, setActivePkmToolCount] = useState(0);
   const [pkmReviews, setPkmReviews] = useState<AgentPkmReview[]>([]);
+  const [actionRecoveryPlan, setActionRecoveryPlan] =
+    useState<AgentActionRecoveryPlan | null>(null);
   const [pkmActivity, setPkmActivity] = useState<AgentPkmActivity[]>([]);
   const [voiceState, setVoiceState] = useState<AgentVoiceStatus>("idle");
   const [voiceTranscriptReview, setVoiceTranscriptReview] =
@@ -987,7 +997,7 @@ export function AgentChatWorkspace({
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [messages, pkmReviews]);
+  }, [actionRecoveryPlan, messages, pkmReviews]);
 
   useEffect(() => {
     const textarea = composerTextareaRef.current;
@@ -1115,6 +1125,7 @@ export function AgentChatWorkspace({
     setActiveFrontendToolCount(0);
     setActivePkmToolCount(0);
     setPkmReviews([]);
+    setActionRecoveryPlan(null);
     setPkmActivity([]);
     setVoiceState("idle");
     setVoiceTranscriptReview(null);
@@ -1223,6 +1234,7 @@ export function AgentChatWorkspace({
       setMessages(restored.length > 0 ? restored : [createGreetingMessage()]);
       setPkmActivity([]);
       setPkmReviews([]);
+    setActionRecoveryPlan(null);
     },
     []
   );
@@ -1247,6 +1259,7 @@ export function AgentChatWorkspace({
     setMessages([createGreetingMessage()]);
     setInput("");
     setPkmReviews([]);
+    setActionRecoveryPlan(null);
     setPkmActivity([]);
   }, [abortAgentTurnWork]);
 
@@ -1489,12 +1502,64 @@ export function AgentChatWorkspace({
     [appendDebugEvent, getVaultOwnerToken, pkmReviews, user?.uid, vaultKey]
   );
 
+  const handleCancelActionRecovery = useCallback(() => {
+    setActionRecoveryPlan(null);
+  }, []);
+
+  const handleContinueActionRecovery = useCallback(() => {
+    if (!actionRecoveryPlan) {
+      return;
+    }
+
+    const executeStep = actionRecoveryPlan.steps.find(
+      (step) => step.kind === "execute_action",
+    );
+
+    if (!executeStep || executeStep.kind !== "execute_action") {
+      setActionRecoveryPlan(null);
+      toast.error("This recovery is no longer available.");
+      return;
+    }
+
+    const symbol = executeStep.slots.symbol;
+    const target = buildKaiAnalysisPreviewRoute({
+      ticker: symbol,
+    });
+
+    setAnalysisParams(null);
+    setActionRecoveryPlan(null);
+    router.push(target);
+
+    onNavigationActionComplete?.({
+      status: "started",
+      effectState: "started",
+      actionId: null,
+      label: "Open Analysis workspace",
+      routeBefore: pathname,
+      routeAfter: target,
+      resultSummary: `Opened the ${symbol} comparison preview after recovery approval.`,
+      data: {
+        symbol,
+        recoveryId: actionRecoveryPlan.id,
+        originalActionId: actionRecoveryPlan.originalActionId,
+      },
+    });
+  }, [
+    actionRecoveryPlan,
+    onNavigationActionComplete,
+    pathname,
+    router,
+    setAnalysisParams,
+  ]);
+
   const runAgentTurn = async (
     textInput: string,
     options: AgentRunTurnOptions = { source: "typed" }
   ) => {
     const text = textInput.trim();
     if (!text || !hasChatAccess || !user?.uid) return;
+
+    setActionRecoveryPlan(null);
 
     const userId = user.uid;
     const token = getVaultOwnerToken();
@@ -1935,6 +2000,23 @@ export function AgentChatWorkspace({
           setAnalysisParams,
         });
         appendDebugEvent(debugTurnId, "tool_result", result);
+
+        const recoveryPlan = buildAgentActionRecoveryPlan({
+          result,
+          slots: toolEvent.slots,
+        });
+
+        setActionRecoveryPlan(recoveryPlan);
+
+        if (recoveryPlan) {
+          appendDebugEvent(debugTurnId, "action_recovery_proposed", {
+            recovery_id: recoveryPlan.id,
+            original_action_id: recoveryPlan.originalActionId,
+            policy_reason: recoveryPlan.policyDecision.reason,
+            requires_fresh_consent: recoveryPlan.requiresFreshConsent,
+          });
+        }
+
         upsertToolStatusMessage(result.resultSummary, toolResultStatus(result));
         if (voiceReceiptSpoken === false) {
           speakVoiceReceipt(result.resultSummary);
@@ -2753,6 +2835,7 @@ export function AgentChatWorkspace({
       return;
     }
     setPkmReviews([]);
+    setActionRecoveryPlan(null);
     setPkmActivity([]);
     void runAgentTurn(retryText, {
       source: "typed",
@@ -3059,6 +3142,14 @@ export function AgentChatWorkspace({
                   onDismiss={() => handleDismissPkmReview(review.id)}
                 />
               ))}
+              {actionRecoveryPlan ? (
+                <AgentActionRecoveryCard
+                  plan={actionRecoveryPlan}
+                  onContinue={handleContinueActionRecovery}
+                  onCancel={handleCancelActionRecovery}
+                />
+              ) : null}
+
               <div ref={messagesEndRef} />
             </div>
           </div>

--- a/hushh-webapp/lib/agent/agent-action-recovery-plan.ts
+++ b/hushh-webapp/lib/agent/agent-action-recovery-plan.ts
@@ -1,0 +1,151 @@
+﻿import {
+  evaluateAgentActionRecovery,
+  type AgentRecoveryPolicyDecision,
+} from "@/lib/agent/agent-action-recovery";
+import type { AgentActionRuntimeResult } from "@/lib/agent/agent-action-runtime";
+import { ROUTES } from "@/lib/navigation/routes";
+
+const ANALYSIS_START_ACTION_ID = "analysis.start";
+
+export type AgentActionRecoveryStep =
+  | {
+      id: "open_analysis_workspace";
+      kind: "navigate";
+      label: string;
+      target: string;
+    }
+  | {
+      id: "wait_for_analysis_workspace";
+      kind: "wait_for_runtime";
+      label: string;
+      condition: "analysis_workspace_ready";
+    }
+  | {
+      id: "confirm_analysis_start";
+      kind: "request_consent";
+      label: string;
+      actionId: typeof ANALYSIS_START_ACTION_ID;
+    }
+  | {
+      id: "execute_analysis_start";
+      kind: "execute_action";
+      label: string;
+      actionId: typeof ANALYSIS_START_ACTION_ID;
+      slots: {
+        symbol: string;
+      };
+    }
+  | {
+      id: "verify_analysis_started";
+      kind: "verify_effect";
+      label: string;
+      actionId: typeof ANALYSIS_START_ACTION_ID;
+      acceptedEffectStates: Array<"started" | "completed">;
+    };
+
+export type AgentActionRecoveryPlan = {
+  id: "analysis.start.open_workspace_then_execute";
+  originalActionId: typeof ANALYSIS_START_ACTION_ID;
+  title: string;
+  summary: string;
+  sourceReason: string | null;
+  requiresFreshConsent: boolean;
+  mayAutoExecute: false;
+  policyDecision: AgentRecoveryPolicyDecision;
+  steps: AgentActionRecoveryStep[];
+};
+
+export type BuildAgentActionRecoveryPlanInput = {
+  result: AgentActionRuntimeResult;
+  slots?: Record<string, unknown>;
+};
+
+function readSymbol(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const symbol = value.trim().toUpperCase();
+  return symbol || null;
+}
+
+/**
+ * Builds a deterministic recovery proposal for analysis.start.
+ *
+ * This function does not execute any step. It only returns a reviewable plan
+ * after the fail-closed policy confirms that the first action never started.
+ */
+export function buildAgentActionRecoveryPlan(
+  input: BuildAgentActionRecoveryPlanInput,
+): AgentActionRecoveryPlan | null {
+  if (
+    input.result.actionId !== ANALYSIS_START_ACTION_ID ||
+    input.result.status !== "blocked"
+  ) {
+    return null;
+  }
+
+  const symbol = readSymbol(input.slots?.symbol);
+  if (!symbol) {
+    return null;
+  }
+
+  const policyDecision = evaluateAgentActionRecovery({
+    effectState: input.result.effectState,
+    hasDeterministicRecovery: true,
+    risk: "state_change",
+    recoveryChangesAction: true,
+  });
+
+  if (policyDecision.disposition !== "propose") {
+    return null;
+  }
+
+  return {
+    id: "analysis.start.open_workspace_then_execute",
+    originalActionId: ANALYSIS_START_ACTION_ID,
+    title: `Start ${symbol} analysis safely`,
+    summary:
+      "Open the Analysis workspace, wait until it is ready, request fresh consent, start the analysis, and verify the resulting effect.",
+    sourceReason: input.result.reason ?? null,
+    requiresFreshConsent: policyDecision.requiresFreshConsent,
+    mayAutoExecute: false,
+    policyDecision,
+    steps: [
+      {
+        id: "open_analysis_workspace",
+        kind: "navigate",
+        label: "Open the Analysis workspace",
+        target: ROUTES.KAI_ANALYSIS,
+      },
+      {
+        id: "wait_for_analysis_workspace",
+        kind: "wait_for_runtime",
+        label: "Wait until the Analysis workspace is ready",
+        condition: "analysis_workspace_ready",
+      },
+      {
+        id: "confirm_analysis_start",
+        kind: "request_consent",
+        label: `Confirm starting an analysis for ${symbol}`,
+        actionId: ANALYSIS_START_ACTION_ID,
+      },
+      {
+        id: "execute_analysis_start",
+        kind: "execute_action",
+        label: `Start the ${symbol} analysis`,
+        actionId: ANALYSIS_START_ACTION_ID,
+        slots: {
+          symbol,
+        },
+      },
+      {
+        id: "verify_analysis_started",
+        kind: "verify_effect",
+        label: "Verify that the analysis started",
+        actionId: ANALYSIS_START_ACTION_ID,
+        acceptedEffectStates: ["started", "completed"],
+      },
+    ],
+  };
+}

--- a/hushh-webapp/lib/agent/agent-action-recovery.ts
+++ b/hushh-webapp/lib/agent/agent-action-recovery.ts
@@ -1,0 +1,113 @@
+﻿import type { AgentActionEffectState } from "@/lib/agent/agent-action-runtime";
+
+export type AgentRecoveryRisk =
+  | "read_only"
+  | "state_change"
+  | "irreversible";
+
+export type AgentRecoveryDisposition =
+  | "not_needed"
+  | "propose"
+  | "stop";
+
+export type AgentRecoveryPolicyReason =
+  | "effect_completed"
+  | "effect_started"
+  | "effect_unknown"
+  | "no_deterministic_recovery"
+  | "irreversible_action"
+  | "safe_recovery_available";
+
+export type EvaluateAgentActionRecoveryInput = {
+  effectState: AgentActionEffectState;
+  hasDeterministicRecovery: boolean;
+  risk?: AgentRecoveryRisk;
+  recoveryChangesAction?: boolean;
+};
+
+export type AgentRecoveryPolicyDecision = {
+  disposition: AgentRecoveryDisposition;
+  reason: AgentRecoveryPolicyReason;
+
+  /**
+   * Recovery is never executed as an automatic retry.
+   * A safe result only allows One to propose the next action.
+   */
+  mayAutoRetry: false;
+
+  /**
+   * True when the proposed recovery introduces a new action or side effect.
+   */
+  requiresFreshConsent: boolean;
+};
+
+/**
+ * Evaluates whether One may propose a governed recovery after an action result.
+ *
+ * This policy is intentionally fail-closed:
+ *
+ * - completed: no recovery is necessary
+ * - started: stop because an effect may already be in progress
+ * - unknown: stop because duplicate execution cannot be ruled out
+ * - not_started: a deterministic recovery may be proposed
+ *
+ * This function never authorizes automatic retries.
+ */
+export function evaluateAgentActionRecovery(
+  input: EvaluateAgentActionRecoveryInput,
+): AgentRecoveryPolicyDecision {
+  if (input.effectState === "completed") {
+    return {
+      disposition: "not_needed",
+      reason: "effect_completed",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    };
+  }
+
+  if (input.effectState === "started") {
+    return {
+      disposition: "stop",
+      reason: "effect_started",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    };
+  }
+
+  if (input.effectState === "unknown") {
+    return {
+      disposition: "stop",
+      reason: "effect_unknown",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    };
+  }
+
+  const risk = input.risk ?? "state_change";
+
+  if (risk === "irreversible") {
+    return {
+      disposition: "stop",
+      reason: "irreversible_action",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    };
+  }
+
+  if (!input.hasDeterministicRecovery) {
+    return {
+      disposition: "stop",
+      reason: "no_deterministic_recovery",
+      mayAutoRetry: false,
+      requiresFreshConsent: false,
+    };
+  }
+
+  return {
+    disposition: "propose",
+    reason: "safe_recovery_available",
+    mayAutoRetry: false,
+    requiresFreshConsent:
+      risk === "state_change" || input.recoveryChangesAction !== false,
+  };
+}

--- a/hushh-webapp/lib/agent/agent-action-runtime.ts
+++ b/hushh-webapp/lib/agent/agent-action-runtime.ts
@@ -13,8 +13,11 @@ type RouterLike = {
   push: (href: string) => void;
 };
 
+export type AgentActionEffectState = "not_started" | "started" | "completed" | "unknown";
+
 export type AgentActionRuntimeResult = {
   status: "succeeded" | "started" | "blocked" | "invalid" | "failed" | "noop";
+  effectState: AgentActionEffectState;
   actionId: string | null;
   label: string | null;
   routeBefore: string | null;
@@ -45,6 +48,7 @@ function readString(value: unknown): string | null {
 function buildResult(input: Partial<AgentActionRuntimeResult>): AgentActionRuntimeResult {
   return {
     status: input.status || "failed",
+    effectState: input.effectState || "unknown",
     actionId: input.actionId ?? null,
     label: input.label ?? null,
     routeBefore: input.routeBefore ?? null,
@@ -67,6 +71,7 @@ function executeConnectedSystemAgentAction(
   if (input.actionId === "connected_system.crm.delete") {
     return buildResult({
       status: "blocked",
+      effectState: "not_started",
       actionId: input.actionId,
       label: "Blocked Salesforce CRM Delete",
       routeBefore: routeBefore.pathname,
@@ -80,6 +85,7 @@ function executeConnectedSystemAgentAction(
   input.router.push(target);
   return buildResult({
     status: "started",
+    effectState: "started",
     actionId: input.actionId,
     label:
       input.actionId === "connected_system.crm.read"
@@ -112,6 +118,7 @@ export async function executeAgentGatewayAction(
   if (!action) {
     return buildResult({
       status: "invalid",
+      effectState: "not_started",
       actionId: input.actionId,
       routeBefore: routeBefore.pathname,
       screenBefore: routeBefore.screen,
@@ -128,6 +135,7 @@ export async function executeAgentGatewayAction(
   if (availability.status !== "available") {
     return buildResult({
       status: "blocked",
+      effectState: "not_started",
       actionId: action.action_id,
       label: action.label,
       routeBefore: routeBefore.pathname,
@@ -143,6 +151,7 @@ export async function executeAgentGatewayAction(
   if (action.execution_target.status !== "wired") {
     return buildResult({
       status: "invalid",
+      effectState: "not_started",
       actionId: action.action_id,
       label: action.label,
       routeBefore: routeBefore.pathname,
@@ -156,6 +165,7 @@ export async function executeAgentGatewayAction(
     input.router.push(action.execution_target.target);
     return buildResult({
       status: "started",
+      effectState: "started",
       actionId: action.action_id,
       label: action.label,
       routeBefore: routeBefore.pathname,
@@ -169,6 +179,7 @@ export async function executeAgentGatewayAction(
   if (action.execution_target.path !== "kai_command") {
     return buildResult({
       status: "blocked",
+      effectState: "not_started",
       actionId: action.action_id,
       label: action.label,
       routeBefore: routeBefore.pathname,
@@ -202,6 +213,13 @@ export async function executeAgentGatewayAction(
 
   return buildResult({
     status: commandResult.actionResult.status,
+    effectState:
+      commandResult.actionResult.status === "succeeded" ||
+      commandResult.actionResult.status === "noop"
+        ? "completed"
+        : commandResult.actionResult.status === "started"
+          ? "started"
+          : "unknown",
     actionId: commandResult.actionResult.actionId || action.action_id,
     label: action.label,
     routeBefore: commandResult.actionResult.routeBefore,


### PR DESCRIPTION
## Summary

Adds a consent-aware, fail-closed recovery workflow for Agent One actions.

When an action cannot safely complete, One now classifies the observed effect, blocks unsafe retries, builds a deterministic recovery proposal, requests fresh user approval, and routes the user into the existing Analysis preview flow.

## What changed

- added conservative action-effect classification:
  - `not_started`
  - `started`
  - `completed`
  - `unknown`
- added a fail-closed recovery policy
- added a deterministic recovery plan for `analysis.start`
- added a user-facing recovery consent-review card
- integrated recovery proposals into Agent One
- clears stale recovery proposals across new turns, chat changes, and session resets
- preserves the stock symbol while opening the existing Analysis comparison preview
- avoids automatic retries and hidden side effects

<img width="1536" height="1024" alt="ChatGPT Image Aug 3, 2026, 06_29_22 PM" src="https://github.com/user-attachments/assets/c6f226a2-b3c4-46d8-bd32-d44bf80b6429" />

## Safety properties

- actions with `started` or `unknown` effects are not retried
- recovery never auto-executes
- state-changing recovery requires fresh consent
- internal action IDs, policy reasons, and runtime diagnostics are not exposed in consumer UI
- approval opens the existing Analysis preview rather than pretending the analysis completed

## Validation

- focused recovery tests: 22 tests passed
- cache contracts: 51 tests passed
- TypeScript passed
- ESLint passed
- design-system verification passed
- cache verification passed
- documentation verification passed
- `git diff --check` passed

## Demo scenario

1. User asks: “Start an analysis for NVIDIA.”
2. The first action is blocked before execution.
3. Runtime evidence is classified as `not_started`.
4. One proposes a deterministic recovery plan.
5. The user reviews and approves the plan.
6. One opens the NVIDIA Analysis comparison preview.
7. The existing Analysis experience owns the actual launch.

User impact

Agent One now behaves more safely when action outcomes are uncertain.

Instead of retrying blindly, it:

observes
reasons
stops when evidence is unsafe
proposes a deterministic recovery
asks the user
continues only after approval
