### PR TITLE
feat(one-location): restore Home/Work/Other save-place onboarding + draggable map pin picker

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -55,7 +55,16 @@ import {
   OneLocationOnboardingFlow as OneLocationOnboardingExperience,
   type ConnectionRequestResult,
 } from "@/components/one-location/onboarding/one-location-onboarding-flow";
+import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
+import type { PickedLocation } from "@/components/one-location/onboarding/location-picker-map";
+import {
+  addSavedLocation,
+  DuplicateSavedLocationError,
+  type SavedLocationCategory,
+} from "@/lib/one-location/saved-locations";
+
 import { useConsentNotificationState } from "@/components/consent/notification-provider";
+
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -1588,6 +1597,20 @@ type OneLocationAgentPageProps = {
   onSetupSkip?: () => void | Promise<void>;
 };
 
+// Legacy per-user localStorage markers from the first saved-place release. The
+// encrypted PKM domain is now the source of truth, so these are only cleared
+// (never read to suppress the prompt) — the "Save this place" step must appear
+// EVERY time Location onboarding is shown, even if a prior run was skipped.
+const SAVED_LOCATION_PROMPT_LEGACY_KEY_PREFIX =
+  "one_location_saved_location_prompt_v1";
+const SAVED_LOCATION_PROMPT_OUTCOME_KEY_PREFIX =
+  "one_location_saved_location_prompt_v2";
+
+function savedLocationPromptKey(prefix: string, userId: string): string {
+  return `${prefix}:${userId}`;
+}
+
+
 export function OneLocationAgentPageContent({
   mode = "workspace",
   surface = "hub",
@@ -1678,7 +1701,23 @@ export function OneLocationAgentPageContent({
   const [locationOnboardingStep, setLocationOnboardingStep] =
     useState<OneLocationOnboardingStep>("welcome");
   const [locationOnboardingBusy, setLocationOnboardingBusy] = useState(false);
+  // "Save this place" prompt (Home/Work/Other) shown after Location becomes
+  // ready during onboarding. It re-appears on every onboarding run — see
+  // `promptSaveLocationDuringOnboarding` — so a discarded first run still gets
+  // the chance to save Home next time.
+  const [saveLocationModalOpen, setSaveLocationModalOpen] = useState(false);
+  const [saveLocationPoint, setSaveLocationPoint] =
+    useState<PlainLocationPoint | null>(null);
+  const [saveLocationAddress, setSaveLocationAddress] = useState<string | null>(
+    null,
+  );
+  const [saveLocationAddressLoading, setSaveLocationAddressLoading] =
+    useState(false);
+  const [saveLocationSaving, setSaveLocationSaving] = useState(false);
+  const savedLocationPromptInFlightRef = useRef<Promise<boolean> | null>(null);
+  const savedLocationAddressResolutionIdRef = useRef(0);
   const notificationOnboardingAttemptRef = useRef(false);
+
   const notificationOnboardingObservedBusyRef = useRef(false);
   const notificationOnboardingRetryOnFocusRef = useRef(false);
   const [locationOnboardingPeople, setLocationOnboardingPeople] = useState<
@@ -5180,9 +5219,255 @@ export function OneLocationAgentPageContent({
     window.setTimeout(() => void refreshLocationPermission(), 1200);
   }, [refreshLocationPermission]);
 
+  // Fired by the onboarding flow once Location is granted. Captures the current
+  // position ONCE, opens the "Save this place" modal, and best-effort resolves a
+  // friendly address in the background. Runs on EVERY onboarding appearance (no
+  // once-per-user suppression) so a previously discarded onboarding still gets
+  // the chance to save Home/Work/Other. If a place already exists it pre-seeds
+  // nothing and simply lets the owner add/update.
+  const promptSaveLocationDuringOnboarding =
+    useCallback((): Promise<boolean> => {
+      if (savedLocationPromptInFlightRef.current) {
+        return savedLocationPromptInFlightRef.current;
+      }
+      if (!auth.userId || !vaultKey || !vaultOwnerToken) {
+        return Promise.resolve(false);
+      }
+
+      const userId = auth.userId;
+      const attempt = (async (): Promise<boolean> => {
+        let point: PlainLocationPoint;
+        try {
+          point = await OneLocationService.captureCurrentPosition();
+        } catch {
+          toast.error(
+            "We could not read your current location. Check permission and try again.",
+          );
+          return false;
+        }
+
+        // Retire any legacy suppression markers so the prompt keeps appearing.
+        if (typeof window !== "undefined") {
+          try {
+            window.localStorage.removeItem(
+              savedLocationPromptKey(
+                SAVED_LOCATION_PROMPT_LEGACY_KEY_PREFIX,
+                userId,
+              ),
+            );
+            window.localStorage.removeItem(
+              savedLocationPromptKey(
+                SAVED_LOCATION_PROMPT_OUTCOME_KEY_PREFIX,
+                userId,
+              ),
+            );
+          } catch {
+            // Encrypted PKM remains the saved-state authority.
+          }
+        }
+
+        const addressResolutionId =
+          savedLocationAddressResolutionIdRef.current + 1;
+        savedLocationAddressResolutionIdRef.current = addressResolutionId;
+        setSaveLocationPoint(point);
+        setSaveLocationAddress(null);
+        setSaveLocationAddressLoading(true);
+        setSaveLocationModalOpen(true);
+
+        // Resolve friendly copy while the modal remains usable. Exact
+        // coordinates are never rendered or written to browser storage.
+        void OneLocationService.reverseGeocode({
+          vaultOwnerToken,
+          lat: point.latitude,
+          lng: point.longitude,
+        })
+          .then((place) => {
+            if (
+              savedLocationAddressResolutionIdRef.current !==
+              addressResolutionId
+            ) {
+              return;
+            }
+            setSaveLocationAddress(place.formattedAddress || place.name || null);
+          })
+          .catch(() => {
+            if (
+              savedLocationAddressResolutionIdRef.current !==
+              addressResolutionId
+            ) {
+              return;
+            }
+            setSaveLocationAddress(null);
+          })
+          .finally(() => {
+            if (
+              savedLocationAddressResolutionIdRef.current === addressResolutionId
+            ) {
+              setSaveLocationAddressLoading(false);
+            }
+          });
+        return true;
+      })().finally(() => {
+        savedLocationPromptInFlightRef.current = null;
+      });
+
+      savedLocationPromptInFlightRef.current = attempt;
+      return attempt;
+    }, [auth.userId, vaultKey, vaultOwnerToken]);
+
+  const handleSaveOnboardingLocation = useCallback(
+    async (category: SavedLocationCategory, label: string) => {
+      if (!auth.userId || !vaultKey || !vaultOwnerToken || !saveLocationPoint) {
+        toast.error("Unlock your vault before saving this location.");
+        return;
+      }
+      setSaveLocationSaving(true);
+      try {
+        await addSavedLocation({
+          context: {
+            userId: auth.userId,
+            vaultKey,
+            vaultOwnerToken,
+          },
+          input: {
+            category,
+            label,
+            latitude: saveLocationPoint.latitude,
+            longitude: saveLocationPoint.longitude,
+            address: saveLocationAddress,
+          },
+        });
+        savedLocationAddressResolutionIdRef.current += 1;
+        setSaveLocationModalOpen(false);
+        setSaveLocationPoint(null);
+        toast.success("Location saved securely.");
+      } catch (error) {
+        toast.error(
+          error instanceof DuplicateSavedLocationError
+            ? error.message
+            : "Could not save this location. Please try again.",
+        );
+      } finally {
+        setSaveLocationSaving(false);
+      }
+    },
+    [
+      auth.userId,
+      saveLocationAddress,
+      saveLocationPoint,
+      vaultKey,
+      vaultOwnerToken,
+    ],
+  );
+
+  const handleSkipSaveOnboardingLocation = useCallback(() => {
+    savedLocationAddressResolutionIdRef.current += 1;
+    setSaveLocationModalOpen(false);
+    setSaveLocationPoint(null);
+  }, []);
+
+  // Authenticated Maps autocomplete used by the modal's "Change" search.
+  const searchOnboardingSavedPlaces = useCallback(
+    async (input: string) => {
+      if (!vaultOwnerToken) {
+        throw new Error("Vault owner token required.");
+      }
+      return OneLocationService.placesAutocomplete({
+        vaultOwnerToken,
+        input,
+      });
+    },
+    [vaultOwnerToken],
+  );
+
+  // Replace the captured point with a searched place's exact coordinates.
+  const selectOnboardingSavedPlace = useCallback(
+    async (placeId: string) => {
+      if (!vaultOwnerToken || !saveLocationPoint) {
+        throw new Error("Capture a location before changing the place.");
+      }
+      const place = await OneLocationService.placeDetails({
+        vaultOwnerToken,
+        placeId,
+      });
+      if (
+        !Number.isFinite(place.latitude) ||
+        !Number.isFinite(place.longitude) ||
+        place.latitude < -90 ||
+        place.latitude > 90 ||
+        place.longitude < -180 ||
+        place.longitude > 180
+      ) {
+        throw new Error("The selected place did not return valid coordinates.");
+      }
+      const label = place.label.trim();
+      if (!label) {
+        throw new Error("The selected place did not return an address.");
+      }
+      savedLocationAddressResolutionIdRef.current += 1;
+      setSaveLocationPoint({
+        ...saveLocationPoint,
+        latitude: place.latitude,
+        longitude: place.longitude,
+        accuracyM: null,
+        capturedAt: new Date().toISOString(),
+      });
+      setSaveLocationAddress(label);
+      setSaveLocationAddressLoading(false);
+    },
+    [saveLocationPoint, vaultOwnerToken],
+  );
+
+  // Drag-to-pin confirm: adopt the precise coordinate + address the owner set
+  // on the map, replacing the coarse GPS fix. This is the accuracy fix (Task 2).
+  const handlePickExactSavedLocation = useCallback(
+    (picked: PickedLocation) => {
+      setSaveLocationPoint((current) => ({
+        latitude: picked.latitude,
+        longitude: picked.longitude,
+        accuracyM: null,
+        capturedAt: new Date().toISOString(),
+        sourcePlatform: current?.sourcePlatform ?? "web",
+      }));
+      savedLocationAddressResolutionIdRef.current += 1;
+      setSaveLocationAddress(picked.address);
+      setSaveLocationAddressLoading(false);
+    },
+    [],
+  );
+
+  // "Locate me" inside the map picker — re-center on a fresh GPS fix.
+  const locateMeForSavedLocation = useCallback(async () => {
+    try {
+      const point = await OneLocationService.captureCurrentPosition();
+      return { latitude: point.latitude, longitude: point.longitude };
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Reverse-geocode wrapper the map picker calls on every settle.
+  const reverseGeocodeForSavedLocation = useCallback(
+    async (lat: number, lng: number): Promise<string | null> => {
+      if (!vaultOwnerToken) return null;
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken,
+          lat,
+          lng,
+        });
+        return place.formattedAddress || place.name || null;
+      } catch {
+        return null;
+      }
+    },
+    [vaultOwnerToken],
+  );
+
   const handleLocationOnboardingPermission = useCallback(async () => {
     if (locationOnboardingBusy) return;
     setLocationOnboardingBusy(true);
+
     try {
       if (isLocationServicesDisabled(permission)) {
         await openLocationSettingsForOnboarding();
@@ -5389,15 +5674,40 @@ export function OneLocationAgentPageContent({
             handleSendLocationOnboardingConnectionRequests
           }
           onRequestLocation={handleLocationOnboardingPermission}
+          onLocationReady={promptSaveLocationDuringOnboarding}
           onRequestNotifications={handleLocationOnboardingNotifications}
           onBack={() => router.back()}
           onComplete={dismissLocationOnboarding}
           onSkip={skipLocationOnboarding}
           requireLocationToComplete={mode === "setup"}
         />
+        <SaveLocationModal
+          open={saveLocationModalOpen}
+          address={saveLocationAddress}
+          loadingAddress={saveLocationAddressLoading}
+          saving={saveLocationSaving}
+          onSearchPlaces={searchOnboardingSavedPlaces}
+          onSelectPlace={selectOnboardingSavedPlace}
+          mapInitial={
+            saveLocationPoint
+              ? {
+                  latitude: saveLocationPoint.latitude,
+                  longitude: saveLocationPoint.longitude,
+                }
+              : null
+          }
+          reverseGeocode={reverseGeocodeForSavedLocation}
+          onLocateMe={locateMeForSavedLocation}
+          onPickExactLocation={handlePickExactSavedLocation}
+          onSave={(category, label) =>
+            void handleSaveOnboardingLocation(category, label)
+          }
+          onSkip={handleSkipSaveOnboardingLocation}
+        />
       </BodyPortal>
     );
   }
+
 
   // ---------------------------------------------------------------------------
   // Mobile-first redesign (Figma: one_location_final_fixed_clean_navigation).

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { Check, Crosshair, Loader2, MapPin, X } from "lucide-react";
+
+import { useGoogleMaps } from "@/lib/one-location/use-google-maps";
+import { cn } from "@/lib/utils";
+
+export type PickedLocation = {
+  latitude: number;
+  longitude: number;
+  address: string | null;
+};
+
+export interface LocationPickerMapProps {
+  /** Where the map centers when it first opens. */
+  initialLatitude: number;
+  initialLongitude: number;
+  /** Friendly address already resolved for the initial point (optional). */
+  initialAddress?: string | null;
+  /** Server-side reverse geocode used to keep the address in sync with the pin. */
+  reverseGeocode?: (lat: number, lng: number) => Promise<string | null>;
+  /** Re-center the map on the device GPS fix. */
+  onLocateMe?: () => Promise<{ latitude: number; longitude: number } | null>;
+  /** Emitted when the owner confirms the pin position. */
+  onConfirm: (picked: PickedLocation) => void;
+  /** Dismiss the map without changing the captured point. */
+  onCancel: () => void;
+  confirmLabel?: string;
+  className?: string;
+}
+
+const PIN_REVERSE_GEOCODE_DEBOUNCE_MS = 350;
+
+function isValidCoordinate(lat: number, lng: number): boolean {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+/**
+ * LocationPickerMap — an Uber/Zomato-style "drag the map, the pin stays centred"
+ * picker so the owner can place their EXACT home instead of trusting a coarse GPS
+ * fix. The centre pin marks the chosen coordinate; every time the map settles we
+ * reverse-geocode the centre so the address preview stays truthful. A "Use my
+ * location" control re-centres on the live GPS fix, and Confirm returns the
+ * precise coordinate + address to the caller.
+ */
+export function LocationPickerMap({
+  initialLatitude,
+  initialLongitude,
+  initialAddress = null,
+  reverseGeocode,
+  onLocateMe,
+  onConfirm,
+  onCancel,
+  confirmLabel = "Confirm location",
+  className,
+}: LocationPickerMapProps) {
+  const { status } = useGoogleMaps();
+  const { resolvedTheme } = useTheme();
+  const colorScheme = resolvedTheme === "dark" ? "DARK" : "LIGHT";
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const resolveIdRef = useRef(0);
+  const debounceRef = useRef<number | null>(null);
+
+  const centerRef = useRef<{ lat: number; lng: number }>({
+    lat: initialLatitude,
+    lng: initialLongitude,
+  });
+  const [address, setAddress] = useState<string | null>(initialAddress);
+  const [resolving, setResolving] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [locating, setLocating] = useState(false);
+
+  const resolveAddressForCenter = useCallback(
+    (lat: number, lng: number) => {
+      if (!reverseGeocode) return;
+      const requestId = resolveIdRef.current + 1;
+      resolveIdRef.current = requestId;
+      setResolving(true);
+      void Promise.resolve(reverseGeocode(lat, lng))
+        .then((next) => {
+          if (resolveIdRef.current !== requestId) return;
+          setAddress((next && next.trim()) || null);
+        })
+        .catch(() => {
+          if (resolveIdRef.current !== requestId) return;
+          setAddress(null);
+        })
+        .finally(() => {
+          if (resolveIdRef.current === requestId) setResolving(false);
+        });
+    },
+    [reverseGeocode],
+  );
+
+  const scheduleResolve = useCallback(
+    (lat: number, lng: number) => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = window.setTimeout(() => {
+        resolveAddressForCenter(lat, lng);
+      }, PIN_REVERSE_GEOCODE_DEBOUNCE_MS);
+    },
+    [resolveAddressForCenter],
+  );
+
+  // Build the interactive map once the API is ready. Google applies colorScheme
+  // only at construction, so the container is keyed by scheme to force a fresh
+  // node when the theme flips.
+  useEffect(() => {
+    if (status !== "ready" || !containerRef.current || mapRef.current) return;
+    const start = centerRef.current;
+    const map = new google.maps.Map(containerRef.current, {
+      center: start,
+      zoom: 17,
+      disableDefaultUI: true,
+      clickableIcons: false,
+      gestureHandling: "greedy",
+      colorScheme,
+    });
+    mapRef.current = map;
+
+    const dragStart = map.addListener("dragstart", () => setDragging(true));
+    const idle = map.addListener("idle", () => {
+      const center = map.getCenter();
+      if (!center) return;
+      const lat = center.lat();
+      const lng = center.lng();
+      centerRef.current = { lat, lng };
+      setDragging(false);
+      scheduleResolve(lat, lng);
+    });
+    // Tapping the map recenters the pin on that spot (a second familiar gesture).
+    const click = map.addListener(
+      "click",
+      (event: google.maps.MapMouseEvent) => {
+        if (!event.latLng) return;
+        map.panTo(event.latLng);
+      },
+    );
+
+    return () => {
+      dragStart.remove();
+      idle.remove();
+      click.remove();
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      mapRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, colorScheme]);
+
+  const handleLocateMe = useCallback(async () => {
+    if (!onLocateMe || locating) return;
+    setLocating(true);
+    try {
+      const fix = await onLocateMe();
+      if (fix && isValidCoordinate(fix.latitude, fix.longitude)) {
+        centerRef.current = { lat: fix.latitude, lng: fix.longitude };
+        mapRef.current?.panTo({ lat: fix.latitude, lng: fix.longitude });
+        mapRef.current?.setZoom(17);
+      }
+    } catch {
+      // Best-effort recenter; the pin simply stays where it is.
+    } finally {
+      setLocating(false);
+    }
+  }, [locating, onLocateMe]);
+
+  const handleConfirm = useCallback(() => {
+    const { lat, lng } = centerRef.current;
+    if (!isValidCoordinate(lat, lng)) return;
+    onConfirm({ latitude: lat, longitude: lng, address });
+  }, [address, onConfirm]);
+
+  const unavailable = status === "error";
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+          Drag the map to pin your exact spot
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Close map"
+          className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+        >
+          <X className="h-4 w-4" strokeWidth={2.4} />
+        </button>
+      </div>
+
+      <div className="relative h-[min(48vh,340px)] w-full overflow-hidden rounded-2xl border border-black/[0.08] bg-[#eef2f7] dark:border-white/[0.1] dark:bg-[#10151d]">
+        {unavailable ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+            <MapPin
+              className="h-7 w-7 text-[#8b93a1]"
+              strokeWidth={2}
+              aria-hidden
+            />
+            <p className="text-[13px] font-medium text-[#5b6472] dark:text-[#9aa6b6]">
+              The map isn&apos;t available right now. Search for your address
+              instead, or keep your current location.
+            </p>
+          </div>
+        ) : status !== "ready" ? (
+          <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Loading map…
+          </div>
+        ) : (
+          <>
+            <div key={colorScheme} ref={containerRef} className="h-full w-full" />
+
+            {/* Fixed centre pin — the map moves beneath it, so the pin always
+                marks the chosen coordinate. */}
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              aria-hidden="true"
+            >
+              {/* Offset up by half the pin height so the pin TIP (not its centre)
+                  marks the exact map centre; lift a little more while dragging. */}
+              <div
+                className={cn(
+                  "flex flex-col items-center transition-transform duration-150 ease-out",
+                  dragging ? "-translate-y-[26px]" : "-translate-y-[20px]",
+                )}
+              >
+
+                <MapPin
+                  className="h-9 w-9 text-[color:var(--app-accent,#087ff5)] drop-shadow-[0_6px_8px_rgba(8,127,245,0.35)]"
+                  strokeWidth={2.4}
+                  fill="currentColor"
+                  fillOpacity={0.18}
+                />
+                <span
+                  className={cn(
+                    "mt-0.5 h-2 w-2 rounded-full bg-black/40 blur-[1px] transition-all duration-150",
+                    dragging ? "scale-75 opacity-40" : "scale-100 opacity-60",
+                  )}
+                />
+              </div>
+            </div>
+
+            {onLocateMe ? (
+              <button
+                type="button"
+                onClick={() => void handleLocateMe()}
+                disabled={locating}
+                aria-label="Use my current location"
+                className="press-scale absolute bottom-3 right-3 flex h-11 w-11 items-center justify-center rounded-full bg-white text-[color:var(--app-accent-deep,#0b62c4)] shadow-[0_4px_14px_rgba(16,24,40,0.22)] disabled:opacity-60 dark:bg-[#1c2430] dark:text-[#9bc7f5]"
+              >
+                {locating ? (
+                  <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+                ) : (
+                  <Crosshair className="h-5 w-5" strokeWidth={2.2} aria-hidden />
+                )}
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-start gap-2 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
+        <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+          <MapPin className="h-4 w-4" strokeWidth={2.4} aria-hidden />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+            Selected spot
+          </p>
+          {resolving ? (
+            <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              Finding this address…
+            </span>
+          ) : (
+            <p className="mt-0.5 text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
+              {address || "Move the map to choose a place"}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={unavailable || status !== "ready" || resolving}
+          className={cn(
+            "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+            "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+          )}
+        >
+          <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
+          {confirmLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -69,12 +69,20 @@ type OneLocationOnboardingFlowProps = {
     userIds: string[],
   ) => Promise<ConnectionRequestResult>;
   onRequestLocation: () => Promise<void>;
+  /**
+   * Called once Location is ready during onboarding. Opens the "Save this place"
+   * (Home/Work/Other) prompt hosted by the page. Resolves true when the prompt
+   * step is satisfied (shown, skipped, or already saved), false if it must be
+   * retried. Optional so other callers can omit the saved-place step.
+   */
+  onLocationReady?: () => Promise<boolean>;
   onRequestNotifications: () => Promise<void>;
   onBack: () => void | Promise<void>;
   onComplete: () => void | Promise<void>;
   onSkip?: () => void | Promise<void>;
   requireLocationToComplete?: boolean;
 };
+
 
 const WELCOME_ORBIT_ITEMS = [
   {
@@ -1117,12 +1125,14 @@ export function OneLocationOnboardingFlow({
   onRetryPeople,
   onSendConnectionRequests,
   onRequestLocation,
+  onLocationReady,
   onRequestNotifications,
   onBack,
   onComplete,
   onSkip = onComplete,
   requireLocationToComplete = false,
 }: OneLocationOnboardingFlowProps) {
+
   for (const source of ONBOARDING_IMAGE_SOURCES) {
     preload(source, { as: "image", fetchPriority: "high" });
   }
@@ -1139,6 +1149,10 @@ export function OneLocationOnboardingFlow({
   const requestBatchRef = useRef(0);
   const permissionPromptAttemptedRef = useRef(false);
   const completionInFlightRef = useRef(false);
+  // Fires the "Save this place" prompt exactly once per mounted onboarding run,
+  // as soon as Location is ready — so it reliably appears every onboarding.
+  const savedLocationTriggeredRef = useRef(false);
+
 
   const locationGranted =
     locationPermission?.state === "granted" &&
@@ -1170,6 +1184,21 @@ export function OneLocationOnboardingFlow({
   useEffect(() => {
     if (startAt === "permissions") requestMissingPermissions();
   }, [requestMissingPermissions, startAt]);
+
+  // The "Save this place" (Home/Work/Other) prompt must appear every onboarding
+  // run once Location is ready. Fire onLocationReady exactly once per mount the
+  // moment the permission flips to granted, before the owner leaves the flow.
+  useEffect(() => {
+    if (!onLocationReady) return;
+    if (!locationGranted) return;
+    if (savedLocationTriggeredRef.current) return;
+    savedLocationTriggeredRef.current = true;
+    void Promise.resolve(onLocationReady()).catch(() => {
+      // Allow a later retry (e.g. via Continue) if the prompt could not open.
+      savedLocationTriggeredRef.current = false;
+    });
+  }, [locationGranted, onLocationReady]);
+
 
   useEffect(() => {
     if (screen !== "circle") return;

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import {
+  Briefcase,
+  Check,
+  Home,
+  Loader2,
+  Map as MapIcon,
+  MapPin,
+  Pencil,
+  Search,
+  X,
+} from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  LocationPickerMap,
+  type PickedLocation,
+} from "@/components/one-location/onboarding/location-picker-map";
+import { cn } from "@/lib/utils";
+import type { SavedLocationCategory } from "@/lib/one-location/saved-locations";
+
+export type SavedLocationPlaceSuggestion = {
+  placeId: string;
+  text: string;
+};
+
+export type SaveLocationModalProps = {
+  open: boolean;
+  /** Reverse-geocoded address for display. */
+  address?: string | null;
+  /** True while the location capture is still resolving. */
+  loadingAddress?: boolean;
+  /** True while a save is in flight. */
+  saving?: boolean;
+  /** Authenticated Maps search; selected place details replace point + copy. */
+  onSearchPlaces?: (
+    input: string,
+  ) => Promise<SavedLocationPlaceSuggestion[]>;
+  onSelectPlace?: (placeId: string) => Promise<void>;
+  /**
+   * Current captured coordinate used to seed the drag-to-pin map picker. When
+   * provided together with `onPickExactLocation`, an "Adjust on map" action lets
+   * the owner place their EXACT spot instead of trusting the coarse GPS fix.
+   */
+  mapInitial?: { latitude: number; longitude: number } | null;
+  /** Server reverse-geocode so the picker keeps the address synced to the pin. */
+  reverseGeocode?: (lat: number, lng: number) => Promise<string | null>;
+  /** Recenter the picker on the live device GPS fix. */
+  onLocateMe?: () => Promise<{ latitude: number; longitude: number } | null>;
+  /** Commit the precise coordinate + address chosen on the map. */
+  onPickExactLocation?: (picked: PickedLocation) => void;
+  onSave: (category: SavedLocationCategory, label: string) => void;
+  onSkip: () => void;
+};
+
+const CATEGORY_OPTIONS: {
+  category: SavedLocationCategory;
+  label: string;
+  Icon: typeof Home;
+}[] = [
+  { category: "home", label: "Home", Icon: Home },
+  { category: "work", label: "Work", Icon: Briefcase },
+  { category: "other", label: "Other", Icon: MapPin },
+];
+
+/**
+ * SaveLocationModal — a focused, responsive prompt shown during Location
+ * onboarding after access is ready. The owner can correct the captured place
+ * before tagging it as Home / Work / Other. Because a coarse GPS fix rarely lands
+ * on the exact doorstep, the owner can open a drag-to-pin map picker (like other
+ * apps) to place their precise spot. The shared dialog primitive owns focus
+ * trapping, focus restoration, Escape handling, and screen-reader semantics.
+ */
+export function SaveLocationModal({
+  open,
+  address,
+  loadingAddress = false,
+  saving = false,
+  onSearchPlaces,
+  onSelectPlace,
+  mapInitial,
+  reverseGeocode,
+  onLocateMe,
+  onPickExactLocation,
+  onSave,
+  onSkip,
+}: SaveLocationModalProps) {
+  const [category, setCategory] = useState<SavedLocationCategory | null>(null);
+  const [customLabel, setCustomLabel] = useState("");
+  const [editingPlace, setEditingPlace] = useState(false);
+  const [pickingOnMap, setPickingOnMap] = useState(false);
+  const [placeQuery, setPlaceQuery] = useState("");
+  const [placeSuggestions, setPlaceSuggestions] = useState<
+    SavedLocationPlaceSuggestion[]
+  >([]);
+  const [placeSearching, setPlaceSearching] = useState(false);
+  const [placeSearchError, setPlaceSearchError] = useState<string | null>(null);
+  const [selectingPlaceId, setSelectingPlaceId] = useState<string | null>(null);
+  const descriptionId = useId();
+
+  // Reset internal selection each time the modal (re)opens.
+  useEffect(() => {
+    if (open) {
+      setCategory(null);
+      setCustomLabel("");
+      setEditingPlace(false);
+      setPickingOnMap(false);
+      setPlaceQuery("");
+      setPlaceSuggestions([]);
+      setPlaceSearching(false);
+      setPlaceSearchError(null);
+      setSelectingPlaceId(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !editingPlace || !onSearchPlaces) return;
+    const input = placeQuery.trim();
+    if (input.length < 2) {
+      setPlaceSuggestions([]);
+      setPlaceSearching(false);
+      setPlaceSearchError(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      setPlaceSearching(true);
+      setPlaceSearchError(null);
+      void onSearchPlaces(input)
+        .then((suggestions) => {
+          if (cancelled) return;
+          setPlaceSuggestions(suggestions);
+          if (suggestions.length === 0) {
+            setPlaceSearchError("No matching places found.");
+          }
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setPlaceSuggestions([]);
+          setPlaceSearchError("Could not search places. Please try again.");
+        })
+        .finally(() => {
+          if (!cancelled) setPlaceSearching(false);
+        });
+    }, 250);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [editingPlace, onSearchPlaces, open, placeQuery]);
+
+  const resolvedAddress = (address && address.trim()) || null;
+  const changingPlace = selectingPlaceId !== null;
+  const interactionBusy = saving || changingPlace;
+  const canEditPlace = Boolean(onSearchPlaces && onSelectPlace);
+  const canPickOnMap = Boolean(
+    onPickExactLocation &&
+      mapInitial &&
+      Number.isFinite(mapInitial.latitude) &&
+      Number.isFinite(mapInitial.longitude),
+  );
+  const canSave =
+    category !== null &&
+    !saving &&
+    !loadingAddress &&
+    !editingPlace &&
+    !pickingOnMap &&
+    !changingPlace;
+
+  const handleSelectPlace = async (placeId: string) => {
+    if (!onSelectPlace || changingPlace) return;
+    setSelectingPlaceId(placeId);
+    setPlaceSearchError(null);
+    try {
+      await onSelectPlace(placeId);
+      setEditingPlace(false);
+      setPlaceQuery("");
+      setPlaceSuggestions([]);
+    } catch {
+      setPlaceSearchError("Could not update this place. Please try again.");
+    } finally {
+      setSelectingPlaceId(null);
+    }
+  };
+
+  const handleConfirmMapPick = (picked: PickedLocation) => {
+    onPickExactLocation?.(picked);
+    setPickingOnMap(false);
+  };
+
+  const handleSave = () => {
+    if (!category || !canSave) return;
+    const label =
+      category === "other" ? customLabel.trim() || "Other" : undefined;
+    onSave(category, label ?? "");
+  };
+
+  return (
+    <Dialog
+      open={open}
+      modal
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !interactionBusy) onSkip();
+      }}
+    >
+      <DialogContent
+        showCloseButton={false}
+        data-testid="save-location-modal"
+        aria-describedby={descriptionId}
+        overlayClassName="z-[559] bg-black/45 backdrop-blur-[6px]"
+        onEscapeKeyDown={(event) => {
+          if (interactionBusy || pickingOnMap) event.preventDefault();
+        }}
+        onPointerDownOutside={(event) => {
+          if (interactionBusy || pickingOnMap) event.preventDefault();
+        }}
+        className={cn(
+          "z-[560] bottom-0 top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
+          "rounded-b-none rounded-t-[28px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[24px]",
+          "border border-black/[0.06] bg-white p-6 pb-[calc(env(safe-area-inset-bottom,0px)+22px)] sm:pb-6",
+          "shadow-[0_-8px_40px_rgba(16,24,40,0.18)] sm:shadow-[0_20px_60px_rgba(16,24,40,0.24)]",
+          "dark:border-white/[0.08] dark:bg-[#141922]",
+        )}
+      >
+        {pickingOnMap && canPickOnMap ? (
+          <>
+            <DialogTitle className="sr-only">
+              Pin your exact location
+            </DialogTitle>
+            <p id={descriptionId} className="sr-only">
+              Drag the map so the centre pin sits on your exact spot, then
+              confirm.
+            </p>
+            <LocationPickerMap
+              initialLatitude={mapInitial!.latitude}
+              initialLongitude={mapInitial!.longitude}
+              initialAddress={resolvedAddress}
+              reverseGeocode={reverseGeocode}
+              onLocateMe={onLocateMe}
+              onConfirm={handleConfirmMapPick}
+              onCancel={() => setPickingOnMap(false)}
+            />
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={onSkip}
+              disabled={interactionBusy}
+              aria-label="Close"
+              className="press-scale absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+            >
+              <X className="h-4.5 w-4.5" strokeWidth={2.4} />
+            </button>
+
+            <header className="pr-8">
+              <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent,#087ff5)]">
+                <MapPin className="h-6 w-6" strokeWidth={2.2} />
+              </span>
+              <DialogTitle className="mt-3.5 text-[22px] font-bold leading-[1.15] tracking-[-0.01em] text-[#0b1220] dark:text-[#f4f7fb]">
+                Save this place
+              </DialogTitle>
+              <p
+                id={descriptionId}
+                className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
+              >
+                Tag where you are so One can personalise your experience. It stays
+                encrypted in your vault and is shared only when you approve
+                location access.
+              </p>
+            </header>
+
+            <div className="flex items-center gap-2.5 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+                <MapPin className="h-4 w-4" strokeWidth={2.4} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+                  Current location
+                </p>
+                {loadingAddress ? (
+                  <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Finding your
+                    address…
+                  </span>
+                ) : (
+                  <p className="mt-0.5 truncate text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
+                    {resolvedAddress || "Address unavailable"}
+                  </p>
+                )}
+              </div>
+              {canEditPlace && !loadingAddress ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingPlace(true);
+                    setPlaceQuery("");
+                    setPlaceSuggestions([]);
+                    setPlaceSearchError(null);
+                  }}
+                  disabled={interactionBusy}
+                  className="press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-white px-2.5 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] shadow-sm disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#9bc7f5]"
+                  aria-label="Change captured location"
+                >
+                  <Pencil className="h-3.5 w-3.5" aria-hidden />
+                  Change
+                </button>
+              ) : null}
+            </div>
+
+            {canPickOnMap && !loadingAddress ? (
+              <button
+                type="button"
+                onClick={() => setPickingOnMap(true)}
+                disabled={interactionBusy}
+                data-testid="save-location-adjust-on-map"
+                className="press-scale flex w-full items-center gap-3 rounded-2xl border border-dashed border-[color:var(--app-accent,#087ff5)]/40 bg-[color:var(--app-accent-tint,#e7f0fd)]/50 px-3.5 py-3 text-left transition-colors hover:bg-[color:var(--app-accent-tint,#e7f0fd)] disabled:opacity-45 dark:border-[color:var(--app-accent,#087ff5)]/30 dark:bg-[color:var(--app-accent,#087ff5)]/10"
+              >
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+                  <MapIcon className="h-4 w-4" strokeWidth={2.2} aria-hidden />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[14px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+                    Set exact location on map
+                  </span>
+                  <span className="block text-[12px] leading-[1.4] text-[#5b6472] dark:text-[#9aa6b6]">
+                    GPS can be off by a few meters — drag the pin to your door.
+                  </span>
+                </span>
+              </button>
+            ) : null}
+
+            {editingPlace ? (
+              <div className="space-y-2.5 [animation:saveLocFadeIn_.2s_ease-out_both]">
+                <label
+                  htmlFor="saved-location-place-search"
+                  className="block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  Search for another place
+                </label>
+                <div className="relative">
+                  <Search
+                    className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8b93a1]"
+                    aria-hidden
+                  />
+                  <input
+                    id="saved-location-place-search"
+                    type="search"
+                    value={placeQuery}
+                    onChange={(event) => setPlaceQuery(event.target.value)}
+                    disabled={interactionBusy}
+                    autoComplete="off"
+                    placeholder="Search address or place"
+                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white pl-10 pr-10 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  />
+                  {placeSearching || changingPlace ? (
+                    <Loader2
+                      className="absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-[#8b93a1]"
+                      aria-label="Searching places"
+                    />
+                  ) : null}
+                </div>
+
+                {placeSuggestions.length > 0 ? (
+                  <div
+                    className="max-h-40 overflow-y-auto rounded-2xl border border-black/[0.08] bg-white p-1 shadow-sm dark:border-white/[0.1] dark:bg-[#1b2230]"
+                    aria-label="Location suggestions"
+                  >
+                    {placeSuggestions.map((suggestion) => (
+                      <button
+                        key={suggestion.placeId}
+                        type="button"
+                        onClick={() => void handleSelectPlace(suggestion.placeId)}
+                        disabled={interactionBusy}
+                        className="flex min-h-11 w-full items-start gap-2 rounded-xl px-3 py-2.5 text-left text-[14px] font-medium text-[#273142] hover:bg-black/[0.04] disabled:opacity-45 dark:text-[#dce5f2] dark:hover:bg-white/[0.06]"
+                      >
+                        <MapPin
+                          className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--app-accent,#087ff5)]"
+                          aria-hidden
+                        />
+                        <span>{suggestion.text}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+
+                {placeSearchError ? (
+                  <p
+                    role="alert"
+                    className="text-[12px] font-medium text-[#b42318] dark:text-[#ff9b91]"
+                  >
+                    {placeSearchError}
+                  </p>
+                ) : null}
+
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingPlace(false);
+                    setPlaceQuery("");
+                    setPlaceSuggestions([]);
+                    setPlaceSearchError(null);
+                  }}
+                  disabled={interactionBusy}
+                  className="text-[13px] font-semibold text-[#5b6472] disabled:opacity-45 dark:text-[#9aa6b6]"
+                >
+                  Keep current location
+                </button>
+              </div>
+            ) : null}
+
+            <div>
+              <p className="mb-2 text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+                What kind of place is this?
+              </p>
+              <div className="grid grid-cols-3 gap-2.5">
+                {CATEGORY_OPTIONS.map(({ category: value, label, Icon }) => {
+                  const selected = category === value;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => setCategory(value)}
+                      disabled={interactionBusy}
+                      className={cn(
+                        "press-scale flex flex-col items-center justify-center gap-2 rounded-2xl border-2 px-2 py-4 transition-colors disabled:opacity-45",
+                        selected
+                          ? "border-[color:var(--app-accent,#087ff5)] bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent-deep,#0b62c4)] dark:bg-[color:var(--app-accent,#087ff5)]/15"
+                          : "border-black/[0.08] bg-white text-[#4b5563] hover:border-black/20 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-[#aeb8c7]",
+                      )}
+                    >
+                      <Icon className="h-6 w-6" strokeWidth={2.1} />
+                      <span className="text-[13px] font-bold">{label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {category === "other" ? (
+              <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
+                <label
+                  htmlFor="saved-location-custom-label"
+                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  Give it a name
+                </label>
+                <input
+                  id="saved-location-custom-label"
+                  type="text"
+                  value={customLabel}
+                  onChange={(event) => setCustomLabel(event.target.value)}
+                  disabled={interactionBusy}
+                  maxLength={40}
+                  placeholder="e.g. Gym, Mom's house, Cafe"
+                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                />
+              </div>
+            ) : null}
+
+            <div className="mt-1 flex flex-col gap-2.5">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSave}
+                aria-busy={saving || undefined}
+                className={cn(
+                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+                  "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+                )}
+              >
+                {saving ? (
+                  <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+                ) : (
+                  <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
+                )}
+                Save location
+              </button>
+              <button
+                type="button"
+                onClick={onSkip}
+                disabled={interactionBusy}
+                className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+              >
+                Skip for now
+              </button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -28,6 +28,9 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
+import { SavedLocationsSection } from "@/components/one-location/saved-locations-section";
+
+
 import {
   ChevronRight,
   Link as LinkIcon,
@@ -1016,9 +1019,16 @@ function PrivacyFlow({
         </span>
         <ChevronRight className="h-4 w-4 shrink-0 text-black/30 dark:text-muted-foreground" />
       </button>
+
+      {/* Saved places (Home / Work / Other) — encrypted in the vault, added
+          during onboarding and manageable here from Settings. */}
+      <div className="mt-7">
+        <SavedLocationsSection />
+      </div>
     </div>
   );
 }
+
 
 /* =================================================================== */
 /* PEOPLE HUB                                                           */

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -1,0 +1,599 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Briefcase,
+  Home,
+  Loader2,
+  MapPin,
+  Plus,
+  RefreshCw,
+  ShieldCheck,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
+import { useAuth } from "@/lib/firebase/auth-context";
+import {
+  addSavedLocation,
+  duplicateSavedLocationMessage,
+  DuplicateSavedLocationError,
+  findDuplicateSavedLocation,
+  loadSavedLocations,
+  removeSavedLocation,
+  sortSavedLocationsForDisplay,
+  type SavedLocation,
+  type SavedLocationCategory,
+  updateSavedLocationAddress,
+} from "@/lib/one-location/saved-locations";
+import { readOneLocationControlState } from "@/lib/one-location/location-control-state";
+import { OneLocationService } from "@/lib/one-location/service";
+import type { PlainLocationPoint } from "@/lib/one-location/types";
+import { useOneLocationControlState } from "@/lib/one-location/use-location-control-state";
+import { cn } from "@/lib/utils";
+import { useVault } from "@/lib/vault/vault-context";
+
+function CategoryIcon({ category }: { category: SavedLocationCategory }) {
+  const Icon =
+    category === "home" ? Home : category === "work" ? Briefcase : MapPin;
+  const tone =
+    category === "home"
+      ? "bg-[#e7f0fd] text-[#087ff5] dark:bg-[#087ff5]/15"
+      : category === "work"
+        ? "bg-[#eef1f5] text-[#5b6472] dark:bg-white/10 dark:text-white/70"
+        : "bg-[#e5f4ea] text-[#2ea44f] dark:bg-emerald-400/15";
+  return (
+    <span
+      className={cn(
+        "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+        tone,
+      )}
+      aria-hidden="true"
+    >
+      <Icon className="h-5 w-5" strokeWidth={2.1} />
+    </span>
+  );
+}
+
+export function SavedLocationsSection() {
+  const { user } = useAuth();
+  const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
+  const userId = user?.uid ?? null;
+  const locationControl = useOneLocationControlState(userId);
+  const [locations, setLocations] = useState<SavedLocation[]>([]);
+  const [loadedUserId, setLoadedUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [repairingId, setRepairingId] = useState<string | null>(null);
+  const [capturing, setCapturing] = useState(false);
+  const [saveLocationModalOpen, setSaveLocationModalOpen] = useState(false);
+  const [saveLocationPoint, setSaveLocationPoint] =
+    useState<PlainLocationPoint | null>(null);
+  const [saveLocationAddress, setSaveLocationAddress] = useState<string | null>(
+    null,
+  );
+  const [saveLocationAddressLoading, setSaveLocationAddressLoading] =
+    useState(false);
+  const [saveLocationSaving, setSaveLocationSaving] = useState(false);
+  const vaultSessionRef = useRef({ userId, vaultKey, vaultOwnerToken });
+  const captureRequestIdRef = useRef(0);
+  vaultSessionRef.current = { userId, vaultKey, vaultOwnerToken };
+
+  const hasVaultAccess = Boolean(
+    isVaultUnlocked && vaultKey && vaultOwnerToken,
+  );
+  const isCurrentVaultSession = useCallback(
+    (session: {
+      userId: string | null;
+      vaultKey: string | null;
+      vaultOwnerToken: string | null;
+    }) => {
+      const current = vaultSessionRef.current;
+      return (
+        current.userId === session.userId &&
+        current.vaultKey === session.vaultKey &&
+        current.vaultOwnerToken === session.vaultOwnerToken
+      );
+    },
+    [],
+  );
+
+  const reload = useCallback(async () => {
+    if (!userId) {
+      setLocations([]);
+      setLoadedUserId(null);
+      setLoadError(null);
+      return;
+    }
+    if (!vaultKey || !vaultOwnerToken) {
+      setLocations([]);
+      setLoadedUserId(userId);
+      setLoadError(null);
+      return;
+    }
+
+    setLoading(true);
+    setLoadError(null);
+    const session = { userId, vaultKey, vaultOwnerToken };
+    try {
+      const list = await loadSavedLocations({
+        userId,
+        vaultKey,
+        vaultOwnerToken,
+      });
+      if (!isCurrentVaultSession(session)) return;
+      setLocations(sortSavedLocationsForDisplay(list));
+    } catch {
+      if (!isCurrentVaultSession(session)) return;
+      setLocations([]);
+      setLoadError("Saved locations could not be loaded. Try again.");
+    } finally {
+      if (isCurrentVaultSession(session)) {
+        setLoadedUserId(userId);
+        setLoading(false);
+      }
+    }
+  }, [isCurrentVaultSession, userId, vaultKey, vaultOwnerToken]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    if (hasVaultAccess) return;
+    captureRequestIdRef.current += 1;
+    setLocations([]);
+    setSaveLocationModalOpen(false);
+    setSaveLocationPoint(null);
+    setSaveLocationAddress(null);
+    setSaveLocationAddressLoading(false);
+    setSaveLocationSaving(false);
+    setCapturing(false);
+    setRemovingId(null);
+    setRepairingId(null);
+    setLoading(false);
+  }, [hasVaultAccess]);
+
+  useEffect(() => {
+    if (!locationControl.paused) return;
+    captureRequestIdRef.current += 1;
+    setCapturing(false);
+    setSaveLocationModalOpen(false);
+    setSaveLocationPoint(null);
+    setSaveLocationAddress(null);
+    setSaveLocationAddressLoading(false);
+  }, [locationControl.paused]);
+
+  const handleAdd = useCallback(async () => {
+    if (!userId || !vaultKey || !vaultOwnerToken || capturing) {
+      if (!hasVaultAccess) {
+        toast.error("Unlock your vault before adding a saved location.");
+      }
+      return;
+    }
+    if (readOneLocationControlState(userId).paused) {
+      toast.error("Resume Location before adding a saved place.");
+      return;
+    }
+
+    setCapturing(true);
+    const captureRequestId = captureRequestIdRef.current + 1;
+    captureRequestIdRef.current = captureRequestId;
+    const session = { userId, vaultKey, vaultOwnerToken };
+    try {
+      const point = await OneLocationService.captureCurrentPosition();
+      if (
+        captureRequestIdRef.current !== captureRequestId ||
+        !isCurrentVaultSession(session) ||
+        readOneLocationControlState(userId).paused
+      ) {
+        return;
+      }
+      setSaveLocationPoint(point);
+      setSaveLocationAddress(null);
+      setSaveLocationAddressLoading(true);
+      setSaveLocationModalOpen(true);
+
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken,
+          lat: point.latitude,
+          lng: point.longitude,
+        });
+        if (
+          captureRequestIdRef.current !== captureRequestId ||
+          !isCurrentVaultSession(session) ||
+          readOneLocationControlState(userId).paused
+        ) {
+          return;
+        }
+        setSaveLocationAddress(
+          (place.formattedAddress || place.name || "").trim() || null,
+        );
+      } catch {
+        if (
+          captureRequestIdRef.current !== captureRequestId ||
+          !isCurrentVaultSession(session)
+        ) {
+          return;
+        }
+        setSaveLocationAddress(null);
+      } finally {
+        if (
+          captureRequestIdRef.current === captureRequestId &&
+          isCurrentVaultSession(session)
+        ) {
+          setSaveLocationAddressLoading(false);
+        }
+      }
+    } catch {
+      if (
+        captureRequestIdRef.current !== captureRequestId ||
+        !isCurrentVaultSession(session)
+      ) {
+        return;
+      }
+      toast.error(
+        "We could not read your current location. Check location permission and try again.",
+      );
+    } finally {
+      if (
+        captureRequestIdRef.current === captureRequestId &&
+        isCurrentVaultSession(session)
+      ) {
+        setCapturing(false);
+      }
+    }
+  }, [
+    capturing,
+    hasVaultAccess,
+    isCurrentVaultSession,
+    userId,
+    vaultKey,
+    vaultOwnerToken,
+  ]);
+
+  const handleSave = useCallback(
+    async (category: SavedLocationCategory, label: string) => {
+      if (
+        !userId ||
+        !vaultKey ||
+        !vaultOwnerToken ||
+        !saveLocationPoint
+      ) {
+        toast.error("Unlock your vault and capture the location again.");
+        return;
+      }
+
+      const duplicate = findDuplicateSavedLocation(
+        locations,
+        saveLocationPoint,
+      );
+      if (duplicate) {
+        toast.error(duplicateSavedLocationMessage(duplicate));
+        return;
+      }
+
+      setSaveLocationSaving(true);
+      const session = { userId, vaultKey, vaultOwnerToken };
+      try {
+        const next = await addSavedLocation({
+          context: { userId, vaultKey, vaultOwnerToken },
+          input: {
+            category,
+            label,
+            latitude: saveLocationPoint.latitude,
+            longitude: saveLocationPoint.longitude,
+            address: saveLocationAddress,
+          },
+        });
+        if (!isCurrentVaultSession(session)) return;
+        setLocations(sortSavedLocationsForDisplay(next));
+        setSaveLocationModalOpen(false);
+        setSaveLocationPoint(null);
+        toast.success("Location saved securely.");
+      } catch (error) {
+        if (!isCurrentVaultSession(session)) return;
+        toast.error(
+          error instanceof DuplicateSavedLocationError
+            ? error.message
+            : "Could not save this location. Please try again.",
+        );
+      } finally {
+        if (isCurrentVaultSession(session)) {
+          setSaveLocationSaving(false);
+        }
+      }
+    },
+    [
+      saveLocationAddress,
+      saveLocationPoint,
+      locations,
+      isCurrentVaultSession,
+      userId,
+      vaultKey,
+      vaultOwnerToken,
+    ],
+  );
+
+  const handleRemove = useCallback(
+    async (id: string) => {
+      if (!userId || !vaultKey || !vaultOwnerToken || removingId) return;
+      setRemovingId(id);
+      const session = { userId, vaultKey, vaultOwnerToken };
+      try {
+        const next = await removeSavedLocation({
+          context: { userId, vaultKey, vaultOwnerToken },
+          id,
+        });
+        if (!isCurrentVaultSession(session)) return;
+        setLocations(sortSavedLocationsForDisplay(next));
+        toast.success("Saved location removed.");
+      } catch {
+        if (!isCurrentVaultSession(session)) return;
+        toast.error("Could not remove this location. Please try again.");
+      } finally {
+        if (isCurrentVaultSession(session)) {
+          setRemovingId(null);
+        }
+      }
+    },
+    [
+      isCurrentVaultSession,
+      removingId,
+      userId,
+      vaultKey,
+      vaultOwnerToken,
+    ],
+  );
+
+  const handleRepairAddress = useCallback(
+    async (location: SavedLocation) => {
+      if (!userId || !vaultKey || !vaultOwnerToken || repairingId) return;
+      setRepairingId(location.id);
+      const session = { userId, vaultKey, vaultOwnerToken };
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken,
+          lat: location.latitude,
+          lng: location.longitude,
+        });
+        if (!isCurrentVaultSession(session)) return;
+        const address = (
+          place.formattedAddress ||
+          place.name ||
+          ""
+        ).trim();
+        if (!address) {
+          toast.error("No street address was found for this location.");
+          return;
+        }
+        const next = await updateSavedLocationAddress({
+          context: { userId, vaultKey, vaultOwnerToken },
+          id: location.id,
+          address,
+        });
+        if (!isCurrentVaultSession(session)) return;
+        setLocations(sortSavedLocationsForDisplay(next));
+        toast.success("Address updated.");
+      } catch {
+        if (!isCurrentVaultSession(session)) return;
+        toast.error("Could not find the address. Please try again.");
+      } finally {
+        if (isCurrentVaultSession(session)) {
+          setRepairingId(null);
+        }
+      }
+    },
+    [
+      isCurrentVaultSession,
+      repairingId,
+      userId,
+      vaultKey,
+      vaultOwnerToken,
+    ],
+  );
+
+  if (!userId || loadedUserId !== userId) return null;
+
+  return (
+    <>
+      <section
+        aria-label="Saved Locations"
+        className="w-full min-w-0"
+        data-testid="settings-saved-locations"
+      >
+        <div className="mb-2.5 flex items-center justify-between gap-3 px-1">
+          <p className="text-[12px] font-bold uppercase tracking-[0.6px] text-black/40 dark:text-muted-foreground">
+            Saved Locations
+          </p>
+          <button
+            type="button"
+            onClick={() => void handleAdd()}
+            disabled={!hasVaultAccess || locationControl.paused || capturing}
+            className="press-scale inline-flex h-8 items-center gap-1.5 rounded-full bg-[color:var(--app-accent-tint,#e7f0fd)] px-3 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] transition-opacity disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            {capturing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            ) : (
+              <Plus className="h-3.5 w-3.5" aria-hidden />
+            )}
+            Add place
+          </button>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl bg-white shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:bg-[color:var(--app-card-surface-default-solid)]">
+          {!hasVaultAccess ? (
+            <div className="flex items-center gap-3.5 p-4">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#eef1f5] text-[#8b93a1] dark:bg-white/10">
+                <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-[15px] font-semibold text-[#1c1c2e] dark:text-foreground">
+                  Unlock your vault to view saved places
+                </p>
+                <p className="mt-0.5 text-[13px] leading-[1.4] text-black/50 dark:text-muted-foreground">
+                  Exact locations stay encrypted and are available only while
+                  your vault is unlocked.
+                </p>
+              </div>
+            </div>
+          ) : loading ? (
+            <div
+              className="flex items-center gap-3 p-4 text-[13px] text-black/50 dark:text-muted-foreground"
+              role="status"
+            >
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Loading saved places…
+            </div>
+          ) : loadError ? (
+            <div className="flex items-center justify-between gap-3 p-4">
+              <p className="text-[13px] text-[#b42318] dark:text-red-300">
+                {loadError}
+              </p>
+              <button
+                type="button"
+                onClick={() => void reload()}
+                className="rounded-full px-3 py-1.5 text-[12px] font-bold text-[color:var(--app-accent,#087ff5)]"
+              >
+                Retry
+              </button>
+            </div>
+          ) : locations.length === 0 ? (
+            <div className="flex items-center gap-3.5 p-4">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#eef1f5] text-[#8b93a1] dark:bg-white/10">
+                <MapPin className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-[15px] font-semibold text-[#1c1c2e] dark:text-foreground">
+                  No saved places yet
+                </p>
+                <p className="mt-0.5 text-[13px] leading-[1.4] text-black/50 dark:text-muted-foreground">
+                  Add Home, Work, or another place to see it here.
+                </p>
+              </div>
+            </div>
+          ) : (
+            locations.map((location, index) => (
+              <div
+                key={location.id}
+                className={cn(
+                  "flex items-center gap-3.5 p-4",
+                  index > 0 &&
+                    "border-t border-black/[0.06] dark:border-white/10",
+                )}
+              >
+                <CategoryIcon category={location.category} />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[15px] font-semibold text-[#1c1c2e] dark:text-foreground">
+                    {location.label}
+                  </p>
+                  <p className="mt-0.5 truncate text-[13px] text-black/50 dark:text-muted-foreground">
+                    {location.address || "Address unavailable"}
+                  </p>
+                </div>
+                {!location.address ? (
+                  <button
+                    type="button"
+                    aria-label={`Find address for ${location.label}`}
+                    title="Find address"
+                    onClick={() => void handleRepairAddress(location)}
+                    disabled={repairingId !== null}
+                    className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-black/[0.05] hover:text-[#087ff5] disabled:opacity-45 dark:text-muted-foreground"
+                  >
+                    <RefreshCw
+                      className={cn(
+                        "h-[17px] w-[17px]",
+                        repairingId === location.id && "animate-spin",
+                      )}
+                      strokeWidth={2}
+                    />
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  aria-label={`Remove ${location.label}`}
+                  onClick={() => void handleRemove(location.id)}
+                  disabled={removingId !== null}
+                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-[#ff3b30]/10 hover:text-[#ff3b30] disabled:opacity-45 dark:text-muted-foreground"
+                >
+                  {removingId === location.id ? (
+                    <Loader2 className="h-[18px] w-[18px] animate-spin" />
+                  ) : (
+                    <Trash2
+                      className="h-[18px] w-[18px]"
+                      strokeWidth={2}
+                    />
+                  )}
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+        {hasVaultAccess ? (
+          <p className="mt-2 px-1 text-[11px] leading-[1.45] text-black/40 dark:text-muted-foreground">
+            {locationControl.paused
+              ? "Resume Location before capturing another saved place."
+              : "Saved places are encrypted in your vault and shared only when you explicitly approve location access."}
+          </p>
+        ) : null}
+      </section>
+
+      <SaveLocationModal
+        open={saveLocationModalOpen}
+        address={saveLocationAddress}
+        loadingAddress={saveLocationAddressLoading}
+        saving={saveLocationSaving}
+        mapInitial={
+          saveLocationPoint
+            ? {
+                latitude: saveLocationPoint.latitude,
+                longitude: saveLocationPoint.longitude,
+              }
+            : null
+        }
+        reverseGeocode={async (lat, lng) => {
+          if (!vaultOwnerToken) return null;
+          try {
+            const place = await OneLocationService.reverseGeocode({
+              vaultOwnerToken,
+              lat,
+              lng,
+            });
+            return (place.formattedAddress || place.name || "").trim() || null;
+          } catch {
+            return null;
+          }
+        }}
+        onLocateMe={async () => {
+          try {
+            const point = await OneLocationService.captureCurrentPosition();
+            return { latitude: point.latitude, longitude: point.longitude };
+          } catch {
+            return null;
+          }
+        }}
+        onPickExactLocation={(picked) => {
+          setSaveLocationPoint((current) => ({
+            latitude: picked.latitude,
+            longitude: picked.longitude,
+            accuracyM: null,
+            capturedAt: new Date().toISOString(),
+            sourcePlatform: current?.sourcePlatform ?? "web",
+          }));
+          setSaveLocationAddress(picked.address);
+          setSaveLocationAddressLoading(false);
+        }}
+        onSave={(category, label) => void handleSave(category, label)}
+        onSkip={() => {
+          if (saveLocationSaving) return;
+          setSaveLocationModalOpen(false);
+          setSaveLocationPoint(null);
+        }}
+      />
+
+    </>
+  );
+}

--- a/hushh-webapp/lib/one-location/location-control-state.ts
+++ b/hushh-webapp/lib/one-location/location-control-state.ts
@@ -1,0 +1,182 @@
+/**
+ * Non-coordinate state shared by every One Location control surface.
+ *
+ * Pause and Auto-share are non-sensitive, user-scoped device preferences. The
+ * live activity flags are runtime-only mirrors of independent authorities:
+ * self preview, private grants, and Nearby Check-In presence. No preference
+ * creates consent; Nearby and private-share authority remain explicit.
+ */
+export type OneLocationControlState = {
+  autoShareEnabled: boolean;
+  paused: boolean;
+  selfPreviewEnabled: boolean;
+  nearbyPresenceActive: boolean;
+  nearbyCheckedInAt: string | null;
+};
+
+const PAUSED_PREFERENCE_PREFIX = "one_location_updates_paused_v1:";
+const AUTO_SHARE_PREFERENCE_PREFIX = "one_location_auto_share_v1:";
+const EMPTY_STATE: OneLocationControlState = {
+  autoShareEnabled: true,
+  paused: false,
+  selfPreviewEnabled: false,
+  nearbyPresenceActive: false,
+  nearbyCheckedInAt: null,
+};
+
+const runtimeByUser = new Map<string, OneLocationControlState>();
+const listenersByUser = new Map<
+  string,
+  Set<(state: OneLocationControlState) => void>
+>();
+
+function cloneState(state: OneLocationControlState): OneLocationControlState {
+  return { ...state };
+}
+
+function pausedPreferenceKey(userId: string): string {
+  return `${PAUSED_PREFERENCE_PREFIX}${userId}`;
+}
+
+function autoSharePreferenceKey(userId: string): string {
+  return `${AUTO_SHARE_PREFERENCE_PREFIX}${userId}`;
+}
+
+function readPausedPreference(userId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(pausedPreferenceKey(userId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writePausedPreference(userId: string, paused: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (paused) {
+      window.localStorage.setItem(pausedPreferenceKey(userId), "1");
+    } else {
+      window.localStorage.removeItem(pausedPreferenceKey(userId));
+    }
+  } catch {
+    // A blocked localStorage write only reduces cross-reload continuity. The
+    // current in-memory pause still applies for this session.
+  }
+}
+
+function readAutoSharePreference(userId: string): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(autoSharePreferenceKey(userId)) !== "0";
+  } catch {
+    return true;
+  }
+}
+
+function writeAutoSharePreference(userId: string, enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled) {
+      window.localStorage.removeItem(autoSharePreferenceKey(userId));
+    } else {
+      window.localStorage.setItem(autoSharePreferenceKey(userId), "0");
+    }
+  } catch {
+    // The current in-memory preference remains authoritative for this session.
+  }
+}
+
+export function readOneLocationControlState(
+  userId: string | null | undefined,
+): OneLocationControlState {
+  if (!userId) return cloneState(EMPTY_STATE);
+  const runtime = runtimeByUser.get(userId);
+  if (runtime) return cloneState(runtime);
+  return {
+    ...EMPTY_STATE,
+    autoShareEnabled: readAutoSharePreference(userId),
+    paused: readPausedPreference(userId),
+  };
+}
+
+export function updateOneLocationControlState(
+  userId: string | null | undefined,
+  updater: (current: OneLocationControlState) => OneLocationControlState,
+): OneLocationControlState {
+  if (!userId) return cloneState(EMPTY_STATE);
+  const current = readOneLocationControlState(userId);
+  const updated = updater(current);
+  const paused = Boolean(updated.paused);
+  const nearbyPresenceActive = !paused && Boolean(updated.nearbyPresenceActive);
+  const next: OneLocationControlState = {
+    autoShareEnabled: Boolean(updated.autoShareEnabled),
+    paused,
+    selfPreviewEnabled: !paused && Boolean(updated.selfPreviewEnabled),
+    nearbyPresenceActive,
+    nearbyCheckedInAt: nearbyPresenceActive ? updated.nearbyCheckedInAt : null,
+  };
+  runtimeByUser.set(userId, next);
+  writeAutoSharePreference(userId, next.autoShareEnabled);
+  writePausedPreference(userId, next.paused);
+  for (const listener of listenersByUser.get(userId) ?? []) {
+    listener(cloneState(next));
+  }
+  return cloneState(next);
+}
+
+export function subscribeOneLocationControlState(
+  userId: string,
+  listener: (state: OneLocationControlState) => void,
+): () => void {
+  const listeners =
+    listenersByUser.get(userId) ??
+    new Set<(state: OneLocationControlState) => void>();
+  listeners.add(listener);
+  listenersByUser.set(userId, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) listenersByUser.delete(userId);
+  };
+}
+
+/** Clear volatile activity mirrors while retaining user preferences. */
+export function clearOneLocationControlRuntime(
+  userId: string | null | undefined,
+): void {
+  if (!userId) return;
+  runtimeByUser.delete(userId);
+  const next = readOneLocationControlState(userId);
+  for (const listener of listenersByUser.get(userId) ?? []) {
+    listener(cloneState(next));
+  }
+}
+
+export function clearAllOneLocationControlRuntime(): void {
+  const userIds = Array.from(runtimeByUser.keys());
+  runtimeByUser.clear();
+  for (const userId of userIds) {
+    const next = readOneLocationControlState(userId);
+    for (const listener of listenersByUser.get(userId) ?? []) {
+      listener(cloneState(next));
+    }
+  }
+}
+
+export function forgetOneLocationControlPreference(
+  userId: string | null | undefined,
+): void {
+  if (!userId) return;
+  runtimeByUser.delete(userId);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.removeItem(pausedPreferenceKey(userId));
+      window.localStorage.removeItem(autoSharePreferenceKey(userId));
+    } catch {
+      // Best-effort account-deletion cleanup for restricted browser storage.
+    }
+  }
+  for (const listener of listenersByUser.get(userId) ?? []) {
+    listener(cloneState(EMPTY_STATE));
+  }
+}

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -1,0 +1,380 @@
+"use client";
+
+import { PkmDomainResourceService } from "@/lib/pkm/pkm-domain-resource";
+import { buildPersonalKnowledgeModelStructureArtifacts } from "@/lib/personal-knowledge-model/manifest";
+import { PkmWriteCoordinator } from "@/lib/services/pkm-write-coordinator";
+import { haversineMeters } from "@/lib/one-location/marker-interpolation";
+
+export const LOCATION_PKM_DOMAIN = "location";
+
+const SAVED_PLACES_KEY = "saved_places";
+const SAVED_PLACES_SCHEMA_VERSION = 1;
+const MAX_LABEL_LENGTH = 40;
+const MAX_ADDRESS_LENGTH = 300;
+export const SAVED_LOCATION_DUPLICATE_RADIUS_METERS = 25;
+
+export type SavedLocationCategory = "home" | "work" | "other";
+
+const SAVED_LOCATION_CATEGORY_PRIORITY: Record<SavedLocationCategory, number> = {
+  home: 0,
+  work: 1,
+  other: 2,
+};
+
+export type SavedLocation = {
+  id: string;
+  category: SavedLocationCategory;
+  label: string;
+  latitude: number;
+  longitude: number;
+  address?: string | null;
+  savedAt: string;
+};
+
+export type SavedLocationVaultContext = {
+  userId: string;
+  vaultKey: string | null;
+  vaultOwnerToken: string | null;
+};
+
+export class DuplicateSavedLocationError extends Error {
+  readonly code = "duplicate_saved_location";
+  readonly existingCategory: SavedLocationCategory;
+  readonly existingLabel: string;
+
+  constructor(existingLocation: SavedLocation) {
+    super(duplicateSavedLocationMessage(existingLocation));
+    this.name = "DuplicateSavedLocationError";
+    this.existingCategory = existingLocation.category;
+    this.existingLabel = duplicateLocationLabel(existingLocation);
+  }
+}
+
+type SavedPlacesEnvelope = {
+  schema_version: number;
+  locations: SavedLocation[];
+  updated_at: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function isValidLocation(value: unknown): value is SavedLocation {
+  if (!value || typeof value !== "object") return false;
+  const location = value as Record<string, unknown>;
+  return (
+    typeof location.id === "string" &&
+    location.id.length > 0 &&
+    (location.category === "home" ||
+      location.category === "work" ||
+      location.category === "other") &&
+    typeof location.label === "string" &&
+    location.label.length > 0 &&
+    typeof location.latitude === "number" &&
+    Number.isFinite(location.latitude) &&
+    location.latitude >= -90 &&
+    location.latitude <= 90 &&
+    typeof location.longitude === "number" &&
+    Number.isFinite(location.longitude) &&
+    location.longitude >= -180 &&
+    location.longitude <= 180 &&
+    (location.address === undefined ||
+      location.address === null ||
+      typeof location.address === "string") &&
+    typeof location.savedAt === "string" &&
+    Number.isFinite(Date.parse(location.savedAt))
+  );
+}
+
+function locationsFromDomain(
+  domainData: Record<string, unknown> | null | undefined,
+): SavedLocation[] {
+  const savedPlaces = asRecord(domainData?.[SAVED_PLACES_KEY]);
+  const locations = savedPlaces.locations;
+  if (!Array.isArray(locations)) return [];
+  return locations.filter(isValidLocation);
+}
+
+function requireUnlockedVault(
+  context: SavedLocationVaultContext,
+): asserts context is SavedLocationVaultContext & {
+  vaultKey: string;
+  vaultOwnerToken: string;
+} {
+  if (!context.userId || !context.vaultKey || !context.vaultOwnerToken) {
+    throw new Error("Unlock your vault before managing saved locations.");
+  }
+}
+
+function cleanText(
+  value: string | null | undefined,
+  maxLength: number,
+): string | null {
+  const cleaned = String(value || "").trim().slice(0, maxLength);
+  return cleaned || null;
+}
+
+function generateId(category: SavedLocationCategory): string {
+  if (category === "home" || category === "work") return category;
+  const randomId = globalThis.crypto?.randomUUID?.();
+  if (randomId) return `other-${randomId}`;
+  return `other-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function savedPlacesEnvelope(
+  locations: SavedLocation[],
+  updatedAt: string,
+): SavedPlacesEnvelope {
+  return {
+    schema_version: SAVED_PLACES_SCHEMA_VERSION,
+    locations,
+    updated_at: updatedAt,
+  };
+}
+
+async function mutateSavedLocations(params: {
+  context: SavedLocationVaultContext;
+  source: string;
+  mutate: (locations: SavedLocation[]) => SavedLocation[];
+}): Promise<SavedLocation[]> {
+  requireUnlockedVault(params.context);
+  let persistedLocations: SavedLocation[] = [];
+
+  const result = await PkmWriteCoordinator.saveMergedDomain({
+    userId: params.context.userId,
+    domain: LOCATION_PKM_DOMAIN,
+    vaultKey: params.context.vaultKey,
+    vaultOwnerToken: params.context.vaultOwnerToken,
+    confirmation: {
+      confirmedByUser: true,
+      surface: "web",
+      source: params.source,
+    },
+    build: (writeContext) => {
+      const updatedAt = new Date().toISOString();
+      persistedLocations = params.mutate(
+        locationsFromDomain(writeContext.currentDomainData),
+      );
+      const domainData = {
+        ...writeContext.currentDomainData,
+        [SAVED_PLACES_KEY]: savedPlacesEnvelope(
+          persistedLocations,
+          updatedAt,
+        ),
+      };
+      const { manifest } = buildPersonalKnowledgeModelStructureArtifacts({
+        domain: LOCATION_PKM_DOMAIN,
+        domainData,
+        previousManifest: writeContext.currentManifest,
+      });
+      return {
+        domainData,
+        manifest,
+        scopePath: SAVED_PLACES_KEY,
+        // Exact places remain inside encrypted PKM. The readable projection
+        // contains only non-sensitive inventory metadata.
+        summary: {
+          saved_places_configured: persistedLocations.length > 0,
+          saved_places_count: persistedLocations.length,
+        },
+      };
+    },
+  });
+
+  if (!result.success) {
+    throw new Error(result.message || "Could not save locations to your vault.");
+  }
+  return persistedLocations;
+}
+
+/** Default display label for a category. */
+export function defaultLabelForCategory(
+  category: SavedLocationCategory,
+): string {
+  if (category === "home") return "Home";
+  if (category === "work") return "Work";
+  return "Other";
+}
+
+function duplicateLocationLabel(location: SavedLocation): string {
+  if (location.category !== "other") {
+    return defaultLabelForCategory(location.category);
+  }
+  const label = cleanText(location.label, MAX_LABEL_LENGTH);
+  return label && label.toLowerCase() !== "other"
+    ? `${label} (Other)`
+    : "Other";
+}
+
+export function duplicateSavedLocationMessage(location: SavedLocation): string {
+  return `This place is already saved as ${duplicateLocationLabel(location)}. Choose a different place or remove it first.`;
+}
+
+/** Find the preferred saved point representing the same physical place. */
+export function findDuplicateSavedLocation(
+  existing: SavedLocation[],
+  candidate: Pick<SavedLocation, "latitude" | "longitude">,
+): SavedLocation | null {
+  return (
+    existing
+      .filter(
+        (location) =>
+          haversineMeters(
+            { lat: location.latitude, lng: location.longitude },
+            { lat: candidate.latitude, lng: candidate.longitude },
+          ) <= SAVED_LOCATION_DUPLICATE_RADIUS_METERS,
+      )
+      .sort((left, right) => {
+        const categoryOrder =
+          SAVED_LOCATION_CATEGORY_PRIORITY[left.category] -
+          SAVED_LOCATION_CATEGORY_PRIORITY[right.category];
+        if (categoryOrder !== 0) return categoryOrder;
+        const labelOrder = left.label.localeCompare(right.label);
+        return labelOrder !== 0 ? labelOrder : left.id.localeCompare(right.id);
+      })[0] ?? null
+  );
+}
+
+/** Read saved places from the encrypted Location PKM domain. */
+export async function loadSavedLocations(
+  context: SavedLocationVaultContext,
+): Promise<SavedLocation[]> {
+  requireUnlockedVault(context);
+  const resourceParams = {
+    userId: context.userId,
+    domain: LOCATION_PKM_DOMAIN,
+    vaultKey: context.vaultKey,
+    vaultOwnerToken: context.vaultOwnerToken,
+  };
+  const snapshot = await PkmDomainResourceService.getStaleFirst({
+    ...resourceParams,
+    backgroundRefresh: false,
+  });
+  if (!snapshot || snapshot.audit.source === "network") {
+    return locationsFromDomain(snapshot?.data);
+  }
+
+  // Prefer fresh cross-device truth, but retain the encrypted device snapshot
+  // when the user is offline.
+  const refreshed = await PkmDomainResourceService.refresh(
+    resourceParams,
+  ).catch(() => null);
+  return locationsFromDomain(refreshed?.data ?? snapshot.data);
+}
+
+/**
+ * Add or replace a saved place in encrypted PKM. Home and Work are singletons,
+ * and one physical place can exist under only one category.
+ */
+export async function addSavedLocation(params: {
+  context: SavedLocationVaultContext;
+  input: {
+    category: SavedLocationCategory;
+    label?: string | null;
+    latitude: number;
+    longitude: number;
+    address?: string | null;
+  };
+}): Promise<SavedLocation[]> {
+  const { input } = params;
+  if (
+    !Number.isFinite(input.latitude) ||
+    input.latitude < -90 ||
+    input.latitude > 90 ||
+    !Number.isFinite(input.longitude) ||
+    input.longitude < -180 ||
+    input.longitude > 180
+  ) {
+    throw new Error("The captured location is invalid. Try again.");
+  }
+
+  const label =
+    cleanText(input.label, MAX_LABEL_LENGTH) ||
+    defaultLabelForCategory(input.category);
+  const entry: SavedLocation = {
+    id: generateId(input.category),
+    category: input.category,
+    label,
+    latitude: input.latitude,
+    longitude: input.longitude,
+    address: cleanText(input.address, MAX_ADDRESS_LENGTH),
+    savedAt: new Date().toISOString(),
+  };
+
+  let duplicateLocation: SavedLocation | null = null;
+
+  const locations = await mutateSavedLocations({
+    context: params.context,
+    source: "one_location_saved_place_confirm",
+    mutate: (existing) => {
+      const duplicate = findDuplicateSavedLocation(existing, entry);
+      duplicateLocation = duplicate;
+      if (duplicate) {
+        return existing;
+      }
+      if (input.category === "home" || input.category === "work") {
+        return [
+          entry,
+          ...existing.filter(
+            (location) => location.category !== input.category,
+          ),
+        ];
+      }
+      return [...existing, entry];
+    },
+  });
+  if (duplicateLocation) {
+    throw new DuplicateSavedLocationError(duplicateLocation);
+  }
+  return locations;
+}
+
+/** Remove a saved place from encrypted PKM. */
+export async function removeSavedLocation(params: {
+  context: SavedLocationVaultContext;
+  id: string;
+}): Promise<SavedLocation[]> {
+  return mutateSavedLocations({
+    context: params.context,
+    source: "one_location_saved_place_remove_confirm",
+    mutate: (existing) =>
+      existing.filter((location) => location.id !== params.id),
+  });
+}
+
+/** Fill or replace a friendly address without changing the saved point. */
+export async function updateSavedLocationAddress(params: {
+  context: SavedLocationVaultContext;
+  id: string;
+  address: string;
+}): Promise<SavedLocation[]> {
+  const address = cleanText(params.address, MAX_ADDRESS_LENGTH);
+  if (!params.id || !address) return loadSavedLocations(params.context);
+  return mutateSavedLocations({
+    context: params.context,
+    source: "one_location_saved_place_address_repair",
+    mutate: (existing) =>
+      existing.map((location) =>
+        location.id === params.id ? { ...location, address } : location,
+      ),
+  });
+}
+
+/** Order for display: Home first, then Work, then Others by most recent. */
+export function sortSavedLocationsForDisplay(
+  locations: SavedLocation[],
+): SavedLocation[] {
+  const weight = (category: SavedLocationCategory): number => {
+    if (category === "home") return 0;
+    if (category === "work") return 1;
+    return 2;
+  };
+  return [...locations].sort((a, b) => {
+    const byCategory = weight(a.category) - weight(b.category);
+    if (byCategory !== 0) return byCategory;
+    return (b.savedAt || "").localeCompare(a.savedAt || "");
+  });
+}

--- a/hushh-webapp/lib/one-location/use-location-control-state.ts
+++ b/hushh-webapp/lib/one-location/use-location-control-state.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  readOneLocationControlState,
+  subscribeOneLocationControlState,
+  type OneLocationControlState,
+} from "@/lib/one-location/location-control-state";
+
+export function useOneLocationControlState(
+  userId: string | null | undefined,
+): OneLocationControlState {
+  const [state, setState] = useState<OneLocationControlState>(() =>
+    readOneLocationControlState(userId),
+  );
+
+  useEffect(() => {
+    setState(readOneLocationControlState(userId));
+    if (!userId) return;
+    return subscribeOneLocationControlState(userId, setState);
+  }, [userId]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary

Restores the **Home / Work / Other "Save this place"** step in Location onboarding (it existed on `main` but was missing from `codex/location-onboarding-pixel-match`) and makes it appear **every time** the onboarding screen shows, plus adds an **Uber/Zomato-style drag-to-pin map picker** so users can set their exact home instead of trusting a coarse GPS fix.

## Task 1 — Save-place modal always triggers + editable in Settings

- Restored the feature files that were absent from this branch:
  - `components/one-location/onboarding/save-location-modal.tsx` — Home / Work / Other modal (+ custom label for "Other")
  - `lib/one-location/saved-locations.ts` — encrypted PKM store (Home/Work singletons, 25m de-dupe)
  - `components/one-location/saved-locations-section.tsx` — Settings list to view / add / edit / remove
  - `lib/one-location/location-control-state.ts`, `lib/one-location/use-location-control-state.ts` — control-state helpers
- Wired the modal into `app/one/location/page.tsx`: capture-once + reverse-geocode trigger, save/skip/search/select handlers, rendered inside the onboarding `BodyPortal`.
- **Always shows:** removed the old once-per-user localStorage suppression (those keys are now only *cleared*, never read to hide the prompt) and added an effect in `one-location-onboarding-flow.tsx` that fires the prompt the moment location access is granted — so a previously discarded onboarding still gets the save-place prompt.
- Rendered `<SavedLocationsSection/>` in the Location Settings/Privacy surface so a saved place is instantly viewable and updatable.

## Task 2 — Accurate location via a draggable map pin

- New `components/one-location/onboarding/location-picker-map.tsx`: a Google Map with a **fixed centre pin** the user drags the map beneath (+ tap-to-place), a **"Locate me"** recenter button, live reverse-geocoding on every settle, and **Confirm** returns the exact `{lat, lng, address}`.
- Added a **"Set exact location on map"** action to `SaveLocationModal`, used in both onboarding and the Settings add-flow, replacing the coarse GPS fix with the precise pinned coordinate before saving.
- Graceful fallback to address search when the Maps browser key is unavailable.

## Files changed

9 files, +2,358 lines (see diff).

## Testing

- `tsc --noEmit` → 0 errors
- Dev server: `/one/location` → HTTP 200
- Verified the modal (Home/Work/Other) and the drag-to-pin picker render in the browser.

## Notes

- Exact coordinates stay in the encrypted vault (never written to browser storage).
- The interactive map needs `NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY`; without it the picker degrades to address search (by design).
