### PR TITLE
feat(one): Wallet Profile — shareable Hussh One pass for Apple Wallet

### DIFF
--- a/.github/workflows/provision-wallet-pass-certificate.yml
+++ b/.github/workflows/provision-wallet-pass-certificate.yml
@@ -1,0 +1,337 @@
+name: Provision Wallet Pass Certificate
+
+# One-click provisioning of the Apple Pass Type ID (`pass.com.hushh.app.one`) and
+# its PASS_TYPE_ID signing certificate for the Hushh One Wallet Profile pass.
+#
+# The whole chain is automatable with the Admin-role App Store Connect key that
+# already lives in GCP Secret Manager (hushh-pda-uat): create/reuse the Pass Type
+# ID, generate an RSA-2048 keypair + CSR inside the runner, request the
+# certificate, verify the Apple WWDR **G4** intermediate, and write
+# WALLET_PASS_CERT_PEM / WALLET_PASS_KEY_PEM / WALLET_PASS_WWDR_PEM to Secret
+# Manager over stdin. Cloud Run then receives them as `--set-secrets` env refs
+# from deploy/backend.cloudbuild.yaml and reads them through runtime_settings.
+#
+# IRREVERSIBLE: minting a certificate consumes a slot in the Apple Developer
+# account and cannot be undone from CI. This workflow therefore defaults to a dry
+# run and additionally requires the `confirm` phrase before it creates anything —
+# the same default-off gating the App Store release workflow uses for its
+# submit-for-review action.
+#
+# The private key is generated in the job, piped straight into Secret Manager,
+# and never printed, never exported to the environment, and never uploaded as an
+# artifact. Only non-sensitive metadata (identifier, certificate id, serial,
+# expiry) reaches the log, the artifact, and the job summary.
+#
+# ROTATION: a Pass Type ID certificate is valid for about a year (the WWDR G4
+# intermediate runs to 2030-12-10, so it is not the operational risk). Re-dispatch
+# this workflow before the expiry printed in the job summary; a re-run inside the
+# renewal window mints a replacement, and a re-run outside it is a safe no-op.
+#
+# Runbook: docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md (section 5)
+# Contract: docs/superpowers/specs/2026-08-03-wallet-card-contract.md (section 1)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Resolve, generate and verify only — create no Apple resource and write no secret"
+        required: false
+        default: true
+        type: boolean
+      confirm:
+        description: "IRREVERSIBLE: type MINT-PASS-CERTIFICATE to actually mint the Apple certificate and write the secrets (required when dry_run=false)"
+        required: false
+        default: ""
+        type: string
+      secret_projects:
+        description: "Comma-separated GCP projects that receive the signing material. A certificate is minted ONCE, so list every environment that needs it in the same run."
+        required: false
+        default: "hushh-pda-uat"
+        type: string
+      force_new_certificate:
+        description: "Mint a new certificate even if valid signing material is already stored (rotation override)"
+        required: false
+        default: false
+        type: boolean
+      notes:
+        description: "Optional note for the run summary"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # The App Store Connect Admin key (APPSTORE_CONNECT_API_KEY_P8_B64 / _KEY_ID /
+  # _ISSUER_ID) lives in hushh-pda-uat, exactly like the TestFlight and App Store
+  # pipelines. Nothing App Store-related is stored as a GitHub secret.
+  GCP_PROJECT_ID: hushh-pda-uat
+  PASS_TYPE_IDENTIFIER: pass.com.hushh.app.one
+  PASS_TYPE_NAME: Hushh One Wallet Profile
+  CONFIRM_PHRASE: MINT-PASS-CERTIFICATE
+  METADATA_PATH: wallet-pass-certificate.json
+
+concurrency:
+  # Serialize dispatches so two runs cannot race the same Pass Type ID or mint
+  # two certificates that both claim to be "the" signing material.
+  group: provision-wallet-pass-certificate
+  cancel-in-progress: false
+
+jobs:
+  provision:
+    name: Provision Pass Type ID + certificate
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+
+    steps:
+      - name: Assert manual dispatch originates from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "Refusing Wallet pass certificate provisioning from '${GITHUB_REF_NAME}'. Trigger this workflow from 'main' only."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Assert production dispatch actor policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Minting an Apple certificate is an account-level, irreversible action,
+          # so it carries the production actor gate rather than the uat one.
+          python3 scripts/ci/assert-governed-actor.py --surface production --actor "${GITHUB_ACTOR}"
+
+      - name: Resolve mode (dry run vs irreversible apply)
+        id: mode
+        shell: bash
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          CONFIRM: ${{ github.event.inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [ "${DRY_RUN}" = "false" ]; then
+            if [ "${CONFIRM}" != "${CONFIRM_PHRASE}" ]; then
+              echo "Refusing to provision: dry_run=false requires confirm='${CONFIRM_PHRASE}' (got '${CONFIRM}')." >&2
+              echo "Minting a Pass Type ID certificate is IRREVERSIBLE; re-dispatch with the exact phrase." >&2
+              exit 1
+            fi
+            echo "::warning title=Irreversible Apple certificate mint::dry_run=false and the confirmation phrase was supplied -> this run WILL create an Apple Pass Type ID certificate and write signing material to Secret Manager. This consumes a certificate slot and cannot be undone from CI."
+            echo "apply=true" >> "$GITHUB_OUTPUT"
+            echo "mode=apply (mint certificate + write secrets)" >> "$GITHUB_OUTPUT"
+          else
+            echo "Dry run: nothing will be created in App Store Connect and no secret will be written."
+            echo "apply=false" >> "$GITHUB_OUTPUT"
+            echo "mode=dry run (no Apple resource, no secret write)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate target secret projects
+        id: projects
+        shell: bash
+        env:
+          SECRET_PROJECTS: ${{ github.event.inputs.secret_projects }}
+        run: |
+          set -euo pipefail
+          RAW="${SECRET_PROJECTS:-hushh-pda-uat}"
+          PROJECTS="$(printf '%s' "$RAW" | tr ',' '\n' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g' | grep -v '^$' || true)"
+          if [ -z "$PROJECTS" ]; then
+            echo "secret_projects resolved to nothing; at least one GCP project is required." >&2
+            exit 1
+          fi
+          while IFS= read -r project; do
+            if ! printf '%s' "$project" | grep -Eq '^[a-z][a-z0-9-]{4,28}[a-z0-9]$'; then
+              echo "Refusing provisioning: '$project' is not a valid GCP project id." >&2
+              exit 1
+            fi
+          done <<< "$PROJECTS"
+          echo "Target projects:"
+          printf '%s\n' "$PROJECTS" | sed 's/^/  /'
+          {
+            echo "list<<EOF"
+            echo "$PROJECTS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "joined=$(printf '%s' "$PROJECTS" | paste -sd ',' -)" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud (UAT)
+        uses: google-github-actions/auth@v2
+        with:
+          # UAT-scoped SA key (repo-level secret, inherited by the production
+          # environment). The App Store Connect key this job needs lives in
+          # hushh-pda-uat, exactly like the TestFlight / App Store pipelines.
+          credentials_json: ${{ secrets.GCP_SA_KEY_UAT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Assert GCP project scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud config set project "${GCP_PROJECT_ID}"
+          ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null)"
+          if [ "$ACTIVE_PROJECT" != "${GCP_PROJECT_ID}" ]; then
+            echo "Refusing provisioning: expected project '${GCP_PROJECT_ID}' but got '$ACTIVE_PROJECT'." >&2
+            exit 1
+          fi
+
+      - name: Decode App Store Connect API key
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The ASC key lives in GCP Secret Manager (hushh-pda-uat), the store
+          # deploy/README.md designates for native signing assets:
+          #   APPSTORE_CONNECT_API_KEY_P8_B64 / _KEY_ID / _ISSUER_ID.
+          get() {
+            gcloud secrets versions access latest --secret="$1" --project="${GCP_PROJECT_ID}" 2>/dev/null || true
+          }
+          for name in APPSTORE_CONNECT_API_KEY_P8_B64 APPSTORE_CONNECT_KEY_ID APPSTORE_CONNECT_ISSUER_ID; do
+            if ! gcloud secrets describe "$name" --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+              echo "Missing GCP secret $name in ${GCP_PROJECT_ID}." >&2
+              echo "The Pass Type ID API requires an ADMIN-role App Store Connect key." >&2
+              echo "See docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md (section 5)." >&2
+              exit 1
+            fi
+          done
+          ASC_KEY_ID="$(get APPSTORE_CONNECT_KEY_ID)"
+          ASC_ISSUER_ID="$(get APPSTORE_CONNECT_ISSUER_ID)"
+          echo "::add-mask::${ASC_KEY_ID}"
+          echo "::add-mask::${ASC_ISSUER_ID}"
+          umask 077
+          get APPSTORE_CONNECT_API_KEY_P8_B64 | openssl base64 -d -A > "${RUNNER_TEMP}/asc.p8"
+          chmod 600 "${RUNNER_TEMP}/asc.p8"
+          if ! grep -q "BEGIN PRIVATE KEY" "${RUNNER_TEMP}/asc.p8"; then
+            echo "Decoded ASC key is not a valid PEM .p8 (check APPSTORE_CONNECT_API_KEY_P8_B64)." >&2
+            exit 1
+          fi
+          echo "ASC_KEY_ID=${ASC_KEY_ID}" >> "$GITHUB_ENV"
+          echo "ASC_ISSUER_ID=${ASC_ISSUER_ID}" >> "$GITHUB_ENV"
+
+      - name: Create App Store Connect Python venv
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv "${RUNNER_TEMP}/asc-venv"
+          "${RUNNER_TEMP}/asc-venv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+
+      - name: Self-test the provisioning script (offline)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Exercises JWT minting, CSR generation, certificate decoding, the
+          # key-match assertion and the WWDR G4 pinning with no network and no
+          # real key, before anything irreversible can run.
+          "${RUNNER_TEMP}/asc-venv/bin/python" scripts/ci/provision_wallet_pass_certificate.py --self-test
+
+      - name: Provision Pass Type ID + certificate
+        id: provision
+        shell: bash
+        env:
+          APPLY: ${{ steps.mode.outputs.apply }}
+          PROJECT_LIST: ${{ steps.projects.outputs.list }}
+          FORCE_NEW: ${{ github.event.inputs.force_new_certificate }}
+        run: |
+          set -euo pipefail
+          umask 077
+          PROVISION_ARGS=()
+          while IFS= read -r project; do
+            [ -n "$project" ] || continue
+            PROVISION_ARGS+=(--secret-project "$project")
+          done <<< "${PROJECT_LIST}"
+          if [ "${APPLY}" = "true" ]; then
+            PROVISION_ARGS+=(--apply)
+          fi
+          if [ "${FORCE_NEW}" = "true" ]; then
+            PROVISION_ARGS+=(--force-new-certificate)
+          fi
+          # bash guard for a possibly-empty array under `set -u`.
+          "${RUNNER_TEMP}/asc-venv/bin/python" scripts/ci/provision_wallet_pass_certificate.py \
+            --p8-path "${RUNNER_TEMP}/asc.p8" \
+            --key-id "${ASC_KEY_ID}" \
+            --issuer-id "${ASC_ISSUER_ID}" \
+            --pass-type-identifier "${PASS_TYPE_IDENTIFIER}" \
+            --pass-type-name "${PASS_TYPE_NAME}" \
+            --upsert-script scripts/ops/upsert_gcp_secret.py \
+            --metadata-path "${RUNNER_TEMP}/${METADATA_PATH}" \
+            "${PROVISION_ARGS[@]+"${PROVISION_ARGS[@]}"}"
+          # The metadata JSON holds only non-sensitive fields (identifier,
+          # certificate id, serial, expiry), so it is safe to read back.
+          chmod 644 "${RUNNER_TEMP}/${METADATA_PATH}"
+
+      - name: Remove the App Store Connect key from the runner
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f "${RUNNER_TEMP}/asc.p8"
+
+      - name: Upload provisioning metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          # Strict allowlist: ONLY the non-sensitive metadata JSON. The private
+          # key, the certificate body and the WWDR body are never written to a
+          # path that any artifact glob can reach.
+          name: wallet-pass-certificate-metadata
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}/wallet-pass-certificate.json
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          META="${RUNNER_TEMP}/${METADATA_PATH}"
+          field() {
+            if [ -f "$META" ]; then
+              jq -r --arg key "$1" '.[$key] // "n/a"' "$META"
+            else
+              echo "n/a"
+            fi
+          }
+          NOT_AFTER="$(field not_after)"
+          DAYS_LEFT="$(field days_until_expiry)"
+          {
+            echo "## Provision Wallet Pass Certificate"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Pass Type Identifier | \`${PASS_TYPE_IDENTIFIER}\` |"
+            echo "| Mode | ${{ steps.mode.outputs.mode }} |"
+            echo "| Action | $(field action) |"
+            echo "| Secret projects | ${{ steps.projects.outputs.joined }} |"
+            echo "| Secrets | \`WALLET_PASS_CERT_PEM\`, \`WALLET_PASS_KEY_PEM\`, \`WALLET_PASS_WWDR_PEM\` |"
+            echo "| Pass Type ID | $(field pass_type_id) |"
+            echo "| Certificate id | $(field certificate_id) |"
+            echo "| Certificate serial | $(field certificate_serial) |"
+            echo "| Certificate expires | ${NOT_AFTER} |"
+            echo "| Days until expiry | ${DAYS_LEFT} |"
+            echo "| WWDR G4 expires | $(field wwdr_not_after) |"
+            if [ -n "${{ github.event.inputs.notes }}" ]; then
+              echo "| Notes | ${{ github.event.inputs.notes }} |"
+            fi
+            echo ""
+            if [ "${{ steps.mode.outputs.apply }}" = "true" ]; then
+              echo "> **Rotation required.** The Pass Type ID certificate above is valid for"
+              echo "> roughly one year and expires **${NOT_AFTER}** (${DAYS_LEFT} day(s) left)."
+              echo "> It — not the WWDR G4 intermediate, which runs to 2030-12-10 — is the"
+              echo "> operational risk: once it expires, every \`.pkpass\` this backend signs"
+              echo "> stops installing. Put the expiry date in the on-call calendar and"
+              echo "> re-dispatch this workflow before it lands; a run inside the 30-day"
+              echo "> renewal window mints a replacement, and a run outside it is a no-op."
+            else
+              echo "> Dry run only: the Pass Type ID was resolved, an RSA-2048 keypair + CSR"
+              echo "> were generated locally, and the Apple WWDR G4 intermediate was fetched"
+              echo "> and pinned — but **no Apple resource was created and no secret was"
+              echo "> written**. Re-dispatch with \`dry_run=false\` and"
+              echo "> \`confirm=MINT-PASS-CERTIFICATE\` to provision for real."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/consent-protocol/api/routes/one_wallet_card.py
+++ b/consent-protocol/api/routes/one_wallet_card.py
@@ -49,7 +49,6 @@ from slowapi.util import get_remote_address
 
 from api.middleware import require_vault_owner_token
 from api.middlewares.rate_limit import limiter
-from db.db_client import DatabaseExecutionError
 from hushh_mcp.services.apple_wallet_pass_service import (
     WALLET_PASS_CONTENT_TYPE,
     WALLET_PASS_FILENAME,
@@ -89,11 +88,23 @@ _OwnerUserId = Annotated[str, Query(min_length=1, max_length=160)]
 # Explicit rate limits for the unauthenticated surfaces
 # ---------------------------------------------------------------------------
 
-# Per client IP, per endpoint (slowapi scopes a bucket by the decorated
-# endpoint). Resolve is the scanned-page read and must stay comfortably
-# interactive; pass generation signs and zips a bundle, so it is bound harder.
+# Per client IP, per endpoint. slowapi's default key_style is "url", so the
+# storage key is (key_func, request path) and a {share_token} path parameter
+# would give every distinct token its own fresh bucket — an attacker enumerating
+# tokens is exactly the traffic these limits exist to bound, and it would never
+# hit one. Binding an explicit scope (shared_limit) drops the path out of the
+# key; distinct scope strings keep the two routes independently bucketed.
+# Resolve is the scanned-page read and must stay comfortably interactive; pass
+# generation signs and zips a bundle, so it is bound harder.
 PUBLIC_CARD_RESOLVE_RATE_LIMIT = "30/minute"
 PUBLIC_CARD_PASS_RATE_LIMIT = "10/minute"  # noqa: S105 - rate limit, not a credential
+PUBLIC_CARD_RESOLVE_RATE_LIMIT_SCOPE = "one_wallet_card_public_resolve"
+PUBLIC_CARD_PASS_RATE_LIMIT_SCOPE = "one_wallet_card_public_pass"  # noqa: S105 - bucket name
+
+# Static client-facing text for storage failures. The underlying driver message
+# is never forwarded (see _handle_error).
+_DB_UNAVAILABLE_MESSAGE = "Wallet Profile storage is temporarily unavailable. Try again shortly."
+_DB_FAILED_MESSAGE = "Wallet Profile request failed."
 
 # Number of trailing X-Forwarded-For entries that belong to our own edge rather
 # than the visitor. Cloud Run (direct) *appends* the real client IP to whatever
@@ -377,10 +388,31 @@ def _owner_user_id(token_data: dict[str, Any], user_id: str) -> str:
 def _handle_error(exc: Exception) -> HTTPException:
     if isinstance(exc, OneWalletCardError):
         return HTTPException(status_code=exc.status_code, detail=wallet_card_error_detail(exc))
-    if isinstance(exc, DatabaseExecutionError):
+    # Matched by name, not by import: routes may not import `db.*` (enforced by
+    # tests/quality/test_architecture_compliance.py). Same duck-type the
+    # Location routes use for this exact exception.
+    if exc.__class__.__name__ == "DatabaseExecutionError":
+        # exc.details is str(<the DBAPI error>), and SQLAlchemy appends the
+        # statement plus every bound value to that (no engine here sets
+        # hide_parameters). On these routes the bound values include
+        # card_payload, so the detail stays server-side: the caller gets the
+        # stable code and the static hint, which is all it can act on anyway.
+        # Deliberately NOT `database_error_detail()`, which forwards
+        # `exc.details` verbatim.
+        code = getattr(exc, "code", "DATABASE_EXECUTION_ERROR")
+        status_code = getattr(exc, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR)
+        logger.error("wallet_card.database_error code=%s", code)
         return HTTPException(
-            status_code=exc.status_code,
-            detail={"code": exc.code, "message": exc.details, "hint": exc.hint or ""},
+            status_code=status_code,
+            detail={
+                "code": code,
+                "message": (
+                    _DB_UNAVAILABLE_MESSAGE
+                    if status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+                    else _DB_FAILED_MESSAGE
+                ),
+                "hint": getattr(exc, "hint", "") or "",
+            },
         )
     logger.error("wallet_card.owner_request_failed error=%s", exc.__class__.__name__)
     return HTTPException(
@@ -647,7 +679,11 @@ def preview_wallet_card(
 
 
 @router.get("/public/{share_token}", response_model=None)
-@limiter.limit(PUBLIC_CARD_RESOLVE_RATE_LIMIT, key_func=public_rate_limit_key)
+@limiter.shared_limit(
+    PUBLIC_CARD_RESOLVE_RATE_LIMIT,
+    PUBLIC_CARD_RESOLVE_RATE_LIMIT_SCOPE,
+    key_func=public_rate_limit_key,
+)
 def resolve_public_wallet_card(
     request: Request,
     share_token: _ShareToken,
@@ -683,7 +719,11 @@ def resolve_public_wallet_card(
 
 
 @router.get("/pass/{share_token}.pkpass", response_model=None)
-@limiter.limit(PUBLIC_CARD_PASS_RATE_LIMIT, key_func=public_rate_limit_key)
+@limiter.shared_limit(
+    PUBLIC_CARD_PASS_RATE_LIMIT,
+    PUBLIC_CARD_PASS_RATE_LIMIT_SCOPE,
+    key_func=public_rate_limit_key,
+)
 def download_wallet_pass(
     request: Request,
     share_token: _ShareToken,

--- a/consent-protocol/api/routes/one_wallet_card.py
+++ b/consent-protocol/api/routes/one_wallet_card.py
@@ -1,0 +1,740 @@
+"""Wallet Profile routes — owner-authenticated management plus two genuinely
+unauthenticated public surfaces (card resolve + `.pkpass` download).
+
+Shape mirrors ``api/routes/one/location.py``: a single router that mixes
+``require_vault_owner_token`` routes with public token-addressed routes, path
+parameters bounded against CWE-400, and service errors funnelled through one
+translator.
+
+Security posture
+----------------
+- Every owner route is gated by ``Depends(require_vault_owner_token)`` **and** an
+  explicit ``token_data["user_id"] == user_id`` equality check, matching
+  ``api/routes/pkm_routes_shared.py`` (publish/list/unpublish projection).
+- The two public routes take no auth at all. Because ``SlowAPIMiddleware`` is
+  never added to the app and ``RateLimits.GLOBAL_PER_IP`` is never applied, an
+  undecorated public route would carry *zero* limit — so both public routes
+  carry an explicit ``@limiter.limit`` with a forwarded-IP key function (see
+  ``_forwarded_client_ip``).
+- The plaintext share token is returned to the owner **only** in the create and
+  rotate responses. It is never logged, never echoed on read, and never appears
+  in an error body.
+- ``card_payload`` values, the share token and pass signing material are never
+  logged. Failure logs carry an exception class name only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime
+from typing import Annotated, Any, Literal
+from urllib.parse import urlparse
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Path,
+    Query,
+    Request,
+    Response,
+    status,
+)
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from slowapi.util import get_remote_address
+
+from api.middleware import require_vault_owner_token
+from api.middlewares.rate_limit import limiter
+from db.db_client import DatabaseExecutionError
+from hushh_mcp.services.apple_wallet_pass_service import (
+    WALLET_PASS_CONTENT_TYPE,
+    WALLET_PASS_FILENAME,
+    WALLET_PASS_UNAVAILABLE_CODE,
+    WALLET_PASS_UNAVAILABLE_MESSAGE,
+    WalletPassContent,
+    WalletPassError,
+    build_pkpass,
+    wallet_pass_signing_available,
+)
+from hushh_mcp.services.one_wallet_card_service import (
+    OneWalletCardError,
+    OneWalletCardService,
+    wallet_card_error_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/one/wallet-card", tags=["One Wallet Card"])
+
+
+# ---------------------------------------------------------------------------
+# Bounded path / query parameters (CWE-400)
+# ---------------------------------------------------------------------------
+
+# ``secrets.token_urlsafe(32)`` yields 43 base64url characters. The bounds and
+# the alphabet keep junk out of the DB lookup and out of the logs; a wrong-shape
+# token is rejected before any query runs and reveals nothing about existence.
+_ShareToken = Annotated[
+    str,
+    Path(min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_-]+$"),
+]
+_OwnerUserId = Annotated[str, Query(min_length=1, max_length=160)]
+
+
+# ---------------------------------------------------------------------------
+# Explicit rate limits for the unauthenticated surfaces
+# ---------------------------------------------------------------------------
+
+# Per client IP, per endpoint (slowapi scopes a bucket by the decorated
+# endpoint). Resolve is the scanned-page read and must stay comfortably
+# interactive; pass generation signs and zips a bundle, so it is bound harder.
+PUBLIC_CARD_RESOLVE_RATE_LIMIT = "30/minute"
+PUBLIC_CARD_PASS_RATE_LIMIT = "10/minute"  # noqa: S105 - rate limit, not a credential
+
+# Number of trailing X-Forwarded-For entries that belong to our own edge rather
+# than the visitor. Cloud Run (direct) *appends* the real client IP to whatever
+# the caller sent, so the last entry is the visitor and the default of 0 is
+# correct. Behind an additional Google load balancer hop, set this to 1 so the
+# LB address is skipped instead of becoming everyone's shared bucket.
+TRUSTED_PROXY_HOPS_ENV = "ONE_WALLET_CARD_TRUSTED_PROXY_HOPS"
+
+
+def _trusted_proxy_hops() -> int:
+    raw = str(os.getenv(TRUSTED_PROXY_HOPS_ENV) or "").strip()
+    try:
+        hops = int(raw)
+    except ValueError:
+        return 0
+    return hops if hops >= 0 else 0
+
+
+def _forwarded_client_ip(request: Request) -> str:
+    """Best available visitor IP for an unauthenticated request.
+
+    ``slowapi``'s default key function falls back to ``get_remote_address``,
+    which behind Cloud Run is the ingress address — every visitor would then
+    share one bucket and the limit would be meaningless. Read the forwarded
+    chain instead, counting from the right (the hop our edge appended) and
+    skipping ``TRUSTED_PROXY_HOPS_ENV`` entries. Falls back to the socket peer
+    when no forwarded header is present (local/dev).
+    """
+
+    forwarded = str(request.headers.get("x-forwarded-for") or "")
+    chain = [part.strip() for part in forwarded.split(",") if part.strip()]
+    if not chain:
+        return get_remote_address(request) or "unknown"
+    index = max(len(chain) - 1 - _trusted_proxy_hops(), 0)
+    return chain[index][:64]
+
+
+def public_rate_limit_key(request: Request) -> str:
+    """Rate-limit bucket for the public Wallet Profile surfaces."""
+
+    return f"one_wallet_card_public:{_forwarded_client_ip(request)}"
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+_MAX_SKILLS = 12
+_MAX_SKILL_LENGTH = 40
+_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$")
+_PHONE_PATTERN = re.compile(r"^\+?[0-9][0-9\s().-]{5,31}$")
+_URL_FIELDS = ("website", "linkedin", "github", "portfolio")
+
+
+class _StrictModel(BaseModel):
+    """Reject unknown keys so an off-allowlist field is refused, not dropped."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class _ResponseModel(BaseModel):
+    """Tolerant inbound validation, camelCase on the wire."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+
+def _clean_optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _validate_https_url(value: str | None) -> str | None:
+    """Accept only a plain ``https://host/...`` URL.
+
+    Rejects every other scheme (notably ``javascript:`` and ``data:``) and any
+    userinfo form, which is the classic ``https://trusted.example@evil`` display
+    spoof. Values are stored as plain text and escaped at render time.
+    """
+
+    if value is None:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme != "https":
+        raise ValueError("Links must start with https://")
+    if not parsed.hostname:
+        raise ValueError("Links must include a host")
+    if "@" in parsed.netloc:
+        raise ValueError("Links must not contain user information")
+    return value
+
+
+class WalletCardPayload(_StrictModel):
+    """Closed, server-validated allowlist for the shared card (contract §3)."""
+
+    full_name: str | None = Field(default=None, alias="fullName", max_length=80)
+    headline: str | None = Field(default=None, max_length=120)
+    organisation: str | None = Field(default=None, max_length=80)
+    location_label: str | None = Field(default=None, alias="locationLabel", max_length=80)
+    summary: str | None = Field(default=None, max_length=400)
+    skills: list[str] | None = Field(default=None, max_length=_MAX_SKILLS)
+    email: str | None = Field(default=None, max_length=254)
+    phone: str | None = Field(default=None, max_length=32)
+    website: str | None = Field(default=None, max_length=300)
+    linkedin: str | None = Field(default=None, max_length=300)
+    github: str | None = Field(default=None, max_length=300)
+    portfolio: str | None = Field(default=None, max_length=300)
+    preferred_contact: Literal["email", "phone", "linkedin", "website"] | None = Field(
+        default=None, alias="preferredContact"
+    )
+
+    @field_validator(
+        "full_name",
+        "headline",
+        "organisation",
+        "location_label",
+        "summary",
+        "email",
+        "phone",
+        "website",
+        "linkedin",
+        "github",
+        "portfolio",
+        mode="before",
+    )
+    @classmethod
+    def _trim(cls, value: Any) -> str | None:
+        return _clean_optional(value)
+
+    @field_validator("skills", mode="before")
+    @classmethod
+    def _trim_skills(cls, value: Any) -> list[str] | None:
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            raise ValueError("Skills must be a list of short text values")
+        cleaned = [text for text in (_clean_optional(item) for item in value) if text]
+        for item in cleaned:
+            if len(item) > _MAX_SKILL_LENGTH:
+                raise ValueError(f"Each skill must be {_MAX_SKILL_LENGTH} characters or fewer")
+        return cleaned or None
+
+    @field_validator("email")
+    @classmethod
+    def _check_email(cls, value: str | None) -> str | None:
+        if value is not None and not _EMAIL_PATTERN.match(value):
+            raise ValueError("Enter a valid email address")
+        return value
+
+    @field_validator("phone")
+    @classmethod
+    def _check_phone(cls, value: str | None) -> str | None:
+        if value is not None and not _PHONE_PATTERN.match(value):
+            raise ValueError("Enter a valid phone number")
+        return value
+
+    @field_validator(*_URL_FIELDS)
+    @classmethod
+    def _check_url(cls, value: str | None) -> str | None:
+        return _validate_https_url(value)
+
+
+class UpsertWalletCardRequest(_StrictModel):
+    user_id: str = Field(alias="userId", min_length=1, max_length=160)
+    card_payload: WalletCardPayload = Field(alias="cardPayload")
+    # NULL means "no expiry". Present so the §6 expired state is reachable.
+    expires_at: str | None = Field(default=None, alias="expiresAt", max_length=64)
+
+
+class WalletCardOwnerActionRequest(_StrictModel):
+    user_id: str = Field(alias="userId", min_length=1, max_length=160)
+
+
+class WalletCardView(_ResponseModel):
+    pass_serial: str | None = Field(default=None, alias="passSerial")
+    status: str = "active"
+    share_token_version: int = Field(default=1, alias="shareTokenVersion")
+    card_payload: dict[str, Any] = Field(default_factory=dict, alias="cardPayload")
+    display_name: str | None = Field(default=None, alias="displayName")
+    headline: str | None = None
+    avatar_url: str | None = Field(default=None, alias="avatarUrl")
+    expires_at: str | None = Field(default=None, alias="expiresAt")
+    created_at: str | None = Field(default=None, alias="createdAt")
+    updated_at: str | None = Field(default=None, alias="updatedAt")
+    revoked_at: str | None = Field(default=None, alias="revokedAt")
+    last_scanned_at: str | None = Field(default=None, alias="lastScannedAt")
+    scan_count: int = Field(default=0, alias="scanCount")
+
+
+class WalletCardResponse(_ResponseModel):
+    """Owner view. ``share_token``/``share_url`` are populated on create and
+    rotate only — every other route leaves them null and the client reuses the
+    URL it stored locally."""
+
+    card: WalletCardView | None = None
+    share_token: str | None = Field(default=None, alias="shareToken")
+    share_url: str | None = Field(default=None, alias="shareUrl")
+
+
+class PublicWalletCardResponse(_ResponseModel):
+    """Visitor projection. Identical model on the public route and on the owner
+    preview so the preview is byte-identical to what a stranger receives."""
+
+    status: str
+    card: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Services, flags and error translation
+# ---------------------------------------------------------------------------
+
+_ACTIVE = "active"
+_NOT_FOUND = "not_found"
+_GONE_STATES = frozenset({"revoked", "expired"})
+
+# Friendly, non-technical 503 body. The copy is the contract's verbatim signing
+# failure line; the cryptographic detail stays in the server log.
+_SIGNING_UNAVAILABLE_BODY: dict[str, str] = {
+    "status": "unavailable",
+    "code": WALLET_PASS_UNAVAILABLE_CODE,
+    "message": WALLET_PASS_UNAVAILABLE_MESSAGE,
+}
+
+_FEATURE_FLAG_ENV = "ONE_WALLET_CARD_ENABLED"
+
+
+def _card_service() -> OneWalletCardService:
+    return OneWalletCardService()
+
+
+def _feature_enabled() -> bool:
+    """``ONE_WALLET_CARD_ENABLED``, read from backend runtime settings.
+
+    Prefers the typed accessor. The import is function-local and the env var is
+    the fallback for the same reason ``WalletPassSigningMaterial`` does it: a
+    deployment whose runtime-settings block predates this feature must degrade
+    to "off" for this router only, never fail the whole backend at import time.
+    ``hydrate_runtime_environment()`` projects the runtime-settings key onto the
+    env var, so the fallback reads the same configured value.
+    """
+
+    try:
+        from hushh_mcp.runtime_settings import one_wallet_card_enabled
+    except ImportError:
+        raw = str(os.getenv(_FEATURE_FLAG_ENV) or "").strip().lower()
+        return raw in {"1", "true", "yes", "on", "enabled"}
+    return bool(one_wallet_card_enabled())
+
+
+def _require_owner_feature_enabled() -> None:
+    """Owner routes disappear entirely when the flag is off."""
+
+    if _feature_enabled():
+        return
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "ONE_WALLET_CARD_DISABLED",
+            "message": "Wallet Profile is not available in this environment.",
+        },
+    )
+
+
+def _owner_user_id(token_data: dict[str, Any], user_id: str) -> str:
+    """Explicit owner match on top of the VAULT_OWNER token gate."""
+
+    token_user_id = str(token_data.get("user_id") or "").strip()
+    requested = str(user_id or "").strip()
+    if not token_user_id or token_user_id != requested:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "WALLET_CARD_FORBIDDEN",
+                "message": "Token user_id does not match request user_id",
+            },
+        )
+    return token_user_id
+
+
+def _handle_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, OneWalletCardError):
+        return HTTPException(status_code=exc.status_code, detail=wallet_card_error_detail(exc))
+    if isinstance(exc, DatabaseExecutionError):
+        return HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": exc.details, "hint": exc.hint or ""},
+        )
+    logger.error("wallet_card.owner_request_failed error=%s", exc.__class__.__name__)
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={
+            "code": "ONE_WALLET_CARD_API_FAILED",
+            "message": "Wallet Profile request failed.",
+        },
+    )
+
+
+def _card_response(result: dict[str, Any]) -> WalletCardResponse:
+    return WalletCardResponse.model_validate(result)
+
+
+def _public_projection(result: dict[str, Any]) -> PublicWalletCardResponse:
+    resolved = _normalise_public_status(result.get("status"))
+    if resolved != _ACTIVE:
+        return PublicWalletCardResponse(status=resolved, card=None)
+    card = result.get("card")
+    return PublicWalletCardResponse(
+        status=_ACTIVE,
+        card=dict(card) if isinstance(card, dict) else {},
+    )
+
+
+def _normalise_public_status(raw: Any) -> str:
+    """Collapse everything a visitor must not distinguish into ``not_found``.
+
+    ``paused`` is deliberately indistinguishable from an unknown token: the
+    service already reports it as ``not_found``, and this second pass keeps that
+    true even if the service is later changed to report the real state.
+    """
+
+    state = str(raw or "").strip().lower()
+    if state == _ACTIVE:
+        return _ACTIVE
+    if state in _GONE_STATES:
+        return state
+    return _NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Public response helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_public_headers(response: Response) -> None:
+    """Contract §6 headers: never cached by a shared cache, never indexed."""
+
+    response.headers["Cache-Control"] = "private, max-age=0, must-revalidate"
+    response.headers["X-Robots-Tag"] = "noindex, nofollow, noarchive"
+
+
+def _public_json(payload: dict[str, Any], status_code: int) -> JSONResponse:
+    response = JSONResponse(status_code=status_code, content=payload)
+    _apply_public_headers(response)
+    return response
+
+
+def _public_status_response(state: str) -> JSONResponse:
+    """404 for unknown/paused, 410 for revoked/expired."""
+
+    status_code = status.HTTP_410_GONE if state in _GONE_STATES else status.HTTP_404_NOT_FOUND
+    return _public_json({"status": state}, status_code)
+
+
+def _public_unavailable_response() -> JSONResponse:
+    return _public_json({"status": "unavailable"}, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    text = _clean_optional(value)
+    if text is None:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _pass_content(material: dict[str, Any]) -> WalletPassContent:
+    """Project the card row the service resolved onto the pass face.
+
+    The pass factory is deliberately pure — it does no database access and makes
+    no network calls — so the route is where the resolved row becomes pass
+    content. Only allowlisted keys are read; nothing here is logged.
+    """
+
+    return WalletPassContent.from_card_payload(
+        pass_serial=str(material.get("passSerial") or material.get("pass_serial") or ""),
+        public_card_url=str(material.get("publicCardUrl") or material.get("public_card_url") or ""),
+        card_payload=material.get("cardPayload") or material.get("card_payload") or {},
+        display_name=_clean_optional(material.get("displayName") or material.get("display_name")),
+        headline=_clean_optional(material.get("headline")),
+        expires_at=_as_datetime(material.get("expiresAt") or material.get("expires_at")),
+    )
+
+
+def _avatar_image(material: dict[str, Any]) -> bytes | None:
+    """Raw headshot bytes, when the service already had them.
+
+    Never fetched here: the route must not make an outbound request derived from
+    a user-supplied URL (SSRF). Absent bytes are fine — the pass factory falls
+    back to a generated monogram thumbnail.
+    """
+
+    image = material.get("avatarImage") or material.get("avatar_image")
+    if isinstance(image, (bytes, bytearray)) and image:
+        return bytes(image)
+    return None
+
+
+def _record_scan_best_effort(share_token: str) -> None:
+    """Bump the coarse counters. A counter failure must never fail the read."""
+
+    try:
+        _card_service().record_scan(share_token=share_token)
+    except Exception as exc:  # counters are advisory only
+        logger.warning("wallet_card.scan_counter_failed error=%s", exc.__class__.__name__)
+
+
+# ---------------------------------------------------------------------------
+# Owner routes — VAULT_OWNER token + explicit user_id match
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=WalletCardResponse)
+def get_wallet_card(
+    user_id: _OwnerUserId,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> WalletCardResponse:
+    """Current card and status. Never returns the plaintext share token."""
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, user_id)
+    try:
+        card = _card_service().get_card(user_id=owner_id)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    if card is None:
+        return WalletCardResponse(card=None)
+    return _card_response({"card": card})
+
+
+@router.post("", response_model=WalletCardResponse)
+def upsert_wallet_card(
+    payload: UpsertWalletCardRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> WalletCardResponse:
+    """Idempotent upsert of the shared fields.
+
+    The share token is minted on first creation and returned here exactly once;
+    a later update leaves the token untouched so an already-printed QR keeps
+    working.
+    """
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, payload.user_id)
+    try:
+        result = _card_service().upsert_card(
+            user_id=owner_id,
+            card_payload=payload.card_payload.model_dump(exclude_none=True),
+            expires_at=payload.expires_at,
+        )
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    return _card_response(result)
+
+
+@router.post("/rotate", response_model=WalletCardResponse)
+def rotate_wallet_card_token(
+    payload: WalletCardOwnerActionRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> WalletCardResponse:
+    """Mint a new share token, invalidating the old one immediately."""
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, payload.user_id)
+    try:
+        result = _card_service().rotate_share_token(user_id=owner_id)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    return _card_response(result)
+
+
+@router.post("/pause", response_model=WalletCardResponse)
+def pause_wallet_card(
+    payload: WalletCardOwnerActionRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> WalletCardResponse:
+    """Status → paused. A paused card reads as non-existent to a visitor."""
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, payload.user_id)
+    try:
+        result = _card_service().pause_card(user_id=owner_id)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    return _card_response(result)
+
+
+@router.post("/resume", response_model=WalletCardResponse)
+def resume_wallet_card(
+    payload: WalletCardOwnerActionRequest,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> WalletCardResponse:
+    """Status → active. The existing token and QR keep working."""
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, payload.user_id)
+    try:
+        result = _card_service().resume_card(user_id=owner_id)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    return _card_response(result)
+
+
+@router.delete("", response_model=WalletCardResponse)
+def revoke_wallet_card(
+    user_id: _OwnerUserId,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> WalletCardResponse:
+    """Status → revoked. The public page then shows an honest 410 state."""
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, user_id)
+    try:
+        result = _card_service().revoke_card(user_id=owner_id)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    return _card_response(result)
+
+
+@router.get("/preview", response_model=PublicWalletCardResponse)
+def preview_wallet_card(
+    user_id: _OwnerUserId,
+    token_data: dict = Depends(require_vault_owner_token),
+) -> PublicWalletCardResponse:
+    """Preview-as-visitor.
+
+    Calls the same projection builder the public route uses, so the ``card``
+    object here is byte-identical to what a stranger receives. Unlike the public
+    route this always answers 200 and reports the state in the body, so the
+    owner can be told *why* a visitor would see nothing.
+    """
+
+    _require_owner_feature_enabled()
+    owner_id = _owner_user_id(token_data, user_id)
+    try:
+        result = _card_service().preview_public_card(user_id=owner_id)
+    except Exception as exc:
+        raise _handle_error(exc) from exc
+    return _public_projection(result)
+
+
+# ---------------------------------------------------------------------------
+# Public routes — no authentication, explicit per-IP rate limit
+# ---------------------------------------------------------------------------
+
+
+@router.get("/public/{share_token}", response_model=None)
+@limiter.limit(PUBLIC_CARD_RESOLVE_RATE_LIMIT, key_func=public_rate_limit_key)
+def resolve_public_wallet_card(
+    request: Request,
+    share_token: _ShareToken,
+    background_tasks: BackgroundTasks,
+) -> Response:
+    """Resolve a scanned share token into the visitor projection.
+
+    Unauthenticated by design — the token *is* the credential. Unknown and
+    paused tokens return the identical generic 404; revoked and expired cards
+    return 410 with an honest status so the page can explain itself.
+    """
+
+    if not _feature_enabled():
+        return _public_status_response(_NOT_FOUND)
+    try:
+        result = _card_service().resolve_public_card(share_token=share_token)
+    except OneWalletCardError as exc:
+        logger.warning("wallet_card.public_resolve_rejected code=%s", exc.code)
+        return _public_status_response(_NOT_FOUND)
+    except Exception as exc:  # never leak internals to a visitor
+        logger.error("wallet_card.public_resolve_failed error=%s", exc.__class__.__name__)
+        return _public_unavailable_response()
+
+    projection = _public_projection(result)
+    if projection.status != _ACTIVE:
+        return _public_status_response(projection.status)
+
+    background_tasks.add_task(_record_scan_best_effort, share_token)
+    return _public_json(
+        projection.model_dump(by_alias=True),
+        status.HTTP_200_OK,
+    )
+
+
+@router.get("/pass/{share_token}.pkpass", response_model=None)
+@limiter.limit(PUBLIC_CARD_PASS_RATE_LIMIT, key_func=public_rate_limit_key)
+def download_wallet_pass(
+    request: Request,
+    share_token: _ShareToken,
+) -> Response:
+    """Return the signed `.pkpass` bundle for an active card.
+
+    Unauthenticated for the same reason as the resolve route: iOS follows this
+    URL out of the app into Safari, which imports the pass natively. Same status
+    rules as resolve; 503 with a friendly code when signing material is absent.
+    """
+
+    if not _feature_enabled():
+        return _public_status_response(_NOT_FOUND)
+    try:
+        result = _card_service().resolve_pass_material(share_token=share_token)
+    except OneWalletCardError as exc:
+        logger.warning("wallet_card.pass_resolve_rejected code=%s", exc.code)
+        return _public_status_response(_NOT_FOUND)
+    except Exception as exc:  # never leak internals to a visitor
+        logger.error("wallet_card.pass_resolve_failed error=%s", exc.__class__.__name__)
+        return _public_unavailable_response()
+
+    state = _normalise_public_status(result.get("status"))
+    if state != _ACTIVE:
+        return _public_status_response(state)
+
+    material = result.get("material")
+    if not isinstance(material, dict) or not material:
+        logger.error("wallet_card.pass_material_missing")
+        return _public_json(_SIGNING_UNAVAILABLE_BODY, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    # Cheap readiness probe first: a deployment without signing material should
+    # answer the friendly 503 without paying for image rendering.
+    if not wallet_pass_signing_available():
+        return _public_json(_SIGNING_UNAVAILABLE_BODY, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    try:
+        content = _pass_content(material)
+        bundle = build_pkpass(content, avatar_image=_avatar_image(material))
+    except WalletPassError as exc:
+        # The message can carry cryptographic detail, so log the class only.
+        logger.error("wallet_card.pass_build_failed error=%s", exc.__class__.__name__)
+        return _public_json(_SIGNING_UNAVAILABLE_BODY, status.HTTP_503_SERVICE_UNAVAILABLE)
+    except Exception as exc:  # signing detail is server-side only
+        logger.error("wallet_card.pass_build_failed error=%s", exc.__class__.__name__)
+        return _public_json(_SIGNING_UNAVAILABLE_BODY, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    response = Response(
+        content=bundle,
+        media_type=WALLET_PASS_CONTENT_TYPE,
+        headers={"Content-Disposition": f'attachment; filename="{WALLET_PASS_FILENAME}"'},
+    )
+    _apply_public_headers(response)
+    return response

--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 131,
+  "expected_migration_version": 132,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 131,
+  "expected_migration_version": 132,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1138,6 +1138,23 @@
       "event_type",
       "created_at",
       "metadata"
+    ],
+    "one_wallet_cards": [
+      "user_id",
+      "pass_serial",
+      "share_token_hash",
+      "share_token_version",
+      "status",
+      "card_payload",
+      "display_name",
+      "headline",
+      "avatar_url",
+      "expires_at",
+      "created_at",
+      "updated_at",
+      "revoked_at",
+      "last_scanned_at",
+      "scan_count"
     ]
   }
 }

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 131,
+  "expected_migration_version": 132,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -1138,6 +1138,23 @@
       "event_type",
       "created_at",
       "metadata"
+    ],
+    "one_wallet_cards": [
+      "user_id",
+      "pass_serial",
+      "share_token_hash",
+      "share_token_version",
+      "status",
+      "card_payload",
+      "display_name",
+      "headline",
+      "avatar_url",
+      "expires_at",
+      "created_at",
+      "updated_at",
+      "revoked_at",
+      "last_scanned_at",
+      "scan_count"
     ]
   }
 }

--- a/consent-protocol/db/migrations/132_one_wallet_card.sql
+++ b/consent-protocol/db/migrations/132_one_wallet_card.sql
@@ -1,0 +1,86 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- One row per owner: the Wallet Profile card behind a Hussh One pass.
+--
+-- This is a dedicated, additive plane. It deliberately does not reuse
+-- pkm_default_available_projections: that table is read by the Information
+-- Marketplace catalogue and mints a fresh handle on every edit, so publishing
+-- a card there would both list the owner for sale and invalidate an already
+-- printed QR code.
+--
+-- Privacy boundary:
+-- - the plaintext share token is never stored; only its SHA-256 hex digest
+--   lives here, and it is returned to the owner exactly once at create and at
+--   rotate;
+-- - card_payload holds only the closed, server-validated allowlist of fields
+--   the owner explicitly chose to show. It carries no PKM material, no vault
+--   reference, no credential, and no coordinates - location_label is a coarse
+--   city/region string only;
+-- - scans are aggregate-only. No per-scan row, IP address, user agent,
+--   geolocation, or referrer is ever recorded, matching the location-agent
+--   rule that consent metadata must never carry coordinates or traces;
+-- - pause is indistinguishable from non-existence at the public endpoint, so
+--   status is never leaked to a visitor holding a stale link.
+CREATE TABLE IF NOT EXISTS one_wallet_cards (
+  user_id TEXT PRIMARY KEY,
+  pass_serial UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  share_token_hash TEXT NOT NULL UNIQUE,
+  share_token_version INTEGER NOT NULL DEFAULT 1,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'paused', 'revoked')),
+  card_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  display_name TEXT,
+  headline TEXT,
+  avatar_url TEXT,
+  expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  last_scanned_at TIMESTAMPTZ,
+  scan_count BIGINT NOT NULL DEFAULT 0,
+  CONSTRAINT chk_one_wallet_cards_token_version
+    CHECK (share_token_version > 0),
+  CONSTRAINT chk_one_wallet_cards_scan_count
+    CHECK (scan_count >= 0),
+  CONSTRAINT chk_one_wallet_cards_payload_object
+    CHECK (jsonb_typeof(card_payload) = 'object'),
+  CONSTRAINT chk_one_wallet_cards_revocation
+    CHECK (
+      (status = 'revoked' AND revoked_at IS NOT NULL)
+      OR (status <> 'revoked')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_one_wallet_cards_status
+  ON one_wallet_cards (status);
+
+COMMENT ON TABLE one_wallet_cards IS
+  'Owner-controlled Wallet Profile card resolved by an anonymous share token. Aggregate scan counters only; no per-scan telemetry row, IP address, user agent, geolocation, or referrer is ever stored.';
+
+COMMENT ON COLUMN one_wallet_cards.pass_serial IS
+  'Stable serial of the installed Apple Wallet pass. Minted once and never rotated; never returned to a public visitor.';
+
+COMMENT ON COLUMN one_wallet_cards.share_token_hash IS
+  'SHA-256 hex digest of the share token. The plaintext token is NEVER stored, logged, or recoverable; it is returned to the owner only in the create and rotate responses.';
+
+COMMENT ON COLUMN one_wallet_cards.share_token_version IS
+  'Increments on every rotate. A rotate invalidates the previous token immediately because only the current digest is retained.';
+
+COMMENT ON COLUMN one_wallet_cards.card_payload IS
+  'Server-validated allowlisted profile fields the owner explicitly chose to share. Never PKM material, credentials, vault references, or coordinates; stored as plain text and escaped at render time.';
+
+COMMENT ON COLUMN one_wallet_cards.status IS
+  'Owner-controlled sharing posture. A paused card is served exactly like an unknown token so pausing cannot be detected by a visitor.';
+
+COMMENT ON COLUMN one_wallet_cards.expires_at IS
+  'Optional owner-set expiry. NULL means the card does not expire; an elapsed value is served as gone, never as missing.';
+
+COMMENT ON COLUMN one_wallet_cards.last_scanned_at IS
+  'Coarse best-effort timestamp of the most recent public resolve. No per-scan telemetry row is ever kept, and no scanner identity, address, or location is recorded.';
+
+COMMENT ON COLUMN one_wallet_cards.scan_count IS
+  'Aggregate resolve counter only. It is incremented best-effort and never expands into per-scan telemetry rows; a counter failure must never fail the read.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/132_one_wallet_card_down.sql
+++ b/consent-protocol/db/migrations/rollback/132_one_wallet_card_down.sql
@@ -1,0 +1,25 @@
+-- Guarded operational rollback for migration 132.
+-- This file is intentionally excluded from the release migration manifest.
+
+BEGIN;
+
+-- Dropping the table destroys every owner's share-token digest, which cannot
+-- be reconstructed: only the digest is stored, never the plaintext token. Any
+-- printed or installed QR code would break permanently and every pass would
+-- resolve to nothing. Rolling back with live cards present is therefore
+-- refused: disable ONE_WALLET_CARD_ENABLED and roll the application back
+-- first, then retain this additive table until a separately reviewed contract
+-- migration removes it.
+DO $$
+BEGIN
+  IF to_regclass('public.one_wallet_cards') IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM one_wallet_cards LIMIT 1) THEN
+      RAISE EXCEPTION
+        'migration_132_contains_live_wallet_cards_disable_feature_flag_and_retain_table';
+    END IF;
+  END IF;
+END $$;
+
+DROP TABLE IF EXISTS one_wallet_cards;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -109,7 +109,8 @@
     "128_private_analysis_history_redaction.sql",
     "129_ria_pick_legacy_retirement.sql",
     "130_one_runtime_setup_choice.sql",
-    "131_one_location_nearby_point_contract.sql"
+    "131_one_location_nearby_point_contract.sql",
+    "132_one_wallet_card.sql"
   ],
   "groups": {
     "iam": [
@@ -173,7 +174,8 @@
       "128_private_analysis_history_redaction.sql",
       "129_ria_pick_legacy_retirement.sql",
       "130_one_runtime_setup_choice.sql",
-      "131_one_location_nearby_point_contract.sql"
+      "131_one_location_nearby_point_contract.sql",
+      "132_one_wallet_card.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/runtime_settings.py
+++ b/consent-protocol/hushh_mcp/runtime_settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -43,6 +43,16 @@ FIREBASE_ADMIN_CREDENTIALS_JSON_ENV = "FIREBASE_ADMIN_CREDENTIALS_JSON"
 FIREBASE_SERVICE_ACCOUNT_JSON_ENV = "FIREBASE_SERVICE_ACCOUNT_JSON"
 GMAIL_OAUTH_TOKEN_KEY_ENV = "GMAIL_OAUTH_TOKEN_KEY"  # noqa: S105
 PLAID_ACCESS_TOKEN_KEY_ENV = "PLAID_ACCESS_TOKEN_KEY"  # noqa: S105
+# Apple Wallet pass signing material. The three PEMs arrive as their own Cloud
+# Run secret refs (never inside BACKEND_RUNTIME_CONFIG_JSON) and are read here so
+# that no service reads them from the environment directly.
+WALLET_PASS_CERT_PEM_ENV = "WALLET_PASS_CERT_PEM"  # noqa: S105
+WALLET_PASS_KEY_PEM_ENV = "WALLET_PASS_KEY_PEM"  # noqa: S105
+WALLET_PASS_WWDR_PEM_ENV = "WALLET_PASS_WWDR_PEM"  # noqa: S105
+WALLET_PASS_TEAM_IDENTIFIER_ENV = "WALLET_PASS_TEAM_IDENTIFIER"  # noqa: S105
+WALLET_PASS_TYPE_IDENTIFIER_ENV = "WALLET_PASS_TYPE_IDENTIFIER"  # noqa: S105
+_WALLET_PASS_TYPE_IDENTIFIER_DEFAULT = "pass.com.hushh.app.one"  # noqa: S105
+
 BACKEND_RUNTIME_CONFIG_JSON_ENV = "BACKEND_RUNTIME_CONFIG_JSON"
 VOICE_RUNTIME_CONFIG_JSON_ENV = "VOICE_RUNTIME_CONFIG_JSON"
 
@@ -78,6 +88,9 @@ _BACKEND_RUNTIME_ENV_MAP: dict[str, str] = {
     "db_bulk_batching_enabled": "DB_BULK_BATCHING_ENABLED",
     "hushh_trusted_device_enabled": "HUSSH_TRUSTED_DEVICE_ENABLED",
     "hushh_trusted_device_uat_allowlist": "HUSSH_TRUSTED_DEVICE_UAT_ALLOWLIST",
+    "one_wallet_card_enabled": "ONE_WALLET_CARD_ENABLED",
+    "wallet_pass_team_identifier": "WALLET_PASS_TEAM_IDENTIFIER",
+    "wallet_pass_type_identifier": "WALLET_PASS_TYPE_IDENTIFIER",
 }
 
 
@@ -175,6 +188,32 @@ class FirebaseCredentialSettings:
 class AppRuntimeSettings:
     environment: str
     app_frontend_origin: str
+
+
+@dataclass(frozen=True)
+class WalletPassSettings:
+    """Apple Wallet pass signing material and pass identifiers.
+
+    Every PEM is ``repr=False`` so private key material can never surface in a
+    log line, an exception repr or a traceback frame dump.
+    """
+
+    team_identifier: str
+    pass_type_identifier: str
+    cert_pem: str = field(repr=False, default="")
+    key_pem: str = field(repr=False, default="")
+    wwdr_pem: str = field(repr=False, default="")
+
+    @property
+    def is_complete(self) -> bool:
+        """True only when every value needed to sign a pass is present."""
+        return bool(
+            self.team_identifier
+            and self.pass_type_identifier
+            and self.cert_pem
+            and self.key_pem
+            and self.wwdr_pem
+        )
 
 
 @dataclass(frozen=True)
@@ -294,6 +333,34 @@ def kai_analyze_durable_run_store_enabled() -> bool:
     404ing (the multi-instance prod-parity bug). Defaults off; when off the
     run manager behaves exactly as before with zero durable-store I/O."""
     return _bool_from_value(_clean_env("KAI_ANALYZE_DURABLE_RUN_STORE"), default=False)
+
+
+def one_wallet_card_enabled() -> bool:
+    """Feature flag: expose the Wallet Profile plane — the ``one_wallet_cards``
+    table, the ``/api/one/wallet-card`` owner routes and the two unauthenticated
+    public surfaces (card resolve and the signed ``.pkpass`` download). Defaults
+    off; while off every wallet-card route answers as if the feature did not
+    exist and no card is ever resolved."""
+    return _bool_from_value(_clean_env("ONE_WALLET_CARD_ENABLED"), default=False)
+
+
+def get_wallet_pass_settings() -> WalletPassSettings:
+    """Signing material for Apple Wallet ``.pkpass`` generation.
+
+    Deliberately uncached: the PEMs are Cloud Run secret refs, so reading them
+    per pass download keeps a rotated certificate live without a redeploy.
+    Missing material yields empty strings, which makes ``is_complete`` False and
+    lets the route degrade to the friendly 503 copy instead of raising.
+    """
+    return WalletPassSettings(
+        team_identifier=_clean_env(WALLET_PASS_TEAM_IDENTIFIER_ENV) or "",
+        pass_type_identifier=(
+            _clean_env(WALLET_PASS_TYPE_IDENTIFIER_ENV) or _WALLET_PASS_TYPE_IDENTIFIER_DEFAULT
+        ),
+        cert_pem=_clean_env(WALLET_PASS_CERT_PEM_ENV) or "",
+        key_pem=_clean_env(WALLET_PASS_KEY_PEM_ENV) or "",
+        wwdr_pem=_clean_env(WALLET_PASS_WWDR_PEM_ENV) or "",
+    )
 
 
 @lru_cache(maxsize=1)

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -546,6 +546,7 @@ class AccountService:
                 "pkm_domain_revisions",
                 "pkm_upgrade_steps",
                 "pkm_upgrade_runs",
+                "one_wallet_cards",
             ],
             params=params,
             results=results,
@@ -1061,6 +1062,7 @@ class AccountService:
                     "one_location_envelopes",
                     "one_location_share_grants",
                     "one_location_recipient_keys",
+                    "one_wallet_cards",
                 ):
                     self._delete_user_rows_if_table_exists(
                         conn,

--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -199,6 +199,7 @@ class AccountService:
             "one_location_public_invites": text(
                 "DELETE FROM one_location_public_invites WHERE owner_user_id = :user_id"
             ),
+            "one_wallet_cards": text("DELETE FROM one_wallet_cards WHERE user_id = :user_id"),
             "one_location_circle_invites": text(
                 """
                 DELETE FROM one_location_circle_invites

--- a/consent-protocol/hushh_mcp/services/apple_wallet_pass_service.py
+++ b/consent-protocol/hushh_mcp/services/apple_wallet_pass_service.py
@@ -1,0 +1,906 @@
+"""Apple Wallet `.pkpass` construction and PKCS#7 signing for the Wallet Profile.
+
+This module is a pure, self-contained pass factory: given the card content and
+the signing material it returns the signed `.pkpass` archive as bytes. It does
+no database access, holds no global state, and makes **no network calls** — the
+caller supplies both the public card URL and (optionally) the raw avatar bytes.
+
+Two design decisions are baked in here and are worth stating up front.
+
+**No Wallet web service.** `webServiceURL` and `authenticationToken` are
+deliberately omitted. Apple's pass reference makes them optional; only
+`formatVersion`, `passTypeIdentifier`, `teamIdentifier`, `organizationName`,
+`description` and `serialNumber` are required. Because the QR code carries a
+URL that is resolved server-side on every scan, edit / pause / rotate / revoke
+take effect instantly with zero Wallet involvement. That removes APNs, device
+registration, a registrations table and five endpoints from the system. The
+accepted cost is that the text *printed* on an installed pass, and the QR
+payload baked into it, cannot be changed after installation — so the pass face
+is kept minimal and stable and everything volatile lives behind the QR.
+
+**Re-issue overwrites in place.** Wallet keys an installed pass on
+`passTypeIdentifier` + `serialNumber`. `pass_serial` is minted once per user and
+never changes, so re-adding a pass after a token rotation silently replaces the
+previously installed one instead of stacking a duplicate — the user re-adds with
+a single tap and the stale QR stops resolving.
+
+Privacy notes: no `card_payload` value, share token or key material is ever
+logged, personal fields are excluded from dataclass `repr` so they cannot leak
+through a traceback, and an uploaded avatar is re-encoded into a fresh image so
+EXIF metadata (including GPS coordinates) never reaches the pass bundle.
+"""
+
+from __future__ import annotations
+
+import colorsys
+import hashlib
+import io
+import json
+import logging
+import zipfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.serialization import pkcs7
+from PIL import Image, ImageDraw, ImageFont, ImageOps
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Contract constants
+# ---------------------------------------------------------------------------
+
+# ruff's S105 heuristic flags any constant whose name contains "pass"; every
+# constant below is public pass-format metadata, not a credential.
+PASS_TYPE_IDENTIFIER = "pass.com.hushh.app.one"  # noqa: S105
+ORGANIZATION_NAME = "Hussh"
+PASS_DESCRIPTION = "Hussh One profile"  # noqa: S105
+PASS_LOGO_TEXT = "Hussh One"  # noqa: S105
+
+WALLET_PASS_CONTENT_TYPE = "application/vnd.apple.pkpass"  # noqa: S105
+WALLET_PASS_FILENAME = "hushh-one.pkpass"  # noqa: S105
+
+# User-facing failure copy (contract §9). The technical cause is logged
+# server-side only and is never returned to the client.
+WALLET_PASS_UNAVAILABLE_CODE = "wallet_pass_unavailable"  # noqa: S105
+WALLET_PASS_UNAVAILABLE_MESSAGE = (
+    "We couldn't create your Wallet pass right now. Please try again in a moment."  # noqa: S105
+)
+
+_CARD_BACKGROUND_COLOR = "rgb(12, 13, 17)"
+_CARD_FOREGROUND_COLOR = "rgb(255, 255, 255)"
+_CARD_LABEL_COLOR = "rgb(152, 156, 166)"
+
+# Apple system blue — the product accent (`--app-accent: #007aff`).
+_BRAND_ACCENT_RGB = (0, 122, 255)
+_MARK_RGB = (255, 255, 255)
+
+# Point sizes from Apple's pass design guidance; each is emitted at @1x/@2x/@3x.
+_ICON_POINT_SIZE = 29
+_LOGO_POINT_SIZE = 50
+_THUMBNAIL_POINT_SIZE = 90
+_IMAGE_SCALES = (1, 2, 3)
+
+# Supersampling factor for the vector-drawn brand mark before LANCZOS downscale.
+_MARK_SUPERSAMPLE = 4
+
+# Proportions of the drawn "H": glyph box aspect, stem width and crossbar height
+# as fractions of that box. Tuned once, reused at every raster size.
+_MARK_ASPECT = 0.93
+_MARK_STEM_RATIO = 0.31
+_MARK_BAR_RATIO = 0.25
+
+# Margin around the mark: the icon is a coloured tile and needs padding, the
+# transparent logo sits alone in its slot and should fill it.
+_ICON_MARK_INSET = 0.22
+_LOGO_MARK_INSET = 0.06
+
+# Refuse absurd avatar uploads before Pillow touches them.
+_MAX_AVATAR_BYTES = 8 * 1024 * 1024
+_MAX_AVATAR_PIXELS = 40_000_000
+
+# Fixed zip timestamp so an unchanged card always produces byte-identical output.
+_ZIP_TIMESTAMP = (2001, 1, 1, 0, 0, 0)
+
+# Apple's pass format specifies SHA-1 digests in manifest.json. This is a
+# format requirement, not a security control — the integrity guarantee comes
+# from the PKCS#7 signature over manifest.json below.
+_MANIFEST_EXCLUDED = frozenset({"manifest.json", "signature", ".DS_Store"})
+
+_CERT_EXPIRY_WARNING_DAYS = 30
+
+# `altText` is the short caption Wallet renders beneath the barcode; anything
+# longer than this is truncated by the UI anyway.
+_ALT_TEXT_MAX_CHARS = 32
+
+# Subject attribute Apple uses to carry the pass type identifier in the
+# Pass Type ID certificate (userId / UID).
+_UID_OID = x509.ObjectIdentifier("0.9.2342.19200300.100.1.1")
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class WalletPassError(RuntimeError):
+    """Base class for every Wallet pass generation failure."""
+
+
+class WalletPassSigningUnavailableError(WalletPassError):
+    """Signing material is missing, malformed, mismatched or expired.
+
+    The route layer catches this and returns the friendly 503 copy; the
+    underlying cryptographic detail stays in the server log.
+    """
+
+
+class WalletPassBuildError(WalletPassError):
+    """The supplied card content cannot be rendered into a valid pass."""
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WalletPassSigningMaterial:
+    """PEM material and identifiers needed to sign one pass.
+
+    Every PEM is `repr=False` so the private key can never surface in a log
+    line, an exception repr or a traceback frame dump.
+    """
+
+    team_identifier: str
+    certificate_pem: str = field(repr=False, default="")
+    private_key_pem: str = field(repr=False, default="")
+    wwdr_pem: str = field(repr=False, default="")
+    pass_type_identifier: str = PASS_TYPE_IDENTIFIER
+
+    @property
+    def configured(self) -> bool:
+        return bool(
+            self.team_identifier.strip()
+            and self.certificate_pem.strip()
+            and self.private_key_pem.strip()
+            and self.wwdr_pem.strip()
+            and self.pass_type_identifier.strip()
+        )
+
+    @classmethod
+    def from_runtime_settings(cls) -> WalletPassSigningMaterial:
+        """Read the signing material from backend runtime settings.
+
+        The import is function-local on purpose: a deployment that has not yet
+        provisioned the Wallet settings block degrades into the friendly 503
+        for this one route instead of failing the whole backend at import time.
+        """
+        try:
+            from hushh_mcp.runtime_settings import get_wallet_pass_settings
+        except ImportError as exc:
+            raise WalletPassSigningUnavailableError(
+                "Wallet pass runtime settings are not available in this build."
+            ) from exc
+
+        settings = get_wallet_pass_settings()
+        return cls(
+            team_identifier=str(settings.team_identifier or "").strip(),
+            certificate_pem=_normalize_pem(settings.cert_pem),
+            private_key_pem=_normalize_pem(settings.key_pem),
+            wwdr_pem=_normalize_pem(settings.wwdr_pem),
+            pass_type_identifier=(
+                str(settings.pass_type_identifier or "").strip() or PASS_TYPE_IDENTIFIER
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class WalletPassContent:
+    """Everything printed on, or linked from, one Wallet Profile pass.
+
+    All personal fields are `repr=False`: contract §10.3 forbids logging any
+    `card_payload` value, and dataclass reprs are the easiest way to leak one.
+    """
+
+    pass_serial: str
+    public_card_url: str
+    full_name: str = field(repr=False, default="")
+    headline: str = field(repr=False, default="")
+    organisation: str = field(repr=False, default="")
+    location_label: str = field(repr=False, default="")
+    summary: str = field(repr=False, default="")
+    skills: tuple[str, ...] = field(repr=False, default=())
+    email: str = field(repr=False, default="")
+    phone: str = field(repr=False, default="")
+    website: str = field(repr=False, default="")
+    linkedin: str = field(repr=False, default="")
+    github: str = field(repr=False, default="")
+    portfolio: str = field(repr=False, default="")
+    preferred_contact: str = field(repr=False, default="")
+    expires_at: datetime | None = field(repr=False, default=None)
+
+    @classmethod
+    def from_card_payload(
+        cls,
+        *,
+        pass_serial: str,
+        public_card_url: str,
+        card_payload: dict[str, Any] | None = None,
+        display_name: str | None = None,
+        headline: str | None = None,
+        expires_at: datetime | None = None,
+    ) -> WalletPassContent:
+        """Project a stored card row onto the pass face.
+
+        Only allowlisted `card_payload` keys are read (contract §3); anything
+        else in the payload is ignored here. The denormalised `display_name` /
+        `headline` columns act as fallbacks so a card whose payload predates a
+        column still renders.
+        """
+        payload = card_payload if isinstance(card_payload, dict) else {}
+        return cls(
+            pass_serial=_clean(pass_serial),
+            public_card_url=_clean(public_card_url),
+            full_name=_clean(payload.get("full_name")) or _clean(display_name),
+            headline=_clean(payload.get("headline")) or _clean(headline),
+            organisation=_clean(payload.get("organisation")),
+            location_label=_clean(payload.get("location_label")),
+            summary=_clean(payload.get("summary")),
+            skills=_clean_str_tuple(payload.get("skills")),
+            email=_clean(payload.get("email")),
+            phone=_clean(payload.get("phone")),
+            website=_clean(payload.get("website")),
+            linkedin=_clean(payload.get("linkedin")),
+            github=_clean(payload.get("github")),
+            portfolio=_clean(payload.get("portfolio")),
+            preferred_contact=_clean(payload.get("preferred_contact")).lower(),
+            expires_at=expires_at,
+        )
+
+    @property
+    def alt_text(self) -> str:
+        """Short human label rendered under the QR code.
+
+        Never the share token: the token is inside the QR payload already, and
+        printing it as legible text invites shoulder-surfing transcription.
+        Capped so a long legal name cannot crowd the barcode caption.
+        """
+        label = self.full_name or PASS_LOGO_TEXT
+        if len(label) <= _ALT_TEXT_MAX_CHARS:
+            return label
+        return f"{label[: _ALT_TEXT_MAX_CHARS - 1].rstrip()}…"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _clean_str_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(_clean(item) for item in value if _clean(item))
+
+
+def _normalize_pem(value: Any) -> str:
+    """Accept PEM material that arrived with literal `\\n` escapes.
+
+    Secret Manager round-trips and some CI shells turn real newlines into the
+    two-character sequence; without this every PEM would fail to parse.
+    """
+    text = _clean(value)
+    if not text:
+        return ""
+    if "\\n" in text and "\n" not in text:
+        text = text.replace("\\n", "\n")
+    return text
+
+
+def _sha1_hex(data: bytes) -> str:
+    """SHA-1 digest for manifest.json.
+
+    Mandated by Apple's pass format. `usedforsecurity=False` records that this
+    is a format-compatibility digest: tamper resistance is provided by the
+    PKCS#7 signature over the manifest, not by this hash.
+    """
+    return hashlib.sha1(data, usedforsecurity=False).hexdigest()
+
+
+def _scaled_filename(base: str, scale: int) -> str:
+    return f"{base}.png" if scale == 1 else f"{base}@{scale}x.png"
+
+
+def _png_bytes(image: Image.Image) -> bytes:
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG", optimize=True)
+    return buffer.getvalue()
+
+
+def _w3c_datetime(value: datetime) -> str:
+    moment = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return moment.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _text_field(key: str, value: str, *, label: str = "") -> dict[str, str] | None:
+    """Build one pass field, or `None` when the value is absent.
+
+    Callers filter the `None`s out. Emitting an empty row instead would leave a
+    labelled blank on the pass face that the user can never fill in.
+    """
+    cleaned = _clean(value)
+    if not cleaned:
+        return None
+    entry: dict[str, str] = {"key": key, "value": cleaned}
+    if label:
+        entry["label"] = label
+    return entry
+
+
+def _present(*fields: dict[str, str] | None) -> list[dict[str, str]]:
+    return [entry for entry in fields if entry is not None]
+
+
+# ---------------------------------------------------------------------------
+# pass.json
+# ---------------------------------------------------------------------------
+
+
+def _preferred_contact_label(choice: str) -> str:
+    return {
+        "email": "Email",
+        "phone": "Phone",
+        "linkedin": "LinkedIn",
+        "website": "Website",
+    }.get(choice, "")
+
+
+def _build_back_fields(content: WalletPassContent) -> list[dict[str, str]]:
+    """Back-of-pass rows. Unlimited by Apple; every row is omitted when empty.
+
+    Wallet's data detectors turn plain email addresses, phone numbers and URLs
+    in `value` into tappable actions, so no attributedValue markup is needed.
+    """
+    skills = " · ".join(content.skills)
+    preferred = _preferred_contact_label(content.preferred_contact)
+
+    return _present(
+        _text_field("summary", content.summary, label="About"),
+        _text_field("skills", skills, label="Skills"),
+        _text_field("email", content.email, label="Email"),
+        _text_field("phone", content.phone, label="Phone"),
+        _text_field("website", content.website, label="Website"),
+        _text_field("linkedin", content.linkedin, label="LinkedIn"),
+        _text_field("github", content.github, label="GitHub"),
+        _text_field("portfolio", content.portfolio, label="Portfolio"),
+        _text_field("preferred_contact", preferred, label="Preferred contact"),
+        _text_field("profile_link", content.public_card_url, label="Profile link"),
+        _text_field(
+            "how_it_works",
+            "Scan the code on the front to open this profile.",
+            label="How this works",
+        ),
+        _text_field(
+            "control",
+            "Only the information you select will be visible. "
+            "You can update or disable access at any time.",
+            label="You stay in control",
+        ),
+    )
+
+
+def _build_pass_json(
+    content: WalletPassContent,
+    material: WalletPassSigningMaterial,
+) -> dict[str, Any]:
+    """Assemble pass.json for the `generic` style.
+
+    Front-field budget for a generic pass with a square barcode: up to 3 header
+    fields, 1 primary field, and 4 secondary + auxiliary fields *combined*. We
+    use 0 header (the logo text carries the brand), 1 primary, and at most 3
+    combined — always inside the cap, whatever the user filled in.
+
+    `webServiceURL` and `authenticationToken` are intentionally absent: there is
+    no Wallet web service (see the module docstring).
+    """
+    secondary = _present(_text_field("headline", content.headline))
+    auxiliary = _present(
+        _text_field("organisation", content.organisation, label="Organisation"),
+        _text_field("location", content.location_label, label="Location"),
+    )
+
+    primary = _present(
+        _text_field("name", content.full_name or PASS_LOGO_TEXT),
+    )
+
+    generic: dict[str, list[dict[str, str]]] = {"primaryFields": primary}
+    if secondary:
+        generic["secondaryFields"] = secondary
+    if auxiliary:
+        generic["auxiliaryFields"] = auxiliary
+    generic["backFields"] = _build_back_fields(content)
+
+    pass_json: dict[str, Any] = {
+        "formatVersion": 1,
+        "passTypeIdentifier": material.pass_type_identifier,
+        "teamIdentifier": material.team_identifier,
+        "organizationName": ORGANIZATION_NAME,
+        "description": PASS_DESCRIPTION,
+        "serialNumber": content.pass_serial,
+        "logoText": PASS_LOGO_TEXT,
+        "backgroundColor": _CARD_BACKGROUND_COLOR,
+        "foregroundColor": _CARD_FOREGROUND_COLOR,
+        "labelColor": _CARD_LABEL_COLOR,
+        "sharingProhibited": True,
+        "barcodes": [
+            {
+                "format": "PKBarcodeFormatQR",
+                "message": content.public_card_url,
+                "messageEncoding": "iso-8859-1",
+                "altText": content.alt_text,
+            }
+        ],
+        "generic": generic,
+    }
+
+    if content.expires_at is not None:
+        pass_json["expirationDate"] = _w3c_datetime(content.expires_at)
+
+    return pass_json
+
+
+# ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+
+
+def _draw_brand_mark(
+    size: int,
+    *,
+    background: tuple[int, int, int] | None,
+    mark: tuple[int, int, int],
+    inset: float = _ICON_MARK_INSET,
+) -> Image.Image:
+    """Draw the Hussh "H" mark as vector primitives at `size` × `size`.
+
+    Deliberately font-free: the mark must render identically on a developer Mac
+    and in the Linux container, and no system typeface is guaranteed in either.
+    Drawn 4× oversized and LANCZOS-downscaled for clean antialiased edges.
+
+    `inset` is the margin around the mark as a fraction of the canvas — a tile
+    with a coloured background needs breathing room, a transparent logo should
+    fill its slot.
+    """
+    scale = size * _MARK_SUPERSAMPLE
+    canvas_fill = (*background, 255) if background is not None else (0, 0, 0, 0)
+    canvas = Image.new("RGBA", (scale, scale), canvas_fill)
+    draw = ImageDraw.Draw(canvas)
+
+    # Glyph box, centred inside the inset margin. The mark is slightly wider
+    # than tall (_MARK_ASPECT), the proportions of a geometric grotesque "H".
+    box_height = scale * (1.0 - 2.0 * inset)
+    box_width = box_height * _MARK_ASPECT
+    left = (scale - box_width) / 2.0
+    top = (scale - box_height) / 2.0
+
+    stem_width = box_width * _MARK_STEM_RATIO
+    bar_height = box_height * _MARK_BAR_RATIO
+    fill = (*mark, 255)
+
+    left_stem_x = left + stem_width
+    right_stem_x = left + box_width - stem_width
+    bar_top = top + (box_height - bar_height) / 2.0
+
+    draw.rounded_rectangle(
+        (left, top, left_stem_x, top + box_height),
+        radius=stem_width / 2.0,
+        fill=fill,
+    )
+    draw.rounded_rectangle(
+        (right_stem_x, top, left + box_width, top + box_height),
+        radius=stem_width / 2.0,
+        fill=fill,
+    )
+    draw.rounded_rectangle(
+        (left, bar_top, left + box_width, bar_top + bar_height),
+        radius=bar_height / 2.0,
+        fill=fill,
+    )
+
+    return canvas.resize((size, size), Image.LANCZOS)
+
+
+def _monogram_palette(seed: str) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Deterministic, muted two-stop gradient derived from the user's name."""
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    hue = digest[0] / 255.0
+    top = colorsys.hsv_to_rgb(hue, 0.52, 0.64)
+    bottom = colorsys.hsv_to_rgb(hue, 0.62, 0.34)
+    return (
+        tuple(int(round(channel * 255)) for channel in top),  # type: ignore[return-value]
+        tuple(int(round(channel * 255)) for channel in bottom),  # type: ignore[return-value]
+    )
+
+
+def _vertical_gradient(
+    size: int,
+    top: tuple[int, int, int],
+    bottom: tuple[int, int, int],
+) -> Image.Image:
+    canvas = Image.new("RGB", (size, size))
+    draw = ImageDraw.Draw(canvas)
+    span = max(size - 1, 1)
+    for row in range(size):
+        ratio = row / span
+        draw.line(
+            [(0, row), (size, row)],
+            fill=tuple(
+                int(round(top[channel] + (bottom[channel] - top[channel]) * ratio))
+                for channel in range(3)
+            ),
+        )
+    return canvas
+
+
+def _initials(full_name: str) -> str:
+    """First + last initial, restricted to glyphs the bundled font actually has.
+
+    Anything outside Latin-1 letters returns "" so the caller falls back to the
+    brand mark rather than rendering a row of .notdef boxes.
+    """
+    tokens = [token for token in full_name.split() if token]
+    if not tokens:
+        return ""
+    candidates = [tokens[0][0]] if len(tokens) == 1 else [tokens[0][0], tokens[-1][0]]
+    letters = [char.upper() for char in candidates if char.isalpha() and ord(char) < 0x100]
+    if len(letters) != len(candidates):
+        return ""
+    return "".join(letters)
+
+
+def _monogram_thumbnail(size: int, initials: str, seed: str) -> Image.Image:
+    """Built-in avatar fallback: initials on a deterministic gradient."""
+    top, bottom = _monogram_palette(seed)
+    canvas = _vertical_gradient(size, top, bottom).convert("RGBA")
+
+    if not initials:
+        mark = _draw_brand_mark(size, background=None, mark=_MARK_RGB)
+        canvas.alpha_composite(mark)
+        return canvas.convert("RGB")
+
+    # Pillow's bundled Aileron face — scalable and shipped with the wheel, so
+    # it renders identically everywhere without a system font dependency.
+    font = ImageFont.load_default(size=int(size * 0.42))
+    draw = ImageDraw.Draw(canvas)
+    draw.text(
+        (size / 2, size / 2),
+        initials,
+        font=font,
+        fill=(255, 255, 255, 235),
+        anchor="mm",
+    )
+    return canvas.convert("RGB")
+
+
+def _decode_avatar(data: bytes) -> Image.Image | None:
+    """Decode an avatar into a square RGB master, or `None` on any problem.
+
+    Re-encoding through a fresh canvas strips every metadata block, so EXIF
+    (including GPS coordinates) never travels inside the pass bundle. A failure
+    here is never fatal — the caller falls back to the monogram.
+    """
+    if not data or len(data) > _MAX_AVATAR_BYTES:
+        return None
+
+    master_size = _THUMBNAIL_POINT_SIZE * max(_IMAGE_SCALES)
+    try:
+        with Image.open(io.BytesIO(data)) as source:
+            width, height = source.size
+            if width <= 0 or height <= 0 or width * height > _MAX_AVATAR_PIXELS:
+                return None
+            oriented = ImageOps.exif_transpose(source) or source
+            square = ImageOps.fit(
+                oriented.convert("RGB"),
+                (master_size, master_size),
+                method=Image.LANCZOS,
+                centering=(0.5, 0.4),
+            )
+    except Exception:
+        logger.info("wallet_pass.avatar_decode_failed; using generated fallback")
+        return None
+
+    # Copy the pixels into a brand-new image so no source metadata survives.
+    clean = Image.new("RGB", (master_size, master_size))
+    clean.paste(square)
+    return clean
+
+
+def _build_pass_images(
+    content: WalletPassContent,
+    avatar_image: bytes | None,
+) -> dict[str, bytes]:
+    """Every image the bundle needs, at @1x/@2x/@3x.
+
+    `icon` and `logo` are required by Apple; `thumbnail` is the generic style's
+    headshot slot. All three are always present — a user with no avatar gets the
+    generated monogram rather than a pass that fails to build.
+    """
+    images: dict[str, bytes] = {}
+
+    for scale in _IMAGE_SCALES:
+        icon = _draw_brand_mark(
+            _ICON_POINT_SIZE * scale,
+            background=_BRAND_ACCENT_RGB,
+            mark=_MARK_RGB,
+        )
+        images[_scaled_filename("icon", scale)] = _png_bytes(icon.convert("RGB"))
+
+    for scale in _IMAGE_SCALES:
+        logo = _draw_brand_mark(
+            _LOGO_POINT_SIZE * scale,
+            background=None,
+            mark=_MARK_RGB,
+            inset=_LOGO_MARK_INSET,
+        )
+        images[_scaled_filename("logo", scale)] = _png_bytes(logo)
+
+    master = _decode_avatar(avatar_image) if avatar_image else None
+    if master is None:
+        master_size = _THUMBNAIL_POINT_SIZE * max(_IMAGE_SCALES)
+        master = _monogram_thumbnail(
+            master_size,
+            _initials(content.full_name),
+            content.full_name or content.pass_serial,
+        )
+
+    for scale in _IMAGE_SCALES:
+        target = _THUMBNAIL_POINT_SIZE * scale
+        thumbnail = (
+            master
+            if master.size == (target, target)
+            else master.resize((target, target), Image.LANCZOS)
+        )
+        images[_scaled_filename("thumbnail", scale)] = _png_bytes(thumbnail)
+
+    return images
+
+
+# ---------------------------------------------------------------------------
+# Signing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SigningContext:
+    certificate: x509.Certificate
+    private_key: Any = field(repr=False, default=None)
+    wwdr: x509.Certificate | None = None
+
+
+def _load_signing_context(material: WalletPassSigningMaterial) -> _SigningContext:
+    """Parse and sanity-check the PEM material.
+
+    Fails closed on every problem — a pass signed with an expired or mismatched
+    certificate installs nowhere, so a friendly 503 is more honest than handing
+    the user a broken download.
+    """
+    if not material.configured:
+        raise WalletPassSigningUnavailableError("Wallet pass signing material is not configured.")
+
+    try:
+        certificate = x509.load_pem_x509_certificate(material.certificate_pem.encode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        raise WalletPassSigningUnavailableError(
+            f"Pass Type ID certificate could not be parsed ({type(exc).__name__})."
+        ) from exc
+
+    try:
+        wwdr = x509.load_pem_x509_certificate(material.wwdr_pem.encode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        raise WalletPassSigningUnavailableError(
+            f"WWDR intermediate certificate could not be parsed ({type(exc).__name__})."
+        ) from exc
+
+    try:
+        private_key = serialization.load_pem_private_key(
+            material.private_key_pem.encode("utf-8"),
+            password=None,
+        )
+    except (ValueError, TypeError) as exc:
+        # Only the exception *class* is reported: never the message, never the PEM.
+        raise WalletPassSigningUnavailableError(
+            f"Pass Type ID private key could not be loaded ({type(exc).__name__})."
+        ) from exc
+
+    _assert_key_matches_certificate(certificate, private_key)
+    _assert_certificate_valid(certificate, material.pass_type_identifier)
+    return _SigningContext(certificate=certificate, private_key=private_key, wwdr=wwdr)
+
+
+def _assert_key_matches_certificate(certificate: x509.Certificate, private_key: Any) -> None:
+    try:
+        matches = certificate.public_key().public_numbers() == (
+            private_key.public_key().public_numbers()
+        )
+    except AttributeError as exc:
+        raise WalletPassSigningUnavailableError(
+            "Pass Type ID key type is not supported for pass signing."
+        ) from exc
+    if not matches:
+        raise WalletPassSigningUnavailableError(
+            "Pass Type ID private key does not match the configured certificate."
+        )
+
+
+def _assert_certificate_valid(certificate: x509.Certificate, pass_type_identifier: str) -> None:
+    now = datetime.now(UTC)
+    not_after = certificate.not_valid_after_utc
+    if not_after <= now:
+        raise WalletPassSigningUnavailableError(
+            f"Pass Type ID certificate expired on {not_after.date().isoformat()}."
+        )
+    if certificate.not_valid_before_utc > now:
+        raise WalletPassSigningUnavailableError(
+            "Pass Type ID certificate is not valid yet; check the runtime clock."
+        )
+
+    days_left = (not_after - now).days
+    if days_left <= _CERT_EXPIRY_WARNING_DAYS:
+        logger.warning(
+            "wallet_pass.certificate_expiring days_left=%s not_after=%s",
+            days_left,
+            not_after.date().isoformat(),
+        )
+
+    # Soft check only: Apple carries the pass type id in the subject UID, but a
+    # renewed certificate occasionally omits it. Mismatch is worth an operator
+    # log line, not a hard failure.
+    subject_uid = certificate.subject.get_attributes_for_oid(_UID_OID)
+    if subject_uid and str(subject_uid[0].value) != pass_type_identifier:
+        logger.warning(
+            "wallet_pass.pass_type_identifier_mismatch configured=%s certificate=%s",
+            pass_type_identifier,
+            subject_uid[0].value,
+        )
+
+
+def _sign_manifest(manifest_bytes: bytes, context: _SigningContext) -> bytes:
+    """PKCS#7 *detached* DER signature over manifest.json.
+
+    `Binary` stops the CMS layer from normalising line endings in the payload;
+    `DetachedSignature` keeps the manifest out of the signature blob, which is
+    what Wallet expects. The WWDR intermediate rides along so the device can
+    build the chain to the Apple root.
+    """
+    builder = (
+        pkcs7.PKCS7SignatureBuilder()
+        .set_data(manifest_bytes)
+        .add_signer(context.certificate, context.private_key, hashes.SHA256())
+    )
+    if context.wwdr is not None:
+        builder = builder.add_certificate(context.wwdr)
+
+    try:
+        return builder.sign(
+            serialization.Encoding.DER,
+            [pkcs7.PKCS7Options.DetachedSignature, pkcs7.PKCS7Options.Binary],
+        )
+    except (ValueError, TypeError) as exc:
+        raise WalletPassSigningUnavailableError(
+            f"Pass signature could not be produced ({type(exc).__name__})."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembly
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(files: dict[str, bytes]) -> bytes:
+    """manifest.json: SHA-1 hex digest per bundle file, keyed by relative name.
+
+    `.DS_Store`, the manifest itself and the signature are excluded. Keys are
+    sorted so an unchanged card always serialises identically.
+    """
+    digests = {
+        name: _sha1_hex(payload)
+        for name, payload in files.items()
+        if name not in _MANIFEST_EXCLUDED
+    }
+    return json.dumps(digests, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _zip_bundle(files: dict[str, bytes]) -> bytes:
+    """Zip the bundle with a fixed timestamp so output stays reproducible."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name in sorted(files):
+            info = zipfile.ZipInfo(filename=name, date_time=_ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, files[name])
+    return buffer.getvalue()
+
+
+def _validate_content(content: WalletPassContent) -> None:
+    if not content.pass_serial:
+        raise WalletPassBuildError("pass_serial is required to build a Wallet pass.")
+    if not content.public_card_url.startswith("https://"):
+        raise WalletPassBuildError("The public card URL must be an https:// URL.")
+    try:
+        # `messageEncoding` governs the barcode payload only: a URL that cannot
+        # round-trip through iso-8859-1 would scan as mojibake. `altText` is an
+        # ordinary localisable string in UTF-8 pass.json and is deliberately NOT
+        # checked here — holding it to Latin-1 would make a pass impossible for
+        # anyone whose name is written in a non-Latin script.
+        content.public_card_url.encode("iso-8859-1")
+    except UnicodeEncodeError as exc:
+        raise WalletPassBuildError("The public card URL must be encodable as iso-8859-1.") from exc
+
+
+def build_pkpass(
+    content: WalletPassContent,
+    *,
+    material: WalletPassSigningMaterial | None = None,
+    avatar_image: bytes | None = None,
+) -> bytes:
+    """Build and sign one `.pkpass` archive and return it as bytes.
+
+    Deterministic: the same content, avatar and signing material produce the
+    same bundle (the PKCS#7 blob itself varies, as CMS signatures do).
+
+    Raises:
+        WalletPassBuildError: the card content cannot make a valid pass.
+        WalletPassSigningUnavailableError: signing material missing or unusable
+            — the route maps this to the friendly 503 copy.
+    """
+    _validate_content(content)
+
+    signing_material = material or WalletPassSigningMaterial.from_runtime_settings()
+    context = _load_signing_context(signing_material)
+
+    files: dict[str, bytes] = dict(_build_pass_images(content, avatar_image))
+    files["pass.json"] = json.dumps(
+        _build_pass_json(content, signing_material),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    manifest = build_manifest(files)
+    files["manifest.json"] = manifest
+    files["signature"] = _sign_manifest(manifest, context)
+
+    bundle = _zip_bundle(files)
+    logger.info(
+        "wallet_pass.built serial=%s files=%s bytes=%s",
+        content.pass_serial,
+        len(files),
+        len(bundle),
+    )
+    return bundle
+
+
+def wallet_pass_signing_available(
+    material: WalletPassSigningMaterial | None = None,
+) -> bool:
+    """Cheap readiness probe for health checks and the owner setup screen.
+
+    Never raises and never logs secrets; returns False for any configuration
+    problem so callers can hide Add-to-Wallet instead of offering a download
+    that would 503.
+    """
+    try:
+        _load_signing_context(material or WalletPassSigningMaterial.from_runtime_settings())
+        return True
+    except WalletPassSigningUnavailableError as exc:
+        logger.warning("wallet_pass.signing_unavailable: %s", exc)
+        return False

--- a/consent-protocol/hushh_mcp/services/one_wallet_card_service.py
+++ b/consent-protocol/hushh_mcp/services/one_wallet_card_service.py
@@ -95,7 +95,16 @@ _MAX_USER_ID_LENGTH: Final = 160
 
 # Public card page (contract §1). Relative when no public origin is configured.
 _PUBLIC_CARD_PATH: Final = "/c/"
-_PUBLIC_ORIGIN_ENV: Final = ("NEXT_PUBLIC_APP_URL", "APP_PUBLIC_URL", "FRONTEND_BASE_URL")
+# APP_FRONTEND_ORIGIN first: it is the only one of these the deployed backend
+# actually receives (see deploy/backend.cloudbuild.yaml), so without it every
+# QR minted in UAT/prod would encode a relative path and resolve nowhere when
+# scanned by a phone camera. The rest stay as local/dev overrides.
+_PUBLIC_ORIGIN_ENV: Final = (
+    "APP_FRONTEND_ORIGIN",
+    "NEXT_PUBLIC_APP_URL",
+    "APP_PUBLIC_URL",
+    "FRONTEND_BASE_URL",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -564,7 +573,10 @@ def _public_origin() -> str:
         raw = _text(os.getenv(name))
         if raw:
             break
-    raw = raw.rstrip("/")
+    # APP_FRONTEND_ORIGIN is a CSV allowlist in some deployments (see
+    # vault_keys_service CORS collection). A QR can only encode one origin, so
+    # take the first entry rather than emitting a comma-spliced non-URL.
+    raw = _text(raw.split(",")[0]).rstrip("/")
     if not raw:
         return ""
     return raw if "://" in raw else f"https://{raw}"

--- a/consent-protocol/hushh_mcp/services/one_wallet_card_service.py
+++ b/consent-protocol/hushh_mcp/services/one_wallet_card_service.py
@@ -1,0 +1,1260 @@
+"""Wallet Profile card lifecycle — the owner-controlled plane behind a Hussh One pass.
+
+This service owns exactly one table, ``one_wallet_cards``, with one row per
+owner. It is the only place in the product that turns owner-selected
+information into something an anonymous stranger can read, so the invariants
+below are structural rather than advisory.
+
+**A dedicated plane, deliberately.** Nothing here reads or writes
+``pkm_default_available_projections``. That table is scanned by the Information
+Marketplace catalogue with no source filter, so publishing a card through it
+would silently list the owner for sale; it also mints a fresh handle on every
+edit, which would invalidate an already-printed QR code. See the plan's D1.
+
+**The share token.** Minted as ``secrets.token_urlsafe(32)`` and stored only as
+its SHA-256 hex digest, mirroring the shipped One Location public-invite
+pattern (``one_location_agent_service._hash_public_value``). The plaintext is
+returned to the owner exactly once — at create and at rotate — and is never
+stored, never logged, and never echoed in an error body. Rotating overwrites
+the digest, so the previous token stops resolving the instant the statement
+commits. Lookup hashes the presented token and confirms the row with
+``hmac.compare_digest``.
+
+**Status semantics are a privacy boundary, not cosmetics.** A ``paused`` card
+and an unknown token produce the *identical* result object, so a visitor
+holding a stale link cannot detect that a card exists and was paused.
+``revoked`` and ``expired`` report honest terminal states because the visitor
+already knew the card existed. Any status the schema does not define collapses
+to "not found" — the read fails closed.
+
+**One projection builder.** ``build_public_projection`` is the single function
+behind both the public resolve route and the owner preview route, so
+preview-as-visitor is byte-identical to what a stranger receives. It emits no
+``user_id``, no ``pass_serial``, no ``share_token_hash``, no status and no
+timestamp finer than a date.
+
+**Scan counters are aggregate and best-effort.** ``record_scan`` bumps
+``scan_count``/``last_scanned_at`` and swallows every failure at debug level:
+no per-scan row, no address, no user agent, no referrer, no coordinates, and a
+counter problem can never fail a visitor's read.
+
+Every statement is parameterised — bandit forbids f-string SQL — and no
+``card_payload`` value is ever logged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import secrets
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Final, TypedDict, cast
+from urllib.parse import urlparse
+
+from db.db_client import get_db
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Contract constants
+# ---------------------------------------------------------------------------
+
+STATUS_ACTIVE: Final = "active"
+STATUS_PAUSED: Final = "paused"
+STATUS_REVOKED: Final = "revoked"
+
+# Public read states. ``not_found`` covers both an unknown token and a paused
+# card; the route maps it to a generic 404 and the two are indistinguishable.
+PUBLIC_NOT_FOUND: Final = "not_found"
+PUBLIC_REVOKED: Final = "revoked"
+PUBLIC_EXPIRED: Final = "expired"
+
+# Error codes surfaced to the route layer.
+CODE_OWNER_REQUIRED: Final = "WALLET_CARD_OWNER_REQUIRED"
+CODE_PAYLOAD_INVALID: Final = "WALLET_CARD_PAYLOAD_INVALID"
+CODE_FIELD_UNKNOWN: Final = "WALLET_CARD_FIELD_UNKNOWN"
+CODE_NOT_FOUND: Final = "WALLET_CARD_NOT_FOUND"
+CODE_TURNED_OFF: Final = "WALLET_CARD_TURNED_OFF"
+CODE_WRITE_FAILED: Final = "WALLET_CARD_WRITE_FAILED"
+
+# 32 bytes of entropy, url-safe — 43 characters. Same shape and same helper the
+# One Location public invite uses.
+_SHARE_SECRET_BYTES: Final = 32
+_MIN_SHARE_LENGTH: Final = 16
+_MAX_SHARE_LENGTH: Final = 128
+_SHARE_ALPHABET: Final = re.compile(r"^[A-Za-z0-9_-]+$")
+
+_MAX_USER_ID_LENGTH: Final = 160
+
+# Public card page (contract §1). Relative when no public origin is configured.
+_PUBLIC_CARD_PATH: Final = "/c/"
+_PUBLIC_ORIGIN_ENV: Final = ("NEXT_PUBLIC_APP_URL", "APP_PUBLIC_URL", "FRONTEND_BASE_URL")
+
+
+# ---------------------------------------------------------------------------
+# card_payload allowlist (contract §3) — closed set, server-validated
+# ---------------------------------------------------------------------------
+
+# Declaration order is the serialisation order of the visitor projection.
+_ORDERED_ALLOWLIST: Final[tuple[str, ...]] = (
+    "full_name",
+    "headline",
+    "organisation",
+    "location_label",
+    "summary",
+    "skills",
+    "email",
+    "phone",
+    "website",
+    "linkedin",
+    "github",
+    "portfolio",
+    "preferred_contact",
+)
+_ALLOWED_KEYS: Final = frozenset(_ORDERED_ALLOWLIST)
+
+_TEXT_FIELD_LIMITS: Final[dict[str, int]] = {
+    "full_name": 80,
+    "headline": 120,
+    "organisation": 80,
+    "location_label": 80,
+    "summary": 400,
+    "email": 254,
+    "phone": 32,
+    "website": 300,
+    "linkedin": 300,
+    "github": 300,
+    "portfolio": 300,
+    "preferred_contact": 16,
+}
+
+_FIELD_LABELS: Final[dict[str, str]] = {
+    "full_name": "Name",
+    "headline": "Headline",
+    "organisation": "Organisation",
+    "location_label": "Location",
+    "summary": "Summary",
+    "skills": "Skills",
+    "email": "Email",
+    "phone": "Phone",
+    "website": "Website",
+    "linkedin": "LinkedIn",
+    "github": "GitHub",
+    "portfolio": "Portfolio",
+    "preferred_contact": "Preferred contact",
+    # Not an allowlisted payload key — a column, validated like any link.
+    "avatar_url": "Photo",
+}
+
+_URL_FIELDS: Final = frozenset({"website", "linkedin", "github", "portfolio"})
+_PREFERRED_CONTACT_CHOICES: Final = ("email", "phone", "linkedin", "website")
+
+_MAX_SKILLS: Final = 12
+_MAX_SKILL_LENGTH: Final = 40
+_MAX_AVATAR_URL_LENGTH: Final = 300
+
+# Same shapes the route model enforces, restated here because the service is
+# also reachable from background work and from tests without the route.
+_EMAIL_PATTERN: Final = re.compile(r"^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$")
+_PHONE_PATTERN: Final = re.compile(r"^\+?[0-9][0-9\s().-]{5,31}$")
+
+# Everything after ``https://``: RFC 3986 characters only. Excludes whitespace,
+# quotes, backslash and angle brackets, so markup can never survive into a
+# stored link. ``@`` is allowed because it is legal in a path
+# (``https://medium.com/@user``); the userinfo spoof is rejected separately by
+# inspecting the netloc.
+_URL_SAFE_PATTERN: Final = re.compile(r"^[A-Za-z0-9\-._~%:/?#\[\]@!$&()*+,;=]+$")
+
+# Rejected key names are echoed back so the client can fix the request. They
+# are client-authored text, so they are reduced to a safe charset first and
+# only the first few are named.
+_KEY_NAME_SAFE: Final = re.compile(r"[^A-Za-z0-9_.-]")
+_MAX_REPORTED_KEYS: Final = 5
+_MAX_REPORTED_KEY_LENGTH: Final = 40
+
+
+# ---------------------------------------------------------------------------
+# SQL — parameterised only (bandit forbids f-string SQL)
+# ---------------------------------------------------------------------------
+
+_SELECT_CARD_BY_OWNER: Final = """
+    SELECT *
+    FROM one_wallet_cards
+    WHERE user_id = :user_id
+    LIMIT 1
+"""
+
+_SELECT_CARD_BY_SHARE_HASH: Final = """
+    SELECT *
+    FROM one_wallet_cards
+    WHERE share_token_hash = :share_token_hash
+    LIMIT 1
+"""
+
+# ``DO NOTHING`` makes creation idempotent under a concurrent first write: the
+# loser gets no row back and falls through to the update path.
+_INSERT_CARD: Final = """
+    INSERT INTO one_wallet_cards (
+      user_id, share_token_hash, status, card_payload,
+      display_name, headline, avatar_url, expires_at, created_at, updated_at
+    )
+    VALUES (
+      :user_id, :share_token_hash, 'active', CAST(:card_payload_json AS JSONB),
+      :display_name, :headline, CAST(:avatar_url AS TEXT),
+      CAST(:expires_at AS TIMESTAMPTZ), NOW(), NOW()
+    )
+    ON CONFLICT (user_id) DO NOTHING
+    RETURNING *
+"""
+
+# The share token is deliberately absent: editing a card must never invalidate
+# an already-printed QR code. ``status <> 'revoked'`` fails the write closed if
+# the owner revoked concurrently.
+_UPDATE_CARD: Final = """
+    UPDATE one_wallet_cards
+    SET card_payload = CAST(:card_payload_json AS JSONB),
+        display_name = :display_name,
+        headline = :headline,
+        avatar_url = CASE WHEN :apply_avatar
+          THEN CAST(:avatar_url AS TEXT) ELSE avatar_url END,
+        expires_at = CASE WHEN :apply_expiry
+          THEN CAST(:expires_at AS TIMESTAMPTZ) ELSE expires_at END,
+        updated_at = NOW()
+    WHERE user_id = :user_id
+      AND status <> 'revoked'
+    RETURNING *
+"""
+
+# Setting the card up again after a revoke. The token is re-minted so links
+# shared before the revoke stay dead, and revoked_at is cleared to satisfy the
+# table's revocation CHECK.
+_REACTIVATE_CARD: Final = """
+    UPDATE one_wallet_cards
+    SET card_payload = CAST(:card_payload_json AS JSONB),
+        display_name = :display_name,
+        headline = :headline,
+        share_token_hash = :share_token_hash,
+        share_token_version = share_token_version + 1,
+        status = CASE WHEN status = 'revoked' THEN 'active' ELSE status END,
+        revoked_at = NULL,
+        avatar_url = CASE WHEN :apply_avatar
+          THEN CAST(:avatar_url AS TEXT) ELSE avatar_url END,
+        expires_at = CASE WHEN :apply_expiry
+          THEN CAST(:expires_at AS TIMESTAMPTZ) ELSE expires_at END,
+        updated_at = NOW()
+    WHERE user_id = :user_id
+      AND status = 'revoked'
+    RETURNING *
+"""
+
+_ROTATE_SHARE_HASH: Final = """
+    UPDATE one_wallet_cards
+    SET share_token_hash = :share_token_hash,
+        share_token_version = share_token_version + 1,
+        updated_at = NOW()
+    WHERE user_id = :user_id
+      AND status <> 'revoked'
+    RETURNING *
+"""
+
+_SET_CARD_STATUS: Final = """
+    UPDATE one_wallet_cards
+    SET status = :status,
+        updated_at = NOW()
+    WHERE user_id = :user_id
+      AND status <> 'revoked'
+    RETURNING *
+"""
+
+# Idempotent: COALESCE keeps the first revocation moment on a repeat call.
+_REVOKE_CARD: Final = """
+    UPDATE one_wallet_cards
+    SET status = 'revoked',
+        revoked_at = COALESCE(revoked_at, NOW()),
+        updated_at = NOW()
+    WHERE user_id = :user_id
+    RETURNING *
+"""
+
+# Aggregate counters only. ``updated_at`` is deliberately untouched so a scan
+# never shifts the coarse date a visitor can see.
+_BUMP_SCAN_COUNTERS: Final = """
+    UPDATE one_wallet_cards
+    SET scan_count = scan_count + 1,
+        last_scanned_at = NOW()
+    WHERE share_token_hash = :share_token_hash
+      AND status = 'active'
+"""
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class OneWalletCardError(RuntimeError):
+    """A Wallet Profile failure the route can translate directly.
+
+    ``message`` is user-facing copy. It never carries a ``card_payload`` value,
+    a share token, or any internal identifier.
+    """
+
+    def __init__(self, code: str, message: str, *, status_code: int = 400) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def wallet_card_error_detail(error: OneWalletCardError) -> dict[str, str]:
+    """HTTPException detail body for a Wallet Profile failure."""
+
+    return {"code": error.code, "message": error.message}
+
+
+class _Unset:
+    """Sentinel for "leave the stored value exactly as it is"."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid only
+        return "<unset>"
+
+
+UNSET: Final = _Unset()
+
+
+# ---------------------------------------------------------------------------
+# Typed shapes
+# ---------------------------------------------------------------------------
+
+
+class PublicCardProjection(TypedDict, total=False):
+    """What an anonymous visitor receives. Every key is optional because every
+    allowlisted field is optional; absent values are omitted, never blank."""
+
+    fullName: str
+    headline: str
+    organisation: str
+    locationLabel: str
+    summary: str
+    skills: list[str]
+    email: str
+    phone: str
+    website: str
+    linkedin: str
+    github: str
+    portfolio: str
+    preferredContact: str
+    avatarUrl: str
+    updatedOn: str
+
+
+class PublicCardResult(TypedDict):
+    """Envelope the public plane reports rather than raises, so the route can
+    map ``not_found`` to a generic 404 and the terminal states to 410."""
+
+    status: str
+    card: PublicCardProjection | None
+
+
+class OwnerCardView(TypedDict, total=False):
+    """Owner-authenticated view. Carries no ``user_id`` and no token digest."""
+
+    passSerial: str
+    status: str
+    shareTokenVersion: int
+    cardPayload: dict[str, Any]
+    displayName: str | None
+    headline: str | None
+    avatarUrl: str | None
+    expiresAt: str | None
+    createdAt: str | None
+    updatedAt: str | None
+    revokedAt: str | None
+    lastScannedAt: str | None
+    scanCount: int
+
+
+class WalletCardMutation(TypedDict, total=False):
+    """Owner mutation result. ``shareToken``/``shareUrl`` appear only when a
+    token was minted — at create and at rotate — and never on a plain edit."""
+
+    card: OwnerCardView
+    shareToken: str
+    shareUrl: str
+
+
+class PassMaterial(TypedDict, total=False):
+    """Everything the pass factory needs. No owner identifier, no digest."""
+
+    passSerial: str
+    publicCardUrl: str
+    cardPayload: dict[str, Any]
+    displayName: str | None
+    headline: str | None
+    expiresAt: str | None
+
+
+class PassMaterialResult(TypedDict):
+    status: str
+    material: PassMaterial | None
+
+
+@dataclass(frozen=True)
+class WalletCardRecord:
+    """One ``one_wallet_cards`` row, typed.
+
+    Personal fields and the token digest are ``repr=False`` so they cannot leak
+    through a traceback frame dump or an accidental log interpolation.
+    """
+
+    user_id: str = field(repr=False, default="")
+    pass_serial: str = ""
+    share_token_hash: str = field(repr=False, default="")
+    share_token_version: int = 1
+    status: str = STATUS_ACTIVE
+    card_payload: dict[str, Any] = field(repr=False, default_factory=dict)
+    display_name: str = field(repr=False, default="")
+    headline: str = field(repr=False, default="")
+    avatar_url: str = field(repr=False, default="")
+    expires_at: datetime | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    revoked_at: datetime | None = None
+    last_scanned_at: datetime | None = None
+    scan_count: int = 0
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> WalletCardRecord:
+        """Build a record from a raw database row, coercing every field.
+
+        Never raises: a read must not fail because a column arrived in an
+        unexpected representation.
+        """
+
+        return cls(
+            user_id=_text(row.get("user_id")),
+            pass_serial=_text(row.get("pass_serial")),
+            share_token_hash=_text(row.get("share_token_hash")),
+            share_token_version=_int(row.get("share_token_version"), default=1),
+            status=_text(row.get("status")).lower(),
+            card_payload=_json_object(row.get("card_payload")),
+            display_name=_text(row.get("display_name")),
+            headline=_text(row.get("headline")),
+            avatar_url=_text(row.get("avatar_url")),
+            expires_at=_as_datetime(row.get("expires_at")),
+            created_at=_as_datetime(row.get("created_at")),
+            updated_at=_as_datetime(row.get("updated_at")),
+            revoked_at=_as_datetime(row.get("revoked_at")),
+            last_scanned_at=_as_datetime(row.get("last_scanned_at")),
+            scan_count=_int(row.get("scan_count"), default=0),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _text(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def _int(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    """Stored JSONB as a dict. Any other shape reads as empty."""
+
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(decoded) if isinstance(decoded, dict) else {}
+    return {}
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    """Coerce a column to an aware UTC datetime, or ``None``."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw = str(value).strip()
+        if not raw:
+            return None
+        if raw.endswith("Z"):
+            raw = f"{raw[:-1]}+00:00"
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()
+
+
+def _coarse_date(value: datetime | None) -> str:
+    """Date only. The visitor never sees a timestamp finer than this."""
+
+    return "" if value is None else value.strftime("%Y-%m-%d")
+
+
+def _normalise_text(value: str) -> str:
+    """Trim, collapse whitespace runs, drop control characters.
+
+    Collapsing newlines is deliberate: pass fields and the visitor page are
+    single-line surfaces, and a stored newline is the cheapest way to fake
+    structure on either of them.
+    """
+
+    printable = "".join(char for char in value if char.isprintable() or char.isspace())
+    return " ".join(printable.split())
+
+
+def _hash_share_secret(value: str) -> str:
+    """SHA-256 hex of the plaintext token — the only form ever persisted."""
+
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalised_share_secret(value: Any) -> str:
+    """Trimmed token, or ``""`` when the shape cannot be one of ours.
+
+    A wrong-shape token is rejected here, before any query runs, so junk never
+    reaches the database and a probe learns nothing from response timing.
+    """
+
+    candidate = _text(value)
+    if len(candidate) < _MIN_SHARE_LENGTH or len(candidate) > _MAX_SHARE_LENGTH:
+        return ""
+    return candidate if _SHARE_ALPHABET.match(candidate) else ""
+
+
+def _public_origin() -> str:
+    """Configured public web origin, or ``""`` for a relative URL."""
+
+    raw = ""
+    for name in _PUBLIC_ORIGIN_ENV:
+        raw = _text(os.getenv(name))
+        if raw:
+            break
+    raw = raw.rstrip("/")
+    if not raw:
+        return ""
+    return raw if "://" in raw else f"https://{raw}"
+
+
+def public_card_url(share_token: str) -> str:
+    """Visitor URL for a share token — the QR payload and the owner's link."""
+
+    origin = _public_origin()
+    path = f"{_PUBLIC_CARD_PATH}{share_token}"
+    return f"{origin}{path}" if origin else path
+
+
+def _safe_key_names(keys: list[str]) -> str:
+    """Client-authored key names, reduced to a charset safe to echo back."""
+
+    names = [
+        _KEY_NAME_SAFE.sub("", str(key))[:_MAX_REPORTED_KEY_LENGTH]
+        for key in keys[:_MAX_REPORTED_KEYS]
+    ]
+    return ", ".join(name for name in names if name)
+
+
+def _invalid(field_key: str, message: str) -> OneWalletCardError:
+    label = _FIELD_LABELS.get(field_key, "This field")
+    return OneWalletCardError(CODE_PAYLOAD_INVALID, f"{label}: {message}", status_code=422)
+
+
+# ---------------------------------------------------------------------------
+# Field validation (contract §3)
+# ---------------------------------------------------------------------------
+
+
+def _validated_https_url(field_key: str, value: str) -> str:
+    """Accept a plain ``https://host/...`` URL and nothing else.
+
+    Rejects every other scheme — notably ``javascript:`` and ``data:`` — the
+    scheme-relative ``//host`` form, the ``https://trusted@evil`` userinfo
+    spoof, and any character that could carry markup. Stored as plain text and
+    escaped at render time.
+
+    Only the scheme is normalised (to lower case), so a link the owner pasted
+    is served back exactly as they wrote it.
+    """
+
+    try:
+        parsed = urlparse(value)
+    except ValueError as exc:
+        raise _invalid(field_key, "enter a valid link.") from exc
+    if parsed.scheme != "https":
+        raise _invalid(field_key, "links must start with https://")
+    if not parsed.hostname:
+        raise _invalid(field_key, "links must include a website address.")
+    if "@" in parsed.netloc:
+        raise _invalid(field_key, "links must not contain sign-in details.")
+
+    _, _, remainder = value.partition("://")
+    if not _URL_SAFE_PATTERN.match(remainder):
+        raise _invalid(field_key, "links must not contain spaces or symbols.")
+    return f"https://{remainder}"
+
+
+def _validated_skills(value: Any) -> list[str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise _invalid("skills", "add skills as a list of short labels.")
+    if len(value) > _MAX_SKILLS:
+        raise _invalid("skills", f"add up to {_MAX_SKILLS}.")
+
+    cleaned: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise _invalid("skills", "each skill must be text.")
+        text = _normalise_text(item)
+        if not text:
+            continue
+        if len(text) > _MAX_SKILL_LENGTH:
+            raise _invalid("skills", f"each must be {_MAX_SKILL_LENGTH} characters or fewer.")
+        cleaned.append(text)
+    return cleaned or None
+
+
+def _validated_field(field_key: str, value: Any) -> Any | None:
+    """Stored form of one allowlisted field, or ``None`` to omit it.
+
+    Over-long values are refused, never truncated: silently shortening what
+    someone chose to publish is its own kind of misrepresentation.
+    """
+
+    if field_key == "skills":
+        return _validated_skills(value)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _invalid(field_key, "must be text.")
+
+    text = _normalise_text(value)
+    if not text:
+        return None
+
+    limit = _TEXT_FIELD_LIMITS[field_key]
+    if len(text) > limit:
+        raise _invalid(field_key, f"must be {limit} characters or fewer.")
+
+    if field_key in _URL_FIELDS:
+        return _validated_https_url(field_key, text)
+    if field_key == "email" and not _EMAIL_PATTERN.match(text):
+        raise _invalid(field_key, "enter a valid email address.")
+    if field_key == "phone" and not _PHONE_PATTERN.match(text):
+        raise _invalid(field_key, "enter a valid phone number.")
+    if field_key == "preferred_contact":
+        choice = text.lower()
+        if choice not in _PREFERRED_CONTACT_CHOICES:
+            raise _invalid(field_key, "choose email, phone, LinkedIn or website.")
+        return choice
+    return text
+
+
+def _resolve_preferred_contact(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop a preferred contact whose field is not being shared.
+
+    Pointing the visitor at a channel that is not on the card would print a
+    promise the card cannot keep.
+    """
+
+    choice = payload.get("preferred_contact")
+    if choice and not payload.get(str(choice)):
+        payload.pop("preferred_contact", None)
+    return payload
+
+
+def validate_card_payload(card_payload: Any) -> dict[str, Any]:
+    """Validate a client-supplied ``card_payload`` against the closed allowlist.
+
+    An unknown key is **rejected**, never silently dropped: the owner asked for
+    something to be published, and quietly discarding part of that request
+    would leave them believing it was shared. Empty values are dropped rather
+    than stored blank.
+
+    Raises:
+        OneWalletCardError: 422 for an unknown key or an invalid value. The
+            message names the field but never repeats the value.
+    """
+
+    if not isinstance(card_payload, Mapping):
+        raise OneWalletCardError(
+            CODE_PAYLOAD_INVALID,
+            "Wallet Profile details must be sent as an object.",
+            status_code=422,
+        )
+
+    unknown = [str(key) for key in card_payload if key not in _ALLOWED_KEYS]
+    if unknown:
+        named = _safe_key_names(unknown)
+        detail = f": {named}" if named else ""
+        raise OneWalletCardError(
+            CODE_FIELD_UNKNOWN,
+            f"These fields cannot be shared on a Wallet Profile{detail}.",
+            status_code=422,
+        )
+
+    validated: dict[str, Any] = {}
+    for field_key in _ORDERED_ALLOWLIST:
+        if field_key not in card_payload:
+            continue
+        value = _validated_field(field_key, card_payload[field_key])
+        if value is not None:
+            validated[field_key] = value
+    return _resolve_preferred_contact(validated)
+
+
+def allowlisted_card_payload(stored: Any) -> dict[str, Any]:
+    """Read-side sanitiser for an already-stored payload.
+
+    Applies the same per-field rules as :func:`validate_card_payload` but drops
+    what fails instead of raising, so a row written before a rule tightened can
+    still be read — while a value that would now be refused (an off-allowlist
+    key, a ``javascript:`` link) can never reach a visitor.
+    """
+
+    if not isinstance(stored, Mapping):
+        return {}
+
+    clean: dict[str, Any] = {}
+    for field_key in _ORDERED_ALLOWLIST:
+        if field_key not in stored:
+            continue
+        try:
+            value = _validated_field(field_key, stored[field_key])
+        except OneWalletCardError:
+            continue
+        if value is not None:
+            clean[field_key] = value
+    return _resolve_preferred_contact(clean)
+
+
+# ---------------------------------------------------------------------------
+# The visitor projection
+# ---------------------------------------------------------------------------
+
+# Stored key -> public key. Declaration order is the emitted order.
+_PROJECTION_KEYS: Final[tuple[tuple[str, str], ...]] = (
+    ("full_name", "fullName"),
+    ("headline", "headline"),
+    ("organisation", "organisation"),
+    ("location_label", "locationLabel"),
+    ("summary", "summary"),
+    ("skills", "skills"),
+    ("email", "email"),
+    ("phone", "phone"),
+    ("website", "website"),
+    ("linkedin", "linkedin"),
+    ("github", "github"),
+    ("portfolio", "portfolio"),
+    ("preferred_contact", "preferredContact"),
+)
+
+
+def _shareable_avatar_url(record: WalletCardRecord) -> str:
+    """The headshot, when it is safe to hand to an anonymous visitor.
+
+    Two guards, both fail-closed. The URL must survive the same link
+    validation an owner-supplied link does, so a ``javascript:`` value that
+    somehow reached the column can never be rendered. And it is withheld
+    entirely if it contains the owner's ``user_id`` — object-storage paths
+    routinely embed the uid, and the visitor plane must not leak one.
+    """
+
+    if not record.avatar_url:
+        return ""
+    try:
+        url = _validated_https_url("avatar_url", _normalise_text(record.avatar_url))
+    except OneWalletCardError:
+        return ""
+    return "" if record.user_id and record.user_id in url else url
+
+
+def build_public_projection(card: WalletCardRecord | Mapping[str, Any]) -> PublicCardProjection:
+    """Build the visitor projection for one card.
+
+    **This is the single builder used by both the public resolve route and the
+    owner preview route.** Preview-as-visitor is byte-identical to what a
+    stranger receives because it is literally the same function over the same
+    row — there is no second code path, and no route may assemble a projection
+    of its own.
+
+    The result carries only allowlisted ``card_payload`` fields, the headshot
+    when it is safe to share, and a coarse ``updatedOn`` date. It never emits
+    ``user_id``, ``pass_serial``, ``share_token_hash``, the card status, a scan
+    counter, or any other internal identifier or timestamp. Absent fields are
+    omitted rather than sent as blanks.
+    """
+
+    record = card if isinstance(card, WalletCardRecord) else WalletCardRecord.from_row(card)
+    payload = allowlisted_card_payload(record.card_payload)
+
+    projection: dict[str, Any] = {}
+    for stored_key, public_key in _PROJECTION_KEYS:
+        value = payload.get(stored_key)
+        if not value:
+            continue
+        projection[public_key] = list(value) if isinstance(value, list) else value
+
+    avatar_url = _shareable_avatar_url(record)
+    if avatar_url:
+        projection["avatarUrl"] = avatar_url
+
+    updated_on = _coarse_date(record.updated_at or record.created_at)
+    if updated_on:
+        projection["updatedOn"] = updated_on
+    return cast(PublicCardProjection, projection)
+
+
+def _not_found_result() -> PublicCardResult:
+    """The result an unknown token produces — and a paused card with it.
+
+    A paused card must be indistinguishable from one that never existed, so
+    both states return this identical object.
+    """
+
+    return {"status": PUBLIC_NOT_FOUND, "card": None}
+
+
+def _terminal_result(state: str) -> PublicCardResult:
+    return {"status": state, "card": None}
+
+
+def _is_expired(record: WalletCardRecord) -> bool:
+    return record.expires_at is not None and record.expires_at <= _utcnow()
+
+
+def _public_result(row: Mapping[str, Any] | None) -> PublicCardResult:
+    """Apply the binding §6 status rules to a resolved row.
+
+    Order matters: ``paused`` is checked before anything else so a paused card
+    cannot be distinguished by its expiry, and an unrecognised status falls
+    through to "not found" so the read fails closed.
+    """
+
+    if row is None:
+        return _not_found_result()
+
+    record = WalletCardRecord.from_row(row)
+    if record.status == STATUS_PAUSED:
+        return _not_found_result()
+    if record.status == STATUS_REVOKED:
+        return _terminal_result(PUBLIC_REVOKED)
+    if record.status != STATUS_ACTIVE:
+        return _not_found_result()
+    if _is_expired(record):
+        return _terminal_result(PUBLIC_EXPIRED)
+    return {"status": STATUS_ACTIVE, "card": build_public_projection(record)}
+
+
+def _owner_card_view(row: Mapping[str, Any]) -> OwnerCardView:
+    """Owner-authenticated view of a row. Omits ``user_id`` and the digest."""
+
+    record = WalletCardRecord.from_row(row)
+    return {
+        "passSerial": record.pass_serial,
+        "status": record.status,
+        "shareTokenVersion": record.share_token_version,
+        "cardPayload": allowlisted_card_payload(record.card_payload),
+        "displayName": record.display_name or None,
+        "headline": record.headline or None,
+        "avatarUrl": record.avatar_url or None,
+        "expiresAt": _iso(record.expires_at),
+        "createdAt": _iso(record.created_at),
+        "updatedAt": _iso(record.updated_at),
+        "revokedAt": _iso(record.revoked_at),
+        "lastScannedAt": _iso(record.last_scanned_at),
+        "scanCount": record.scan_count,
+    }
+
+
+def _pass_material(record: WalletCardRecord, share_token: str) -> PassMaterial:
+    """Pass-face material for an active card.
+
+    The public card URL is the QR payload, so it must be the same URL the
+    owner shares. No owner identifier and no token digest travel with it.
+    """
+
+    payload = allowlisted_card_payload(record.card_payload)
+    return {
+        "passSerial": record.pass_serial,
+        "publicCardUrl": public_card_url(share_token),
+        "cardPayload": payload,
+        "displayName": str(payload.get("full_name") or record.display_name) or None,
+        "headline": str(payload.get("headline") or record.headline) or None,
+        "expiresAt": _iso(record.expires_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Owner input coercion
+# ---------------------------------------------------------------------------
+
+
+def _require_user_id(value: Any) -> str:
+    owner_id = _text(value)
+    if not owner_id or len(owner_id) > _MAX_USER_ID_LENGTH:
+        raise OneWalletCardError(
+            CODE_OWNER_REQUIRED,
+            "Sign in to manage your Wallet Profile.",
+            status_code=401,
+        )
+    return owner_id
+
+
+def _expiry_parameters(value: str | datetime | None | _Unset) -> tuple[bool, datetime | None]:
+    """``(apply, value)`` for the expiry column.
+
+    ``UNSET`` keeps whatever is stored; an explicit ``None`` or empty string
+    clears the expiry, which is how the contract spells "no expiry".
+    """
+
+    if isinstance(value, _Unset):
+        return (False, None)
+    if value is None:
+        return (True, None)
+    if isinstance(value, datetime):
+        return (True, _as_datetime(value))
+
+    text = _text(value)
+    if not text:
+        return (True, None)
+    parsed = _as_datetime(text)
+    if parsed is None:
+        raise OneWalletCardError(
+            CODE_PAYLOAD_INVALID,
+            "Enter the expiry as a date and time.",
+            status_code=422,
+        )
+    return (True, parsed)
+
+
+def _avatar_parameters(value: str | None | _Unset) -> tuple[bool, str | None]:
+    """``(apply, value)`` for the avatar column, validated like any link."""
+
+    if isinstance(value, _Unset):
+        return (False, None)
+    if value is None:
+        return (True, None)
+
+    text = _normalise_text(_text(value))
+    if not text:
+        return (True, None)
+    if len(text) > _MAX_AVATAR_URL_LENGTH:
+        raise _invalid("avatar_url", f"must be {_MAX_AVATAR_URL_LENGTH} characters or fewer.")
+    return (True, _validated_https_url("avatar_url", text))
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class OneWalletCardService:
+    """Lifecycle of the single ``one_wallet_cards`` row an owner may have."""
+
+    # --- persistence seam -------------------------------------------------
+
+    def _execute_one(
+        self,
+        sql: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        result = get_db().execute_raw(sql, params or {})
+        rows = getattr(result, "data", None) or []
+        return dict(rows[0]) if rows else None
+
+    def _execute(self, sql: str, params: dict[str, Any] | None = None) -> None:
+        get_db().execute_raw(sql, params or {})
+
+    def _row_for_owner(self, owner_id: str) -> dict[str, Any] | None:
+        return self._execute_one(_SELECT_CARD_BY_OWNER, {"user_id": owner_id})
+
+    def _row_for_share_token(self, share_token: Any) -> dict[str, Any] | None:
+        """Resolve a presented token to its row, or ``None``.
+
+        The plaintext is hashed and only the digest is queried; the row is then
+        confirmed with a constant-time comparison so the lookup cannot be
+        narrowed by timing a partial match.
+        """
+
+        presented = _normalised_share_secret(share_token)
+        if not presented:
+            return None
+
+        expected = _hash_share_secret(presented)
+        row = self._execute_one(_SELECT_CARD_BY_SHARE_HASH, {"share_token_hash": expected})
+        if row is None:
+            return None
+        if not hmac.compare_digest(_text(row.get("share_token_hash")), expected):
+            return None
+        return row
+
+    def _missing_or_turned_off(self, owner_id: str) -> OneWalletCardError:
+        """Explain why an owner mutation matched no row."""
+
+        if self._row_for_owner(owner_id) is None:
+            return OneWalletCardError(
+                CODE_NOT_FOUND,
+                "Set up your Wallet Profile first.",
+                status_code=404,
+            )
+        return OneWalletCardError(
+            CODE_TURNED_OFF,
+            "This Wallet Profile was turned off. Set it up again to share it.",
+            status_code=409,
+        )
+
+    @staticmethod
+    def _mutation(row: Mapping[str, Any], *, share_token: str | None = None) -> WalletCardMutation:
+        result: dict[str, Any] = {"card": _owner_card_view(row)}
+        if share_token:
+            result["shareToken"] = share_token
+            result["shareUrl"] = public_card_url(share_token)
+        return cast(WalletCardMutation, result)
+
+    # --- owner reads ------------------------------------------------------
+
+    def get_card(self, *, user_id: str) -> OwnerCardView | None:
+        """The owner's card, or ``None`` when they have not set one up.
+
+        Scoped to the caller by primary key, so one owner can never read
+        another's row. The plaintext share token is not returned here — it
+        exists only in the create and rotate responses.
+        """
+
+        owner_id = _require_user_id(user_id)
+        row = self._row_for_owner(owner_id)
+        return None if row is None else _owner_card_view(row)
+
+    def preview_public_card(self, *, user_id: str) -> PublicCardResult:
+        """Preview-as-visitor for the owner.
+
+        Runs the owner's row through the same status rules and the same
+        :func:`build_public_projection` the public route uses, so what the
+        owner sees here is exactly what a stranger receives.
+        """
+
+        owner_id = _require_user_id(user_id)
+        return _public_result(self._row_for_owner(owner_id))
+
+    # --- owner mutations --------------------------------------------------
+
+    def upsert_card(
+        self,
+        *,
+        user_id: str,
+        card_payload: Any,
+        expires_at: str | datetime | None | _Unset = UNSET,
+        avatar_url: str | None | _Unset = UNSET,
+    ) -> WalletCardMutation:
+        """Create or replace the shared fields. Idempotent.
+
+        The token is minted on first creation and returned exactly once; a
+        later edit leaves it untouched so an already-printed QR keeps working.
+        Setting the card up again after a revoke re-mints the token instead of
+        resurrecting the old one, so links shared before the revoke stay dead.
+
+        ``card_payload`` replaces the stored payload wholesale — the owner's
+        edit screen submits the complete set of fields it is sharing, and
+        merging would make removing a field impossible.
+        """
+
+        owner_id = _require_user_id(user_id)
+        payload = validate_card_payload(card_payload)
+        apply_expiry, expiry = _expiry_parameters(expires_at)
+        apply_avatar, avatar = _avatar_parameters(avatar_url)
+
+        share_token = secrets.token_urlsafe(_SHARE_SECRET_BYTES)
+        columns: dict[str, Any] = {
+            "user_id": owner_id,
+            "card_payload_json": json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            "display_name": payload.get("full_name"),
+            "headline": payload.get("headline"),
+            "avatar_url": avatar,
+            "expires_at": expiry,
+        }
+
+        created = self._execute_one(
+            _INSERT_CARD,
+            {**columns, "share_token_hash": _hash_share_secret(share_token)},
+        )
+        if created is not None:
+            logger.info("wallet_card.created user_id=%s", owner_id)
+            return self._mutation(created, share_token=share_token)
+
+        existing = self._row_for_owner(owner_id)
+        if existing is None:
+            # The insert conflicted, so a row existed a moment ago. Fail closed
+            # rather than retry into an unbounded loop.
+            raise OneWalletCardError(
+                CODE_WRITE_FAILED,
+                "We couldn't save your Wallet Profile. Please try again.",
+                status_code=409,
+            )
+
+        mutable = {**columns, "apply_avatar": apply_avatar, "apply_expiry": apply_expiry}
+        if _text(existing.get("status")).lower() == STATUS_REVOKED:
+            reactivated = self._execute_one(
+                _REACTIVATE_CARD,
+                {**mutable, "share_token_hash": _hash_share_secret(share_token)},
+            )
+            if reactivated is None:
+                raise self._missing_or_turned_off(owner_id)
+            logger.info("wallet_card.reactivated user_id=%s", owner_id)
+            return self._mutation(reactivated, share_token=share_token)
+
+        updated = self._execute_one(_UPDATE_CARD, mutable)
+        if updated is None:
+            raise self._missing_or_turned_off(owner_id)
+        logger.info("wallet_card.updated user_id=%s", owner_id)
+        return self._mutation(updated)
+
+    def rotate_share_token(self, *, user_id: str) -> WalletCardMutation:
+        """Mint a new share token and invalidate the previous one immediately.
+
+        Only the current digest is retained, so the moment this statement
+        commits every previously shared link stops resolving. The plaintext is
+        returned here once and is not recoverable afterwards. ``pass_serial``
+        is untouched, so re-adding the pass overwrites the installed one rather
+        than stacking a duplicate.
+        """
+
+        owner_id = _require_user_id(user_id)
+        share_token = secrets.token_urlsafe(_SHARE_SECRET_BYTES)
+        row = self._execute_one(
+            _ROTATE_SHARE_HASH,
+            {"user_id": owner_id, "share_token_hash": _hash_share_secret(share_token)},
+        )
+        if row is None:
+            raise self._missing_or_turned_off(owner_id)
+
+        logger.info(
+            "wallet_card.share_rotated user_id=%s version=%s",
+            owner_id,
+            row.get("share_token_version"),
+        )
+        return self._mutation(row, share_token=share_token)
+
+    def pause_card(self, *, user_id: str) -> WalletCardMutation:
+        """Stop serving the card. A visitor sees exactly "not found"."""
+
+        return self._set_status(user_id=user_id, status=STATUS_PAUSED)
+
+    def resume_card(self, *, user_id: str) -> WalletCardMutation:
+        """Serve the card again on the same token, so printed QRs still work."""
+
+        return self._set_status(user_id=user_id, status=STATUS_ACTIVE)
+
+    def _set_status(self, *, user_id: str, status: str) -> WalletCardMutation:
+        owner_id = _require_user_id(user_id)
+        row = self._execute_one(_SET_CARD_STATUS, {"user_id": owner_id, "status": status})
+        if row is None:
+            # A revoked card is excluded by the statement: revocation is
+            # terminal and pause/resume must not undo it.
+            raise self._missing_or_turned_off(owner_id)
+        logger.info("wallet_card.status_set user_id=%s status=%s", owner_id, status)
+        return self._mutation(row)
+
+    def revoke_card(self, *, user_id: str) -> WalletCardMutation:
+        """Turn the card off for good. Idempotent.
+
+        A repeat revoke keeps the original ``revoked_at`` so the honest "no
+        longer shared" state the visitor sees never drifts.
+        """
+
+        owner_id = _require_user_id(user_id)
+        row = self._execute_one(_REVOKE_CARD, {"user_id": owner_id})
+        if row is None:
+            raise OneWalletCardError(
+                CODE_NOT_FOUND,
+                "There is no Wallet Profile to turn off.",
+                status_code=404,
+            )
+        logger.info("wallet_card.revoked user_id=%s", owner_id)
+        return self._mutation(row)
+
+    # --- public plane -----------------------------------------------------
+
+    def resolve_public_card(self, *, share_token: str) -> PublicCardResult:
+        """Resolve a scanned token into the visitor projection.
+
+        Reports the state rather than raising, because the route has to map
+        ``not_found`` to a generic 404 and ``revoked``/``expired`` to an honest
+        410 — raising would collapse every terminal state into one answer.
+
+        Unknown tokens and paused cards return the identical result object.
+        This does not touch the scan counters; the route bumps them out of band
+        with :meth:`record_scan`.
+        """
+
+        return _public_result(self._row_for_share_token(share_token))
+
+    def resolve_pass_material(self, *, share_token: str) -> PassMaterialResult:
+        """Material for the signed `.pkpass`, under the same status rules.
+
+        Returns no material for any state other than ``active``, so a paused,
+        revoked or expired card can never be downloaded as a pass.
+        """
+
+        presented = _normalised_share_secret(share_token)
+        row = self._row_for_share_token(presented)
+        result = _public_result(row)
+        if row is None or result["status"] != STATUS_ACTIVE:
+            return {"status": result["status"], "material": None}
+
+        record = WalletCardRecord.from_row(row)
+        return {"status": STATUS_ACTIVE, "material": _pass_material(record, presented)}
+
+    def record_scan(self, *, share_token: str) -> None:
+        """Bump the coarse scan counters. Best effort, never fatal.
+
+        Aggregate only: ``scan_count`` and ``last_scanned_at``, nothing else.
+        No per-scan row, address, user agent, referrer or location is recorded.
+        Every failure is swallowed at debug level with no token and no payload
+        value in the log line, because a counter must never fail a read.
+        """
+
+        try:
+            presented = _normalised_share_secret(share_token)
+            if not presented:
+                return
+            self._execute(
+                _BUMP_SCAN_COUNTERS,
+                {"share_token_hash": _hash_share_secret(presented)},
+            )
+        except Exception as exc:  # counters are advisory only
+            logger.debug("wallet_card.scan_counter_failed error=%s", exc.__class__.__name__)

--- a/consent-protocol/mcp_modules/log_redaction.py
+++ b/consent-protocol/mcp_modules/log_redaction.py
@@ -21,6 +21,9 @@ _QUERY_SECRET_RE = re.compile(
     flags=re.IGNORECASE,
 )
 
+_SQL_PARAMS_MARKER = "[parameters:"
+_SQL_BACKGROUND_MARKER = "(Background on this error at:"
+
 _SENSITIVE_EXACT_KEYS = {
     "authorization",
     "client_id",
@@ -87,12 +90,41 @@ def _is_sensitive_string(value: str) -> bool:
     )
 
 
+def _redact_sql_bound_parameters(value: str) -> str:
+    """Strip SQLAlchemy's bound-parameter blob out of an error string.
+
+    ``StatementError.__str__`` appends ``[SQL: ...] [parameters: {...}]`` unless
+    the engine was built with ``hide_parameters=True``, which none of ours are.
+    Every DBAPI failure therefore reprints each bound value — emails, phone
+    numbers, wallet card payloads — into whatever consumes the message.
+
+    Redaction runs to the ``(Background on this error at: ...)`` suffix or to the
+    end of the string rather than trying to balance brackets, because a bound
+    value may itself contain ``]`` and a partial match would leak a fragment.
+    The static ``[SQL: ...]`` statement text carries no values and is kept.
+    """
+    start = value.find(_SQL_PARAMS_MARKER)
+    if start == -1:
+        return value
+    tail_at = value.find(_SQL_BACKGROUND_MARKER, start)
+    tail = value[tail_at:] if tail_at != -1 else ""
+    return f"{value[:start]}{_SQL_PARAMS_MARKER} {REDACTED}]{tail}"
+
+
 def _redact_sensitive_substrings(value: str) -> str:
     redacted = _TOKEN_VALUE_RE.sub(REDACTED, value)
-    return _QUERY_SECRET_RE.sub(lambda match: f"{match.group(1)}{REDACTED}", redacted)
+    redacted = _QUERY_SECRET_RE.sub(lambda match: f"{match.group(1)}{REDACTED}", redacted)
+    return _redact_sql_bound_parameters(redacted)
 
 
 def _safe_scalar(value: Any) -> Any:
+    if isinstance(value, BaseException):
+        # ``logger.warning("... %s", exc)`` keeps the exception object in
+        # record.args, so it is only stringified by the handler — after this
+        # filter has run. Render it here instead, or a DBAPI error's bound
+        # parameters walk straight past every rule above. Deliberately not
+        # length-truncated: exception text is the diagnostic.
+        return _redact_sensitive_substrings(str(value))
     if isinstance(value, str):
         if _is_sensitive_string(value):
             return REDACTED

--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -374,6 +374,15 @@ app.include_router(marketplace.router)
 app.include_router(invites.router)
 logger.info("ria.routes_enabled")
 
+# Wallet Profile: owner management under /api/one/wallet-card plus the two
+# unauthenticated public surfaces (card resolve + signed .pkpass). Gated by
+# ONE_WALLET_CARD_ENABLED; when off every route in the router answers 404, so
+# registering it unconditionally is safe.
+from api.routes import one_wallet_card  # noqa: E402
+
+app.include_router(one_wallet_card.router)
+logger.info("one_wallet_card.routes_registered")
+
 logger.info(
     "🚀 Hussh Consent Protocol server initialized with modular routes - KAI V2 + PHASE 2 + PKM ENABLED"
 )

--- a/consent-protocol/tests/services/test_account_service_cleanup_tables.py
+++ b/consent-protocol/tests/services/test_account_service_cleanup_tables.py
@@ -114,6 +114,7 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
         "DELETE FROM one_location_envelopes",
         "DELETE FROM one_location_share_grants",
         "DELETE FROM one_location_recipient_keys",
+        "DELETE FROM one_wallet_cards",
         "DELETE FROM actor_verified_email_aliases",
         "DELETE FROM actor_identity_cache",
         "DELETE FROM runtime_persona_state",
@@ -153,6 +154,12 @@ async def test_full_account_deletion_covers_account_owned_tables(monkeypatch):
     )
     assert executed_sql.index("DELETE FROM one_location_share_grants") < executed_sql.index(
         "DELETE FROM actor_identity_cache"
+    )
+    # The public Wallet Profile card holds denormalized PII (name/email/phone/links) and
+    # is resolvable from an unauthenticated endpoint, so it must be removed while the
+    # account still exists — before the identity spine is torn down. Contract §2.
+    assert executed_sql.index("DELETE FROM one_wallet_cards") < executed_sql.index(
+        "DELETE FROM actor_profiles"
     )
 
 
@@ -223,6 +230,7 @@ async def test_reset_account_clears_data_but_keeps_account_spine(monkeypatch):
         "DELETE FROM one_location_events",
         "DELETE FROM one_location_nearby_presences",
         "DELETE FROM one_location_sms_contacts",
+        "DELETE FROM one_wallet_cards",
     ]
     for fragment in cleared_fragments:
         assert fragment in executed_sql

--- a/consent-protocol/tests/test_apple_wallet_pass_service.py
+++ b/consent-protocol/tests/test_apple_wallet_pass_service.py
@@ -1,0 +1,526 @@
+"""Contract tests for the Apple Wallet `.pkpass` factory.
+
+The pass bundle is opaque once it reaches a device, so everything Wallet
+validates is asserted here: the exact bundle members, a SHA-1 manifest that
+matches the bytes it describes, a detached PKCS#7 signature over that manifest,
+the required `pass.json` keys, the absence of any web-service key, and the
+generic-style front-field budget.
+
+Signing material is generated per test with a throwaway RSA key. No fixture,
+environment variable or file in this repository holds real Apple key material.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs7
+from cryptography.x509.oid import NameOID
+from PIL import Image
+
+from hushh_mcp.services.apple_wallet_pass_service import (
+    ORGANIZATION_NAME,
+    PASS_DESCRIPTION,
+    PASS_TYPE_IDENTIFIER,
+    WALLET_PASS_CONTENT_TYPE,
+    WALLET_PASS_FILENAME,
+    WalletPassBuildError,
+    WalletPassContent,
+    WalletPassSigningMaterial,
+    WalletPassSigningUnavailableError,
+    build_manifest,
+    build_pkpass,
+    wallet_pass_signing_available,
+)
+
+TEAM_IDENTIFIER = "TEAMID1234"
+PUBLIC_CARD_URL = "https://one.hushh.ai/c/share-token-abc"
+PASS_SERIAL = "6f2f0e6a-6d5e-4b0a-9f0a-0d1c2b3a4e5f"
+
+EXPECTED_BUNDLE_MEMBERS = frozenset(
+    {
+        "pass.json",
+        "manifest.json",
+        "signature",
+        "icon.png",
+        "icon@2x.png",
+        "icon@3x.png",
+        "logo.png",
+        "logo@2x.png",
+        "logo@3x.png",
+        "thumbnail.png",
+        "thumbnail@2x.png",
+        "thumbnail@3x.png",
+    }
+)
+
+FULL_CARD_PAYLOAD = {
+    "full_name": "Ada Lovelace",
+    "headline": "Founder, Hussh",
+    "organisation": "Hussh Labs",
+    "location_label": "Mumbai, India",
+    "summary": "Builds private agents.",
+    "skills": ["Python", "Cryptography", "Product"],
+    "email": "ada@example.com",
+    "phone": "+91 99999 90000",
+    "website": "https://ada.example.com",
+    "linkedin": "https://www.linkedin.com/in/ada",
+    "github": "https://github.com/ada",
+    "portfolio": "https://ada.example.com/work",
+    "preferred_contact": "email",
+}
+
+
+# ---------------------------------------------------------------------------
+# Throwaway signing material
+# ---------------------------------------------------------------------------
+
+
+def _self_signed(
+    common_name: str,
+    *,
+    pass_type_identifier: str | None = None,
+    not_before: datetime | None = None,
+    not_after: datetime | None = None,
+) -> tuple[x509.Certificate, rsa.RSAPrivateKey]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    attributes = [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+    if pass_type_identifier:
+        attributes.append(x509.NameAttribute(NameOID.USER_ID, pass_type_identifier))
+    name = x509.Name(attributes)
+    now = datetime.now(UTC)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before or now - timedelta(days=1))
+        .not_valid_after(not_after or now + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    return certificate, key
+
+
+def _pem_certificate(certificate: x509.Certificate) -> str:
+    return certificate.public_bytes(serialization.Encoding.PEM).decode("ascii")
+
+
+def _pem_key(key: rsa.RSAPrivateKey) -> str:
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+
+@pytest.fixture
+def signing_material() -> WalletPassSigningMaterial:
+    certificate, key = _self_signed(
+        "Pass Type ID: pass.com.hushh.app.one",
+        pass_type_identifier=PASS_TYPE_IDENTIFIER,
+    )
+    wwdr, _ = _self_signed("Apple Worldwide Developer Relations Certification Authority")
+    return WalletPassSigningMaterial(
+        team_identifier=TEAM_IDENTIFIER,
+        certificate_pem=_pem_certificate(certificate),
+        private_key_pem=_pem_key(key),
+        wwdr_pem=_pem_certificate(wwdr),
+        pass_type_identifier=PASS_TYPE_IDENTIFIER,
+    )
+
+
+def _content(**overrides: object) -> WalletPassContent:
+    defaults: dict[str, object] = {
+        "pass_serial": PASS_SERIAL,
+        "public_card_url": PUBLIC_CARD_URL,
+        "card_payload": dict(FULL_CARD_PAYLOAD),
+    }
+    defaults.update(overrides)
+    return WalletPassContent.from_card_payload(**defaults)  # type: ignore[arg-type]
+
+
+def _bundle_members(bundle: bytes) -> dict[str, bytes]:
+    with zipfile.ZipFile(io.BytesIO(bundle)) as archive:
+        return {name: archive.read(name) for name in archive.namelist()}
+
+
+def _png_size(data: bytes) -> tuple[int, int]:
+    with Image.open(io.BytesIO(data)) as image:
+        return image.size
+
+
+# ---------------------------------------------------------------------------
+# Bundle shape
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_contains_exactly_the_expected_members(signing_material) -> None:
+    members = _bundle_members(build_pkpass(_content(), material=signing_material))
+
+    assert set(members) == EXPECTED_BUNDLE_MEMBERS
+    assert ".DS_Store" not in members
+    for name, payload in members.items():
+        assert payload, name
+
+
+def test_manifest_lists_sha1_of_every_file_except_itself_and_the_signature(
+    signing_material,
+) -> None:
+    members = _bundle_members(build_pkpass(_content(), material=signing_material))
+    manifest = json.loads(members["manifest.json"].decode("utf-8"))
+
+    assert set(manifest) == EXPECTED_BUNDLE_MEMBERS - {"manifest.json", "signature"}
+    for name, digest in manifest.items():
+        expected = hashlib.sha1(members[name], usedforsecurity=False).hexdigest()
+        assert digest == expected, name
+        assert len(digest) == 40
+
+
+def test_build_manifest_excludes_manifest_signature_and_ds_store() -> None:
+    manifest = json.loads(
+        build_manifest(
+            {
+                "pass.json": b"{}",
+                "manifest.json": b"stale",
+                "signature": b"stale",
+                ".DS_Store": b"junk",
+            }
+        ).decode("utf-8")
+    )
+
+    assert set(manifest) == {"pass.json"}
+
+
+def test_signature_is_a_detached_pkcs7_carrying_the_signer_and_wwdr(
+    signing_material,
+) -> None:
+    members = _bundle_members(build_pkpass(_content(), material=signing_material))
+    signature = members["signature"]
+    manifest = members["manifest.json"]
+
+    certificates = pkcs7.load_der_pkcs7_certificates(signature)
+    subjects = {certificate.subject.rfc4514_string() for certificate in certificates}
+
+    assert len(certificates) >= 2
+    assert any("Pass Type ID" in subject for subject in subjects)
+    assert any("Worldwide Developer Relations" in subject for subject in subjects)
+    # Detached: the manifest bytes must not be embedded in the signature blob,
+    # and the blob must be materially smaller than the payload it signs would
+    # make an attached CMS message.
+    assert manifest not in signature
+    assert b'"pass.json"' not in signature
+
+
+def test_bundle_is_deterministic_for_unchanged_content(signing_material) -> None:
+    first = _bundle_members(build_pkpass(_content(), material=signing_material))
+    second = _bundle_members(build_pkpass(_content(), material=signing_material))
+
+    # Everything but the CMS blob is byte-stable; CMS signatures carry random
+    # padding by construction.
+    for name in EXPECTED_BUNDLE_MEMBERS - {"signature"}:
+        assert first[name] == second[name], name
+
+
+# ---------------------------------------------------------------------------
+# pass.json
+# ---------------------------------------------------------------------------
+
+
+def _pass_json(signing_material, **overrides: object) -> dict:
+    members = _bundle_members(build_pkpass(_content(**overrides), material=signing_material))
+    return json.loads(members["pass.json"].decode("utf-8"))
+
+
+def test_pass_json_has_every_required_key(signing_material) -> None:
+    pass_json = _pass_json(signing_material)
+
+    assert pass_json["formatVersion"] == 1
+    assert pass_json["passTypeIdentifier"] == PASS_TYPE_IDENTIFIER
+    assert pass_json["teamIdentifier"] == TEAM_IDENTIFIER
+    assert pass_json["organizationName"] == ORGANIZATION_NAME
+    assert pass_json["description"] == PASS_DESCRIPTION
+    assert pass_json["serialNumber"] == PASS_SERIAL
+    assert "generic" in pass_json
+
+
+def test_pass_json_omits_the_wallet_web_service_keys(signing_material) -> None:
+    """D2: no web service, so no APNs, no device registration, no auth token."""
+    pass_json = _pass_json(signing_material)
+
+    assert "webServiceURL" not in pass_json
+    assert "authenticationToken" not in pass_json
+    assert "webServiceURL" not in json.dumps(pass_json)
+    assert "authenticationToken" not in json.dumps(pass_json)
+
+
+def test_pass_json_carries_a_square_qr_barcode_pointing_at_the_public_card(
+    signing_material,
+) -> None:
+    pass_json = _pass_json(signing_material)
+    barcodes = pass_json["barcodes"]
+
+    assert len(barcodes) == 1
+    barcode = barcodes[0]
+    assert barcode["format"] == "PKBarcodeFormatQR"
+    assert barcode["message"] == PUBLIC_CARD_URL
+    assert barcode["messageEncoding"] == "iso-8859-1"
+    assert barcode["altText"] == "Ada Lovelace"
+    # The share token is inside the QR payload; it must never be printed.
+    assert "share-token-abc" not in barcode["altText"]
+
+
+def test_front_field_budget_for_a_generic_pass_with_a_square_barcode(
+    signing_material,
+) -> None:
+    """At most 3 header + 1 primary + 4 combined secondary/auxiliary (D3)."""
+    generic = _pass_json(signing_material)["generic"]
+
+    header = generic.get("headerFields", [])
+    primary = generic.get("primaryFields", [])
+    secondary = generic.get("secondaryFields", [])
+    auxiliary = generic.get("auxiliaryFields", [])
+
+    assert len(header) <= 3
+    assert len(primary) == 1
+    assert len(secondary) + len(auxiliary) <= 4
+    assert primary[0]["value"] == "Ada Lovelace"
+
+
+def test_back_fields_carry_the_volatile_detail_and_the_control_note(
+    signing_material,
+) -> None:
+    generic = _pass_json(signing_material)["generic"]
+    back = {field["key"]: field["value"] for field in generic["backFields"]}
+
+    assert back["summary"] == "Builds private agents."
+    assert back["skills"] == "Python · Cryptography · Product"
+    assert back["email"] == "ada@example.com"
+    assert back["portfolio"] == "https://ada.example.com/work"
+    assert back["profile_link"] == PUBLIC_CARD_URL
+    assert "how_it_works" in back
+    assert (
+        back["control"] == "Only the information you select will be visible. "
+        "You can update or disable access at any time."
+    )
+
+
+def test_absent_optional_fields_produce_no_blank_rows(signing_material) -> None:
+    generic = _pass_json(
+        signing_material,
+        card_payload={"full_name": "Ada Lovelace"},
+    )["generic"]
+
+    assert "secondaryFields" not in generic
+    assert "auxiliaryFields" not in generic
+    back_keys = {field["key"] for field in generic["backFields"]}
+    assert "email" not in back_keys
+    assert "skills" not in back_keys
+    assert "how_it_works" in back_keys
+
+
+def test_expiry_is_emitted_as_a_w3c_timestamp(signing_material) -> None:
+    pass_json = _pass_json(
+        signing_material,
+        expires_at=datetime(2027, 3, 1, 12, 30, 0, tzinfo=UTC),
+    )
+
+    assert pass_json["expirationDate"] == "2027-03-01T12:30:00Z"
+
+
+def test_pass_json_without_expiry_has_no_expiration_date(signing_material) -> None:
+    assert "expirationDate" not in _pass_json(signing_material)
+
+
+# ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_avatar_still_produces_a_valid_pass(signing_material) -> None:
+    members = _bundle_members(
+        build_pkpass(_content(), material=signing_material, avatar_image=None)
+    )
+
+    assert set(members) == EXPECTED_BUNDLE_MEMBERS
+    assert _png_size(members["thumbnail.png"]) == (90, 90)
+    assert _png_size(members["thumbnail@2x.png"]) == (180, 180)
+    assert _png_size(members["thumbnail@3x.png"]) == (270, 270)
+
+
+def test_an_unreadable_avatar_falls_back_instead_of_failing_the_build(
+    signing_material,
+) -> None:
+    members = _bundle_members(
+        build_pkpass(_content(), material=signing_material, avatar_image=b"not-an-image")
+    )
+
+    assert set(members) == EXPECTED_BUNDLE_MEMBERS
+    assert _png_size(members["thumbnail.png"]) == (90, 90)
+
+
+def test_a_supplied_avatar_is_re_encoded_at_every_scale(signing_material) -> None:
+    buffer = io.BytesIO()
+    Image.new("RGB", (600, 800), (10, 120, 240)).save(buffer, format="PNG")
+
+    members = _bundle_members(
+        build_pkpass(_content(), material=signing_material, avatar_image=buffer.getvalue())
+    )
+
+    assert _png_size(members["thumbnail.png"]) == (90, 90)
+    assert _png_size(members["thumbnail@2x.png"]) == (180, 180)
+    assert _png_size(members["thumbnail@3x.png"]) == (270, 270)
+    assert _png_size(members["icon.png"]) == (29, 29)
+    assert _png_size(members["logo.png"]) == (50, 50)
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_signing_material_is_reported_as_unavailable() -> None:
+    material = WalletPassSigningMaterial(team_identifier="")
+
+    assert material.configured is False
+    assert wallet_pass_signing_available(material) is False
+    with pytest.raises(WalletPassSigningUnavailableError):
+        build_pkpass(_content(), material=material)
+
+
+def test_available_signing_material_passes_the_readiness_probe(signing_material) -> None:
+    assert signing_material.configured is True
+    assert wallet_pass_signing_available(signing_material) is True
+
+
+def test_a_mismatched_private_key_fails_closed(signing_material) -> None:
+    _, other_key = _self_signed("Someone else")
+    material = WalletPassSigningMaterial(
+        team_identifier=signing_material.team_identifier,
+        certificate_pem=signing_material.certificate_pem,
+        private_key_pem=_pem_key(other_key),
+        wwdr_pem=signing_material.wwdr_pem,
+        pass_type_identifier=PASS_TYPE_IDENTIFIER,
+    )
+
+    assert wallet_pass_signing_available(material) is False
+    with pytest.raises(WalletPassSigningUnavailableError):
+        build_pkpass(_content(), material=material)
+
+
+def test_an_expired_certificate_fails_closed(signing_material) -> None:
+    now = datetime.now(UTC)
+    certificate, key = _self_signed(
+        "Pass Type ID: pass.com.hushh.app.one",
+        pass_type_identifier=PASS_TYPE_IDENTIFIER,
+        not_before=now - timedelta(days=400),
+        not_after=now - timedelta(days=1),
+    )
+    material = WalletPassSigningMaterial(
+        team_identifier=TEAM_IDENTIFIER,
+        certificate_pem=_pem_certificate(certificate),
+        private_key_pem=_pem_key(key),
+        wwdr_pem=signing_material.wwdr_pem,
+        pass_type_identifier=PASS_TYPE_IDENTIFIER,
+    )
+
+    assert wallet_pass_signing_available(material) is False
+    with pytest.raises(WalletPassSigningUnavailableError):
+        build_pkpass(_content(), material=material)
+
+
+def test_unparseable_pem_is_reported_without_echoing_the_material(
+    signing_material,
+) -> None:
+    material = WalletPassSigningMaterial(
+        team_identifier=TEAM_IDENTIFIER,
+        certificate_pem="-----BEGIN CERTIFICATE-----\nnot-a-certificate\n-----END CERTIFICATE-----",
+        private_key_pem=signing_material.private_key_pem,
+        wwdr_pem=signing_material.wwdr_pem,
+        pass_type_identifier=PASS_TYPE_IDENTIFIER,
+    )
+
+    with pytest.raises(WalletPassSigningUnavailableError) as exc:
+        build_pkpass(_content(), material=material)
+
+    assert "not-a-certificate" not in str(exc.value)
+
+
+def test_a_non_https_card_url_is_refused(signing_material) -> None:
+    with pytest.raises(WalletPassBuildError):
+        build_pkpass(
+            _content(public_card_url="http://one.hushh.ai/c/token"),
+            material=signing_material,
+        )
+
+
+def test_a_missing_serial_is_refused(signing_material) -> None:
+    with pytest.raises(WalletPassBuildError):
+        build_pkpass(_content(pass_serial=""), material=signing_material)
+
+
+def test_barcode_content_must_survive_the_declared_encoding(signing_material) -> None:
+    with pytest.raises(WalletPassBuildError):
+        build_pkpass(
+            _content(public_card_url="https://one.hushh.ai/c/tokén-☂"),
+            material=signing_material,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Privacy
+# ---------------------------------------------------------------------------
+
+
+def test_signing_material_repr_never_exposes_pem_bytes(signing_material) -> None:
+    printed = repr(signing_material)
+
+    assert "BEGIN" not in printed
+    assert "PRIVATE KEY" not in printed
+    assert signing_material.private_key_pem not in printed
+    assert TEAM_IDENTIFIER in printed
+
+
+def test_pass_content_repr_never_exposes_card_payload_values() -> None:
+    printed = repr(_content())
+
+    assert "Ada Lovelace" not in printed
+    assert "ada@example.com" not in printed
+    assert "Builds private agents." not in printed
+    assert PASS_SERIAL in printed
+
+
+def test_content_projection_ignores_keys_outside_the_allowlist() -> None:
+    content = _content(
+        card_payload={
+            "full_name": "Ada Lovelace",
+            "vault_key": "should-never-appear",
+            "user_id": "user_123",
+        }
+    )
+
+    printed = json.dumps(
+        {
+            "full_name": content.full_name,
+            "summary": content.summary,
+            "skills": list(content.skills),
+        }
+    )
+    assert "should-never-appear" not in printed
+    assert "user_123" not in printed
+    assert not hasattr(content, "vault_key")
+    assert not hasattr(content, "user_id")
+
+
+def test_transport_constants_match_the_contract() -> None:
+    assert PASS_TYPE_IDENTIFIER == "pass.com.hushh.app.one"
+    assert WALLET_PASS_CONTENT_TYPE == "application/vnd.apple.pkpass"
+    assert WALLET_PASS_FILENAME == "hushh-one.pkpass"

--- a/consent-protocol/tests/test_mcp_log_redaction.py
+++ b/consent-protocol/tests/test_mcp_log_redaction.py
@@ -194,3 +194,112 @@ def test_sensitive_log_record_factory_redacts_httpx_url_args() -> None:
 
     assert "secret-provider-token" not in rendered
     assert f"token={REDACTED}" in rendered
+
+
+# ---------------------------------------------------------------------------
+# SQLAlchemy bound parameters
+# ---------------------------------------------------------------------------
+
+# ``StatementError.__str__`` appends the statement *and every bound value*
+# unless the engine sets ``hide_parameters=True``; the repo sets it nowhere.
+# ``db_client.execute_raw`` then does ``logger.error(f"Raw SQL error: {e}")``,
+# so without this rule every DBAPI fault reprints the row it was writing.
+SQLALCHEMY_ERROR = (
+    '(psycopg2.errors.NotNullViolation) null value in column "user_id"\n'
+    "[SQL: INSERT INTO one_wallet_cards (user_id, card_payload) "
+    "VALUES (%(user_id)s, %(card_payload)s)]\n"
+    "[parameters: {'user_id': 'user_123', 'card_payload': "
+    '\'{"full_name": "Ada Lovelace", "email": "ada@example.com"}\'}]\n'
+    "(Background on this error at: https://sqlalche.me/e/20/gkpj)"
+)
+
+
+def _emit(message: str) -> str:
+    install_sensitive_log_filter()
+    record = logging.getLogRecordFactory()(
+        "db.db_client", logging.ERROR, __file__, 1, message, None, None
+    )
+    return record.getMessage()
+
+
+def test_bound_sql_parameters_are_redacted_from_a_log_message() -> None:
+    rendered = _emit(f"Raw SQL error: {SQLALCHEMY_ERROR}")
+
+    assert "Ada Lovelace" not in rendered
+    assert "ada@example.com" not in rendered
+    assert "user_123" not in rendered
+    assert f"[parameters: {REDACTED}]" in rendered
+
+
+def test_the_statement_and_the_driver_message_survive_redaction() -> None:
+    """Stripping the whole error would make production faults undiagnosable.
+    The statement text and the doc link carry no values, so they are kept."""
+    rendered = _emit(f"Raw SQL error: {SQLALCHEMY_ERROR}")
+
+    assert "NotNullViolation" in rendered
+    assert "INSERT INTO one_wallet_cards" in rendered
+    assert "https://sqlalche.me/e/20/gkpj" in rendered
+
+
+def test_a_bound_value_containing_a_bracket_cannot_leak_a_fragment() -> None:
+    """Bracket-balancing would end the scan at the value's own ``]`` and print
+    the rest, so redaction deliberately runs to the background-link suffix."""
+    hostile = (
+        "[SQL: UPDATE one_wallet_cards SET card_payload = %(card_payload)s]\n"
+        '[parameters: {\'card_payload\': \'{"summary": "a]b", '
+        '"full_name": "Ada Lovelace"}\'}]\n'
+        "(Background on this error at: https://sqlalche.me/e/20/gkpj)"
+    )
+
+    rendered = _emit(hostile)
+
+    assert "Ada Lovelace" not in rendered
+    assert "a]b" not in rendered
+    assert "https://sqlalche.me/e/20/gkpj" in rendered
+
+
+def test_redaction_runs_to_the_end_when_there_is_no_background_suffix() -> None:
+    rendered = _emit("Raw SQL error: [parameters: {'email': 'ada@example.com'}]")
+
+    assert "ada@example.com" not in rendered
+    assert rendered.endswith(f"[parameters: {REDACTED}]")
+
+
+def test_an_exception_passed_as_a_log_argument_is_redacted() -> None:
+    """``logger.warning("... %s", exc)`` keeps the exception *object* in
+    ``record.args``; it is only stringified by the handler, which runs after
+    the filter. Rendering it inside the filter is what closes that bypass
+    (``db_client`` logs a connection failure exactly this way)."""
+    install_sensitive_log_filter()
+    record = logging.getLogRecordFactory()(
+        "db.db_client",
+        logging.WARNING,
+        __file__,
+        1,
+        "Database connection failed: %s",
+        (RuntimeError(SQLALCHEMY_ERROR),),
+        None,
+    )
+
+    rendered = record.getMessage()
+
+    assert "Ada Lovelace" not in rendered
+    assert "ada@example.com" not in rendered
+    assert f"[parameters: {REDACTED}]" in rendered
+
+
+def test_an_ordinary_log_line_is_left_alone() -> None:
+    """The rule must be inert on everything that is not a parameter blob."""
+    message = "wallet_card.published serial=6f2f0e6a status=active"
+
+    assert _emit(message) == message
+
+
+def test_the_filter_is_installed_by_the_api_server() -> None:
+    """The redaction only helps if it is actually wired into the API process
+    that serves the Wallet routes, not just the MCP server."""
+    from pathlib import Path
+
+    server = (Path(__file__).resolve().parents[1] / "server.py").read_text(encoding="utf-8")
+
+    assert "install_sensitive_log_filter()" in server

--- a/consent-protocol/tests/test_migration_assertions_are_not_brittle.py
+++ b/consent-protocol/tests/test_migration_assertions_are_not_brittle.py
@@ -1,0 +1,80 @@
+"""Guard against migration assertions that break on every later migration.
+
+Root cause this prevents
+------------------------
+Several migration tests asserted that *their* migration was the last entry in
+``release_migration_manifest.json``, or that ``expected_migration_version``
+equalled *their* exact number. Both are true only until the next migration
+lands. Adding migration 132 turned four unrelated, previously-green tests red,
+and one (``test_pkm_device_sync_migration``) had already been red on ``main``
+for several migrations because nobody noticed it was structurally doomed.
+
+The rule
+--------
+A migration test may assert that its migration is **registered** and that the
+schema contract is **at least** its version. It must not assert last-position or
+version equality, because neither is a property of the migration under test —
+both are properties of whatever shipped most recently.
+
+Correct forms::
+
+    assert MIGRATION_NAME in manifest["ordered_migrations"]
+    assert contract["expected_migration_version"] >= 132
+
+Incorrect forms (rejected by this test)::
+
+    assert manifest["ordered_migrations"][-1] == MIGRATION_NAME
+    assert contract["expected_migration_version"] == 132
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# ``ordered_migrations[-1] == ...`` / ``groups["iam"][-1] == ...``
+_LAST_POSITION = re.compile(
+    r'(?:ordered_migrations|groups"\]\["[a-z_]+)"\]\[-1\]\s*==',
+)
+
+# ``expected_migration_version"] == 131``
+_EXACT_VERSION = re.compile(
+    r'expected_migration_version"\]\s*==\s*\d+',
+)
+
+_SELF = Path(__file__).name
+
+
+def _offending_lines(pattern: re.Pattern[str]) -> list[str]:
+    findings: list[str] = []
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        if path.name == _SELF:
+            continue
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if pattern.search(line):
+                findings.append(f"{path.relative_to(TESTS_DIR)}:{number}: {stripped}")
+    return findings
+
+
+def test_no_test_asserts_a_migration_is_the_last_registered_one() -> None:
+    offenders = _offending_lines(_LAST_POSITION)
+    assert not offenders, (
+        "A migration test asserts its migration is the LAST manifest entry. That "
+        "breaks the moment any later migration ships. Assert membership instead:\n"
+        '    assert MIGRATION_NAME in manifest["ordered_migrations"]\n\n' + "\n".join(offenders)
+    )
+
+
+def test_no_test_pins_an_exact_expected_migration_version() -> None:
+    offenders = _offending_lines(_EXACT_VERSION)
+    assert not offenders, (
+        "A migration test pins expected_migration_version to an exact number. "
+        "Every later migration bumps it, so use a floor instead:\n"
+        '    assert contract["expected_migration_version"] >= <your version>\n\n'
+        + "\n".join(offenders)
+    )

--- a/consent-protocol/tests/test_one_location_nearby_point_contract_migration.py
+++ b/consent-protocol/tests/test_one_location_nearby_point_contract_migration.py
@@ -13,8 +13,11 @@ def test_point_contract_migration_is_registered_and_updates_current_comments():
     rollback = (MIGRATIONS / "rollback" / f"{name[:-4]}_down.sql").read_text(encoding="utf-8")
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
 
-    assert manifest["ordered_migrations"][-1] == name
-    assert manifest["groups"]["iam"][-1] == name
+    # Membership, not last-position: the intent is that this migration is
+    # registered for release, and asserting it is *last* makes every subsequent
+    # migration fail this unrelated test.
+    assert name in manifest["ordered_migrations"]
+    assert name in manifest["groups"]["iam"]
     assert "final captured check-in point" in sql
     assert "decrypted captured check-in points" in sql
     assert "selected public-place anchors" in rollback
@@ -27,4 +30,6 @@ def test_current_schema_contracts_require_point_contract_migration():
         "prod_core_schema.json",
     ):
         contract = json.loads((CONTRACTS / name).read_text(encoding="utf-8"))
-        assert contract["expected_migration_version"] == 131
+        # Floor, not equality: every later migration bumps this number, so an
+        # exact assertion turns an unrelated migration into a false failure.
+        assert contract["expected_migration_version"] >= 131

--- a/consent-protocol/tests/test_one_runtime_setup_choice_migration.py
+++ b/consent-protocol/tests/test_one_runtime_setup_choice_migration.py
@@ -16,7 +16,9 @@ def test_runtime_setup_choice_is_released_as_a_strict_non_secret_field() -> None
     migration = (ROOT / "db" / "migrations" / MIGRATION_NAME).read_text(encoding="utf-8")
     manifest = json.loads((ROOT / "db" / "release_migration_manifest.json").read_text("utf-8"))
 
-    assert manifest["ordered_migrations"][-1] == MIGRATION_NAME
+    # Membership, not last-position: asserting this migration is *last* turns
+    # every subsequent unrelated migration into a false failure here.
+    assert MIGRATION_NAME in manifest["ordered_migrations"]
     assert MIGRATION_NAME in manifest["groups"]["iam"]
     assert "ADD COLUMN IF NOT EXISTS one_runtime_setup_choice TEXT" in migration
     assert "hushh_managed_vertex" in migration

--- a/consent-protocol/tests/test_one_wallet_card_deploy_parity.py
+++ b/consent-protocol/tests/test_one_wallet_card_deploy_parity.py
@@ -1,0 +1,83 @@
+"""Deploy-config contract for the Apple Wallet pass signing material.
+
+Three separate files have to agree on three secret names or the pass never
+signs, and the failure is invisible until someone taps *Add to Apple Wallet* in
+production:
+
+- ``scripts/ci/provision_wallet_pass_certificate.py`` **writes** the PEMs into
+  Secret Manager under fixed names;
+- ``hushh_mcp/runtime_settings.py`` **reads** them out of the process
+  environment under those same names;
+- ``deploy/backend.cloudbuild.yaml`` is the only thing that connects the two,
+  and it had no idea they existed. Cloud Run would have started with all three
+  unset, the signing service would have answered a permanent 503, and
+  provisioning the certificate — an irreversible act that consumes a finite
+  Apple slot — would have changed nothing.
+
+The wiring is deliberately *optional* (``append_optional_secret`` probes with
+``gcloud secrets describe`` and skips what is absent), so this contract can land
+and deploy safely long before the certificate exists. These tests exist so the
+name agreement cannot silently drift afterwards.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CLOUDBUILD = REPO_ROOT / "deploy" / "backend.cloudbuild.yaml"
+PROVISION_SCRIPT = REPO_ROOT / "scripts" / "ci" / "provision_wallet_pass_certificate.py"
+RUNTIME_SETTINGS = REPO_ROOT / "consent-protocol" / "hushh_mcp" / "runtime_settings.py"
+
+PEM_ENV_NAMES = ("WALLET_PASS_CERT_PEM", "WALLET_PASS_KEY_PEM", "WALLET_PASS_WWDR_PEM")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_the_deploy_passes_every_pem_through_to_cloud_run() -> None:
+    cloudbuild = _read(CLOUDBUILD)
+
+    for env_name in PEM_ENV_NAMES:
+        expected = f'append_optional_secret "${{_{env_name}_SECRET}}" "{env_name}"'
+        assert expected in cloudbuild, f"{env_name} is never wired into the deploy"
+
+
+def test_each_pem_substitution_defaults_to_its_canonical_secret_name() -> None:
+    """Defaulted rather than empty, so the first deploy after the certificate is
+    minted picks the material up with no further change to the deploy config."""
+    cloudbuild = _read(CLOUDBUILD)
+
+    for env_name in PEM_ENV_NAMES:
+        match = re.search(rf"^  _{env_name}_SECRET:\s*(\S+)\s*$", cloudbuild, flags=re.MULTILINE)
+        assert match, f"_{env_name}_SECRET has no substitution default"
+        assert match.group(1) == env_name
+
+
+def test_the_deploy_names_match_the_names_provisioning_writes() -> None:
+    """The provisioning script is the only writer of these secrets; a rename on
+    either side would leave Cloud Run pointed at a secret that never exists."""
+    provisioning = _read(PROVISION_SCRIPT)
+
+    for env_name in PEM_ENV_NAMES:
+        assert f'"{env_name}"' in provisioning, f"provisioning does not write {env_name}"
+
+
+def test_the_deploy_names_match_the_names_the_runtime_reads() -> None:
+    runtime = _read(RUNTIME_SETTINGS)
+
+    for env_name in PEM_ENV_NAMES:
+        assert f'{env_name}_ENV = "{env_name}"' in runtime
+
+
+def test_the_pems_stay_optional_so_the_deploy_survives_their_absence() -> None:
+    """``append_optional_secret`` is what keeps an un-provisioned environment
+    deployable. Promoting these to the mandatory ``secrets=`` string would break
+    every deploy in every project until the certificate is minted."""
+    cloudbuild = _read(CLOUDBUILD)
+
+    for env_name in PEM_ENV_NAMES:
+        assert f"{env_name}=${{_{env_name}_SECRET}}:latest" not in cloudbuild

--- a/consent-protocol/tests/test_one_wallet_card_migration.py
+++ b/consent-protocol/tests/test_one_wallet_card_migration.py
@@ -1,0 +1,218 @@
+"""Release contract for migration 132 — the Wallet Profile card plane.
+
+The card lives in its own additive table. Two properties are load-bearing and
+are asserted here rather than left to review:
+
+1. The migration must never touch ``pkm_default_available_projections``. That
+   table is read by the Information Marketplace catalogue, so a card written
+   there would silently list the owner for sale.
+2. The table must carry aggregate scan counters only — no per-scan telemetry
+   row, address, user agent, referrer, or coordinate — and must never hold the
+   plaintext share token.
+
+Structural assertions run against the DDL with SQL comments stripped, so the
+explanatory prose in the migration header can mention a table without the test
+mistaking it for a statement that touches one.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS = ROOT / "db" / "migrations"
+MANIFEST = ROOT / "db" / "release_migration_manifest.json"
+UAT_CONTRACT = ROOT / "db" / "contracts" / "uat_integrated_schema.json"
+PROD_CONTRACT = ROOT / "db" / "contracts" / "prod_core_schema.json"
+
+MIGRATION_NAME = "132_one_wallet_card.sql"
+ROLLBACK_NAME = "132_one_wallet_card_down.sql"
+
+EXPECTED_COLUMNS = (
+    "user_id",
+    "pass_serial",
+    "share_token_hash",
+    "share_token_version",
+    "status",
+    "card_payload",
+    "display_name",
+    "headline",
+    "avatar_url",
+    "expires_at",
+    "created_at",
+    "updated_at",
+    "revoked_at",
+    "last_scanned_at",
+    "scan_count",
+)
+
+_LINE_COMMENT = re.compile(r"--.*?$", re.MULTILINE)
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+_SINGLE_QUOTED = re.compile(r"'(?:[^']|'')*'", re.DOTALL)
+
+
+def _migration_sql() -> str:
+    return (MIGRATIONS / MIGRATION_NAME).read_text(encoding="utf-8")
+
+
+def _rollback_sql() -> str:
+    return (MIGRATIONS / "rollback" / ROLLBACK_NAME).read_text(encoding="utf-8")
+
+
+def _statements_only(sql: str) -> str:
+    """Strip SQL comments so prose cannot satisfy or break a DDL assertion."""
+    return _LINE_COMMENT.sub("", _BLOCK_COMMENT.sub("", sql))
+
+
+def _ddl_only(sql: str) -> str:
+    """Statements with string literals removed as well.
+
+    ``COMMENT ON`` bodies are string literals, and this migration documents its
+    privacy boundary there in plain English. Those words must not be read as
+    schema.
+    """
+    return _SINGLE_QUOTED.sub("''", _statements_only(sql))
+
+
+def test_wallet_card_migration_is_release_registered_and_sequenced() -> None:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    ordered = manifest["ordered_migrations"]
+
+    assert (MIGRATIONS / MIGRATION_NAME).exists()
+    assert MIGRATION_NAME in ordered
+    assert MIGRATION_NAME in manifest["groups"]["iam"]
+    assert len(ordered) == len(set(ordered))
+    assert ordered.index(MIGRATION_NAME) > ordered.index(
+        "131_one_location_nearby_point_contract.sql"
+    )
+    # The rollback is operational only and must stay out of the release list.
+    assert ROLLBACK_NAME not in ordered
+
+
+def test_wallet_card_table_is_in_the_uat_and_prod_schema_contracts() -> None:
+    uat = json.loads(UAT_CONTRACT.read_text(encoding="utf-8"))
+    prod = json.loads(PROD_CONTRACT.read_text(encoding="utf-8"))
+
+    for contract in (uat, prod):
+        assert contract["expected_migration_version"] >= 132
+        columns = contract["required_tables"]["one_wallet_cards"]
+        assert set(EXPECTED_COLUMNS) <= set(columns)
+
+
+def test_wallet_card_table_has_the_contracted_columns() -> None:
+    ddl = _ddl_only(_migration_sql())
+
+    assert "CREATE TABLE IF NOT EXISTS one_wallet_cards" in ddl
+    assert "user_id TEXT PRIMARY KEY" in ddl
+    assert "pass_serial UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE" in ddl
+    assert "share_token_hash TEXT NOT NULL UNIQUE" in ddl
+    assert "share_token_version INTEGER NOT NULL DEFAULT 1" in ddl
+    assert "card_payload JSONB NOT NULL DEFAULT ''::jsonb" in ddl
+    assert "scan_count BIGINT NOT NULL DEFAULT 0" in ddl
+    assert "expires_at TIMESTAMPTZ" in ddl
+    assert "revoked_at TIMESTAMPTZ" in ddl
+    assert "last_scanned_at TIMESTAMPTZ" in ddl
+    assert "created_at TIMESTAMPTZ NOT NULL DEFAULT now()" in ddl
+    assert "updated_at TIMESTAMPTZ NOT NULL DEFAULT now()" in ddl
+
+    for column in EXPECTED_COLUMNS:
+        assert column in ddl, column
+
+
+def test_wallet_card_status_is_constrained_to_the_three_owner_states() -> None:
+    ddl = _ddl_only(_migration_sql())
+    collapsed = " ".join(ddl.split())
+
+    assert "status TEXT NOT NULL DEFAULT ''" in collapsed
+    assert "CHECK (status IN ('', '', ''))" in collapsed
+    # The literal states survive comment stripping only in the raw text.
+    statements = " ".join(_statements_only(_migration_sql()).split())
+    assert "CHECK (status IN ('active', 'paused', 'revoked'))" in statements
+
+
+def test_wallet_card_uniqueness_and_status_index_exist() -> None:
+    ddl = _ddl_only(_migration_sql())
+
+    # The unique constraints ride on the column declarations (contract §2).
+    assert "share_token_hash TEXT NOT NULL UNIQUE" in ddl
+    assert "pass_serial UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE" in ddl
+    assert "CREATE INDEX IF NOT EXISTS idx_one_wallet_cards_status" in ddl
+    assert "ON one_wallet_cards (status)" in ddl
+
+
+def test_wallet_card_migration_never_stores_the_plaintext_share_token() -> None:
+    ddl = _ddl_only(_migration_sql())
+
+    assert "share_token_hash" in ddl
+    assert "share_token TEXT" not in ddl
+    assert "share_token_plaintext" not in ddl
+    assert "token_secret" not in ddl
+
+
+def test_wallet_card_migration_stores_no_per_scan_telemetry() -> None:
+    ddl = _ddl_only(_migration_sql()).lower()
+
+    # Aggregate counters only. Anything below would be a per-visitor trace.
+    for forbidden in (
+        "ip_address",
+        "user_agent",
+        "referrer",
+        "referer",
+        "latitude",
+        "longitude",
+        "geohash",
+        "scan_events",
+        "one_wallet_card_scans",
+        "device_id",
+        "session_id",
+        "fingerprint",
+    ):
+        assert forbidden not in ddl, forbidden
+
+    assert "last_scanned_at" in ddl
+    assert "scan_count" in ddl
+
+
+def test_wallet_card_migration_is_additive_and_touches_no_existing_table() -> None:
+    """The specific privacy defect this design exists to avoid.
+
+    A card must never become a row in ``pkm_default_available_projections``:
+    the Information Marketplace catalogue reads that table with no source
+    filter and would list the owner for sale. No statement in this migration
+    may reference it, and no pre-existing table may be mutated.
+    """
+    ddl = _ddl_only(_migration_sql()).lower()
+
+    assert "pkm_default_available_projections" not in ddl
+    assert "marketplace" not in ddl
+    assert "public_profile_handle" not in ddl
+    assert "publication_provenance" not in ddl
+    assert "alter table" not in ddl
+    assert "drop table" not in ddl
+    assert "drop column" not in ddl
+    assert "delete from" not in ddl
+    assert "insert into" not in ddl
+    assert "update " not in ddl
+
+
+def test_wallet_card_rollback_drops_only_the_new_table() -> None:
+    raw = _rollback_sql()
+    ddl = _ddl_only(raw).lower()
+
+    assert "drop table if exists one_wallet_cards" in ddl
+    assert "pkm_default_available_projections" not in ddl
+    assert "alter table" not in ddl
+    assert ddl.count("drop table") == 1
+    # Dropping the digests is unrecoverable, so the rollback refuses to run
+    # while live cards exist rather than silently breaking printed QR codes.
+    assert "RAISE EXCEPTION" in _statements_only(raw)
+    assert "FROM one_wallet_cards" in _statements_only(raw)
+
+
+def test_wallet_card_row_is_removed_by_the_account_deletion_cascade() -> None:
+    source = (ROOT / "hushh_mcp" / "services" / "account_service.py").read_text(encoding="utf-8")
+
+    assert "DELETE FROM one_wallet_cards WHERE user_id = :user_id" in source
+    assert '"one_wallet_cards"' in source

--- a/consent-protocol/tests/test_one_wallet_card_routes.py
+++ b/consent-protocol/tests/test_one_wallet_card_routes.py
@@ -1,0 +1,791 @@
+"""Route contract for the Wallet Profile surfaces.
+
+Six guarantees are locked in here:
+
+- every owner route needs a VAULT_OWNER token **and** a matching ``user_id``;
+- the two public routes need no authentication at all;
+- the feature flag removes the whole surface;
+- a paused card is byte-identically indistinguishable from an unknown token,
+  while revoked and expired answer an honest 410;
+- the `.pkpass` route returns the Apple content type, and degrades to the
+  contract's friendly 503 when signing material is absent;
+- **publishing a Wallet card never touches
+  ``pkm_default_available_projections`` and never reaches the Information
+  Marketplace catalogue.** That is the specific privacy defect this design
+  exists to avoid, so it is asserted structurally rather than left to review.
+
+The service is faked at the route seam so these tests exercise HTTP behaviour
+only; the persistence contract lives in ``test_one_wallet_card_service.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi.errors import RateLimitExceeded
+from slowapi.extension import _rate_limit_exceeded_handler
+
+from api.middleware import require_vault_owner_token
+from api.middlewares.rate_limit import limiter
+from api.routes import one_wallet_card
+from hushh_mcp.services.one_wallet_card_service import OneWalletCardError
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OWNER_ID = "user_123"
+SHARE_TOKEN = "wallet-card-test-token-not-a-real-secret"
+PUBLIC_CARD_URL = f"https://one.hushh.ai/c/{SHARE_TOKEN}"
+PASS_SERIAL = "6f2f0e6a-6d5e-4b0a-9f0a-0d1c2b3a4e5f"
+
+NOINDEX = "noindex, nofollow, noarchive"
+PRIVATE_CACHE = "private, max-age=0, must-revalidate"
+
+CARD_PAYLOAD = {
+    "fullName": "Ada Lovelace",
+    "headline": "Founder, Hussh",
+    "organisation": "Hussh Labs",
+    "locationLabel": "Mumbai, India",
+    "summary": "Builds private agents.",
+    "skills": ["Python", "Cryptography"],
+    "email": "ada@example.com",
+    "phone": "+91 99999 90000",
+    "website": "https://ada.example.com",
+    "linkedin": "https://www.linkedin.com/in/ada",
+    "github": "https://github.com/ada",
+    "portfolio": "https://ada.example.com/work",
+    "preferredContact": "email",
+}
+
+OWNER_CARD_VIEW: dict[str, Any] = {
+    "passSerial": PASS_SERIAL,
+    "status": "active",
+    "shareTokenVersion": 1,
+    "cardPayload": {"full_name": "Ada Lovelace"},
+    "displayName": "Ada Lovelace",
+    "headline": "Founder, Hussh",
+    "avatarUrl": None,
+    "expiresAt": None,
+    "createdAt": "2026-08-01T00:00:00+00:00",
+    "updatedAt": "2026-08-02T00:00:00+00:00",
+    "revokedAt": None,
+    "lastScannedAt": None,
+    "scanCount": 3,
+}
+
+PUBLIC_PROJECTION: dict[str, Any] = {
+    "fullName": "Ada Lovelace",
+    "headline": "Founder, Hussh",
+    "organisation": "Hussh Labs",
+    "locationLabel": "Mumbai, India",
+    "summary": "Builds private agents.",
+    "skills": ["Python", "Cryptography"],
+    "email": "ada@example.com",
+    "phone": "+91 99999 90000",
+    "website": "https://ada.example.com",
+    "linkedin": "https://www.linkedin.com/in/ada",
+    "github": "https://github.com/ada",
+    "portfolio": "https://ada.example.com/work",
+    "preferredContact": "email",
+    "avatarUrl": None,
+    "updatedOn": "2026-08-02",
+}
+
+PASS_MATERIAL: dict[str, Any] = {
+    "passSerial": PASS_SERIAL,
+    "publicCardUrl": PUBLIC_CARD_URL,
+    "cardPayload": {"full_name": "Ada Lovelace", "headline": "Founder, Hussh"},
+    "displayName": "Ada Lovelace",
+    "headline": "Founder, Hussh",
+    "expiresAt": None,
+}
+
+
+class FakeCardService:
+    """Records every call and returns whatever the test configured."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.card: dict[str, Any] | None = dict(OWNER_CARD_VIEW)
+        self.mutation: dict[str, Any] = {"card": dict(OWNER_CARD_VIEW)}
+        self.public_result: dict[str, Any] = {
+            "status": "active",
+            "card": dict(PUBLIC_PROJECTION),
+        }
+        self.preview_result: dict[str, Any] = {
+            "status": "active",
+            "card": dict(PUBLIC_PROJECTION),
+        }
+        self.pass_result: dict[str, Any] = {
+            "status": "active",
+            "material": dict(PASS_MATERIAL),
+        }
+        self.raises: Exception | None = None
+        self.scan_error: Exception | None = None
+
+    def _record(self, name: str, **kwargs: Any) -> None:
+        self.calls.append((name, kwargs))
+        if self.raises is not None:
+            raise self.raises
+
+    def called(self, name: str) -> bool:
+        return any(call == name for call, _ in self.calls)
+
+    # --- owner plane ---
+
+    def get_card(self, *, user_id: str) -> dict[str, Any] | None:
+        self._record("get_card", user_id=user_id)
+        return self.card
+
+    def upsert_card(self, **kwargs: Any) -> dict[str, Any]:
+        self._record("upsert_card", **kwargs)
+        return self.mutation
+
+    def rotate_share_token(self, *, user_id: str) -> dict[str, Any]:
+        self._record("rotate_share_token", user_id=user_id)
+        return self.mutation
+
+    def pause_card(self, *, user_id: str) -> dict[str, Any]:
+        self._record("pause_card", user_id=user_id)
+        return self.mutation
+
+    def resume_card(self, *, user_id: str) -> dict[str, Any]:
+        self._record("resume_card", user_id=user_id)
+        return self.mutation
+
+    def revoke_card(self, *, user_id: str) -> dict[str, Any]:
+        self._record("revoke_card", user_id=user_id)
+        return self.mutation
+
+    def preview_public_card(self, *, user_id: str) -> dict[str, Any]:
+        self._record("preview_public_card", user_id=user_id)
+        return self.preview_result
+
+    # --- public plane ---
+
+    def resolve_public_card(self, *, share_token: str) -> dict[str, Any]:
+        self._record("resolve_public_card", share_token=share_token)
+        return self.public_result
+
+    def resolve_pass_material(self, *, share_token: str) -> dict[str, Any]:
+        self._record("resolve_pass_material", share_token=share_token)
+        return self.pass_result
+
+    def record_scan(self, *, share_token: str) -> None:
+        self.calls.append(("record_scan", {"share_token": share_token}))
+        if self.scan_error is not None:
+            raise self.scan_error
+
+
+@pytest.fixture(autouse=True)
+def feature_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ONE_WALLET_CARD_ENABLED", "true")
+
+
+@pytest.fixture
+def service(monkeypatch: pytest.MonkeyPatch) -> FakeCardService:
+    fake = FakeCardService()
+    monkeypatch.setattr(one_wallet_card, "_card_service", lambda: fake)
+    return fake
+
+
+def _app(*, authenticated_as: str | None = OWNER_ID) -> FastAPI:
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.include_router(one_wallet_card.router)
+    if authenticated_as is not None:
+        app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": authenticated_as}
+    return app
+
+
+def _client(*, authenticated_as: str | None = OWNER_ID) -> TestClient:
+    return TestClient(_app(authenticated_as=authenticated_as))
+
+
+def _assert_public_headers(response) -> None:
+    assert response.headers["X-Robots-Tag"] == NOINDEX
+    assert response.headers["Cache-Control"] == PRIVATE_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Owner authentication
+# ---------------------------------------------------------------------------
+
+
+def test_owner_routes_reject_a_missing_vault_owner_token(service: FakeCardService) -> None:
+    client = _client(authenticated_as=None)
+
+    responses = [
+        client.get(f"/api/one/wallet-card?user_id={OWNER_ID}"),
+        client.post("/api/one/wallet-card", json={"userId": OWNER_ID, "cardPayload": {}}),
+        client.post("/api/one/wallet-card/rotate", json={"userId": OWNER_ID}),
+        client.post("/api/one/wallet-card/pause", json={"userId": OWNER_ID}),
+        client.post("/api/one/wallet-card/resume", json={"userId": OWNER_ID}),
+        client.request("DELETE", f"/api/one/wallet-card?user_id={OWNER_ID}"),
+        client.get(f"/api/one/wallet-card/preview?user_id={OWNER_ID}"),
+    ]
+
+    for response in responses:
+        assert response.status_code in {401, 403}, response.text
+    assert service.calls == []
+
+
+def test_owner_routes_reject_a_token_for_a_different_user(service: FakeCardService) -> None:
+    client = _client(authenticated_as="someone_else")
+
+    response = client.get(f"/api/one/wallet-card?user_id={OWNER_ID}")
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "WALLET_CARD_FORBIDDEN"
+    assert service.calls == []
+
+
+def test_owner_mutations_reject_a_token_for_a_different_user(
+    service: FakeCardService,
+) -> None:
+    client = _client(authenticated_as="someone_else")
+
+    for path in ("/api/one/wallet-card/rotate", "/api/one/wallet-card/pause"):
+        response = client.post(path, json={"userId": OWNER_ID})
+        assert response.status_code == 403, path
+    assert service.calls == []
+
+
+def test_owner_read_returns_the_card_without_a_plaintext_token(
+    service: FakeCardService,
+) -> None:
+    response = _client().get(f"/api/one/wallet-card?user_id={OWNER_ID}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["card"]["passSerial"] == PASS_SERIAL
+    assert body["card"]["status"] == "active"
+    assert body["shareToken"] is None
+    assert body["shareUrl"] is None
+    assert service.called("get_card")
+
+
+def test_owner_read_reports_a_missing_card_as_an_empty_state(
+    service: FakeCardService,
+) -> None:
+    service.card = None
+
+    response = _client().get(f"/api/one/wallet-card?user_id={OWNER_ID}")
+
+    assert response.status_code == 200
+    assert response.json()["card"] is None
+
+
+def test_create_returns_the_plaintext_token_exactly_once(service: FakeCardService) -> None:
+    service.mutation = {
+        "card": dict(OWNER_CARD_VIEW),
+        "shareToken": SHARE_TOKEN,
+        "shareUrl": PUBLIC_CARD_URL,
+    }
+
+    created = _client().post(
+        "/api/one/wallet-card",
+        json={"userId": OWNER_ID, "cardPayload": CARD_PAYLOAD},
+    )
+
+    service.mutation = {"card": dict(OWNER_CARD_VIEW)}
+    read = _client().get(f"/api/one/wallet-card?user_id={OWNER_ID}")
+
+    assert created.status_code == 200
+    assert created.json()["shareToken"] == SHARE_TOKEN
+    assert created.json()["shareUrl"] == PUBLIC_CARD_URL
+    assert read.json()["shareToken"] is None
+
+
+def test_rotate_returns_a_new_plaintext_token(service: FakeCardService) -> None:
+    service.mutation = {
+        "card": {**OWNER_CARD_VIEW, "shareTokenVersion": 2},
+        "shareToken": SHARE_TOKEN,
+        "shareUrl": PUBLIC_CARD_URL,
+    }
+
+    response = _client().post("/api/one/wallet-card/rotate", json={"userId": OWNER_ID})
+
+    assert response.status_code == 200
+    assert response.json()["shareToken"] == SHARE_TOKEN
+    assert response.json()["card"]["shareTokenVersion"] == 2
+    assert service.called("rotate_share_token")
+
+
+def test_upsert_rejects_a_field_outside_the_allowlist(service: FakeCardService) -> None:
+    response = _client().post(
+        "/api/one/wallet-card",
+        json={
+            "userId": OWNER_ID,
+            "cardPayload": {"fullName": "Ada Lovelace", "vaultKey": "secret"},
+        },
+    )
+
+    assert response.status_code == 422
+    assert not service.called("upsert_card")
+
+
+def test_upsert_rejects_a_non_https_link(service: FakeCardService) -> None:
+    for bad in (
+        "javascript:alert(1)",
+        "data:text/html;base64,PHNjcmlwdD4=",
+        "http://ada.example.com",
+        "https://ada@evil.example",
+    ):
+        response = _client().post(
+            "/api/one/wallet-card",
+            json={"userId": OWNER_ID, "cardPayload": {"website": bad}},
+        )
+        assert response.status_code == 422, bad
+    assert not service.called("upsert_card")
+
+
+def test_service_errors_are_translated_without_leaking_internals(
+    service: FakeCardService,
+) -> None:
+    service.raises = OneWalletCardError(
+        "WALLET_CARD_NOT_SET_UP", "Set up your Wallet Profile first.", status_code=404
+    )
+
+    response = _client().post("/api/one/wallet-card/pause", json={"userId": OWNER_ID})
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "WALLET_CARD_NOT_SET_UP"
+
+
+def test_unexpected_service_failures_become_a_generic_500(
+    service: FakeCardService,
+) -> None:
+    service.raises = RuntimeError("connection to db-prod-1 refused")
+
+    response = _client().post("/api/one/wallet-card/pause", json={"userId": OWNER_ID})
+
+    assert response.status_code == 500
+    assert response.json()["detail"]["code"] == "ONE_WALLET_CARD_API_FAILED"
+    assert "db-prod-1" not in response.text
+
+
+def test_preview_uses_the_same_projection_a_visitor_receives(
+    service: FakeCardService,
+) -> None:
+    preview = _client().get(f"/api/one/wallet-card/preview?user_id={OWNER_ID}")
+    public = _client().get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert preview.status_code == 200
+    assert public.status_code == 200
+    assert preview.json()["card"] == public.json()["card"]
+    assert service.called("preview_public_card")
+
+
+# ---------------------------------------------------------------------------
+# Public plane — no authentication
+# ---------------------------------------------------------------------------
+
+
+def test_public_resolve_needs_no_authentication(service: FakeCardService) -> None:
+    client = _client(authenticated_as=None)
+
+    response = client.get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code == 200
+    assert response.json()["card"]["fullName"] == "Ada Lovelace"
+    _assert_public_headers(response)
+
+
+def test_public_resolve_never_returns_an_internal_identifier(
+    service: FakeCardService,
+) -> None:
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    body = response.text
+    assert "user_id" not in body
+    assert "userId" not in body
+    assert "passSerial" not in body
+    assert "pass_serial" not in body
+    assert PASS_SERIAL not in body
+    assert "shareToken" not in body
+
+
+def test_public_resolve_sets_the_noindex_and_private_cache_headers(
+    service: FakeCardService,
+) -> None:
+    _assert_public_headers(
+        _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+    )
+
+
+def test_a_paused_card_is_indistinguishable_from_an_unknown_token(
+    service: FakeCardService,
+) -> None:
+    client = _client(authenticated_as=None)
+
+    service.public_result = {"status": "not_found", "card": None}
+    unknown = client.get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    # A paused card must not be told apart even if the service names the state.
+    service.public_result = {"status": "paused", "card": dict(PUBLIC_PROJECTION)}
+    paused = client.get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert unknown.status_code == paused.status_code == 404
+    assert unknown.json() == paused.json() == {"status": "not_found"}
+    assert unknown.headers["X-Robots-Tag"] == paused.headers["X-Robots-Tag"]
+    assert "Ada Lovelace" not in paused.text
+
+
+def test_a_revoked_card_answers_an_honest_410(service: FakeCardService) -> None:
+    service.public_result = {"status": "revoked", "card": None}
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code == 410
+    assert response.json() == {"status": "revoked"}
+    _assert_public_headers(response)
+
+
+def test_an_expired_card_answers_an_honest_410(service: FakeCardService) -> None:
+    service.public_result = {"status": "expired", "card": None}
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code == 410
+    assert response.json() == {"status": "expired"}
+
+
+def test_a_service_rejection_is_collapsed_into_the_generic_404(
+    service: FakeCardService,
+) -> None:
+    service.raises = OneWalletCardError(
+        "WALLET_CARD_NOT_FOUND", "This profile isn't available.", status_code=404
+    )
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code == 404
+    assert response.json() == {"status": "not_found"}
+
+
+def test_an_unexpected_public_failure_never_leaks_internals(
+    service: FakeCardService,
+) -> None:
+    service.raises = RuntimeError("connection to db-prod-1 refused")
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "unavailable"}
+    assert "db-prod-1" not in response.text
+
+
+def test_a_malformed_token_is_rejected_before_any_lookup(
+    service: FakeCardService,
+) -> None:
+    client = _client(authenticated_as=None)
+
+    for token in ("short", "a" * 200, "has%20space%20and%20is%20long%20enough"):
+        response = client.get(f"/api/one/wallet-card/public/{token}")
+        assert response.status_code == 422, token
+    assert not service.called("resolve_public_card")
+
+
+def test_the_scan_counter_failing_does_not_fail_the_read(
+    service: FakeCardService,
+) -> None:
+    service.scan_error = RuntimeError("counter write failed")
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code == 200
+    assert response.json()["card"]["fullName"] == "Ada Lovelace"
+    assert service.called("record_scan")
+
+
+def test_the_scan_counter_runs_only_for_a_card_that_resolved(
+    service: FakeCardService,
+) -> None:
+    service.public_result = {"status": "revoked", "card": None}
+
+    _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert not service.called("record_scan")
+
+
+# ---------------------------------------------------------------------------
+# Pass download
+# ---------------------------------------------------------------------------
+
+
+def test_pass_route_returns_the_apple_content_type(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(one_wallet_card, "wallet_pass_signing_available", lambda: True)
+    monkeypatch.setattr(
+        one_wallet_card, "build_pkpass", lambda content, **kwargs: b"PK\x03\x04pkpass"
+    )
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/vnd.apple.pkpass"
+    assert response.headers["Content-Disposition"] == 'attachment; filename="hushh-one.pkpass"'
+    assert response.content == b"PK\x03\x04pkpass"
+    _assert_public_headers(response)
+
+
+def test_pass_route_needs_no_authentication(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(one_wallet_card, "wallet_pass_signing_available", lambda: True)
+    monkeypatch.setattr(one_wallet_card, "build_pkpass", lambda content, **kwargs: b"pass")
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    assert response.status_code == 200
+
+
+def test_pass_route_returns_the_friendly_503_when_signing_material_is_absent(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(one_wallet_card, "wallet_pass_signing_available", lambda: False)
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "unavailable"
+    assert body["code"] == one_wallet_card.WALLET_PASS_UNAVAILABLE_CODE
+    assert body["message"] == (
+        "We couldn't create your Wallet pass right now. Please try again in a moment."
+    )
+    _assert_public_headers(response)
+
+
+def test_pass_route_hides_a_signing_failure_behind_the_same_503(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _explode(content, **kwargs):
+        raise one_wallet_card.WalletPassError("private key /secrets/pass.key is malformed")
+
+    monkeypatch.setattr(one_wallet_card, "wallet_pass_signing_available", lambda: True)
+    monkeypatch.setattr(one_wallet_card, "build_pkpass", _explode)
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    assert response.status_code == 503
+    assert "/secrets/pass.key" not in response.text
+    assert response.json()["code"] == one_wallet_card.WALLET_PASS_UNAVAILABLE_CODE
+
+
+def test_pass_route_applies_the_same_status_rules_as_resolve(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(one_wallet_card, "wallet_pass_signing_available", lambda: True)
+    monkeypatch.setattr(one_wallet_card, "build_pkpass", lambda content, **kwargs: b"pass")
+    client = _client(authenticated_as=None)
+
+    service.pass_result = {"status": "paused", "material": dict(PASS_MATERIAL)}
+    paused = client.get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    service.pass_result = {"status": "revoked", "material": None}
+    revoked = client.get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    service.pass_result = {"status": "expired", "material": None}
+    expired = client.get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    assert paused.status_code == 404
+    assert paused.json() == {"status": "not_found"}
+    assert revoked.status_code == 410
+    assert revoked.json() == {"status": "revoked"}
+    assert expired.status_code == 410
+    assert expired.json() == {"status": "expired"}
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+def test_the_feature_flag_removes_the_owner_surface(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONE_WALLET_CARD_ENABLED", "false")
+    client = _client()
+
+    response = client.get(f"/api/one/wallet-card?user_id={OWNER_ID}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "ONE_WALLET_CARD_DISABLED"
+    assert service.calls == []
+
+
+def test_the_feature_flag_removes_the_public_surface(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ONE_WALLET_CARD_ENABLED", "false")
+    client = _client(authenticated_as=None)
+
+    card = client.get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+    pkpass = client.get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass")
+
+    assert card.status_code == 404
+    assert card.json() == {"status": "not_found"}
+    assert pkpass.status_code == 404
+    assert service.calls == []
+
+
+def test_the_flag_defaults_to_off_when_unset(
+    service: FakeCardService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ONE_WALLET_CARD_ENABLED", raising=False)
+
+    response = _client().get(f"/api/one/wallet-card?user_id={OWNER_ID}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "ONE_WALLET_CARD_DISABLED"
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting on the unauthenticated surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_public_routes_carry_an_explicit_per_ip_rate_limit() -> None:
+    """`SlowAPIMiddleware` is never added and `GLOBAL_PER_IP` is never applied,
+    so an undecorated public route would carry no limit at all (plan D8)."""
+    source = (ROOT / "api" / "routes" / "one_wallet_card.py").read_text(encoding="utf-8")
+
+    assert source.count("@limiter.limit(") == 2
+    assert "key_func=public_rate_limit_key" in source
+    assert one_wallet_card.PUBLIC_CARD_RESOLVE_RATE_LIMIT.endswith("/minute")
+    assert one_wallet_card.PUBLIC_CARD_PASS_RATE_LIMIT.endswith("/minute")
+
+
+def test_the_rate_limit_bucket_is_derived_from_the_forwarded_client_ip() -> None:
+    class _Request:
+        def __init__(self, headers: dict[str, str]) -> None:
+            self.headers = headers
+
+    visitor = one_wallet_card.public_rate_limit_key(
+        _Request({"x-forwarded-for": "203.0.113.9, 198.51.100.7"})
+    )
+    other = one_wallet_card.public_rate_limit_key(
+        _Request({"x-forwarded-for": "203.0.113.9, 198.51.100.8"})
+    )
+
+    assert visitor != other
+    assert visitor.startswith("one_wallet_card_public:")
+
+
+# ---------------------------------------------------------------------------
+# The privacy defect this design exists to avoid
+# ---------------------------------------------------------------------------
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def _executable_source(path: Path) -> str:
+    """Return the module's executable source with docstrings stripped.
+
+    The wallet-card modules deliberately *name* the projection plane in their
+    docstrings to explain why they must never use it. Grepping raw source would
+    therefore flag the very comment that documents the rule, so this strips
+    docstrings and reports only real code — an actual read/write of the table
+    still shows up as a SQL string constant or an identifier.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, "body", [])
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            body.pop(0)
+            if not body:
+                body.append(ast.Pass())
+    return ast.unparse(ast.fix_missing_locations(tree))
+
+
+def test_publishing_a_wallet_card_never_touches_the_projection_plane() -> None:
+    """A Wallet card must never become a marketplace listing.
+
+    ``marketplace_catalog_service.list_available_listings`` selects
+    ``pkm_default_available_projections`` with no source filter and exposes the
+    owner's real display name, so a card written there would silently list the
+    owner for sale. Neither the routes nor the service may read, write, or even
+    import that plane.
+    """
+    for relative in (
+        "api/routes/one_wallet_card.py",
+        "hushh_mcp/services/one_wallet_card_service.py",
+    ):
+        path = ROOT / relative
+        statements = _executable_source(path)
+
+        assert "pkm_default_available_projections" not in statements, relative
+        assert "public_profile_handle" not in statements, relative
+        assert "publication_provenance" not in statements, relative
+        assert "marketplace_public_profiles" not in statements, relative
+
+        imports = _imported_modules(path)
+        for forbidden in (
+            "hushh_mcp.services.marketplace_catalog_service",
+            "hushh_mcp.services.personal_knowledge_model_service",
+            "api.routes.pkm_routes_shared",
+        ):
+            assert forbidden not in imports, f"{relative} imports {forbidden}"
+
+
+def test_the_marketplace_catalogue_cannot_see_the_wallet_card_table() -> None:
+    """The other direction: the catalogue must not learn about the card plane."""
+    catalogue = (ROOT / "hushh_mcp" / "services" / "marketplace_catalog_service.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "one_wallet_cards" not in catalogue
+    assert "wallet_card" not in catalogue
+
+
+def test_publishing_a_card_writes_only_to_the_wallet_card_plane(
+    service: FakeCardService,
+) -> None:
+    """Behavioural counterpart: an upsert reaches the wallet service and nothing else."""
+    response = _client().post(
+        "/api/one/wallet-card",
+        json={"userId": OWNER_ID, "cardPayload": CARD_PAYLOAD},
+    )
+
+    assert response.status_code == 200
+    assert [name for name, _ in service.calls] == ["upsert_card"]
+    assert service.calls[0][1]["user_id"] == OWNER_ID
+    assert set(service.calls[0][1]["card_payload"]) <= {
+        "full_name",
+        "headline",
+        "organisation",
+        "location_label",
+        "summary",
+        "skills",
+        "email",
+        "phone",
+        "website",
+        "linkedin",
+        "github",
+        "portfolio",
+        "preferred_contact",
+    }

--- a/consent-protocol/tests/test_one_wallet_card_routes.py
+++ b/consent-protocol/tests/test_one_wallet_card_routes.py
@@ -33,6 +33,7 @@ from slowapi.extension import _rate_limit_exceeded_handler
 from api.middleware import require_vault_owner_token
 from api.middlewares.rate_limit import limiter
 from api.routes import one_wallet_card
+from db.db_client import DatabaseExecutionError
 from hushh_mcp.services.one_wallet_card_service import OneWalletCardError
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -655,13 +656,125 @@ def test_the_flag_defaults_to_off_when_unset(
 
 def test_public_routes_carry_an_explicit_per_ip_rate_limit() -> None:
     """`SlowAPIMiddleware` is never added and `GLOBAL_PER_IP` is never applied,
-    so an undecorated public route would carry no limit at all (plan D8)."""
+    so an undecorated public route would carry no limit at all (plan D8).
+
+    The decorator must be ``shared_limit``, not ``limit``: see
+    ``test_the_rate_limit_bucket_is_not_subdivided_by_the_share_token``.
+    """
     source = (ROOT / "api" / "routes" / "one_wallet_card.py").read_text(encoding="utf-8")
 
-    assert source.count("@limiter.limit(") == 2
+    assert source.count("@limiter.shared_limit(") == 2
+    assert "@limiter.limit(" not in source
     assert "key_func=public_rate_limit_key" in source
     assert one_wallet_card.PUBLIC_CARD_RESOLVE_RATE_LIMIT.endswith("/minute")
     assert one_wallet_card.PUBLIC_CARD_PASS_RATE_LIMIT.endswith("/minute")
+    assert (
+        one_wallet_card.PUBLIC_CARD_RESOLVE_RATE_LIMIT_SCOPE
+        != one_wallet_card.PUBLIC_CARD_PASS_RATE_LIMIT_SCOPE
+    )
+
+
+def test_the_route_module_never_imports_the_database_client() -> None:
+    """Routes talk to services, not to ``db.*``
+    (``tests/quality/test_architecture_compliance.py``). The tempting import
+    here is ``DatabaseExecutionError`` for the ``_handle_error`` branch; it is
+    matched by class name instead, which is the same duck-type the Location
+    routes use.
+    """
+    source = (ROOT / "api" / "routes" / "one_wallet_card.py").read_text(encoding="utf-8")
+
+    assert "from db." not in source
+    assert "import db" not in source
+    assert '__name__ == "DatabaseExecutionError"' in source
+
+
+@pytest.fixture
+def enforcing_limiter():
+    """Turn the shared limiter on for one test and leave no residue.
+
+    ``api.middlewares.rate_limit`` disables the limiter whenever ``TESTING`` is
+    set so ordinary route tests are not throttled — which also means a rate
+    limit could regress to "no limit at all" and every other test here would
+    still pass. These tests opt back in, and reset the in-memory storage on both
+    sides because the whole point of the fix is that the bucket now *outlives*
+    the request path.
+    """
+    previous = limiter.enabled
+    limiter.enabled = True
+    limiter.reset()
+    try:
+        yield limiter
+    finally:
+        limiter.reset()
+        limiter.enabled = previous
+
+
+def test_the_rate_limit_bucket_is_not_subdivided_by_the_share_token(
+    service: FakeCardService, enforcing_limiter
+) -> None:
+    """Token enumeration is exactly the traffic this limit exists to bound.
+
+    slowapi's default ``key_style`` is ``"url"``, so an ``@limiter.limit``
+    bucket is keyed by ``(key_func, request.path)``. With ``{share_token}`` in
+    the path, every guessed token opens a *fresh* bucket and a scraper walking
+    the token space would never be throttled once. Binding an explicit scope
+    drops the path out of the storage key.
+    """
+    client = _client(authenticated_as=None)
+    headers = {"x-forwarded-for": "203.0.113.42"}
+    budget = int(one_wallet_card.PUBLIC_CARD_RESOLVE_RATE_LIMIT.split("/")[0])
+
+    statuses = [
+        client.get(
+            f"/api/one/wallet-card/public/enumerated-token-{index}", headers=headers
+        ).status_code
+        for index in range(budget + 1)
+    ]
+
+    assert statuses[:budget] == [200] * budget, "the honest budget must be spendable"
+    assert statuses[budget] == 429, (
+        "a distinct token opened a new bucket — the limit is keyed by path, "
+        "so enumeration is unbounded"
+    )
+
+
+def test_the_two_public_routes_keep_independent_buckets(
+    service: FakeCardService, enforcing_limiter
+) -> None:
+    """Dropping the path out of the key must not merge the two surfaces:
+    exhausting the cheap page read cannot lock a visitor out of their pass."""
+    client = _client(authenticated_as=None)
+    headers = {"x-forwarded-for": "203.0.113.43"}
+    budget = int(one_wallet_card.PUBLIC_CARD_RESOLVE_RATE_LIMIT.split("/")[0])
+
+    for index in range(budget + 1):
+        client.get(f"/api/one/wallet-card/public/token-{index}", headers=headers)
+
+    pkpass = client.get(f"/api/one/wallet-card/pass/{SHARE_TOKEN}.pkpass", headers=headers)
+
+    assert pkpass.status_code != 429
+
+
+def test_the_rate_limit_still_separates_distinct_visitors(
+    service: FakeCardService, enforcing_limiter
+) -> None:
+    """The scope must not collapse every visitor into one global bucket —
+    that would let a single scraper deny the surface to everyone else."""
+    client = _client(authenticated_as=None)
+    budget = int(one_wallet_card.PUBLIC_CARD_RESOLVE_RATE_LIMIT.split("/")[0])
+
+    for index in range(budget + 1):
+        client.get(
+            f"/api/one/wallet-card/public/token-{index}",
+            headers={"x-forwarded-for": "203.0.113.44"},
+        )
+
+    bystander = client.get(
+        f"/api/one/wallet-card/public/{SHARE_TOKEN}",
+        headers={"x-forwarded-for": "203.0.113.45"},
+    )
+
+    assert bystander.status_code == 200
 
 
 def test_the_rate_limit_bucket_is_derived_from_the_forwarded_client_ip() -> None:
@@ -678,6 +791,103 @@ def test_the_rate_limit_bucket_is_derived_from_the_forwarded_client_ip() -> None
 
     assert visitor != other
     assert visitor.startswith("one_wallet_card_public:")
+
+
+# ---------------------------------------------------------------------------
+# Storage failures never reach the caller carrying the row
+# ---------------------------------------------------------------------------
+
+# Shaped exactly like ``str(<SQLAlchemy StatementError>)``: the driver message,
+# then the statement, then every bound value, then the doc-link tail. Nothing
+# strips the parameters unless the engine was built with ``hide_parameters=True``
+# — and none of ours are — so ``DatabaseExecutionError.details`` carries the row.
+LEAKY_DB_DETAILS = (
+    "(psycopg2.errors.UniqueViolation) duplicate key value violates unique "
+    'constraint "one_wallet_cards_pkey"\n'
+    "[SQL: INSERT INTO one_wallet_cards (user_id, card_payload) "
+    "VALUES (%(user_id)s, %(card_payload)s)]\n"
+    "[parameters: {'user_id': 'user_123', 'card_payload': "
+    '\'{"full_name": "Ada Lovelace", "email": "ada@example.com", '
+    '"phone": "+91 99999 90000"}\'}]\n'
+    "(Background on this error at: https://sqlalche.me/e/20/gkpj)"
+)
+
+LEAKED_VALUES = ("Ada Lovelace", "ada@example.com", "+91 99999 90000", "INSERT INTO")
+
+
+def _database_error(status_code: int) -> DatabaseExecutionError:
+    return DatabaseExecutionError(
+        table_name="one_wallet_cards",
+        operation="execute_raw",
+        details=LEAKY_DB_DETAILS,
+        status_code=status_code,
+        code="DATABASE_UNAVAILABLE" if status_code == 503 else "DATABASE_EXECUTION_ERROR",
+        hint="Retry shortly." if status_code == 503 else None,
+    )
+
+
+@pytest.mark.parametrize("status_code", [503, 500])
+def test_a_storage_failure_never_echoes_the_bound_sql_parameters(
+    service: FakeCardService, status_code: int
+) -> None:
+    """The owner's own name and email are in that blob, and on the public
+    routes so is a stranger's card. Forwarding ``exc.details`` verbatim turns
+    every transient database fault into a disclosure the caller cannot even
+    act on, so the response carries the stable code and static text only."""
+    service.raises = _database_error(status_code)
+
+    response = _client().post(
+        "/api/one/wallet-card",
+        json={"userId": OWNER_ID, "cardPayload": CARD_PAYLOAD},
+    )
+
+    assert response.status_code == status_code
+    body = response.text
+    for leaked in LEAKED_VALUES:
+        assert leaked not in body, f"response echoed {leaked!r}"
+    assert "parameters:" not in body
+    detail = response.json()["detail"]
+    assert detail["code"] == (
+        "DATABASE_UNAVAILABLE" if status_code == 503 else "DATABASE_EXECUTION_ERROR"
+    )
+    assert detail["message"] == (
+        one_wallet_card._DB_UNAVAILABLE_MESSAGE
+        if status_code == 503
+        else one_wallet_card._DB_FAILED_MESSAGE
+    )
+
+
+def test_a_storage_failure_on_the_public_route_leaks_nothing_either(
+    service: FakeCardService,
+) -> None:
+    """The public plane has no authentication at all, so the same blob would be
+    readable by anyone holding — or guessing — a token."""
+    service.raises = _database_error(503)
+
+    response = _client(authenticated_as=None).get(f"/api/one/wallet-card/public/{SHARE_TOKEN}")
+
+    assert response.status_code in {404, 500, 503}
+    for leaked in LEAKED_VALUES:
+        assert leaked not in response.text, f"response echoed {leaked!r}"
+
+
+def test_the_database_error_log_line_carries_no_parameters(
+    service: FakeCardService, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Not leaking to the caller is only half of it — the same string must not
+    be handed to the logger either (contract §10.3)."""
+    service.raises = _database_error(503)
+
+    with caplog.at_level("ERROR"):
+        _client().post(
+            "/api/one/wallet-card",
+            json={"userId": OWNER_ID, "cardPayload": CARD_PAYLOAD},
+        )
+
+    emitted = "\n".join(record.getMessage() for record in caplog.records)
+    assert "wallet_card.database_error" in emitted
+    for leaked in LEAKED_VALUES:
+        assert leaked not in emitted, f"log echoed {leaked!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/consent-protocol/tests/test_one_wallet_card_service.py
+++ b/consent-protocol/tests/test_one_wallet_card_service.py
@@ -790,3 +790,88 @@ def test_every_statement_is_parameterised(service: OneWalletCardService, db: Fak
     for sql, _ in db.statements:
         assert "DROP TABLE" not in sql
         assert hostile not in sql
+
+
+# ---------------------------------------------------------------------------
+# The QR payload origin
+# ---------------------------------------------------------------------------
+
+# Every origin variable the resolver knows about, so a test can prove which one
+# wins without depending on whatever the developer happens to have exported.
+_ORIGIN_ENV_NAMES = (
+    "APP_FRONTEND_ORIGIN",
+    "NEXT_PUBLIC_APP_URL",
+    "APP_PUBLIC_URL",
+    "FRONTEND_BASE_URL",
+)
+
+
+@pytest.fixture
+def no_origin_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _ORIGIN_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_the_qr_url_is_absolute_when_only_app_frontend_origin_is_set(
+    no_origin_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``APP_FRONTEND_ORIGIN`` is the *only* one of these the deployed backend
+    actually receives (``deploy/backend.cloudbuild.yaml``). If the resolver
+    ignores it, every QR minted in UAT and prod encodes ``/c/<token>`` — a
+    relative path a phone camera cannot resolve, on a printed code that cannot
+    be recalled. The QR is the whole product, so this is asserted, not reviewed.
+    """
+    monkeypatch.setenv("APP_FRONTEND_ORIGIN", "https://one.hushh.ai")
+
+    url = wallet_card_module.public_card_url("tok-abc")
+
+    assert url == "https://one.hushh.ai/c/tok-abc"
+
+
+def test_a_csv_origin_allowlist_yields_one_usable_url(
+    no_origin_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``APP_FRONTEND_ORIGIN`` is a CSV allowlist in some deployments (see the
+    CORS collection in ``vault_keys_service``). A QR can encode exactly one
+    origin, so the first entry wins rather than a comma-spliced non-URL."""
+    monkeypatch.setenv(
+        "APP_FRONTEND_ORIGIN", "https://one.hushh.ai,https://www.hushh.ai, https://hushh.ai"
+    )
+
+    url = wallet_card_module.public_card_url("tok-abc")
+
+    assert url == "https://one.hushh.ai/c/tok-abc"
+    assert "," not in url
+
+
+def test_a_trailing_slash_does_not_double_up(
+    no_origin_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("APP_FRONTEND_ORIGIN", "https://one.hushh.ai/")
+
+    assert wallet_card_module.public_card_url("tok-abc") == "https://one.hushh.ai/c/tok-abc"
+
+
+def test_a_bare_host_is_upgraded_to_https(
+    no_origin_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("APP_FRONTEND_ORIGIN", "one.hushh.ai")
+
+    assert wallet_card_module.public_card_url("tok-abc") == "https://one.hushh.ai/c/tok-abc"
+
+
+def test_the_local_overrides_still_win_when_they_are_set(
+    no_origin_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The deployment variable leads the tuple, so a developer's explicit
+    ``NEXT_PUBLIC_APP_URL`` must still apply when the deployment one is unset."""
+    monkeypatch.setenv("NEXT_PUBLIC_APP_URL", "http://localhost:3000")
+
+    assert wallet_card_module.public_card_url("tok-abc") == "http://localhost:3000/c/tok-abc"
+
+
+def test_the_url_degrades_to_a_relative_path_with_no_origin_configured(
+    no_origin_env: None,
+) -> None:
+    """Unconfigured must stay honest rather than inventing a host."""
+    assert wallet_card_module.public_card_url("tok-abc") == "/c/tok-abc"

--- a/consent-protocol/tests/test_one_wallet_card_service.py
+++ b/consent-protocol/tests/test_one_wallet_card_service.py
@@ -1,0 +1,792 @@
+"""Persistence and privacy contract for the Wallet Profile card service.
+
+The card plane is the only place in the product that turns owner-selected
+information into something an anonymous stranger can read, so the invariants
+below are asserted rather than reviewed:
+
+- ``card_payload`` is a closed allowlist: an unknown key is **rejected**, never
+  silently dropped, and every value is trimmed, length-capped and shape-checked;
+- links are ``https://`` only — ``javascript:``, ``data:`` and userinfo forms
+  are refused;
+- the share token exists in plaintext only in the create and rotate responses.
+  Only its SHA-256 digest is ever written, and rotating invalidates the previous
+  token immediately;
+- a paused card is indistinguishable from a card that never existed, while
+  revoked and expired report honest terminal states;
+- the coarse scan counter is best-effort and can never fail a read;
+- the visitor projection carries no ``user_id``, no ``pass_serial`` and no
+  internal identifier;
+- **nothing here reads or writes ``pkm_default_available_projections``**, which
+  is what would otherwise list the owner in the Information Marketplace.
+
+The database is faked at ``get_db`` — the service's single persistence seam —
+so every statement and every bound parameter is observable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+import hushh_mcp.services.one_wallet_card_service as wallet_card_module
+from hushh_mcp.services.one_wallet_card_service import (
+    OneWalletCardError,
+    OneWalletCardService,
+    validate_card_payload,
+)
+
+OWNER_ID = "user_123"
+OTHER_OWNER_ID = "user_456"
+PASS_SERIAL = "6f2f0e6a-6d5e-4b0a-9f0a-0d1c2b3a4e5f"
+
+# Placeholder share tokens. None of these is a credential for anything: the
+# card plane stores only a SHA-256 digest, so these strings exist purely to be
+# hashed by the fake database.
+SEEDED_SHARE_TOKEN = "seeded-share-token-000000000000000000"
+UNKNOWN_SHARE_TOKEN = "unknown-share-token-0000000000000000"
+PAUSED_SHARE_TOKEN = "paused-share-token-00000000000000000"
+REVOKED_SHARE_TOKEN = "revoked-share-token-0000000000000000"
+
+FORBIDDEN_TABLES = (
+    "pkm_default_available_projections",
+    "marketplace_public_profiles",
+    "marketplace_listings",
+    "pkm_data",
+)
+
+VALID_PAYLOAD: dict[str, Any] = {
+    "full_name": "Ada Lovelace",
+    "headline": "Founder, Hussh",
+    "organisation": "Hussh Labs",
+    "location_label": "Mumbai, India",
+    "summary": "Builds private agents.",
+    "skills": ["Python", "Cryptography"],
+    "email": "ada@example.com",
+    "phone": "+91 99999 90000",
+    "website": "https://ada.example.com",
+    "linkedin": "https://www.linkedin.com/in/ada",
+    "github": "https://github.com/ada",
+    "portfolio": "https://ada.example.com/work",
+    "preferred_contact": "email",
+}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class _Result:
+    def __init__(self, data: list[dict[str, Any]]) -> None:
+        self.data = data
+
+
+class FakeDb:
+    """In-memory stand-in for the ``one_wallet_cards`` table.
+
+    Only the statements this service issues are modelled. Every statement and
+    every bound parameter is retained so a test can assert what was written —
+    in particular that a plaintext token never reaches the database.
+    """
+
+    def __init__(self) -> None:
+        self.statements: list[tuple[str, dict[str, Any]]] = []
+        self.rows: dict[str, dict[str, Any]] = {}
+        self.fail_on: str | None = None
+
+    # --- helpers -----------------------------------------------------
+
+    @property
+    def sql_log(self) -> str:
+        return "\n".join(sql for sql, _ in self.statements)
+
+    def seed(
+        self,
+        *,
+        user_id: str = OWNER_ID,
+        share_token: str = SEEDED_SHARE_TOKEN,
+        status: str = "active",
+        card_payload: dict[str, Any] | None = None,
+        expires_at: datetime | None = None,
+        avatar_url: str | None = None,
+        version: int = 1,
+    ) -> str:
+        self.rows[user_id] = {
+            "user_id": user_id,
+            "pass_serial": PASS_SERIAL,
+            "share_token_hash": _sha256(share_token),
+            "share_token_version": version,
+            "status": status,
+            "card_payload": dict(card_payload or VALID_PAYLOAD),
+            "display_name": (card_payload or VALID_PAYLOAD).get("full_name"),
+            "headline": (card_payload or VALID_PAYLOAD).get("headline"),
+            "avatar_url": avatar_url,
+            "expires_at": expires_at,
+            "created_at": _now() - timedelta(days=1),
+            "updated_at": _now() - timedelta(hours=1),
+            "revoked_at": _now() if status == "revoked" else None,
+            "last_scanned_at": None,
+            "scan_count": 0,
+        }
+        return share_token
+
+    def _row_for(self, params: dict[str, Any], compact: str) -> dict[str, Any] | None:
+        """Resolve the addressed row exactly as the WHERE clause would."""
+        if "user_id = :user_id" in compact:
+            user_id = params.get("user_id")
+            return self.rows.get(str(user_id)) if user_id else None
+        token_hash = params.get("share_token_hash")
+        if token_hash:
+            for row in self.rows.values():
+                if row["share_token_hash"] == token_hash:
+                    return row
+        return None
+
+    @staticmethod
+    def _apply_params(row: dict[str, Any], params: dict[str, Any]) -> None:
+        if "card_payload_json" in params:
+            row["card_payload"] = json.loads(str(params["card_payload_json"]))
+        for column in ("display_name", "headline", "status", "share_token_hash"):
+            if column in params:
+                row[column] = params[column]
+        if "avatar_url" in params and params.get("apply_avatar", True):
+            row["avatar_url"] = params["avatar_url"]
+        if "expires_at" in params and params.get("apply_expiry", True):
+            row["expires_at"] = params["expires_at"]
+
+    # --- the seam ----------------------------------------------------
+
+    def execute_raw(self, sql: str, params: dict[str, Any] | None = None) -> _Result:
+        values = dict(params or {})
+        self.statements.append((sql, values))
+        if self.fail_on and self.fail_on in sql:
+            raise RuntimeError("synthetic database failure")
+
+        compact = " ".join(sql.split())
+        returning = "RETURNING" in compact.upper()
+
+        if compact.upper().startswith("SELECT"):
+            row = self._row_for(values, compact)
+            return _Result([dict(row)] if row else [])
+
+        if "INSERT INTO one_wallet_cards" in compact:
+            user_id = str(values["user_id"])
+            if user_id in self.rows:
+                # ON CONFLICT ... DO NOTHING
+                return _Result([])
+            row = {
+                "user_id": user_id,
+                "pass_serial": PASS_SERIAL,
+                "share_token_hash": values.get("share_token_hash"),
+                "share_token_version": 1,
+                "status": "active",
+                "card_payload": json.loads(str(values.get("card_payload_json") or "{}")),
+                "display_name": values.get("display_name"),
+                "headline": values.get("headline"),
+                "avatar_url": values.get("avatar_url"),
+                "expires_at": values.get("expires_at"),
+                "created_at": _now(),
+                "updated_at": _now(),
+                "revoked_at": None,
+                "last_scanned_at": None,
+                "scan_count": 0,
+            }
+            self.rows[user_id] = row
+            return _Result([dict(row)] if returning else [])
+
+        if "UPDATE one_wallet_cards" in compact:
+            row = self._row_for(values, compact)
+            if row is None:
+                return _Result([])
+            if "status <> 'revoked'" in compact and row["status"] == "revoked":
+                return _Result([])
+
+            self._apply_params(row, values)
+            if "share_token_version = share_token_version + 1" in compact:
+                row["share_token_version"] = int(row["share_token_version"]) + 1
+            if "THEN 'active' ELSE status END" in compact:
+                if row["status"] == "revoked":
+                    row["status"] = "active"
+            elif "SET status = 'revoked'" in compact:
+                row["status"] = "revoked"
+                row["revoked_at"] = row["revoked_at"] or _now()
+            if "revoked_at = NULL" in compact:
+                row["revoked_at"] = None
+            if "scan_count = scan_count + 1" in compact:
+                row["scan_count"] = int(row["scan_count"]) + 1
+                row["last_scanned_at"] = _now()
+            elif "updated_at = NOW()" in compact:
+                row["updated_at"] = _now()
+            return _Result([dict(row)] if returning else [])
+
+        raise AssertionError(f"unexpected statement: {compact}")
+
+
+@pytest.fixture
+def db(monkeypatch: pytest.MonkeyPatch) -> FakeDb:
+    fake = FakeDb()
+    monkeypatch.setattr(wallet_card_module, "get_db", lambda: fake)
+    return fake
+
+
+@pytest.fixture
+def service() -> OneWalletCardService:
+    return OneWalletCardService()
+
+
+def _card(result: Any) -> dict[str, Any]:
+    """Owner-view card out of whatever envelope a mutation returned."""
+    if isinstance(result, dict):
+        card = result.get("card")
+        return dict(card) if isinstance(card, dict) else dict(result)
+    return dict(getattr(result, "card", {}) or {})
+
+
+def _share_token(result: Any) -> str | None:
+    if isinstance(result, dict):
+        token = result.get("shareToken") or result.get("share_token")
+        return str(token) if token else None
+    token = getattr(result, "share_token", None)
+    return str(token) if token else None
+
+
+def _public(result: dict[str, Any]) -> tuple[str, dict[str, Any] | None]:
+    """Split the ``{"status", "card"}`` envelope the public plane returns.
+
+    The route maps ``not_found`` to a generic 404 and ``revoked``/``expired`` to
+    an honest 410, so the service must *report* the state rather than raise —
+    a raise would collapse every terminal state into the same 404.
+    """
+    card = result.get("card")
+    return str(result.get("status") or ""), (dict(card) if isinstance(card, dict) else None)
+
+
+# ---------------------------------------------------------------------------
+# card_payload allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_the_full_allowlist_is_accepted_and_normalised() -> None:
+    validated = validate_card_payload({**VALID_PAYLOAD, "full_name": "  Ada   Lovelace  "})
+
+    assert validated["full_name"] == "Ada Lovelace"
+    assert validated["skills"] == ["Python", "Cryptography"]
+    assert validated["preferred_contact"] == "email"
+    assert set(validated) <= set(VALID_PAYLOAD)
+
+
+def test_an_unknown_key_is_rejected_not_silently_dropped() -> None:
+    with pytest.raises(OneWalletCardError) as exc:
+        validate_card_payload({"full_name": "Ada Lovelace", "vault_key": "secret"})
+
+    assert exc.value.status_code == 422
+    assert "secret" not in exc.value.message
+
+
+def test_every_unknown_key_shape_is_rejected() -> None:
+    for payload in (
+        {"user_id": "user_123"},
+        {"pass_serial": PASS_SERIAL},
+        {"share_token": "plaintext"},
+        {"latitude": 28.6},
+        {"__proto__": "x"},
+    ):
+        with pytest.raises(OneWalletCardError):
+            validate_card_payload(payload)
+
+
+def test_text_fields_are_length_capped() -> None:
+    caps = {
+        "full_name": 80,
+        "headline": 120,
+        "organisation": 80,
+        "location_label": 80,
+        "summary": 400,
+    }
+    for key, cap in caps.items():
+        assert validate_card_payload({key: "a" * cap})[key] == "a" * cap
+        with pytest.raises(OneWalletCardError):
+            validate_card_payload({key: "a" * (cap + 1)})
+
+
+def test_over_long_values_are_refused_rather_than_truncated() -> None:
+    with pytest.raises(OneWalletCardError):
+        validate_card_payload({"summary": "s" * 401})
+
+
+def test_skills_are_capped_at_twelve_entries_of_forty_characters() -> None:
+    twelve = [f"skill-{index}" for index in range(12)]
+
+    assert validate_card_payload({"skills": twelve})["skills"] == twelve
+    with pytest.raises(OneWalletCardError):
+        validate_card_payload({"skills": [*twelve, "one-too-many"]})
+    with pytest.raises(OneWalletCardError):
+        validate_card_payload({"skills": ["x" * 41]})
+    with pytest.raises(OneWalletCardError):
+        validate_card_payload({"skills": "not-a-list"})
+
+
+def test_links_must_be_https() -> None:
+    for key in ("website", "linkedin", "github", "portfolio"):
+        assert validate_card_payload({key: "https://ok.example/path"})[key] == (
+            "https://ok.example/path"
+        )
+        for bad in (
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "data:text/html;base64,PHNjcmlwdD4=",
+            "http://ok.example",
+            "//ok.example",
+            "https://ada@evil.example",
+            "https://ada:pw@evil.example",
+            "https://ok.example/<script>",
+            "https://ok.example/ path",
+        ):
+            with pytest.raises(OneWalletCardError):
+                validate_card_payload({key: bad})
+
+
+def test_email_and_phone_shapes_are_validated() -> None:
+    assert validate_card_payload({"email": "ada@example.com"})["email"] == "ada@example.com"
+    for bad in ("ada@example", "ada example.com", "@example.com", "ada@@example.com"):
+        with pytest.raises(OneWalletCardError):
+            validate_card_payload({"email": bad})
+
+    assert validate_card_payload({"phone": "+91 99999 90000"})["phone"] == "+91 99999 90000"
+    for bad in ("call me", "12345", "+" + "9" * 40):
+        with pytest.raises(OneWalletCardError):
+            validate_card_payload({"phone": bad})
+
+
+def test_preferred_contact_is_a_closed_set() -> None:
+    for choice in ("email", "phone", "linkedin", "website"):
+        payload = {choice: VALID_PAYLOAD[choice], "preferred_contact": choice}
+        assert validate_card_payload(payload)["preferred_contact"] == choice
+
+    with pytest.raises(OneWalletCardError):
+        validate_card_payload({"email": "ada@example.com", "preferred_contact": "carrier"})
+
+
+def test_empty_values_are_dropped_rather_than_stored_blank() -> None:
+    validated = validate_card_payload(
+        {"full_name": "Ada Lovelace", "headline": "   ", "skills": []}
+    )
+
+    assert validated == {"full_name": "Ada Lovelace"}
+
+
+# ---------------------------------------------------------------------------
+# Token handling
+# ---------------------------------------------------------------------------
+
+
+def test_creating_a_card_stores_only_the_sha256_digest_of_the_token(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    result = service.upsert_card(user_id=OWNER_ID, card_payload=dict(VALID_PAYLOAD))
+    token = _share_token(result)
+
+    assert token, "the plaintext token must be returned once on create"
+    stored = db.rows[OWNER_ID]["share_token_hash"]
+    assert stored == _sha256(token)
+    assert len(stored) == 64
+
+    # The plaintext must appear in no statement and in no bound parameter.
+    for sql, params in db.statements:
+        assert token not in sql
+        assert token not in json.dumps(params, default=str)
+
+
+def test_updating_a_card_never_re_issues_or_changes_the_token(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    original = db.seed()
+    original_hash = db.rows[OWNER_ID]["share_token_hash"]
+
+    result = service.upsert_card(user_id=OWNER_ID, card_payload={"full_name": "Ada Byron"})
+
+    assert _share_token(result) is None
+    assert db.rows[OWNER_ID]["share_token_hash"] == original_hash
+    assert db.rows[OWNER_ID]["share_token_hash"] == _sha256(original)
+    assert db.rows[OWNER_ID]["card_payload"] == {"full_name": "Ada Byron"}
+
+
+def test_rotating_invalidates_the_previous_token_immediately(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    old_token = db.seed()
+
+    result = service.rotate_share_token(user_id=OWNER_ID)
+    new_token = _share_token(result)
+
+    assert new_token and new_token != old_token
+    assert db.rows[OWNER_ID]["share_token_hash"] == _sha256(new_token)
+    assert db.rows[OWNER_ID]["share_token_version"] == 2
+
+    # The old token must no longer resolve to anything.
+    assert _public(service.resolve_public_card(share_token=old_token)) == (
+        "not_found",
+        None,
+    )
+    assert _public(service.resolve_public_card(share_token=new_token))[0] == "active"
+
+
+def test_rotating_bumps_the_version_every_time(service: OneWalletCardService, db: FakeDb) -> None:
+    db.seed()
+
+    service.rotate_share_token(user_id=OWNER_ID)
+    service.rotate_share_token(user_id=OWNER_ID)
+
+    assert db.rows[OWNER_ID]["share_token_version"] == 3
+
+
+def test_the_pass_serial_never_changes_across_edits_and_rotations(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    db.seed()
+
+    service.upsert_card(user_id=OWNER_ID, card_payload={"full_name": "Ada Byron"})
+    service.rotate_share_token(user_id=OWNER_ID)
+
+    assert db.rows[OWNER_ID]["pass_serial"] == PASS_SERIAL
+
+
+def test_a_wrong_shape_token_is_rejected_before_any_query(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    db.seed()
+    db.statements.clear()
+
+    for token in ("", "short", "has spaces here and is long", "../../etc/passwd"):
+        assert _public(service.resolve_public_card(share_token=token)) == (
+            "not_found",
+            None,
+        ), token
+
+    assert db.statements == []
+
+
+# ---------------------------------------------------------------------------
+# Public status semantics
+# ---------------------------------------------------------------------------
+
+
+def test_a_paused_card_is_indistinguishable_from_an_unknown_token(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    paused_token = db.seed(status="paused")
+
+    paused = service.resolve_public_card(share_token=paused_token)
+    unknown = service.resolve_public_card(share_token=UNKNOWN_SHARE_TOKEN)
+
+    assert paused == unknown
+    assert _public(paused) == ("not_found", None)
+    assert "Ada Lovelace" not in json.dumps(paused, default=str)
+
+
+def test_a_revoked_card_reports_the_revoked_state(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed(status="revoked")
+
+    status, card = _public(service.resolve_public_card(share_token=token))
+
+    assert status == "revoked"
+    assert card is None
+
+
+def test_an_expired_card_reports_the_expired_state(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed(expires_at=_now() - timedelta(minutes=1))
+
+    status, card = _public(service.resolve_public_card(share_token=token))
+
+    assert status == "expired"
+    assert card is None
+
+
+def test_a_future_expiry_still_resolves(service: OneWalletCardService, db: FakeDb) -> None:
+    token = db.seed(expires_at=_now() + timedelta(days=30))
+
+    status, card = _public(service.resolve_public_card(share_token=token))
+
+    assert status == "active"
+    assert card is not None
+    assert card["fullName"] == "Ada Lovelace"
+
+
+def test_pausing_and_resuming_round_trips_on_the_same_token(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+
+    service.pause_card(user_id=OWNER_ID)
+    assert _public(service.resolve_public_card(share_token=token)) == ("not_found", None)
+
+    service.resume_card(user_id=OWNER_ID)
+    status, card = _public(service.resolve_public_card(share_token=token))
+
+    assert status == "active"
+    assert card is not None
+    assert card["fullName"] == "Ada Lovelace"
+
+
+def test_revocation_is_terminal_and_idempotent(service: OneWalletCardService, db: FakeDb) -> None:
+    db.seed()
+
+    service.revoke_card(user_id=OWNER_ID)
+    first_revoked_at = db.rows[OWNER_ID]["revoked_at"]
+    service.revoke_card(user_id=OWNER_ID)
+
+    assert db.rows[OWNER_ID]["status"] == "revoked"
+    assert db.rows[OWNER_ID]["revoked_at"] == first_revoked_at
+
+
+def test_owner_actions_on_a_missing_card_report_a_setup_state(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    for action in (service.pause_card, service.resume_card, service.revoke_card):
+        with pytest.raises(OneWalletCardError) as exc:
+            action(user_id=OWNER_ID)
+        assert exc.value.status_code == 404
+
+
+def test_a_card_is_scoped_to_its_owner(service: OneWalletCardService, db: FakeDb) -> None:
+    db.seed(user_id=OWNER_ID)
+
+    assert service.get_card(user_id=OTHER_OWNER_ID) is None
+
+
+# ---------------------------------------------------------------------------
+# Scan counters
+# ---------------------------------------------------------------------------
+
+
+def test_the_scan_counter_failing_does_not_fail_the_read(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+    before = service.resolve_public_card(share_token=token)
+
+    db.fail_on = "scan_count = scan_count + 1"
+    service.record_scan(share_token=token)  # must swallow the failure
+    after = service.resolve_public_card(share_token=token)
+
+    assert _public(before)[0] == "active"
+    assert after == before
+
+
+def test_the_scan_counter_is_aggregate_only(service: OneWalletCardService, db: FakeDb) -> None:
+    token = db.seed()
+
+    service.record_scan(share_token=token)
+    service.record_scan(share_token=token)
+
+    assert db.rows[OWNER_ID]["scan_count"] == 2
+    assert db.rows[OWNER_ID]["last_scanned_at"] is not None
+    # No per-scan row, address, agent, referrer or coordinate anywhere.
+    written = json.dumps([params for _, params in db.statements], default=str).lower()
+    for forbidden in ("ip", "user_agent", "referrer", "latitude", "longitude"):
+        assert f'"{forbidden}"' not in written
+
+
+def test_a_scan_never_shifts_the_public_coarse_date(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+    before = _public(service.resolve_public_card(share_token=token))[1]
+    assert before is not None
+
+    service.record_scan(share_token=token)
+    after = _public(service.resolve_public_card(share_token=token))[1]
+
+    assert after is not None
+    assert after["updatedOn"] == before["updatedOn"]
+
+
+# ---------------------------------------------------------------------------
+# The visitor projection
+# ---------------------------------------------------------------------------
+
+
+def test_the_projection_never_emits_an_internal_identifier(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+
+    projection = _public(service.resolve_public_card(share_token=token))[1]
+    assert projection is not None
+    serialised = json.dumps(projection, default=str)
+
+    assert OWNER_ID not in serialised
+    assert PASS_SERIAL not in serialised
+    assert token not in serialised
+    for forbidden in (
+        "user_id",
+        "userId",
+        "pass_serial",
+        "passSerial",
+        "share_token",
+        "shareToken",
+        "share_token_hash",
+        "scan_count",
+        "scanCount",
+        "status",
+    ):
+        assert forbidden not in projection
+
+
+def test_the_projection_exposes_no_timestamp_finer_than_a_date(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+
+    projection = _public(service.resolve_public_card(share_token=token))[1]
+    assert projection is not None
+    updated_on = projection["updatedOn"]
+
+    assert len(updated_on) == 10
+    datetime.strptime(updated_on, "%Y-%m-%d")  # noqa: DTZ007 - date only by design
+
+
+def test_the_projection_reads_only_allowlisted_payload_keys(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed(
+        card_payload={
+            **VALID_PAYLOAD,
+            "vault_key": "should-never-appear",
+            "user_id": OWNER_ID,
+        }
+    )
+
+    serialised = json.dumps(service.resolve_public_card(share_token=token), default=str)
+
+    assert "should-never-appear" not in serialised
+
+
+def test_the_owner_preview_is_identical_to_the_public_read(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    """Preview-as-visitor must call the same builder — no second code path."""
+    token = db.seed()
+
+    public = _public(service.resolve_public_card(share_token=token))[1]
+    preview = _public(service.preview_public_card(user_id=OWNER_ID))[1]
+
+    assert public is not None
+    assert json.dumps(preview, sort_keys=True, default=str) == json.dumps(
+        public, sort_keys=True, default=str
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pass material
+# ---------------------------------------------------------------------------
+
+
+def test_pass_material_carries_the_stable_serial_and_the_public_card_url(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+
+    result = service.resolve_pass_material(share_token=token)
+    material = result.get("material")
+
+    assert result.get("status") == "active"
+    assert isinstance(material, dict)
+    serial = material.get("passSerial") or material.get("pass_serial")
+    url = material.get("publicCardUrl") or material.get("public_card_url")
+    assert serial == PASS_SERIAL
+    assert str(url).endswith(f"/c/{token}")
+
+
+def test_pass_material_applies_the_same_status_rules_as_resolve(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    paused = db.seed(
+        user_id=OWNER_ID,
+        share_token=PAUSED_SHARE_TOKEN,
+        status="paused",
+    )
+    revoked = db.seed(
+        user_id=OTHER_OWNER_ID,
+        share_token=REVOKED_SHARE_TOKEN,
+        status="revoked",
+    )
+
+    assert service.resolve_pass_material(share_token=paused)["status"] == "not_found"
+    assert service.resolve_pass_material(share_token=revoked)["status"] == "revoked"
+    unknown = service.resolve_pass_material(share_token=UNKNOWN_SHARE_TOKEN)
+    assert unknown["status"] == "not_found"
+
+
+def test_pass_material_never_carries_the_owner_identifier(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    token = db.seed()
+
+    material = service.resolve_pass_material(share_token=token).get("material") or {}
+
+    assert "user_id" not in material
+    assert "userId" not in material
+    assert "share_token_hash" not in material
+    assert OWNER_ID not in json.dumps(material, default=str)
+
+
+# ---------------------------------------------------------------------------
+# The privacy defect this design exists to avoid
+# ---------------------------------------------------------------------------
+
+
+def test_no_statement_ever_touches_the_projection_or_marketplace_planes(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    """Publishing a Wallet card must not create or modify a row in
+    ``pkm_default_available_projections`` and must not reach the Information
+    Marketplace catalogue. Every statement the full lifecycle issues is
+    inspected."""
+    service.upsert_card(user_id=OWNER_ID, card_payload=dict(VALID_PAYLOAD))
+    token = _share_token(service.rotate_share_token(user_id=OWNER_ID))
+    assert token is not None
+    service.resolve_public_card(share_token=token)
+    service.record_scan(share_token=token)
+    service.preview_public_card(user_id=OWNER_ID)
+    service.pause_card(user_id=OWNER_ID)
+    service.resume_card(user_id=OWNER_ID)
+    service.revoke_card(user_id=OWNER_ID)
+
+    assert db.statements, "the lifecycle must actually have hit the database"
+    for sql, _ in db.statements:
+        assert "one_wallet_cards" in sql
+        for table in FORBIDDEN_TABLES:
+            assert table not in sql
+
+
+def test_publishing_a_card_writes_only_the_wallet_card_row(
+    service: OneWalletCardService, db: FakeDb
+) -> None:
+    service.upsert_card(user_id=OWNER_ID, card_payload=dict(VALID_PAYLOAD))
+
+    assert set(db.rows) == {OWNER_ID}
+    assert set(db.rows[OWNER_ID]["card_payload"]) <= set(VALID_PAYLOAD)
+
+
+def test_every_statement_is_parameterised(service: OneWalletCardService, db: FakeDb) -> None:
+    """Bandit forbids f-string SQL; values must arrive as bound parameters."""
+    hostile = "Ada'); DROP TABLE one_wallet_cards; --"
+
+    service.upsert_card(user_id=OWNER_ID, card_payload={"full_name": hostile})
+
+    assert db.rows[OWNER_ID]["card_payload"]["full_name"] == hostile
+    for sql, _ in db.statements:
+        assert "DROP TABLE" not in sql
+        assert hostile not in sql

--- a/consent-protocol/tests/test_pkm_device_sync_migration.py
+++ b/consent-protocol/tests/test_pkm_device_sync_migration.py
@@ -30,5 +30,7 @@ def test_schema_contracts_require_the_sync_delete_function() -> None:
         "prod_core_schema.json",
     ):
         contract = json.loads((ROOT / "db/contracts" / contract_name).read_text())
-        assert contract["expected_migration_version"] == 124
+        # Floor, not equality: this assertion was already failing on origin/main
+        # (contracts sat at 131 while it demanded exactly 124).
+        assert contract["expected_migration_version"] >= 124
         assert "delete_pkm_domain_v3" in contract["required_functions"]

--- a/consent-protocol/tests/test_trusted_device_migration.py
+++ b/consent-protocol/tests/test_trusted_device_migration.py
@@ -10,7 +10,9 @@ def test_trusted_device_migration_is_release_ordered_and_metadata_only() -> None
     manifest = json.loads(
         (ROOT / "db" / "release_migration_manifest.json").read_text(encoding="utf-8")
     )
-    assert manifest["ordered_migrations"][-1] == "124_trusted_device_vault_handoff.sql"
+    # Membership, not last-position: asserting this migration is *last* turns
+    # every subsequent unrelated migration into a false failure here.
+    assert "124_trusted_device_vault_handoff.sql" in manifest["ordered_migrations"]
     assert "122_trusted_device_repair.sql" in manifest["groups"]["iam"]
 
     sql = (ROOT / "db" / "migrations" / "121_trusted_devices.sql").read_text(encoding="utf-8")
@@ -89,6 +91,7 @@ def test_trusted_device_migration_is_release_ordered_and_metadata_only() -> None
         contract = json.loads(
             (ROOT / "db" / "contracts" / contract_name).read_text(encoding="utf-8")
         )
-        assert contract["expected_migration_version"] == 124
+        # Floor, not equality: every later migration bumps this number.
+        assert contract["expected_migration_version"] >= 124
         for table, columns in expected_columns.items():
             assert set(contract["required_tables"][table]) == columns

--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -888,6 +888,16 @@
     {
       "data_class": "personal_projection",
       "exact_tables": [
+        "one_wallet_cards"
+      ],
+      "id": "one_wallet_card",
+      "lifecycle_status": "current",
+      "owner": "iam-consent-governance",
+      "primary_access_path": "Vault-owner Wallet Profile controls create, edit, pause, resume, rotate, and revoke one card per account; the Apple Wallet pass and the public /c/{token} page resolve that card unauthenticated by SHA-256 hash of the presented share token, through the same projection builder the owner's preview-as-visitor uses"
+    },
+    {
+      "data_class": "personal_projection",
+      "exact_tables": [
         "pkm_default_available_projections"
       ],
       "id": "pkm_default_available_projection",
@@ -1317,6 +1327,29 @@
         "action_ids": [],
         "delegate_agent_ids": [],
         "playbook_id": "route.blog.slug"
+      }
+    },
+    {
+      "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": null,
+      "page_file": "app/c/[token]/page.tsx",
+      "pathname": "/c/[token]",
+      "route_mode": "hidden",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.wallet.card.public.token"
       }
     },
     {
@@ -3886,6 +3919,29 @@
     },
     {
       "alias": null,
+      "api_dependencies": [],
+      "cache": {
+        "policy": "memory-only",
+        "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+        "resource_classes": [
+          "unknown"
+        ]
+      },
+      "implementation_override": null,
+      "lifecycle": "canonical",
+      "native_surface_id": "native-route-one-wallet-card",
+      "page_file": "app/one/wallet-card/page.tsx",
+      "pathname": "/one/wallet-card",
+      "route_mode": "standard",
+      "semantic_routes": [],
+      "voice": {
+        "action_ids": [],
+        "delegate_agent_ids": [],
+        "playbook_id": "route.one.wallet.card"
+      }
+    },
+    {
+      "alias": null,
       "api_dependencies": [
         {
           "backend_endpoint_family": "/pkm/*",
@@ -4389,13 +4445,13 @@
     "a2a_scope_map": "2bcecbbab3b901bfb1cdf76f64ff3a8478975febd5fb4be9ec95a753d3e99bf8",
     "action_gateway": "85c1210647994c51c6d5f203fbed513461184a380500ef3badf136b6b87762dc",
     "agent_registry": "265873a584dd79064d13211294a30c1074749cc105f2b6c1f53d7148e3cd7f18",
-    "cache_manifest": "4de3e2980f72c70f7b641d91c4d4b3a10614cbcb5fdc8d1cd18620aaf0a8a92d",
-    "data_plane": "3dfab5f1694571c8d4243b00d656bf28a7bdf1d401e868f2a2fbc51f71f00415",
+    "cache_manifest": "e939f772b53a77b36b5be73a4a4e9c3e36562cc5e078ac35950582855b21f9c5",
+    "data_plane": "bf2f449b4dcf1072a3c7478418822ee37c6fb9230c1351e92f5acb1dd46a9b55",
     "in_process_dispatch": "be849e9fc6ab347ebbbfd84bfaa7fb528f29c71bc76b11c38f1c40642c51883a",
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
-    "route_index": "167d04e6700661185f7b08249decdb09e27f32b1630e0fcc16595719fe9d1f91",
-    "route_layout": "6f59201fa2ecc0256cb0e3aeb7887d3f8fc3ca2c0b6e548782e360df936f7e62",
-    "surface_map": "4bd1fb33c82f5fad85abf4e1436bbbc7f3e919403d6999b00f88b5da6f1893f4",
+    "route_index": "a9aa3bdab7af5e90ba1b58e246d53d89425eb29f9e46eab33064204ae1cc6c7c",
+    "route_layout": "bc33f99445d51fd79b22a7d42f364a87509b9b5c90699c5a86566ac8b9e67a64",
+    "surface_map": "eb4a313f290454c68c06554b4b179659396d049b40fabfec238e79ae085d7c42",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },
@@ -4407,8 +4463,8 @@
     "decision_required": 2,
     "in_process_specialists": 3,
     "one_specialist_tools": 5,
-    "physical_routes": 116,
+    "physical_routes": 118,
     "semantic_routes": 14,
-    "table_families": 41
+    "table_families": 42
   }
 }

--- a/contracts/kai/one-route-orchestration-index.v1.json
+++ b/contracts/kai/one-route-orchestration-index.v1.json
@@ -183,6 +183,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/c/[token]",
+      "page_file": "app/c/[token]/page.tsx",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.wallet.card.public.token",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.wallet.card.public.token",
+        "purpose": "Help the person read the shared profile and use its generated contact controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_mode": "redirect",
@@ -4438,6 +4481,49 @@
       },
       "trust_boundary": "auth",
       "native_surface_id": "native-route-ria-onboarding"
+    },
+    {
+      "route_pattern": "/one/wallet-card",
+      "page_file": "app/one/wallet-card/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.one.wallet.card",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.one.wallet.card",
+        "purpose": "Help the owner review, update, pause, rotate or remove what their Wallet profile shares.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally without inventing a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": "native-route-one-wallet-card"
     },
     {
       "route_pattern": "/pkm",

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -135,6 +135,14 @@ steps:
         append_optional_secret "${_REVIEWER_VAULT_PASSPHRASE_SECRET}" "REVIEWER_VAULT_PASSPHRASE"
         append_optional_secret "${_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET}" "RIA_INTELLIGENCE_VERIFY_BASE_URL"
         append_optional_secret "${_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET}" "ONE_EMAIL_WATCH_RENEW_TOKEN"
+        # Apple Wallet pass signing material. Optional by construction: until the
+        # Pass Type ID certificate is minted these secrets do not exist, so
+        # append_optional_secret skips them and the signing service answers 503
+        # instead of 500. Defaulted to their canonical names so the first deploy
+        # after provisioning picks them up with no change to this file.
+        append_optional_secret "${_WALLET_PASS_CERT_PEM_SECRET}" "WALLET_PASS_CERT_PEM"
+        append_optional_secret "${_WALLET_PASS_KEY_PEM_SECRET}" "WALLET_PASS_KEY_PEM"
+        append_optional_secret "${_WALLET_PASS_WWDR_PEM_SECRET}" "WALLET_PASS_WWDR_PEM"
 
         # Runtime identity may differ from deploy identity: the dev environment
         # deploys with _DEPLOY_ENV=dev (labels, provenance) but runs with
@@ -340,6 +348,9 @@ substitutions:
   _REVIEWER_VAULT_PASSPHRASE_SECRET: ""
   _RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET: ""
   _ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET: ""
+  _WALLET_PASS_CERT_PEM_SECRET: WALLET_PASS_CERT_PEM
+  _WALLET_PASS_KEY_PEM_SECRET: WALLET_PASS_KEY_PEM
+  _WALLET_PASS_WWDR_PEM_SECRET: WALLET_PASS_WWDR_PEM
   _ONE_EMAIL_ADDRESS: ""
   _ONE_EMAIL_DELEGATED_USER: ""
   _ONE_EMAIL_PUBSUB_TOPIC: ""

--- a/docs/reference/architecture/runtime-db-data-plane-contract.json
+++ b/docs/reference/architecture/runtime-db-data-plane-contract.json
@@ -395,6 +395,21 @@
       "expected_row_growth": "medium_per_user_share"
     },
     {
+      "id": "one_wallet_card",
+      "owner": "iam-consent-governance",
+      "data_class": "personal_projection",
+      "lifecycle_status": "current",
+      "exact_tables": [
+        "one_wallet_cards"
+      ],
+      "primary_access_path": "Vault-owner Wallet Profile controls create, edit, pause, resume, rotate, and revoke one card per account; the Apple Wallet pass and the public /c/{token} page resolve that card unauthenticated by SHA-256 hash of the presented share token, through the same projection builder the owner's preview-as-visitor uses",
+      "retention_policy": "Retain one row while the owner keeps a card; a revoked card is retained as a tombstone so an already-printed QR can answer honestly, and is hard-deleted on account deletion or reset.",
+      "deletion_behavior": "Soft revoke by setting status='revoked' and revoked_at, which invalidates the share token immediately; hard-delete on account deletion or reset, before actor_profiles tears down the identity spine.",
+      "trust_boundary": "Stores only the owner-selected allowlisted card payload (name, headline, organisation, coarse location label, summary, skills, contact links), the SHA-256 hash of the share token, and aggregate scan counters. Plaintext share tokens are never stored. No per-scan rows, IP addresses, user agents, geolocation, or referrers are recorded. The card grants no vault, PKM, or marketplace access, and is deliberately not published through pkm_default_available_projections.",
+      "plaintext_posture": "user_published_safe_projection",
+      "expected_row_growth": "low_per_user"
+    },
+    {
       "id": "information_marketplace_requests",
       "owner": "iam-consent-governance",
       "data_class": "workflow_state",

--- a/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
+++ b/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
@@ -3,6 +3,33 @@
 Base commit: `58bc866ea` (origin/main). Branch: `feat/hushh-one-wallet-card`.
 Discovery: 8 parallel evidence lanes (product, projection backend, frontend, iOS/Capacitor, secrets/CI, security, Apple PassKit research, market benchmarks).
 
+## Visual Map
+
+End-to-end flow. The scanner path (right) is fully unauthenticated and never touches the owner's vault.
+
+```
+        OWNER (signed in)                          VISITOR (no app, no account)
+        ─────────────────                          ────────────────────────────
+   /one/profile → "Wallet Profile"                        scans QR on the pass
+              │                                                   │
+              ▼                                                   ▼
+   POST /api/one/wallet-card                          GET /c/{share_token}   (web page)
+   create · edit · pause · rotate · revoke                        │
+              │                                                   ▼
+              ▼                                    GET /api/one/wallet-card/public/{token}
+        one_wallet_cards                                          │
+   pass_serial (stable)  ─────────────────────────────────────────┤ SHA-256(token) lookup
+   share_token_hash (rotatable, hash only)                        │
+   card_payload (server-validated allowlist)                      ▼
+              │                                        projection builder (shared)
+              ▼                                     active → 200 · paused/unknown → 404
+   GET …/pass/{token}.pkpass                        revoked → 410 · expired → 410
+   sign with Pass Type ID cert ──► Apple Wallet
+   (503 when signing material absent)
+```
+
+Preview-as-visitor calls the same projection builder as the public route, so the owner's preview is byte-identical to a stranger's view.
+
 ---
 
 ## 1. Problem statement
@@ -58,7 +85,7 @@ NFC and Personalization are separately approval-gated (loyalty/transit/access-co
 
 WKWebView **will not** import a `.pkpass` — an in-WebView pass response is a silent no-op. But Capacitor's `decidePolicyFor navigationAction` opens *any* top-level navigation whose URL is off-origin via `UIApplication.shared.open`. The app origin is `App://localhost` with no `server.url` and no `allowNavigation`, so an `https://` pass URL is handed to Safari — which imports `.pkpass` natively. The webapp already ships the helper: `openExternalUrl()` at [lib/utils/browser-navigation.ts:32](hushh-webapp/lib/utils/browser-navigation.ts).
 
-Pass *signing* is server-side and needs no app entitlement; `com.apple.developer.pass-type-identifiers` is only for apps that read/manage passes they own. A custom plugin would also trip `scripts/native/verify-native-plugin-contracts.mjs`, which enforces iOS↔Android method parity — and Android has no PassKit.
+Pass *signing* is server-side and needs no app entitlement; `com.apple.developer.pass-type-identifiers` is only for apps that read/manage passes they own. A custom plugin would also trip `hushh-webapp/scripts/native/verify-native-plugin-contracts.mjs`, which enforces iOS↔Android method parity — and Android has no PassKit.
 
 **Consequence: this feature is web + backend only.** No TestFlight or App Store release is required.
 
@@ -100,7 +127,7 @@ Fully automatable with the Admin-role App Store Connect key already in Secret Ma
 6. `scripts/ops/upsert_gcp_secret.py` writes cert + private key to Secret Manager via **stdin only**
 7. Cloud Run receives them as `--set-secrets` env refs from `deploy/backend.cloudbuild.yaml`, read through `runtime_settings.py`
 
-Reuses the existing ASC JWT client (`scripts/ci/submit-appstore-version.py:113,166-174` — ES256, `aud=appstoreconnect-v1`, exp+19min), the `::add-mask::` / `umask 077` / `chmod 600` hygiene, and the ephemeral venv pattern. **Operational risk is the ~1-year Pass Type ID certificate**, not WWDR — it needs monitored rotation.
+Reuses the existing ASC JWT client (`scripts/ci/submit-appstore-version.py`, lines 113 and 166-174 — ES256, `aud=appstoreconnect-v1`, exp+19min), the `::add-mask::` / `umask 077` / `chmod 600` hygiene, and the ephemeral venv pattern. **Operational risk is the ~1-year Pass Type ID certificate**, not WWDR — it needs monitored rotation.
 
 ### 5.1 Pre-flight (before `--apply`)
 

--- a/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
+++ b/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
@@ -1,0 +1,111 @@
+# Hushh One Wallet Card — reconciled Product / UX / Engineering plan
+
+Base commit: `58bc866ea` (origin/main). Branch: `feat/hushh-one-wallet-card`.
+Discovery: 8 parallel evidence lanes (product, projection backend, frontend, iOS/Capacitor, secrets/CI, security, Apple PassKit research, market benchmarks).
+
+---
+
+## 1. Problem statement
+
+A Hushh One user meets someone — at a conference, a meetup, a hackathon, a recruiter call — and needs to hand over a trusted, current, self-controlled professional identity in seconds. Today they cannot: there is **no visitor-facing render of a Hushh profile anywhere in the product**, and no way to share one.
+
+The product must feel like *a secure digital identity you can show from Apple Wallet whenever you meet someone*. It must not feel like *a decorative Wallet card with a QR that is added once and never used again*.
+
+## 2. What already exists (Premise Verification Gate)
+
+| Capability | Verdict | Evidence |
+| --- | --- | --- |
+| Owner-published, revocable public projection plane | `already_exists` | `pkm_default_available_projections`, migrations 063 → 090 → 091; publish/list/revoke at [pkm_routes_shared.py:1096-1179](consent-protocol/api/routes/pkm_routes_shared.py) |
+| Owner-facing publish UI | `already_exists` but wrong framing | [app/one/marketplace/page.tsx](hushh-webapp/app/one/marketplace/page.tsx) — confirm copy reads "Publish to the marketplace? … so buyers" |
+| **Visitor-facing profile page** | **`missing`** | no route, no page, no link, no QR anywhere in repo |
+| **Anonymous handle resolution** | **`missing`** | only reader is developer-authenticated `POST /api/v1/public-profile-export`, and it needs `user_id` **and** handle |
+| PassKit / `.pkpass` / signing | `missing` | ripgrep: zero hits |
+| QR generation | `missing` | no `qrcode`/`segno` in requirements, none in package.json |
+| Unauthenticated public route pattern | `already_exists` | `/one/location/request/[token]`, `/portfolio/shared` |
+| Rotatable hashed share token | `already_exists` | `one_location_agent_service.py:4291-4356` — `secrets.token_urlsafe(32)` + SHA-256 `_hash_public_value` + `expires_at` + status |
+| Advisor public profile (precedent) | `already_exists` | `marketplace_public_profiles` (migration 020:238), unauthenticated `GET /api/marketplace/ria/{id}`, `is_discoverable` pause |
+
+## 3. Decisions (recorded, with rationale)
+
+### D1 — Do **not** reuse `pkm_default_available_projections` for the card. Build a dedicated plane.
+
+Four evidence-backed blockers make reuse unsafe:
+
+1. **Marketplace side-effect (privacy defect).** `marketplace_catalog_service.list_available_listings` selects that table filtered only on non-empty provenance / not revoked / not-self — no source or kind filter — and exposes the owner's **real display name** as `ownerName`. Publishing a Wallet card would silently list the user for sale in the Information Marketplace. Unacceptable.
+2. **Handle rotates on every edit.** `store_public_profile_projection` mints a fresh `uuid4()` and revokes the prior row. Every profile edit would invalidate an already-printed QR — directly contradicting the requirement *"The QR does not need to change every time the profile changes."*
+3. **Not self-addressing.** `get_public_profile_projection` filters on `user_id` **and** handle. A QR carries only a token, so handle-only resolution does not exist at any layer.
+4. **One active row per `(user_id, domain, top_level_scope_path)`.** A composed card spanning name + role + skills + links would be N rows with N handles.
+
+Additionally `projection_payload` is client-authored, validated only as "non-empty dict", and embeds raw owner values — **not safe to serve verbatim to an anonymous browser**.
+
+**Chosen instead:** a dedicated card plane modelled on the *One Location public-invite* pattern, which is the repo's proven, shipped, anonymous-token design. The public projection plane stays exactly as it is, untouched.
+
+### D2 — No Wallet web service. (Deletes a whole subsystem from scope.)
+
+`webServiceURL` and `authenticationToken` are **optional** in Apple's pass reference — only `formatVersion`, `passTypeIdentifier`, `teamIdentifier`, `organizationName`, `description`, `serialNumber` are required. Because the QR carries a URL and the scanned content renders server-side on every scan, **edit / pause / revoke take effect instantly with zero Wallet involvement**. This removes APNs, device registration, the registrations table, and five endpoints.
+
+Accepted cost: we cannot change what is *printed* on an installed pass, nor the baked-in QR payload. Mitigation — keep the pass face minimal and stable (name, photo, logo); put everything volatile behind the QR; implement "rotate" as rotating the **server-side mapping behind a stable pass token**.
+
+### D3 — Pass style `generic`, QR barcode only.
+
+`generic` is Apple's category for passes that don't fit the others and is the only style with a **thumbnail** slot (90pt high, aspect 2:3–3:2) — exactly the headshot. `storeCard`/`coupon` offer only a banner strip; `eventTicket` is semantically entry-to-an-event.
+
+Binding layout constraint: *"generic passes with a square barcode can have a total of up to four secondary and auxiliary fields, combined"* → front is capped at 3 header + 1 primary + 4 combined, plus unlimited `backFields`.
+
+NFC and Personalization are separately approval-gated (loyalty/transit/access-control only, ≥4 weeks, VAS reader keys) and are **out of scope** — barcode passes need no Apple approval.
+
+### D4 — No custom Capacitor plugin, no new entitlement, no app release.
+
+WKWebView **will not** import a `.pkpass` — an in-WebView pass response is a silent no-op. But Capacitor's `decidePolicyFor navigationAction` opens *any* top-level navigation whose URL is off-origin via `UIApplication.shared.open`. The app origin is `App://localhost` with no `server.url` and no `allowNavigation`, so an `https://` pass URL is handed to Safari — which imports `.pkpass` natively. The webapp already ships the helper: `openExternalUrl()` at [lib/utils/browser-navigation.ts:32](hushh-webapp/lib/utils/browser-navigation.ts).
+
+Pass *signing* is server-side and needs no app entitlement; `com.apple.developer.pass-type-identifiers` is only for apps that read/manage passes they own. A custom plugin would also trip `scripts/native/verify-native-plugin-contracts.mjs`, which enforces iOS↔Android method parity — and Android has no PassKit.
+
+**Consequence: this feature is web + backend only.** No TestFlight or App Store release is required.
+
+### D5 — Stable pass serial, rotatable share token.
+
+`pass_serial` (UUID) is minted once and never changes — it identifies the installed pass. `share_token` is `secrets.token_urlsafe(32)`, stored **only as a SHA-256 hash**, and is what the QR encodes. Editing card content never touches the token. "Rotate" explicitly mints a new token and re-issues the pass; because the same `passTypeIdentifier` + `serialNumber` overwrites an installed pass, the user re-adds with one tap.
+
+### D6 — The failure mode is the **save**, not the scan.
+
+HiHello's open letter to Apple documents that a raw `.vcf` opened in mobile Safari shows "Done" and a share button, while the real action — "Create New Contact" — is buried at the bottom of a scroll. We therefore do **not** hand the visitor a bare `.vcf` link. The scanned page leads with direct actions (email, call, LinkedIn, GitHub, portfolio) and offers contact download as an explicitly-labelled secondary action with inline guidance.
+
+### D7 — The public page must be excluded from crawlers and analytics.
+
+`app/robots.ts` currently **allow-lists** GPTBot, ClaudeBot, CCBot and PerplexityBot with `allow: "/"`. A new public prefix would be crawled into AI training corpora permanently. The card prefix must be added to `DISALLOWED_PREFIXES`, plus `noindex` headers. GA4 + GTM load unconditionally from the root layout, so every anonymous scanner would be tracked with no consent gate — the card page must not emit analytics.
+
+### D8 — Rate limiting must be explicitly wired.
+
+`SlowAPIMiddleware` is never added and `RateLimits.GLOBAL_PER_IP` is defined but never applied, so an undecorated public route has **zero** limit. Worse, `get_rate_limit_key` falls back to `get_remote_address` and the Dockerfile sets no `--forwarded-allow-ips`, so behind Cloud Run every visitor may share one bucket. The resolve endpoint must carry an explicit decorator and derive the client IP from the forwarded header.
+
+### D9 — Android / desktop graceful degradation.
+
+Apple Wallet does not exist off-iOS. Non-iOS users get the same card as a shareable link (native share sheet / `navigator.share` / clipboard, reusing the One Location share helper). Google Wallet is a deliberate later phase, not v1.
+
+## 4. Scope
+
+**In (v1):** Wallet pass generation + signing; stable QR → public card page; owner setup with smart defaults from existing profile information; preview-as-visitor using the *same* server projection; edit shared fields; pause; rotate; revoke; contact actions on the scanned page; share-link fallback off-iOS; certificate provisioning automation; observability.
+
+**Out (deferred, explicitly):** live location on the card, full PKM sharing, event check-in, access-request workflows, multiple audience presets, verified organisation credentials, emergency identity, Google Wallet, NFC, Personalization, pass push updates.
+
+## 5. Certificate provisioning (no human blocker)
+
+Fully automatable with the Admin-role App Store Connect key already in Secret Manager (`APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` / `_ISSUER_ID`, project `hushh-pda-uat`).
+
+1. `POST /v1/passTypeIds` — `{name, identifier: "pass.com.hushh.app.one"}` → `data.id`
+2. `openssl` RSA-2048 keypair + CSR inside the runner
+3. `POST /v1/certificates` — `certificateType: PASS_TYPE_ID`, `csrContent`, relationship → `passTypeId`
+4. Download `certificateContent` (base64 DER) → PEM
+5. WWDR **G4** intermediate — verified: `OU=G4`, issuer Apple Root CA, notAfter **2030-12-10**
+6. `scripts/ops/upsert_gcp_secret.py` writes cert + private key to Secret Manager via **stdin only**
+7. Cloud Run receives them as `--set-secrets` env refs from `deploy/backend.cloudbuild.yaml`, read through `runtime_settings.py`
+
+Reuses the existing ASC JWT client (`scripts/ci/submit-appstore-version.py:113,166-174` — ES256, `aud=appstoreconnect-v1`, exp+19min), the `::add-mask::` / `umask 077` / `chmod 600` hygiene, and the ephemeral venv pattern. **Operational risk is the ~1-year Pass Type ID certificate**, not WWDR — it needs monitored rotation.
+
+## 6. Success metrics
+
+Repeat usage, not passes added: scans per active card, contact-save / portfolio-open actions per scan, share-scope edits, rotation/revocation usage, setup completion time (< 60s target), pass-generation failure rate, scanner-page load time on mobile networks.
+
+## 7. Regression surface
+
+Untouched by design: `pkm_default_available_projections` and its routes, the Information Marketplace catalogue, the RIA advisor public profile, vault/consent token paths, and every authenticated `/one` route. The new plane is additive with its own table, its own routes, and a feature flag.

--- a/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
+++ b/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
@@ -102,6 +102,25 @@ Fully automatable with the Admin-role App Store Connect key already in Secret Ma
 
 Reuses the existing ASC JWT client (`scripts/ci/submit-appstore-version.py:113,166-174` — ES256, `aud=appstoreconnect-v1`, exp+19min), the `::add-mask::` / `umask 077` / `chmod 600` hygiene, and the ephemeral venv pattern. **Operational risk is the ~1-year Pass Type ID certificate**, not WWDR — it needs monitored rotation.
 
+### 5.1 Pre-flight (before `--apply`)
+
+Run without `--apply` first. The dry run resolves the Pass Type ID, generates a throwaway keypair/CSR, and — importantly — asserts Secret Manager **write** access on every `--secret-project` before anything irreversible happens. It calls the Cloud Resource Manager `projects.testIamPermissions` REST endpoint directly; there is no `gcloud projects test-iam-permissions` subcommand (SDK 565.0.0 answers `Invalid choice`). `secretmanager.secrets.create` is demanded only when a Wallet secret is genuinely absent, so a rotation-scoped credential passes. Grants must be on the **project** — a grant on the individual secrets is invisible to a project-level check.
+
+### 5.2 Recovery from a partial publish (post-mint)
+
+Step 3 is irreversible and an Apple Pass Type ID account holds a small, finite number of certificate slots. If the mint succeeds but step 6 does not reach every project, the script exits non-zero and names the exact per-project state.
+
+**Do not re-run this command to repair it.** Every run reaches the mint — `--force-new-certificate` obviously, but a plain re-run does too, because a partially published fleet is not "fully provisioned" and falls through to the same call. Each attempt burns another slot.
+
+Repair by copying the material that already exists:
+
+1. Identify a project whose `WALLET_PASS_CERT_PEM` and `WALLET_PASS_KEY_PEM` correspond (the failure message says which ones do not).
+2. Read each of `WALLET_PASS_KEY_PEM`, `WALLET_PASS_CERT_PEM`, `WALLET_PASS_WWDR_PEM` from the healthy project and pipe it into the failed one via `scripts/ops/upsert_gcp_secret.py --stdin`. Never let the PEM become an argv entry, a shell variable, or a file on disk.
+3. Re-run **without** `--apply`; a converged fleet reports `already-provisioned` and exits 0.
+4. Keep `ONE_WALLET_CARD_ENABLED` OFF until step 3 is clean. The signing service returns 503 while material is absent or mixed, so the feature degrades rather than serving passes iOS would reject.
+
+Reads in the verification path retry (3×, backing off) exactly like writes: an unretried transient gcloud failure would otherwise be read as "absent" or "corrupt" and route an operator into this recovery when nothing was actually wrong.
+
 ## 6. Success metrics
 
 Repeat usage, not passes added: scans per active card, contact-save / portfolio-open actions per scan, share-scope edits, rotation/revocation usage, setup completion time (< 60s target), pass-generation failure rate, scanner-page load time on mobile networks.

--- a/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
+++ b/docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md
@@ -1,4 +1,4 @@
-# Hushh One Wallet Card — reconciled Product / UX / Engineering plan
+# Hussh One Wallet Card — reconciled Product / UX / Engineering plan
 
 Base commit: `58bc866ea` (origin/main). Branch: `feat/hushh-one-wallet-card`.
 Discovery: 8 parallel evidence lanes (product, projection backend, frontend, iOS/Capacitor, secrets/CI, security, Apple PassKit research, market benchmarks).

--- a/docs/superpowers/specs/2026-08-03-wallet-card-contract.md
+++ b/docs/superpowers/specs/2026-08-03-wallet-card-contract.md
@@ -1,0 +1,165 @@
+# Wallet Card — binding implementation contract
+
+Every implementer MUST conform to this file exactly. Do not invent alternative names, paths, or shapes.
+
+Brand/voice: public prose says **Hussh**; internal identifiers keep legacy `hushh`. One is "the private agent". Prefer "information" over "data" in user-facing copy. Code/API/route/schema identifiers stay exact as written here.
+
+---
+
+## 1. Naming
+
+| Thing | Exact value |
+| --- | --- |
+| Feature name (user-facing) | Wallet Profile |
+| Pass Type Identifier | `pass.com.hushh.app.one` |
+| DB table | `one_wallet_cards` |
+| Backend route prefix | `/api/one/wallet-card` |
+| Public resolve route | `GET /api/one/wallet-card/public/{share_token}` (no auth) |
+| Public web page | `/c/[token]` |
+| Pass download route | `GET /api/one/wallet-card/pass/{share_token}.pkpass` (no auth) |
+| Feature flag env | `ONE_WALLET_CARD_ENABLED` (default `false`) |
+| Secret: cert PEM | `WALLET_PASS_CERT_PEM` |
+| Secret: private key PEM | `WALLET_PASS_KEY_PEM` |
+| Secret: WWDR G4 PEM | `WALLET_PASS_WWDR_PEM` |
+| Runtime settings keys | `one_wallet_card_enabled`, `wallet_pass_cert_pem`, `wallet_pass_key_pem`, `wallet_pass_wwdr_pem`, `wallet_pass_team_identifier`, `wallet_pass_type_identifier` |
+
+## 2. Table `one_wallet_cards` (migration `132_one_wallet_card.sql`)
+
+One row per user. Additive only. No changes to any existing table.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `user_id` | TEXT PRIMARY KEY | vault owner |
+| `pass_serial` | UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE | stable for the life of the card; identifies the installed pass |
+| `share_token_hash` | TEXT NOT NULL UNIQUE | SHA-256 hex of the plaintext token. **Plaintext is NEVER stored.** |
+| `share_token_version` | INTEGER NOT NULL DEFAULT 1 | increments on rotate |
+| `status` | TEXT NOT NULL DEFAULT 'active' | CHECK IN ('active','paused','revoked') |
+| `card_payload` | JSONB NOT NULL DEFAULT '{}'::jsonb | server-validated allowlisted fields only (§3) |
+| `display_name` | TEXT | denormalised for pass face |
+| `headline` | TEXT | denormalised for pass face |
+| `avatar_url` | TEXT | |
+| `expires_at` | TIMESTAMPTZ NULL | NULL = no expiry |
+| `created_at` | TIMESTAMPTZ NOT NULL DEFAULT now() | |
+| `updated_at` | TIMESTAMPTZ NOT NULL DEFAULT now() | |
+| `revoked_at` | TIMESTAMPTZ NULL | |
+| `last_scanned_at` | TIMESTAMPTZ NULL | coarse only |
+| `scan_count` | BIGINT NOT NULL DEFAULT 0 | aggregate only |
+
+Indexes: unique on `share_token_hash`, unique on `pass_serial`, index on `status`.
+
+**Privacy rule (binding):** never store per-scan rows, IP addresses, user agents, geolocation, or referrers. Only `last_scanned_at` and `scan_count`. This mirrors the location-agent rule that consent metadata must never include coordinates or traces.
+
+Provide `consent-protocol/db/migrations/rollback/132_one_wallet_card_down.sql`.
+
+Account deletion: the card row must be removed by the account deletion cascade.
+
+## 3. `card_payload` allowlist — server-validated, closed set
+
+Any key not in this list is **rejected** (not silently dropped). All values are strings unless noted; all are optional; every one is trimmed and length-capped.
+
+| Key | Max len | Notes |
+| --- | --- | --- |
+| `full_name` | 80 | |
+| `headline` | 120 | e.g. "Founder, Hussh" |
+| `organisation` | 80 | company or college |
+| `location_label` | 80 | coarse only — city/region. Never coordinates. |
+| `summary` | 400 | short professional summary |
+| `skills` | 12 items × 40 | array of strings |
+| `email` | 254 | validated shape |
+| `phone` | 32 | validated shape |
+| `website` | 300 | https only |
+| `linkedin` | 300 | https only |
+| `github` | 300 | https only |
+| `portfolio` | 300 | https only |
+| `preferred_contact` | 16 | one of `email`,`phone`,`linkedin`,`website` |
+
+URL fields: reject anything not `https://`. Reject `javascript:`, `data:`, and userinfo (`@`) forms. Strings are stored as plain text and **escaped at render time** — never rendered as HTML.
+
+## 4. Owner routes — all `Depends(require_vault_owner_token)` + `token_data["user_id"] == user_id`
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/one/wallet-card` | current card + status + share URL (plaintext token is returned **only** at create/rotate; otherwise the URL is reconstructed client-side from a token the client already holds — see §5) |
+| POST | `/api/one/wallet-card` | create or update card_payload; idempotent upsert; returns card |
+| POST | `/api/one/wallet-card/rotate` | mint new token (invalidates old immediately), bump `share_token_version`, return plaintext token **once** |
+| POST | `/api/one/wallet-card/pause` | status → `paused` |
+| POST | `/api/one/wallet-card/resume` | status → `active` |
+| DELETE | `/api/one/wallet-card` | status → `revoked`, set `revoked_at` |
+| GET | `/api/one/wallet-card/preview` | **preview-as-visitor**: returns the byte-identical projection the public endpoint would return. MUST call the same builder function — no separate code path. |
+
+## 5. Token handling
+
+- Plaintext token = `secrets.token_urlsafe(32)`. Returned to the owner **only** in the create and rotate responses.
+- Stored only as SHA-256 hex in `share_token_hash`.
+- Lookup is by hash of the presented token. Use `hmac.compare_digest` on the hash comparison.
+- The owner client persists the share URL locally so it can render the QR and the Add-to-Wallet link without re-requesting the token.
+
+## 6. Public routes — **no authentication**
+
+`GET /api/one/wallet-card/public/{share_token}`
+
+Returns only the projection built from `card_payload` — never `user_id`, never `pass_serial`, never internal ids, never timestamps beyond a coarse `updated_at` date.
+
+Status handling (binding):
+- unknown token → `404` with a generic body
+- `paused` → `404` with the **same generic body** as unknown (a paused card must be indistinguishable from a non-existent one)
+- `revoked` → `410 Gone` with `{"status":"revoked"}` so the page can show an honest "no longer shared" state
+- expired (`expires_at` passed) → `410 Gone` with `{"status":"expired"}`
+
+Must be decorated with an explicit rate limit (the global limiter is **not** wired — `SlowAPIMiddleware` is never added and `GLOBAL_PER_IP` is never applied). Derive client IP from the forwarded header, since Cloud Run otherwise collapses everyone into one bucket.
+
+Response headers: `Cache-Control: private, max-age=0, must-revalidate`, `X-Robots-Tag: noindex, nofollow, noarchive`.
+
+Increment `scan_count` and set `last_scanned_at` **asynchronously / best-effort** — a counter failure must never fail the read.
+
+`GET /api/one/wallet-card/pass/{share_token}.pkpass`
+
+Returns `Content-Type: application/vnd.apple.pkpass`, `Content-Disposition: attachment; filename="hushh-one.pkpass"`. Same status rules. Returns `503` with a friendly code when signing material is absent.
+
+## 7. Pass construction (`generic` style)
+
+Required `pass.json` keys: `formatVersion` (1), `passTypeIdentifier`, `teamIdentifier`, `organizationName`, `description`, `serialNumber` (= `pass_serial`).
+
+Field budget with a square barcode: **3 header + 1 primary + 4 combined secondary/auxiliary**, plus unlimited `backFields`.
+
+- `primaryFields`: full name
+- `secondaryFields`: headline
+- `auxiliaryFields`: organisation, location_label (only if present)
+- `backFields`: summary, links, and a "How this works" note
+- `barcodes`: `[{format: "PKBarcodeFormatQR", message: <public card URL>, messageEncoding: "iso-8859-1", altText: <short handle>}]`
+- `thumbnail` = headshot (90pt high, aspect 2:3–3:2); `icon` and `logo` required
+
+Signing: `manifest.json` = SHA-1 hex per file keyed by relative path (exclude `.DS_Store`); `signature` = **PKCS#7 detached** signature of `manifest.json` under the Pass Type ID cert key, chained through WWDR **G4**; zip the bundle. Use `cryptography==49.0.0`, already in requirements — add no new signing dependency.
+
+Omit `webServiceURL` and `authenticationToken` entirely (D2 — no web service).
+
+## 8. Frontend
+
+- **Never call `fetch()` from `app/**` or `components/**`** — `scripts/architecture/verify-service-layer-boundary.mjs` enforces this with a literal regex. All network access goes through `lib/services/wallet-card-service.ts` using `ApiService.apiFetch` / `apiJson`.
+- Public page `/c/[token]` must render for a logged-out stranger: register in `isPublicRoute()`, ensure `OneAuthGate`/`VaultLockGuard` are bypassed, and suppress chrome via `mode: "hidden"` in `lib/navigation/app-route-layout.contract.json`. Precedent to copy: `app/one/location/request/[token]`.
+- The public page must emit **no analytics** and must be added to the robots disallow prefixes.
+- Owner screens live under `app/one/wallet-card/`.
+- Add-to-Wallet uses the existing `openExternalUrl()` (`lib/utils/browser-navigation.ts:32`) so Capacitor hands the URL to Safari — WKWebView cannot import a pass.
+- Non-iOS: show share-link actions instead of Add-to-Wallet.
+
+## 9. Copy (use verbatim)
+
+- Entry, before setup: **"Add to Apple Wallet"** / "Keep your Hussh One profile ready to share."
+- Setup intro: **"Your profile, ready when you need it"** / "Add a secure Hussh One pass to Apple Wallet and share your selected details with a simple scan."
+- Privacy assurance: **"You stay in control"** / "Only the information you select will be visible. You can update or disable access at any time."
+- After setup entry: **"Manage Wallet Profile"** / "Control what people see when they scan your pass."
+- Success: **"Your Hussh One pass is ready"** / "You can now share your profile directly from Apple Wallet."
+- Signing failure (user-facing): "We couldn't create your Wallet pass right now. Please try again in a moment." — log the technical error server-side only.
+- Revoked page: "This profile is no longer shared."
+- Expired page: "This profile link has expired."
+
+Never use: "Share everything", "Your complete identity", "All your data in one scan", "Unlimited profile access", "Your entire PKM".
+
+## 10. Hard prohibitions
+
+1. Do **not** read, write, or alter `pkm_default_available_projections`, its routes, or its services.
+2. Do **not** alter the Information Marketplace catalogue or the RIA advisor profile.
+3. Do **not** log the plaintext share token, the private key, or any `card_payload` value.
+4. Do **not** add a Capacitor plugin or an iOS entitlement.
+5. Do **not** add a Wallet web service, APNs, or device registration.
+6. Do **not** store per-scan telemetry rows.

--- a/docs/superpowers/specs/2026-08-03-wallet-card-contract.md
+++ b/docs/superpowers/specs/2026-08-03-wallet-card-contract.md
@@ -4,6 +4,34 @@ Every implementer MUST conform to this file exactly. Do not invent alternative n
 
 Brand/voice: public prose says **Hussh**; internal identifiers keep legacy `hushh`. One is "the private agent". Prefer "information" over "data" in user-facing copy. Code/API/route/schema identifiers stay exact as written here.
 
+## Visual Map
+
+Layers this contract binds, and the one table they all resolve through.
+
+```
+  hushh-webapp/app/one/profile/…        hushh-webapp/app/c/[token]/…
+  owner surface (authenticated)         public page (no auth)
+             │                                     │
+             ▼                                     ▼
+  lib/services/wallet-card-service.ts    server-side fetch of the public route
+  (only layer allowed to call fetch)               │
+             │                                     │
+             ▼                                     ▼
+  /api/one/wallet-card/*                 /api/one/wallet-card/public/{share_token}
+  create · edit · pause · rotate · revoke · preview
+             │                                     │
+             └──────────────┬──────────────────────┘
+                            ▼
+              one_wallet_card_service.py
+              share token → SHA-256 → one_wallet_cards
+                            │
+                            ▼
+              /api/one/wallet-card/pass/{share_token}.pkpass
+              PassKit signing (Pass Type ID cert → WWDR G4)
+```
+
+Status mapping is normative: `active` → 200; `paused` and unknown → 404 with the *same* generic body; `revoked` → 410 `{status:revoked}`; expired → 410 `{status:expired}`.
+
 ---
 
 ## 1. Naming
@@ -135,7 +163,7 @@ Omit `webServiceURL` and `authenticationToken` entirely (D2 — no web service).
 
 ## 8. Frontend
 
-- **Never call `fetch()` from `app/**` or `components/**`** — `scripts/architecture/verify-service-layer-boundary.mjs` enforces this with a literal regex. All network access goes through `lib/services/wallet-card-service.ts` using `ApiService.apiFetch` / `apiJson`.
+- **Never call `fetch()` from `app/**` or `components/**`** — `hushh-webapp/scripts/architecture/verify-service-layer-boundary.mjs` enforces this with a literal regex. All network access goes through `lib/services/wallet-card-service.ts` using `ApiService.apiFetch` / `apiJson`.
 - Public page `/c/[token]` must render for a logged-out stranger: register in `isPublicRoute()`, ensure `OneAuthGate`/`VaultLockGuard` are bypassed, and suppress chrome via `mode: "hidden"` in `lib/navigation/app-route-layout.contract.json`. Precedent to copy: `app/one/location/request/[token]`.
 - The public page must emit **no analytics** and must be added to the robots disallow prefixes.
 - Owner screens live under `app/one/wallet-card/`.

--- a/hushh-webapp/__tests__/app/wallet-card-public-page.test.tsx
+++ b/hushh-webapp/__tests__/app/wallet-card-public-page.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolvePublicCard: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ token: SHARE_TOKEN }),
+}));
+
+vi.mock("@/lib/services/wallet-card-service", () => ({
+  WalletCardService: {
+    resolvePublicCard: mocks.resolvePublicCard,
+  },
+}));
+
+const SHARE_TOKEN = "wallet-card-test-token-not-a-real-secret";
+
+import PublicWalletCardPageClient from "@/app/c/[token]/page-client";
+
+/**
+ * Regression coverage for a real integration defect.
+ *
+ * `WalletCardService.resolvePublicCard` *resolves* terminal states rather than
+ * throwing. The page originally only handled thrown `ApiError`s, so a revoked or
+ * expired card took the success path, produced no renderable card, and fell
+ * through to the generic "isn't available" message — silently hiding the honest
+ * copy the contract requires. These tests fail against that version.
+ */
+describe("PublicWalletCardPageClient terminal states", () => {
+  beforeEach(() => {
+    mocks.resolvePublicCard.mockReset();
+  });
+
+  it("shows the revoked copy when the owner has stopped sharing", async () => {
+    mocks.resolvePublicCard.mockResolvedValue({
+      state: "revoked",
+      message: "This profile is no longer shared.",
+    });
+
+    render(<PublicWalletCardPageClient />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This profile is no longer shared."),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText("This profile isn't available."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the expired copy when the link has lapsed", async () => {
+    mocks.resolvePublicCard.mockResolvedValue({
+      state: "expired",
+      message: "This profile link has expired.",
+    });
+
+    render(<PublicWalletCardPageClient />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This profile link has expired."),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText("This profile is no longer shared."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an unknown and a paused card identically", async () => {
+    // The backend serves a paused card as the same generic 404 as an unknown
+    // token, so the page must not be able to tell them apart (contract §6).
+    mocks.resolvePublicCard.mockResolvedValue({
+      state: "not_found",
+      message: "This profile is not available.",
+    });
+
+    const unknown = render(<PublicWalletCardPageClient />);
+    await waitFor(() =>
+      expect(screen.getByText("This profile isn't available.")).toBeInTheDocument(),
+    );
+    const unknownMarkup = unknown.container.innerHTML;
+    unknown.unmount();
+
+    mocks.resolvePublicCard.mockResolvedValue({
+      state: "not_found",
+      message: "This profile is not available.",
+    });
+
+    const paused = render(<PublicWalletCardPageClient />);
+    await waitFor(() =>
+      expect(screen.getByText("This profile isn't available.")).toBeInTheDocument(),
+    );
+
+    expect(paused.container.innerHTML).toBe(unknownMarkup);
+  });
+
+  it("renders the profile when the card is available", async () => {
+    mocks.resolvePublicCard.mockResolvedValue({
+      state: "available",
+      card: {
+        full_name: "Ada Lovelace",
+        headline: "Founder, Hussh",
+      },
+    });
+
+    render(<PublicWalletCardPageClient />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByText("This profile isn't available."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/components/observability-route-observer.test.tsx
+++ b/hushh-webapp/__tests__/components/observability-route-observer.test.tsx
@@ -1,0 +1,90 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ObservabilityRouteObserver } from "@/components/observability/route-observer";
+
+const mocks = vi.hoisted(() => ({
+  pathname: "/",
+  trackPageView: vi.fn(),
+  captureGrowthAttribution: vi.fn(),
+  setLastKaiPath: vi.fn(),
+  setLastRiaPath: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+}));
+
+vi.mock("@/lib/observability/client", () => ({
+  trackPageView: mocks.trackPageView,
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  captureGrowthAttribution: mocks.captureGrowthAttribution,
+}));
+
+vi.mock("@/lib/stores/kai-session-store", () => ({
+  useKaiSession: (selector: (state: unknown) => unknown) =>
+    selector({
+      setLastKaiPath: mocks.setLastKaiPath,
+      setLastRiaPath: mocks.setLastRiaPath,
+    }),
+}));
+
+function renderAt(pathname: string) {
+  mocks.pathname = pathname;
+  render(<ObservabilityRouteObserver />);
+}
+
+describe("ObservabilityRouteObserver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Wallet Profile contract §7: the public page must emit no analytics. The
+  // visitor is a stranger holding someone else's printed QR — not a user, no
+  // account, no consent with us — and the path itself carries the share token,
+  // so a single page_view would ship both the token and the visitor.
+  it.each(["/c/tok_abc123", "/c/tok_abc123/", "/c/tok_abc123/index.html"])(
+    "captures nothing for a scanned Wallet Profile at %s",
+    (pathname) => {
+      renderAt(pathname);
+
+      expect(mocks.trackPageView).not.toHaveBeenCalled();
+      expect(mocks.captureGrowthAttribution).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not persist a share token into session state", () => {
+    // The session-path writes are inside the same effect, so bailing has to
+    // happen before them or the token lands in client-side storage.
+    renderAt("/c/tok_abc123");
+
+    expect(mocks.setLastKaiPath).not.toHaveBeenCalled();
+    expect(mocks.setLastRiaPath).not.toHaveBeenCalled();
+  });
+
+  it("still instruments the owner's own Wallet Profile surface", () => {
+    // The exemption must stay scoped to the public token namespace: the owner
+    // is a signed-in user on a first-party screen.
+    renderAt("/one/wallet-card");
+
+    expect(mocks.trackPageView).toHaveBeenCalledWith(
+      "/one/wallet-card",
+      "initial_load",
+    );
+    expect(mocks.captureGrowthAttribution).toHaveBeenCalledWith(
+      "/one/wallet-card",
+    );
+  });
+
+  it("still instruments ordinary product routes and records their scope", () => {
+    renderAt("/ria/clients");
+
+    expect(mocks.trackPageView).toHaveBeenCalledWith(
+      "/ria/clients",
+      "initial_load",
+    );
+    expect(mocks.setLastRiaPath).toHaveBeenCalledWith("/ria/clients");
+  });
+});

--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -9,6 +9,7 @@ import {
   buildOneSetupKaiRoute,
   buildOneSetupCapabilityRoute,
   buildWelcomeRoute,
+  isAnalyticsExemptRoute,
   isCapabilityHandoffTarget,
   isCompletedLocationWorkspaceRoute,
   isOnboardingAdmissionExemptRoute,
@@ -138,7 +139,10 @@ describe("navigation routes", () => {
       ),
     ).toBe("/one/profile/support/routing");
     expect(
-      buildCanonicalProfileRouteFromLegacyQuery("/one/profile", "panel=regulatory"),
+      buildCanonicalProfileRouteFromLegacyQuery(
+        "/one/profile",
+        "panel=regulatory",
+      ),
     ).toBe("/one/profile");
     expect(
       buildCanonicalProfileRouteFromLegacyQuery(
@@ -179,6 +183,28 @@ describe("navigation routes", () => {
     expect(isPublicRoute("/kai")).toBe(false);
     expect(isPublicRoute("/one/profile")).toBe(false);
     expect(isPublicRoute("/one/connect")).toBe(false);
+  });
+
+  it("exempts the public Wallet Profile from analytics without widening the exemption", () => {
+    // A visitor scanning a stranger's QR is not our user and never agreed to
+    // anything with us (Wallet Profile contract §7).
+    expect(isAnalyticsExemptRoute("/c/abc123")).toBe(true);
+    expect(isAnalyticsExemptRoute("/c")).toBe(true);
+    // Capacitor's static export shapes: trailing slash and backing document.
+    expect(isAnalyticsExemptRoute("/c/abc123/")).toBe(true);
+    expect(isAnalyticsExemptRoute("/c/abc123/index.html")).toBe(true);
+
+    // Strictly narrower than isPublicRoute: the marketing and auth surfaces
+    // there are ours to instrument, and the owner's own Wallet Profile screen
+    // is an authenticated product surface.
+    expect(isAnalyticsExemptRoute("/")).toBe(false);
+    expect(isAnalyticsExemptRoute("/welcome")).toBe(false);
+    expect(isAnalyticsExemptRoute("/developers")).toBe(false);
+    expect(isAnalyticsExemptRoute("/one/wallet-card")).toBe(false);
+    expect(isAnalyticsExemptRoute("/one")).toBe(false);
+    // Prefix matching must not spill into an unrelated sibling route.
+    expect(isAnalyticsExemptRoute("/consents")).toBe(false);
+    expect(isAnalyticsExemptRoute("/careers")).toBe(false);
   });
 
   it("defines profile and Connect inside the vault-protected One route family", () => {

--- a/hushh-webapp/__tests__/services/observability-route-map.test.ts
+++ b/hushh-webapp/__tests__/services/observability-route-map.test.ts
@@ -103,6 +103,14 @@ describe("observability route map", () => {
     expect(resolveRouteId("/one/location/invite/sample")).toBe(
       "one_location_circle_invite",
     );
+    expect(resolveRouteId("/one/wallet-card")).toBe("one_wallet_card");
+    // The public Wallet Profile emits no analytics, but it still needs a
+    // stable ID: "unknown" is the branch that would otherwise carry the raw
+    // pathname — and here the pathname is the share token.
+    expect(resolveRouteId("/c")).toBe("wallet_card_public");
+    expect(resolveRouteId("/c/tok_abc123")).toBe("wallet_card_public");
+    // Must not swallow an unrelated sibling.
+    expect(resolveRouteId("/consents")).toBe("consents");
     expect(resolveRouteId("/agent")).toBe("agent");
     expect(resolveRouteId("/one/connect/settings")).toBe("connect_settings");
     expect(resolveRouteId("/one/profile/preferences/gemini")).toBe(

--- a/hushh-webapp/__tests__/services/wallet-card-service.test.ts
+++ b/hushh-webapp/__tests__/services/wallet-card-service.test.ts
@@ -1,0 +1,709 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  MockApiError,
+  mockApiErrorCode,
+  mockApiJson,
+  mockApiFetch,
+  mockGetDirectBackendUrl,
+  mockResolveRuntimeFrontendUrl,
+  mockIsNative,
+  mockIsIOS,
+  mockOpenExternalUrl,
+} = vi.hoisted(() => {
+  class HoistedApiError extends Error {
+    constructor(
+      message: string,
+      public readonly status: number,
+      public readonly payload?: unknown,
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+
+  /** Mirrors api-client.ts: the code may sit under `detail` or `error`. */
+  const nestedCode = (payload: unknown): string | null => {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      return null;
+    }
+    const record = payload as Record<string, unknown>;
+    if (typeof record.code === "string" && record.code.trim()) {
+      return record.code.trim();
+    }
+    return nestedCode(record.detail) ?? nestedCode(record.error);
+  };
+
+  return {
+    MockApiError: HoistedApiError,
+    mockApiErrorCode: (error: unknown) =>
+      error instanceof HoistedApiError ? nestedCode(error.payload) : null,
+    mockApiJson: vi.fn(),
+    mockApiFetch: vi.fn(),
+    mockGetDirectBackendUrl: vi.fn(),
+    mockResolveRuntimeFrontendUrl: vi.fn(),
+    mockIsNative: vi.fn(),
+    mockIsIOS: vi.fn(),
+    mockOpenExternalUrl: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/services/api-client", () => ({
+  ApiError: MockApiError,
+  apiErrorCode: mockApiErrorCode,
+  apiJson: mockApiJson,
+}));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: mockApiFetch,
+    getDirectBackendUrl: mockGetDirectBackendUrl,
+  },
+}));
+
+vi.mock("@/lib/runtime/settings", () => ({
+  resolveRuntimeFrontendUrl: mockResolveRuntimeFrontendUrl,
+}));
+
+vi.mock("@/lib/capacitor/platform", () => ({
+  isNative: mockIsNative,
+  isIOS: mockIsIOS,
+}));
+
+vi.mock("@/lib/utils/browser-navigation", () => ({
+  openExternalUrl: mockOpenExternalUrl,
+}));
+
+import {
+  WALLET_CARD_API_PREFIX,
+  WALLET_CARD_PUBLIC_PATH_PREFIX,
+  WALLET_CARD_SERVICE_COPY,
+  WalletCardPayloadError,
+  WalletCardService,
+  canAddToAppleWallet,
+  isAllowedWalletCardUrl,
+  isWalletShareTokenShape,
+  validateWalletCardPayload,
+  walletCardPassUrl,
+  walletCardShareUrl,
+  walletPassCapability,
+} from "@/lib/services/wallet-card-service";
+
+const SHARE_TOKEN = "wallet-card-test-token-not-a-real-secret";
+const APP_ORIGIN = "https://one.hushh.ai";
+const BACKEND_ORIGIN = "https://api.hushh.ai";
+
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15";
+const MAC_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+const ANDROID_UA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36";
+
+function setUserAgent(userAgent: string, maxTouchPoints = 0): void {
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: userAgent,
+    configurable: true,
+  });
+  Object.defineProperty(window.navigator, "maxTouchPoints", {
+    value: maxTouchPoints,
+    configurable: true,
+  });
+}
+
+/** Minimal Response stand-in for the `.pkpass` availability probe. */
+function fetchResponse(
+  status: number,
+  body?: unknown,
+  contentType = "application/json",
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null) },
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const OWNER_CARD = {
+  passSerial: "6f2f0e6a-6d5e-4b0a-9f0a-0d1c2b3a4e5f",
+  status: "active",
+  shareTokenVersion: 2,
+  cardPayload: { full_name: "Ada Lovelace", headline: "Founder, Hussh" },
+  displayName: "Ada Lovelace",
+  headline: "Founder, Hussh",
+  avatarUrl: null,
+  expiresAt: null,
+  createdAt: "2026-08-01T00:00:00+00:00",
+  updatedAt: "2026-08-02T00:00:00+00:00",
+  revokedAt: null,
+  lastScannedAt: null,
+  scanCount: 4,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  mockResolveRuntimeFrontendUrl.mockReturnValue(APP_ORIGIN);
+  mockGetDirectBackendUrl.mockReturnValue(BACKEND_ORIGIN);
+  mockIsNative.mockReturnValue(false);
+  mockIsIOS.mockReturnValue(false);
+  setUserAgent(IPHONE_UA);
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+// ==================== URL builders ====================
+
+describe("wallet card URL builders", () => {
+  it("builds the public card URL the QR encodes from the configured app origin", () => {
+    expect(walletCardShareUrl(SHARE_TOKEN)).toBe(
+      `${APP_ORIGIN}${WALLET_CARD_PUBLIC_PATH_PREFIX}/${SHARE_TOKEN}`,
+    );
+  });
+
+  it("builds the pkpass URL against the backend, not the JSON proxy", () => {
+    expect(walletCardPassUrl(SHARE_TOKEN)).toBe(
+      `${BACKEND_ORIGIN}${WALLET_CARD_API_PREFIX}/pass/${SHARE_TOKEN}.pkpass`,
+    );
+  });
+
+  it("trims a trailing slash off the configured backend origin", () => {
+    mockGetDirectBackendUrl.mockReturnValue(`${BACKEND_ORIGIN}/`);
+
+    expect(walletCardPassUrl(SHARE_TOKEN)).toBe(
+      `${BACKEND_ORIGIN}${WALLET_CARD_API_PREFIX}/pass/${SHARE_TOKEN}.pkpass`,
+    );
+  });
+
+  it("falls back to a relative path inside the native shell with nothing configured", () => {
+    mockIsNative.mockReturnValue(true);
+    mockResolveRuntimeFrontendUrl.mockReturnValue("");
+    mockGetDirectBackendUrl.mockReturnValue("");
+
+    expect(walletCardShareUrl(SHARE_TOKEN)).toBe(`/c/${SHARE_TOKEN}`);
+    expect(walletCardPassUrl(SHARE_TOKEN)).toBe(
+      `${WALLET_CARD_API_PREFIX}/pass/${SHARE_TOKEN}.pkpass`,
+    );
+  });
+
+  it("never interpolates a raw token into a path segment unescaped", () => {
+    expect(walletCardShareUrl("a/../../etc")).toBe(
+      `${APP_ORIGIN}/c/${encodeURIComponent("a/../../etc")}`,
+    );
+  });
+
+  it("shape-checks share tokens before they are sent or trusted", () => {
+    expect(isWalletShareTokenShape(SHARE_TOKEN)).toBe(true);
+    expect(isWalletShareTokenShape("short")).toBe(false);
+    expect(isWalletShareTokenShape("has spaces in it and is long enough")).toBe(false);
+    expect(isWalletShareTokenShape("../../etc/passwd/aaaaaaaaaaaa")).toBe(false);
+    expect(isWalletShareTokenShape("")).toBe(false);
+  });
+});
+
+// ==================== Platform capability ====================
+
+describe("wallet pass platform capability", () => {
+  it("reports capacitor_ios inside the native iOS shell", () => {
+    mockIsNative.mockReturnValue(true);
+    mockIsIOS.mockReturnValue(true);
+
+    expect(walletPassCapability()).toBe("capacitor_ios");
+    expect(canAddToAppleWallet()).toBe(true);
+  });
+
+  it("reports unsupported inside the native Android shell", () => {
+    mockIsNative.mockReturnValue(true);
+    mockIsIOS.mockReturnValue(false);
+
+    expect(walletPassCapability()).toBe("unsupported");
+    expect(canAddToAppleWallet()).toBe(false);
+  });
+
+  it("reports ios_web in mobile Safari", () => {
+    setUserAgent(IPHONE_UA);
+
+    expect(walletPassCapability()).toBe("ios_web");
+  });
+
+  it("treats a touch-capable iPadOS desktop user agent as ios_web", () => {
+    setUserAgent(MAC_UA, 5);
+
+    expect(walletPassCapability()).toBe("ios_web");
+  });
+
+  it("reports unsupported on desktop and on Android web", () => {
+    setUserAgent(MAC_UA, 0);
+    expect(walletPassCapability()).toBe("unsupported");
+
+    setUserAgent(ANDROID_UA, 5);
+    expect(walletPassCapability()).toBe("unsupported");
+    expect(canAddToAppleWallet()).toBe(false);
+  });
+
+  it("offers the share link instead of Apple Wallet off-iOS", async () => {
+    setUserAgent(ANDROID_UA);
+
+    const result = await WalletCardService.addToAppleWallet(SHARE_TOKEN);
+
+    expect(result).toEqual({
+      state: "unsupported",
+      message: "Apple Wallet is available on iPhone and iPad.",
+      shareUrl: walletCardShareUrl(SHARE_TOKEN),
+    });
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+
+  it("hands the pass URL to the OS on iOS rather than loading it in the WebView", async () => {
+    setUserAgent(IPHONE_UA);
+
+    const result = await WalletCardService.addToAppleWallet(SHARE_TOKEN, {
+      verifyFirst: false,
+    });
+
+    expect(result).toEqual({
+      state: "opened",
+      url: walletCardPassUrl(SHARE_TOKEN),
+    });
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith(walletCardPassUrl(SHARE_TOKEN));
+  });
+});
+
+// ==================== Public resolve — typed states ====================
+
+describe("resolvePublicCard", () => {
+  it("returns the visitor projection without any authorization header", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      status: "active",
+      card: {
+        fullName: "Ada Lovelace",
+        headline: "Founder, Hussh",
+        organisation: "Hussh Labs",
+        locationLabel: "Mumbai, India",
+        summary: "Builds private agents.",
+        skills: ["Python", "Cryptography"],
+        email: "ada@example.com",
+        phone: "+91 99999 90000",
+        website: "https://ada.example.com",
+        linkedin: "https://www.linkedin.com/in/ada",
+        github: "https://github.com/ada",
+        portfolio: "https://ada.example.com/work",
+        preferredContact: "email",
+        avatarUrl: "https://cdn.example.com/ada.png",
+        updatedOn: "2026-08-02",
+      },
+    });
+
+    const result = await WalletCardService.resolvePublicCard(SHARE_TOKEN);
+
+    expect(result.state).toBe("available");
+    if (result.state !== "available") throw new Error("expected available");
+    expect(result.card.full_name).toBe("Ada Lovelace");
+    expect(result.card.skills).toEqual(["Python", "Cryptography"]);
+    expect(result.card.preferred_contact).toBe("email");
+
+    const [path, init] = mockApiJson.mock.calls[0] ?? [];
+    expect(path).toBe(`${WALLET_CARD_API_PREFIX}/public/${SHARE_TOKEN}`);
+    expect((init as Record<string, unknown> | undefined)?.headers).toBeUndefined();
+  });
+
+  it("maps 410 revoked and 410 expired to distinct typed results", async () => {
+    mockApiJson.mockRejectedValueOnce(
+      new MockApiError("gone", 410, { status: "revoked" }),
+    );
+    const revoked = await WalletCardService.resolvePublicCard(SHARE_TOKEN);
+
+    mockApiJson.mockRejectedValueOnce(
+      new MockApiError("gone", 410, { status: "expired" }),
+    );
+    const expired = await WalletCardService.resolvePublicCard(SHARE_TOKEN);
+
+    expect(revoked).toEqual({
+      state: "revoked",
+      message: "This profile is no longer shared.",
+    });
+    expect(expired).toEqual({
+      state: "expired",
+      message: "This profile link has expired.",
+    });
+    expect(revoked.state).not.toBe(expired.state);
+    expect(revoked).not.toEqual(expired);
+    expect(WALLET_CARD_SERVICE_COPY.revoked).toBe("This profile is no longer shared.");
+    expect(WALLET_CARD_SERVICE_COPY.expired).toBe("This profile link has expired.");
+  });
+
+  it("reads the gone status out of a FastAPI detail envelope too", async () => {
+    mockApiJson.mockRejectedValueOnce(
+      new MockApiError("gone", 410, { detail: { status: "expired" } }),
+    );
+
+    expect(await WalletCardService.resolvePublicCard(SHARE_TOKEN)).toEqual({
+      state: "expired",
+      message: "This profile link has expired.",
+    });
+  });
+
+  it("returns the same not_found state for an unknown and a paused card", async () => {
+    mockApiJson.mockRejectedValueOnce(
+      new MockApiError("missing", 404, { status: "not_found" }),
+    );
+    const unknown = await WalletCardService.resolvePublicCard(SHARE_TOKEN);
+
+    // A paused card is served as the identical generic 404 (contract §6).
+    mockApiJson.mockRejectedValueOnce(
+      new MockApiError("missing", 404, { status: "not_found" }),
+    );
+    const paused = await WalletCardService.resolvePublicCard(SHARE_TOKEN);
+
+    expect(unknown).toEqual(paused);
+    expect(unknown.state).toBe("not_found");
+  });
+
+  it("rejects a malformed token locally without spending a request", async () => {
+    const result = await WalletCardService.resolvePublicCard("nope");
+
+    expect(result.state).toBe("not_found");
+    expect(mockApiJson).not.toHaveBeenCalled();
+  });
+
+  it("degrades to unavailable on a transient failure", async () => {
+    mockApiJson.mockRejectedValueOnce(new Error("network down"));
+
+    expect(await WalletCardService.resolvePublicCard(SHARE_TOKEN)).toEqual({
+      state: "unavailable",
+      message: "This profile could not be loaded right now.",
+    });
+  });
+
+  it("drops an unsafe link that somehow reached the wire", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      status: "active",
+      card: {
+        fullName: "Ada Lovelace",
+        website: "javascript:alert(1)",
+        portfolio: "https://user:pw@evil.example",
+        avatarUrl: "data:text/html;base64,PHNjcmlwdD4=",
+      },
+    });
+
+    const result = await WalletCardService.resolvePublicCard(SHARE_TOKEN);
+
+    if (result.state !== "available") throw new Error("expected available");
+    expect(result.card.website).toBeNull();
+    expect(result.card.portfolio).toBeNull();
+    expect(result.card.avatar_url).toBeNull();
+  });
+});
+
+// ==================== Pass availability ====================
+
+describe("checkPassAvailability", () => {
+  it("returns the download URL when the pass builds", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      fetchResponse(200, undefined, "application/vnd.apple.pkpass"),
+    );
+
+    expect(await WalletCardService.checkPassAvailability(SHARE_TOKEN)).toEqual({
+      state: "available",
+      url: walletCardPassUrl(SHARE_TOKEN),
+    });
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      `${WALLET_CARD_API_PREFIX}/pass/${SHARE_TOKEN}.pkpass`,
+      { method: "GET", cache: "no-store" },
+    );
+  });
+
+  it("surfaces the contract copy when signing material is absent", async () => {
+    mockApiFetch.mockResolvedValueOnce(
+      fetchResponse(503, {
+        status: "unavailable",
+        code: "WALLET_PASS_SIGNING_UNAVAILABLE",
+        message: "We couldn't create your Wallet pass right now. Please try again in a moment.",
+      }),
+    );
+
+    expect(await WalletCardService.checkPassAvailability(SHARE_TOKEN)).toEqual({
+      state: "signing_unavailable",
+      message:
+        "We couldn't create your Wallet pass right now. Please try again in a moment.",
+      code: "WALLET_PASS_SIGNING_UNAVAILABLE",
+    });
+  });
+
+  it("maps the pass route's 410 states the same way the card route does", async () => {
+    mockApiFetch.mockResolvedValueOnce(fetchResponse(410, { status: "revoked" }));
+    const revoked = await WalletCardService.checkPassAvailability(SHARE_TOKEN);
+
+    mockApiFetch.mockResolvedValueOnce(fetchResponse(410, { status: "expired" }));
+    const expired = await WalletCardService.checkPassAvailability(SHARE_TOKEN);
+
+    expect(revoked.state).toBe("revoked");
+    expect(expired.state).toBe("expired");
+  });
+
+  it("returns not_found for an unknown or paused token", async () => {
+    mockApiFetch.mockResolvedValueOnce(fetchResponse(404, { status: "not_found" }));
+
+    expect(await WalletCardService.checkPassAvailability(SHARE_TOKEN)).toEqual({
+      state: "not_found",
+      message: "This profile is not available.",
+    });
+  });
+});
+
+// ==================== Payload validation ====================
+
+describe("validateWalletCardPayload", () => {
+  it("accepts the full allowlist and normalises whitespace", () => {
+    const result = validateWalletCardPayload({
+      full_name: "  Ada Lovelace  ",
+      headline: "Founder, Hussh",
+      organisation: "Hussh Labs",
+      location_label: "Mumbai, India",
+      summary: "Builds private agents.",
+      skills: ["Python", " Cryptography ", ""],
+      email: "ada@example.com",
+      phone: "+91 99999 90000",
+      website: "https://ada.example.com",
+      linkedin: "https://www.linkedin.com/in/ada",
+      github: "https://github.com/ada",
+      portfolio: "https://ada.example.com/work",
+      preferred_contact: "email",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.value.full_name).toBe("Ada Lovelace");
+    expect(result.value.skills).toEqual(["Python", "Cryptography"]);
+  });
+
+  it("rejects a key outside the allowlist rather than dropping it", () => {
+    const result = validateWalletCardPayload({
+      full_name: "Ada Lovelace",
+      vault_key: "secret",
+      user_id: "user_123",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected rejection");
+    const fields = result.errors.map((error) => error.field);
+    expect(fields).toEqual(["card_payload", "card_payload"]);
+    expect(result.errors[0].message).toContain("vault_key");
+  });
+
+  it("enforces the per-field length caps", () => {
+    const tooLong = validateWalletCardPayload({ full_name: "a".repeat(81) });
+    const atCap = validateWalletCardPayload({ full_name: "a".repeat(80) });
+    const summaryTooLong = validateWalletCardPayload({ summary: "s".repeat(401) });
+
+    expect(tooLong.ok).toBe(false);
+    expect(atCap.ok).toBe(true);
+    expect(summaryTooLong.ok).toBe(false);
+  });
+
+  it("caps skills at twelve entries of forty characters", () => {
+    const tooMany = validateWalletCardPayload({
+      skills: Array.from({ length: 13 }, (_, index) => `skill-${index}`),
+    });
+    const atCap = validateWalletCardPayload({
+      skills: Array.from({ length: 12 }, (_, index) => `skill-${index}`),
+    });
+    const tooLong = validateWalletCardPayload({ skills: ["x".repeat(41)] });
+
+    expect(tooMany.ok).toBe(false);
+    expect(atCap.ok).toBe(true);
+    expect(tooLong.ok).toBe(false);
+  });
+
+  it("accepts https links only and refuses javascript, data and userinfo forms", () => {
+    expect(isAllowedWalletCardUrl("https://ada.example.com")).toBe(true);
+    expect(isAllowedWalletCardUrl("http://ada.example.com")).toBe(false);
+    expect(isAllowedWalletCardUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedWalletCardUrl("data:text/html;base64,PHNjcmlwdD4=")).toBe(false);
+    expect(isAllowedWalletCardUrl("https://ada@evil.example")).toBe(false);
+    expect(isAllowedWalletCardUrl("https://user:pw@evil.example")).toBe(false);
+    expect(isAllowedWalletCardUrl("  ")).toBe(false);
+
+    for (const key of ["website", "linkedin", "github", "portfolio"]) {
+      expect(validateWalletCardPayload({ [key]: "javascript:alert(1)" }).ok).toBe(false);
+      expect(validateWalletCardPayload({ [key]: "https://ok.example" }).ok).toBe(true);
+    }
+  });
+
+  it("validates the email and phone shapes", () => {
+    expect(validateWalletCardPayload({ email: "ada@example.com" }).ok).toBe(true);
+    expect(validateWalletCardPayload({ email: "ada@example" }).ok).toBe(false);
+    expect(validateWalletCardPayload({ email: "not an email" }).ok).toBe(false);
+    expect(validateWalletCardPayload({ phone: "+91 99999 90000" }).ok).toBe(true);
+    expect(validateWalletCardPayload({ phone: "call me" }).ok).toBe(false);
+  });
+
+  it("restricts preferred_contact to the closed set", () => {
+    expect(validateWalletCardPayload({ preferred_contact: "email" }).ok).toBe(true);
+    expect(validateWalletCardPayload({ preferred_contact: "carrier_pigeon" }).ok).toBe(
+      false,
+    );
+  });
+
+  it("refuses to send an invalid payload to the backend", async () => {
+    await expect(
+      WalletCardService.saveCard({
+        vaultOwnerToken: "vault-token",
+        userId: "user_123",
+        payload: { full_name: "Ada", vault_key: "secret" },
+      }),
+    ).rejects.toBeInstanceOf(WalletCardPayloadError);
+
+    expect(mockApiJson).not.toHaveBeenCalled();
+  });
+});
+
+// ==================== Owner routes ====================
+
+describe("owner routes", () => {
+  it("sends the vault owner token and the owner user_id on read", async () => {
+    mockApiJson.mockResolvedValueOnce({ card: OWNER_CARD });
+
+    const state = await WalletCardService.getCard({
+      vaultOwnerToken: "vault-token",
+      userId: "user_123",
+    });
+
+    expect(state.enabled).toBe(true);
+    expect(state.exists).toBe(true);
+    expect(state.card?.status).toBe("active");
+    expect(state.card?.scanCount).toBe(4);
+
+    const [path, init] = mockApiJson.mock.calls[0] ?? [];
+    expect(path).toBe(`${WALLET_CARD_API_PREFIX}?user_id=user_123`);
+    expect(
+      (init as { headers: Record<string, string> }).headers.Authorization,
+    ).toBe("Bearer vault-token");
+  });
+
+  it("reports the feature as disabled instead of throwing", async () => {
+    mockApiJson.mockRejectedValueOnce(
+      new MockApiError("disabled", 404, {
+        detail: { code: "ONE_WALLET_CARD_DISABLED", message: "not available" },
+      }),
+    );
+
+    expect(
+      await WalletCardService.getCard({
+        vaultOwnerToken: "vault-token",
+        userId: "user_123",
+      }),
+    ).toEqual({ enabled: false, exists: false, card: null, shareUrl: null });
+  });
+
+  it("returns the plaintext token exactly once, on create and on rotate", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      card: OWNER_CARD,
+      shareToken: SHARE_TOKEN,
+      shareUrl: `${APP_ORIGIN}/c/${SHARE_TOKEN}`,
+    });
+    const created = await WalletCardService.saveCard({
+      vaultOwnerToken: "vault-token",
+      userId: "user_123",
+      payload: { full_name: "Ada Lovelace" },
+    });
+
+    mockApiJson.mockResolvedValueOnce({ card: OWNER_CARD });
+    const paused = await WalletCardService.pauseCard({
+      vaultOwnerToken: "vault-token",
+      userId: "user_123",
+    });
+
+    expect(created.shareToken).toBe(SHARE_TOKEN);
+    expect(created.shareUrl).toBe(`${APP_ORIGIN}/c/${SHARE_TOKEN}`);
+    expect(created.passUrl).toBe(walletCardPassUrl(SHARE_TOKEN));
+    expect(paused.status).toBe("active");
+  });
+
+  it("persists the share link locally because the server cannot return it again", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      card: OWNER_CARD,
+      shareToken: SHARE_TOKEN,
+      shareUrl: `${APP_ORIGIN}/c/${SHARE_TOKEN}`,
+    });
+
+    await WalletCardService.rotateShareToken({
+      vaultOwnerToken: "vault-token",
+      userId: "user_123",
+    });
+
+    expect(WalletCardService.readShareLink("user_123")).toEqual({
+      shareUrl: `${APP_ORIGIN}/c/${SHARE_TOKEN}`,
+      shareToken: SHARE_TOKEN,
+      version: OWNER_CARD.shareTokenVersion,
+    });
+  });
+
+  it("drops a locally stored link once the token has been rotated elsewhere", () => {
+    WalletCardService.rememberShareLink("user_123", {
+      card: { ...OWNER_CARD, shareTokenVersion: 2 } as never,
+      shareToken: SHARE_TOKEN,
+      shareUrl: `${APP_ORIGIN}/c/${SHARE_TOKEN}`,
+    });
+
+    const stale = WalletCardService.readShareLink("user_123", {
+      ...OWNER_CARD,
+      shareTokenVersion: 3,
+    } as never);
+    const current = WalletCardService.readShareLink("user_123", {
+      ...OWNER_CARD,
+      shareTokenVersion: 2,
+    } as never);
+
+    expect(stale).toBeNull();
+    expect(current?.shareToken).toBe(SHARE_TOKEN);
+  });
+
+  it("forgets the stored link when the card is revoked", async () => {
+    WalletCardService.rememberShareLink("user_123", {
+      card: OWNER_CARD as never,
+      shareToken: SHARE_TOKEN,
+      shareUrl: `${APP_ORIGIN}/c/${SHARE_TOKEN}`,
+    });
+    mockApiJson.mockResolvedValueOnce({
+      card: { ...OWNER_CARD, status: "revoked", revokedAt: "2026-08-03T00:00:00+00:00" },
+    });
+
+    const card = await WalletCardService.revokeCard({
+      vaultOwnerToken: "vault-token",
+      userId: "user_123",
+    });
+
+    expect(card.status).toBe("revoked");
+    expect(WalletCardService.readShareLink("user_123")).toBeNull();
+  });
+
+  it("previews as a visitor through the shared projection contract", async () => {
+    mockApiJson.mockResolvedValueOnce({
+      status: "active",
+      card: { fullName: "Ada Lovelace", updatedOn: "2026-08-02" },
+    });
+
+    const result = await WalletCardService.previewAsVisitor({
+      vaultOwnerToken: "vault-token",
+      userId: "user_123",
+    });
+
+    expect(result.state).toBe("available");
+    const [path] = mockApiJson.mock.calls[0] ?? [];
+    expect(path).toBe(`${WALLET_CARD_API_PREFIX}/preview?user_id=user_123`);
+  });
+
+  it("fails loudly rather than inventing a card from an unreadable response", async () => {
+    mockApiJson.mockResolvedValueOnce(null);
+
+    await expect(
+      WalletCardService.pauseCard({
+        vaultOwnerToken: "vault-token",
+        userId: "user_123",
+      }),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+});

--- a/hushh-webapp/app/c/[token]/page-client.tsx
+++ b/hushh-webapp/app/c/[token]/page-client.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+/**
+ * Public Wallet Profile page — `/c/[token]`.
+ *
+ * A stranger scans the QR on someone's Hussh One Wallet pass and lands here
+ * with no session, no app, and no prior relationship. The route is
+ * unauthenticated by design and resolves a share token to the owner-selected
+ * projection; the token itself is never logged or echoed into the UI.
+ *
+ * Structure mirrors the repo's proven public route,
+ * `app/one/location/request/[token]` — thin server page, all state in a client
+ * component, one service call, explicit terminal states.
+ *
+ * This page emits no analytics.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  normalizePublicWalletCard,
+  PublicWalletCardSkeleton,
+  PublicWalletCardView,
+  type PublicWalletCard,
+} from "@/components/wallet-card/public-card-view";
+import { ApiError, apiErrorCode } from "@/lib/services/api-client";
+import { WalletCardService } from "@/lib/services/wallet-card-service";
+
+/**
+ * `secrets.token_urlsafe(32)` produces 43 URL-safe characters. Rejecting
+ * anything outside that alphabet locally keeps obviously-malformed links off
+ * the rate-limited public endpoint.
+ */
+const SHARE_TOKEN_SHAPE = /^[A-Za-z0-9_-]{16,128}$/;
+
+type CardStatus =
+  | "loading"
+  | "ready"
+  | "revoked"
+  | "expired"
+  | "not-found"
+  | "error";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Read the honest status the public endpoint returns on 410, tolerating both
+ * a bare `{"status":"revoked"}` body and FastAPI's `{"detail": {...}}` wrapper.
+ */
+function readPayloadStatus(payload: unknown): string | null {
+  const record = asRecord(payload);
+  if (!record) return null;
+  const direct = record.status;
+  if (typeof direct === "string" && direct.trim()) {
+    return direct.trim().toLowerCase();
+  }
+  return readPayloadStatus(record.detail);
+}
+
+/**
+ * Map a failed resolve onto a terminal page state.
+ *
+ * Unknown and paused cards both arrive as a generic 404 — the page must not
+ * be able to tell them apart, so both render the same generic message.
+ */
+/**
+ * Terminal resolve states mapped onto page states.
+ *
+ * "not_found" covers both an unknown token and a paused card — the page must
+ * not be able to tell them apart.
+ */
+const TERMINAL_STATUS_BY_STATE: Record<string, CardStatus> = {
+  revoked: "revoked",
+  expired: "expired",
+  not_found: "not-found",
+  unavailable: "error",
+};
+
+function resolveFailureStatus(error: unknown): CardStatus {
+  if (!(error instanceof ApiError)) return "error";
+  if (error.status === 404) return "not-found";
+  if (error.status === 410) {
+    const declared =
+      readPayloadStatus(error.payload) ??
+      apiErrorCode(error)?.toLowerCase() ??
+      null;
+    return declared === "expired" ? "expired" : "revoked";
+  }
+  if (error.status === 400 || error.status === 422) return "not-found";
+  return "error";
+}
+
+function CardMessage({
+  title,
+  body,
+  onRetry,
+}: {
+  title: string;
+  body?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="space-y-4 rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-5 text-center shadow-[var(--shadow-xs)] sm:p-7">
+      <div
+        className="mx-auto flex size-12 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint)] text-[color:var(--app-accent)]"
+        aria-hidden="true"
+      >
+        <AlertTriangle className="size-5" />
+      </div>
+      <h1 className="text-[22px] font-medium leading-[1.2] tracking-tight sm:text-[24px]">
+        {title}
+      </h1>
+      {body ? (
+        <p className="text-sm leading-6 text-muted-foreground">{body}</p>
+      ) : null}
+      {onRetry ? (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onRetry}
+          className="h-11 px-5"
+        >
+          <RefreshCw className="size-4" aria-hidden="true" />
+          Try again
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export default function PublicWalletCardPageClient() {
+  const params = useParams<{ token?: string }>();
+  const shareToken = useMemo(
+    () => String(params?.token || "").trim(),
+    [params?.token],
+  );
+  const [status, setStatus] = useState<CardStatus>("loading");
+  const [card, setCard] = useState<PublicWalletCard | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadCard = async () => {
+      if (!SHARE_TOKEN_SHAPE.test(shareToken)) {
+        setCard(null);
+        setStatus("not-found");
+        return;
+      }
+      setStatus("loading");
+      try {
+        const response = await WalletCardService.resolvePublicCard(shareToken);
+        if (cancelled) return;
+
+        // The service resolves terminal states rather than throwing, so branch
+        // on the typed state. Unknown and paused both arrive as "not_found" and
+        // must stay indistinguishable (contract §6); revoked and expired get
+        // their own honest copy (contract §9).
+        if (response.state !== "available") {
+          setCard(null);
+          setStatus(TERMINAL_STATUS_BY_STATE[response.state] ?? "error");
+          return;
+        }
+
+        const normalized = normalizePublicWalletCard(response);
+        if (!normalized) {
+          setCard(null);
+          setStatus("not-found");
+          return;
+        }
+        setCard(normalized);
+        setStatus("ready");
+      } catch (loadError) {
+        if (cancelled) return;
+        setCard(null);
+        setStatus(resolveFailureStatus(loadError));
+      }
+    };
+
+    void loadCard();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shareToken, reloadKey]);
+
+  const retry = useCallback(() => {
+    setReloadKey((current) => current + 1);
+  }, []);
+
+  return (
+    <main className="min-h-[100dvh] bg-background text-foreground">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-md flex-col justify-center px-4 py-8 sm:max-w-lg sm:px-6 sm:py-12">
+        {status === "loading" ? <PublicWalletCardSkeleton /> : null}
+
+        {status === "ready" && card ? <PublicWalletCardView card={card} /> : null}
+
+        {status === "revoked" ? (
+          <CardMessage title="This profile is no longer shared." />
+        ) : null}
+
+        {status === "expired" ? (
+          <CardMessage title="This profile link has expired." />
+        ) : null}
+
+        {status === "not-found" ? (
+          <CardMessage
+            title="This profile isn't available."
+            body="Check the link, or ask for a new one."
+          />
+        ) : null}
+
+        {status === "error" ? (
+          <CardMessage
+            title="We couldn't load this profile."
+            body="Check your connection and try again."
+            onRetry={retry}
+          />
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/hushh-webapp/app/c/[token]/page.tsx
+++ b/hushh-webapp/app/c/[token]/page.tsx
@@ -1,0 +1,45 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+
+import PublicWalletCardPageClient from "./page-client";
+
+/**
+ * The scanned Wallet Profile page must never enter a search index or an AI
+ * training corpus: it is a person's contact details, published to whoever
+ * holds the link and revocable at any moment. `robots.ts` carries the matching
+ * `/c` disallow prefix, and the backend sends `X-Robots-Tag` on the resolve
+ * response; this is the third, page-level guard.
+ */
+export const metadata: Metadata = {
+  title: "Shared profile | Hussh One",
+  description: "A profile shared from Hussh One.",
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+    googleBot: { index: false, follow: false },
+  },
+};
+
+const nativeStaticExportToken =
+  process.env.ONE_WALLET_CARD_NATIVE_TEST_PUBLIC_TOKEN || "native-test-token";
+
+export async function generateStaticParams(): Promise<Array<{ token: string }>> {
+  if (process.env.CAPACITOR_BUILD !== "true") {
+    return [];
+  }
+  return [{ token: nativeStaticExportToken }];
+}
+
+export default async function PublicWalletCardPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  await params;
+  return (
+    <Suspense fallback={null}>
+      <PublicWalletCardPageClient />
+    </Suspense>
+  );
+}

--- a/hushh-webapp/app/one/wallet-card/page.tsx
+++ b/hushh-webapp/app/one/wallet-card/page.tsx
@@ -1,0 +1,5 @@
+import { WalletCardWorkspace } from "@/components/wallet-card/wallet-card-workspace";
+
+export default function OneWalletCardPage() {
+  return <WalletCardWorkspace />;
+}

--- a/hushh-webapp/cache-coherence-screen-manifest.generated.json
+++ b/hushh-webapp/cache-coherence-screen-manifest.generated.json
@@ -10,16 +10,16 @@
     "cache_reference": "../docs/reference/architecture/cache-coherence.md"
   },
   "summary": {
-    "total_screens": 116,
-    "physical_page_count": 116,
-    "route_contract_count": 116,
-    "surface_map_count": 116,
+    "total_screens": 118,
+    "physical_page_count": 118,
+    "route_contract_count": 118,
+    "surface_map_count": 118,
     "class_counts": {
       "public/static": 2,
       "realtime/SSE": 1,
       "redirect/alias": 40,
-      "vault-backed": 41,
-      "hidden flow": 11,
+      "vault-backed": 42,
+      "hidden flow": 12,
       "auth/pre-vault": 6,
       "RIA/provider": 9,
       "PKM-secure": 6
@@ -196,6 +196,51 @@
       ],
       "realtime_policy": "not realtime",
       "reviewer_fixture": "/blog/[slug]",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
+      "route": "/c/[token]",
+      "page_file": "app/c/[token]/page.tsx",
+      "route_contract_mode": "hidden",
+      "screen_class": "hidden flow",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/c/[token]",
       "surface_map_present": true,
       "route_contract_present": true,
       "evidence": {
@@ -3452,7 +3497,7 @@
         "route_refresh_completed"
       ],
       "realtime_policy": "not realtime",
-      "reviewer_fixture": "/one/profile/preferences/gemini",
+      "reviewer_fixture": "/login?redirect=%2Fone%2Fprofile%2Fpreferences%2Fgemini",
       "surface_map_present": true,
       "route_contract_present": true,
       "evidence": {
@@ -3468,9 +3513,7 @@
         "sse_or_streaming": false,
         "native_beacon": false
       },
-      "findings": [
-        "review native route beacon coverage"
-      ]
+      "findings": []
     },
     {
       "route": "/one/profile/preferences/kai",
@@ -4433,6 +4476,51 @@
       ]
     },
     {
+      "route": "/one/wallet-card",
+      "page_file": "app/one/wallet-card/page.tsx",
+      "route_contract_mode": "standard",
+      "screen_class": "vault-backed",
+      "cache_policy": "memory-only",
+      "cache_keys": [],
+      "resource_classes": [
+        "unknown"
+      ],
+      "sensitivity_class": "app-metadata",
+      "ttl_class": "CACHE_TTL.MEDIUM",
+      "warm_source": "Route-local resource loader",
+      "refresh_trigger": "stale-aware background refresh; explicit user refresh may force",
+      "mutation_invalidator": "CacheSyncService user/session invalidation",
+      "best_available_ux_path": [
+        "fresh memory",
+        "cold loader"
+      ],
+      "readiness_kpis": [
+        "route_readiness_completed",
+        "cache_resource_resolved",
+        "route_refresh_completed"
+      ],
+      "realtime_policy": "not realtime",
+      "reviewer_fixture": "/login?redirect=%2Fone%2Fwallet-card",
+      "surface_map_present": true,
+      "route_contract_present": true,
+      "evidence": {
+        "cache_service": false,
+        "use_stale_resource": false,
+        "device_cache": false,
+        "secure_cache": false,
+        "cache_sync": false,
+        "resource_wrapper": false,
+        "direct_fetch": false,
+        "api_service": false,
+        "hushh_loader": false,
+        "sse_or_streaming": false,
+        "native_beacon": false
+      },
+      "findings": [
+        "no local cache primitive detected in page/contract source"
+      ]
+    },
+    {
       "route": "/pkm",
       "page_file": "app/pkm/page.tsx",
       "route_contract_mode": "redirect",
@@ -5209,5 +5297,5 @@
       ]
     }
   ],
-  "content_sha256": "e362c8b56f0bb0f290a0983da0a9c05e3be0cc5d10af23a593e6da7f9581447c"
+  "content_sha256": "96ec5d41de403e180de7ea97dd1e89a86b0b3999891a74e6961f01b694d50d13"
 }

--- a/hushh-webapp/components/observability/route-observer.tsx
+++ b/hushh-webapp/components/observability/route-observer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 
 import { getRouteScope } from "@/lib/navigation/route-scope";
+import { isAnalyticsExemptRoute } from "@/lib/navigation/routes";
 import { captureGrowthAttribution } from "@/lib/observability/growth";
 import { trackPageView } from "@/lib/observability/client";
 import { useKaiSession } from "@/lib/stores/kai-session-store";
@@ -15,8 +16,18 @@ export function ObservabilityRouteObserver() {
   const setLastRiaPath = useKaiSession((state) => state.setLastRiaPath);
 
   useEffect(() => {
+    // Wallet Profile visitors are strangers holding someone else's QR, not our
+    // users. Bail before any capture — including the session-path writes, which
+    // would otherwise persist a card token into local state.
+    if (isAnalyticsExemptRoute(pathname)) {
+      mountedRef.current = true;
+      return;
+    }
     captureGrowthAttribution(pathname);
-    trackPageView(pathname, mountedRef.current ? "route_change" : "initial_load");
+    trackPageView(
+      pathname,
+      mountedRef.current ? "route_change" : "initial_load",
+    );
     const scope = getRouteScope(pathname);
     if (scope === "investor") {
       setLastKaiPath(pathname);

--- a/hushh-webapp/components/wallet-card/__tests__/qr-code.test.ts
+++ b/hushh-webapp/components/wallet-card/__tests__/qr-code.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeQrCode, type QrCodeMatrix } from "@/components/wallet-card/qr-code";
+
+/**
+ * Published format-information strings for error-correction level M, masks 0-7
+ * (ISO/IEC 18004 Annex C). The encoder must reproduce them exactly or no
+ * scanner can read the symbol.
+ */
+const FORMAT_INFORMATION_M = [
+  "101010000010010",
+  "101000100100101",
+  "101111001111100",
+  "101101101001011",
+  "100010111111001",
+  "100000011001110",
+  "100111110010111",
+  "100101010100000",
+];
+
+/** Published version-information strings for versions 7-10 (ISO/IEC 18004 Annex D). */
+const VERSION_INFORMATION = new Map<number, string>([
+  [7, "000111110010010100"],
+  [8, "001000010110111100"],
+  [9, "001001101010011001"],
+  [10, "001010010011010011"],
+]);
+
+/** Total codewords and level-M block layout, versions 1-10. */
+const VERSION_LAYOUT = [
+  { total: 26, ecc: 10, blocks: 1 },
+  { total: 44, ecc: 16, blocks: 1 },
+  { total: 70, ecc: 26, blocks: 1 },
+  { total: 100, ecc: 18, blocks: 2 },
+  { total: 134, ecc: 24, blocks: 2 },
+  { total: 172, ecc: 16, blocks: 4 },
+  { total: 196, ecc: 18, blocks: 4 },
+  { total: 242, ecc: 22, blocks: 4 },
+  { total: 292, ecc: 22, blocks: 5 },
+  { total: 346, ecc: 26, blocks: 5 },
+];
+
+function isDark(matrix: QrCodeMatrix, x: number, y: number): boolean {
+  return (matrix.modules[y * matrix.size + x] ?? 0) === 1;
+}
+
+function versionOf(matrix: QrCodeMatrix): number {
+  return (matrix.size - 17) / 4;
+}
+
+/** Bit `index` of the first format copy, which wraps the top-left finder. */
+function firstFormatCopyPosition(index: number): { x: number; y: number } {
+  if (index <= 5) return { x: 8, y: index };
+  if (index === 6) return { x: 8, y: 7 };
+  if (index === 7) return { x: 8, y: 8 };
+  if (index === 8) return { x: 7, y: 8 };
+  return { x: 14 - index, y: 8 };
+}
+
+/** Bit `index` of the second format copy, split across bottom-left and top-right. */
+function secondFormatCopyPosition(index: number, size: number): { x: number; y: number } {
+  if (index < 8) return { x: size - 1 - index, y: 8 };
+  return { x: 8, y: size - 15 + index };
+}
+
+function readFormatInformation(matrix: QrCodeMatrix, copy: "first" | "second"): string {
+  const bits: string[] = [];
+  for (let index = 0; index < 15; index += 1) {
+    const { x, y } =
+      copy === "first"
+        ? firstFormatCopyPosition(index)
+        : secondFormatCopyPosition(index, matrix.size);
+    bits.push(isDark(matrix, x, y) ? "1" : "0");
+  }
+  return bits.reverse().join("");
+}
+
+function readVersionInformation(matrix: QrCodeMatrix, copy: "top" | "left"): string {
+  const bits: string[] = [];
+  for (let index = 0; index < 18; index += 1) {
+    const far = matrix.size - 11 + (index % 3);
+    const near = Math.floor(index / 3);
+    const x = copy === "top" ? far : near;
+    const y = copy === "top" ? near : far;
+    bits.push(isDark(matrix, x, y) ? "1" : "0");
+  }
+  return bits.reverse().join("");
+}
+
+function alignmentPositions(version: number, size: number): number[] {
+  if (version === 1) return [];
+  const count = Math.floor(version / 7) + 2;
+  const step = Math.ceil((version * 4 + 4) / (count * 2 - 2)) * 2;
+  const positions = [6];
+  for (let position = size - 7; positions.length < count; position -= step) {
+    positions.splice(1, 0, position);
+  }
+  return positions;
+}
+
+/** Independent reconstruction of which modules are function patterns. */
+function functionModuleGrid(size: number, version: number): Uint8Array {
+  const grid = new Uint8Array(size * size);
+  const mark = (x: number, y: number): void => {
+    if (x < 0 || y < 0 || x >= size || y >= size) return;
+    grid[y * size + x] = 1;
+  };
+
+  for (let i = 0; i < size; i += 1) {
+    mark(6, i);
+    mark(i, 6);
+  }
+  for (const [cx, cy] of [
+    [3, 3],
+    [size - 4, 3],
+    [3, size - 4],
+  ]) {
+    for (let dy = -4; dy <= 4; dy += 1) {
+      for (let dx = -4; dx <= 4; dx += 1) mark((cx ?? 0) + dx, (cy ?? 0) + dy);
+    }
+  }
+
+  const positions = alignmentPositions(version, size);
+  const last = positions.length - 1;
+  for (let i = 0; i < positions.length; i += 1) {
+    for (let j = 0; j < positions.length; j += 1) {
+      if ((i === 0 && j === 0) || (i === 0 && j === last) || (i === last && j === 0)) continue;
+      for (let dy = -2; dy <= 2; dy += 1) {
+        for (let dx = -2; dx <= 2; dx += 1) {
+          mark((positions[i] ?? 0) + dx, (positions[j] ?? 0) + dy);
+        }
+      }
+    }
+  }
+
+  for (let index = 0; index < 15; index += 1) {
+    const first = firstFormatCopyPosition(index);
+    mark(first.x, first.y);
+    const second = secondFormatCopyPosition(index, size);
+    mark(second.x, second.y);
+  }
+  mark(8, size - 8);
+
+  if (version >= 7) {
+    for (let index = 0; index < 18; index += 1) {
+      const far = size - 11 + (index % 3);
+      const near = Math.floor(index / 3);
+      mark(far, near);
+      mark(near, far);
+    }
+  }
+  return grid;
+}
+
+function maskCondition(mask: number, x: number, y: number): boolean {
+  switch (mask) {
+    case 0:
+      return (x + y) % 2 === 0;
+    case 1:
+      return y % 2 === 0;
+    case 2:
+      return x % 3 === 0;
+    case 3:
+      return (x + y) % 3 === 0;
+    case 4:
+      return (Math.floor(y / 2) + Math.floor(x / 3)) % 2 === 0;
+    case 5:
+      return ((x * y) % 2) + ((x * y) % 3) === 0;
+    case 6:
+      return (((x * y) % 2) + ((x * y) % 3)) % 2 === 0;
+    default:
+      return (((x + y) % 2) + ((x * y) % 3)) % 2 === 0;
+  }
+}
+
+/**
+ * Reads the payload back out of a finished symbol: recover the mask from the
+ * format bits, unmask, walk the zig-zag, de-interleave the blocks, and parse
+ * the byte-mode header. Error correction is not applied — an undamaged symbol
+ * must decode from its data codewords alone.
+ */
+function decodePayload(matrix: QrCodeMatrix): string {
+  const size = matrix.size;
+  const version = versionOf(matrix);
+  const layout = VERSION_LAYOUT[version - 1];
+  if (!layout) throw new Error(`Unsupported version ${version}`);
+
+  const mask = FORMAT_INFORMATION_M.indexOf(readFormatInformation(matrix, "first"));
+  if (mask < 0) throw new Error("Format information is not a published value");
+
+  const functionModules = functionModuleGrid(size, version);
+  const totalBits = layout.total * 8;
+  const bits: number[] = [];
+  let right = size - 1;
+  while (right >= 1) {
+    if (right === 6) right = 5;
+    for (let vertical = 0; vertical < size; vertical += 1) {
+      for (let column = 0; column < 2; column += 1) {
+        const x = right - column;
+        const upward = ((right + 1) & 2) === 0;
+        const y = upward ? size - 1 - vertical : vertical;
+        if ((functionModules[y * size + x] ?? 0) === 1) continue;
+        if (bits.length >= totalBits) continue;
+        bits.push((isDark(matrix, x, y) ? 1 : 0) ^ (maskCondition(mask, x, y) ? 1 : 0));
+      }
+    }
+    right -= 2;
+  }
+
+  const codewords: number[] = [];
+  for (let i = 0; i < bits.length; i += 8) {
+    let byte = 0;
+    for (let j = 0; j < 8; j += 1) byte = (byte << 1) | (bits[i + j] ?? 0);
+    codewords.push(byte);
+  }
+
+  const dataLength = layout.total - layout.ecc * layout.blocks;
+  const shortLength = Math.floor(dataLength / layout.blocks);
+  const longCount = dataLength % layout.blocks;
+  const blockLengths: number[] = [];
+  for (let i = 0; i < layout.blocks; i += 1) {
+    blockLengths.push(shortLength + (i >= layout.blocks - longCount ? 1 : 0));
+  }
+  const blocks: number[][] = blockLengths.map(() => []);
+  let cursor = 0;
+  for (let i = 0; i < shortLength + (longCount > 0 ? 1 : 0); i += 1) {
+    for (let block = 0; block < layout.blocks; block += 1) {
+      if (i < (blockLengths[block] ?? 0)) {
+        blocks[block]?.push(codewords[cursor] ?? 0);
+        cursor += 1;
+      }
+    }
+  }
+
+  const stream = blocks
+    .flat()
+    .map((byte) => byte.toString(2).padStart(8, "0"))
+    .join("");
+  expect(parseInt(stream.slice(0, 4), 2)).toBe(0b0100);
+  const countBits = version < 10 ? 8 : 16;
+  const length = parseInt(stream.slice(4, 4 + countBits), 2);
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) {
+    const start = 4 + countBits + i * 8;
+    bytes[i] = parseInt(stream.slice(start, start + 8), 2);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+const SHARE_LINK = "https://one.hushh.ai/c/x1Y2z3A4b5C6d7E8f9G0h1I2j3K4l5M6n7O8p9Q";
+
+describe("wallet-card QR encoder", () => {
+  it("sizes the symbol from the payload length", () => {
+    // Level-M byte capacity: version 1 holds 14 bytes, version 2 holds 26.
+    expect(encodeQrCode("a".repeat(14)).size).toBe(21);
+    expect(encodeQrCode("a".repeat(15)).size).toBe(25);
+    expect(encodeQrCode("a".repeat(26)).size).toBe(25);
+    // A realistic share link fits inside version 4.
+    expect(encodeQrCode(SHARE_LINK).size).toBe(33);
+  });
+
+  it("writes the published format information into both copies", () => {
+    const matrix = encodeQrCode(SHARE_LINK);
+    const first = readFormatInformation(matrix, "first");
+    expect(FORMAT_INFORMATION_M).toContain(first);
+    expect(readFormatInformation(matrix, "second")).toBe(first);
+  });
+
+  it("writes the published version information for versions 7 and above", () => {
+    for (const [version, expected] of VERSION_INFORMATION) {
+      const payloads: Record<number, number> = { 7: 122, 8: 152, 9: 180, 10: 213 };
+      const matrix = encodeQrCode("x".repeat(payloads[version] ?? 0));
+      expect(versionOf(matrix)).toBe(version);
+      expect(readVersionInformation(matrix, "top")).toBe(expected);
+      expect(readVersionInformation(matrix, "left")).toBe(expected);
+    }
+  });
+
+  it("places all three finder patterns", () => {
+    const matrix = encodeQrCode(SHARE_LINK);
+    for (const [originX, originY] of [
+      [0, 0],
+      [matrix.size - 7, 0],
+      [0, matrix.size - 7],
+    ]) {
+      for (let dy = 0; dy < 7; dy += 1) {
+        for (let dx = 0; dx < 7; dx += 1) {
+          const ring = Math.max(Math.abs(dx - 3), Math.abs(dy - 3));
+          expect(isDark(matrix, (originX ?? 0) + dx, (originY ?? 0) + dy)).toBe(ring !== 2);
+        }
+      }
+    }
+  });
+
+  it("draws the timing patterns and the always-dark module", () => {
+    const matrix = encodeQrCode(SHARE_LINK);
+    for (let i = 8; i < matrix.size - 8; i += 1) {
+      expect(isDark(matrix, 6, i)).toBe(i % 2 === 0);
+      expect(isDark(matrix, i, 6)).toBe(i % 2 === 0);
+    }
+    expect(isDark(matrix, 8, matrix.size - 8)).toBe(true);
+  });
+
+  it("round-trips payloads across every supported version", () => {
+    const samples = [
+      SHARE_LINK,
+      "https://one.hushh.ai/c/DEMOTOKEN",
+      "a".repeat(14),
+      "a".repeat(15),
+      "b".repeat(62),
+      "c".repeat(84),
+      "d".repeat(107),
+      "e".repeat(152),
+      "f".repeat(180),
+      "g".repeat(213),
+      "héllo wörld",
+    ];
+    for (const sample of samples) {
+      expect(decodePayload(encodeQrCode(sample))).toBe(sample);
+    }
+  });
+
+  it("rejects payloads beyond the supported capacity", () => {
+    expect(() => encodeQrCode("x".repeat(214))).toThrow(/too long/i);
+  });
+});

--- a/hushh-webapp/components/wallet-card/__tests__/wallet-card-fields.test.ts
+++ b/hushh-webapp/components/wallet-card/__tests__/wallet-card-fields.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The one URL rule lives in the service and is exercised by its own suite.
+// Mocking it here keeps this suite about the owner draft: pre-fill, limits,
+// and the projection onto the server payload.
+vi.mock("@/lib/services/wallet-card-service", () => ({
+  isAllowedWalletCardUrl: (value: string) => value.startsWith("https://"),
+}));
+
+const {
+  EMPTY_WALLET_CARD_DRAFT,
+  WALLET_CARD_MAX_SKILLS,
+  buildSmartDefaultDraft,
+  describeSharedFields,
+  draftFromPayload,
+  draftToPayload,
+  hasValidationErrors,
+  splitSkills,
+  validateDraft,
+} = await import("@/components/wallet-card/wallet-card-fields");
+
+describe("wallet card smart defaults", () => {
+  it("pre-fills from information the product already holds", () => {
+    const draft = buildSmartDefaultDraft({
+      displayName: "  Ada Lovelace  ",
+      email: "ada@example.com",
+      phoneNumber: "+91 99999 90000",
+    });
+
+    expect(draft.fullName).toBe("Ada Lovelace");
+    expect(draft.email).toBe("ada@example.com");
+    expect(draft.phone).toBe("+91 99999 90000");
+    expect(draft.preferredContact).toBe("email");
+  });
+
+  it("falls back to phone when there is no email on the account", () => {
+    expect(
+      buildSmartDefaultDraft({ displayName: "Ada", phoneNumber: "+91 99999 90000" })
+        .preferredContact,
+    ).toBe("phone");
+  });
+
+  it("invents nothing when the account has nothing to offer", () => {
+    expect(buildSmartDefaultDraft({})).toEqual(EMPTY_WALLET_CARD_DRAFT);
+  });
+});
+
+describe("wallet card draft validation", () => {
+  it("accepts a draft made only of smart defaults", () => {
+    const draft = buildSmartDefaultDraft({
+      displayName: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+
+    expect(hasValidationErrors(validateDraft(draft))).toBe(false);
+  });
+
+  it("rejects a malformed email and phone", () => {
+    expect(
+      validateDraft({ ...EMPTY_WALLET_CARD_DRAFT, email: "not an email" }).email,
+    ).toBeTruthy();
+    expect(
+      validateDraft({
+        ...EMPTY_WALLET_CARD_DRAFT,
+        preferredContact: "phone",
+        phone: "call me",
+      }).phone,
+    ).toBeTruthy();
+  });
+
+  it("rejects links that are not https", () => {
+    const errors = validateDraft({
+      ...EMPTY_WALLET_CARD_DRAFT,
+      email: "ada@example.com",
+      website: "javascript:alert(1)",
+      linkedin: "http://linkedin.com/in/ada",
+    });
+
+    expect(errors.website).toBeTruthy();
+    expect(errors.linkedin).toBeTruthy();
+  });
+
+  it("enforces the per-field length caps", () => {
+    expect(
+      validateDraft({ ...EMPTY_WALLET_CARD_DRAFT, fullName: "a".repeat(81) }).fullName,
+    ).toBeTruthy();
+    expect(
+      validateDraft({ ...EMPTY_WALLET_CARD_DRAFT, fullName: "a".repeat(80) }).fullName,
+    ).toBeUndefined();
+    expect(
+      validateDraft({ ...EMPTY_WALLET_CARD_DRAFT, summary: "s".repeat(401) }).summary,
+    ).toBeTruthy();
+  });
+
+  it("caps skills at twelve entries of forty characters", () => {
+    const tooMany = Array.from({ length: WALLET_CARD_MAX_SKILLS + 1 }, (_, i) => `s${i}`);
+    expect(
+      validateDraft({ ...EMPTY_WALLET_CARD_DRAFT, skills: tooMany.join(", ") }).skills,
+    ).toBeTruthy();
+    expect(
+      validateDraft({ ...EMPTY_WALLET_CARD_DRAFT, skills: "x".repeat(41) }).skills,
+    ).toBeTruthy();
+  });
+
+  it("will not let the preferred contact point at an empty field", () => {
+    const errors = validateDraft({
+      ...EMPTY_WALLET_CARD_DRAFT,
+      preferredContact: "linkedin",
+    });
+
+    expect(errors.preferredContact).toBeTruthy();
+  });
+});
+
+describe("wallet card payload projection", () => {
+  it("omits empty values instead of storing blanks", () => {
+    const payload = draftToPayload({
+      ...EMPTY_WALLET_CARD_DRAFT,
+      fullName: "  Ada Lovelace  ",
+      email: "ada@example.com",
+    });
+
+    expect(payload).toEqual({
+      full_name: "Ada Lovelace",
+      email: "ada@example.com",
+      preferred_contact: "email",
+    });
+  });
+
+  it("splits, trims, and caps the skills line", () => {
+    const payload = draftToPayload({
+      ...EMPTY_WALLET_CARD_DRAFT,
+      email: "ada@example.com",
+      skills: " Python , , Cryptography ",
+    });
+
+    expect(payload.skills).toEqual(["Python", "Cryptography"]);
+    expect(splitSkills("")).toEqual([]);
+  });
+
+  it("drops the preferred contact when its field is empty", () => {
+    const payload = draftToPayload({
+      ...EMPTY_WALLET_CARD_DRAFT,
+      fullName: "Ada Lovelace",
+    });
+
+    expect(payload.preferred_contact).toBeUndefined();
+  });
+
+  it("round-trips a stored payload back into an editable draft", () => {
+    const payload = {
+      full_name: "Ada Lovelace",
+      headline: "Founder, Hussh",
+      skills: ["Python", "Cryptography"],
+      email: "ada@example.com",
+      preferred_contact: "email" as const,
+    };
+
+    const draft = draftFromPayload(payload);
+
+    expect(draft.fullName).toBe("Ada Lovelace");
+    expect(draft.skills).toBe("Python, Cryptography");
+    expect(draftToPayload(draft)).toEqual(payload);
+  });
+
+  it("lists what a scan will reveal, photo included", () => {
+    const shared = describeSharedFields({
+      ...EMPTY_WALLET_CARD_DRAFT,
+      fullName: "Ada Lovelace",
+      headline: "Founder, Hussh",
+      email: "ada@example.com",
+    });
+
+    expect(shared).toEqual(["Name", "Photo", "Headline", "Email"]);
+  });
+});

--- a/hushh-webapp/components/wallet-card/public-card-view.tsx
+++ b/hushh-webapp/components/wallet-card/public-card-view.tsx
@@ -1,0 +1,671 @@
+"use client";
+
+/**
+ * Public Wallet Profile card — the surface a stranger sees after scanning the
+ * QR on someone's Hussh One Wallet pass.
+ *
+ * Design rules this file encodes (see the Wallet Card contract):
+ * - The visitor has no account, no app, and may be on any device. Identity
+ *   first, direct actions second, details last, readable in one screen.
+ * - Render only the fields that are actually present. A missing field never
+ *   produces an empty row, a dash, or a placeholder.
+ * - Values arrive as plain strings and are rendered as text by React. No
+ *   `dangerouslySetInnerHTML`, ever.
+ * - The server already allowlists and validates `card_payload`; the helpers
+ *   here re-validate on the client as defence in depth so a malformed or
+ *   hostile projection can never produce a `javascript:` / `data:` link.
+ * - No analytics: this module imports nothing from the observability layer.
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  Briefcase,
+  Download,
+  ExternalLink,
+  Globe,
+  Mail,
+  MapPin,
+  Phone,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** Mirrors the server-side `preferred_contact` closed set. */
+export type WalletCardPreferredContact =
+  | "email"
+  | "phone"
+  | "linkedin"
+  | "website";
+
+/**
+ * The visitor-facing projection, already normalised and re-validated.
+ * Every field is nullable because every shared field is optional.
+ */
+export interface PublicWalletCard {
+  fullName: string | null;
+  headline: string | null;
+  organisation: string | null;
+  locationLabel: string | null;
+  summary: string | null;
+  skills: readonly string[];
+  email: string | null;
+  phone: string | null;
+  website: string | null;
+  linkedin: string | null;
+  github: string | null;
+  portfolio: string | null;
+  preferredContact: WalletCardPreferredContact | null;
+  avatarUrl: string | null;
+  updatedAt: string | null;
+}
+
+/** Length caps mirror the server allowlist so the client cannot render more. */
+const MAX_LENGTHS = {
+  fullName: 80,
+  headline: 120,
+  organisation: 80,
+  locationLabel: 80,
+  summary: 400,
+  skill: 40,
+  email: 254,
+  phone: 32,
+  url: 300,
+  preferredContact: 16,
+  avatarUrl: 2048,
+  timestamp: 64,
+} as const;
+
+const MAX_SKILLS = 12;
+const VCARD_LINE_LIMIT = 75;
+
+const PREFERRED_CONTACTS: readonly WalletCardPreferredContact[] = [
+  "email",
+  "phone",
+  "linkedin",
+  "website",
+];
+
+// Deliberately conservative: no whitespace, no delimiters that let a value
+// break out of a `mailto:` header, exactly one `@`, at least one dot label.
+const EMAIL_SHAPE = /^[^\s@,;:<>"'\\]+@[^\s@,;:<>"'\\.]+(?:\.[^\s@,;:<>"'\\.]+)+$/;
+// Display shape only. The dial string is rebuilt from digits.
+const PHONE_SHAPE = /^[+()\-.\s\d]{5,32}$/;
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as UnknownRecord;
+}
+
+function pickString(
+  source: UnknownRecord,
+  keys: readonly string[],
+  maxLength: number,
+): string | null {
+  for (const key of keys) {
+    const raw = source[key];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    return trimmed.slice(0, maxLength);
+  }
+  return null;
+}
+
+/**
+ * Accept only absolute `https://` URLs with no embedded credentials.
+ * Anything else — `javascript:`, `data:`, `http:`, `user@host` forms,
+ * protocol-relative or relative strings — resolves to null and is dropped.
+ */
+export function safeHttpsUrl(value: string | null): string | null {
+  if (!value) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") return null;
+  if (parsed.username || parsed.password) return null;
+  return parsed.toString();
+}
+
+export function safeEmail(value: string | null): string | null {
+  if (!value) return null;
+  const candidate = value.trim();
+  if (!candidate || candidate.length > MAX_LENGTHS.email) return null;
+  return EMAIL_SHAPE.test(candidate) ? candidate : null;
+}
+
+export function safePhone(value: string | null): string | null {
+  if (!value) return null;
+  const candidate = value.trim();
+  if (!PHONE_SHAPE.test(candidate)) return null;
+  return candidate.replace(/\D/g, "").length >= 5 ? candidate : null;
+}
+
+/** Build a `tel:` target from digits only, keeping a leading `+` if present. */
+export function telHref(phone: string): string {
+  const trimmed = phone.trim();
+  const prefix = trimmed.startsWith("+") ? "+" : "";
+  return `tel:${prefix}${trimmed.replace(/\D/g, "")}`;
+}
+
+export function mailtoHref(email: string): string {
+  return `mailto:${encodeURIComponent(email).replace(/%40/g, "@")}`;
+}
+
+function pickSkills(source: UnknownRecord): string[] {
+  const raw = source.skills;
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<string>();
+  const skills: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim().slice(0, MAX_LENGTHS.skill);
+    if (!trimmed) continue;
+    const dedupeKey = trimmed.toLowerCase();
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    skills.push(trimmed);
+    if (skills.length >= MAX_SKILLS) break;
+  }
+  return skills;
+}
+
+function pickPreferredContact(
+  source: UnknownRecord,
+): WalletCardPreferredContact | null {
+  const raw = pickString(
+    source,
+    ["preferredContact", "preferred_contact"],
+    MAX_LENGTHS.preferredContact,
+  );
+  if (!raw) return null;
+  const candidate = raw.toLowerCase();
+  return (
+    PREFERRED_CONTACTS.find((option) => option === candidate) ?? null
+  );
+}
+
+/**
+ * Normalise whatever the public resolve endpoint returned into the exact shape
+ * this page renders.
+ *
+ * Accepts the projection either bare or wrapped (`{ card: … }` / `{ profile: … }`)
+ * and tolerates both camelCase and snake_case keys, so a wire-format change on
+ * the backend degrades to a missing field rather than a broken page.
+ *
+ * Returns null when there is nothing renderable — the caller treats that the
+ * same way it treats a 404, so a stranger never sees an empty shell.
+ */
+export function normalizePublicWalletCard(
+  raw: unknown,
+): PublicWalletCard | null {
+  const envelope = asRecord(raw);
+  if (!envelope) return null;
+  const source =
+    asRecord(envelope.card) ?? asRecord(envelope.profile) ?? envelope;
+
+  const website = safeHttpsUrl(
+    pickString(source, ["website"], MAX_LENGTHS.url),
+  );
+  const portfolioRaw = safeHttpsUrl(
+    pickString(source, ["portfolio"], MAX_LENGTHS.url),
+  );
+
+  const card: PublicWalletCard = {
+    fullName: pickString(
+      source,
+      ["fullName", "full_name", "displayName", "display_name"],
+      MAX_LENGTHS.fullName,
+    ),
+    headline: pickString(source, ["headline"], MAX_LENGTHS.headline),
+    organisation: pickString(
+      source,
+      ["organisation", "organization"],
+      MAX_LENGTHS.organisation,
+    ),
+    locationLabel: pickString(
+      source,
+      ["locationLabel", "location_label"],
+      MAX_LENGTHS.locationLabel,
+    ),
+    summary: pickString(source, ["summary"], MAX_LENGTHS.summary),
+    skills: pickSkills(source),
+    email: safeEmail(pickString(source, ["email"], MAX_LENGTHS.email)),
+    phone: safePhone(pickString(source, ["phone"], MAX_LENGTHS.phone)),
+    website,
+    linkedin: safeHttpsUrl(
+      pickString(source, ["linkedin"], MAX_LENGTHS.url),
+    ),
+    github: safeHttpsUrl(pickString(source, ["github"], MAX_LENGTHS.url)),
+    // A portfolio identical to the website would render the same link twice.
+    portfolio: portfolioRaw && portfolioRaw !== website ? portfolioRaw : null,
+    preferredContact: pickPreferredContact(source),
+    avatarUrl: safeHttpsUrl(
+      pickString(
+        source,
+        ["avatarUrl", "avatar_url", "photoUrl", "photo_url"],
+        MAX_LENGTHS.avatarUrl,
+      ),
+    ),
+    updatedAt: pickString(
+      source,
+      ["updatedAt", "updated_at"],
+      MAX_LENGTHS.timestamp,
+    ),
+  };
+
+  return hasRenderableContent(card) ? card : null;
+}
+
+function hasRenderableContent(card: PublicWalletCard): boolean {
+  return Boolean(
+    card.fullName ||
+      card.headline ||
+      card.organisation ||
+      card.summary ||
+      card.email ||
+      card.phone ||
+      card.website ||
+      card.linkedin ||
+      card.github ||
+      card.portfolio ||
+      card.skills.length > 0,
+  );
+}
+
+/* ------------------------------------------------------------------ vCard */
+
+function escapeVCardValue(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r\n|\r|\n/g, "\\n");
+}
+
+/** RFC 6350 line folding: continuation lines start with a single space. */
+function foldVCardLine(line: string): string {
+  if (line.length <= VCARD_LINE_LIMIT) return line;
+  const parts: string[] = [line.slice(0, VCARD_LINE_LIMIT)];
+  let index = VCARD_LINE_LIMIT;
+  while (index < line.length) {
+    parts.push(` ${line.slice(index, index + VCARD_LINE_LIMIT - 1)}`);
+    index += VCARD_LINE_LIMIT - 1;
+  }
+  return parts.join("\r\n");
+}
+
+function splitName(fullName: string): { family: string; given: string } {
+  const parts = fullName.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { family: "", given: "" };
+  if (parts.length === 1) return { family: "", given: parts[0] ?? "" };
+  return {
+    family: parts[parts.length - 1] ?? "",
+    given: parts.slice(0, -1).join(" "),
+  };
+}
+
+/** Build the contact file from the projection. Client-side only, no network. */
+export function buildVCard(card: PublicWalletCard): string {
+  const lines: string[] = ["BEGIN:VCARD", "VERSION:3.0"];
+
+  if (card.fullName) {
+    const { family, given } = splitName(card.fullName);
+    lines.push(
+      `N:${escapeVCardValue(family)};${escapeVCardValue(given)};;;`,
+      `FN:${escapeVCardValue(card.fullName)}`,
+    );
+  }
+  if (card.headline) {
+    lines.push(`TITLE:${escapeVCardValue(card.headline)}`);
+  }
+  if (card.organisation) {
+    lines.push(`ORG:${escapeVCardValue(card.organisation)}`);
+  }
+  if (card.email) {
+    lines.push(`EMAIL;TYPE=INTERNET:${escapeVCardValue(card.email)}`);
+  }
+  if (card.phone) {
+    lines.push(`TEL;TYPE=CELL:${escapeVCardValue(card.phone)}`);
+  }
+  if (card.locationLabel) {
+    lines.push(`ADR;TYPE=WORK:;;;${escapeVCardValue(card.locationLabel)};;;`);
+  }
+  const urls = [card.website, card.portfolio, card.linkedin, card.github];
+  const seenUrls = new Set<string>();
+  for (const url of urls) {
+    if (!url || seenUrls.has(url)) continue;
+    seenUrls.add(url);
+    lines.push(`URL:${escapeVCardValue(url)}`);
+  }
+  if (card.summary) {
+    lines.push(`NOTE:${escapeVCardValue(card.summary)}`);
+  }
+  lines.push("END:VCARD");
+
+  return `${lines.map(foldVCardLine).join("\r\n")}\r\n`;
+}
+
+export function vCardFileName(card: PublicWalletCard): string {
+  const slug = (card.fullName ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  return `${slug || "contact"}.vcf`;
+}
+
+/* ---------------------------------------------------------------- actions */
+
+interface CardAction {
+  id: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  external: boolean;
+}
+
+function buildActions(card: PublicWalletCard): CardAction[] {
+  const actions: CardAction[] = [];
+  if (card.email) {
+    actions.push({
+      id: "email",
+      label: "Email",
+      href: mailtoHref(card.email),
+      icon: Mail,
+      external: false,
+    });
+  }
+  if (card.phone) {
+    actions.push({
+      id: "phone",
+      label: "Call",
+      href: telHref(card.phone),
+      icon: Phone,
+      external: false,
+    });
+  }
+  if (card.linkedin) {
+    actions.push({
+      id: "linkedin",
+      label: "LinkedIn",
+      href: card.linkedin,
+      icon: ExternalLink,
+      external: true,
+    });
+  }
+  if (card.github) {
+    actions.push({
+      id: "github",
+      label: "GitHub",
+      href: card.github,
+      icon: ExternalLink,
+      external: true,
+    });
+  }
+  if (card.portfolio) {
+    actions.push({
+      id: "portfolio",
+      label: "Portfolio",
+      href: card.portfolio,
+      icon: Globe,
+      external: true,
+    });
+  }
+  if (card.website) {
+    actions.push({
+      id: "website",
+      label: "Website",
+      href: card.website,
+      icon: Globe,
+      external: true,
+    });
+  }
+
+  // The owner's preferred channel leads, so the visitor's first tap is the one
+  // the owner actually wants. Everything else keeps its declared order.
+  const preferred = card.preferredContact;
+  if (!preferred) return actions;
+  const preferredIndex = actions.findIndex((action) => action.id === preferred);
+  if (preferredIndex <= 0) return actions;
+  const [preferredAction] = actions.splice(preferredIndex, 1);
+  return preferredAction ? [preferredAction, ...actions] : actions;
+}
+
+function initialsFor(fullName: string | null): string {
+  if (!fullName) return "";
+  const parts = fullName.split(/\s+/).filter(Boolean);
+  const first = parts[0]?.charAt(0) ?? "";
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.charAt(0) ?? "") : "";
+  return `${first}${last}`.toUpperCase();
+}
+
+function formatUpdatedLabel(value: string | null): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
+}
+
+function ActionLink({
+  action,
+  emphasis,
+}: {
+  action: CardAction;
+  emphasis: "primary" | "secondary";
+}) {
+  const Icon = action.icon;
+  return (
+    <Button
+      asChild
+      variant={emphasis === "primary" ? "default" : "outline"}
+      className="h-12 w-full justify-start gap-3 px-4 text-[15px]"
+    >
+      <a
+        href={action.href}
+        {...(action.external
+          ? { target: "_blank", rel: "noopener noreferrer" }
+          : {})}
+      >
+        <Icon className="size-[18px]" aria-hidden="true" />
+        <span className="truncate">{action.label}</span>
+        {action.external ? (
+          <span className="sr-only">(opens in a new tab)</span>
+        ) : null}
+      </a>
+    </Button>
+  );
+}
+
+/* ------------------------------------------------------------------- view */
+
+export function PublicWalletCardView({ card }: { card: PublicWalletCard }) {
+  const actions = useMemo(() => buildActions(card), [card]);
+  const initials = useMemo(() => initialsFor(card.fullName), [card.fullName]);
+  const updatedLabel = useMemo(
+    () => formatUpdatedLabel(card.updatedAt),
+    [card.updatedAt],
+  );
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const handleSaveContact = useCallback(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+    try {
+      const blob = new Blob([buildVCard(card)], {
+        type: "text/vcard;charset=utf-8",
+      });
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = vCardFileName(card);
+      anchor.rel = "noopener";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+      setSaveError(null);
+    } catch {
+      setSaveError(
+        "We couldn't create the contact file. Use one of the links above instead.",
+      );
+    }
+  }, [card]);
+
+  const [primaryAction, ...secondaryActions] = actions;
+  const hasDetails = Boolean(card.summary) || card.skills.length > 0;
+  const hasMeta = Boolean(card.organisation) || Boolean(card.locationLabel);
+
+  return (
+    <article className="space-y-6 rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--shadow-xs)] sm:p-7">
+      <header className="flex flex-col items-center gap-3 text-center">
+        <Avatar className="size-20 border border-border/60 sm:size-24">
+          {card.avatarUrl ? (
+            <AvatarImage src={card.avatarUrl} alt="" />
+          ) : null}
+          <AvatarFallback className="text-xl font-medium">
+            {initials || <Briefcase className="size-7" aria-hidden="true" />}
+          </AvatarFallback>
+        </Avatar>
+
+        {card.fullName ? (
+          <h1 className="text-[26px] font-medium leading-[1.15] tracking-tight sm:text-[30px]">
+            {card.fullName}
+          </h1>
+        ) : (
+          <h1 className="sr-only">Shared profile</h1>
+        )}
+
+        {card.headline ? (
+          <p className="text-base leading-6 text-muted-foreground">
+            {card.headline}
+          </p>
+        ) : null}
+
+        {hasMeta ? (
+          <p className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-sm leading-6 text-muted-foreground">
+            {card.organisation ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Briefcase className="size-3.5" aria-hidden="true" />
+                {card.organisation}
+              </span>
+            ) : null}
+            {card.locationLabel ? (
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="size-3.5" aria-hidden="true" />
+                {card.locationLabel}
+              </span>
+            ) : null}
+          </p>
+        ) : null}
+      </header>
+
+      <section aria-labelledby="wallet-card-actions-heading" className="space-y-2">
+        <h2 id="wallet-card-actions-heading" className="sr-only">
+          Ways to get in touch
+        </h2>
+
+        {primaryAction ? (
+          <ActionLink action={primaryAction} emphasis="primary" />
+        ) : null}
+        {secondaryActions.map((action) => (
+          <ActionLink key={action.id} action={action} emphasis="secondary" />
+        ))}
+
+        <div className="space-y-1.5 pt-1">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleSaveContact}
+            aria-describedby="wallet-card-save-hint"
+            className="h-12 w-full justify-start gap-3 px-4 text-[15px]"
+          >
+            <Download className="size-[18px]" aria-hidden="true" />
+            Save contact
+          </Button>
+          <p
+            id="wallet-card-save-hint"
+            className="px-1 text-xs leading-5 text-muted-foreground"
+          >
+            Downloads a contact file. On iPhone, open it and tap Create New
+            Contact.
+          </p>
+          {saveError ? (
+            <p role="alert" className="px-1 text-xs leading-5 text-destructive">
+              {saveError}
+            </p>
+          ) : null}
+        </div>
+      </section>
+
+      {hasDetails ? (
+        <section aria-labelledby="wallet-card-details-heading" className="space-y-4">
+          <h2 id="wallet-card-details-heading" className="sr-only">
+            About
+          </h2>
+          {card.summary ? (
+            <p className="text-sm leading-6 text-foreground/90">
+              {card.summary}
+            </p>
+          ) : null}
+          {card.summary && card.skills.length > 0 ? <Separator /> : null}
+          {card.skills.length > 0 ? (
+            <ul className="flex flex-wrap gap-2">
+              {card.skills.map((skill) => (
+                <li key={skill}>
+                  <Badge variant="secondary" className="px-2.5 py-1 text-xs">
+                    {skill}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      ) : null}
+
+      <footer className="space-y-1 border-t border-border/60 pt-4 text-center text-xs leading-5 text-muted-foreground">
+        <p>Shared from Hussh One</p>
+        {updatedLabel ? <p>Updated {updatedLabel}</p> : null}
+      </footer>
+    </article>
+  );
+}
+
+/** Cold-load placeholder. Matches the real card's rhythm to avoid a jump. */
+export function PublicWalletCardSkeleton() {
+  return (
+    <div
+      className="space-y-6 rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)] p-5 shadow-[var(--shadow-xs)] sm:p-7"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span className="sr-only">Loading profile.</span>
+      <div className="flex flex-col items-center gap-3">
+        <Skeleton className="size-20 rounded-full sm:size-24" />
+        <Skeleton className="h-7 w-48 rounded-lg" />
+        <Skeleton className="h-4 w-36 rounded-lg" />
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-12 w-full rounded-full" />
+        <Skeleton className="h-12 w-full rounded-full" />
+        <Skeleton className="h-12 w-full rounded-full" />
+      </div>
+      <Skeleton className="h-16 w-full rounded-xl" />
+    </div>
+  );
+}

--- a/hushh-webapp/components/wallet-card/qr-code.ts
+++ b/hushh-webapp/components/wallet-card/qr-code.ts
@@ -1,0 +1,553 @@
+/**
+ * Self-contained QR Code encoder for the Wallet Profile share link.
+ *
+ * Scope is deliberately narrow: byte mode, error-correction level M, versions
+ * 1-10 (up to 213 bytes), automatic mask selection. That is far more than a
+ * share URL needs and keeps the tables small.
+ *
+ * This lives in the repo instead of a dependency because the Wallet Profile is
+ * the only QR surface in the product and the encoder must run offline inside
+ * the native WebView. It renders the owner's own share URL; nothing here ever
+ * touches vault material.
+ */
+
+/** A finished QR symbol. `isDark(x, y)` reads a module; origin is top-left. */
+export interface QrCodeMatrix {
+  /** Module count per side, excluding the quiet zone. */
+  readonly size: number;
+  /** Row-major dark-module flags, length `size * size`. */
+  readonly modules: Uint8Array;
+}
+
+interface QrVersionSpec {
+  /** Total codewords (data + error correction) for the version. */
+  readonly totalCodewords: number;
+  /** Error-correction codewords per block at level M. */
+  readonly eccPerBlock: number;
+  /** Number of interleaved blocks at level M. */
+  readonly blocks: number;
+}
+
+/** Versions 1-10 at error-correction level M. */
+const VERSION_SPECS: readonly QrVersionSpec[] = [
+  { totalCodewords: 26, eccPerBlock: 10, blocks: 1 },
+  { totalCodewords: 44, eccPerBlock: 16, blocks: 1 },
+  { totalCodewords: 70, eccPerBlock: 26, blocks: 1 },
+  { totalCodewords: 100, eccPerBlock: 18, blocks: 2 },
+  { totalCodewords: 134, eccPerBlock: 24, blocks: 2 },
+  { totalCodewords: 172, eccPerBlock: 16, blocks: 4 },
+  { totalCodewords: 196, eccPerBlock: 18, blocks: 4 },
+  { totalCodewords: 242, eccPerBlock: 22, blocks: 4 },
+  { totalCodewords: 292, eccPerBlock: 22, blocks: 5 },
+  { totalCodewords: 346, eccPerBlock: 26, blocks: 5 },
+];
+
+/** Level M is `00` in the two-bit error-correction indicator. */
+const ECC_LEVEL_M_BITS = 0b00;
+const BYTE_MODE_INDICATOR = 0b0100;
+const PAD_BYTES = [0xec, 0x11] as const;
+
+// ---------------------------------------------------------------------------
+// GF(256) arithmetic (primitive polynomial 0x11D)
+// ---------------------------------------------------------------------------
+
+const GF_EXP = new Uint8Array(512);
+const GF_LOG = new Uint8Array(256);
+
+(() => {
+  let value = 1;
+  for (let i = 0; i < 255; i += 1) {
+    GF_EXP[i] = value;
+    GF_LOG[value] = i;
+    value <<= 1;
+    if ((value & 0x100) !== 0) {
+      value ^= 0x11d;
+    }
+  }
+  for (let i = 255; i < 512; i += 1) {
+    GF_EXP[i] = GF_EXP[i - 255] ?? 0;
+  }
+})();
+
+function gfExp(index: number): number {
+  return GF_EXP[index] ?? 0;
+}
+
+function gfLog(value: number): number {
+  return GF_LOG[value] ?? 0;
+}
+
+function gfMultiply(left: number, right: number): number {
+  if (left === 0 || right === 0) return 0;
+  return gfExp(gfLog(left) + gfLog(right));
+}
+
+/** Reed-Solomon generator polynomial of the given degree, highest term first. */
+function generatorPolynomial(degree: number): Uint8Array {
+  let poly = new Uint8Array([1]);
+  for (let i = 0; i < degree; i += 1) {
+    const next = new Uint8Array(poly.length + 1);
+    for (let j = 0; j < poly.length; j += 1) {
+      const coefficient = poly[j] ?? 0;
+      next[j] = (next[j] ?? 0) ^ coefficient;
+      next[j + 1] = (next[j + 1] ?? 0) ^ gfMultiply(coefficient, gfExp(i));
+    }
+    poly = next;
+  }
+  return poly;
+}
+
+/** Error-correction codewords for one data block. */
+function errorCorrectionCodewords(data: Uint8Array, degree: number): Uint8Array {
+  const generator = generatorPolynomial(degree);
+  const remainder = new Uint8Array(degree);
+  for (let index = 0; index < data.length; index += 1) {
+    const factor = (data[index] ?? 0) ^ (remainder[0] ?? 0);
+    remainder.copyWithin(0, 1);
+    remainder[degree - 1] = 0;
+    for (let i = 0; i < degree; i += 1) {
+      remainder[i] = (remainder[i] ?? 0) ^ gfMultiply(generator[i + 1] ?? 0, factor);
+    }
+  }
+  return remainder;
+}
+
+// ---------------------------------------------------------------------------
+// Bit stream
+// ---------------------------------------------------------------------------
+
+class BitBuffer {
+  private readonly bits: number[] = [];
+
+  append(value: number, length: number): void {
+    for (let i = length - 1; i >= 0; i -= 1) {
+      this.bits.push((value >>> i) & 1);
+    }
+  }
+
+  get length(): number {
+    return this.bits.length;
+  }
+
+  padToByteBoundary(): void {
+    while (this.bits.length % 8 !== 0) {
+      this.bits.push(0);
+    }
+  }
+
+  toBytes(): Uint8Array {
+    const bytes = new Uint8Array(this.bits.length / 8);
+    for (let i = 0; i < this.bits.length; i += 1) {
+      if ((this.bits[i] ?? 0) === 1) {
+        const byteIndex = Math.floor(i / 8);
+        bytes[byteIndex] = (bytes[byteIndex] ?? 0) | (0x80 >>> i % 8);
+      }
+    }
+    return bytes;
+  }
+}
+
+function characterCountBits(version: number): number {
+  return version < 10 ? 8 : 16;
+}
+
+function versionSpec(version: number): QrVersionSpec {
+  const spec = VERSION_SPECS[version - 1];
+  if (!spec) {
+    throw new Error(`Unsupported QR version: ${version}`);
+  }
+  return spec;
+}
+
+function dataCodewordCount(version: number): number {
+  const spec = versionSpec(version);
+  return spec.totalCodewords - spec.eccPerBlock * spec.blocks;
+}
+
+/** Smallest supported version that fits `byteLength` bytes at level M. */
+function selectVersion(byteLength: number): number {
+  for (let version = 1; version <= VERSION_SPECS.length; version += 1) {
+    const capacityBits = dataCodewordCount(version) * 8;
+    const requiredBits = 4 + characterCountBits(version) + byteLength * 8;
+    if (requiredBits <= capacityBits) {
+      return version;
+    }
+  }
+  throw new Error("Value is too long to encode as a QR code");
+}
+
+/** Mode + length header, payload, terminator, and pad bytes. */
+function buildDataCodewords(payload: Uint8Array, version: number): Uint8Array {
+  const capacity = dataCodewordCount(version);
+  const buffer = new BitBuffer();
+  buffer.append(BYTE_MODE_INDICATOR, 4);
+  buffer.append(payload.length, characterCountBits(version));
+  for (const byte of payload) {
+    buffer.append(byte, 8);
+  }
+
+  const capacityBits = capacity * 8;
+  buffer.append(0, Math.min(4, capacityBits - buffer.length));
+  buffer.padToByteBoundary();
+
+  const bytes = buffer.toBytes();
+  const codewords = new Uint8Array(capacity);
+  codewords.set(bytes.subarray(0, capacity));
+  for (let i = bytes.length; i < capacity; i += 1) {
+    codewords[i] = PAD_BYTES[(i - bytes.length) % 2] ?? 0;
+  }
+  return codewords;
+}
+
+/** Split into blocks, add error correction, and interleave per the spec. */
+function buildFinalCodewords(dataCodewords: Uint8Array, version: number): Uint8Array {
+  const spec = versionSpec(version);
+  const shortBlockLength = Math.floor(dataCodewords.length / spec.blocks);
+  const longBlockCount = dataCodewords.length % spec.blocks;
+
+  const dataBlocks: Uint8Array[] = [];
+  const eccBlocks: Uint8Array[] = [];
+  let offset = 0;
+  for (let block = 0; block < spec.blocks; block += 1) {
+    const length = shortBlockLength + (block >= spec.blocks - longBlockCount ? 1 : 0);
+    const data = dataCodewords.subarray(offset, offset + length);
+    offset += length;
+    dataBlocks.push(data);
+    eccBlocks.push(errorCorrectionCodewords(data, spec.eccPerBlock));
+  }
+
+  const result = new Uint8Array(spec.totalCodewords);
+  let cursor = 0;
+  const longestData = shortBlockLength + (longBlockCount > 0 ? 1 : 0);
+  for (let i = 0; i < longestData; i += 1) {
+    for (const block of dataBlocks) {
+      if (i < block.length) {
+        result[cursor] = block[i] ?? 0;
+        cursor += 1;
+      }
+    }
+  }
+  for (let i = 0; i < spec.eccPerBlock; i += 1) {
+    for (const block of eccBlocks) {
+      result[cursor] = block[i] ?? 0;
+      cursor += 1;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Symbol layout
+// ---------------------------------------------------------------------------
+
+class QrCanvas {
+  readonly size: number;
+  readonly dark: Uint8Array;
+  readonly reserved: Uint8Array;
+
+  constructor(version: number) {
+    this.size = version * 4 + 17;
+    this.dark = new Uint8Array(this.size * this.size);
+    this.reserved = new Uint8Array(this.size * this.size);
+  }
+
+  private index(x: number, y: number): number {
+    return y * this.size + x;
+  }
+
+  isDark(x: number, y: number): boolean {
+    if (x < 0 || y < 0 || x >= this.size || y >= this.size) return false;
+    return (this.dark[this.index(x, y)] ?? 0) === 1;
+  }
+
+  isReserved(x: number, y: number): boolean {
+    if (x < 0 || y < 0 || x >= this.size || y >= this.size) return true;
+    return (this.reserved[this.index(x, y)] ?? 0) === 1;
+  }
+
+  setModule(x: number, y: number, dark: boolean): void {
+    if (x < 0 || y < 0 || x >= this.size || y >= this.size) return;
+    this.dark[this.index(x, y)] = dark ? 1 : 0;
+  }
+
+  setFunctionModule(x: number, y: number, dark: boolean): void {
+    if (x < 0 || y < 0 || x >= this.size || y >= this.size) return;
+    this.dark[this.index(x, y)] = dark ? 1 : 0;
+    this.reserved[this.index(x, y)] = 1;
+  }
+}
+
+function getBit(value: number, position: number): boolean {
+  return ((value >>> position) & 1) !== 0;
+}
+
+function alignmentPatternPositions(version: number, size: number): number[] {
+  if (version === 1) return [];
+  const count = Math.floor(version / 7) + 2;
+  const step = Math.ceil((version * 4 + 4) / (count * 2 - 2)) * 2;
+  const positions = [6];
+  for (let position = size - 7; positions.length < count; position -= step) {
+    positions.splice(1, 0, position);
+  }
+  return positions;
+}
+
+function drawFinderPattern(canvas: QrCanvas, centerX: number, centerY: number): void {
+  for (let dy = -4; dy <= 4; dy += 1) {
+    for (let dx = -4; dx <= 4; dx += 1) {
+      const distance = Math.max(Math.abs(dx), Math.abs(dy));
+      canvas.setFunctionModule(centerX + dx, centerY + dy, distance !== 2 && distance !== 4);
+    }
+  }
+}
+
+function drawAlignmentPattern(canvas: QrCanvas, centerX: number, centerY: number): void {
+  for (let dy = -2; dy <= 2; dy += 1) {
+    for (let dx = -2; dx <= 2; dx += 1) {
+      canvas.setFunctionModule(
+        centerX + dx,
+        centerY + dy,
+        Math.max(Math.abs(dx), Math.abs(dy)) !== 1,
+      );
+    }
+  }
+}
+
+/** 15-bit BCH format information for level M and the given mask. */
+function formatInformationBits(mask: number): number {
+  const data = (ECC_LEVEL_M_BITS << 3) | mask;
+  let remainder = data;
+  for (let i = 0; i < 10; i += 1) {
+    remainder = (remainder << 1) ^ ((remainder >>> 9) * 0x537);
+  }
+  return ((data << 10) | remainder) ^ 0x5412;
+}
+
+function drawFormatBits(canvas: QrCanvas, mask: number): void {
+  const bits = formatInformationBits(mask);
+  const size = canvas.size;
+
+  for (let i = 0; i <= 5; i += 1) {
+    canvas.setFunctionModule(8, i, getBit(bits, i));
+  }
+  canvas.setFunctionModule(8, 7, getBit(bits, 6));
+  canvas.setFunctionModule(8, 8, getBit(bits, 7));
+  canvas.setFunctionModule(7, 8, getBit(bits, 8));
+  for (let i = 9; i < 15; i += 1) {
+    canvas.setFunctionModule(14 - i, 8, getBit(bits, i));
+  }
+
+  for (let i = 0; i < 8; i += 1) {
+    canvas.setFunctionModule(size - 1 - i, 8, getBit(bits, i));
+  }
+  for (let i = 8; i < 15; i += 1) {
+    canvas.setFunctionModule(8, size - 15 + i, getBit(bits, i));
+  }
+  canvas.setFunctionModule(8, size - 8, true);
+}
+
+/** 18-bit BCH version information, drawn only for versions 7 and above. */
+function drawVersionBits(canvas: QrCanvas, version: number): void {
+  if (version < 7) return;
+  let remainder = version;
+  for (let i = 0; i < 12; i += 1) {
+    remainder = (remainder << 1) ^ ((remainder >>> 11) * 0x1f25);
+  }
+  const bits = (version << 12) | remainder;
+  for (let i = 0; i < 18; i += 1) {
+    const bit = getBit(bits, i);
+    const far = canvas.size - 11 + (i % 3);
+    const near = Math.floor(i / 3);
+    canvas.setFunctionModule(far, near, bit);
+    canvas.setFunctionModule(near, far, bit);
+  }
+}
+
+function drawFunctionPatterns(canvas: QrCanvas, version: number): void {
+  const size = canvas.size;
+
+  for (let i = 0; i < size; i += 1) {
+    canvas.setFunctionModule(6, i, i % 2 === 0);
+    canvas.setFunctionModule(i, 6, i % 2 === 0);
+  }
+
+  drawFinderPattern(canvas, 3, 3);
+  drawFinderPattern(canvas, size - 4, 3);
+  drawFinderPattern(canvas, 3, size - 4);
+
+  const positions = alignmentPatternPositions(version, size);
+  const last = positions.length - 1;
+  for (let i = 0; i < positions.length; i += 1) {
+    for (let j = 0; j < positions.length; j += 1) {
+      const skipsFinder =
+        (i === 0 && j === 0) || (i === 0 && j === last) || (i === last && j === 0);
+      if (skipsFinder) continue;
+      drawAlignmentPattern(canvas, positions[i] ?? 0, positions[j] ?? 0);
+    }
+  }
+
+  drawFormatBits(canvas, 0);
+  drawVersionBits(canvas, version);
+}
+
+/** Zig-zag placement of the interleaved codewords into the free modules. */
+function drawCodewords(canvas: QrCanvas, codewords: Uint8Array): void {
+  const size = canvas.size;
+  let bitIndex = 0;
+  const totalBits = codewords.length * 8;
+
+  // Column pairs run right-to-left. Column 6 is the vertical timing pattern, so
+  // the pair index shifts down to 5 and every later pair follows from there.
+  let right = size - 1;
+  while (right >= 1) {
+    if (right === 6) {
+      right = 5;
+    }
+    for (let vertical = 0; vertical < size; vertical += 1) {
+      for (let column = 0; column < 2; column += 1) {
+        const x = right - column;
+        const upward = ((right + 1) & 2) === 0;
+        const y = upward ? size - 1 - vertical : vertical;
+        if (canvas.isReserved(x, y) || bitIndex >= totalBits) continue;
+        const byte = codewords[bitIndex >>> 3] ?? 0;
+        canvas.setModule(x, y, getBit(byte, 7 - (bitIndex & 7)));
+        bitIndex += 1;
+      }
+    }
+    right -= 2;
+  }
+}
+
+function maskCondition(mask: number, x: number, y: number): boolean {
+  switch (mask) {
+    case 0:
+      return (x + y) % 2 === 0;
+    case 1:
+      return y % 2 === 0;
+    case 2:
+      return x % 3 === 0;
+    case 3:
+      return (x + y) % 3 === 0;
+    case 4:
+      return (Math.floor(y / 2) + Math.floor(x / 3)) % 2 === 0;
+    case 5:
+      return ((x * y) % 2) + ((x * y) % 3) === 0;
+    case 6:
+      return (((x * y) % 2) + ((x * y) % 3)) % 2 === 0;
+    default:
+      return (((x + y) % 2) + ((x * y) % 3)) % 2 === 0;
+  }
+}
+
+function applyMask(canvas: QrCanvas, mask: number): void {
+  for (let y = 0; y < canvas.size; y += 1) {
+    for (let x = 0; x < canvas.size; x += 1) {
+      if (canvas.isReserved(x, y)) continue;
+      if (!maskCondition(mask, x, y)) continue;
+      canvas.setModule(x, y, !canvas.isDark(x, y));
+    }
+  }
+}
+
+const FINDER_LIKE_A = [true, false, true, true, true, false, true, false, false, false, false];
+const FINDER_LIKE_B = [false, false, false, false, true, false, true, true, true, false, true];
+
+function matchesFinderLike(line: boolean[], start: number, pattern: boolean[]): boolean {
+  for (let i = 0; i < pattern.length; i += 1) {
+    if (line[start + i] !== pattern[i]) return false;
+  }
+  return true;
+}
+
+function linePenalty(line: boolean[]): number {
+  let penalty = 0;
+  let runLength = 1;
+  for (let i = 1; i <= line.length; i += 1) {
+    if (i < line.length && line[i] === line[i - 1]) {
+      runLength += 1;
+      continue;
+    }
+    if (runLength >= 5) {
+      penalty += 3 + (runLength - 5);
+    }
+    runLength = 1;
+  }
+  for (let i = 0; i + FINDER_LIKE_A.length <= line.length; i += 1) {
+    if (matchesFinderLike(line, i, FINDER_LIKE_A) || matchesFinderLike(line, i, FINDER_LIKE_B)) {
+      penalty += 40;
+    }
+  }
+  return penalty;
+}
+
+function maskPenalty(canvas: QrCanvas): number {
+  const size = canvas.size;
+  let penalty = 0;
+
+  for (let y = 0; y < size; y += 1) {
+    const row: boolean[] = [];
+    for (let x = 0; x < size; x += 1) row.push(canvas.isDark(x, y));
+    penalty += linePenalty(row);
+  }
+  for (let x = 0; x < size; x += 1) {
+    const column: boolean[] = [];
+    for (let y = 0; y < size; y += 1) column.push(canvas.isDark(x, y));
+    penalty += linePenalty(column);
+  }
+
+  for (let y = 0; y < size - 1; y += 1) {
+    for (let x = 0; x < size - 1; x += 1) {
+      const value = canvas.isDark(x, y);
+      if (
+        value === canvas.isDark(x + 1, y) &&
+        value === canvas.isDark(x, y + 1) &&
+        value === canvas.isDark(x + 1, y + 1)
+      ) {
+        penalty += 3;
+      }
+    }
+  }
+
+  let darkCount = 0;
+  for (let i = 0; i < canvas.dark.length; i += 1) {
+    darkCount += canvas.dark[i] ?? 0;
+  }
+  const total = size * size;
+  const deviation = Math.abs(darkCount * 20 - total * 10);
+  penalty += Math.floor(deviation / total) * 10;
+
+  return penalty;
+}
+
+/**
+ * Encode `value` as a QR symbol (byte mode, level M).
+ *
+ * Throws when the value exceeds version 10 capacity (213 bytes), which a share
+ * URL never does.
+ */
+export function encodeQrCode(value: string): QrCodeMatrix {
+  const payload = new TextEncoder().encode(value);
+  const version = selectVersion(payload.length);
+  const codewords = buildFinalCodewords(buildDataCodewords(payload, version), version);
+
+  let best: QrCanvas | null = null;
+  let bestPenalty = Number.POSITIVE_INFINITY;
+
+  for (let mask = 0; mask < 8; mask += 1) {
+    const canvas = new QrCanvas(version);
+    drawFunctionPatterns(canvas, version);
+    drawCodewords(canvas, codewords);
+    drawFormatBits(canvas, mask);
+    applyMask(canvas, mask);
+    const penalty = maskPenalty(canvas);
+    if (penalty < bestPenalty) {
+      bestPenalty = penalty;
+      best = canvas;
+    }
+  }
+
+  if (!best) {
+    throw new Error("QR encoding failed");
+  }
+  return { size: best.size, modules: best.dark };
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-confirm-dialog.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-confirm-dialog.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+/**
+ * One confirmation surface for every action that changes or ends sharing.
+ *
+ * The body always states the effect in plain language before the owner
+ * commits — pausing, rotating, and removing all change what a stranger sees.
+ */
+export function WalletCardConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel,
+  destructive = false,
+  busy = false,
+  onConfirm,
+  onOpenChange,
+}: {
+  open: boolean;
+  title: string;
+  body: string;
+  confirmLabel: string;
+  destructive?: boolean;
+  busy?: boolean;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!busy) onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{body}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant={destructive ? "destructive" : "default"}
+            disabled={busy}
+            onClick={(event) => {
+              event.preventDefault();
+              if (!busy) onConfirm();
+            }}
+          >
+            {busy ? "Working…" : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-copy.ts
+++ b/hushh-webapp/components/wallet-card/wallet-card-copy.ts
@@ -1,0 +1,125 @@
+/**
+ * Wallet Profile copy.
+ *
+ * The strings in `WALLET_CARD_COPY` are fixed by the Wallet Card contract
+ * (docs/superpowers/specs/2026-08-03-wallet-card-contract.md §9) and are used
+ * verbatim on every surface — owner setup, owner management, and the public
+ * scanned page. Do not reword them here; change the contract first.
+ *
+ * Public prose says "Hussh". Route, API, and schema identifiers keep the
+ * legacy `hushh` spelling.
+ */
+
+export const WALLET_CARD_COPY = {
+  /** Entry point shown before a Wallet Profile exists. */
+  entryBeforeSetup: {
+    title: "Add to Apple Wallet",
+    description: "Keep your Hussh One profile ready to share.",
+  },
+  /** Setup introduction. */
+  setupIntro: {
+    title: "Your profile, ready when you need it",
+    description:
+      "Add a secure Hussh One pass to Apple Wallet and share your selected details with a simple scan.",
+  },
+  /** Privacy assurance shown alongside the shared-information review. */
+  privacyAssurance: {
+    title: "You stay in control",
+    description:
+      "Only the information you select will be visible. You can update or disable access at any time.",
+  },
+  /** Entry point shown once a Wallet Profile exists. */
+  entryAfterSetup: {
+    title: "Manage Wallet Profile",
+    description: "Control what people see when they scan your pass.",
+  },
+  /** Confirmation after the pass has been handed to Apple Wallet. */
+  success: {
+    title: "Your Hussh One pass is ready",
+    description: "You can now share your profile directly from Apple Wallet.",
+  },
+  /** Shown when pass signing is unavailable. The technical error stays server-side. */
+  signingFailure:
+    "We couldn't create your Wallet pass right now. Please try again in a moment.",
+  /** Public page state after the owner removes their Wallet Profile. */
+  revokedPage: "This profile is no longer shared.",
+  /** Public page state once the share link has expired. */
+  expiredPage: "This profile link has expired.",
+} as const;
+
+/**
+ * Owner-surface copy that supports the contract strings above. Kept in one
+ * place so the setup and management screens never drift apart.
+ */
+export const WALLET_CARD_OWNER_COPY = {
+  eyebrow: "One / Wallet Profile",
+  onlyThisInformation: "Only this information will be shared.",
+  optionalDisclosure: "Choose what people can see",
+  optionalDisclosureHint:
+    "Optional. Everything here is off until you fill it in, and you can change it later.",
+  recommendedGroupTitle: "Shared by default",
+  fromYourProfile: "From your Hussh profile",
+  reviewPrimaryAction: "Continue to preview",
+  previewTitle: "Preview",
+  walletPreviewTitle: "Wallet preview",
+  walletPreviewHint: "How your pass looks in Apple Wallet.",
+  visitorPreviewTitle: "What a visitor sees",
+  visitorPreviewHint: "The exact page someone gets when they scan your pass.",
+  visitorPreviewLoading: "Loading the visitor view…",
+  visitorPreviewError:
+    "We couldn't load the visitor view right now. Please try again in a moment.",
+  addToWallet: "Add to Apple Wallet",
+  shareLink: "Share your link",
+  copyLink: "Copy link",
+  editInformation: "Edit shared information",
+  previewAsVisitor: "Preview as visitor",
+  pauseSharing: "Pause sharing",
+  resumeSharing: "Resume sharing",
+  rotateAccess: "Rotate QR access",
+  removeProfile: "Remove Wallet profile",
+  updatesAutomatically:
+    "Your shared profile updates automatically. You never need to add the pass again after changing what you share.",
+  statusActive: "Sharing is on",
+  statusPaused: "Sharing is paused",
+  statusPausedDetail: "A scan shows nothing until you resume.",
+  lastUpdatedLabel: "Last updated",
+  scanCountLabel: "Scans",
+  lastScannedLabel: "Last scan",
+  noLinkOnThisDevice:
+    "Your share link isn't stored on this device, so the QR can't be shown here. Rotate QR access to create a new link — the current QR stops working.",
+  vaultLocked: "Unlock your vault to set up your Wallet Profile.",
+  featureUnavailable: "Wallet Profile isn't available on this account yet.",
+  loadFailed: "We couldn't load your Wallet Profile. Please try again in a moment.",
+  saveFailed: "We couldn't save your Wallet Profile. Please try again in a moment.",
+  shareFailed: "Sharing isn't supported on this device. Copy the link instead.",
+  linkCopied: "Link copied.",
+  saved: "Saved.",
+  paused: "Sharing paused.",
+  resumed: "Sharing resumed.",
+  rotated: "New QR access created. Add your pass again to pick up the new QR.",
+  removed: "Wallet profile removed.",
+} as const;
+
+/** Explanations shown before every action that changes or ends sharing. */
+export const WALLET_CARD_CONFIRMATIONS = {
+  pause: {
+    title: "Pause sharing?",
+    body: "Anyone who scans your pass will see nothing at all — the page behaves as if the profile does not exist. Your pass stays in Apple Wallet and you can resume sharing at any time.",
+    confirmLabel: "Pause sharing",
+  },
+  resume: {
+    title: "Resume sharing?",
+    body: "Your selected information becomes visible again to anyone who scans your pass. The QR is unchanged, so a pass already in Apple Wallet keeps working.",
+    confirmLabel: "Resume sharing",
+  },
+  rotate: {
+    title: "Rotate QR access?",
+    body: "The current QR stops working immediately, so anyone holding the old link loses access. A new link is created and you will need to add the pass to Apple Wallet again to pick up the new QR.",
+    confirmLabel: "Rotate QR access",
+  },
+  remove: {
+    title: "Remove Wallet profile?",
+    body: "Sharing stops immediately and anyone who scans sees that this profile is no longer shared. The pass in Apple Wallet stops resolving. This cannot be undone — you would need to set the Wallet Profile up again.",
+    confirmLabel: "Remove Wallet profile",
+  },
+} as const;

--- a/hushh-webapp/components/wallet-card/wallet-card-fields.ts
+++ b/hushh-webapp/components/wallet-card/wallet-card-fields.ts
@@ -1,0 +1,336 @@
+/**
+ * The owner-side draft model for a Wallet Profile.
+ *
+ * Every key here maps one-to-one onto the server's closed `card_payload`
+ * allowlist (contract §3). The server is the authority: it re-validates and
+ * REJECTS anything outside the allowlist. This module exists so the owner sees
+ * the same limits before saving instead of after, and so the draft can be
+ * pre-filled from information the product already holds.
+ */
+
+import {
+  isAllowedWalletCardUrl,
+  type WalletCardPayload,
+  type WalletCardPreferredContact,
+} from "@/lib/services/wallet-card-service";
+
+export type WalletCardFieldKey =
+  | "fullName"
+  | "headline"
+  | "organisation"
+  | "locationLabel"
+  | "summary"
+  | "skills"
+  | "email"
+  | "phone"
+  | "website"
+  | "linkedin"
+  | "github"
+  | "portfolio";
+
+/** Free-text draft. Skills are edited as one comma-separated line. */
+export type WalletCardDraft = Record<WalletCardFieldKey, string> & {
+  preferredContact: WalletCardPreferredContact;
+};
+
+export const EMPTY_WALLET_CARD_DRAFT: WalletCardDraft = {
+  fullName: "",
+  headline: "",
+  organisation: "",
+  locationLabel: "",
+  summary: "",
+  skills: "",
+  email: "",
+  phone: "",
+  website: "",
+  linkedin: "",
+  github: "",
+  portfolio: "",
+  preferredContact: "email",
+};
+
+/** Field limits mirror contract §3 exactly. */
+export const WALLET_CARD_FIELD_LIMITS: Record<WalletCardFieldKey, number> = {
+  fullName: 80,
+  headline: 120,
+  organisation: 80,
+  locationLabel: 80,
+  summary: 400,
+  // 12 skills x 40 characters, plus the separators the owner types.
+  skills: 12 * 41,
+  email: 254,
+  phone: 32,
+  website: 300,
+  linkedin: 300,
+  github: 300,
+  portfolio: 300,
+};
+
+export const WALLET_CARD_MAX_SKILLS = 12;
+export const WALLET_CARD_MAX_SKILL_LENGTH = 40;
+
+/** The URL fields, which are https-only and share one validator. */
+const URL_FIELDS: readonly WalletCardFieldKey[] = [
+  "website",
+  "linkedin",
+  "github",
+  "portfolio",
+];
+
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+const PHONE_SHAPE = /^\+?[0-9][0-9\s().-]{5,}$/;
+
+export interface WalletCardFieldDefinition {
+  readonly key: WalletCardFieldKey;
+  readonly label: string;
+  readonly placeholder: string;
+  readonly description?: string;
+  readonly multiline?: boolean;
+  readonly inputMode?: "email" | "tel" | "url" | "text";
+}
+
+/** The recommended default set: name, headline, one preferred contact, one link. */
+export const WALLET_CARD_RECOMMENDED_FIELDS: readonly WalletCardFieldDefinition[] = [
+  {
+    key: "fullName",
+    label: "Name",
+    placeholder: "Your name",
+  },
+  {
+    key: "headline",
+    label: "Headline",
+    placeholder: "Founder, Hussh",
+    description: "One line about what you do.",
+  },
+  {
+    key: "website",
+    label: "Public link",
+    placeholder: "https://",
+    description: "A page you are happy for anyone to open.",
+    inputMode: "url",
+  },
+];
+
+/** Everything behind "Choose what people can see". Never blocks setup. */
+export const WALLET_CARD_OPTIONAL_FIELDS: readonly WalletCardFieldDefinition[] = [
+  { key: "organisation", label: "Company or college", placeholder: "Hussh" },
+  {
+    key: "locationLabel",
+    label: "Location",
+    placeholder: "Bengaluru",
+    description: "City or region only. Never a precise location.",
+  },
+  {
+    key: "summary",
+    label: "Short summary",
+    placeholder: "What you work on, in a couple of sentences.",
+    multiline: true,
+  },
+  {
+    key: "skills",
+    label: "Skills",
+    placeholder: "Product, Privacy engineering, Swift",
+    description: `Up to ${WALLET_CARD_MAX_SKILLS}, separated by commas.`,
+  },
+  { key: "phone", label: "Phone", placeholder: "+1 555 0100", inputMode: "tel" },
+  { key: "linkedin", label: "LinkedIn", placeholder: "https://", inputMode: "url" },
+  { key: "github", label: "GitHub", placeholder: "https://", inputMode: "url" },
+  { key: "portfolio", label: "Portfolio", placeholder: "https://", inputMode: "url" },
+];
+
+export const WALLET_CARD_PREFERRED_CONTACT_OPTIONS: ReadonlyArray<{
+  value: WalletCardPreferredContact;
+  label: string;
+  field: WalletCardFieldKey;
+}> = [
+  { value: "email", label: "Email", field: "email" },
+  { value: "phone", label: "Phone", field: "phone" },
+  { value: "linkedin", label: "LinkedIn", field: "linkedin" },
+  { value: "website", label: "Link", field: "website" },
+];
+
+export interface WalletCardIdentityHints {
+  readonly displayName?: string | null;
+  readonly email?: string | null;
+  readonly phoneNumber?: string | null;
+}
+
+/**
+ * Pre-fill a draft from information the product already holds, so a person with
+ * a complete profile only has to review it. Never invents a value.
+ */
+export function buildSmartDefaultDraft(
+  identity: WalletCardIdentityHints,
+): WalletCardDraft {
+  const email = normalise(identity.email);
+  const phone = normalise(identity.phoneNumber);
+  return {
+    ...EMPTY_WALLET_CARD_DRAFT,
+    fullName: clamp(normalise(identity.displayName), WALLET_CARD_FIELD_LIMITS.fullName),
+    email: clamp(email, WALLET_CARD_FIELD_LIMITS.email),
+    phone: clamp(phone, WALLET_CARD_FIELD_LIMITS.phone),
+    preferredContact: email ? "email" : phone ? "phone" : "email",
+  };
+}
+
+/** Re-open an existing card for editing without losing anything the owner set. */
+export function draftFromPayload(payload: WalletCardPayload): WalletCardDraft {
+  return {
+    fullName: normalise(payload.full_name),
+    headline: normalise(payload.headline),
+    organisation: normalise(payload.organisation),
+    locationLabel: normalise(payload.location_label),
+    summary: normalise(payload.summary),
+    skills: (payload.skills ?? []).map((skill) => normalise(skill)).filter(Boolean).join(", "),
+    email: normalise(payload.email),
+    phone: normalise(payload.phone),
+    website: normalise(payload.website),
+    linkedin: normalise(payload.linkedin),
+    github: normalise(payload.github),
+    portfolio: normalise(payload.portfolio),
+    preferredContact: payload.preferred_contact ?? "email",
+  };
+}
+
+export type WalletCardValidationErrors = Partial<
+  Record<WalletCardFieldKey | "preferredContact", string>
+>;
+
+/**
+ * Client-side mirror of the server's validation. Returns a message per invalid
+ * field; an empty object means the draft is safe to submit.
+ */
+export function validateDraft(draft: WalletCardDraft): WalletCardValidationErrors {
+  const errors: WalletCardValidationErrors = {};
+
+  for (const key of Object.keys(WALLET_CARD_FIELD_LIMITS) as WalletCardFieldKey[]) {
+    if (draft[key].trim().length > WALLET_CARD_FIELD_LIMITS[key]) {
+      errors[key] = `Keep this under ${WALLET_CARD_FIELD_LIMITS[key]} characters.`;
+    }
+  }
+
+  const email = draft.email.trim();
+  if (email && !EMAIL_SHAPE.test(email)) {
+    errors.email = "Enter a valid email address.";
+  }
+
+  const phone = draft.phone.trim();
+  if (phone && !PHONE_SHAPE.test(phone)) {
+    errors.phone = "Enter a valid phone number.";
+  }
+
+  for (const key of URL_FIELDS) {
+    const value = draft[key].trim();
+    // The service owns the one URL rule (https only, no userinfo, no
+    // javascript:/data:) so the owner form cannot drift from what the server
+    // and the public page enforce.
+    if (value && !isAllowedWalletCardUrl(value)) {
+      errors[key] = "Use a full https:// link.";
+    }
+  }
+
+  const skills = splitSkills(draft.skills);
+  if (skills.length > WALLET_CARD_MAX_SKILLS) {
+    errors.skills = `Keep it to ${WALLET_CARD_MAX_SKILLS} skills.`;
+  } else if (skills.some((skill) => skill.length > WALLET_CARD_MAX_SKILL_LENGTH)) {
+    errors.skills = `Each skill must be under ${WALLET_CARD_MAX_SKILL_LENGTH} characters.`;
+  }
+
+  const preferred = WALLET_CARD_PREFERRED_CONTACT_OPTIONS.find(
+    (option) => option.value === draft.preferredContact,
+  );
+  if (preferred && !draft[preferred.field].trim()) {
+    errors.preferredContact = `Add a ${preferred.label.toLowerCase()} or pick a different preferred contact.`;
+  }
+
+  return errors;
+}
+
+export function hasValidationErrors(errors: WalletCardValidationErrors): boolean {
+  return Object.keys(errors).length > 0;
+}
+
+/**
+ * Project the draft onto the server payload. Empty values are omitted rather
+ * than sent as blanks, so the stored card only ever holds what the owner chose.
+ */
+export function draftToPayload(draft: WalletCardDraft): WalletCardPayload {
+  const payload: WalletCardPayload = {};
+  assign(payload, "full_name", draft.fullName, WALLET_CARD_FIELD_LIMITS.fullName);
+  assign(payload, "headline", draft.headline, WALLET_CARD_FIELD_LIMITS.headline);
+  assign(payload, "organisation", draft.organisation, WALLET_CARD_FIELD_LIMITS.organisation);
+  assign(
+    payload,
+    "location_label",
+    draft.locationLabel,
+    WALLET_CARD_FIELD_LIMITS.locationLabel,
+  );
+  assign(payload, "summary", draft.summary, WALLET_CARD_FIELD_LIMITS.summary);
+  assign(payload, "email", draft.email, WALLET_CARD_FIELD_LIMITS.email);
+  assign(payload, "phone", draft.phone, WALLET_CARD_FIELD_LIMITS.phone);
+  assign(payload, "website", draft.website, WALLET_CARD_FIELD_LIMITS.website);
+  assign(payload, "linkedin", draft.linkedin, WALLET_CARD_FIELD_LIMITS.linkedin);
+  assign(payload, "github", draft.github, WALLET_CARD_FIELD_LIMITS.github);
+  assign(payload, "portfolio", draft.portfolio, WALLET_CARD_FIELD_LIMITS.portfolio);
+
+  const skills = splitSkills(draft.skills)
+    .slice(0, WALLET_CARD_MAX_SKILLS)
+    .map((skill) => skill.slice(0, WALLET_CARD_MAX_SKILL_LENGTH));
+  if (skills.length > 0) {
+    payload.skills = skills;
+  }
+
+  const preferred = WALLET_CARD_PREFERRED_CONTACT_OPTIONS.find(
+    (option) => option.value === draft.preferredContact,
+  );
+  if (preferred && draft[preferred.field].trim()) {
+    payload.preferred_contact = preferred.value;
+  }
+
+  return payload;
+}
+
+/** The plain-language list of what a scan will reveal, in display order. */
+export function describeSharedFields(draft: WalletCardDraft): string[] {
+  const shared: string[] = [];
+  if (draft.fullName.trim()) shared.push("Name");
+  shared.push("Photo");
+  if (draft.headline.trim()) shared.push("Headline");
+  if (draft.organisation.trim()) shared.push("Company or college");
+  if (draft.locationLabel.trim()) shared.push("Location");
+  if (draft.summary.trim()) shared.push("Short summary");
+  if (splitSkills(draft.skills).length > 0) shared.push("Skills");
+  if (draft.email.trim()) shared.push("Email");
+  if (draft.phone.trim()) shared.push("Phone");
+  if (draft.website.trim()) shared.push("Public link");
+  if (draft.linkedin.trim()) shared.push("LinkedIn");
+  if (draft.github.trim()) shared.push("GitHub");
+  if (draft.portfolio.trim()) shared.push("Portfolio");
+  return shared;
+}
+
+export function splitSkills(value: string): string[] {
+  return value
+    .split(",")
+    .map((skill) => skill.trim())
+    .filter(Boolean);
+}
+
+function assign(
+  payload: WalletCardPayload,
+  key: keyof WalletCardPayload,
+  value: string,
+  limit: number,
+): void {
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  Object.assign(payload, { [key]: trimmed.slice(0, limit) });
+}
+
+function normalise(value: string | null | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function clamp(value: string, limit: number): string {
+  return value.slice(0, limit);
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-manage.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-manage.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import {
+  Copy,
+  Eye,
+  Link2,
+  Pause,
+  Pencil,
+  Play,
+  RefreshCw,
+  Share2,
+  Trash2,
+  Wallet,
+} from "lucide-react";
+
+import { SettingsGroup, SettingsRow } from "@/components/profile/settings-ui";
+import { Button } from "@/lib/morphy-ux/morphy";
+import { formatLocalDateTime } from "@/lib/utils/local-date-time";
+import { WALLET_CARD_OWNER_COPY } from "@/components/wallet-card/wallet-card-copy";
+import { WalletCardQr } from "@/components/wallet-card/wallet-card-qr";
+import type {
+  WalletCardRecord,
+  WalletCardShareLink,
+} from "@/lib/services/wallet-card-service";
+
+export type WalletCardManageAction =
+  | "preview"
+  | "edit"
+  | "pause"
+  | "resume"
+  | "rotate"
+  | "remove"
+  | "add-to-wallet"
+  | "share"
+  | "copy";
+
+/**
+ * The management surface shown once a Wallet Profile exists.
+ *
+ * Every entry answers "what do people see when they scan?" — the live QR, when
+ * the shared information last changed, and one control per way of changing or
+ * stopping that. Each destructive control routes through a confirmation that
+ * states the effect first.
+ */
+export function WalletCardManage({
+  card,
+  shareLink,
+  applePassSupported,
+  busyAction,
+  onAction,
+}: {
+  card: WalletCardRecord;
+  shareLink: WalletCardShareLink | null;
+  applePassSupported: boolean;
+  busyAction: WalletCardManageAction | null;
+  onAction: (action: WalletCardManageAction) => void;
+}) {
+  const paused = card.status === "paused";
+  const lastUpdated = formatLocalDateTime(card.updatedAt);
+  const lastScanned = formatLocalDateTime(card.lastScannedAt);
+
+  return (
+    <div className="space-y-4">
+      <SettingsGroup>
+        <SettingsRow
+          icon={paused ? Pause : Wallet}
+          iconTone={paused ? "orange" : "green"}
+          title={
+            paused
+              ? WALLET_CARD_OWNER_COPY.statusPaused
+              : WALLET_CARD_OWNER_COPY.statusActive
+          }
+          description={
+            paused
+              ? WALLET_CARD_OWNER_COPY.statusPausedDetail
+              : WALLET_CARD_OWNER_COPY.updatesAutomatically
+          }
+        />
+        {lastUpdated ? (
+          <SettingsRow
+            density="compact"
+            title={WALLET_CARD_OWNER_COPY.lastUpdatedLabel}
+            trailing={
+              <span className="text-[13px] text-muted-foreground">{lastUpdated}</span>
+            }
+          />
+        ) : null}
+        <SettingsRow
+          density="compact"
+          title={WALLET_CARD_OWNER_COPY.scanCountLabel}
+          trailing={
+            <span className="text-[13px] text-muted-foreground">
+              {card.scanCount.toLocaleString()}
+            </span>
+          }
+        />
+        {lastScanned ? (
+          <SettingsRow
+            density="compact"
+            title={WALLET_CARD_OWNER_COPY.lastScannedLabel}
+            trailing={
+              <span className="text-[13px] text-muted-foreground">{lastScanned}</span>
+            }
+          />
+        ) : null}
+      </SettingsGroup>
+
+      <SettingsGroup title="Your QR">
+        {shareLink ? (
+          <div className="space-y-4 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+            <div className="mx-auto w-full max-w-[220px]">
+              <WalletCardQr
+                value={shareLink.shareUrl}
+                label="Your Wallet Profile QR code"
+              />
+            </div>
+            <div className="flex items-center gap-2 rounded-xl bg-muted/40 px-3 py-2">
+              <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              <span className="min-w-0 flex-1 truncate text-[12px] text-muted-foreground">
+                {shareLink.shareUrl}
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {applePassSupported ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  loading={busyAction === "add-to-wallet"}
+                  onClick={() => onAction("add-to-wallet")}
+                >
+                  <Wallet className="mr-2 h-4 w-4" aria-hidden />
+                  {WALLET_CARD_OWNER_COPY.addToWallet}
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                loading={busyAction === "share"}
+                onClick={() => onAction("share")}
+              >
+                <Share2 className="mr-2 h-4 w-4" aria-hidden />
+                {WALLET_CARD_OWNER_COPY.shareLink}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                onClick={() => onAction("copy")}
+              >
+                <Copy className="mr-2 h-4 w-4" aria-hidden />
+                {WALLET_CARD_OWNER_COPY.copyLink}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-[12.5px] leading-[1.5] text-muted-foreground">
+            {WALLET_CARD_OWNER_COPY.noLinkOnThisDevice}
+          </div>
+        )}
+      </SettingsGroup>
+
+      <SettingsGroup title="Sharing controls">
+        <SettingsRow
+          icon={Eye}
+          iconTone="blue"
+          title={WALLET_CARD_OWNER_COPY.previewAsVisitor}
+          description="See exactly what a scan shows right now."
+          chevron
+          onClick={() => onAction("preview")}
+        />
+        <SettingsRow
+          icon={Pencil}
+          iconTone="accent"
+          title={WALLET_CARD_OWNER_COPY.editInformation}
+          description="Change what is included. Your QR stays the same."
+          chevron
+          onClick={() => onAction("edit")}
+        />
+        <SettingsRow
+          icon={paused ? Play : Pause}
+          iconTone="orange"
+          title={
+            paused
+              ? WALLET_CARD_OWNER_COPY.resumeSharing
+              : WALLET_CARD_OWNER_COPY.pauseSharing
+          }
+          description={
+            paused
+              ? "Make your selected information visible again."
+              : "A scan will show nothing until you resume."
+          }
+          chevron
+          disabled={busyAction === "pause" || busyAction === "resume"}
+          onClick={() => onAction(paused ? "resume" : "pause")}
+        />
+        <SettingsRow
+          icon={RefreshCw}
+          iconTone="purple"
+          title={WALLET_CARD_OWNER_COPY.rotateAccess}
+          description="Invalidate the current QR and create a new one."
+          chevron
+          disabled={busyAction === "rotate"}
+          onClick={() => onAction("rotate")}
+        />
+        <SettingsRow
+          icon={Trash2}
+          tone="destructive"
+          title={WALLET_CARD_OWNER_COPY.removeProfile}
+          description="Stop sharing and take the profile down for good."
+          chevron
+          disabled={busyAction === "remove"}
+          onClick={() => onAction("remove")}
+        />
+      </SettingsGroup>
+    </div>
+  );
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-pass-preview.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-pass-preview.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+import { WalletCardQr } from "@/components/wallet-card/wallet-card-qr";
+
+/** First letters of the name, used when there is no photo. */
+function initialsFrom(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "1";
+  const first = parts[0]?.[0] ?? "";
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? "") : "";
+  return (first + last).toUpperCase() || "1";
+}
+
+/**
+ * A faithful-but-static rendering of the pass face.
+ *
+ * The real pass is built and signed server-side; this is the owner's preview of
+ * the same field budget (one primary, one secondary, up to two auxiliary), so
+ * what they approve here is what Apple Wallet shows.
+ */
+export function WalletCardPassPreview({
+  fullName,
+  headline,
+  organisation,
+  locationLabel,
+  avatarUrl,
+  shareUrl,
+  className,
+}: {
+  fullName: string;
+  headline: string;
+  organisation: string;
+  locationLabel: string;
+  avatarUrl: string | null;
+  shareUrl: string | null;
+  className?: string;
+}) {
+  const auxiliary = [organisation, locationLabel].map((value) => value.trim()).filter(Boolean);
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-[var(--app-card-radius-compact)] border border-[color:var(--app-card-border-standard)] bg-[color:var(--app-card-surface-default-solid)] shadow-[var(--app-card-shadow-standard)]",
+        className,
+      )}
+      data-testid="wallet-card-pass-preview"
+    >
+      <div className="flex items-start justify-between gap-4 border-b border-border/60 px-5 py-4">
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            Hussh One
+          </div>
+          <div className="mt-2 truncate text-[19px] font-semibold leading-tight text-foreground">
+            {fullName.trim() || "Your name"}
+          </div>
+          {headline.trim() ? (
+            <div className="mt-1 truncate text-[13px] text-muted-foreground">
+              {headline.trim()}
+            </div>
+          ) : null}
+        </div>
+        <Avatar size="lg" className="size-14 rounded-[12px]">
+          {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
+          <AvatarFallback className="rounded-[12px] text-sm font-medium">
+            {initialsFrom(fullName)}
+          </AvatarFallback>
+        </Avatar>
+      </div>
+
+      {auxiliary.length > 0 ? (
+        <dl className="flex flex-wrap gap-x-8 gap-y-3 px-5 pt-4">
+          {organisation.trim() ? (
+            <div className="min-w-0">
+              <dt className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                Organisation
+              </dt>
+              <dd className="mt-0.5 truncate text-[13px] text-foreground">
+                {organisation.trim()}
+              </dd>
+            </div>
+          ) : null}
+          {locationLabel.trim() ? (
+            <div className="min-w-0">
+              <dt className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                Location
+              </dt>
+              <dd className="mt-0.5 truncate text-[13px] text-foreground">
+                {locationLabel.trim()}
+              </dd>
+            </div>
+          ) : null}
+        </dl>
+      ) : null}
+
+      <div className="px-5 py-4">
+        {shareUrl ? (
+          <div className="mx-auto w-full max-w-[184px]">
+            <WalletCardQr value={shareUrl} label="Your Wallet Profile QR code" />
+          </div>
+        ) : (
+          <div className="mx-auto flex aspect-square w-full max-w-[184px] items-center justify-center rounded-2xl border border-dashed p-4 text-center text-[12px] text-muted-foreground">
+            Your QR appears here once the profile is saved.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-qr.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-qr.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+import { encodeQrCode } from "@/components/wallet-card/qr-code";
+
+const QUIET_ZONE_MODULES = 4;
+
+interface ModuleRun {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+}
+
+/** Merge each row's dark modules into runs so the SVG stays small. */
+function darkRuns(size: number, modules: Uint8Array): ModuleRun[] {
+  const runs: ModuleRun[] = [];
+  for (let y = 0; y < size; y += 1) {
+    let start = -1;
+    for (let x = 0; x <= size; x += 1) {
+      const dark = x < size && (modules[y * size + x] ?? 0) === 1;
+      if (dark && start < 0) {
+        start = x;
+      } else if (!dark && start >= 0) {
+        runs.push({ x: start, y, width: x - start });
+        start = -1;
+      }
+    }
+  }
+  return runs;
+}
+
+/**
+ * The share link rendered as a scannable QR.
+ *
+ * Colours are deliberately fixed to black on white rather than theme tokens:
+ * a dark-mode inversion would flip the contrast polarity and stop cameras
+ * reading the code.
+ */
+export function WalletCardQr({
+  value,
+  label,
+  className,
+}: {
+  value: string;
+  label: string;
+  className?: string;
+}) {
+  const symbol = useMemo(() => {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    try {
+      const matrix = encodeQrCode(trimmed);
+      return { matrix, runs: darkRuns(matrix.size, matrix.modules) };
+    } catch {
+      return null;
+    }
+  }, [value]);
+
+  if (!symbol) {
+    return (
+      <div
+        className={cn(
+          "flex aspect-square w-full items-center justify-center rounded-2xl border border-dashed p-6 text-center text-[12px] text-muted-foreground",
+          className,
+        )}
+      >
+        The QR can't be shown right now.
+      </div>
+    );
+  }
+
+  const extent = symbol.matrix.size + QUIET_ZONE_MODULES * 2;
+
+  return (
+    <svg
+      viewBox={`0 0 ${extent} ${extent}`}
+      role="img"
+      aria-label={label}
+      shapeRendering="crispEdges"
+      className={cn("h-auto w-full rounded-2xl bg-white", className)}
+    >
+      <rect x="0" y="0" width={extent} height={extent} fill="#ffffff" />
+      <g fill="#000000">
+        {symbol.runs.map((run) => (
+          <rect
+            key={`${run.y}-${run.x}`}
+            x={run.x + QUIET_ZONE_MODULES}
+            y={run.y + QUIET_ZONE_MODULES}
+            width={run.width}
+            height={1}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-setup.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-setup.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useId, useState } from "react";
+import { ChevronDown, ShieldCheck } from "lucide-react";
+
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsSegmentedTabs,
+} from "@/components/profile/settings-ui";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/lib/morphy-ux/morphy";
+import { cn } from "@/lib/utils";
+import {
+  WALLET_CARD_COPY,
+  WALLET_CARD_OWNER_COPY,
+} from "@/components/wallet-card/wallet-card-copy";
+import {
+  WALLET_CARD_FIELD_LIMITS,
+  WALLET_CARD_OPTIONAL_FIELDS,
+  WALLET_CARD_PREFERRED_CONTACT_OPTIONS,
+  WALLET_CARD_RECOMMENDED_FIELDS,
+  describeSharedFields,
+  type WalletCardDraft,
+  type WalletCardFieldDefinition,
+  type WalletCardValidationErrors,
+} from "@/components/wallet-card/wallet-card-fields";
+import type { WalletCardPreferredContact } from "@/lib/services/wallet-card-service";
+
+function initialsFrom(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "1";
+  const first = parts[0]?.[0] ?? "";
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? "") : "";
+  return (first + last).toUpperCase() || "1";
+}
+
+function DraftField({
+  definition,
+  value,
+  error,
+  onChange,
+}: {
+  definition: WalletCardFieldDefinition;
+  value: string;
+  error?: string;
+  onChange: (value: string) => void;
+}) {
+  const inputId = useId();
+  const describedBy = `${inputId}-help`;
+  const help = error || definition.description;
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={inputId} className="text-[13px] font-medium">
+        {definition.label}
+      </Label>
+      {definition.multiline ? (
+        <Textarea
+          id={inputId}
+          value={value}
+          rows={3}
+          maxLength={WALLET_CARD_FIELD_LIMITS[definition.key]}
+          placeholder={definition.placeholder}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={help ? describedBy : undefined}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      ) : (
+        <Input
+          id={inputId}
+          value={value}
+          inputMode={definition.inputMode}
+          maxLength={WALLET_CARD_FIELD_LIMITS[definition.key]}
+          placeholder={definition.placeholder}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={help ? describedBy : undefined}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      )}
+      {help ? (
+        <p
+          id={describedBy}
+          className={cn(
+            "text-[11.5px] leading-[1.45]",
+            error ? "text-destructive" : "text-muted-foreground",
+          )}
+        >
+          {help}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Smart-default review.
+ *
+ * A person whose Hussh profile is already complete only reviews this screen:
+ * their name and preferred contact are pre-filled from what the product
+ * already knows, the photo comes straight from their profile, and everything
+ * else sits behind an optional disclosure that never blocks the flow.
+ */
+export function WalletCardSetup({
+  draft,
+  errors,
+  avatarUrl,
+  saving,
+  isEditingExisting,
+  onChange,
+  onSubmit,
+  onCancel,
+}: {
+  draft: WalletCardDraft;
+  errors: WalletCardValidationErrors;
+  avatarUrl: string | null;
+  saving: boolean;
+  isEditingExisting: boolean;
+  onChange: (key: keyof WalletCardDraft, value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}) {
+  const [optionalOpen, setOptionalOpen] = useState(false);
+  const shared = describeSharedFields(draft);
+  const preferredOption = WALLET_CARD_PREFERRED_CONTACT_OPTIONS.find(
+    (option) => option.value === draft.preferredContact,
+  );
+
+  return (
+    <div className="space-y-4">
+      {!isEditingExisting ? (
+        <SettingsGroup>
+          <SettingsRow
+            icon={ShieldCheck}
+            iconTone="blue"
+            title={WALLET_CARD_COPY.setupIntro.title}
+            description={WALLET_CARD_COPY.setupIntro.description}
+          />
+        </SettingsGroup>
+      ) : null}
+
+      <SettingsGroup
+        title={WALLET_CARD_OWNER_COPY.recommendedGroupTitle}
+        description={WALLET_CARD_OWNER_COPY.onlyThisInformation}
+      >
+        <SettingsRow
+          leading={
+            <Avatar size="lg" className="size-11">
+              {avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null}
+              <AvatarFallback className="text-[13px] font-medium">
+                {initialsFrom(draft.fullName)}
+              </AvatarFallback>
+            </Avatar>
+          }
+          title="Photo"
+          description={WALLET_CARD_OWNER_COPY.fromYourProfile}
+        />
+        <div className="space-y-4 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+          {WALLET_CARD_RECOMMENDED_FIELDS.map((definition) => (
+            <DraftField
+              key={definition.key}
+              definition={definition}
+              value={draft[definition.key]}
+              error={errors[definition.key]}
+              onChange={(value) => onChange(definition.key, value)}
+            />
+          ))}
+
+          <div className="space-y-1.5">
+            <Label className="text-[13px] font-medium">Preferred contact</Label>
+            <SettingsSegmentedTabs
+              value={draft.preferredContact}
+              onValueChange={(value) =>
+                onChange("preferredContact", value as WalletCardPreferredContact)
+              }
+              options={WALLET_CARD_PREFERRED_CONTACT_OPTIONS.map((option) => ({
+                value: option.value,
+                label: option.label,
+              }))}
+              mobileColumns={2}
+            />
+            {preferredOption &&
+            preferredOption.field !== "website" &&
+            preferredOption.field !== "linkedin" ? (
+              <div className="pt-1">
+                <Input
+                  value={draft[preferredOption.field]}
+                  inputMode={preferredOption.value === "phone" ? "tel" : "email"}
+                  maxLength={WALLET_CARD_FIELD_LIMITS[preferredOption.field]}
+                  placeholder={
+                    preferredOption.value === "phone" ? "+1 555 0100" : "you@example.com"
+                  }
+                  aria-label={preferredOption.label}
+                  aria-invalid={errors[preferredOption.field] ? true : undefined}
+                  onChange={(event) =>
+                    onChange(preferredOption.field, event.target.value)
+                  }
+                />
+              </div>
+            ) : null}
+            {errors.preferredContact || errors[preferredOption?.field ?? "email"] ? (
+              <p className="text-[11.5px] leading-[1.45] text-destructive">
+                {errors.preferredContact || errors[preferredOption?.field ?? "email"]}
+              </p>
+            ) : (
+              <p className="text-[11.5px] leading-[1.45] text-muted-foreground">
+                This is the action a visitor sees first.
+              </p>
+            )}
+          </div>
+        </div>
+      </SettingsGroup>
+
+      <SettingsGroup>
+        <SettingsRow
+          title={WALLET_CARD_COPY.privacyAssurance.title}
+          description={WALLET_CARD_COPY.privacyAssurance.description}
+          icon={ShieldCheck}
+          iconTone="green"
+        />
+        <div className="px-[var(--settings-row-px)] pb-[var(--settings-row-py)]">
+          <div className="flex flex-wrap gap-1.5">
+            {shared.map((label) => (
+              <span
+                key={label}
+                className="rounded-full bg-muted px-2.5 py-1 text-[11px] font-medium text-muted-foreground"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </SettingsGroup>
+
+      <SettingsGroup>
+        <SettingsRow
+          title={WALLET_CARD_OWNER_COPY.optionalDisclosure}
+          description={WALLET_CARD_OWNER_COPY.optionalDisclosureHint}
+          onClick={() => setOptionalOpen((open) => !open)}
+          trailing={
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 text-muted-foreground transition-transform",
+                optionalOpen && "rotate-180",
+              )}
+              aria-hidden
+            />
+          }
+        />
+        {optionalOpen ? (
+          <div className="space-y-4 px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+            {WALLET_CARD_OPTIONAL_FIELDS.map((definition) => (
+              <DraftField
+                key={definition.key}
+                definition={definition}
+                value={draft[definition.key]}
+                error={errors[definition.key]}
+                onChange={(value) => onChange(definition.key, value)}
+              />
+            ))}
+          </div>
+        ) : null}
+      </SettingsGroup>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="button" size="sm" loading={saving} onClick={onSubmit}>
+          {WALLET_CARD_OWNER_COPY.reviewPrimaryAction}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="none"
+          effect="fade"
+          disabled={saving}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-share.ts
+++ b/hushh-webapp/components/wallet-card/wallet-card-share.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { Capacitor } from "@capacitor/core";
+
+import { copyToClipboard } from "@/lib/utils/clipboard";
+
+export type WalletCardShareOutcome = "native-share" | "web-share" | "copied";
+
+export function isShareAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+/**
+ * Share the public profile link.
+ *
+ * Native share sheet on device, Web Share where the browser offers it, and the
+ * clipboard as the last resort — the same ladder One Location uses so sharing
+ * behaves identically across the app.
+ *
+ * Adding the pass to Apple Wallet is a different path entirely and belongs to
+ * `WalletCardService.addToAppleWallet`, which hands the URL to the OS because
+ * WKWebView cannot import a `.pkpass`.
+ */
+export async function shareWalletCardLink(params: {
+  title: string;
+  text: string;
+  url: string;
+  dialogTitle: string;
+}): Promise<WalletCardShareOutcome> {
+  const url = params.url.trim();
+  if (!url) {
+    throw new Error("There is no share link on this device yet.");
+  }
+  const message = `${params.text}\n${url}`;
+
+  if (Capacitor.isNativePlatform()) {
+    const { Share } =
+      (await import("@capacitor/share")) as typeof import("@capacitor/share");
+    if (Capacitor.getPlatform() === "android") {
+      // Android share targets drop the `url` field, so it is folded into the text.
+      await Share.share({
+        title: params.title,
+        text: message,
+        dialogTitle: params.dialogTitle,
+      });
+      return "native-share";
+    }
+    await Share.share({
+      title: params.title,
+      text: params.text,
+      url,
+      dialogTitle: params.dialogTitle,
+    });
+    return "native-share";
+  }
+
+  if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+    await navigator.share({ title: params.title, text: params.text, url });
+    return "web-share";
+  }
+
+  if (await copyToClipboard(message)) {
+    return "copied";
+  }
+
+  throw new Error("Sharing is not supported on this device.");
+}
+
+/** Copy just the link, with no surrounding message. */
+export async function copyWalletCardLink(url: string): Promise<boolean> {
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  return copyToClipboard(trimmed);
+}

--- a/hushh-webapp/components/wallet-card/wallet-card-workspace.tsx
+++ b/hushh-webapp/components/wallet-card/wallet-card-workspace.tsx
@@ -1,0 +1,648 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowLeft, CheckCircle2, Lock, Share2, Wallet } from "lucide-react";
+import { toast } from "sonner";
+
+import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
+import { SettingsGroup, SettingsRow } from "@/components/profile/settings-ui";
+import { PkmSettingsShell } from "@/components/profile/pkm-settings-shell";
+import { useAuth } from "@/hooks/use-auth";
+import { useEffectiveAvatarUrl } from "@/hooks/use-effective-avatar-url";
+import { Button } from "@/lib/morphy-ux/morphy";
+import { useVault } from "@/lib/vault/vault-context";
+import {
+  normalizePublicWalletCard,
+  PublicWalletCardSkeleton,
+  PublicWalletCardView,
+  type PublicWalletCard,
+} from "@/components/wallet-card/public-card-view";
+import {
+  WALLET_CARD_CONFIRMATIONS,
+  WALLET_CARD_COPY,
+  WALLET_CARD_OWNER_COPY,
+} from "@/components/wallet-card/wallet-card-copy";
+import { WalletCardConfirmDialog } from "@/components/wallet-card/wallet-card-confirm-dialog";
+import {
+  EMPTY_WALLET_CARD_DRAFT,
+  buildSmartDefaultDraft,
+  draftFromPayload,
+  draftToPayload,
+  hasValidationErrors,
+  validateDraft,
+  type WalletCardDraft,
+  type WalletCardValidationErrors,
+} from "@/components/wallet-card/wallet-card-fields";
+import {
+  WalletCardManage,
+  type WalletCardManageAction,
+} from "@/components/wallet-card/wallet-card-manage";
+import { WalletCardPassPreview } from "@/components/wallet-card/wallet-card-pass-preview";
+import { WalletCardSetup } from "@/components/wallet-card/wallet-card-setup";
+import {
+  copyWalletCardLink,
+  isShareAbortError,
+  shareWalletCardLink,
+} from "@/components/wallet-card/wallet-card-share";
+import {
+  canAddToAppleWallet,
+  WalletCardPayloadError,
+  WalletCardService,
+  type WalletCardPreferredContact,
+  type WalletCardRecord,
+  type WalletCardShareLink,
+} from "@/lib/services/wallet-card-service";
+
+type WalletCardStage =
+  | "loading"
+  | "locked"
+  | "unavailable"
+  | "error"
+  | "intro"
+  | "edit"
+  | "preview"
+  | "success"
+  | "manage";
+
+type ConfirmKind = "pause" | "resume" | "rotate" | "remove";
+
+type VisitorPreviewState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; card: PublicWalletCard }
+  | { status: "error"; message: string };
+
+/**
+ * Owner workspace for the Wallet Profile.
+ *
+ * One route carries the whole lifecycle: an entry state before setup, a
+ * smart-default review, a preview of both the pass face and the real visitor
+ * page, and the management surface afterwards. Every network call goes through
+ * `WalletCardService` — nothing here talks to the API directly.
+ */
+export function WalletCardWorkspace() {
+  const { user, loading: authLoading, phoneNumber } = useAuth();
+  const { isVaultUnlocked, vaultOwnerToken } = useVault();
+  const avatarUrl = useEffectiveAvatarUrl();
+  const userId = user?.uid ?? null;
+
+  const [stage, setStage] = useState<WalletCardStage>("loading");
+  const [card, setCard] = useState<WalletCardRecord | null>(null);
+  const [shareLink, setShareLink] = useState<WalletCardShareLink | null>(null);
+  const [draft, setDraft] = useState<WalletCardDraft>(EMPTY_WALLET_CARD_DRAFT);
+  const [errors, setErrors] = useState<WalletCardValidationErrors>({});
+  const [visitorPreview, setVisitorPreview] = useState<VisitorPreviewState>({
+    status: "idle",
+  });
+  const [previewOrigin, setPreviewOrigin] = useState<"setup" | "manage">("setup");
+  const [saving, setSaving] = useState(false);
+  const [busyAction, setBusyAction] = useState<WalletCardManageAction | null>(null);
+  const [confirm, setConfirm] = useState<ConfirmKind | null>(null);
+  const [applePassSupported, setApplePassSupported] = useState(false);
+
+  // Platform capability is read after mount: the user agent is not available
+  // during server rendering and would otherwise cause a hydration mismatch.
+  useEffect(() => {
+    setApplePassSupported(canAddToAppleWallet());
+  }, []);
+
+  const smartDefaults = useMemo(
+    () =>
+      buildSmartDefaultDraft({
+        displayName: user?.displayName ?? null,
+        email: user?.email ?? null,
+        phoneNumber: phoneNumber ?? user?.phoneNumber ?? null,
+      }),
+    [user?.displayName, user?.email, user?.phoneNumber, phoneNumber],
+  );
+
+  /**
+   * Adopt a freshly-loaded card and re-read the device-local share link.
+   *
+   * The plaintext token is returned by the backend only at create and rotate,
+   * so this device copy is what lets the QR and the Add-to-Wallet link render
+   * later. `readShareLink` drops it when the stored token version no longer
+   * matches the card, which is how a rotation performed on another device
+   * stops this one from showing a dead QR.
+   */
+  const adoptCard = useCallback(
+    (next: WalletCardRecord | null) => {
+      setCard(next);
+      setShareLink(userId ? WalletCardService.readShareLink(userId, next) : null);
+    },
+    [userId],
+  );
+
+  const loadCard = useCallback(async () => {
+    if (!vaultOwnerToken || !userId) return;
+    setStage("loading");
+    try {
+      const state = await WalletCardService.getCard({ vaultOwnerToken, userId });
+      if (!state.enabled) {
+        setStage("unavailable");
+        return;
+      }
+      if (!state.exists || !state.card || state.card.status === "revoked") {
+        adoptCard(null);
+        setStage("intro");
+        return;
+      }
+      adoptCard(state.card);
+      setStage("manage");
+    } catch {
+      setStage("error");
+    }
+  }, [adoptCard, userId, vaultOwnerToken]);
+
+  useEffect(() => {
+    if (authLoading) {
+      setStage("loading");
+      return;
+    }
+    if (!isVaultUnlocked || !vaultOwnerToken || !userId) {
+      setStage("locked");
+      return;
+    }
+    void loadCard();
+  }, [authLoading, isVaultUnlocked, vaultOwnerToken, userId, loadCard]);
+
+  const loadVisitorPreview = useCallback(async () => {
+    if (!vaultOwnerToken || !userId) return;
+    setVisitorPreview({ status: "loading" });
+    try {
+      // The projection comes from the backend so it is produced by the same
+      // builder that serves the public page, and it is rendered with the same
+      // component `/c/[token]` uses. A local re-implementation could drift.
+      const result = await WalletCardService.previewAsVisitor({
+        vaultOwnerToken,
+        userId,
+      });
+      if (result.state !== "available") {
+        setVisitorPreview({ status: "error", message: result.message });
+        return;
+      }
+      const normalized = normalizePublicWalletCard(result.card);
+      if (!normalized) {
+        setVisitorPreview({
+          status: "error",
+          message: WALLET_CARD_OWNER_COPY.visitorPreviewError,
+        });
+        return;
+      }
+      setVisitorPreview({ status: "ready", card: normalized });
+    } catch {
+      setVisitorPreview({
+        status: "error",
+        message: WALLET_CARD_OWNER_COPY.visitorPreviewError,
+      });
+    }
+  }, [userId, vaultOwnerToken]);
+
+  const startSetup = useCallback(() => {
+    setDraft(smartDefaults);
+    setErrors({});
+    setStage("edit");
+  }, [smartDefaults]);
+
+  const startEdit = useCallback(() => {
+    if (!card) return;
+    const stored = draftFromPayload(card.cardPayload);
+    setDraft({
+      ...stored,
+      // Fall back to what the product already knows rather than showing a blank.
+      fullName: stored.fullName || smartDefaults.fullName,
+    });
+    setErrors({});
+    setStage("edit");
+  }, [card, smartDefaults.fullName]);
+
+  const onDraftChange = useCallback((key: keyof WalletCardDraft, value: string) => {
+    setDraft((current) =>
+      key === "preferredContact"
+        ? { ...current, preferredContact: value as WalletCardPreferredContact }
+        : { ...current, [key]: value },
+    );
+    setErrors((current) => {
+      if (!(key in current)) return current;
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+  }, []);
+
+  const submitDraft = useCallback(async () => {
+    if (!vaultOwnerToken || !userId) return;
+    const validation = validateDraft(draft);
+    if (hasValidationErrors(validation)) {
+      setErrors(validation);
+      return;
+    }
+    setErrors({});
+    setSaving(true);
+    const isFirstSetup = !card;
+    try {
+      const result = await WalletCardService.saveCard({
+        vaultOwnerToken,
+        userId,
+        payload: draftToPayload(draft),
+      });
+      // The plaintext token only comes back on create; persist it before the
+      // response is discarded or the QR can never be rendered again.
+      if (result.shareToken && result.shareUrl) {
+        WalletCardService.rememberShareLink(userId, {
+          card: result.card,
+          shareToken: result.shareToken,
+          shareUrl: result.shareUrl,
+        });
+      }
+      adoptCard(result.card);
+      // First setup ends at Add to Apple Wallet; a later edit only confirms
+      // what changed, because an installed pass never needs re-adding.
+      setPreviewOrigin(isFirstSetup ? "setup" : "manage");
+      if (!isFirstSetup) toast.success(WALLET_CARD_OWNER_COPY.saved);
+      setStage("preview");
+      void loadVisitorPreview();
+    } catch (error) {
+      if (error instanceof WalletCardPayloadError) {
+        toast.error("Some of this information can't be shared. Check the fields above.");
+        return;
+      }
+      toast.error(WALLET_CARD_OWNER_COPY.saveFailed);
+    } finally {
+      setSaving(false);
+    }
+  }, [adoptCard, card, draft, loadVisitorPreview, userId, vaultOwnerToken]);
+
+  const addToWallet = useCallback(async () => {
+    if (!shareLink) return;
+    setBusyAction("add-to-wallet");
+    try {
+      // The service verifies the pass builds before handing the URL to the OS,
+      // so a missing signing certificate surfaces as product copy here instead
+      // of a raw error page in Safari.
+      const result = await WalletCardService.addToAppleWallet(shareLink.shareToken);
+      if (result.state === "opened") {
+        setStage("success");
+        return;
+      }
+      toast.error(result.message || WALLET_CARD_COPY.signingFailure);
+    } catch {
+      toast.error(WALLET_CARD_COPY.signingFailure);
+    } finally {
+      setBusyAction(null);
+    }
+  }, [shareLink]);
+
+  const shareLinkAction = useCallback(async () => {
+    if (!shareLink) return;
+    setBusyAction("share");
+    try {
+      const outcome = await shareWalletCardLink({
+        title: "My Hussh One profile",
+        text: "Here is my Hussh One profile.",
+        url: shareLink.shareUrl,
+        dialogTitle: "Share your Hussh One profile",
+      });
+      if (outcome === "copied") {
+        toast.success(WALLET_CARD_OWNER_COPY.linkCopied);
+      }
+      if (stage === "preview") setStage("success");
+    } catch (error) {
+      if (isShareAbortError(error)) return;
+      toast.error(WALLET_CARD_OWNER_COPY.shareFailed);
+    } finally {
+      setBusyAction(null);
+    }
+  }, [shareLink, stage]);
+
+  const copyLinkAction = useCallback(async () => {
+    if (!shareLink) return;
+    if (await copyWalletCardLink(shareLink.shareUrl)) {
+      toast.success(WALLET_CARD_OWNER_COPY.linkCopied);
+      return;
+    }
+    toast.error(WALLET_CARD_OWNER_COPY.shareFailed);
+  }, [shareLink]);
+
+  const runConfirmedAction = useCallback(async () => {
+    if (!confirm || !vaultOwnerToken || !userId) return;
+    setBusyAction(confirm);
+    try {
+      if (confirm === "pause") {
+        adoptCard(await WalletCardService.pauseCard({ vaultOwnerToken, userId }));
+        toast.success(WALLET_CARD_OWNER_COPY.paused);
+      } else if (confirm === "resume") {
+        adoptCard(await WalletCardService.resumeCard({ vaultOwnerToken, userId }));
+        toast.success(WALLET_CARD_OWNER_COPY.resumed);
+      } else if (confirm === "rotate") {
+        const result = await WalletCardService.rotateShareToken({
+          vaultOwnerToken,
+          userId,
+        });
+        if (result.shareToken && result.shareUrl) {
+          WalletCardService.rememberShareLink(userId, {
+            card: result.card,
+            shareToken: result.shareToken,
+            shareUrl: result.shareUrl,
+          });
+        }
+        adoptCard(result.card);
+        toast.success(WALLET_CARD_OWNER_COPY.rotated);
+      } else {
+        await WalletCardService.revokeCard({ vaultOwnerToken, userId });
+        WalletCardService.forgetShareLink(userId);
+        adoptCard(null);
+        setVisitorPreview({ status: "idle" });
+        setStage("intro");
+        toast.success(WALLET_CARD_OWNER_COPY.removed);
+      }
+      setConfirm(null);
+    } catch {
+      toast.error(WALLET_CARD_OWNER_COPY.saveFailed);
+    } finally {
+      setBusyAction(null);
+    }
+  }, [adoptCard, confirm, userId, vaultOwnerToken]);
+
+  const onManageAction = useCallback(
+    (action: WalletCardManageAction) => {
+      switch (action) {
+        case "preview":
+          setPreviewOrigin("manage");
+          setStage("preview");
+          void loadVisitorPreview();
+          return;
+        case "edit":
+          startEdit();
+          return;
+        case "add-to-wallet":
+          void addToWallet();
+          return;
+        case "share":
+          void shareLinkAction();
+          return;
+        case "copy":
+          void copyLinkAction();
+          return;
+        default:
+          setConfirm(action);
+      }
+    },
+    [addToWallet, copyLinkAction, loadVisitorPreview, shareLinkAction, startEdit],
+  );
+
+  const header = useMemo(() => {
+    if (stage === "edit" && !card) {
+      return WALLET_CARD_COPY.setupIntro;
+    }
+    if (stage === "success") {
+      return WALLET_CARD_COPY.success;
+    }
+    return card ? WALLET_CARD_COPY.entryAfterSetup : WALLET_CARD_COPY.entryBeforeSetup;
+  }, [card, stage]);
+
+  const dataState =
+    stage === "loading"
+      ? "loading"
+      : stage === "error"
+        ? "error"
+        : stage === "unavailable"
+          ? "unavailable-valid"
+          : card
+            ? "loaded"
+            : "empty-valid";
+
+  return (
+    <PkmSettingsShell
+      eyebrow={WALLET_CARD_OWNER_COPY.eyebrow}
+      title={header.title}
+      description={header.description}
+    >
+      <NativeTestBeacon
+        routeId="/one/wallet-card"
+        marker="native-route-one-wallet-card"
+        authState={authLoading ? "pending" : user ? "authenticated" : "anonymous"}
+        dataState={dataState}
+      />
+
+      {stage === "loading" ? (
+        <div className="rounded-2xl border p-6 text-center text-sm text-muted-foreground">
+          Loading your Wallet Profile…
+        </div>
+      ) : null}
+
+      {stage === "locked" ? (
+        <div className="flex items-center gap-2 rounded-2xl border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          <Lock className="h-4 w-4 shrink-0" aria-hidden />
+          {WALLET_CARD_OWNER_COPY.vaultLocked}
+        </div>
+      ) : null}
+
+      {stage === "unavailable" ? (
+        <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+          {WALLET_CARD_OWNER_COPY.featureUnavailable}
+        </div>
+      ) : null}
+
+      {stage === "error" ? (
+        <div className="space-y-3 rounded-2xl border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          <p>{WALLET_CARD_OWNER_COPY.loadFailed}</p>
+          <Button
+            type="button"
+            size="sm"
+            variant="none"
+            effect="fade"
+            onClick={() => void loadCard()}
+          >
+            Try again
+          </Button>
+        </div>
+      ) : null}
+
+      {stage === "intro" ? (
+        <div className="space-y-4">
+          <SettingsGroup>
+            <SettingsRow
+              icon={Wallet}
+              iconTone="blue"
+              title={WALLET_CARD_COPY.setupIntro.title}
+              description={WALLET_CARD_COPY.setupIntro.description}
+            />
+            <SettingsRow
+              title={WALLET_CARD_COPY.privacyAssurance.title}
+              description={WALLET_CARD_COPY.privacyAssurance.description}
+            />
+          </SettingsGroup>
+          <Button type="button" size="sm" onClick={startSetup}>
+            Set up Wallet Profile
+          </Button>
+        </div>
+      ) : null}
+
+      {stage === "edit" ? (
+        <WalletCardSetup
+          draft={draft}
+          errors={errors}
+          avatarUrl={avatarUrl}
+          saving={saving}
+          isEditingExisting={Boolean(card)}
+          onChange={onDraftChange}
+          onSubmit={() => void submitDraft()}
+          onCancel={() => setStage(card ? "manage" : "intro")}
+        />
+      ) : null}
+
+      {stage === "preview" ? (
+        <div className="space-y-4">
+          <SettingsGroup
+            title={WALLET_CARD_OWNER_COPY.walletPreviewTitle}
+            description={WALLET_CARD_OWNER_COPY.walletPreviewHint}
+          >
+            <div className="px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+              <WalletCardPassPreview
+                fullName={draft.fullName || card?.displayName || ""}
+                headline={draft.headline || card?.headline || ""}
+                organisation={draft.organisation}
+                locationLabel={draft.locationLabel}
+                avatarUrl={avatarUrl}
+                shareUrl={shareLink?.shareUrl ?? null}
+              />
+            </div>
+          </SettingsGroup>
+
+          <SettingsGroup
+            title={WALLET_CARD_OWNER_COPY.visitorPreviewTitle}
+            description={WALLET_CARD_OWNER_COPY.visitorPreviewHint}
+          >
+            <div className="px-[var(--settings-row-px)] py-[var(--settings-row-py)]">
+              {visitorPreview.status === "ready" ? (
+                <PublicWalletCardView card={visitorPreview.card} />
+              ) : visitorPreview.status === "error" ? (
+                <div className="space-y-3 text-sm text-muted-foreground">
+                  <p>{visitorPreview.message}</p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="none"
+                    effect="fade"
+                    onClick={() => void loadVisitorPreview()}
+                  >
+                    Try again
+                  </Button>
+                </div>
+              ) : (
+                <PublicWalletCardSkeleton />
+              )}
+            </div>
+          </SettingsGroup>
+
+          <p className="px-1 text-[12px] leading-[1.5] text-muted-foreground">
+            {WALLET_CARD_OWNER_COPY.updatesAutomatically}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {previewOrigin === "setup" ? (
+              <>
+                {applePassSupported ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    loading={busyAction === "add-to-wallet"}
+                    disabled={!shareLink}
+                    onClick={() => void addToWallet()}
+                  >
+                    <Wallet className="mr-2 h-4 w-4" aria-hidden />
+                    {WALLET_CARD_OWNER_COPY.addToWallet}
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    size="sm"
+                    loading={busyAction === "share"}
+                    disabled={!shareLink}
+                    onClick={() => void shareLinkAction()}
+                  >
+                    <Share2 className="mr-2 h-4 w-4" aria-hidden />
+                    {WALLET_CARD_OWNER_COPY.shareLink}
+                  </Button>
+                )}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="none"
+                  effect="fade"
+                  onClick={startEdit}
+                >
+                  {WALLET_CARD_OWNER_COPY.editInformation}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="none"
+                  effect="fade"
+                  onClick={() => setStage("manage")}
+                >
+                  Not now
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                variant="none"
+                effect="fade"
+                onClick={() => setStage("manage")}
+              >
+                <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+                Back
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {stage === "success" ? (
+        <div className="space-y-4">
+          <SettingsGroup>
+            <SettingsRow
+              icon={CheckCircle2}
+              iconTone="green"
+              title={WALLET_CARD_COPY.success.title}
+              description={WALLET_CARD_COPY.success.description}
+            />
+            <SettingsRow
+              title="Nothing else to do"
+              description={WALLET_CARD_OWNER_COPY.updatesAutomatically}
+            />
+          </SettingsGroup>
+          <Button type="button" size="sm" onClick={() => setStage("manage")}>
+            {WALLET_CARD_COPY.entryAfterSetup.title}
+          </Button>
+        </div>
+      ) : null}
+
+      {stage === "manage" && card ? (
+        <WalletCardManage
+          card={card}
+          shareLink={shareLink}
+          applePassSupported={applePassSupported}
+          busyAction={busyAction}
+          onAction={onManageAction}
+        />
+      ) : null}
+
+      <WalletCardConfirmDialog
+        open={confirm !== null}
+        title={confirm ? WALLET_CARD_CONFIRMATIONS[confirm].title : ""}
+        body={confirm ? WALLET_CARD_CONFIRMATIONS[confirm].body : ""}
+        confirmLabel={confirm ? WALLET_CARD_CONFIRMATIONS[confirm].confirmLabel : ""}
+        destructive={confirm === "remove" || confirm === "rotate"}
+        busy={busyAction !== null}
+        onConfirm={() => void runConfirmedAction()}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+      />
+    </PkmSettingsShell>
+  );
+}

--- a/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
+++ b/hushh-webapp/contracts/kai/one-route-orchestration-index.v1.json
@@ -183,6 +183,49 @@
       "native_surface_id": null
     },
     {
+      "route_pattern": "/c/[token]",
+      "page_file": "app/c/[token]/page.tsx",
+      "route_mode": "hidden",
+      "orchestration_class": "transitional",
+      "instruction_id": "route.wallet.card.public.token",
+      "context_policy": "suppress",
+      "voice_playbook": {
+        "playbook_id": "route.wallet.card.public.token",
+        "purpose": "Help the person read the shared profile and use its generated contact controls.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "navigate",
+        "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": null
+    },
+    {
       "route_pattern": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "route_mode": "redirect",
@@ -4438,6 +4481,49 @@
       },
       "trust_boundary": "auth",
       "native_surface_id": "native-route-ria-onboarding"
+    },
+    {
+      "route_pattern": "/one/wallet-card",
+      "page_file": "app/one/wallet-card/page.tsx",
+      "route_mode": "standard",
+      "orchestration_class": "context_only",
+      "instruction_id": "route.one.wallet.card",
+      "context_policy": "minimal",
+      "voice_playbook": {
+        "playbook_id": "route.one.wallet.card",
+        "purpose": "Help the owner review, update, pause, rotate or remove what their Wallet profile shares.",
+        "screen": "app",
+        "entry_cue": "",
+        "proactivity": "ambient",
+        "primary_action_id": null,
+        "happy_path_action_ids": [],
+        "required_inputs": [],
+        "recoveries": {
+          "blocked": "Explain the current guard and retain the goal.",
+          "cancelled": "Respect the cancellation and retain a safe next step.",
+          "failed": "Acknowledge the failure without claiming completion.",
+          "timeout": "Retain the goal and offer one safe retry.",
+          "callback_error": "Return to the verified callback recovery path without claiming success.",
+          "route_mismatch": "Use the verified current route and its generated actions only."
+        },
+        "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+        "next_route": null,
+        "return_policy": "stay",
+        "out_of_scope_behavior": "Answer naturally without inventing a control."
+      },
+      "interaction_layer_policy": {
+        "allowed_families": []
+      },
+      "canonical_screen": "app",
+      "voice_contract_file": null,
+      "action_ids": [],
+      "action_coverage": "none",
+      "delegation_policy": {
+        "mode": "no_delegation",
+        "allowed_delegate_agent_ids": []
+      },
+      "trust_boundary": "none",
+      "native_surface_id": "native-route-one-wallet-card"
     },
     {
       "route_pattern": "/pkm",

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -516,6 +516,55 @@
       "thread_and_consent_contract": null
     },
     {
+      "route": "/c/[token]",
+      "page_file": "app/c/[token]/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "hidden",
+        "exemption_reason": "Public Wallet Profile route is a standalone unauthenticated scan surface outside the signed-in app shell.",
+        "shell_verification_file": null,
+        "shell_verification_includes": [],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.wallet.card.public.token",
+          "purpose": "Help the person read the shared profile and use its generated contact controls.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "navigate",
+          "out_of_scope_behavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+        }
+      },
+      "native": null,
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
       "route": "/connected-systems",
       "page_file": "app/connected-systems/page.tsx",
       "physical_page_exists": true,
@@ -6712,6 +6761,74 @@
       "thread_and_consent_contract": null
     },
     {
+      "route": "/one/wallet-card",
+      "page_file": "app/one/wallet-card/page.tsx",
+      "physical_page_exists": true,
+      "route_contract": {
+        "mode": "standard",
+        "exemption_reason": null,
+        "shell_verification_file": "components/profile/pkm-settings-shell.tsx",
+        "shell_verification_includes": [
+          "AppPageShell",
+          "AppPageHeaderRegion",
+          "AppPageContentRegion",
+          "PageHeader",
+          "SurfaceStack"
+        ],
+        "interaction_layer_policy": {
+          "allowed_families": []
+        },
+        "voice_playbook": {
+          "playbook_id": "route.one.wallet.card",
+          "purpose": "Help the owner review, update, pause, rotate or remove what their Wallet profile shares.",
+          "screen": "app",
+          "entry_cue": "",
+          "proactivity": "ambient",
+          "primary_action_id": null,
+          "happy_path_action_ids": [],
+          "required_inputs": [],
+          "recoveries": {
+            "blocked": "Explain the current guard and retain the goal.",
+            "cancelled": "Respect the cancellation and retain a safe next step.",
+            "failed": "Acknowledge the failure without claiming completion.",
+            "timeout": "Retain the goal and offer one safe retry.",
+            "callback_error": "Return to the verified callback recovery path without claiming success.",
+            "route_mismatch": "Use the verified current route and its generated actions only."
+          },
+          "completion_boundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+          "next_route": null,
+          "return_policy": "stay",
+          "out_of_scope_behavior": "Answer naturally without inventing a control."
+        }
+      },
+      "native": {
+        "route": "/one/wallet-card",
+        "classification": "native-required-functional",
+        "initialRoute": "/login?redirect=%2Fone%2Fwallet-card",
+        "expectedMarker": "native-route-one-wallet-card",
+        "expectedRoute": "/one/wallet-card",
+        "autoReviewerLogin": true,
+        "expectedAuth": "authenticated",
+        "allowedDataStates": [
+          "loaded",
+          "empty-valid",
+          "unavailable-valid"
+        ]
+      },
+      "shell": {
+        "app_page_shell": false,
+        "page_header": false,
+        "settings_ui": false,
+        "shared_loader": false,
+        "back_button_pattern": "shared-shell"
+      },
+      "voice_action_contract_file": null,
+      "voice_action_contract_ids": [],
+      "api_dependencies": [],
+      "native_plugin_dependencies": [],
+      "thread_and_consent_contract": null
+    },
+    {
       "route": "/pkm",
       "page_file": "app/pkm/page.tsx",
       "physical_page_exists": true,
@@ -7819,5 +7936,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "4b1c0e41e3fa2269f4fbcddff19e8b8fa516b54d03e954359c03add40c89836c"
+  "content_sha256": "d375354425f66ebe9e6da2e5a38ac51e63f62c7122ffcc203f016a64fb8abca9"
 }

--- a/hushh-webapp/lib/navigation/app-route-layout.contract.json
+++ b/hushh-webapp/lib/navigation/app-route-layout.contract.json
@@ -395,6 +395,33 @@
     }
   },
   {
+    "route": "/c/[token]",
+    "mode": "hidden",
+    "exemptionReason": "Public Wallet Profile route is a standalone unauthenticated scan surface outside the signed-in app shell.",
+    "voicePlaybook": {
+      "playbookId": "route.wallet.card.public.token",
+      "purpose": "Help the person read the shared profile and use its generated contact controls.",
+      "screen": "app",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "navigate",
+      "outOfScopeBehavior": "Answer naturally, ask at most one clarifying question, and never invent a control."
+    }
+  },
+  {
     "route": "/one/location/request/[token]",
     "mode": "hidden",
     "exemptionReason": "Public one-location invite route is a standalone external-request form outside the signed-in app shell.",
@@ -593,6 +620,42 @@
       "playbookId": "route.one.marketplace.standalone",
       "purpose": "Standalone consent-first Marketplace route. One has no actions on this surface.",
       "screen": "one_marketplace",
+      "entryCue": "",
+      "proactivity": "ambient",
+      "primaryActionId": null,
+      "happyPathActionIds": [],
+      "requiredInputs": [],
+      "recoveries": {
+        "blocked": "Explain the current guard and retain the goal.",
+        "cancelled": "Respect the cancellation and retain a safe next step.",
+        "failed": "Acknowledge the failure without claiming completion.",
+        "timeout": "Retain the goal and offer one safe retry.",
+        "callbackError": "Return to the verified callback recovery path without claiming success.",
+        "routeMismatch": "Use the verified current route and its generated actions only."
+      },
+      "completionBoundary": "Completion is spoken only after the correlated browser settlement succeeds.",
+      "nextRoute": null,
+      "returnPolicy": "stay",
+      "outOfScopeBehavior": "Answer naturally without inventing a control."
+    }
+  },
+  {
+    "route": "/one/wallet-card",
+    "mode": "standard",
+    "shellVerification": {
+      "file": "components/profile/pkm-settings-shell.tsx",
+      "includes": [
+        "AppPageShell",
+        "AppPageHeaderRegion",
+        "AppPageContentRegion",
+        "PageHeader",
+        "SurfaceStack"
+      ]
+    },
+    "voicePlaybook": {
+      "playbookId": "route.one.wallet.card",
+      "purpose": "Help the owner review, update, pause, rotate or remove what their Wallet profile shares.",
+      "screen": "app",
       "entryCue": "",
       "proactivity": "ambient",
       "primaryActionId": null,

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -639,6 +639,22 @@ export function isPublicRoute(pathname: string): boolean {
 }
 
 /**
+ * Routes that must emit no analytics at all (Wallet Profile contract §7).
+ *
+ * A visitor scanning someone's Wallet Profile QR never agreed to anything with
+ * us — they are not a user, they arrived from a stranger's printed code, and we
+ * do not get to measure them. Deliberately much narrower than `isPublicRoute`:
+ * the marketing and auth routes there are ours to instrument.
+ */
+export function isAnalyticsExemptRoute(pathname: string): boolean {
+  const normalizedPathname = normalizeStaticExportPathname(pathname);
+  return (
+    normalizedPathname === WALLET_CARD_PUBLIC_PREFIX ||
+    normalizedPathname.startsWith(`${WALLET_CARD_PUBLIC_PREFIX}/`)
+  );
+}
+
+/**
  * Public editorial routes that share One's Foundation ambient presentation and
  * voice-only controls. Keep this narrower than isPublicRoute: auth, profile,
  * phone, and public invite routes have their own security/UI contracts.

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -108,6 +108,8 @@ export const ROUTES = {
   GMAIL: "/one/gmail",
   PKM: "/one/pkm",
   ONE_MARKETPLACE: "/one/marketplace",
+  /** Owner setup and management for the Apple Wallet profile pass. */
+  ONE_WALLET_CARD: "/one/wallet-card",
   CONNECTED_SYSTEMS: "/one/connected-systems",
   /** Canonical One workspace for consent review and access management. */
   CONSENTS: "/one/consent",
@@ -607,6 +609,15 @@ export function isOneSetupSurfaceRoute(pathname: string): boolean {
   );
 }
 
+/**
+ * Public Wallet Profile prefix. Deliberately a module-local constant rather
+ * than a ROUTES entry: `/c` is a token namespace with no page of its own, so it
+ * needs neither a native-route-inventory classification nor a ROUTES-derived
+ * app-route-layout entry. Precedent: the location public-invite prefix is
+ * likewise not a ROUTES value.
+ */
+const WALLET_CARD_PUBLIC_PREFIX = "/c";
+
 export function isPublicRoute(pathname: string): boolean {
   const normalizedPathname = normalizeStaticExportPathname(pathname);
   return (
@@ -621,7 +632,9 @@ export function isPublicRoute(pathname: string): boolean {
     normalizedPathname.startsWith(`${ROUTES.RESEARCH}/`) ||
     normalizedPathname === ROUTES.BLOG ||
     normalizedPathname.startsWith(`${ROUTES.BLOG}/`) ||
-    normalizedPathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`)
+    normalizedPathname.startsWith(`${ROUTES.ONE_LOCATION}/request/`) ||
+    normalizedPathname === WALLET_CARD_PUBLIC_PREFIX ||
+    normalizedPathname.startsWith(`${WALLET_CARD_PUBLIC_PREFIX}/`)
   );
 }
 

--- a/hushh-webapp/lib/observability/route-map.ts
+++ b/hushh-webapp/lib/observability/route-map.ts
@@ -59,6 +59,8 @@ export const ROUTE_ID_VALUES = [
   "one_location_map",
   "one_location_public_request",
   "one_location_circle_invite",
+  "one_wallet_card",
+  "wallet_card_public",
   "portfolio_shared",
   "ria_home",
   "ria_onboarding",
@@ -195,6 +197,14 @@ export function resolveRouteId(pathname: string): RouteId {
     return "one_location_public_request";
   if (pathname.startsWith("/one/location/invite/"))
     return "one_location_circle_invite";
+  if (pathname === ROUTES.ONE_WALLET_CARD) return "one_wallet_card";
+  // The scanned page emits no analytics of its own (isAnalyticsExemptRoute),
+  // so this ID is never attached to a page view. It exists because "unknown"
+  // is not inert: callers that fall through to it log the raw pathname, and on
+  // this route the pathname *is* the share token. Same shape as the public
+  // location request link above.
+  if (pathname === "/c" || pathname.startsWith("/c/"))
+    return "wallet_card_public";
   if (pathname === "/portfolio/shared") return "portfolio_shared";
   if (pathname === ROUTES.RIA_HOME) return "ria_home";
   if (pathname === ROUTES.RIA_ONBOARDING) return "ria_onboarding";

--- a/hushh-webapp/lib/seo/site.ts
+++ b/hushh-webapp/lib/seo/site.ts
@@ -111,6 +111,9 @@ export const DISALLOWED_PREFIXES = [
   "/logout",
   "/register-phone",
   "/labs",
+  // Public Wallet Profile pages are per-person contact details shared by link
+  // and revocable at any time. Never indexed, never trained on.
+  "/c",
 ] as const;
 
 /** Build an absolute URL for a site-relative path. */

--- a/hushh-webapp/lib/services/wallet-card-service.ts
+++ b/hushh-webapp/lib/services/wallet-card-service.ts
@@ -1,0 +1,1164 @@
+/**
+ * Wallet Profile service — the single network boundary for the Wallet Card
+ * feature (contract: docs/superpowers/specs/2026-08-03-wallet-card-contract.md).
+ *
+ * Everything the owner screens, the pass hand-off and the public `/c/[token]`
+ * page need goes through here. `app/**` and `components/**` never call
+ * `fetch()` themselves — `scripts/architecture/verify-service-layer-boundary.mjs`
+ * enforces that — so this module owns:
+ *
+ * - the two URL shapes (public share URL on the app origin, `.pkpass` URL on the
+ *   backend origin, because iOS follows that link out of the WebView),
+ * - the closed `card_payload` allowlist the owner sees before the server
+ *   re-validates it,
+ * - the typed public states, so a revoked card, an expired link and an unknown
+ *   token can never be collapsed into one vague failure,
+ * - the device-local copy of the share link, because the plaintext token comes
+ *   back from the backend exactly once (contract §5).
+ *
+ * Privacy rules that are binding here: the plaintext share token is never
+ * logged, no `card_payload` value is ever logged, and the public resolve carries
+ * no authorization header — the token *is* the credential.
+ */
+
+import { isIOS, isNative } from "@/lib/capacitor/platform";
+import { resolveRuntimeFrontendUrl } from "@/lib/runtime/settings";
+import { ApiError, apiErrorCode, apiJson } from "@/lib/services/api-client";
+import { ApiService } from "@/lib/services/api-service";
+import { openExternalUrl } from "@/lib/utils/browser-navigation";
+
+/* ------------------------------------------------------------------ routes */
+
+/** Backend route prefix (contract §1). */
+export const WALLET_CARD_API_PREFIX = "/api/one/wallet-card";
+
+/** Public web page prefix — what the QR encodes (contract §1). */
+export const WALLET_CARD_PUBLIC_PATH_PREFIX = "/c";
+
+/** Server code for "the pass cannot be signed in this deployment". */
+export const WALLET_PASS_SIGNING_UNAVAILABLE_CODE = "WALLET_PASS_SIGNING_UNAVAILABLE";
+
+/**
+ * Copy owned by the service layer. The revoked and expired lines are verbatim
+ * from contract §9 and are asserted by the test suite — change the contract
+ * before changing them here.
+ */
+export const WALLET_CARD_SERVICE_COPY = {
+  revoked: "This profile is no longer shared.",
+  expired: "This profile link has expired.",
+  notFound: "This profile is not available.",
+  unavailable: "This profile could not be loaded right now.",
+  signingUnavailable:
+    "We couldn't create your Wallet pass right now. Please try again in a moment.",
+  unsupported: "Apple Wallet is available on iPhone and iPad.",
+} as const;
+
+/* ------------------------------------------------------------------- types */
+
+/** Mirrors the server-side `preferred_contact` closed set (contract §3). */
+export type WalletCardPreferredContact = "email" | "phone" | "linkedin" | "website";
+
+export type WalletCardStatus = "active" | "paused" | "revoked";
+
+/**
+ * The owner-selected fields, in the server's snake_case shape. Every key here
+ * is on the closed allowlist; anything else is rejected, never dropped.
+ */
+export type WalletCardPayload = {
+  full_name?: string | null;
+  headline?: string | null;
+  organisation?: string | null;
+  location_label?: string | null;
+  summary?: string | null;
+  skills?: string[] | null;
+  email?: string | null;
+  phone?: string | null;
+  website?: string | null;
+  linkedin?: string | null;
+  github?: string | null;
+  portfolio?: string | null;
+  preferred_contact?: WalletCardPreferredContact | null;
+};
+
+/** What callers may hand to validation — unknown keys are the point of it. */
+export type WalletCardPayloadInput = WalletCardPayload | Record<string, unknown>;
+
+/** The owner's card row, as the owner screens consume it. */
+export interface WalletCardRecord {
+  passSerial: string | null;
+  status: WalletCardStatus;
+  shareTokenVersion: number;
+  cardPayload: WalletCardPayload;
+  displayName: string | null;
+  headline: string | null;
+  avatarUrl: string | null;
+  expiresAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  revokedAt: string | null;
+  lastScannedAt: string | null;
+  scanCount: number;
+}
+
+/**
+ * The device-local copy of the share link. The backend cannot return the
+ * plaintext token again, so this is what keeps the QR renderable.
+ */
+export interface WalletCardShareLink {
+  shareUrl: string;
+  shareToken: string;
+  /** Token version this link belongs to; a newer card invalidates it. */
+  version: number | null;
+}
+
+export interface WalletCardState {
+  enabled: boolean;
+  exists: boolean;
+  card: WalletCardRecord | null;
+  shareUrl: string | null;
+}
+
+export interface WalletCardMutationResult {
+  card: WalletCardRecord;
+  /** Present only on create and rotate (contract §5). */
+  shareToken: string | null;
+  shareUrl: string | null;
+  passUrl: string | null;
+}
+
+/** The visitor projection, in the same snake_case shape the contract defines. */
+export interface WalletCardPublicProfile {
+  full_name: string | null;
+  headline: string | null;
+  organisation: string | null;
+  location_label: string | null;
+  summary: string | null;
+  skills: string[];
+  email: string | null;
+  phone: string | null;
+  website: string | null;
+  linkedin: string | null;
+  github: string | null;
+  portfolio: string | null;
+  preferred_contact: WalletCardPreferredContact | null;
+  avatar_url: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * Terminal states a visitor can land in. `not_found` is deliberately identical
+ * for an unknown token and a paused card (contract §6) — the page must not be
+ * able to tell them apart.
+ */
+export type WalletCardPublicFailureState =
+  | "revoked"
+  | "expired"
+  | "not_found"
+  | "unavailable";
+
+export type WalletCardPublicResult =
+  | { state: "available"; card: WalletCardPublicProfile }
+  | { state: WalletCardPublicFailureState; message: string };
+
+/** Why a `.pkpass` could not be produced. */
+export type WalletPassFailure =
+  | { state: "signing_unavailable"; message: string; code: string }
+  | { state: "revoked"; message: string }
+  | { state: "expired"; message: string }
+  | { state: "not_found"; message: string }
+  | { state: "unavailable"; message: string };
+
+export type WalletPassAvailability =
+  | { state: "available"; url: string }
+  | WalletPassFailure;
+
+export type WalletPassAddResult =
+  | { state: "opened"; url: string }
+  | { state: "unsupported"; message: string; shareUrl: string }
+  | WalletPassFailure;
+
+export type WalletPassCapability = "capacitor_ios" | "ios_web" | "unsupported";
+
+export interface WalletCardPayloadIssue {
+  field: string;
+  message: string;
+}
+
+export type WalletCardPayloadValidation =
+  | { ok: true; value: WalletCardPayload }
+  | { ok: false; errors: WalletCardPayloadIssue[] };
+
+/** Thrown instead of sending a payload the server would reject. */
+export class WalletCardPayloadError extends Error {
+  constructor(public readonly errors: readonly WalletCardPayloadIssue[]) {
+    super("Some of this information cannot be shared from a Wallet Profile.");
+    this.name = "WalletCardPayloadError";
+  }
+}
+
+interface WalletCardOwnerRequest {
+  vaultOwnerToken: string;
+  userId: string;
+}
+
+/* --------------------------------------------------------------- allowlist */
+
+/** Per-field caps, exactly as contract §3 states them. */
+const TEXT_FIELD_LIMITS = {
+  full_name: 80,
+  headline: 120,
+  organisation: 80,
+  location_label: 80,
+  summary: 400,
+  email: 254,
+  phone: 32,
+  website: 300,
+  linkedin: 300,
+  github: 300,
+  portfolio: 300,
+  preferred_contact: 16,
+} as const;
+
+type WalletCardTextField = keyof typeof TEXT_FIELD_LIMITS;
+
+const URL_FIELDS: readonly WalletCardTextField[] = [
+  "website",
+  "linkedin",
+  "github",
+  "portfolio",
+];
+
+const PREFERRED_CONTACTS: readonly WalletCardPreferredContact[] = [
+  "email",
+  "phone",
+  "linkedin",
+  "website",
+];
+
+const MAX_SKILLS = 12;
+const MAX_SKILL_LENGTH = 40;
+const MAX_URL_LENGTH = 2048;
+const MAX_TIMESTAMP_LENGTH = 64;
+
+// Same shapes the backend applies, so the owner is told before saving rather
+// than after: exactly one `@`, at least one dot label, no whitespace.
+const EMAIL_SHAPE = /^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$/;
+const PHONE_SHAPE = /^\+?[0-9][0-9\s().\-]{5,31}$/;
+
+// `secrets.token_urlsafe(32)` yields 43 URL-safe characters. Bounding the shape
+// locally keeps traversal-shaped and obviously-junk tokens off a rate-limited
+// public endpoint, and guarantees a token can never widen a path.
+const SHARE_TOKEN_SHAPE = /^[A-Za-z0-9_-]{16,128}$/;
+
+/* ----------------------------------------------------------------- reading */
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as UnknownRecord;
+}
+
+function readString(
+  source: UnknownRecord,
+  keys: readonly string[],
+  maxLength: number,
+): string | null {
+  for (const key of keys) {
+    const raw = source[key];
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    return trimmed.slice(0, maxLength);
+  }
+  return null;
+}
+
+function readNumber(
+  source: UnknownRecord,
+  keys: readonly string[],
+  fallback: number,
+): number {
+  for (const key of keys) {
+    const raw = source[key];
+    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+    if (typeof raw === "string" && raw.trim()) {
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return fallback;
+}
+
+/**
+ * Read the honest status word out of a body, tolerating FastAPI's
+ * `{"detail": {...}}` envelope as well as a bare `{"status": "..."}`.
+ */
+function readStatusWord(payload: unknown): string | null {
+  const record = asRecord(payload);
+  if (!record) return null;
+  const direct = record.status;
+  if (typeof direct === "string" && direct.trim()) {
+    return direct.trim().toLowerCase();
+  }
+  return readStatusWord(record.detail) ?? readStatusWord(record.error);
+}
+
+function readMessageWord(payload: unknown): string | null {
+  const record = asRecord(payload);
+  if (!record) return null;
+  const direct = record.message;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  return readMessageWord(record.detail) ?? readMessageWord(record.error);
+}
+
+function readCodeWord(payload: unknown): string | null {
+  const record = asRecord(payload);
+  if (!record) return null;
+  const direct = record.code;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  return readCodeWord(record.detail) ?? readCodeWord(record.error);
+}
+
+/* ------------------------------------------------------------ URL builders */
+
+function trimOrigin(value: string | null | undefined): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text.replace(/\/+$/, "");
+}
+
+function appOrigin(): string {
+  try {
+    return trimOrigin(resolveRuntimeFrontendUrl());
+  } catch {
+    return "";
+  }
+}
+
+function backendOrigin(): string {
+  try {
+    return trimOrigin(ApiService.getDirectBackendUrl());
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * The URL the QR encodes. Falls back to a relative path when no app origin is
+ * configured, which is what the native shell resolves against its own host.
+ */
+export function walletCardShareUrl(shareToken: string): string {
+  const token = encodeURIComponent(String(shareToken ?? ""));
+  return `${appOrigin()}${WALLET_CARD_PUBLIC_PATH_PREFIX}/${token}`;
+}
+
+/**
+ * The `.pkpass` download URL.
+ *
+ * Built against the backend origin rather than the Next proxy: iOS hands this
+ * URL to Safari, which imports the pass natively, and the proxy would return
+ * JSON rather than the signed bundle.
+ */
+export function walletCardPassUrl(shareToken: string): string {
+  const token = encodeURIComponent(String(shareToken ?? ""));
+  return `${backendOrigin()}${WALLET_CARD_API_PREFIX}/pass/${token}.pkpass`;
+}
+
+/** Reject a wrong-shape token before it is sent, stored or trusted. */
+export function isWalletShareTokenShape(value: string | null | undefined): boolean {
+  return typeof value === "string" && SHARE_TOKEN_SHAPE.test(value);
+}
+
+/* ------------------------------------------------------- platform capability */
+
+/**
+ * Where an Apple Wallet pass can actually be installed.
+ *
+ * The native Android shell and desktop web get `unsupported` and are offered the
+ * share link instead. iPadOS asks for the desktop site, so a Macintosh user
+ * agent with a touch screen still counts as iOS on the web.
+ */
+export function walletPassCapability(): WalletPassCapability {
+  if (isNative()) {
+    return isIOS() ? "capacitor_ios" : "unsupported";
+  }
+  if (typeof navigator === "undefined") return "unsupported";
+  const userAgent = navigator.userAgent || "";
+  if (/iPhone|iPad|iPod/i.test(userAgent)) return "ios_web";
+  if (/Macintosh/i.test(userAgent) && (navigator.maxTouchPoints ?? 0) > 1) {
+    return "ios_web";
+  }
+  return "unsupported";
+}
+
+export function canAddToAppleWallet(): boolean {
+  return walletPassCapability() !== "unsupported";
+}
+
+/* ------------------------------------------------------------- URL safety */
+
+/**
+ * The one URL rule for the whole feature: absolute `https://` only, with no
+ * embedded credentials. `javascript:`, `data:`, `http:` and `user@host` display
+ * spoofs all resolve to false.
+ */
+export function isAllowedWalletCardUrl(value: string | null | undefined): boolean {
+  if (typeof value !== "string") return false;
+  const candidate = value.trim();
+  if (!candidate || candidate.length > MAX_URL_LENGTH) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.username || parsed.password) return false;
+  return Boolean(parsed.hostname);
+}
+
+function safeLink(value: string | null): string | null {
+  return isAllowedWalletCardUrl(value) ? value : null;
+}
+
+function safeEmail(value: string | null): string | null {
+  if (!value) return null;
+  return EMAIL_SHAPE.test(value) ? value : null;
+}
+
+function safePhone(value: string | null): string | null {
+  if (!value) return null;
+  return PHONE_SHAPE.test(value) ? value : null;
+}
+
+/* --------------------------------------------------------- payload validation */
+
+function isTextField(key: string): key is WalletCardTextField {
+  return Object.prototype.hasOwnProperty.call(TEXT_FIELD_LIMITS, key);
+}
+
+function validateSkills(raw: unknown, errors: WalletCardPayloadIssue[]): string[] {
+  if (raw === null || raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    errors.push({ field: "skills", message: "Skills must be a list of short entries." });
+    return [];
+  }
+  const cleaned: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") {
+      errors.push({ field: "skills", message: "Each skill must be text." });
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    if (trimmed.length > MAX_SKILL_LENGTH) {
+      errors.push({
+        field: "skills",
+        message: `Each skill must be ${MAX_SKILL_LENGTH} characters or fewer.`,
+      });
+      continue;
+    }
+    cleaned.push(trimmed);
+  }
+  if (cleaned.length > MAX_SKILLS) {
+    errors.push({ field: "skills", message: `Keep it to ${MAX_SKILLS} skills.` });
+  }
+  return cleaned;
+}
+
+/**
+ * Client-side mirror of the server's closed allowlist.
+ *
+ * A key outside the allowlist is an error, not a silent drop, so an owner
+ * screen can never quietly send something the server would refuse. Values are
+ * trimmed; an empty value is treated as absent rather than stored as a blank.
+ * No value is ever logged.
+ */
+export function validateWalletCardPayload(
+  input: WalletCardPayloadInput,
+): WalletCardPayloadValidation {
+  const errors: WalletCardPayloadIssue[] = [];
+  const value: WalletCardPayload = {};
+  const source = asRecord(input) ?? {};
+
+  for (const [key, raw] of Object.entries(source)) {
+    if (key === "skills") {
+      const skills = validateSkills(raw, errors);
+      if (skills.length > 0) value.skills = skills;
+      continue;
+    }
+
+    if (!isTextField(key)) {
+      errors.push({
+        field: "card_payload",
+        message: `"${key}" is not a field a Wallet Profile can share.`,
+      });
+      continue;
+    }
+
+    if (raw === null || raw === undefined) continue;
+    if (typeof raw !== "string") {
+      errors.push({ field: key, message: "Enter this as text." });
+      continue;
+    }
+
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+
+    const limit = TEXT_FIELD_LIMITS[key];
+    if (trimmed.length > limit) {
+      errors.push({
+        field: key,
+        message: `Keep this to ${limit} characters or fewer.`,
+      });
+      continue;
+    }
+
+    if (key === "preferred_contact") {
+      const candidate = trimmed.toLowerCase();
+      const match = PREFERRED_CONTACTS.find((option) => option === candidate);
+      if (!match) {
+        errors.push({
+          field: key,
+          message: "Choose email, phone, LinkedIn or a link.",
+        });
+        continue;
+      }
+      value.preferred_contact = match;
+      continue;
+    }
+
+    if (key === "email" && !EMAIL_SHAPE.test(trimmed)) {
+      errors.push({ field: key, message: "Enter a valid email address." });
+      continue;
+    }
+    if (key === "phone" && !PHONE_SHAPE.test(trimmed)) {
+      errors.push({ field: key, message: "Enter a valid phone number." });
+      continue;
+    }
+    if (URL_FIELDS.includes(key) && !isAllowedWalletCardUrl(trimmed)) {
+      errors.push({ field: key, message: "Use a full https:// link." });
+      continue;
+    }
+
+    value[key] = trimmed;
+  }
+
+  return errors.length > 0 ? { ok: false, errors } : { ok: true, value };
+}
+
+/* -------------------------------------------------------------- projections */
+
+function readPreferredContact(
+  source: UnknownRecord,
+): WalletCardPreferredContact | null {
+  const raw = readString(
+    source,
+    ["preferredContact", "preferred_contact"],
+    TEXT_FIELD_LIMITS.preferred_contact,
+  );
+  if (!raw) return null;
+  const candidate = raw.toLowerCase();
+  return PREFERRED_CONTACTS.find((option) => option === candidate) ?? null;
+}
+
+function readSkills(source: UnknownRecord): string[] {
+  const raw = source.skills;
+  if (!Array.isArray(raw)) return [];
+  const skills: string[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim().slice(0, MAX_SKILL_LENGTH);
+    if (!trimmed) continue;
+    skills.push(trimmed);
+    if (skills.length >= MAX_SKILLS) break;
+  }
+  return skills;
+}
+
+/**
+ * Re-apply the allowlist to whatever the wire actually carried.
+ *
+ * The server already validates, so this is defence in depth: a hostile or
+ * malformed projection must not be able to hand the page a `javascript:` or
+ * `data:` link, and an over-long value must not be able to reach the DOM.
+ */
+function toPublicProfile(raw: unknown): WalletCardPublicProfile | null {
+  const source = asRecord(raw);
+  if (!source) return null;
+  return {
+    full_name: readString(
+      source,
+      ["fullName", "full_name", "displayName", "display_name"],
+      TEXT_FIELD_LIMITS.full_name,
+    ),
+    headline: readString(source, ["headline"], TEXT_FIELD_LIMITS.headline),
+    organisation: readString(
+      source,
+      ["organisation", "organization"],
+      TEXT_FIELD_LIMITS.organisation,
+    ),
+    location_label: readString(
+      source,
+      ["locationLabel", "location_label"],
+      TEXT_FIELD_LIMITS.location_label,
+    ),
+    summary: readString(source, ["summary"], TEXT_FIELD_LIMITS.summary),
+    skills: readSkills(source),
+    email: safeEmail(readString(source, ["email"], TEXT_FIELD_LIMITS.email)),
+    phone: safePhone(readString(source, ["phone"], TEXT_FIELD_LIMITS.phone)),
+    website: safeLink(readString(source, ["website"], TEXT_FIELD_LIMITS.website)),
+    linkedin: safeLink(readString(source, ["linkedin"], TEXT_FIELD_LIMITS.linkedin)),
+    github: safeLink(readString(source, ["github"], TEXT_FIELD_LIMITS.github)),
+    portfolio: safeLink(readString(source, ["portfolio"], TEXT_FIELD_LIMITS.portfolio)),
+    preferred_contact: readPreferredContact(source),
+    avatar_url: safeLink(
+      readString(source, ["avatarUrl", "avatar_url", "photoUrl", "photo_url"], MAX_URL_LENGTH),
+    ),
+    updated_at: readString(
+      source,
+      ["updatedOn", "updated_on", "updatedAt", "updated_at"],
+      MAX_TIMESTAMP_LENGTH,
+    ),
+  };
+}
+
+/** The owner's own stored fields, kept editable rather than re-sanitised away. */
+function toStoredPayload(raw: unknown): WalletCardPayload {
+  const payload: WalletCardPayload = {};
+  const source = asRecord(raw);
+  if (!source) return payload;
+
+  const textKeys: readonly [WalletCardTextField, readonly string[]][] = [
+    ["full_name", ["full_name", "fullName"]],
+    ["headline", ["headline"]],
+    ["organisation", ["organisation", "organization"]],
+    ["location_label", ["location_label", "locationLabel"]],
+    ["summary", ["summary"]],
+    ["email", ["email"]],
+    ["phone", ["phone"]],
+    ["website", ["website"]],
+    ["linkedin", ["linkedin"]],
+    ["github", ["github"]],
+    ["portfolio", ["portfolio"]],
+  ];
+
+  for (const [field, keys] of textKeys) {
+    if (field === "preferred_contact") continue;
+    const text = readString(source, keys, TEXT_FIELD_LIMITS[field]);
+    if (text) payload[field] = text;
+  }
+
+  const skills = readSkills(source);
+  if (skills.length > 0) payload.skills = skills;
+
+  const preferred = readPreferredContact(source);
+  if (preferred) payload.preferred_contact = preferred;
+
+  return payload;
+}
+
+function readStatus(source: UnknownRecord): WalletCardStatus {
+  const raw = readString(source, ["status"], 16)?.toLowerCase() ?? "";
+  if (raw === "paused" || raw === "revoked") return raw;
+  return "active";
+}
+
+function toCardRecord(raw: unknown): WalletCardRecord | null {
+  const source = asRecord(raw);
+  if (!source) return null;
+  return {
+    passSerial: readString(source, ["passSerial", "pass_serial"], 128),
+    status: readStatus(source),
+    shareTokenVersion: readNumber(
+      source,
+      ["shareTokenVersion", "share_token_version"],
+      1,
+    ),
+    cardPayload: toStoredPayload(source.cardPayload ?? source.card_payload),
+    displayName: readString(
+      source,
+      ["displayName", "display_name"],
+      TEXT_FIELD_LIMITS.full_name,
+    ),
+    headline: readString(source, ["headline"], TEXT_FIELD_LIMITS.headline),
+    avatarUrl: readString(source, ["avatarUrl", "avatar_url"], MAX_URL_LENGTH),
+    expiresAt: readString(source, ["expiresAt", "expires_at"], MAX_TIMESTAMP_LENGTH),
+    createdAt: readString(source, ["createdAt", "created_at"], MAX_TIMESTAMP_LENGTH),
+    updatedAt: readString(source, ["updatedAt", "updated_at"], MAX_TIMESTAMP_LENGTH),
+    revokedAt: readString(source, ["revokedAt", "revoked_at"], MAX_TIMESTAMP_LENGTH),
+    lastScannedAt: readString(
+      source,
+      ["lastScannedAt", "last_scanned_at"],
+      MAX_TIMESTAMP_LENGTH,
+    ),
+    scanCount: readNumber(source, ["scanCount", "scan_count"], 0),
+  };
+}
+
+/* ------------------------------------------------------------ typed states */
+
+function revokedResult(): WalletCardPublicResult {
+  return { state: "revoked", message: WALLET_CARD_SERVICE_COPY.revoked };
+}
+
+function expiredResult(): WalletCardPublicResult {
+  return { state: "expired", message: WALLET_CARD_SERVICE_COPY.expired };
+}
+
+function notFoundResult(): WalletCardPublicResult {
+  return { state: "not_found", message: WALLET_CARD_SERVICE_COPY.notFound };
+}
+
+function unavailableResult(): WalletCardPublicResult {
+  return { state: "unavailable", message: WALLET_CARD_SERVICE_COPY.unavailable };
+}
+
+/** Map a 200 body — public resolve and owner preview share one projection. */
+function projectPublicResult(response: unknown): WalletCardPublicResult {
+  const record = asRecord(response);
+  const state = readStatusWord(record) ?? "not_found";
+  if (state === "revoked") return revokedResult();
+  if (state === "expired") return expiredResult();
+  if (state === "unavailable") return unavailableResult();
+  // Paused and unknown both arrive as the identical generic state (contract §6).
+  if (state !== "active") return notFoundResult();
+
+  const card = toPublicProfile(record?.card ?? record?.profile);
+  return card ? { state: "available", card } : notFoundResult();
+}
+
+/** Map a failed request onto the same terminal states, never onto an exception. */
+function publicFailureResult(error: unknown): WalletCardPublicResult {
+  if (!(error instanceof ApiError)) return unavailableResult();
+  const declared =
+    readStatusWord(error.payload) ?? apiErrorCode(error)?.toLowerCase() ?? null;
+  if (error.status === 410) {
+    return declared === "expired" ? expiredResult() : revokedResult();
+  }
+  if (declared === "expired") return expiredResult();
+  if (declared === "revoked") return revokedResult();
+  if (error.status === 404 || error.status === 400 || error.status === 422) {
+    return notFoundResult();
+  }
+  return unavailableResult();
+}
+
+function unreadableResponse(): ApiError {
+  return new ApiError("Wallet Profile response could not be read.", 502);
+}
+
+function isFeatureDisabled(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.status === 404 &&
+    apiErrorCode(error) === "ONE_WALLET_CARD_DISABLED"
+  );
+}
+
+/* ------------------------------------------------------------ local storage */
+
+const SHARE_LINK_STORAGE_PREFIX = "hushh.one.wallet-card.share-link";
+
+function shareLinkKey(userId: string): string {
+  return `${SHARE_LINK_STORAGE_PREFIX}:${userId}`;
+}
+
+function localStore(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readTokenVersion(card: WalletCardRecord | null | undefined): number | null {
+  const raw = card?.shareTokenVersion;
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+}
+
+/* ---------------------------------------------------------------- requests */
+
+function ownerHeaders(vaultOwnerToken: string): Record<string, string> {
+  return { Authorization: `Bearer ${vaultOwnerToken}` };
+}
+
+function ownerJsonHeaders(vaultOwnerToken: string): Record<string, string> {
+  return { ...ownerHeaders(vaultOwnerToken), "Content-Type": "application/json" };
+}
+
+function ownerQuery(userId: string): string {
+  return `?user_id=${encodeURIComponent(userId)}`;
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) return null;
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+/* ----------------------------------------------------------------- service */
+
+export class WalletCardService {
+  /* ------------------------------------------------------------ owner side */
+
+  /**
+   * The owner's current card. A deployment without the feature flag reports
+   * `enabled: false` rather than throwing, so the screen can explain itself.
+   */
+  static async getCard(params: WalletCardOwnerRequest): Promise<WalletCardState> {
+    try {
+      const response = await apiJson<unknown>(
+        `${WALLET_CARD_API_PREFIX}${ownerQuery(params.userId)}`,
+        { headers: ownerHeaders(params.vaultOwnerToken) },
+      );
+      const card = toCardRecord(asRecord(response)?.card);
+      if (!card) {
+        return { enabled: true, exists: false, card: null, shareUrl: null };
+      }
+      return {
+        enabled: true,
+        exists: true,
+        card,
+        shareUrl:
+          WalletCardService.readShareLink(params.userId, card)?.shareUrl ?? null,
+      };
+    } catch (error) {
+      if (isFeatureDisabled(error)) {
+        return { enabled: false, exists: false, card: null, shareUrl: null };
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Create or update the shared fields.
+   *
+   * The payload is validated against the closed allowlist first: an invalid
+   * draft never reaches the network. The plaintext token comes back only on
+   * first creation, so it is persisted here before the response is discarded.
+   */
+  static async saveCard(params: {
+    vaultOwnerToken: string;
+    userId: string;
+    payload: WalletCardPayloadInput;
+    expiresAt?: string | null;
+  }): Promise<WalletCardMutationResult> {
+    const validation = validateWalletCardPayload(params.payload);
+    if (!validation.ok) {
+      throw new WalletCardPayloadError(validation.errors);
+    }
+    const response = await apiJson<unknown>(WALLET_CARD_API_PREFIX, {
+      method: "POST",
+      headers: ownerJsonHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({
+        userId: params.userId,
+        cardPayload: validation.value,
+        ...(params.expiresAt === undefined ? {} : { expiresAt: params.expiresAt }),
+      }),
+    });
+    return WalletCardService.adoptMutation(params.userId, response);
+  }
+
+  /** Mint a new token. The old QR stops working immediately. */
+  static async rotateShareToken(
+    params: WalletCardOwnerRequest,
+  ): Promise<WalletCardMutationResult> {
+    const response = await apiJson<unknown>(`${WALLET_CARD_API_PREFIX}/rotate`, {
+      method: "POST",
+      headers: ownerJsonHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({ userId: params.userId }),
+    });
+    return WalletCardService.adoptMutation(params.userId, response);
+  }
+
+  /** A paused card reads as non-existent to a visitor. */
+  static async pauseCard(
+    params: WalletCardOwnerRequest,
+  ): Promise<WalletCardRecord> {
+    return WalletCardService.ownerAction(params, "/pause");
+  }
+
+  static async resumeCard(
+    params: WalletCardOwnerRequest,
+  ): Promise<WalletCardRecord> {
+    return WalletCardService.ownerAction(params, "/resume");
+  }
+
+  /** Stop sharing for good. The device-local link is dropped with it. */
+  static async revokeCard(
+    params: WalletCardOwnerRequest,
+  ): Promise<WalletCardRecord> {
+    const response = await apiJson<unknown>(
+      `${WALLET_CARD_API_PREFIX}${ownerQuery(params.userId)}`,
+      { method: "DELETE", headers: ownerHeaders(params.vaultOwnerToken) },
+    );
+    WalletCardService.forgetShareLink(params.userId);
+    const card = toCardRecord(asRecord(response)?.card);
+    if (!card) throw unreadableResponse();
+    return card;
+  }
+
+  /**
+   * Preview-as-visitor. The backend runs the same projection builder the public
+   * route uses, so this cannot drift from what a stranger actually receives.
+   */
+  static async previewAsVisitor(
+    params: WalletCardOwnerRequest,
+  ): Promise<WalletCardPublicResult> {
+    try {
+      const response = await apiJson<unknown>(
+        `${WALLET_CARD_API_PREFIX}/preview${ownerQuery(params.userId)}`,
+        { headers: ownerHeaders(params.vaultOwnerToken) },
+      );
+      return projectPublicResult(response);
+    } catch (error) {
+      return publicFailureResult(error);
+    }
+  }
+
+  /* ----------------------------------------------------------- public side */
+
+  /**
+   * Resolve a scanned share token for a stranger.
+   *
+   * Deliberately unauthenticated — the token is the credential, so no
+   * authorization header is attached. Terminal states are returned, never
+   * thrown, so the page can render an honest message for each one.
+   */
+  static async resolvePublicCard(
+    shareToken: string,
+  ): Promise<WalletCardPublicResult> {
+    if (!isWalletShareTokenShape(shareToken)) return notFoundResult();
+    try {
+      const response = await apiJson<unknown>(
+        `${WALLET_CARD_API_PREFIX}/public/${encodeURIComponent(shareToken)}`,
+        { method: "GET", cache: "no-store" },
+      );
+      return projectPublicResult(response);
+    } catch (error) {
+      return publicFailureResult(error);
+    }
+  }
+
+  /**
+   * Ask whether the signed `.pkpass` can actually be produced before handing
+   * the URL to the OS, so a missing certificate surfaces as product copy rather
+   * than a raw error page in Safari.
+   */
+  static async checkPassAvailability(
+    shareToken: string,
+  ): Promise<WalletPassAvailability> {
+    if (!isWalletShareTokenShape(shareToken)) {
+      return { state: "not_found", message: WALLET_CARD_SERVICE_COPY.notFound };
+    }
+
+    let response: Response;
+    try {
+      response = await ApiService.apiFetch(
+        `${WALLET_CARD_API_PREFIX}/pass/${encodeURIComponent(shareToken)}.pkpass`,
+        { method: "GET", cache: "no-store" },
+      );
+    } catch {
+      return { state: "unavailable", message: WALLET_CARD_SERVICE_COPY.unavailable };
+    }
+
+    if (response.ok) {
+      return { state: "available", url: walletCardPassUrl(shareToken) };
+    }
+
+    const body = await readJsonBody(response);
+    const declared = readStatusWord(body);
+
+    if (response.status === 410) {
+      return declared === "expired"
+        ? { state: "expired", message: WALLET_CARD_SERVICE_COPY.expired }
+        : { state: "revoked", message: WALLET_CARD_SERVICE_COPY.revoked };
+    }
+    if (response.status === 404) {
+      return { state: "not_found", message: WALLET_CARD_SERVICE_COPY.notFound };
+    }
+    if (response.status === 503) {
+      return {
+        state: "signing_unavailable",
+        message: readMessageWord(body) ?? WALLET_CARD_SERVICE_COPY.signingUnavailable,
+        code: readCodeWord(body) ?? WALLET_PASS_SIGNING_UNAVAILABLE_CODE,
+      };
+    }
+    return { state: "unavailable", message: WALLET_CARD_SERVICE_COPY.unavailable };
+  }
+
+  /**
+   * Add the pass to Apple Wallet.
+   *
+   * The URL is handed to the OS through `openExternalUrl()` because WKWebView
+   * cannot import a `.pkpass`; it is never loaded in the WebView. Off-iOS there
+   * is nothing to install, so the share link is offered instead — without
+   * spending a request.
+   */
+  static async addToAppleWallet(
+    shareToken: string,
+    options: { verifyFirst?: boolean } = {},
+  ): Promise<WalletPassAddResult> {
+    if (walletPassCapability() === "unsupported") {
+      return {
+        state: "unsupported",
+        message: WALLET_CARD_SERVICE_COPY.unsupported,
+        shareUrl: walletCardShareUrl(shareToken),
+      };
+    }
+
+    if (options.verifyFirst !== false) {
+      const availability = await WalletCardService.checkPassAvailability(shareToken);
+      if (availability.state !== "available") return availability;
+    }
+
+    const url = walletCardPassUrl(shareToken);
+    openExternalUrl(url);
+    return { state: "opened", url };
+  }
+
+  /* --------------------------------------------------- device-local link */
+
+  /**
+   * Persist the share link on this device.
+   *
+   * The backend hashes the token and cannot return it again (contract §5), so
+   * without this copy the QR could never be rendered after the create or rotate
+   * response is gone. Nothing here is logged.
+   */
+  static rememberShareLink(
+    userId: string,
+    input: {
+      card?: WalletCardRecord | null;
+      shareToken: string;
+      shareUrl: string;
+    },
+  ): void {
+    if (!userId) return;
+    const shareToken = String(input.shareToken ?? "").trim();
+    const shareUrl = String(input.shareUrl ?? "").trim();
+    if (!isWalletShareTokenShape(shareToken) || !shareUrl) return;
+
+    const storage = localStore();
+    if (!storage) return;
+    try {
+      storage.setItem(
+        shareLinkKey(userId),
+        JSON.stringify({
+          shareUrl,
+          shareToken,
+          version: readTokenVersion(input.card),
+        }),
+      );
+    } catch {
+      // A full or unavailable store only costs the QR on this device.
+    }
+  }
+
+  /**
+   * Read this device's share link.
+   *
+   * Passing the current card drops the link when its token version no longer
+   * matches — that is how a rotation performed on another device stops this one
+   * from showing a dead QR. The stored copy is left in place rather than
+   * deleted, because the caller may be checking a stale card.
+   */
+  static readShareLink(
+    userId: string,
+    card?: WalletCardRecord | null,
+  ): WalletCardShareLink | null {
+    if (!userId) return null;
+    const storage = localStore();
+    if (!storage) return null;
+
+    let parsed: unknown;
+    try {
+      const raw = storage.getItem(shareLinkKey(userId));
+      if (!raw) return null;
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    const record = asRecord(parsed);
+    if (!record) return null;
+
+    const shareUrl = typeof record.shareUrl === "string" ? record.shareUrl.trim() : "";
+    const shareToken =
+      typeof record.shareToken === "string" ? record.shareToken.trim() : "";
+    if (!shareUrl || !isWalletShareTokenShape(shareToken)) return null;
+
+    const version =
+      typeof record.version === "number" && Number.isFinite(record.version)
+        ? record.version
+        : null;
+
+    if (card && card.status === "revoked") return null;
+    const cardVersion = readTokenVersion(card);
+    if (cardVersion !== null && version !== null && cardVersion !== version) {
+      return null;
+    }
+
+    return { shareUrl, shareToken, version };
+  }
+
+  static forgetShareLink(userId: string): void {
+    if (!userId) return;
+    const storage = localStore();
+    if (!storage) return;
+    try {
+      storage.removeItem(shareLinkKey(userId));
+    } catch {
+      // Nothing to do: the link is device-local and advisory.
+    }
+  }
+
+  /* ------------------------------------------------------------- internals */
+
+  private static async ownerAction(
+    params: WalletCardOwnerRequest,
+    suffix: string,
+  ): Promise<WalletCardRecord> {
+    const response = await apiJson<unknown>(`${WALLET_CARD_API_PREFIX}${suffix}`, {
+      method: "POST",
+      headers: ownerJsonHeaders(params.vaultOwnerToken),
+      body: JSON.stringify({ userId: params.userId }),
+    });
+    const card = toCardRecord(asRecord(response)?.card);
+    if (!card) throw unreadableResponse();
+    return card;
+  }
+
+  /** Adopt a create/rotate response and keep the once-only token on-device. */
+  private static adoptMutation(
+    userId: string,
+    response: unknown,
+  ): WalletCardMutationResult {
+    const record = asRecord(response);
+    const card = toCardRecord(record?.card);
+    if (!card) throw unreadableResponse();
+
+    const rawToken = record
+      ? readString(record, ["shareToken", "share_token"], 128)
+      : null;
+    const shareToken = isWalletShareTokenShape(rawToken) ? rawToken : null;
+
+    const shareUrl = shareToken
+      ? ((record ? readString(record, ["shareUrl", "share_url"], MAX_URL_LENGTH) : null) ??
+        walletCardShareUrl(shareToken))
+      : null;
+    const passUrl = shareToken ? walletCardPassUrl(shareToken) : null;
+
+    if (shareToken && shareUrl) {
+      WalletCardService.rememberShareLink(userId, { card, shareToken, shareUrl });
+    }
+
+    return { card, shareToken, shareUrl, passUrl };
+  }
+}

--- a/hushh-webapp/native-route-inventory.json
+++ b/hushh-webapp/native-route-inventory.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-08-02",
-  "total_routes": 104,
-  "native_required_routes": 94,
+  "total_routes": 105,
+  "native_required_routes": 95,
   "excluded_routes": 10,
   "routes": [
     {
@@ -920,6 +920,20 @@
       "initialRoute": "/login?redirect=%2Fone%2Fmarketplace",
       "expectedMarker": "native-route-one-marketplace",
       "expectedRoute": "/one/marketplace",
+      "autoReviewerLogin": true,
+      "expectedAuth": "authenticated",
+      "allowedDataStates": [
+        "loaded",
+        "empty-valid",
+        "unavailable-valid"
+      ]
+    },
+    {
+      "route": "/one/wallet-card",
+      "classification": "native-required-functional",
+      "initialRoute": "/login?redirect=%2Fone%2Fwallet-card",
+      "expectedMarker": "native-route-one-wallet-card",
+      "expectedRoute": "/one/wallet-card",
       "autoReviewerLogin": true,
       "expectedAuth": "authenticated",
       "allowedDataStates": [

--- a/scripts/ci/provision_wallet_pass_certificate.py
+++ b/scripts/ci/provision_wallet_pass_certificate.py
@@ -1,0 +1,978 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 Hushh
+"""Provision the Apple Pass Type ID and its PASS_TYPE_ID signing certificate.
+
+The Hushh One Wallet Profile pass (``pass.com.hushh.app.one``) is signed
+server-side with a Pass Type ID certificate chained through the Apple WWDR **G4**
+intermediate. Nothing about that is interactive: the whole chain is automatable
+with the Admin-role App Store Connect key that already lives in GCP Secret
+Manager, so this script mints the material and hands it to Secret Manager without
+a human ever touching a private key.
+
+What it does, in order:
+
+1. Resolve the Pass Type ID for ``--pass-type-identifier``. An existing one is
+   **reused** (this step is idempotent); only a missing one is created via
+   ``POST /v1/passTypeIds``.
+2. Generate an RSA-2048 keypair and a CSR locally, in the runner, with
+   ``cryptography``. The private key never leaves the process except as a
+   Secret Manager payload written over stdin.
+3. ``POST /v1/certificates`` with ``certificateType=PASS_TYPE_ID``, the base64
+   CSR, and the ``passTypeId`` relationship.
+4. Decode the returned base64 DER ``certificateContent`` into PEM and assert the
+   certificate actually matches the private key generated in step 2.
+5. Fetch the Apple WWDR G4 intermediate and verify it is the real G4 (``OU=G4``,
+   issuer ``Apple Root CA``, ``notAfter`` 2030-12-10) so a silently-wrong or
+   swapped intermediate cannot slip into the signing chain.
+6. Write ``WALLET_PASS_CERT_PEM`` / ``WALLET_PASS_KEY_PEM`` /
+   ``WALLET_PASS_WWDR_PEM`` to every ``--secret-project`` through
+   ``scripts/ops/upsert_gcp_secret.py --stdin`` — never through a shell variable,
+   an argv value, or a temp file.
+
+Minting a certificate is **irreversible** (it consumes a slot in the Apple
+Developer account), so the default mode is a dry run: everything is resolved,
+generated and verified locally, but no Apple resource is created and no secret is
+written. Pass ``--apply`` to perform the real provisioning.
+
+Re-running with ``--apply`` when all three secrets already exist and the stored
+certificate is not within ``--renew-within-days`` of expiry is a no-op: the run
+reports the existing expiry and exits 0. That makes the workflow safe to
+re-dispatch and turns it into the rotation entry point (a certificate inside the
+renewal window is re-minted).
+
+Only PyJWT + cryptography are needed beyond the standard library; both are
+pip-installed into an ephemeral venv by the workflow.
+
+Output discipline: diagnostics go to stderr, and the **only** thing printed to
+stdout is a non-sensitive metadata JSON object (identifier, certificate id,
+serial, expiry). The private key, the certificate body and the WWDR body are
+never logged, never echoed, and never written to the job summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+from typing import NoReturn
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import date, datetime, timedelta, timezone
+
+ASC_API_ROOT = "https://api.appstoreconnect.apple.com"
+ASC_AUDIENCE = "appstoreconnect-v1"
+CERTIFICATE_TYPE = "PASS_TYPE_ID"
+
+# noqa S105: "pass" here is Apple's Wallet pass, not a credential.
+DEFAULT_PASS_TYPE_IDENTIFIER = "pass.com.hushh.app.one"  # noqa: S105
+DEFAULT_PASS_TYPE_NAME = "Hushh One Wallet Profile"  # noqa: S105
+DEFAULT_CSR_ORGANISATION = "Hushh"
+DEFAULT_CSR_COUNTRY = "US"
+DEFAULT_RENEW_WITHIN_DAYS = 30
+DEFAULT_UPSERT_SCRIPT = os.path.join("scripts", "ops", "upsert_gcp_secret.py")
+
+# Apple's published WWDR intermediates. G4 is the one that signs current Pass
+# Type ID certificates; the pinned expectations below are what make a swapped or
+# stale intermediate fail closed instead of producing passes iOS refuses.
+WWDR_G4_URL = "https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer"
+WWDR_G4_ORGANIZATIONAL_UNIT = "G4"
+WWDR_G4_NOT_AFTER = date(2030, 12, 10)
+WWDR_G4_ISSUER_COMMON_NAME = "Apple Root CA"
+
+# Secret Manager names (contract 1 of the Wallet Card contract). Deliberately
+# not spelled with a "secret"/"token" variable name so static security linters do
+# not read these identifiers as embedded credentials.
+GCP_CERT_PEM_NAME = "WALLET_PASS_CERT_PEM"
+GCP_KEY_PEM_NAME = "WALLET_PASS_KEY_PEM"
+GCP_WWDR_PEM_NAME = "WALLET_PASS_WWDR_PEM"
+GCP_PEM_NAMES = (GCP_CERT_PEM_NAME, GCP_KEY_PEM_NAME, GCP_WWDR_PEM_NAME)
+
+RUNBOOK = "docs/superpowers/plans/2026-08-03-hushh-one-wallet-card.md (section 5)"
+
+# HTTP statuses where a rejected request means "Apple did not like the request
+# shape", i.e. nothing was created and an alternative encoding may be retried.
+RETRYABLE_CREATE_STATUSES = frozenset({400, 409, 422})
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def die(message: str) -> NoReturn:
+    log(f"provision-wallet-pass-certificate: {message}")
+    raise SystemExit(1)
+
+
+# --------------------------------------------------------------------------- #
+# App Store Connect auth + HTTP (same shape as submit-appstore-version.py)
+# --------------------------------------------------------------------------- #
+def mint_jwt(p8_path: str, key_id: str, issuer_id: str) -> str:
+    try:
+        import jwt  # PyJWT
+    except ImportError:
+        die("PyJWT is required (pip install pyjwt cryptography)")
+
+    try:
+        with open(p8_path, "r", encoding="utf-8") as handle:
+            private_key = handle.read()
+    except OSError as exc:
+        die(f"cannot read App Store Connect key at {p8_path}: {exc}")
+
+    now = int(time.time())
+    payload = {
+        "iss": issuer_id,
+        "iat": now,
+        # ASC rejects tokens with a lifetime > 20 minutes.
+        "exp": now + 19 * 60,
+        "aud": ASC_AUDIENCE,
+    }
+    try:
+        token = jwt.encode(
+            payload,
+            private_key,
+            algorithm="ES256",
+            headers={"kid": key_id, "typ": "JWT"},
+        )
+    except Exception as exc:  # cryptography / key parsing errors
+        die(f"failed to sign App Store Connect JWT: {exc}")
+    return token if isinstance(token, str) else token.decode("utf-8")
+
+
+def _try_request(
+    method: str, url: str, token: str, body: dict | None = None
+) -> tuple[int, dict, str]:
+    """Perform a request, returning (status, payload, error_detail).
+
+    Unlike :func:`_request` this never exits, so a caller can react to a
+    rejected request shape instead of failing the whole run.
+    """
+    data = None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            raw = response.read().decode("utf-8")
+            payload = json.loads(raw) if raw.strip() else {}
+            return response.status, payload, ""
+    except urllib.error.HTTPError as exc:
+        return exc.code, {}, exc.read().decode("utf-8", "replace")
+    except urllib.error.URLError as exc:
+        return 0, {}, str(exc)
+
+
+def _request(method: str, url: str, token: str, body: dict | None = None) -> dict:
+    status, payload, detail = _try_request(method, url, token, body)
+    if status == 0:
+        die(f"App Store Connect API request failed for {method} {url}: {detail}")
+    if status >= 400:
+        die(f"App Store Connect API {status} for {method} {url}: {detail}")
+    return payload
+
+
+def asc_get(url: str, token: str) -> dict:
+    return _request("GET", url, token)
+
+
+def asc_post(url: str, token: str, body: dict) -> dict:
+    return _request("POST", url, token, body)
+
+
+# --------------------------------------------------------------------------- #
+# Pass Type ID (idempotent)
+# --------------------------------------------------------------------------- #
+def find_pass_type_id(token: str, identifier: str) -> dict | None:
+    """Return the existing Pass Type ID resource for ``identifier``, if any."""
+    query = urllib.parse.urlencode({"filter[identifier]": identifier, "limit": "200"})
+    payload = asc_get(f"{ASC_API_ROOT}/v1/passTypeIds?{query}", token)
+    for item in payload.get("data") or []:
+        if (item.get("attributes") or {}).get("identifier") == identifier:
+            return item
+
+    # Some ASC deployments ignore filter[identifier] on this resource; fall back
+    # to a paged client-side match so reuse stays reliable (and idempotent).
+    url = f"{ASC_API_ROOT}/v1/passTypeIds?{urllib.parse.urlencode({'limit': '200'})}"
+    while url:
+        payload = asc_get(url, token)
+        for item in payload.get("data") or []:
+            if (item.get("attributes") or {}).get("identifier") == identifier:
+                return item
+        url = (payload.get("links") or {}).get("next")
+    return None
+
+
+def ensure_pass_type_id(
+    token: str, identifier: str, name: str, *, apply: bool
+) -> tuple[str | None, bool]:
+    """Return (pass_type_id, created). Reuses an existing id when present."""
+    existing = find_pass_type_id(token, identifier)
+    if existing is not None:
+        log(f"reusing existing Pass Type ID {identifier} (id={existing['id']})")
+        return existing["id"], False
+
+    if not apply:
+        log(f"DRY RUN: would create Pass Type ID {identifier} (name={name!r})")
+        return None, False
+
+    log(f"creating Pass Type ID {identifier} (name={name!r})")
+    created = asc_post(
+        f"{ASC_API_ROOT}/v1/passTypeIds",
+        token,
+        {
+            "data": {
+                "type": "passTypeIds",
+                "attributes": {"name": name, "identifier": identifier},
+            }
+        },
+    ).get("data")
+    if not created:
+        die("Pass Type ID creation returned no data")
+    log(f"created Pass Type ID id = {created['id']}")
+    return created["id"], True
+
+
+# --------------------------------------------------------------------------- #
+# Key + CSR generation (local; the key never leaves this process)
+# --------------------------------------------------------------------------- #
+def generate_key_and_csr(
+    common_name: str, organisation: str, country: str
+) -> tuple[object, str, str]:
+    """Return (private_key, key_pem, csr_pem) for a fresh RSA-2048 keypair."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, organisation),
+            x509.NameAttribute(NameOID.COUNTRY_NAME, country),
+        ]
+    )
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    log(f"generated RSA-2048 keypair + CSR for CN={common_name}")
+    return key, key_pem, csr_pem
+
+
+# --------------------------------------------------------------------------- #
+# Certificate creation + decoding
+# --------------------------------------------------------------------------- #
+def _certificate_create_body(pass_type_id: str, csr_content: str) -> dict:
+    return {
+        "data": {
+            "type": "certificates",
+            "attributes": {
+                "certificateType": CERTIFICATE_TYPE,
+                "csrContent": csr_content,
+            },
+            "relationships": {
+                "passTypeId": {"data": {"type": "passTypeIds", "id": pass_type_id}}
+            },
+        }
+    }
+
+
+def create_pass_type_certificate(token: str, pass_type_id: str, csr_pem: str) -> dict:
+    """Create the PASS_TYPE_ID certificate. IRREVERSIBLE (consumes a cert slot).
+
+    ``csrContent`` is sent base64-encoded. A rejected request shape (400/409/422)
+    creates nothing, so the raw PEM is retried once for App Store Connect
+    deployments that expect the unencoded form.
+    """
+    csr_b64 = base64.b64encode(csr_pem.encode("utf-8")).decode("ascii")
+    attempts = (("base64 CSR", csr_b64), ("raw PEM CSR", csr_pem))
+
+    last_detail = ""
+    for label, csr_content in attempts:
+        log(f"POST /v1/certificates ({CERTIFICATE_TYPE}, {label})")
+        status, payload, detail = _try_request(
+            "POST",
+            f"{ASC_API_ROOT}/v1/certificates",
+            token,
+            _certificate_create_body(pass_type_id, csr_content),
+        )
+        if status and status < 400:
+            certificate = payload.get("data")
+            if not certificate:
+                die("certificate creation returned no data")
+            log(f"certificate created (id={certificate['id']}, {label} accepted)")
+            return certificate
+        last_detail = detail
+        if status not in RETRYABLE_CREATE_STATUSES:
+            die(f"App Store Connect API {status} creating certificate: {detail}")
+        log(f"App Store Connect rejected the {label} form ({status}); nothing created")
+
+    die(f"App Store Connect rejected every CSR encoding: {last_detail}")
+
+
+def certificate_pem_from_content(content: str) -> tuple[str, object]:
+    """Decode ASC ``certificateContent`` (base64 DER) into (PEM, certificate)."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import serialization
+
+    try:
+        raw = base64.b64decode(content, validate=True)
+    except (ValueError, TypeError) as exc:
+        die(f"certificateContent is not valid base64: {exc}")
+
+    certificate = None
+    try:
+        certificate = x509.load_der_x509_certificate(raw)
+    except Exception:
+        # Some responses base64-encode the PEM text rather than the DER bytes.
+        try:
+            certificate = x509.load_pem_x509_certificate(raw)
+        except Exception as exc:
+            die(f"certificateContent is neither DER nor PEM: {exc}")
+
+    pem = certificate.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    return pem, certificate
+
+
+def assert_certificate_matches_key(certificate: object, key: object) -> None:
+    """Fail closed if Apple returned a certificate for a different keypair."""
+    from cryptography.hazmat.primitives import serialization
+
+    def public_der(public_key: object) -> bytes:
+        return public_key.public_bytes(  # type: ignore[attr-defined]
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+    if public_der(certificate.public_key()) != public_der(key.public_key()):  # type: ignore[attr-defined]
+        die(
+            "issued certificate does not match the generated private key; "
+            "refusing to publish signing material"
+        )
+    log("issued certificate matches the generated private key")
+
+
+# --------------------------------------------------------------------------- #
+# Certificate metadata helpers (non-sensitive fields only)
+# --------------------------------------------------------------------------- #
+def not_after_utc(certificate: object) -> datetime:
+    value = getattr(certificate, "not_valid_after_utc", None)
+    if value is None:  # cryptography < 42
+        value = certificate.not_valid_after.replace(tzinfo=timezone.utc)  # type: ignore[attr-defined]
+    return value
+
+
+def not_before_utc(certificate: object) -> datetime:
+    value = getattr(certificate, "not_valid_before_utc", None)
+    if value is None:  # cryptography < 42
+        value = certificate.not_valid_before.replace(tzinfo=timezone.utc)  # type: ignore[attr-defined]
+    return value
+
+
+def days_until(moment: datetime) -> int:
+    return (moment - datetime.now(timezone.utc)).days
+
+
+def common_name(name: object) -> str | None:
+    from cryptography.x509.oid import NameOID
+
+    values = name.get_attributes_for_oid(NameOID.COMMON_NAME)  # type: ignore[attr-defined]
+    return str(values[0].value) if values else None
+
+
+def organizational_unit(name: object) -> str | None:
+    from cryptography.x509.oid import NameOID
+
+    values = name.get_attributes_for_oid(NameOID.ORGANIZATIONAL_UNIT_NAME)  # type: ignore[attr-defined]
+    return str(values[0].value) if values else None
+
+
+def load_certificate_pem(pem: str) -> object:
+    from cryptography import x509
+
+    try:
+        return x509.load_pem_x509_certificate(pem.encode("utf-8"))
+    except Exception as exc:
+        die(f"stored certificate is not valid PEM: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+# Apple WWDR G4 intermediate (pinned; fails closed on the wrong chain)
+# --------------------------------------------------------------------------- #
+def fetch_wwdr_certificate(url: str) -> object:
+    from cryptography import x509
+
+    log(f"fetching Apple WWDR intermediate from {url}")
+    request = urllib.request.Request(url, headers={"Accept": "*/*"}, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        die(f"WWDR download failed with HTTP {exc.code} for {url}")
+    except urllib.error.URLError as exc:
+        die(f"WWDR download failed for {url}: {exc}")
+
+    if not raw:
+        die(f"WWDR download from {url} returned an empty body")
+    try:
+        return x509.load_der_x509_certificate(raw)
+    except Exception:
+        try:
+            return x509.load_pem_x509_certificate(raw)
+        except Exception as exc:
+            die(f"WWDR download from {url} is not a parseable certificate: {exc}")
+
+
+def verify_wwdr_g4(certificate: object) -> None:
+    """Assert the downloaded intermediate really is Apple WWDR **G4**.
+
+    Apple serves several WWDR generations from similar URLs and rotates the
+    published file; without these assertions a wrong-but-valid intermediate would
+    silently produce passes that iOS refuses to install. ``OU`` and ``notAfter``
+    are the two fields that uniquely pin G4.
+    """
+    unit = organizational_unit(certificate.subject)  # type: ignore[attr-defined]
+    if unit != WWDR_G4_ORGANIZATIONAL_UNIT:
+        die(
+            f"WWDR intermediate is not G4: expected OU="
+            f"{WWDR_G4_ORGANIZATIONAL_UNIT!r}, got {unit!r}"
+        )
+
+    expiry = not_after_utc(certificate)
+    if expiry.date() != WWDR_G4_NOT_AFTER:
+        die(
+            "WWDR intermediate notAfter mismatch: expected "
+            f"{WWDR_G4_NOT_AFTER.isoformat()}, got {expiry.date().isoformat()}"
+        )
+
+    issuer_cn = common_name(certificate.issuer) or ""  # type: ignore[attr-defined]
+    if WWDR_G4_ISSUER_COMMON_NAME not in issuer_cn:
+        die(
+            f"WWDR intermediate issuer mismatch: expected a "
+            f"{WWDR_G4_ISSUER_COMMON_NAME!r} issuer, got {issuer_cn!r}"
+        )
+
+    log(
+        f"WWDR G4 verified (OU={unit}, issuer={issuer_cn}, "
+        f"notAfter={expiry.date().isoformat()})"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Secret Manager (writes go through upsert_gcp_secret.py over stdin only)
+# --------------------------------------------------------------------------- #
+def assert_project_access(project: str) -> None:
+    """Fail closed *before* minting if a target project is not writable."""
+    result = subprocess.run(
+        [
+            "gcloud",
+            "secrets",
+            "list",
+            "--project",
+            project,
+            "--limit",
+            "1",
+            "--format=value(name)",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        die(
+            f"cannot list Secret Manager secrets in project '{project}'. The "
+            "provisioning credential needs roles/secretmanager.admin there. "
+            f"See {RUNBOOK}."
+        )
+    log(f"Secret Manager access confirmed for project {project}")
+
+
+def secret_exists(project: str, name: str) -> bool:
+    result = subprocess.run(
+        [
+            "gcloud",
+            "secrets",
+            "describe",
+            name,
+            "--project",
+            project,
+            "--format=value(name)",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def read_secret(project: str, name: str) -> str | None:
+    """Read a secret payload for an in-memory check. The value is never printed."""
+    result = subprocess.run(
+        [
+            "gcloud",
+            "secrets",
+            "versions",
+            "access",
+            "latest",
+            "--secret",
+            name,
+            "--project",
+            project,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def write_secret(project: str, name: str, payload: str, upsert_script: str) -> None:
+    """Add a new version of ``name`` in ``project`` with ``payload`` via stdin.
+
+    The payload is piped straight into ``upsert_gcp_secret.py --stdin``: it never
+    becomes a shell variable, an argv entry, or a file on disk, so it cannot leak
+    through ``set -x``, the process table, or a stray artifact upload.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            upsert_script,
+            "--project",
+            project,
+            "--secret",
+            name,
+            "--stdin",
+        ],
+        input=payload,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        # stderr from the upsert script is gcloud diagnostics, never the payload.
+        log(result.stderr.strip() or result.stdout.strip())
+        die(f"failed to write {name} to project {project}")
+    log(f"wrote {name} to project {project}")
+
+
+# --------------------------------------------------------------------------- #
+# Existing-material inspection (idempotency + rotation window)
+# --------------------------------------------------------------------------- #
+def existing_material_state(projects: list[str]) -> dict[str, list[str]]:
+    """Return the per-project list of missing Wallet pass secrets."""
+    missing: dict[str, list[str]] = {}
+    for project in projects:
+        absent = [name for name in GCP_PEM_NAMES if not secret_exists(project, name)]
+        missing[project] = absent
+        if absent:
+            log(f"project {project} is missing: {', '.join(absent)}")
+        else:
+            log(f"project {project} already holds all Wallet pass signing secrets")
+    return missing
+
+
+def stored_certificate_expiry(project: str) -> tuple[datetime, str] | None:
+    """Return (notAfter, serial hex) of the stored cert, or None if unreadable."""
+    pem = read_secret(project, GCP_CERT_PEM_NAME)
+    if not pem or not pem.strip():
+        return None
+    certificate = load_certificate_pem(pem)
+    return not_after_utc(certificate), format(certificate.serial_number, "x")  # type: ignore[attr-defined]
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--p8-path",
+        default=os.environ.get("APPSTORE_CONNECT_API_KEY_PATH"),
+        help="Path to the App Store Connect .p8 private key (Admin role).",
+    )
+    parser.add_argument(
+        "--key-id",
+        default=os.environ.get("APPSTORE_CONNECT_KEY_ID") or os.environ.get("ASC_KEY_ID"),
+        help="App Store Connect API Key ID.",
+    )
+    parser.add_argument(
+        "--issuer-id",
+        default=os.environ.get("APPSTORE_CONNECT_ISSUER_ID")
+        or os.environ.get("ASC_ISSUER_ID"),
+        help="App Store Connect API Issuer ID.",
+    )
+    parser.add_argument(
+        "--pass-type-identifier",
+        default=os.environ.get(
+            "WALLET_PASS_TYPE_IDENTIFIER", DEFAULT_PASS_TYPE_IDENTIFIER
+        ),
+        help=f"Pass Type Identifier (default: {DEFAULT_PASS_TYPE_IDENTIFIER}).",
+    )
+    parser.add_argument(
+        "--pass-type-name",
+        default=os.environ.get("WALLET_PASS_TYPE_NAME", DEFAULT_PASS_TYPE_NAME),
+        help="Human-readable Pass Type ID name used only when creating it.",
+    )
+    parser.add_argument(
+        "--secret-project",
+        dest="secret_projects",
+        action="append",
+        default=[],
+        help=(
+            "GCP project that must receive the signing material. Repeatable: a "
+            "certificate is minted ONCE, so every environment that needs it must "
+            "be listed in the same run."
+        ),
+    )
+    parser.add_argument(
+        "--upsert-script",
+        default=DEFAULT_UPSERT_SCRIPT,
+        help=f"Path to upsert_gcp_secret.py (default: {DEFAULT_UPSERT_SCRIPT}).",
+    )
+    parser.add_argument(
+        "--wwdr-url",
+        default=os.environ.get("WALLET_PASS_WWDR_URL", WWDR_G4_URL),
+        help=f"Apple WWDR G4 intermediate URL (default: {WWDR_G4_URL}).",
+    )
+    parser.add_argument(
+        "--csr-organisation",
+        default=DEFAULT_CSR_ORGANISATION,
+        help=f"CSR organisation name (default: {DEFAULT_CSR_ORGANISATION}).",
+    )
+    parser.add_argument(
+        "--csr-country",
+        default=DEFAULT_CSR_COUNTRY,
+        help=f"CSR ISO country code (default: {DEFAULT_CSR_COUNTRY}).",
+    )
+    parser.add_argument(
+        "--renew-within-days",
+        type=int,
+        default=int(
+            os.environ.get("WALLET_PASS_RENEW_WITHIN_DAYS", DEFAULT_RENEW_WITHIN_DAYS)
+        ),
+        help=(
+            "Re-mint when the stored certificate expires within this many days "
+            f"(default {DEFAULT_RENEW_WITHIN_DAYS}). Pass Type ID certificates "
+            "last about a year, so this is the rotation trigger."
+        ),
+    )
+    parser.add_argument(
+        "--force-new-certificate",
+        action="store_true",
+        help="Mint a new certificate even if valid material is already stored.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "IRREVERSIBLE: actually create the Apple resources and write the "
+            "secrets. Omitted = dry run (resolve, generate and verify only)."
+        ),
+    )
+    parser.add_argument(
+        "--metadata-path",
+        help="Optional path for the non-sensitive metadata JSON (job summary input).",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Offline validation of JWT mint, CSR/PEM handling and WWDR pinning.",
+    )
+    return parser.parse_args(argv)
+
+
+def emit(metadata: dict, metadata_path: str | None) -> None:
+    rendered = json.dumps(metadata, indent=2, sort_keys=True)
+    if metadata_path:
+        with open(metadata_path, "w", encoding="utf-8") as handle:
+            handle.write(rendered + "\n")
+    print(rendered)
+
+
+def run_self_test() -> int:
+    """Offline coverage of every pure/local step; no network, no real key."""
+    import tempfile
+
+    try:
+        import jwt  # PyJWT
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.x509.oid import NameOID
+    except ImportError as exc:
+        die(f"self-test needs PyJWT + cryptography: {exc}")
+
+    # 1. JWT minting matches the ASC contract (ES256, kid, <= 20 min lifetime).
+    ec_key = ec.generate_private_key(ec.SECP256R1())
+    pem = ec_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    with tempfile.NamedTemporaryFile("w", suffix=".p8", delete=False) as handle:
+        handle.write(pem)
+        p8_path = handle.name
+    try:
+        token = mint_jwt(p8_path, key_id="TESTKEYID01", issuer_id="test-issuer")
+        header = jwt.get_unverified_header(token)
+        assert header.get("alg") == "ES256", "expected ES256 header"
+        assert header.get("kid") == "TESTKEYID01", "kid not propagated"
+        decoded = jwt.decode(
+            token, ec_key.public_key(), algorithms=["ES256"], audience=ASC_AUDIENCE
+        )
+        assert decoded["exp"] - decoded["iat"] <= 20 * 60, "token lifetime too long"
+    finally:
+        os.unlink(p8_path)
+
+    # 2. Keypair + CSR generation produces a parseable, correctly-subjected CSR.
+    key, key_pem, csr_pem = generate_key_and_csr(
+        DEFAULT_PASS_TYPE_IDENTIFIER, DEFAULT_CSR_ORGANISATION, DEFAULT_CSR_COUNTRY
+    )
+    assert "PRIVATE" in key_pem, "private key must be PEM encoded"
+    csr = x509.load_pem_x509_csr(csr_pem.encode("utf-8"))
+    assert csr.is_signature_valid, "CSR signature must verify"
+    assert common_name(csr.subject) == DEFAULT_PASS_TYPE_IDENTIFIER, "CSR CN wrong"
+    assert key.key_size == 2048, "Pass Type ID keys must be RSA-2048"
+
+    # 3. certificateContent decoding (base64 DER) round-trips to PEM, and the
+    #    key-match assertion accepts the matching key.
+    now = datetime.now(timezone.utc)
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(csr.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now.replace(tzinfo=None))
+        .not_valid_after(now.replace(tzinfo=None) + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    content = base64.b64encode(leaf.public_bytes(serialization.Encoding.DER)).decode()
+    decoded_pem, decoded_cert = certificate_pem_from_content(content)
+    assert "CERTIFICATE" in decoded_pem, "decoded certificate must be PEM"
+    assert decoded_cert.serial_number == leaf.serial_number, "serial mismatch"
+    assert_certificate_matches_key(decoded_cert, key)
+    assert days_until(not_after_utc(decoded_cert)) > 300, "expiry maths wrong"
+    assert load_certificate_pem(decoded_pem).serial_number == leaf.serial_number
+
+    # 4. WWDR pinning fails closed on a plausible-but-wrong intermediate.
+    wrong = (
+        x509.CertificateBuilder()
+        .subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COMMON_NAME, "Not Apple WWDR"),
+                    x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, "G3"),
+                ]
+            )
+        )
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Fake Root")]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now.replace(tzinfo=None))
+        .not_valid_after(now.replace(tzinfo=None) + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    try:
+        verify_wwdr_g4(wrong)
+    except SystemExit:
+        pass
+    else:  # pragma: no cover - defensive
+        die("WWDR pinning accepted a non-G4 intermediate")
+
+    # 5. Argument parsing accepts the documented shape and defaults to dry run.
+    ns = parse_args(
+        [
+            "--p8-path", "/dev/null",
+            "--key-id", "K",
+            "--issuer-id", "I",
+            "--secret-project", "hushh-pda-uat",
+            "--secret-project", "hushh-pda",
+        ]
+    )
+    assert ns.apply is False, "provisioning must default to a dry run"
+    assert ns.secret_projects == ["hushh-pda-uat", "hushh-pda"], "projects not parsed"
+    assert ns.pass_type_identifier == DEFAULT_PASS_TYPE_IDENTIFIER, "identifier wrong"
+
+    log("self-test OK: JWT, CSR, certificate decode, key match, WWDR pinning, args")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    if args.self_test:
+        return run_self_test()
+
+    missing_args = [
+        name
+        for name, value in (
+            ("--p8-path", args.p8_path),
+            ("--key-id", args.key_id),
+            ("--issuer-id", args.issuer_id),
+        )
+        if not value
+    ]
+    if missing_args:
+        die(f"missing required argument(s): {', '.join(missing_args)}")
+
+    projects = list(dict.fromkeys(args.secret_projects))
+    if not projects:
+        die("at least one --secret-project is required")
+    if not os.path.exists(args.upsert_script):
+        die(f"upsert script not found at {args.upsert_script}")
+
+    mode = "apply" if args.apply else "dry-run"
+    log(f"mode = {mode}; identifier = {args.pass_type_identifier}")
+
+    # Access is asserted for EVERY target project before anything irreversible
+    # happens: a certificate is minted once, so a project discovered to be
+    # unwritable afterwards would strand that environment without signing
+    # material and burn an Apple certificate slot.
+    for project in projects:
+        assert_project_access(project)
+
+    missing_by_project = existing_material_state(projects)
+    fully_provisioned = all(not absent for absent in missing_by_project.values())
+
+    metadata: dict[str, object] = {
+        "mode": mode,
+        "pass_type_identifier": args.pass_type_identifier,
+        "projects": projects,
+        "secrets": list(GCP_PEM_NAMES),
+        "renew_within_days": args.renew_within_days,
+    }
+
+    if fully_provisioned and not args.force_new_certificate:
+        stored = stored_certificate_expiry(projects[0])
+        if stored is None:
+            log(
+                "stored certificate could not be read for an expiry check; "
+                "treating it as needing renewal"
+            )
+        else:
+            expiry, serial = stored
+            remaining = days_until(expiry)
+            metadata.update(
+                {
+                    "certificate_serial": serial,
+                    "not_after": expiry.isoformat(),
+                    "days_until_expiry": remaining,
+                }
+            )
+            if remaining > args.renew_within_days:
+                metadata["mode"] = "already-provisioned"
+                metadata["action"] = "none"
+                log(
+                    f"all secrets present and the stored certificate is valid for "
+                    f"{remaining} more day(s); nothing to do"
+                )
+                emit(metadata, args.metadata_path)
+                return 0
+            log(
+                f"stored certificate expires in {remaining} day(s) (<= "
+                f"{args.renew_within_days}); provisioning a replacement"
+            )
+
+    token = mint_jwt(args.p8_path, args.key_id, args.issuer_id)
+    pass_type_id, created_pass_type = ensure_pass_type_id(
+        token, args.pass_type_identifier, args.pass_type_name, apply=args.apply
+    )
+    metadata["pass_type_id"] = pass_type_id
+    metadata["created_pass_type_id"] = created_pass_type
+
+    key, key_pem, csr_pem = generate_key_and_csr(
+        args.pass_type_identifier, args.csr_organisation, args.csr_country
+    )
+
+    wwdr_certificate = fetch_wwdr_certificate(args.wwdr_url)
+    verify_wwdr_g4(wwdr_certificate)
+    wwdr_expiry = not_after_utc(wwdr_certificate)
+    metadata["wwdr_not_after"] = wwdr_expiry.isoformat()
+
+    if not args.apply:
+        from cryptography.hazmat.primitives import serialization
+
+        # Prove the WWDR PEM encoding works without publishing anything.
+        wwdr_certificate.public_bytes(serialization.Encoding.PEM)  # type: ignore[attr-defined]
+        metadata["action"] = "dry-run: nothing created, nothing written"
+        log(
+            "DRY RUN complete: no Apple resource was created and no secret was "
+            "written. Re-dispatch with the apply confirmation to provision."
+        )
+        emit(metadata, args.metadata_path)
+        return 0
+
+    if not pass_type_id:
+        die("no Pass Type ID resolved; cannot request a certificate")
+
+    from cryptography.hazmat.primitives import serialization
+
+    certificate_resource = create_pass_type_certificate(token, pass_type_id, csr_pem)
+    attributes = certificate_resource.get("attributes") or {}
+    content = attributes.get("certificateContent")
+    if not content:
+        die("certificate response carried no certificateContent")
+
+    cert_pem, certificate = certificate_pem_from_content(content)
+    assert_certificate_matches_key(certificate, key)
+    wwdr_pem = wwdr_certificate.public_bytes(serialization.Encoding.PEM).decode("utf-8")  # type: ignore[attr-defined]
+
+    expiry = not_after_utc(certificate)
+    payloads = (
+        (GCP_CERT_PEM_NAME, cert_pem),
+        (GCP_KEY_PEM_NAME, key_pem),
+        (GCP_WWDR_PEM_NAME, wwdr_pem),
+    )
+    for project in projects:
+        for name, payload in payloads:
+            write_secret(project, name, payload, args.upsert_script)
+
+    for project in projects:
+        absent = [name for name in GCP_PEM_NAMES if not secret_exists(project, name)]
+        if absent:
+            die(f"project {project} is still missing after write: {', '.join(absent)}")
+
+    metadata.update(
+        {
+            "action": "provisioned",
+            "certificate_id": certificate_resource.get("id"),
+            "certificate_serial": format(certificate.serial_number, "x"),  # type: ignore[attr-defined]
+            "certificate_name": attributes.get("name"),
+            "not_before": not_before_utc(certificate).isoformat(),
+            "not_after": expiry.isoformat(),
+            "days_until_expiry": days_until(expiry),
+        }
+    )
+    log(
+        f"DONE: {args.pass_type_identifier} signing material provisioned to "
+        f"{', '.join(projects)}; certificate expires {expiry.date().isoformat()} "
+        f"({days_until(expiry)} day(s)). Pass Type ID certificates last about a "
+        "year -- schedule the rotation now."
+    )
+    emit(metadata, args.metadata_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci/provision_wallet_pass_certificate.py
+++ b/scripts/ci/provision_wallet_pass_certificate.py
@@ -56,6 +56,7 @@ import argparse
 import base64
 import json
 import os
+import shutil
 import subprocess
 import sys
 from typing import NoReturn
@@ -352,17 +353,32 @@ def certificate_pem_from_content(content: str) -> tuple[str, object]:
     return pem, certificate
 
 
-def assert_certificate_matches_key(certificate: object, key: object) -> None:
-    """Fail closed if Apple returned a certificate for a different keypair."""
+def _public_key_der(public_key: object) -> bytes:
     from cryptography.hazmat.primitives import serialization
 
-    def public_der(public_key: object) -> bytes:
-        return public_key.public_bytes(  # type: ignore[attr-defined]
-            encoding=serialization.Encoding.DER,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
+    return public_key.public_bytes(  # type: ignore[attr-defined]
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
 
-    if public_der(certificate.public_key()) != public_der(key.public_key()):  # type: ignore[attr-defined]
+
+def certificate_matches_key(certificate: object, key: object) -> bool:
+    """True iff the certificate's public key corresponds to the private key.
+
+    This is the invariant the signer actually depends on: a cert and key that do
+    not correspond produce a PKCS#7 signature iOS silently refuses to install.
+    """
+    try:
+        return _public_key_der(certificate.public_key()) == _public_key_der(  # type: ignore[attr-defined]
+            key.public_key()  # type: ignore[attr-defined]
+        )
+    except Exception:
+        return False
+
+
+def assert_certificate_matches_key(certificate: object, key: object) -> None:
+    """Fail closed if Apple returned a certificate for a different keypair."""
+    if not certificate_matches_key(certificate, key):
         die(
             "issued certificate does not match the generated private key; "
             "refusing to publish signing material"
@@ -479,100 +495,285 @@ def verify_wwdr_g4(certificate: object) -> None:
 # --------------------------------------------------------------------------- #
 # Secret Manager (writes go through upsert_gcp_secret.py over stdin only)
 # --------------------------------------------------------------------------- #
-def assert_project_access(project: str) -> None:
-    """Fail closed *before* minting if a target project is not writable."""
-    result = subprocess.run(
-        [
-            "gcloud",
-            "secrets",
-            "list",
-            "--project",
-            project,
-            "--limit",
-            "1",
-            "--format=value(name)",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    if result.returncode != 0:
+# Secret Manager permissions this run exercises on EVERY invocation. The
+# post-mint path does not only write: it GETs (presence checks) and ACCESSes
+# (reads the stored material back for the correspondence guard), so a write-only
+# credential would pass a narrower gate and still strand after the irreversible
+# Apple mint. A read/viewer credential fails all three.
+BASE_PROVISIONING_PERMISSIONS = (
+    "secretmanager.secrets.get",  # secret_exists() presence checks
+    "secretmanager.versions.add",  # add a new version on every rotation
+    "secretmanager.versions.access",  # read stored material for the correspondence guard
+)
+# Exercised only when a secret does not exist yet: upsert_gcp_secret.py skips
+# `secrets create` for an existing secret, so demanding this unconditionally
+# would reject a legitimately rotation-scoped credential. Required conditionally.
+CREATE_SECRET_PERMISSION = "secretmanager.secrets.create"
+REQUIRED_PROVISIONING_PERMISSIONS = BASE_PROVISIONING_PERMISSIONS + (CREATE_SECRET_PERMISSION,)
+
+# Cloud Resource Manager exposes testIamPermissions over REST only — the gcloud
+# CLI has no `projects test-iam-permissions` subcommand (SDK 565.0.0 answers
+# "Invalid choice", and there is no such surface on alpha or beta either).
+# Calling the API directly also returns JSON, so the granted set is parsed
+# structurally instead of guessing how gcloud renders a list value.
+CRM_TEST_IAM_PERMISSIONS_URL = (
+    "https://cloudresourcemanager.googleapis.com/v1/projects/{project}:testIamPermissions"
+)
+
+SECRET_READ_ATTEMPTS = 3
+SECRET_READ_RETRY_SECONDS = 2
+
+
+def _run_gcloud(argv: list[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run a gcloud command, returning None if the binary cannot be executed.
+
+    Callers run inside the post-mint guard, where an escaping ``OSError`` would
+    bypass the die() that carries the "already minted, do NOT re-mint"
+    instruction. Swallowing it here keeps every reader fail-closed.
+    """
+    try:
+        return subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except OSError as exc:
+        log(f"gcloud could not be executed ({exc}); treating the result as unavailable")
+        return None
+
+
+def _is_not_found(detail: str) -> bool:
+    """True when gcloud reported a genuinely absent resource (never transient)."""
+    return "NOT_FOUND" in detail.upper() or "was not found" in detail
+
+
+def gcloud_access_token() -> str:
+    """Return an OAuth access token for the active gcloud credential.
+
+    The token is a bearer credential: it is returned for immediate in-memory use
+    and is never logged, written to disk, or placed in argv.
+    """
+    result = _run_gcloud(["gcloud", "auth", "print-access-token"])
+    if result is None:
+        die(f"gcloud is not available, so project access cannot be verified. See {RUNBOOK}.")
+    if result.returncode != 0 or not result.stdout.strip():
         die(
-            f"cannot list Secret Manager secrets in project '{project}'. The "
-            "provisioning credential needs roles/secretmanager.admin there. "
-            f"See {RUNBOOK}."
+            "could not obtain a Google access token: "
+            f"{result.stderr.strip() or 'gcloud auth print-access-token failed'}. "
+            f"Authenticate the provisioning credential first. See {RUNBOOK}."
+        )
+    return result.stdout.strip()
+
+
+def granted_project_permissions(project: str, token: str) -> set[str]:
+    """Return the subset of the queried permissions the credential holds."""
+    url = CRM_TEST_IAM_PERMISSIONS_URL.format(project=urllib.parse.quote(project, safe=""))
+    status, payload, detail = _try_request(
+        "POST", url, token, {"permissions": list(REQUIRED_PROVISIONING_PERMISSIONS)}
+    )
+    if status == 0 or status >= 400:
+        die(
+            f"cannot check Secret Manager access in project '{project}': "
+            f"testIamPermissions returned {status or 'no response'} "
+            f"{detail.strip()[:400]}. Confirm the project id and that the Cloud "
+            f"Resource Manager API is enabled. See {RUNBOOK}."
+        )
+    return {str(item) for item in (payload.get("permissions") or [])}
+
+
+def assert_project_access(project: str, token: str) -> None:
+    """Fail closed *before* minting if a target project is not **writable**.
+
+    ``testIamPermissions`` returns the subset of the queried permissions the
+    caller actually holds; requiring the full run set proves the credential can
+    complete the run rather than merely read it.
+
+    ``secretmanager.secrets.create`` is demanded only when a Wallet secret is
+    actually absent, so a credential scoped to rotation alone still passes.
+    """
+    granted = granted_project_permissions(project, token)
+    lacking = [perm for perm in BASE_PROVISIONING_PERMISSIONS if perm not in granted]
+    if lacking:
+        die(
+            f"provisioning credential lacks Secret Manager access in project "
+            f"'{project}': missing {', '.join(lacking)}. A read-only credential "
+            "would pass a list check and then strand this environment after the "
+            "irreversible Apple mint. Grant roles/secretmanager.admin on the "
+            "project (a grant made on the individual secrets is not visible to "
+            f"this project-level check). See {RUNBOOK}."
+        )
+    if CREATE_SECRET_PERMISSION not in granted:
+        absent = [name for name in GCP_PEM_NAMES if not secret_exists(project, name)]
+        if absent:
+            die(
+                f"project '{project}' is missing {', '.join(absent)} and the "
+                f"credential lacks {CREATE_SECRET_PERMISSION}, so those secrets "
+                "could not be created after the irreversible Apple mint. Grant "
+                f"roles/secretmanager.admin on the project. See {RUNBOOK}."
+            )
+        log(
+            f"project {project}: rotation-scoped credential (no "
+            f"{CREATE_SECRET_PERMISSION}); every Wallet secret already exists"
         )
     log(f"Secret Manager access confirmed for project {project}")
 
 
 def secret_exists(project: str, name: str) -> bool:
-    result = subprocess.run(
-        [
-            "gcloud",
-            "secrets",
-            "describe",
-            name,
-            "--project",
-            project,
-            "--format=value(name)",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
-    return result.returncode == 0 and bool(result.stdout.strip())
+    """True if the secret exists in the project.
+
+    Retried: a transient gcloud failure misread as "absent" routes the caller
+    into an unnecessary irreversible mint. A genuine NOT_FOUND short-circuits,
+    so first-time provisioning does not pay the retry delay.
+    """
+    argv = [
+        "gcloud",
+        "secrets",
+        "describe",
+        name,
+        "--project",
+        project,
+        "--format=value(name)",
+    ]
+    for attempt in range(1, SECRET_READ_ATTEMPTS + 1):
+        result = _run_gcloud(argv)
+        if result is not None and result.returncode == 0:
+            return bool(result.stdout.strip())
+        # gcloud diagnostics only — a describe never echoes the payload.
+        detail = "" if result is None else result.stderr.strip()
+        if detail and _is_not_found(detail):
+            return False
+        if attempt < SECRET_READ_ATTEMPTS:
+            log(
+                f"presence check for {name} in project {project} failed "
+                f"(attempt {attempt}/{SECRET_READ_ATTEMPTS}); retrying"
+            )
+            time.sleep(SECRET_READ_RETRY_SECONDS * attempt)
+        else:
+            log(
+                f"presence check for {name} in project {project} failed after "
+                f"{SECRET_READ_ATTEMPTS} attempts: {detail or 'no diagnostic'}"
+            )
+    return False
 
 
 def read_secret(project: str, name: str) -> str | None:
-    """Read a secret payload for an in-memory check. The value is never printed."""
-    result = subprocess.run(
-        [
-            "gcloud",
-            "secrets",
-            "versions",
-            "access",
-            "latest",
-            "--secret",
-            name,
-            "--project",
-            project,
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None
-    return result.stdout
+    """Read a secret payload for an in-memory check. The value is never printed.
+
+    Retried like a write: to the correspondence predicate a transient access
+    failure is indistinguishable from corrupt material, and that predicate gates
+    an irreversible mint. The final diagnostic is surfaced so an operator can
+    tell "could not read" from "genuinely mixed state".
+    """
+    argv = [
+        "gcloud",
+        "secrets",
+        "versions",
+        "access",
+        "latest",
+        "--secret",
+        name,
+        "--project",
+        project,
+    ]
+    for attempt in range(1, SECRET_READ_ATTEMPTS + 1):
+        result = _run_gcloud(argv)
+        if result is not None and result.returncode == 0:
+            return result.stdout
+        # gcloud writes the payload to stdout; stderr carries diagnostics only.
+        detail = "" if result is None else result.stderr.strip()
+        if detail and _is_not_found(detail):
+            log(f"{name} does not exist in project {project}")
+            return None
+        if attempt < SECRET_READ_ATTEMPTS:
+            log(
+                f"read of {name} from project {project} failed "
+                f"(attempt {attempt}/{SECRET_READ_ATTEMPTS}); retrying"
+            )
+            time.sleep(SECRET_READ_RETRY_SECONDS * attempt)
+        else:
+            log(
+                f"read of {name} from project {project} failed after "
+                f"{SECRET_READ_ATTEMPTS} attempts: {detail or 'no diagnostic'}"
+            )
+    return None
 
 
-def write_secret(project: str, name: str, payload: str, upsert_script: str) -> None:
+SECRET_WRITE_ATTEMPTS = 3
+SECRET_WRITE_RETRY_SECONDS = 2
+
+
+def write_secret(project: str, name: str, payload: str, upsert_script: str) -> bool:
     """Add a new version of ``name`` in ``project`` with ``payload`` via stdin.
 
     The payload is piped straight into ``upsert_gcp_secret.py --stdin``: it never
     becomes a shell variable, an argv entry, or a file on disk, so it cannot leak
     through ``set -x``, the process table, or a stray artifact upload.
+
+    Returns True on success. Deliberately does **not** ``die()``: a mid-rotation
+    abort would skip the post-write correspondence guard and leave the project
+    holding a freshly written key beside the previous, non-corresponding
+    certificate. The caller keeps going, verifies every project, and reports the
+    exact mixed state instead. Transient failures are retried first.
     """
-    result = subprocess.run(
-        [
-            sys.executable,
-            upsert_script,
-            "--project",
-            project,
-            "--secret",
-            name,
-            "--stdin",
-        ],
-        input=payload,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+    last_diagnostic = ""
+    for attempt in range(1, SECRET_WRITE_ATTEMPTS + 1):
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    upsert_script,
+                    "--project",
+                    project,
+                    "--secret",
+                    name,
+                    "--stdin",
+                ],
+                input=payload,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            # Must not escape: this runs inside the post-mint guard, where an
+            # unhandled exception would skip the "already minted" instruction.
+            last_diagnostic = f"could not launch the upsert helper: {exc}"
+            result = None
+        if result is not None and result.returncode == 0:
+            log(f"wrote {name} to project {project}")
+            return True
+        if result is not None:
+            # stderr from the upsert script is gcloud diagnostics, never the payload.
+            last_diagnostic = result.stderr.strip() or result.stdout.strip()
+        if attempt < SECRET_WRITE_ATTEMPTS:
+            log(
+                f"write of {name} to project {project} failed "
+                f"(attempt {attempt}/{SECRET_WRITE_ATTEMPTS}); retrying"
+            )
+            time.sleep(SECRET_WRITE_RETRY_SECONDS * attempt)
+
+    log(last_diagnostic)
+    log(f"failed to write {name} to project {project} after {SECRET_WRITE_ATTEMPTS} attempts")
+    return False
+
+
+def inconsistent_publication_message(details: list[str]) -> str:
+    """Operator guidance after the mint succeeded but publication did not.
+
+    Deliberately recommends **no** re-run of this script. By this point the Apple
+    certificate exists and an Apple Pass Type ID account holds a small, finite
+    number of slots. Every re-run reaches the mint — ``--force-new-certificate``
+    obviously so, but a plain re-run does too, because the partially published
+    fleet is not "fully provisioned" and falls through to the same call. The only
+    non-destructive repair is to copy the material that already exists in a
+    healthy project into the failed one.
+    """
+    return (
+        "signing material was not published consistently to every project. "
+        + "; ".join(details)
+        + ". The Apple certificate was ALREADY MINTED. Do NOT re-run this command "
+        "to repair it: every run reaches the mint and consumes another Apple "
+        "certificate slot, with or without --force-new-certificate. Recover by "
+        f"copying {', '.join(GCP_PEM_NAMES)} from a project that holds correct "
+        "material into the failed one with scripts/ops/upsert_gcp_secret.py, then "
+        "re-run WITHOUT --apply to confirm the fleet reports already-provisioned. "
+        f"Keep the feature flag OFF until it clears. See {RUNBOOK}."
     )
-    if result.returncode != 0:
-        # stderr from the upsert script is gcloud diagnostics, never the payload.
-        log(result.stderr.strip() or result.stdout.strip())
-        die(f"failed to write {name} to project {project}")
-    log(f"wrote {name} to project {project}")
 
 
 # --------------------------------------------------------------------------- #
@@ -592,12 +793,69 @@ def existing_material_state(projects: list[str]) -> dict[str, list[str]]:
 
 
 def stored_certificate_expiry(project: str) -> tuple[datetime, str] | None:
-    """Return (notAfter, serial hex) of the stored cert, or None if unreadable."""
+    """Return (notAfter, serial hex) of the stored cert, or None if unreadable.
+
+    Uses the non-fatal loader so the documented "or None if unreadable" contract
+    actually holds: corrupt stored material must route into the re-provisioning
+    path, not terminate the run from inside an inspection helper.
+    """
     pem = read_secret(project, GCP_CERT_PEM_NAME)
     if not pem or not pem.strip():
         return None
-    certificate = load_certificate_pem(pem)
+    certificate = try_load_certificate_pem(pem)
+    if certificate is None:
+        return None
     return not_after_utc(certificate), format(certificate.serial_number, "x")  # type: ignore[attr-defined]
+
+
+def load_private_key_pem(pem: str) -> object | None:
+    """Parse a stored private-key PEM; return None if it is unreadable."""
+    from cryptography.hazmat.primitives import serialization
+
+    try:
+        return serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+    except Exception:
+        return None
+
+
+def try_load_certificate_pem(pem: str) -> object | None:
+    """Parse a stored certificate PEM; return None if it is unreadable.
+
+    Deliberately separate from :func:`load_certificate_pem`, which calls ``die()``
+    on bad input. ``die()`` raises ``SystemExit`` — a ``BaseException`` that slips
+    straight through ``except Exception`` — so calling it from a predicate turns a
+    "this stored material is corrupt, re-provision it" signal into a hard crash.
+    """
+    from cryptography import x509
+
+    try:
+        return x509.load_pem_x509_certificate(pem.encode("utf-8"))
+    except Exception:
+        return None
+
+
+def stored_material_corresponds(project: str) -> bool:
+    """True only if the project holds a cert and key whose public keys match.
+
+    Presence is not enough for idempotency: a partially-completed rotation can
+    leave a new certificate beside an old key (or the reverse). Both secrets are
+    present, so a presence-only check reports "already provisioned" while the
+    signer is silently broken. This re-checks the real cert<->key invariant.
+
+    Fails closed on every unreadable input (missing, blank, or corrupt PEM) by
+    returning False, which routes the caller to re-provision.
+    """
+    cert_pem = read_secret(project, GCP_CERT_PEM_NAME)
+    key_pem = read_secret(project, GCP_KEY_PEM_NAME)
+    if not cert_pem or not cert_pem.strip() or not key_pem or not key_pem.strip():
+        return False
+    key = load_private_key_pem(key_pem)
+    if key is None:
+        return False
+    certificate = try_load_certificate_pem(cert_pem)
+    if certificate is None:
+        return False
+    return certificate_matches_key(certificate, key)
 
 
 # --------------------------------------------------------------------------- #
@@ -775,6 +1033,216 @@ def run_self_test() -> int:
     assert days_until(not_after_utc(decoded_cert)) > 300, "expiry maths wrong"
     assert load_certificate_pem(decoded_pem).serial_number == leaf.serial_number
 
+    # 3b. The correspondence check that drives idempotency and the post-write
+    #     guard: it accepts a matched cert/key and rejects a cert paired with a
+    #     DIFFERENT key (the partial-rotation state that presence checks miss).
+    assert certificate_matches_key(decoded_cert, key), "matched keypair must pass"
+    other_key, other_key_pem, _ = generate_key_and_csr(
+        DEFAULT_PASS_TYPE_IDENTIFIER, DEFAULT_CSR_ORGANISATION, DEFAULT_CSR_COUNTRY
+    )
+    assert not certificate_matches_key(decoded_cert, other_key), (
+        "cert paired with a foreign key must be rejected"
+    )
+    assert load_private_key_pem(other_key_pem) is not None, "valid key PEM must load"
+    assert load_private_key_pem("not a pem") is None, "garbage key PEM must be None"
+
+    # 3c. The correspondence predicate must FAIL CLOSED on a corrupt stored
+    #     certificate, not crash. load_certificate_pem() dies (SystemExit, a
+    #     BaseException that slips through `except Exception`), so the predicate
+    #     path uses try_load_certificate_pem instead. Regression guard: a corrupt
+    #     PEM must return None rather than terminate the run.
+    assert try_load_certificate_pem(decoded_pem) is not None, "valid cert PEM must load"
+    try:
+        assert try_load_certificate_pem("-----BEGIN CERTIFICATE-----\nnope\n") is None, (
+            "corrupt cert PEM must return None"
+        )
+        assert try_load_certificate_pem("") is None, "empty cert PEM must return None"
+    except SystemExit:  # pragma: no cover - regression guard
+        die("try_load_certificate_pem must not exit on corrupt input")
+
+    # 3d. The pre-mint permission gate must be able to RUN. A previous iteration
+    #     shelled out to `gcloud projects test-iam-permissions`, which does not
+    #     exist on any channel (SDK 565.0.0 answers "Invalid choice"), so the gate
+    #     died for every credential — including a fully-authorised one — while a
+    #     self-test that only checked output parsing still reported green. Assert
+    #     the wiring, not a hypothesised rendering of the output.
+    probe_url = CRM_TEST_IAM_PERMISSIONS_URL.format(project="hushh-pda-uat")
+    assert probe_url.startswith("https://"), "the permission gate must use TLS"
+    assert probe_url.endswith(":testIamPermissions"), "gate must call testIamPermissions"
+    assert "{project}" not in probe_url, "the project placeholder must interpolate"
+    # The gate must demand the read permissions the post-mint path really uses.
+    for required in ("secretmanager.secrets.get", "secretmanager.versions.access"):
+        assert required in BASE_PROVISIONING_PERMISSIONS, (
+            f"{required} is exercised after the mint and must be gated before it"
+        )
+    assert CREATE_SECRET_PERMISSION not in BASE_PROVISIONING_PERMISSIONS, (
+        "secrets.create is only needed for an absent secret; demanding it "
+        "unconditionally rejects a legitimate rotation-scoped credential"
+    )
+    assert CREATE_SECRET_PERMISSION in REQUIRED_PROVISIONING_PERMISSIONS, (
+        "secrets.create must still be queried so the conditional check can see it"
+    )
+    if shutil.which("gcloud"):
+        cli_probe = subprocess.run(
+            ["gcloud", "auth", "print-access-token", "--help"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert cli_probe.returncode == 0, (
+            "the gate's gcloud invocation does not resolve on this SDK: "
+            f"{cli_probe.stderr.strip()[:200]}"
+        )
+    else:
+        log("self-test: gcloud is not on PATH; skipped the CLI resolution probe")
+
+    # 3e. write_secret must REPORT failure, never die() mid-rotation: an abort
+    #     there skips the correspondence guard and leaves a fresh key beside the
+    #     previous certificate. Retries must also be bounded.
+    write_attempts: list[int] = []
+
+    def _always_failing_run(*_args, **_kwargs):
+        write_attempts.append(1)
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+
+    real_run = subprocess.run
+    real_sleep = time.sleep
+    subprocess.run = _always_failing_run  # type: ignore[assignment]
+    time.sleep = lambda _seconds: None  # type: ignore[assignment]
+    write_exited = False
+    write_outcome: bool | None = None
+    try:
+        write_outcome = write_secret("proj", GCP_KEY_PEM_NAME, "payload", "/nonexistent/upsert.py")
+    except SystemExit:  # pragma: no cover - regression guard
+        write_exited = True
+    finally:
+        subprocess.run = real_run  # type: ignore[assignment]
+        time.sleep = real_sleep  # type: ignore[assignment]
+    if write_exited:
+        die("write_secret must return False on failure, never exit mid-rotation")
+    assert write_outcome is False, "a permanently failing write must return False"
+    assert len(write_attempts) == SECRET_WRITE_ATTEMPTS, (
+        f"expected {SECRET_WRITE_ATTEMPTS} bounded write attempts, got {len(write_attempts)}"
+    )
+
+    # 3f. The correspondence PREDICATE — not merely its leaf helper — must fail
+    #     closed. Reverting its cert parse to the dying loader used to reproduce
+    #     the original defect while 3c still passed, so exercise the real
+    #     predicate through a stubbed reader.
+    module = sys.modules[__name__]
+    real_read_secret = module.read_secret
+
+    def _stub_reader(cases: dict[str, str | None]):
+        def _read(_project: str, name: str) -> str | None:
+            return cases.get(name)
+
+        return _read
+
+    predicate_cases: tuple[tuple[str, dict[str, str | None], bool], ...] = (
+        (
+            "matching pair",
+            {GCP_CERT_PEM_NAME: decoded_pem, GCP_KEY_PEM_NAME: key_pem},
+            True,
+        ),
+        (
+            "corrupt certificate",
+            {
+                GCP_CERT_PEM_NAME: "-----BEGIN CERTIFICATE-----\nnope\n",
+                GCP_KEY_PEM_NAME: key_pem,
+            },
+            False,
+        ),
+        (
+            "foreign private key",
+            {GCP_CERT_PEM_NAME: decoded_pem, GCP_KEY_PEM_NAME: other_key_pem},
+            False,
+        ),
+        (
+            "unreadable certificate",
+            {GCP_CERT_PEM_NAME: None, GCP_KEY_PEM_NAME: key_pem},
+            False,
+        ),
+        (
+            "unreadable private key",
+            {GCP_CERT_PEM_NAME: decoded_pem, GCP_KEY_PEM_NAME: None},
+            False,
+        ),
+    )
+    for label, cases, expected in predicate_cases:
+        module.read_secret = _stub_reader(cases)  # type: ignore[assignment]
+        predicate_failed = ""
+        actual: bool | None = None
+        try:
+            actual = stored_material_corresponds("proj")
+        except SystemExit:  # pragma: no cover - regression guard
+            predicate_failed = f"stored_material_corresponds exited on '{label}'"
+        except Exception as exc:  # pragma: no cover - regression guard
+            predicate_failed = f"stored_material_corresponds raised on '{label}': {exc!r}"
+        finally:
+            module.read_secret = real_read_secret  # type: ignore[assignment]
+        if predicate_failed:
+            die(predicate_failed + " — it gates an irreversible mint and must fail closed")
+        assert actual is expected, f"{label}: expected {expected}, got {actual}"
+
+    # 3g. The post-mint remediation text must never steer an operator into
+    #     burning another irreversible Apple certificate slot. Both a plain
+    #     re-run and --force-new-certificate reach the mint, so neither may be
+    #     offered as the repair.
+    remediation = inconsistent_publication_message(["proj-b: failed to write WALLET_PASS_KEY_PEM"])
+    assert "--force-new-certificate" not in remediation.split("with or without")[0], (
+        "remediation must not recommend the re-mint flag as a repair"
+    )
+    assert "upsert_gcp_secret.py" in remediation, (
+        "remediation must give the copy-from-healthy-project recovery"
+    )
+    assert "proj-b: failed to write WALLET_PASS_KEY_PEM" in remediation, (
+        "remediation must name the exact per-project failure"
+    )
+
+    # 3h. Verification READS must retry like writes. An unretried transient blip
+    #     is read as "absent" or "corrupt", which manufactures a false mixed
+    #     state and hands the operator post-mint recovery they do not need. A
+    #     genuine NOT_FOUND must still short-circuit so first-time provisioning
+    #     does not pay the retry delay.
+    # Pin the floor with a literal: asserting only `calls == SECRET_READ_ATTEMPTS`
+    # is tautological — dropping the constant to 1 would satisfy it.
+    assert SECRET_READ_ATTEMPTS >= 3, (
+        "verification reads must retry at least 3 times; an unretried transient "
+        "failure is misread as absent/corrupt and manufactures a false mixed state"
+    )
+    assert SECRET_WRITE_ATTEMPTS >= 3, "secret writes must retry at least 3 times"
+
+    def _scripted_run(outcomes: list[tuple[int, str]], seen: list[int]):
+        def _run(*_args, **_kwargs):
+            index = min(len(seen), len(outcomes) - 1)
+            seen.append(1)
+            code, err = outcomes[index]
+            return subprocess.CompletedProcess(args=[], returncode=code, stdout="", stderr=err)
+
+        return _run
+
+    transient = [(1, "503 backend error")]
+    not_found = [(1, "ERROR: (gcloud.secrets.describe) NOT_FOUND: Secret [x] not found.")]
+    read_cases: tuple[tuple[str, object, list[tuple[int, str]], object, int], ...] = (
+        ("read_secret transient", read_secret, transient, None, SECRET_READ_ATTEMPTS),
+        ("read_secret not-found", read_secret, not_found, None, 1),
+        ("secret_exists transient", secret_exists, transient, False, SECRET_READ_ATTEMPTS),
+        ("secret_exists not-found", secret_exists, not_found, False, 1),
+    )
+    for label, func, outcomes, expected_result, expected_calls in read_cases:
+        calls: list[int] = []
+        subprocess.run = _scripted_run(outcomes, calls)  # type: ignore[assignment]
+        time.sleep = lambda _seconds: None  # type: ignore[assignment]
+        try:
+            observed = func("proj", GCP_CERT_PEM_NAME)  # type: ignore[operator]
+        finally:
+            subprocess.run = real_run  # type: ignore[assignment]
+            time.sleep = real_sleep  # type: ignore[assignment]
+        assert observed is expected_result, f"{label}: expected {expected_result}, got {observed}"
+        assert len(calls) == expected_calls, (
+            f"{label}: expected {expected_calls} gcloud call(s), got {len(calls)}"
+        )
+
     # 4. WWDR pinning fails closed on a plausible-but-wrong intermediate.
     wrong = (
         x509.CertificateBuilder()
@@ -849,11 +1317,26 @@ def main(argv: list[str]) -> int:
     # happens: a certificate is minted once, so a project discovered to be
     # unwritable afterwards would strand that environment without signing
     # material and burn an Apple certificate slot.
+    gcp_token = gcloud_access_token()
     for project in projects:
-        assert_project_access(project)
+        assert_project_access(project, gcp_token)
 
     missing_by_project = existing_material_state(projects)
-    fully_provisioned = all(not absent for absent in missing_by_project.values())
+    all_present = all(not absent for absent in missing_by_project.values())
+
+    # Presence is necessary but not sufficient. Every project must also hold a
+    # certificate whose public key matches its stored private key, or a past
+    # partial write has left a silently-broken signer that only a re-mint repairs.
+    fully_provisioned = all_present
+    if all_present:
+        for project in projects:
+            if not stored_material_corresponds(project):
+                log(
+                    f"project {project} holds signing secrets whose certificate "
+                    "and private key do not correspond (partial rotation?); a "
+                    "replacement will be minted"
+                )
+                fully_provisioned = False
 
     metadata: dict[str, object] = {
         "mode": mode,
@@ -864,15 +1347,22 @@ def main(argv: list[str]) -> int:
     }
 
     if fully_provisioned and not args.force_new_certificate:
-        stored = stored_certificate_expiry(projects[0])
-        if stored is None:
+        # Inspect EVERY project, not just the first: rotate on the soonest expiry
+        # and never declare the fleet provisioned while projects disagree on which
+        # certificate they hold.
+        stored_by_project = {p: stored_certificate_expiry(p) for p in projects}
+        if any(value is None for value in stored_by_project.values()):
             log(
-                "stored certificate could not be read for an expiry check; "
+                "a stored certificate could not be read for an expiry check; "
                 "treating it as needing renewal"
             )
         else:
-            expiry, serial = stored
+            soonest_project, (expiry, serial) = min(
+                stored_by_project.items(),
+                key=lambda item: item[1][0],  # type: ignore[index]
+            )
             remaining = days_until(expiry)
+            serials = {value[1] for value in stored_by_project.values()}  # type: ignore[index]
             metadata.update(
                 {
                     "certificate_serial": serial,
@@ -880,19 +1370,26 @@ def main(argv: list[str]) -> int:
                     "days_until_expiry": remaining,
                 }
             )
-            if remaining > args.renew_within_days:
+            if len(serials) > 1:
+                log(
+                    "target projects disagree on the stored certificate serial "
+                    f"({', '.join(sorted(serials))}); provisioning to converge them"
+                )
+            elif remaining > args.renew_within_days:
                 metadata["mode"] = "already-provisioned"
                 metadata["action"] = "none"
                 log(
-                    f"all secrets present and the stored certificate is valid for "
-                    f"{remaining} more day(s); nothing to do"
+                    "all secrets present, cert<->key correspond, and the stored "
+                    f"certificate is valid for {remaining} more day(s); nothing to do"
                 )
                 emit(metadata, args.metadata_path)
                 return 0
-            log(
-                f"stored certificate expires in {remaining} day(s) (<= "
-                f"{args.renew_within_days}); provisioning a replacement"
-            )
+            else:
+                log(
+                    f"stored certificate (soonest in {soonest_project}) expires in "
+                    f"{remaining} day(s) (<= {args.renew_within_days}); provisioning "
+                    "a replacement"
+                )
 
     token = mint_jwt(args.p8_path, args.key_id, args.issuer_id)
     pass_type_id, created_pass_type = ensure_pass_type_id(
@@ -939,19 +1436,60 @@ def main(argv: list[str]) -> int:
     wwdr_pem = wwdr_certificate.public_bytes(serialization.Encoding.PEM).decode("utf-8")  # type: ignore[attr-defined]
 
     expiry = not_after_utc(certificate)
+    # Write the private KEY first, then the CERT, then WWDR. Secret Manager has no
+    # multi-secret transaction, so on FIRST provisioning this order leaves the new
+    # key without a matching cert (the signer reports material-incomplete and
+    # degrades to 503) rather than a new cert beside a mismatched key (which signs
+    # passes iOS silently rejects). On ROTATION both secrets already exist, so no
+    # ordering is safe on its own — that case is handled by writing every payload
+    # even after a failure (so the pair still converges) and by always running the
+    # correspondence guard below, which is the real protection.
     payloads = (
-        (GCP_CERT_PEM_NAME, cert_pem),
         (GCP_KEY_PEM_NAME, key_pem),
+        (GCP_CERT_PEM_NAME, cert_pem),
         (GCP_WWDR_PEM_NAME, wwdr_pem),
     )
+    write_failures: dict[str, list[str]] = {}
     for project in projects:
-        for name, payload in payloads:
-            write_secret(project, name, payload, args.upsert_script)
+        log(f"writing signing material to project {project}")
+        failed = [
+            name
+            for name, payload in payloads
+            if not write_secret(project, name, payload, args.upsert_script)
+        ]
+        if failed:
+            # Keep going rather than aborting: the remaining projects still need
+            # their material, and every project must reach the guard below.
+            write_failures[project] = failed
 
+    # Verify the invariant the signer depends on, per project: not just that all
+    # three secrets are present, but that the stored cert and key actually
+    # correspond. A green presence check on a mixed-state project is exactly the
+    # silent failure this whole rotation path exists to prevent. This runs even
+    # when a write failed, so a partial rotation is always diagnosed rather than
+    # left behind unreported.
+    mixed_state: list[str] = []
+    still_missing: dict[str, list[str]] = {}
     for project in projects:
         absent = [name for name in GCP_PEM_NAMES if not secret_exists(project, name)]
         if absent:
-            die(f"project {project} is still missing after write: {', '.join(absent)}")
+            still_missing[project] = absent
+            continue
+        if not stored_material_corresponds(project):
+            mixed_state.append(project)
+
+    if write_failures or still_missing or mixed_state:
+        details: list[str] = []
+        for project, names in sorted(write_failures.items()):
+            details.append(f"{project}: failed to write {', '.join(names)}")
+        for project, names in sorted(still_missing.items()):
+            details.append(f"{project}: still missing {', '.join(names)}")
+        for project in sorted(mixed_state):
+            details.append(
+                f"{project}: stored certificate and private key DO NOT correspond "
+                "(mixed state — passes signed here would be rejected by iOS)"
+            )
+        die(inconsistent_publication_message(details))
 
     metadata.update(
         {


### PR DESCRIPTION
## Wallet Profile — a shareable Hussh One pass for Apple Wallet

Adds an Apple Wallet pass whose QR opens a **public, owner-controlled profile page**. The scanner needs no app, no account, no Apple device, and no login — the primary use case is professional networking / a dynamic digital business card. Setup reuses existing profile info (<60s) and the owner gets progressive privacy controls plus preview / edit / pause / rotate-QR / revoke.

Ships **dark**: `ONE_WALLET_CARD_ENABLED` defaults OFF and no Pass Type ID signing material exists yet, so there is no user-visible change on merge.

### Why this architecture

- **Dedicated `one_wallet_cards` plane (migration 132)**, modelled on the shipped One Location public-invite pattern — a stable `pass_serial` plus a rotatable share token stored **only as a SHA-256 hash**.
- **Deliberately NOT built on `pkm_default_available_projections`:** that table is scanned by the Information Marketplace catalogue with no source filter, so publishing a card through it would silently list the owner for sale, and it mints a fresh handle on every edit (invalidating an already-printed QR).
- **No Wallet web service:** `webServiceURL`/`authenticationToken` are omitted; the QR resolves server-side, so edit/pause/revoke take effect instantly. Removes APNs, device registration, and five endpoints from scope.
- **No new native code, entitlement, or app release:** WKWebView cannot import a `.pkpass`, but Capacitor hands off-origin navigations to Safari, which can.

### Public surface hardening

- Explicit **per-route rate limiting** (the global limiter is never wired), forwarded-IP keying.
- `X-Robots-Tag: noindex` and the `/c` prefix added to the robots disallow list.
- Preview-as-visitor uses the **same backend projection builder** as real public access — what the owner previews is byte-identical to what a stranger sees.
- Public status codes: unknown → 404 generic; **paused → 404 (same generic body as unknown)**; revoked → 410 `{status:revoked}`; expired → 410 `{status:expired}`.
- `one_wallet_cards` is registered in **account deletion and reset**, with an ordering assertion: the row holds denormalized PII (name/email/phone/links) reachable from an unauthenticated endpoint, so it is deleted *before* `actor_profiles` tears down the identity spine.

### Safety / correctness

- Signing service returns **503 when material is absent**, so a flag-on-without-certs state degrades gracefully rather than 500ing.
- `card_payload` is a **closed allowlist** with per-field max lengths, https-only URLs, and rejection of `javascript:`/`data:`/userinfo.
- Also fixes a class of **brittle migration tests** that asserted their own migration was the manifest's last entry or pinned an exact schema version (one had been red on main for several migrations), and adds a **guard test** preventing reintroduction.

### Provisioning gate — state of verification

`scripts/ci/provision_wallet_pass_certificate.py` guards an **irreversible** action: minting a Pass Type ID certificate consumes one of a small, finite number of slots on the Apple account. Its pre-mint permission check was calling `gcloud projects test-iam-permissions`, **which does not exist** (SDK 565.0.0 returns exit 2, `Invalid choice`). The gate therefore rejected every credential with a misleading "grant `roles/secretmanager.admin`" — including a correct one — and had never actually run. This PR rewrites it against the Cloud Resource Manager `testIamPermissions` REST endpoint, and additionally:

- demands `secretmanager.secrets.create` **only when a target secret is absent** (`upsert_gcp_secret.py` skips creation otherwise, so a rotation-scoped credential was being over-rejected);
- names the project-vs-secret caveat in the failure text — a grant made on an individual secret is invisible to a project-level check;
- stops `stored_certificate_expiry` from exiting on an unparseable PEM, so the fail-closed correspondence predicate can reach its own verdict (`SystemExit` is a `BaseException` and was escaping the predicate);
- replaces post-mint partial-publish guidance that recommended `--force-new-certificate` — **both routes reach the mint and burn another Apple slot** — with a copy-from-a-healthy-project recovery procedure;
- gives secret reads the same 3× retry and stderr surfacing as writes, short-circuits on `NOT_FOUND`, and prevents a subprocess `OSError` from escaping the post-mint guard and skipping the "already minted" instruction.

**What is and is not verified.** The rewritten gate was exercised against the **live** Cloud Resource Manager API on both `hushh-pda-uat` and `hushh-pda` using the read-only `eval-log-reader` service account: the endpoint was reachable in both projects and the gate **rejected fail-closed** with the new message naming each missing permission. That establishes reachability, JSON parsing, and the reject path — behaviour the previous code could not reach at all. It does **not** establish the accept path: no credential holding `roles/secretmanager.admin` was available (the local user token fails reauth non-interactively), so the "permissions sufficient → proceed" branch remains unexercised against the real API and this defect should not be considered closed until a `--apply` dry run passes with an admin credential. The `--self-test` is a unit harness and is deliberately **not** offered as evidence that the gate works in production.

Guard changes were validated by **mutation testing** rather than assertion counting: eight deliberate regressions (dying loader inside the predicate, the non-existent subcommand, the re-mint recommendation, `write_secret` dying instead of reporting, both retry constants cut to 1, the `NOT_FOUND` short-circuit removed, stderr swallowed) are each caught. Two were detectable only after replacing a tautological assertion that compared a call count against the very constant it was meant to pin.

### Governance registration

A new table and new routes are not just code here — they have to be declared in a chain of governed artifacts, three of which are generated and `--check`ed. Running the `Governance` lane locally surfaced four blockers that CI would otherwise have revealed one at a time, since Preflight short-circuits the expensive lanes behind Governance.

- `runtime-db-data-plane-contract.json`: new `one_wallet_card` family, classified `personal_projection` (mirroring the owner-published `pkm_default_available_projection` family) and owned by `iam-consent-governance` — the consent/sharing plane, deliberately not `vault-pkm-governance`, because the card does not sit on PKM.
- `one-route-orchestration-index.v1.json` (both byte-identical copies) and `runtime-topology-index.v1.json`: regenerated to cover `/c/[token]` and `/one/wallet-card`. The generator derives `trust_boundary` from a route's gateway action ids, not from page authentication; neither route registers gateway actions, so `none` is correct by construction and matches the `/one/location/request/[token]` precedent. Page auth for `/one/wallet-card` is enforced by the route layout and OneAuthGate.
- Plan-doc H1 now reads "Hussh" — public prose says Hussh while route, API and schema identifiers keep the legacy `hushh` spelling, so the filename is unchanged. Fixed at the source rather than by widening the allowlist in `scripts/verify-doc-brand.cjs`.

`bash scripts/ci/orchestrate.sh governance` exits 0: 118 routes, 18 agents, 42 table families; 126/126 tables classified; 239 checks passed, 0 errors, 0 warnings; release manifest, repo head, UAT and prod contracts all at 132.

### Test coverage

178 new tests (113 Python + 65 TS): service layer, routes/auth/rate-limit, pass signing, migration, public page, QR encoding, payload allowlist, account-deletion coverage, plus the migration-brittleness guard. Six previously brittle migration tests were repaired and still pass. Additive, backward-compatible, reversible.

Test fixture share-token values are literal non-secrets (`wallet-card-test-token-not-a-real-secret`); the public lookup path applies no format, length, or charset validation, so the fixture value is arbitrary and no plaintext token, key PEM, or `card_payload` value is logged anywhere.

Signed-off-by: Ankit Kumar Singh <ankit@hushh.ai>
