### PR TITLE
feat(one-location): complete exact saved-place onboarding

### DIFF
--- a/hushh-webapp/__tests__/app/one/setup/location-onboarding-setup-route.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one/setup/location-onboarding-setup-route.contract.test.ts
@@ -31,11 +31,23 @@ describe("Location setup route contract", () => {
   it("keeps Location setup vault-free until the root setup completion", () => {
     const locationPage = read("app/one/location/page.tsx");
 
-    expect(locationPage).toContain("mode !== \"setup\"");
+    expect(locationPage).toContain('mode !== "setup"');
     expect(locationPage).toContain(
       'Boolean(auth.userId && (mode === "setup" || vaultOwnerToken))',
     );
     expect(locationPage).toContain(
+      "onLocationReady={promptSaveLocationDuringOnboarding}",
+    );
+    expect(locationPage).toContain(
+      "PreVaultSensitiveDraftService.stageSavedLocation(auth.userId, input)",
+    );
+    expect(locationPage).toContain(
+      "deferredUntilVault={!vaultKey || !vaultOwnerToken}",
+    );
+    expect(locationPage).toContain(
+      "vaultOwnerToken ? reverseGeocodeForSavedLocation : undefined",
+    );
+    expect(locationPage).not.toContain(
       'mode === "setup"\n              ? async () => true',
     );
   });

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -24,8 +24,13 @@ const {
   mockReverseGeocode,
   mockPlacesAutocomplete,
   mockPlaceDetails,
+  mockGetMapState,
+  mockUpdateMapPreferences,
   mockAddSavedLocation,
   mockLoadSavedLocations,
+  mockStageSavedLocation,
+  mockClearSavedLocation,
+  mockClearPreVaultForUser,
   mockCreateGrant,
   mockStoreEnvelope,
   mockViewEnvelope,
@@ -65,8 +70,13 @@ const {
   mockReverseGeocode: vi.fn(),
   mockPlacesAutocomplete: vi.fn(),
   mockPlaceDetails: vi.fn(),
+  mockGetMapState: vi.fn(),
+  mockUpdateMapPreferences: vi.fn(),
   mockAddSavedLocation: vi.fn(),
   mockLoadSavedLocations: vi.fn(),
+  mockStageSavedLocation: vi.fn(),
+  mockClearSavedLocation: vi.fn(),
+  mockClearPreVaultForUser: vi.fn(),
   mockCreateGrant: vi.fn(),
   mockStoreEnvelope: vi.fn(),
   mockViewEnvelope: vi.fn(),
@@ -120,6 +130,42 @@ vi.mock("@/lib/firebase/auth-context", () => ({
 
 vi.mock("@/lib/vault/vault-context", () => ({
   useVault: mockUseVault,
+}));
+
+vi.mock("@/components/one-location/onboarding/location-picker-map", () => ({
+  LocationPickerMap: ({
+    onConfirm,
+    onCancel,
+    confirmLabel,
+    cancelLabel,
+  }: {
+    onConfirm: (picked: {
+      latitude: number;
+      longitude: number;
+      address: string;
+    }) => void;
+    onCancel: () => void;
+    confirmLabel: string;
+    cancelLabel: string;
+  }) => (
+    <div aria-label="Mock location picker">
+      <button
+        type="button"
+        onClick={() =>
+          onConfirm({
+            latitude: 28.6139,
+            longitude: 77.209,
+            address: "Kartavya Path, New Delhi, Delhi 110001, India",
+          })
+        }
+      >
+        {confirmLabel}
+      </button>
+      <button type="button" onClick={onCancel}>
+        {cancelLabel}
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/one-location/saved-locations-section", () => ({
@@ -213,6 +259,8 @@ vi.mock("@/lib/one-location/service", () => ({
     reverseGeocode: mockReverseGeocode,
     placesAutocomplete: mockPlacesAutocomplete,
     placeDetails: mockPlaceDetails,
+    getMapState: mockGetMapState,
+    updateMapPreferences: mockUpdateMapPreferences,
     watchCurrentPosition: vi.fn().mockResolvedValue(null),
     clearWatch: vi.fn(),
     clearLocationWatch: vi.fn().mockResolvedValue(undefined),
@@ -238,6 +286,14 @@ vi.mock("@/lib/one-location/saved-locations", () => ({
   DuplicateSavedLocationError: class extends Error {},
   addSavedLocation: mockAddSavedLocation,
   loadSavedLocations: mockLoadSavedLocations,
+}));
+
+vi.mock("@/lib/services/pre-vault-sensitive-draft-service", () => ({
+  PreVaultSensitiveDraftService: {
+    stageSavedLocation: mockStageSavedLocation,
+    clearSavedLocation: mockClearSavedLocation,
+    clearForUser: mockClearPreVaultForUser,
+  },
 }));
 
 vi.mock("@/lib/one-location/contact-signals", () => ({
@@ -475,17 +531,13 @@ async function openLocationFeatureStep() {
 async function openLocationPeopleStep() {
   await openLocationFeatureStep();
   await waitFor(() => {
-    const savePrompt = screen.queryByRole("dialog", {
-      name: "Save this place",
-    });
+    const savePrompt = screen.queryByTestId("save-location-modal");
     const continueButton = screen.queryByRole("button", {
       name: /Add my people|Allow location/,
     });
     expect(savePrompt || continueButton).toBeTruthy();
   });
-  const savePrompt = screen.queryByRole("dialog", {
-    name: "Save this place",
-  });
+  const savePrompt = screen.queryByTestId("save-location-modal");
   if (savePrompt) {
     fireEvent.click(
       within(savePrompt).getByRole("button", { name: "Skip for now" }),
@@ -528,6 +580,11 @@ async function skipLocationEntryFlow(options: { expectMain?: boolean } = {}) {
       await screen.findByRole("heading", { name: "Location Agent" }),
     ).toBeTruthy();
   }
+
+  // Tests after this helper exercise workspace actions. Ignore the deliberate
+  // onboarding picker capture so their assertions count only the action under
+  // test (share, request, Nearby, emergency, and public-link flows).
+  mockCaptureCurrentPosition.mockClear();
 }
 
 async function openLocationPermissionsStep() {
@@ -689,6 +746,18 @@ describe("OneLocationAgentPage", () => {
       label: "Hushh Office, Bengaluru, Karnataka, India",
       latitude: 12.9716,
       longitude: 77.5946,
+    });
+    mockGetMapState.mockResolvedValue({
+      preferences: {
+        presenceMode: "ghost",
+        rendererConsentVersion: "google-maps-renderer-v1",
+      },
+      freshnessSeconds: 60,
+      markers: [],
+    });
+    mockUpdateMapPreferences.mockResolvedValue({
+      presenceMode: "ghost",
+      rendererConsentVersion: "google-maps-renderer-v1",
     });
     mockAddSavedLocation.mockResolvedValue([
       {
@@ -1024,10 +1093,10 @@ describe("OneLocationAgentPage", () => {
       ).toHaveAttribute("aria-checked", "true"),
     );
 
-    fireEvent.click(
-      screen.getByRole("switch", { name: "Turn location off" }),
+    fireEvent.click(screen.getByRole("switch", { name: "Turn location off" }));
+    await waitFor(() =>
+      expect(screen.getByText("Location paused")).toBeTruthy(),
     );
-    await waitFor(() => expect(screen.getByText("Location paused")).toBeTruthy());
 
     mockCaptureCurrentPosition.mockClear();
     mockCaptureCurrentPosition.mockRejectedValue(
@@ -1194,9 +1263,7 @@ describe("OneLocationAgentPage", () => {
       target: { value: "Trusted" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-    fireEvent.click(
-      screen.getByRole("radio", { name: /Approximate area/i }),
-    );
+    fireEvent.click(screen.getByRole("radio", { name: /Approximate area/i }));
     fireEvent.click(screen.getByRole("combobox", { name: "Duration" }));
     fireEvent.click(screen.getByRole("option", { name: "4 hours" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Optional note" }), {
@@ -1271,9 +1338,9 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("combobox", { name: "Duration" }).textContent,
     ).toContain("15 min");
-    expect(
-      screen.getByRole("textbox", { name: "Optional note" }),
-    ).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Optional note" })).toHaveValue(
+      "",
+    );
     expect(screen.getByText("0/140")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Review share" }));
@@ -1301,9 +1368,7 @@ describe("OneLocationAgentPage", () => {
     expect(
       screen.getByRole("region", { name: "Saved Locations" }),
     ).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Manage sharing" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Manage sharing" })).toBeNull();
     expect(mockRouterPush).toHaveBeenCalledWith(
       "/one/location?action=settings",
       { scroll: false },
@@ -1567,9 +1632,7 @@ describe("OneLocationAgentPage", () => {
     await openLocationPermissionsStep();
     expect(screen.getByTestId("one-location-onboarding-features")).toBeTruthy();
     await waitFor(() => expect(mockOpenAppSettings).toHaveBeenCalled());
-    expect(
-      screen.getByRole("button", { name: "Add my people" }),
-    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Add my people" })).toBeEnabled();
     expect(onSetupComplete).not.toHaveBeenCalled();
   });
 
@@ -1608,9 +1671,7 @@ describe("OneLocationAgentPage", () => {
       appInteractionCoordinator.handleLifecycle("active");
     });
 
-    expect(
-      await screen.findByRole("dialog", { name: "Save this place" }),
-    ).toBeTruthy();
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
   });
 
@@ -1625,7 +1686,7 @@ describe("OneLocationAgentPage", () => {
     expect(screen.queryByText("Workspace state unavailable")).toBeNull();
   });
 
-  it("starts Location setup without vault authority or a saved-place prompt", async () => {
+  it("stages the onboarding location in memory when vault authority is not ready", async () => {
     mockUseVault.mockReturnValue({
       isVaultUnlocked: false,
       vaultKey: null,
@@ -1639,9 +1700,121 @@ describe("OneLocationAgentPage", () => {
     ).toBeTruthy();
     expect(mockRegisterKey).not.toHaveBeenCalled();
     expect(mockGetState).not.toHaveBeenCalled();
-    expect(
-      screen.queryByRole("dialog", { name: "Save this place" }),
-    ).toBeNull();
+
+    await openLocationPermissionsStep();
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+    expect(mockReverseGeocode).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Flat 4B" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save location" }));
+
+    await waitFor(() =>
+      expect(mockStageSavedLocation).toHaveBeenCalledWith("user_a", {
+        category: "home",
+        label: "",
+        latitude: 28.6139,
+        longitude: 77.209,
+        address: "Flat 4B, Kartavya Path, New Delhi, Delhi 110001, India",
+      }),
+    );
+    expect(mockAddSavedLocation).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("save-location-modal")).toBeNull();
+  });
+
+  it("never carries an in-flight location capture across an account switch", async () => {
+    let resolveUserACapture:
+      | ((value: {
+          latitude: number;
+          longitude: number;
+          accuracyM: number;
+          capturedAt: string;
+          sourcePlatform: "web";
+        }) => void)
+      | undefined;
+    mockUseVault.mockReturnValue({
+      isVaultUnlocked: false,
+      vaultKey: null,
+      vaultOwnerToken: null,
+    });
+    mockCaptureCurrentPosition
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveUserACapture = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        latitude: 12.9716,
+        longitude: 77.5946,
+        accuracyM: 15,
+        capturedAt: "2026-08-04T01:00:00.000Z",
+        sourcePlatform: "web",
+      });
+
+    const view = render(<OneLocationAgentPage mode="setup" />);
+    await openLocationPermissionsStep();
+    await waitFor(() =>
+      expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1),
+    );
+
+    mockUseRequireAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      userId: "user_b",
+      user: {
+        uid: "user_b",
+        displayName: "Second User",
+        email: "second@example.com",
+        photoURL: null,
+        getIdToken: vi.fn().mockResolvedValue("id-token-b"),
+      },
+    });
+    view.rerender(<OneLocationAgentPage mode="setup" />);
+
+    await waitFor(() =>
+      expect(mockClearPreVaultForUser).toHaveBeenCalledWith("user_a"),
+    );
+    await openLocationPermissionsStep();
+    await waitFor(() =>
+      expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(2),
+    );
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+
+    await act(async () => {
+      resolveUserACapture?.({
+        latitude: 40.7128,
+        longitude: -74.006,
+        accuracyM: 10,
+        capturedAt: "2026-08-04T00:59:00.000Z",
+        sourcePlatform: "web",
+      });
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Second user's home" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save location" }));
+
+    await waitFor(() =>
+      expect(mockStageSavedLocation).toHaveBeenCalledWith(
+        "user_b",
+        expect.objectContaining({
+          category: "home",
+          address: expect.stringContaining("Second user's home"),
+        }),
+      ),
+    );
+    expect(mockStageSavedLocation).not.toHaveBeenCalledWith(
+      "user_a",
+      expect.anything(),
+    );
   });
 
   it("keeps contact prefetch alive across steps and renders the first available source", async () => {
@@ -1837,7 +2010,11 @@ describe("OneLocationAgentPage", () => {
       expect(mockRequestLocationPermission).toHaveBeenCalledTimes(1),
     );
     expect(toast.success).toHaveBeenCalledWith("Location access enabled.");
-    expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1),
+    );
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
     expect(
       await screen.findByRole("heading", { name: "Add people" }),
@@ -1894,9 +2071,7 @@ describe("OneLocationAgentPage", () => {
 
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openLocationPermissionsStep();
-    expect(
-      await screen.findByRole("dialog", { name: "Save this place" }),
-    ).toBeTruthy();
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     await waitFor(() =>
       expect(mockReverseGeocode).toHaveBeenCalledWith({
         vaultOwnerToken: "vault-token",
@@ -1905,6 +2080,10 @@ describe("OneLocationAgentPage", () => {
       }),
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Flat 4B" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
     fireEvent.click(screen.getByRole("button", { name: "Save location" }));
 
@@ -1920,14 +2099,12 @@ describe("OneLocationAgentPage", () => {
           label: "",
           latitude: 28.6139,
           longitude: 77.209,
-          address: "Kartavya Path, New Delhi, Delhi 110001, India",
+          address: "Flat 4B, Kartavya Path, New Delhi, Delhi 110001, India",
         },
       }),
     );
     await waitFor(() =>
-      expect(
-        screen.queryByRole("dialog", { name: "Save this place" }),
-      ).toBeNull(),
+      expect(screen.queryByTestId("save-location-modal")).toBeNull(),
     );
     expect(
       window.localStorage.getItem(
@@ -1973,17 +2150,15 @@ describe("OneLocationAgentPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 
-    expect(
-      await screen.findByRole("dialog", { name: "Save this place" }),
-    ).toBeTruthy();
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(2);
   });
 
-  it("reoffers the workspace prompt when legacy state says answered but encrypted PKM is empty", async () => {
-    window.localStorage.removeItem(
+  it("retires a legacy skipped outcome and still opens the onboarding picker", async () => {
+    window.localStorage.setItem(
       "one_location_saved_location_prompt_v2:user_a",
+      "skipped",
     );
-    mockLoadSavedLocations.mockResolvedValue([]);
     mockGetState.mockResolvedValue({
       ...locationState(),
       ownerGrants: [],
@@ -1994,17 +2169,15 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openLocationPermissionsStep();
 
-    expect(
-      await screen.findByRole("dialog", { name: "Save this place" }),
-    ).toBeTruthy();
-    expect(mockLoadSavedLocations).toHaveBeenCalledWith({
-      userId: "user_a",
-      vaultKey: "vault-key",
-      vaultOwnerToken: "vault-token",
-    });
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     expect(
       window.localStorage.getItem(
         "one_location_saved_location_prompt_v1:user_a",
+      ),
+    ).toBeNull();
+    expect(
+      window.localStorage.getItem(
+        "one_location_saved_location_prompt_v2:user_a",
       ),
     ).toBeNull();
   });
@@ -2020,6 +2193,8 @@ describe("OneLocationAgentPage", () => {
     await waitFor(() => expect(mockGetState).toHaveBeenCalled());
     await openLocationPermissionsStep();
     expect(mockRequestLocationPermission).not.toHaveBeenCalled();
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
     expect(
       await screen.findByRole("heading", { name: "Add people" }),
@@ -2033,14 +2208,14 @@ describe("OneLocationAgentPage", () => {
     expect(
       await screen.findByRole("heading", { name: "Location Agent" }),
     ).toBeTruthy();
-    expect(mockCaptureCurrentPosition).not.toHaveBeenCalled();
+    expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
     // Completing onboarding persists the one-time intro flag.
     expect(
       window.localStorage.getItem("one_location_onboarding_v2:user_a"),
     ).toBe("1");
   });
 
-  it("reoffers the encrypted saved-place prompt in the unlocked workspace when Location is already granted", async () => {
+  it("reoffers the two-step saved-place flow when Location is already granted", async () => {
     window.localStorage.removeItem(
       "one_location_saved_location_prompt_v2:user_a",
     );
@@ -2061,46 +2236,19 @@ describe("OneLocationAgentPage", () => {
     await openLocationPermissionsStep();
 
     expect(mockRequestLocationPermission).not.toHaveBeenCalled();
-    expect(
-      await screen.findByRole("dialog", { name: "Save this place" }),
-    ).toBeTruthy();
+    expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     expect(mockCaptureCurrentPosition).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Change captured location",
-      }),
-    );
-    fireEvent.change(
-      screen.getByRole("searchbox", {
-        name: "Search for another place",
-      }),
-      { target: { value: "Hushh Office" } },
-    );
-    await waitFor(() =>
-      expect(mockPlacesAutocomplete).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        input: "Hushh Office",
-      }),
-    );
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "Hushh Office, Bengaluru",
-      }),
-    );
-
-    await waitFor(() =>
-      expect(mockPlaceDetails).toHaveBeenCalledWith({
-        vaultOwnerToken: "vault-token",
-        placeId: "hushh-office",
-      }),
-    );
-    expect(
-      await screen.findByText(
-        "Hushh Office, Bengaluru, Karnataka, India",
-      ),
-    ).toBeTruthy();
-    expect(screen.queryByText(/12\.9716|77\.5946/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Tower 2, Floor 4" },
+    });
+    fireEvent.change(screen.getByLabelText(/Building colour/), {
+      target: { value: "White gate" },
+    });
+    fireEvent.change(screen.getByLabelText(/Nearby landmark/), {
+      target: { value: "India Gate" },
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
     fireEvent.click(screen.getByRole("button", { name: "Save location" }));
@@ -2115,9 +2263,10 @@ describe("OneLocationAgentPage", () => {
         input: {
           category: "work",
           label: "",
-          latitude: 12.9716,
-          longitude: 77.5946,
-          address: "Hushh Office, Bengaluru, Karnataka, India",
+          latitude: 28.6139,
+          longitude: 77.209,
+          address:
+            "Tower 2, Floor 4, White gate, Near India Gate, Kartavya Path, New Delhi, Delhi 110001, India",
         },
       }),
     );
@@ -3023,9 +3172,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
 
     mockRouterPush.mockClear();
-    fireEvent.click(
-      screen.getByRole("button", { name: /Add Connections/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Add Connections/i }));
     expect(mockRouterPush).toHaveBeenCalledWith("/one/connect");
 
     fireEvent.click(screen.getByRole("button", { name: "Links" }));

--- a/hushh-webapp/__tests__/components/post-auth-onboarding-sync-bridge.test.tsx
+++ b/hushh-webapp/__tests__/components/post-auth-onboarding-sync-bridge.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  authState,
+  finalizeForVaultMock,
+  pathnameState,
+  postUnlockRunMock,
+  vaultState,
+} = vi.hoisted(() => ({
+  authState: {
+    current: {
+      user: { uid: "user-a" } as { uid: string } | null,
+      loading: false,
+    },
+  },
+  finalizeForVaultMock: vi.fn(),
+  pathnameState: { current: "/one" },
+  postUnlockRunMock: vi.fn(),
+  vaultState: {
+    current: {
+      isVaultUnlocked: true,
+      vaultKey: "vault-key-a" as string | null,
+      vaultOwnerToken: "vault-token-a" as string | null,
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathnameState.current,
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => authState.current,
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => vaultState.current,
+}));
+
+vi.mock("@/lib/services/pre-vault-sensitive-draft-service", () => ({
+  PreVaultSensitiveDraftService: {
+    finalizeForVault: (...args: unknown[]) => finalizeForVaultMock(...args),
+  },
+}));
+
+vi.mock("@/lib/services/post-unlock-sync-service", () => ({
+  PostUnlockSyncService: {
+    run: (...args: unknown[]) => postUnlockRunMock(...args),
+  },
+}));
+
+import { PostAuthOnboardingSyncBridge } from "@/components/onboarding/PostAuthOnboardingSyncBridge";
+
+describe("PostAuthOnboardingSyncBridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.current = { user: { uid: "user-a" }, loading: false };
+    vaultState.current = {
+      isVaultUnlocked: true,
+      vaultKey: "vault-key-a",
+      vaultOwnerToken: "vault-token-a",
+    };
+    pathnameState.current = "/one";
+    finalizeForVaultMock.mockResolvedValue(undefined);
+    postUnlockRunMock.mockResolvedValue(undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  it("stays inert until complete auth and vault authority exist", async () => {
+    authState.current = { user: { uid: "user-a" }, loading: true };
+    const view = render(<PostAuthOnboardingSyncBridge />);
+
+    await Promise.resolve();
+    expect(finalizeForVaultMock).not.toHaveBeenCalled();
+
+    authState.current = { user: { uid: "user-a" }, loading: false };
+    vaultState.current = {
+      isVaultUnlocked: false,
+      vaultKey: null,
+      vaultOwnerToken: null,
+    };
+    view.rerender(<PostAuthOnboardingSyncBridge />);
+    await Promise.resolve();
+
+    expect(finalizeForVaultMock).not.toHaveBeenCalled();
+    expect(postUnlockRunMock).not.toHaveBeenCalled();
+  });
+
+  it("waits until setup navigation finishes, then finalizes before ordinary sync", async () => {
+    const order: string[] = [];
+    pathnameState.current = "/one/setup/location";
+    finalizeForVaultMock.mockImplementation(async () => {
+      order.push("finalize");
+    });
+    postUnlockRunMock.mockImplementation(async () => {
+      order.push("post-unlock");
+    });
+    const view = render(<PostAuthOnboardingSyncBridge />);
+
+    await Promise.resolve();
+    expect(finalizeForVaultMock).not.toHaveBeenCalled();
+
+    pathnameState.current = "/one";
+    view.rerender(<PostAuthOnboardingSyncBridge />);
+
+    await waitFor(() => expect(postUnlockRunMock).toHaveBeenCalledTimes(1));
+    expect(order).toEqual(["finalize", "post-unlock"]);
+
+    view.rerender(<PostAuthOnboardingSyncBridge />);
+    await Promise.resolve();
+    expect(finalizeForVaultMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues a new account session instead of dropping it behind an active flush", async () => {
+    let releaseUserA: (() => void) | undefined;
+    finalizeForVaultMock.mockImplementation((params: { userId: string }) =>
+      params.userId === "user-a"
+        ? new Promise<void>((resolve) => {
+            releaseUserA = resolve;
+          })
+        : Promise.resolve(),
+    );
+    const view = render(<PostAuthOnboardingSyncBridge />);
+    await waitFor(() => expect(finalizeForVaultMock).toHaveBeenCalledTimes(1));
+
+    authState.current = { user: { uid: "user-b" }, loading: false };
+    vaultState.current = {
+      isVaultUnlocked: true,
+      vaultKey: "vault-key-b",
+      vaultOwnerToken: "vault-token-b",
+    };
+    view.rerender(<PostAuthOnboardingSyncBridge />);
+    expect(finalizeForVaultMock).toHaveBeenCalledTimes(1);
+
+    releaseUserA?.();
+
+    await waitFor(() => expect(finalizeForVaultMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(postUnlockRunMock).toHaveBeenCalledTimes(1));
+    expect(
+      finalizeForVaultMock.mock.calls.map(([params]) => params.userId),
+    ).toEqual(["user-a", "user-b"]);
+    expect(
+      postUnlockRunMock.mock.calls.map(([params]) => params.userId),
+    ).toEqual(["user-b"]);
+  });
+
+  it("does not run ordinary sync after finalization fails and retries new authority", async () => {
+    finalizeForVaultMock.mockRejectedValueOnce(new Error("PKM_WRITE_FAILED"));
+    const view = render(<PostAuthOnboardingSyncBridge />);
+
+    await waitFor(() => expect(finalizeForVaultMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(console.warn).toHaveBeenCalled());
+    expect(postUnlockRunMock).not.toHaveBeenCalled();
+
+    vaultState.current = {
+      isVaultUnlocked: true,
+      vaultKey: "vault-key-a-rotated",
+      vaultOwnerToken: "vault-token-a-rotated",
+    };
+    view.rerender(<PostAuthOnboardingSyncBridge />);
+
+    await waitFor(() => expect(postUnlockRunMock).toHaveBeenCalledTimes(1));
+    expect(finalizeForVaultMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a transient finalization failure in the same vault session", async () => {
+    finalizeForVaultMock.mockRejectedValueOnce(new Error("PKM_WRITE_FAILED"));
+    render(<PostAuthOnboardingSyncBridge />);
+
+    await waitFor(() => expect(finalizeForVaultMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(postUnlockRunMock).toHaveBeenCalledTimes(1));
+
+    expect(finalizeForVaultMock.mock.calls[0]?.[0]).toEqual(
+      finalizeForVaultMock.mock.calls[1]?.[0],
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("retrying"),
+      expect.any(Error),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/lib/one-location/saved-location-address.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/saved-location-address.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSavedLocationAddress,
+  inferPostalCode,
+  isValidPostalCode,
+  normalizeSavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
+
+describe("saved location address helpers", () => {
+  it("infers common Indian and US postal-code shapes", () => {
+    expect(inferPostalCode("New Delhi, Delhi 110001, India")).toBe("110001");
+    expect(inferPostalCode("Seattle, WA 98101-1234, USA")).toBe("98101-1234");
+    expect(inferPostalCode("Address without a postal code")).toBe("");
+  });
+
+  it("accepts global alphanumeric postal codes and rejects unsafe shapes", () => {
+    expect(isValidPostalCode("560001")).toBe(true);
+    expect(isValidPostalCode("SW1A 1AA")).toBe(true);
+    expect(isValidPostalCode("98101-1234")).toBe(true);
+    expect(isValidPostalCode("!")).toBe(false);
+    expect(isValidPostalCode("12")).toBe(false);
+  });
+
+  it("normalizes owner-entered details before persistence", () => {
+    expect(
+      normalizeSavedLocationAddressDetails({
+        houseOrFlat: "  Flat   4B  ",
+        buildingColor: "  Blue   gate ",
+        landmark: " Opposite   City Mall ",
+        postalCode: " 110001 ",
+      }),
+    ).toEqual({
+      houseOrFlat: "Flat 4B",
+      buildingColor: "Blue gate",
+      landmark: "Opposite City Mall",
+      postalCode: "110001",
+    });
+  });
+
+  it("composes details into the encrypted address without repeating postal code", () => {
+    expect(
+      buildSavedLocationAddress(
+        "Kartavya Path, New Delhi, Delhi 110001, India",
+        {
+          houseOrFlat: "Flat 4B, Tower 2",
+          buildingColor: "Blue",
+          landmark: "City Mall",
+          postalCode: "110001",
+        },
+      ),
+    ).toBe(
+      "Flat 4B, Tower 2, Blue building, Near City Mall, Kartavya Path, New Delhi, Delhi 110001, India",
+    );
+  });
+
+  it("returns null instead of persisting an empty address", () => {
+    expect(
+      buildSavedLocationAddress(null, {
+        houseOrFlat: "",
+        buildingColor: "",
+        landmark: "",
+        postalCode: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps the required entrance and postal code within the address limit", () => {
+    const address = buildSavedLocationAddress("A".repeat(300), {
+      houseOrFlat: "Flat 4B, Tower 2",
+      buildingColor: "Blue gate",
+      landmark: "Opposite a very long landmark near the main road",
+      postalCode: "110001",
+    });
+
+    expect(address).toHaveLength(300);
+    expect(address).toMatch(/^Flat 4B, Tower 2/);
+    expect(address).toMatch(/, 110001$/);
+  });
+});

--- a/hushh-webapp/__tests__/services/pre-vault-sensitive-draft-service.test.ts
+++ b/hushh-webapp/__tests__/services/pre-vault-sensitive-draft-service.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { storeRuntimeSecretMock } = vi.hoisted(() => ({
-  storeRuntimeSecretMock: vi.fn(),
-}));
+const { addSavedLocationMock, loadSavedLocationsMock, storeRuntimeSecretMock } =
+  vi.hoisted(() => ({
+    addSavedLocationMock: vi.fn(),
+    loadSavedLocationsMock: vi.fn(),
+    storeRuntimeSecretMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
   GEMINI_RUNTIME_CREDENTIAL_REF: "credential",
@@ -15,6 +18,23 @@ vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
   },
 }));
 
+vi.mock("@/lib/one-location/saved-locations", () => ({
+  addSavedLocation: (...args: unknown[]) => addSavedLocationMock(...args),
+  loadSavedLocations: (...args: unknown[]) => loadSavedLocationsMock(...args),
+  defaultLabelForCategory: (category: "home" | "work" | "other") =>
+    category === "home" ? "Home" : category === "work" ? "Work" : "Other",
+  DuplicateSavedLocationError: class DuplicateSavedLocationError extends Error {
+    readonly existingCategory: "home" | "work" | "other";
+
+    constructor(existingLocation: { category: "home" | "work" | "other" }) {
+      super("This place is already saved.");
+      this.name = "DuplicateSavedLocationError";
+      this.existingCategory = existingLocation.category;
+    }
+  },
+}));
+
+import { DuplicateSavedLocationError } from "@/lib/one-location/saved-locations";
 import { PreVaultSensitiveDraftService } from "@/lib/services/pre-vault-sensitive-draft-service";
 
 describe("PreVaultSensitiveDraftService", () => {
@@ -22,6 +42,8 @@ describe("PreVaultSensitiveDraftService", () => {
     vi.clearAllMocks();
     PreVaultSensitiveDraftService.clearForUser("user-1");
     storeRuntimeSecretMock.mockResolvedValue({ success: true });
+    addSavedLocationMock.mockResolvedValue([]);
+    loadSavedLocationsMock.mockResolvedValue([]);
   });
 
   it("holds a Gemini credential only in memory until every encrypted write succeeds", async () => {
@@ -39,7 +61,9 @@ describe("PreVaultSensitiveDraftService", () => {
     });
 
     expect(storeRuntimeSecretMock).toHaveBeenCalledTimes(3);
-    expect(PreVaultSensitiveDraftService.hasGeminiRuntime("user-1")).toBe(false);
+    expect(PreVaultSensitiveDraftService.hasGeminiRuntime("user-1")).toBe(
+      false,
+    );
   });
 
   it("retains a staged credential for a retry when encrypted persistence fails", async () => {
@@ -72,11 +96,15 @@ describe("PreVaultSensitiveDraftService", () => {
     });
 
     expect(PreVaultSensitiveDraftService.hasFinanceIntent("user-1")).toBe(true);
-    expect(PreVaultSensitiveDraftService.consumeFinanceIntent("user-1")).toEqual({
+    expect(
+      PreVaultSensitiveDraftService.consumeFinanceIntent("user-1"),
+    ).toEqual({
       kind: "statement",
       file,
     });
-    expect(PreVaultSensitiveDraftService.hasFinanceIntent("user-1")).toBe(false);
+    expect(PreVaultSensitiveDraftService.hasFinanceIntent("user-1")).toBe(
+      false,
+    );
   });
 
   it("clears a pending finance action with all other pre-vault drafts", () => {
@@ -87,6 +115,270 @@ describe("PreVaultSensitiveDraftService", () => {
 
     PreVaultSensitiveDraftService.clearForUser("user-1");
 
-    expect(PreVaultSensitiveDraftService.hasFinanceIntent("user-1")).toBe(false);
+    expect(PreVaultSensitiveDraftService.hasFinanceIntent("user-1")).toBe(
+      false,
+    );
+  });
+
+  it("keeps a saved-location draft only in memory until the vault is ready", async () => {
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "home",
+      label: "",
+      latitude: 28.6139,
+      longitude: 77.209,
+      address: "Flat 4B, Kartavya Path, New Delhi 110001, India",
+    });
+
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(true);
+    expect(addSavedLocationMock).not.toHaveBeenCalled();
+
+    await PreVaultSensitiveDraftService.finalizeForVault({
+      userId: "user-1",
+      vaultKey: "memory-only-vault-key",
+      vaultOwnerToken: "memory-only-owner-token",
+    });
+
+    expect(addSavedLocationMock).toHaveBeenCalledWith({
+      context: {
+        userId: "user-1",
+        vaultKey: "memory-only-vault-key",
+        vaultOwnerToken: "memory-only-owner-token",
+      },
+      input: {
+        category: "home",
+        label: "",
+        latitude: 28.6139,
+        longitude: 77.209,
+        address: "Flat 4B, Kartavya Path, New Delhi 110001, India",
+      },
+    });
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(
+      false,
+    );
+  });
+
+  it("retains a saved-location draft when encrypted persistence fails", async () => {
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "work",
+      label: "",
+      latitude: 12.9716,
+      longitude: 77.5946,
+      address: "Hushh Office, Bengaluru 560001, India",
+    });
+    addSavedLocationMock.mockRejectedValueOnce(new Error("PKM_WRITE_FAILED"));
+
+    await expect(
+      PreVaultSensitiveDraftService.finalizeForVault({
+        userId: "user-1",
+        vaultKey: "memory-only-vault-key",
+        vaultOwnerToken: "memory-only-owner-token",
+      }),
+    ).rejects.toThrow("PKM_WRITE_FAILED");
+
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(true);
+  });
+
+  it("treats a same-category duplicate as an idempotent finalization retry", async () => {
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "home",
+      label: "",
+      latitude: 28.6139,
+      longitude: 77.209,
+      address: "New Delhi 110001, India",
+    });
+    addSavedLocationMock.mockRejectedValueOnce(
+      new DuplicateSavedLocationError({ category: "home" } as never),
+    );
+    loadSavedLocationsMock.mockResolvedValueOnce([
+      {
+        id: "home",
+        category: "home",
+        label: "Home",
+        latitude: 28.6139,
+        longitude: 77.209,
+        address: "New Delhi 110001, India",
+        savedAt: "2026-08-04T00:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      PreVaultSensitiveDraftService.finalizeForVault({
+        userId: "user-1",
+        vaultKey: "memory-only-vault-key",
+        vaultOwnerToken: "memory-only-owner-token",
+      }),
+    ).resolves.toBeUndefined();
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(
+      false,
+    );
+  });
+
+  it("keeps a cross-category duplicate for explicit owner resolution", async () => {
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "work",
+      label: "",
+      latitude: 28.6139,
+      longitude: 77.209,
+      address: "New Delhi 110001, India",
+    });
+    addSavedLocationMock.mockRejectedValueOnce(
+      new DuplicateSavedLocationError({ category: "home" } as never),
+    );
+
+    await expect(
+      PreVaultSensitiveDraftService.finalizeForVault({
+        userId: "user-1",
+        vaultKey: "memory-only-vault-key",
+        vaultOwnerToken: "memory-only-owner-token",
+      }),
+    ).rejects.toBeInstanceOf(DuplicateSavedLocationError);
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(true);
+  });
+
+  it("does not mistake a nearby same-category place for an exact retry", async () => {
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "home",
+      label: "",
+      latitude: 28.6139,
+      longitude: 77.209,
+      address: "Flat 4B, New Delhi 110001, India",
+    });
+    addSavedLocationMock.mockRejectedValueOnce(
+      new DuplicateSavedLocationError({ category: "home" } as never),
+    );
+    loadSavedLocationsMock.mockResolvedValueOnce([
+      {
+        id: "home",
+        category: "home",
+        label: "Home",
+        latitude: 28.61391,
+        longitude: 77.20901,
+        address: "Flat 3A, New Delhi 110001, India",
+        savedAt: "2026-08-04T00:00:00.000Z",
+      },
+    ]);
+
+    await expect(
+      PreVaultSensitiveDraftService.finalizeForVault({
+        userId: "user-1",
+        vaultKey: "memory-only-vault-key",
+        vaultOwnerToken: "memory-only-owner-token",
+      }),
+    ).rejects.toBeInstanceOf(DuplicateSavedLocationError);
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(true);
+  });
+
+  it("does not persist a captured location after the user clears the session", async () => {
+    let releaseGeminiWrite: ((value: { success: boolean }) => void) | undefined;
+    storeRuntimeSecretMock.mockImplementationOnce(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          releaseGeminiWrite = resolve;
+        }),
+    );
+    PreVaultSensitiveDraftService.stageGeminiRuntime("user-1", {
+      transport: "developer_api",
+      credential: "memory-only-gemini-key",
+      vertexProject: null,
+      vertexLocation: null,
+    });
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "home",
+      label: "",
+      latitude: 28.6139,
+      longitude: 77.209,
+      address: "New Delhi 110001, India",
+    });
+
+    const finalization = PreVaultSensitiveDraftService.finalizeForVault({
+      userId: "user-1",
+      vaultKey: "memory-only-vault-key",
+      vaultOwnerToken: "memory-only-owner-token",
+    });
+    await vi.waitFor(() => expect(storeRuntimeSecretMock).toHaveBeenCalled());
+
+    PreVaultSensitiveDraftService.clearForUser("user-1");
+    releaseGeminiWrite?.({ success: true });
+    await finalization;
+
+    expect(addSavedLocationMock).not.toHaveBeenCalled();
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(
+      false,
+    );
+  });
+
+  it("replays a new same-user draft with fresh authority after cancellation", async () => {
+    let releaseOldWrite: ((value: { success: boolean }) => void) | undefined;
+    storeRuntimeSecretMock.mockImplementationOnce(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          releaseOldWrite = resolve;
+        }),
+    );
+    PreVaultSensitiveDraftService.stageGeminiRuntime("user-1", {
+      transport: "developer_api",
+      credential: "old-session-key",
+      vertexProject: null,
+      vertexLocation: null,
+    });
+
+    const oldFinalization = PreVaultSensitiveDraftService.finalizeForVault({
+      userId: "user-1",
+      vaultKey: "old-vault-key",
+      vaultOwnerToken: "old-owner-token",
+    });
+    await vi.waitFor(() => expect(storeRuntimeSecretMock).toHaveBeenCalled());
+
+    PreVaultSensitiveDraftService.clearForUser("user-1");
+    PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+      category: "work",
+      label: "",
+      latitude: 12.9716,
+      longitude: 77.5946,
+      address: "Hushh Office, Bengaluru 560001, India",
+    });
+    const newFinalization = PreVaultSensitiveDraftService.finalizeForVault({
+      userId: "user-1",
+      vaultKey: "new-vault-key",
+      vaultOwnerToken: "new-owner-token",
+    });
+
+    expect(addSavedLocationMock).not.toHaveBeenCalled();
+    releaseOldWrite?.({ success: true });
+    await Promise.all([oldFinalization, newFinalization]);
+
+    expect(addSavedLocationMock).toHaveBeenCalledTimes(1);
+    expect(addSavedLocationMock).toHaveBeenCalledWith({
+      context: {
+        userId: "user-1",
+        vaultKey: "new-vault-key",
+        vaultOwnerToken: "new-owner-token",
+      },
+      input: {
+        category: "work",
+        label: "",
+        latitude: 12.9716,
+        longitude: 77.5946,
+        address: "Hushh Office, Bengaluru 560001, India",
+      },
+    });
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(
+      false,
+    );
+  });
+
+  it("rejects invalid coordinates before staging sensitive information", () => {
+    expect(() =>
+      PreVaultSensitiveDraftService.stageSavedLocation("user-1", {
+        category: "other",
+        label: "Gym",
+        latitude: 91,
+        longitude: 77.209,
+        address: "Invalid",
+      }),
+    ).toThrow("Choose a valid location before continuing.");
+    expect(PreVaultSensitiveDraftService.hasSavedLocation("user-1")).toBe(
+      false,
+    );
   });
 });

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -56,12 +56,14 @@ import {
   type ConnectionRequestResult,
 } from "@/components/one-location/onboarding/one-location-onboarding-flow";
 import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
+import type { PickedLocation } from "@/components/one-location/onboarding/location-picker-map";
 import {
   addSavedLocation,
   DuplicateSavedLocationError,
-  loadSavedLocations,
   type SavedLocationCategory,
 } from "@/lib/one-location/saved-locations";
+
+
 import { useConsentNotificationState } from "@/components/consent/notification-provider";
 
 import { Badge } from "@/components/ui/badge";
@@ -5663,9 +5665,14 @@ export function OneLocationAgentPageContent({
     window.setTimeout(() => void refreshLocationPermission(), 1200);
   }, [refreshLocationPermission]);
 
-  // Active setup replay always offers the saved-place step once per mounted
-  // journey. Workspace onboarding uses encrypted PKM as the saved-state
-  // authority and keeps only an explicit, non-sensitive skip outcome locally.
+  // The "Save this place" step must appear on EVERY Location onboarding run once
+  // access is ready — even if the owner discarded a previous onboarding or has
+  // already saved a place. We only guard against double-firing within a single
+  // mounted journey (savedLocationPromptedRef) and against concurrent captures
+  // (savedLocationPromptInFlightRef). The legacy "skipped"/existing-location
+  // suppression is deliberately retired: those localStorage markers are now only
+  // cleared, never read to hide the prompt, so a prior skip can never permanently
+  // suppress it.
   const promptSaveLocationDuringOnboarding =
     useCallback((): Promise<boolean> => {
       if (savedLocationPromptedRef.current) return Promise.resolve(true);
@@ -5686,50 +5693,19 @@ export function OneLocationAgentPageContent({
         userId,
       );
       const attempt = (async (): Promise<boolean> => {
-        if (mode !== "setup") {
-          let existingLocations;
+        // Retire any legacy suppression markers so the prompt keeps appearing on
+        // every onboarding, regardless of a previous skip or existing places.
+        if (typeof window !== "undefined") {
           try {
-            existingLocations = await loadSavedLocations({
-              userId,
-              vaultKey,
-              vaultOwnerToken,
-            });
+            window.localStorage.removeItem(legacyKey);
+            window.localStorage.removeItem(outcomeKey);
           } catch {
-            toast.error(
-              "Could not check your saved locations. Please try again.",
-            );
-            return false;
-          }
-
-          if (existingLocations.length > 0) {
-            if (typeof window !== "undefined") {
-              try {
-                window.localStorage.removeItem(legacyKey);
-                window.localStorage.removeItem(outcomeKey);
-              } catch {
-                // PKM remains authoritative if browser storage is unavailable.
-              }
-            }
-            savedLocationPromptedRef.current = true;
-            return true;
-          }
-
-          if (typeof window !== "undefined") {
-            try {
-              const outcome = window.localStorage.getItem(outcomeKey);
-              // An empty PKM read proves the old binary marker is ambiguous.
-              window.localStorage.removeItem(legacyKey);
-              if (outcome === "skipped") {
-                savedLocationPromptedRef.current = true;
-                return true;
-              }
-            } catch {
-              // Browser storage is optional; continue with the owner prompt.
-            }
+            // Encrypted PKM remains the saved-state authority.
           }
         }
 
         let point: PlainLocationPoint;
+
         try {
           point = await OneLocationService.captureCurrentPosition();
         } catch {
@@ -5790,7 +5766,8 @@ export function OneLocationAgentPageContent({
 
       savedLocationPromptInFlightRef.current = attempt;
       return attempt;
-    }, [auth.userId, mode, vaultKey, vaultOwnerToken]);
+    }, [auth.userId, vaultKey, vaultOwnerToken]);
+
 
   const handleSaveOnboardingLocation = useCallback(
     async (category: SavedLocationCategory, label: string) => {
@@ -5930,7 +5907,51 @@ export function OneLocationAgentPageContent({
     [saveLocationPoint, vaultOwnerToken],
   );
 
+  // Drag-to-pin confirm: adopt the precise coordinate + address the owner set
+  // on the map, replacing the coarse GPS fix. This is the accuracy fix (Task 2).
+  const handlePickExactSavedLocation = useCallback((picked: PickedLocation) => {
+    setSaveLocationPoint((current) => ({
+      latitude: picked.latitude,
+      longitude: picked.longitude,
+      accuracyM: null,
+      capturedAt: new Date().toISOString(),
+      sourcePlatform: current?.sourcePlatform ?? "web",
+    }));
+    savedLocationAddressResolutionIdRef.current += 1;
+    setSaveLocationAddress(picked.address);
+    setSaveLocationAddressLoading(false);
+  }, []);
+
+  // "Locate me" inside the map picker — re-center on a fresh GPS fix.
+  const locateMeForSavedLocation = useCallback(async () => {
+    try {
+      const point = await OneLocationService.captureCurrentPosition();
+      return { latitude: point.latitude, longitude: point.longitude };
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Reverse-geocode wrapper the map picker calls on every settle.
+  const reverseGeocodeForSavedLocation = useCallback(
+    async (lat: number, lng: number): Promise<string | null> => {
+      if (!vaultOwnerToken) return null;
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken,
+          lat,
+          lng,
+        });
+        return place.formattedAddress || place.name || null;
+      } catch {
+        return null;
+      }
+    },
+    [vaultOwnerToken],
+  );
+
   const handleLocationOnboardingPermission = useCallback(async () => {
+
     if (locationOnboardingBusy) return;
     setLocationOnboardingBusy(true);
     try {
@@ -6186,11 +6207,23 @@ export function OneLocationAgentPageContent({
           saving={saveLocationSaving}
           onSearchPlaces={searchOnboardingSavedPlaces}
           onSelectPlace={selectOnboardingSavedPlace}
+          mapInitial={
+            saveLocationPoint
+              ? {
+                  latitude: saveLocationPoint.latitude,
+                  longitude: saveLocationPoint.longitude,
+                }
+              : null
+          }
+          reverseGeocode={reverseGeocodeForSavedLocation}
+          onLocateMe={locateMeForSavedLocation}
+          onPickExactLocation={handlePickExactSavedLocation}
           onSave={(category, label) =>
             void handleSaveOnboardingLocation(category, label)
           }
           onSkip={handleSkipSaveOnboardingLocation}
         />
+
       </BodyPortal>
     );
   }

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -62,7 +62,12 @@ import {
   DuplicateSavedLocationError,
   type SavedLocationCategory,
 } from "@/lib/one-location/saved-locations";
-
+import {
+  buildSavedLocationAddress,
+  type SavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
+import { PreVaultSensitiveDraftService } from "@/lib/services/pre-vault-sensitive-draft-service";
+import { GOOGLE_MAPS_RENDERER_CONSENT_VERSION } from "@/lib/one-location/map-renderer-consent";
 
 import { useConsentNotificationState } from "@/components/consent/notification-provider";
 
@@ -928,11 +933,12 @@ function LocalMapPreview({
     fixedCheckIn: Boolean(point.checkIn),
   });
   const isStale = freshness.state === "paused";
-  const statusLabel = freshness.state === "check_in"
-    ? `Checked in · ${freshness.agoLabel}`
-    : freshness.state === "live"
-      ? `Live · ${freshness.agoLabel}`
-      : `Paused · last seen ${freshness.agoLabel}`;
+  const statusLabel =
+    freshness.state === "check_in"
+      ? `Checked in · ${freshness.agoLabel}`
+      : freshness.state === "live"
+        ? `Live · ${freshness.agoLabel}`
+        : `Paused · last seen ${freshness.agoLabel}`;
 
   return (
     <div className="w-full min-w-0 max-w-full overflow-hidden rounded-[var(--app-card-radius-standard)] border border-border/70 bg-[color:var(--app-card-surface-default-solid)]">
@@ -1730,11 +1736,41 @@ export function OneLocationAgentPageContent({
   const [saveLocationAddressLoading, setSaveLocationAddressLoading] =
     useState(false);
   const [saveLocationSaving, setSaveLocationSaving] = useState(false);
+  const [savedLocationRendererAccepted, setSavedLocationRendererAccepted] =
+    useState(false);
+  const [savedLocationSessionUserId, setSavedLocationSessionUserId] = useState(
+    auth.userId,
+  );
   const savedLocationPromptedRef = useRef(false);
   const savedLocationPromptInFlightRef = useRef<Promise<boolean> | null>(null);
   const savedLocationAddressResolutionIdRef = useRef(0);
+  const savedLocationSessionEpochRef = useRef(0);
+  const savedLocationPointUserIdRef = useRef<string | null>(null);
   const locationOnboardingRetryOnResumeRef = useRef(false);
   const notificationOnboardingAttemptRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSavedLocationRendererAccepted(false);
+    if (!vaultOwnerToken) return () => undefined;
+
+    void OneLocationService.getMapState(vaultOwnerToken)
+      .then((state) => {
+        if (cancelled) return;
+        setSavedLocationRendererAccepted(
+          state.preferences.rendererConsentVersion ===
+            GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
+        );
+      })
+      .catch(() => {
+        // Fail closed and show the disclosure when canonical preference state
+        // is unavailable. Root setup without a vault stays session-only.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.userId, vaultOwnerToken]);
 
   const notificationOnboardingObservedBusyRef = useRef(false);
   const notificationOnboardingRetryOnFocusRef = useRef(false);
@@ -1825,6 +1861,25 @@ export function OneLocationAgentPageContent({
     }
     previousWorkspaceUserId.current = auth.userId ?? null;
   }, [auth.userId]);
+  useEffect(() => {
+    if (savedLocationSessionUserId === auth.userId) return;
+
+    const previousUserId = savedLocationSessionUserId;
+    savedLocationSessionEpochRef.current += 1;
+    savedLocationAddressResolutionIdRef.current += 1;
+    savedLocationPromptedRef.current = false;
+    savedLocationPromptInFlightRef.current = null;
+    savedLocationPointUserIdRef.current = null;
+    setSaveLocationModalOpen(false);
+    setSaveLocationPoint(null);
+    setSaveLocationAddress(null);
+    setSaveLocationAddressLoading(false);
+    setSaveLocationSaving(false);
+    if (previousUserId) {
+      PreVaultSensitiveDraftService.clearForUser(previousUserId);
+    }
+    setSavedLocationSessionUserId(auth.userId);
+  }, [auth.userId, savedLocationSessionUserId]);
   useEffect(() => {
     if (!vaultOwnerToken && mode !== "setup") {
       clearLocationWorkspaceMemory(auth.userId);
@@ -4572,9 +4627,7 @@ export function OneLocationAgentPageContent({
       const recipientId = initialRecipientId?.trim() || "";
       resetShareComposer(recipientId || undefined);
       if (!recipientId) return;
-      const recipient = recipients.find(
-        (item) => item.userId === recipientId,
-      );
+      const recipient = recipients.find((item) => item.userId === recipientId);
       if (recipient) {
         trackRecommendationSelection(recipient, "share", "section_list", 1);
       }
@@ -5675,15 +5728,22 @@ export function OneLocationAgentPageContent({
   // suppress it.
   const promptSaveLocationDuringOnboarding =
     useCallback((): Promise<boolean> => {
+      if (savedLocationSessionUserId !== auth.userId) {
+        return Promise.resolve(false);
+      }
       if (savedLocationPromptedRef.current) return Promise.resolve(true);
       if (savedLocationPromptInFlightRef.current) {
         return savedLocationPromptInFlightRef.current;
       }
-      if (!auth.userId || !vaultKey || !vaultOwnerToken) {
-        return Promise.resolve(false);
-      }
+      // Root setup intentionally has no vault yet. Capture the owner-confirmed
+      // point now, then stage it in process memory until Finish setup.
+      if (!auth.userId) return Promise.resolve(false);
 
       const userId = auth.userId;
+      const sessionEpoch = savedLocationSessionEpochRef.current;
+      const sessionIsCurrent = () =>
+        savedLocationSessionEpochRef.current === sessionEpoch &&
+        savedLocationSessionUserId === userId;
       const legacyKey = savedLocationPromptKey(
         SAVED_LOCATION_PROMPT_LEGACY_KEY_PREFIX,
         userId,
@@ -5692,7 +5752,8 @@ export function OneLocationAgentPageContent({
         SAVED_LOCATION_PROMPT_OUTCOME_KEY_PREFIX,
         userId,
       );
-      const attempt = (async (): Promise<boolean> => {
+      let attempt: Promise<boolean>;
+      attempt = (async (): Promise<boolean> => {
         // Retire any legacy suppression markers so the prompt keeps appearing on
         // every onboarding, regardless of a previous skip or existing places.
         if (typeof window !== "undefined") {
@@ -5709,13 +5770,17 @@ export function OneLocationAgentPageContent({
         try {
           point = await OneLocationService.captureCurrentPosition();
         } catch {
+          if (!sessionIsCurrent()) return false;
           toast.error(
             "We could not read your current location. Check permission and try again.",
           );
           return false;
         }
 
+        if (!sessionIsCurrent()) return false;
+
         savedLocationPromptedRef.current = true;
+        savedLocationPointUserIdRef.current = userId;
         const addressResolutionId =
           savedLocationAddressResolutionIdRef.current + 1;
         savedLocationAddressResolutionIdRef.current = addressResolutionId;
@@ -5726,6 +5791,13 @@ export function OneLocationAgentPageContent({
 
         // Resolve friendly copy while the modal remains usable. Exact
         // coordinates are never rendered or written to browser storage.
+        if (!vaultOwnerToken) {
+          // The map picker has a browser-side reverse-geocode fallback. Do not
+          // invent vault authority during root setup just to resolve display
+          // copy; the selected point stays process-memory-only until Finish.
+          setSaveLocationAddressLoading(false);
+          return true;
+        }
         void OneLocationService.reverseGeocode({
           vaultOwnerToken,
           lat: point.latitude,
@@ -5733,8 +5805,9 @@ export function OneLocationAgentPageContent({
         })
           .then((place) => {
             if (
+              !sessionIsCurrent() ||
               savedLocationAddressResolutionIdRef.current !==
-              addressResolutionId
+                addressResolutionId
             ) {
               return;
             }
@@ -5744,8 +5817,9 @@ export function OneLocationAgentPageContent({
           })
           .catch(() => {
             if (
+              !sessionIsCurrent() ||
               savedLocationAddressResolutionIdRef.current !==
-              addressResolutionId
+                addressResolutionId
             ) {
               return;
             }
@@ -5753,44 +5827,74 @@ export function OneLocationAgentPageContent({
           })
           .finally(() => {
             if (
+              sessionIsCurrent() &&
               savedLocationAddressResolutionIdRef.current ===
-              addressResolutionId
+                addressResolutionId
             ) {
               setSaveLocationAddressLoading(false);
             }
           });
         return true;
       })().finally(() => {
-        savedLocationPromptInFlightRef.current = null;
+        if (savedLocationPromptInFlightRef.current === attempt) {
+          savedLocationPromptInFlightRef.current = null;
+        }
       });
 
       savedLocationPromptInFlightRef.current = attempt;
       return attempt;
-    }, [auth.userId, vaultKey, vaultOwnerToken]);
-
+    }, [auth.userId, savedLocationSessionUserId, vaultOwnerToken]);
 
   const handleSaveOnboardingLocation = useCallback(
-    async (category: SavedLocationCategory, label: string) => {
-      if (!auth.userId || !vaultKey || !vaultOwnerToken || !saveLocationPoint) {
-        toast.error("Unlock your vault before saving this location.");
+    async (
+      category: SavedLocationCategory,
+      label: string,
+      details?: SavedLocationAddressDetails,
+    ) => {
+      if (
+        !auth.userId ||
+        savedLocationSessionUserId !== auth.userId ||
+        savedLocationPointUserIdRef.current !== auth.userId ||
+        !saveLocationPoint
+      ) {
+        toast.error("Choose a location before continuing.");
         return;
       }
+      const savingUserId = auth.userId;
+      const sessionEpoch = savedLocationSessionEpochRef.current;
       setSaveLocationSaving(true);
       try {
-        await addSavedLocation({
-          context: {
-            userId: auth.userId,
-            vaultKey,
-            vaultOwnerToken,
-          },
-          input: {
-            category,
-            label,
-            latitude: saveLocationPoint.latitude,
-            longitude: saveLocationPoint.longitude,
-            address: saveLocationAddress,
-          },
-        });
+        const input = {
+          category,
+          label,
+          latitude: saveLocationPoint.latitude,
+          longitude: saveLocationPoint.longitude,
+          address: details
+            ? buildSavedLocationAddress(saveLocationAddress, details)
+            : saveLocationAddress,
+        };
+        const canPersistNow = Boolean(vaultKey && vaultOwnerToken);
+        if (vaultKey && vaultOwnerToken) {
+          await addSavedLocation({
+            context: {
+              userId: auth.userId,
+              vaultKey,
+              vaultOwnerToken,
+            },
+            input,
+          });
+        } else {
+          // Root onboarding deliberately precedes vault creation. Keep the
+          // owner-confirmed point and entrance details only in process memory;
+          // existing Finish setup transaction commits it after vault unlock.
+          PreVaultSensitiveDraftService.stageSavedLocation(auth.userId, input);
+        }
+        if (
+          savedLocationSessionEpochRef.current !== sessionEpoch ||
+          savedLocationSessionUserId !== savingUserId
+        ) {
+          return;
+        }
         if (typeof window !== "undefined") {
           try {
             window.localStorage.removeItem(
@@ -5812,19 +5916,37 @@ export function OneLocationAgentPageContent({
         savedLocationAddressResolutionIdRef.current += 1;
         setSaveLocationModalOpen(false);
         setSaveLocationPoint(null);
-        toast.success("Location saved securely.");
+        setSaveLocationAddress(null);
+        savedLocationPointUserIdRef.current = null;
+        toast.success(
+          canPersistNow
+            ? "Location saved securely."
+            : "Location ready. One will save it after your private vault is set up.",
+        );
       } catch (error) {
+        if (
+          savedLocationSessionEpochRef.current !== sessionEpoch ||
+          savedLocationSessionUserId !== savingUserId
+        ) {
+          return;
+        }
         toast.error(
           error instanceof DuplicateSavedLocationError
             ? error.message
             : "Could not save this location. Please try again.",
         );
       } finally {
-        setSaveLocationSaving(false);
+        if (
+          savedLocationSessionEpochRef.current === sessionEpoch &&
+          savedLocationSessionUserId === savingUserId
+        ) {
+          setSaveLocationSaving(false);
+        }
       }
     },
     [
       auth.userId,
+      savedLocationSessionUserId,
       saveLocationAddress,
       saveLocationPoint,
       vaultKey,
@@ -5833,6 +5955,9 @@ export function OneLocationAgentPageContent({
   );
 
   const handleSkipSaveOnboardingLocation = useCallback(() => {
+    if (auth.userId) {
+      PreVaultSensitiveDraftService.clearSavedLocation(auth.userId);
+    }
     if (typeof window !== "undefined" && auth.userId) {
       try {
         window.localStorage.removeItem(
@@ -5855,6 +5980,9 @@ export function OneLocationAgentPageContent({
     savedLocationAddressResolutionIdRef.current += 1;
     setSaveLocationModalOpen(false);
     setSaveLocationPoint(null);
+    setSaveLocationAddress(null);
+    setSaveLocationAddressLoading(false);
+    savedLocationPointUserIdRef.current = null;
   }, [auth.userId]);
 
   const searchOnboardingSavedPlaces = useCallback(
@@ -5872,13 +6000,26 @@ export function OneLocationAgentPageContent({
 
   const selectOnboardingSavedPlace = useCallback(
     async (placeId: string) => {
-      if (!vaultOwnerToken || !saveLocationPoint) {
+      if (
+        !auth.userId ||
+        savedLocationSessionUserId !== auth.userId ||
+        savedLocationPointUserIdRef.current !== auth.userId ||
+        !vaultOwnerToken ||
+        !saveLocationPoint
+      ) {
         throw new Error("Capture a location before changing the place.");
       }
+      const sessionEpoch = savedLocationSessionEpochRef.current;
       const place = await OneLocationService.placeDetails({
         vaultOwnerToken,
         placeId,
       });
+      if (
+        savedLocationSessionEpochRef.current !== sessionEpoch ||
+        savedLocationPointUserIdRef.current !== auth.userId
+      ) {
+        throw new Error("The location session changed. Try again.");
+      }
       if (
         !Number.isFinite(place.latitude) ||
         !Number.isFinite(place.longitude) ||
@@ -5904,33 +6045,76 @@ export function OneLocationAgentPageContent({
       setSaveLocationAddress(label);
       setSaveLocationAddressLoading(false);
     },
-    [saveLocationPoint, vaultOwnerToken],
+    [
+      auth.userId,
+      saveLocationPoint,
+      savedLocationSessionUserId,
+      vaultOwnerToken,
+    ],
   );
 
-  // Drag-to-pin confirm: adopt the precise coordinate + address the owner set
-  // on the map, replacing the coarse GPS fix. This is the accuracy fix (Task 2).
-  const handlePickExactSavedLocation = useCallback((picked: PickedLocation) => {
-    setSaveLocationPoint((current) => ({
-      latitude: picked.latitude,
-      longitude: picked.longitude,
-      accuracyM: null,
-      capturedAt: new Date().toISOString(),
-      sourcePlatform: current?.sourcePlatform ?? "web",
-    }));
-    savedLocationAddressResolutionIdRef.current += 1;
-    setSaveLocationAddress(picked.address);
-    setSaveLocationAddressLoading(false);
-  }, []);
+  // Drag-to-pin confirm replaces the coarse device fix with the map centre the
+  // owner explicitly confirmed for this auth session.
+  const handlePickExactSavedLocation = useCallback(
+    (picked: PickedLocation) => {
+      if (
+        !auth.userId ||
+        savedLocationSessionUserId !== auth.userId ||
+        savedLocationPointUserIdRef.current !== auth.userId
+      ) {
+        return;
+      }
+      setSaveLocationPoint((current) => ({
+        latitude: picked.latitude,
+        longitude: picked.longitude,
+        accuracyM: null,
+        capturedAt: new Date().toISOString(),
+        sourcePlatform: current?.sourcePlatform ?? "web",
+      }));
+      savedLocationAddressResolutionIdRef.current += 1;
+      setSaveLocationAddress(picked.address);
+      setSaveLocationAddressLoading(false);
+    },
+    [auth.userId, savedLocationSessionUserId],
+  );
+
+  const acceptSavedLocationMapRenderer = useCallback(async () => {
+    // Root setup has no vault yet, so its acceptance intentionally lasts only
+    // for this open modal. Once vault authority exists, reuse the canonical
+    // durable renderer-consent preference used by Your Map.
+    if (!vaultOwnerToken) return;
+    const next = await OneLocationService.updateMapPreferences({
+      vaultOwnerToken,
+      rendererConsentVersion: GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
+    });
+    setSavedLocationRendererAccepted(
+      next.rendererConsentVersion === GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
+    );
+  }, [vaultOwnerToken]);
 
   // "Locate me" inside the map picker — re-center on a fresh GPS fix.
   const locateMeForSavedLocation = useCallback(async () => {
+    if (
+      !auth.userId ||
+      savedLocationSessionUserId !== auth.userId ||
+      savedLocationPointUserIdRef.current !== auth.userId
+    ) {
+      return null;
+    }
+    const sessionEpoch = savedLocationSessionEpochRef.current;
     try {
       const point = await OneLocationService.captureCurrentPosition();
+      if (
+        savedLocationSessionEpochRef.current !== sessionEpoch ||
+        savedLocationPointUserIdRef.current !== auth.userId
+      ) {
+        return null;
+      }
       return { latitude: point.latitude, longitude: point.longitude };
     } catch {
       return null;
     }
-  }, []);
+  }, [auth.userId, savedLocationSessionUserId]);
 
   // Reverse-geocode wrapper the map picker calls on every settle.
   const reverseGeocodeForSavedLocation = useCallback(
@@ -5951,7 +6135,6 @@ export function OneLocationAgentPageContent({
   );
 
   const handleLocationOnboardingPermission = useCallback(async () => {
-
     if (locationOnboardingBusy) return;
     setLocationOnboardingBusy(true);
     try {
@@ -6166,6 +6349,7 @@ export function OneLocationAgentPageContent({
     return (
       <BodyPortal>
         <OneLocationOnboardingExperience
+          key={auth.userId}
           startAt={locationOnboardingStep}
           currentUserName={
             String(
@@ -6189,11 +6373,10 @@ export function OneLocationAgentPageContent({
             handleSendLocationOnboardingConnectionRequests
           }
           onRequestLocation={handleLocationOnboardingPermission}
-          onLocationReady={
-            mode === "setup"
-              ? async () => true
-              : promptSaveLocationDuringOnboarding
-          }
+          // Every onboarding run opens the pin-and-address flow once Location
+          // is ready. Root setup stages the confirmed draft in memory; an
+          // unlocked workspace persists it immediately.
+          onLocationReady={promptSaveLocationDuringOnboarding}
           onRequestNotifications={handleLocationOnboardingNotifications}
           onBack={() => router.back()}
           onComplete={dismissLocationOnboarding}
@@ -6201,12 +6384,19 @@ export function OneLocationAgentPageContent({
           requireLocationToComplete={mode === "setup"}
         />
         <SaveLocationModal
-          open={saveLocationModalOpen}
+          key={`saved-location-${auth.userId}`}
+          open={
+            saveLocationModalOpen && savedLocationSessionUserId === auth.userId
+          }
           address={saveLocationAddress}
           loadingAddress={saveLocationAddressLoading}
           saving={saveLocationSaving}
-          onSearchPlaces={searchOnboardingSavedPlaces}
-          onSelectPlace={selectOnboardingSavedPlace}
+          onSearchPlaces={
+            vaultOwnerToken ? searchOnboardingSavedPlaces : undefined
+          }
+          onSelectPlace={
+            vaultOwnerToken ? selectOnboardingSavedPlace : undefined
+          }
           mapInitial={
             saveLocationPoint
               ? {
@@ -6215,15 +6405,22 @@ export function OneLocationAgentPageContent({
                 }
               : null
           }
-          reverseGeocode={reverseGeocodeForSavedLocation}
+          reverseGeocode={
+            vaultOwnerToken ? reverseGeocodeForSavedLocation : undefined
+          }
           onLocateMe={locateMeForSavedLocation}
           onPickExactLocation={handlePickExactSavedLocation}
-          onSave={(category, label) =>
-            void handleSaveOnboardingLocation(category, label)
+          startWithMapPicker
+          collectAddressDetails
+          deferredUntilVault={!vaultKey || !vaultOwnerToken}
+          initialAccuracyM={saveLocationPoint?.accuracyM}
+          rendererDisclosureAccepted={savedLocationRendererAccepted}
+          onAcceptRendererDisclosure={acceptSavedLocationMapRenderer}
+          onSave={(category, label, details) =>
+            void handleSaveOnboardingLocation(category, label, details)
           }
           onSkip={handleSkipSaveOnboardingLocation}
         />
-
       </BodyPortal>
     );
   }

--- a/hushh-webapp/components/onboarding/PostAuthOnboardingSyncBridge.tsx
+++ b/hushh-webapp/components/onboarding/PostAuthOnboardingSyncBridge.tsx
@@ -1,24 +1,65 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 
 import { useAuth } from "@/hooks/use-auth";
 import { PostUnlockSyncService } from "@/lib/services/post-unlock-sync-service";
+import { PreVaultSensitiveDraftService } from "@/lib/services/pre-vault-sensitive-draft-service";
 import { useVault } from "@/lib/vault/vault-context";
 
+const POST_UNLOCK_RETRY_DELAYS_MS = [250, 1_000, 3_000] as const;
+
 /**
- * Syncs locally captured pre-vault onboarding answers into encrypted financial.profile
- * after vault creation/unlock succeeds.
+ * Flushes memory-only setup drafts and ordinary onboarding answers through
+ * their existing encrypted stores after vault creation/unlock succeeds.
  */
 export function PostAuthOnboardingSyncBridge() {
   const { user, loading } = useAuth();
   const { isVaultUnlocked, vaultKey, vaultOwnerToken } = useVault();
+  const pathname = usePathname();
   const userId = user?.uid ?? null;
-  const syncingRef = useRef(false);
+  const activeSignatureRef = useRef<string | null>(null);
   const lastSyncedSignatureRef = useRef<string | null>(null);
+  const pendingRef = useRef<{
+    signature: string;
+    params: { userId: string; vaultKey: string; vaultOwnerToken: string };
+    attempt: number;
+  } | null>(null);
+  const mountedRef = useRef(true);
+  const eligibleSignatureRef = useRef<string | null>(null);
+  const retryTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (loading || !userId || !isVaultUnlocked || !vaultKey || !vaultOwnerToken) {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      pendingRef.current = null;
+      eligibleSignatureRef.current = null;
+      if (retryTimerRef.current !== null) {
+        window.clearTimeout(retryTimerRef.current);
+        retryTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const cancelScheduledRetry = () => {
+      if (retryTimerRef.current === null) return;
+      window.clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    };
+
+    if (
+      loading ||
+      !userId ||
+      !isVaultUnlocked ||
+      !vaultKey ||
+      !vaultOwnerToken
+    ) {
+      eligibleSignatureRef.current = null;
+      pendingRef.current = null;
+      cancelScheduledRetry();
       return;
     }
 
@@ -26,38 +67,102 @@ export function PostAuthOnboardingSyncBridge() {
     // bridge while the setup hub is finalizing would create duplicate PKM
     // revisions and could clear a volatile draft before the hub can report a
     // retryable failure.
-    if (typeof window !== "undefined" && window.location.pathname.startsWith("/one/setup")) {
+    if (pathname.startsWith("/one/setup")) {
+      eligibleSignatureRef.current = null;
+      pendingRef.current = null;
+      cancelScheduledRetry();
       return;
     }
 
-    const signature = `${userId}:${vaultOwnerToken}`;
+    const signature = `${userId}:${vaultOwnerToken}:${vaultKey}`;
+    if (eligibleSignatureRef.current !== signature) {
+      cancelScheduledRetry();
+    }
+    eligibleSignatureRef.current = signature;
     if (lastSyncedSignatureRef.current === signature) {
       return;
     }
-
-    if (syncingRef.current) {
+    if (retryTimerRef.current !== null) {
+      return;
+    }
+    if (activeSignatureRef.current === signature) {
       return;
     }
 
-    syncingRef.current = true;
-    lastSyncedSignatureRef.current = signature;
+    const params = { userId, vaultKey, vaultOwnerToken };
+    pendingRef.current = { signature, params, attempt: 0 };
 
-    void PostUnlockSyncService.run({
-      userId,
-      vaultKey,
-      vaultOwnerToken,
-    })
-      .catch((error) => {
-        lastSyncedSignatureRef.current = null;
-        console.warn(
-          "[PostAuthOnboardingSyncBridge] Post-unlock sync failed, will retry later:",
-          error
+    const drain = () => {
+      if (!mountedRef.current || activeSignatureRef.current) return;
+      const next = pendingRef.current;
+      pendingRef.current = null;
+      if (
+        !next ||
+        lastSyncedSignatureRef.current === next.signature ||
+        eligibleSignatureRef.current !== next.signature
+      ) {
+        return;
+      }
+
+      activeSignatureRef.current = next.signature;
+      void (async (): Promise<boolean> => {
+        await PreVaultSensitiveDraftService.finalizeForVault(next.params);
+        if (
+          !mountedRef.current ||
+          eligibleSignatureRef.current !== next.signature
+        ) {
+          return false;
+        }
+        await PostUnlockSyncService.run(next.params);
+        return (
+          mountedRef.current && eligibleSignatureRef.current === next.signature
         );
-      })
-      .finally(() => {
-        syncingRef.current = false;
-      });
-  }, [loading, userId, isVaultUnlocked, vaultKey, vaultOwnerToken]);
+      })()
+        .then((completed) => {
+          if (completed) {
+            lastSyncedSignatureRef.current = next.signature;
+          }
+        })
+        .catch((error) => {
+          const retryDelay = POST_UNLOCK_RETRY_DELAYS_MS[next.attempt];
+          console.warn(
+            retryDelay === undefined
+              ? "[PostAuthOnboardingSyncBridge] Post-unlock sync failed after bounded retries:"
+              : "[PostAuthOnboardingSyncBridge] Post-unlock sync failed, retrying:",
+            error,
+          );
+          if (
+            retryDelay !== undefined &&
+            mountedRef.current &&
+            eligibleSignatureRef.current === next.signature
+          ) {
+            retryTimerRef.current = window.setTimeout(() => {
+              retryTimerRef.current = null;
+              if (
+                !mountedRef.current ||
+                eligibleSignatureRef.current !== next.signature ||
+                lastSyncedSignatureRef.current === next.signature
+              ) {
+                return;
+              }
+              pendingRef.current = {
+                ...next,
+                attempt: next.attempt + 1,
+              };
+              drain();
+            }, retryDelay);
+          }
+        })
+        .finally(() => {
+          if (activeSignatureRef.current === next.signature) {
+            activeSignatureRef.current = null;
+          }
+          if (pendingRef.current) drain();
+        });
+    };
+
+    drain();
+  }, [isVaultUnlocked, loading, pathname, userId, vaultKey, vaultOwnerToken]);
 
   return null;
 }

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   updateSavedLocationAddress: vi.fn(),
   captureCurrentPosition: vi.fn(),
   reverseGeocode: vi.fn(),
+  getMapState: vi.fn(),
+  updateMapPreferences: vi.fn(),
   toastError: vi.fn(),
 }));
 
@@ -51,15 +59,16 @@ vi.mock("@/lib/one-location/saved-locations", () => ({
   addSavedLocation: mocks.addSavedLocation,
   removeSavedLocation: mocks.removeSavedLocation,
   updateSavedLocationAddress: mocks.updateSavedLocationAddress,
-  sortSavedLocationsForDisplay: (
-    locations: Array<Record<string, unknown>>,
-  ) => locations,
+  sortSavedLocationsForDisplay: (locations: Array<Record<string, unknown>>) =>
+    locations,
 }));
 
 vi.mock("@/lib/one-location/service", () => ({
   OneLocationService: {
     captureCurrentPosition: mocks.captureCurrentPosition,
     reverseGeocode: mocks.reverseGeocode,
+    getMapState: mocks.getMapState,
+    updateMapPreferences: mocks.updateMapPreferences,
   },
 }));
 
@@ -109,6 +118,18 @@ describe("SavedLocationsSection", () => {
       name: null,
       countryCode: "IN",
     });
+    mocks.getMapState.mockReset().mockResolvedValue({
+      preferences: {
+        presenceMode: "ghost",
+        rendererConsentVersion: "google-maps-renderer-v1",
+      },
+      freshnessSeconds: 60,
+      markers: [],
+    });
+    mocks.updateMapPreferences.mockReset().mockResolvedValue({
+      presenceMode: "ghost",
+      rendererConsentVersion: "google-maps-renderer-v1",
+    });
     mocks.toastError.mockReset();
   });
 
@@ -119,7 +140,9 @@ describe("SavedLocationsSection", () => {
   it("loads the encrypted saved place into Settings without exposing coordinates", async () => {
     render(<SavedLocationsSection />);
 
-    expect(await screen.findByText("Kasturba Road, Bengaluru")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Kasturba Road, Bengaluru"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Home")).toBeInTheDocument();
     expect(screen.queryByText(/12\.9763|77\.5929/)).not.toBeInTheDocument();
     expect(mocks.loadSavedLocations).toHaveBeenCalledWith({
@@ -127,6 +150,7 @@ describe("SavedLocationsSection", () => {
       vaultKey: "vault-key",
       vaultOwnerToken: "vault-owner-token",
     });
+    expect(mocks.getMapState).toHaveBeenCalledWith("vault-owner-token");
   });
 
   it("fails closed while the vault is locked", async () => {
@@ -175,7 +199,9 @@ describe("SavedLocationsSection", () => {
     render(<SavedLocationsSection />);
     await screen.findByText("Kasturba Road, Bengaluru");
     fireEvent.click(screen.getByRole("button", { name: /add place/i }));
-    await waitFor(() => expect(mocks.captureCurrentPosition).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mocks.captureCurrentPosition).toHaveBeenCalled(),
+    );
 
     await act(async () => {
       updateOneLocationControlState("user-123", (current) => ({

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -59,8 +59,8 @@ import {
 import { beginRouteTransition } from "@/lib/morphy-ux/hooks/use-route-transition";
 import { motionDurations, motionEasings } from "@/lib/morphy-ux/motion";
 import { useVault } from "@/lib/vault/vault-context";
+import { GOOGLE_MAPS_RENDERER_CONSENT_VERSION } from "@/lib/one-location/map-renderer-consent";
 
-const RENDERER_CONSENT_VERSION = "google-maps-renderer-v1";
 const MAP_ID = "one-location-private-map";
 const MAP_ACCENT_CONTROL_CLASSNAME =
   "!border-[var(--app-accent-border)] !bg-[var(--app-accent-surface)] !text-[var(--app-accent-deep)] hover:!bg-[var(--app-accent-surface-strong)] dark:!text-[var(--app-accent-bright)]";
@@ -310,13 +310,7 @@ export function LocationImmersiveMap() {
     router.push(`${ROUTES.ONE_LOCATION_MAP}?${params.toString()}`, {
       scroll: false,
     });
-  }, [
-    demoMode,
-    nearbyCheckInAvailable,
-    rendererReady,
-    router,
-    searchParams,
-  ]);
+  }, [demoMode, nearbyCheckInAvailable, rendererReady, router, searchParams]);
 
   const closeNearbyCheckIn = useCallback(() => {
     setNearbyCheckInOpen(false);
@@ -541,7 +535,8 @@ export function LocationImmersiveMap() {
         if (cancelled) return;
         setPreferences(state.preferences);
         setAcceptedRenderer(
-          state.preferences.rendererConsentVersion === RENDERER_CONSENT_VERSION,
+          state.preferences.rendererConsentVersion ===
+            GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
         );
       })
       .catch(() => {
@@ -817,7 +812,7 @@ export function LocationImmersiveMap() {
     try {
       const next = await OneLocationService.updateMapPreferences({
         vaultOwnerToken,
-        rendererConsentVersion: RENDERER_CONSENT_VERSION,
+        rendererConsentVersion: GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
       });
       setPreferences(next);
       setAcceptedRenderer(true);
@@ -1025,8 +1020,7 @@ export function LocationImmersiveMap() {
           currentOwner.vaultOwnerToken === ownerSnapshot.vaultOwnerToken &&
           currentPresence.presence?.checkedInAt === presenceCheckedInAt &&
           currentPresence.attendees.some(
-            (item) =>
-              item.participantAlias === attendee.participantAlias,
+            (item) => item.participantAlias === attendee.participantAlias,
           )
         );
       };

--- a/hushh-webapp/components/one-location/onboarding/__tests__/location-picker-map.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/location-picker-map.test.tsx
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mapsHookMock, mapsStatus } = vi.hoisted(() => ({
+  mapsHookMock: vi.fn(),
+  mapsStatus: { current: "ready" as "loading" | "ready" | "error" },
+}));
+
+vi.mock("@/lib/one-location/use-google-maps", () => ({
+  useGoogleMaps: ({ enabled = true }: { enabled?: boolean } = {}) => {
+    mapsHookMock({ enabled });
+    return { status: enabled ? mapsStatus.current : "loading" };
+  },
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+import { LocationPickerMap } from "@/components/one-location/onboarding/location-picker-map";
+
+type MapListener = () => void;
+
+describe("LocationPickerMap", () => {
+  let listeners: Map<string, MapListener>;
+  let currentCenter: { lat: number; lng: number };
+  let mapConstructor: ReturnType<typeof vi.fn>;
+  let browserGeocode: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mapsStatus.current = "ready";
+    listeners = new Map();
+    currentCenter = { lat: 28.6139, lng: 77.209 };
+    mapConstructor = vi.fn();
+    browserGeocode = vi.fn().mockResolvedValue({ results: [] });
+
+    class MockGoogleMap {
+      constructor(
+        _element: HTMLElement,
+        options: { center: { lat: number; lng: number } },
+      ) {
+        currentCenter = options.center;
+        mapConstructor(options);
+      }
+
+      addListener(name: string, listener: MapListener) {
+        listeners.set(name, listener);
+        return { remove: () => listeners.delete(name) };
+      }
+
+      getCenter() {
+        return {
+          lat: () => currentCenter.lat,
+          lng: () => currentCenter.lng,
+        };
+      }
+
+      panTo(point: { lat: number; lng: number }) {
+        currentCenter = point;
+      }
+
+      setZoom() {}
+    }
+
+    class MockGeocoder {
+      geocode = browserGeocode;
+    }
+
+    Object.defineProperty(globalThis, "google", {
+      configurable: true,
+      value: {
+        maps: {
+          Map: MockGoogleMap,
+          Geocoder: MockGeocoder,
+        },
+      },
+    });
+  });
+
+  it("does not initialize Google Maps or geocode before renderer disclosure", async () => {
+    const acceptRenderer = vi.fn().mockResolvedValue(undefined);
+
+    function Harness() {
+      const [accepted, setAccepted] = useState(false);
+      return (
+        <LocationPickerMap
+          initialLatitude={28.6139}
+          initialLongitude={77.209}
+          initialAddress="New Delhi 110001, India"
+          rendererDisclosureAccepted={accepted}
+          onAcceptRendererDisclosure={async () => {
+            await acceptRenderer();
+            setAccepted(true);
+          }}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("saved-location-map-disclosure")).toBeTruthy();
+    expect(
+      screen.getByText(/Google Maps receives the selected point/i),
+    ).toBeTruthy();
+    expect(mapConstructor).not.toHaveBeenCalled();
+    expect(browserGeocode).not.toHaveBeenCalled();
+    expect(mapsHookMock).toHaveBeenLastCalledWith({ enabled: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Use Google Maps" }));
+
+    await waitFor(() => expect(acceptRenderer).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mapConstructor).toHaveBeenCalledTimes(1));
+    expect(mapsHookMock).toHaveBeenLastCalledWith({ enabled: true });
+  });
+
+  it("blocks confirmation until the moved centre has a matching address", async () => {
+    vi.useFakeTimers();
+    let resolveAddress: ((value: string | null) => void) | undefined;
+    const reverseGeocode = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveAddress = resolve;
+        }),
+    );
+    const onConfirm = vi.fn();
+    render(
+      <LocationPickerMap
+        initialLatitude={28.6139}
+        initialLongitude={77.209}
+        initialAddress="Old address"
+        rendererDisclosureAccepted
+        onAcceptRendererDisclosure={vi.fn().mockResolvedValue(undefined)}
+        reverseGeocode={reverseGeocode}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await act(async () => undefined);
+
+    currentCenter = { lat: 28.6142, lng: 77.2094 };
+    act(() => {
+      listeners.get("dragstart")?.();
+      listeners.get("idle")?.();
+    });
+
+    const confirmButton = screen.getByRole("button", {
+      name: "Confirm location",
+    });
+    expect(confirmButton).toBeDisabled();
+    fireEvent.click(confirmButton);
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+    expect(reverseGeocode).toHaveBeenCalledWith(28.6142, 77.2094);
+    expect(confirmButton).toBeDisabled();
+
+    await act(async () => {
+      resolveAddress?.("Updated address 110001, India");
+      await Promise.resolve();
+    });
+    expect(confirmButton).toBeEnabled();
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledWith({
+      latitude: 28.6142,
+      longitude: 77.2094,
+      address: "Updated address 110001, India",
+    });
+    vi.useRealTimers();
+  });
+
+  it("ignores an older reverse-geocode result after the centre moves again", async () => {
+    vi.useFakeTimers();
+    const resolveAddresses: Array<(value: string | null) => void> = [];
+    const reverseGeocode = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveAddresses.push(resolve);
+        }),
+    );
+    const onConfirm = vi.fn();
+    render(
+      <LocationPickerMap
+        initialLatitude={28.6139}
+        initialLongitude={77.209}
+        initialAddress="Initial address"
+        rendererDisclosureAccepted
+        onAcceptRendererDisclosure={vi.fn().mockResolvedValue(undefined)}
+        reverseGeocode={reverseGeocode}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await act(async () => undefined);
+
+    currentCenter = { lat: 28.6142, lng: 77.2094 };
+    act(() => {
+      listeners.get("dragstart")?.();
+      listeners.get("idle")?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    currentCenter = { lat: 12.9716, lng: 77.5946 };
+    act(() => {
+      listeners.get("dragstart")?.();
+      listeners.get("idle")?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    expect(reverseGeocode).toHaveBeenNthCalledWith(1, 28.6142, 77.2094);
+    expect(reverseGeocode).toHaveBeenNthCalledWith(2, 12.9716, 77.5946);
+
+    await act(async () => {
+      resolveAddresses[1]?.("Bengaluru address 560001, India");
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Bengaluru address 560001, India")).toBeTruthy();
+
+    await act(async () => {
+      resolveAddresses[0]?.("Stale New Delhi address 110001, India");
+      await Promise.resolve();
+    });
+    expect(
+      screen.queryByText("Stale New Delhi address 110001, India"),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm location" }));
+    expect(onConfirm).toHaveBeenCalledWith({
+      latitude: 12.9716,
+      longitude: 77.5946,
+      address: "Bengaluru address 560001, India",
+    });
+    vi.useRealTimers();
+  });
+
+  it("lets the owner continue manually when the provider map is unavailable", () => {
+    mapsStatus.current = "error";
+    const onConfirm = vi.fn();
+    render(
+      <LocationPickerMap
+        initialLatitude={28.6139}
+        initialLongitude={77.209}
+        initialAddress={null}
+        rendererDisclosureAccepted
+        onAcceptRendererDisclosure={vi.fn().mockResolvedValue(undefined)}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/interactive map isn't available/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Use captured point" }));
+    expect(onConfirm).toHaveBeenCalledWith({
+      latitude: 28.6139,
+      longitude: 77.209,
+      address: null,
+    });
+  });
+});

--- a/hushh-webapp/components/one-location/onboarding/__tests__/location-picker-map.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/location-picker-map.test.tsx
@@ -86,21 +86,18 @@ describe("LocationPickerMap", () => {
     });
   });
 
-  it("does not initialize Google Maps or geocode before renderer disclosure", async () => {
-    const acceptRenderer = vi.fn().mockResolvedValue(undefined);
-
+  it("opens the map directly without a pre-map disclosure step", async () => {
     function Harness() {
-      const [accepted, setAccepted] = useState(false);
+      const [accepted] = useState(false);
       return (
         <LocationPickerMap
           initialLatitude={28.6139}
           initialLongitude={77.209}
           initialAddress="New Delhi 110001, India"
+          // Even when the legacy disclosure flag is false, the picker now opens
+          // the interactive map immediately (the extra disclosure screen was
+          // removed) and initializes Google Maps right away.
           rendererDisclosureAccepted={accepted}
-          onAcceptRendererDisclosure={async () => {
-            await acceptRenderer();
-            setAccepted(true);
-          }}
           onConfirm={vi.fn()}
           onCancel={vi.fn()}
         />
@@ -109,20 +106,18 @@ describe("LocationPickerMap", () => {
 
     render(<Harness />);
 
-    expect(screen.getByTestId("saved-location-map-disclosure")).toBeTruthy();
+    // The old "Before the map opens" disclosure card is gone.
+    expect(screen.queryByTestId("saved-location-map-disclosure")).toBeNull();
     expect(
-      screen.getByText(/Google Maps receives the selected point/i),
-    ).toBeTruthy();
-    expect(mapConstructor).not.toHaveBeenCalled();
-    expect(browserGeocode).not.toHaveBeenCalled();
-    expect(mapsHookMock).toHaveBeenLastCalledWith({ enabled: false });
+      screen.queryByText(/Google Maps receives the selected point/i),
+    ).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Use Google Maps" }));
-
-    await waitFor(() => expect(acceptRenderer).toHaveBeenCalledTimes(1));
+    // The map surface renders and Google Maps initializes immediately.
+    expect(screen.getByText(/Pin your entrance on the map/i)).toBeTruthy();
     await waitFor(() => expect(mapConstructor).toHaveBeenCalledTimes(1));
     expect(mapsHookMock).toHaveBeenLastCalledWith({ enabled: true });
   });
+
 
   it("blocks confirmation until the moved centre has a matching address", async () => {
     vi.useFakeTimers();

--- a/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
+++ b/hushh-webapp/components/one-location/onboarding/__tests__/save-location-modal.test.tsx
@@ -1,16 +1,63 @@
 // @vitest-environment jsdom
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mapPickerMockState = vi.hoisted(() => ({
+  picked: {
+    latitude: 28.614,
+    longitude: 77.2091,
+    address: "Kartavya Path, New Delhi, Delhi 110001, India",
+  },
+}));
+
+vi.mock("@/components/one-location/onboarding/location-picker-map", () => ({
+  LocationPickerMap: ({
+    onConfirm,
+    onCancel,
+    confirmLabel,
+    cancelLabel,
+    rendererDisclosureAccepted,
+    onAcceptRendererDisclosure,
+  }: {
+    onConfirm: (picked: {
+      latitude: number;
+      longitude: number;
+      address: string;
+    }) => void;
+    onCancel: () => void;
+    confirmLabel: string;
+    cancelLabel: string;
+    rendererDisclosureAccepted: boolean;
+    onAcceptRendererDisclosure: () => Promise<void>;
+  }) => {
+    if (!rendererDisclosureAccepted) {
+      return (
+        <button type="button" onClick={() => void onAcceptRendererDisclosure()}>
+          Use Google Maps
+        </button>
+      );
+    }
+    return (
+      <div aria-label="Mock location picker">
+        <button
+          type="button"
+          onClick={() => onConfirm(mapPickerMockState.picked)}
+        >
+          {confirmLabel}
+        </button>
+        <button type="button" onClick={onCancel}>
+          {cancelLabel}
+        </button>
+      </div>
+    );
+  },
+}));
 
 import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
 
 const baseProps = {
   open: true,
+  rendererDisclosureAccepted: true,
   onSave: vi.fn(),
   onSkip: vi.fn(),
 };
@@ -19,16 +66,15 @@ describe("SaveLocationModal", () => {
   beforeEach(() => {
     baseProps.onSave.mockReset();
     baseProps.onSkip.mockReset();
+    mapPickerMockState.picked = {
+      latitude: 28.614,
+      longitude: 77.2091,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+    };
   });
 
   it("shows address lookup progress without exposing coordinates", () => {
-    render(
-      <SaveLocationModal
-        {...baseProps}
-        address={null}
-        loadingAddress
-      />,
-    );
+    render(<SaveLocationModal {...baseProps} address={null} loadingAddress />);
 
     expect(screen.getByText(/finding your address/i)).toBeInTheDocument();
     expect(screen.queryByText(/12\.9763|77\.5929/)).not.toBeInTheDocument();
@@ -66,11 +112,7 @@ describe("SaveLocationModal", () => {
 
   it("requires a category and completed address lookup before saving", () => {
     const { rerender } = render(
-      <SaveLocationModal
-        {...baseProps}
-        address={null}
-        loadingAddress
-      />,
+      <SaveLocationModal {...baseProps} address={null} loadingAddress />,
     );
     const saveButton = screen.getByRole("button", { name: /save location/i });
     expect(saveButton).toBeDisabled();
@@ -92,10 +134,7 @@ describe("SaveLocationModal", () => {
 
   it("saves a custom label for Other", () => {
     render(
-      <SaveLocationModal
-        {...baseProps}
-        address="Kasturba Road, Bengaluru"
-      />,
+      <SaveLocationModal {...baseProps} address="Kasturba Road, Bengaluru" />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Other" }));
@@ -142,9 +181,7 @@ describe("SaveLocationModal", () => {
         name: "Hushh Office, Bengaluru",
       }),
     );
-    await waitFor(() =>
-      expect(onSelectPlace).toHaveBeenCalledWith("office"),
-    );
+    await waitFor(() => expect(onSelectPlace).toHaveBeenCalledWith("office"));
 
     rerender(
       <SaveLocationModal
@@ -160,13 +197,245 @@ describe("SaveLocationModal", () => {
     expect(screen.queryByText(/12\.9716|77\.5946/)).not.toBeInTheDocument();
   });
 
-  it("prevents dismissal while an encrypted save is in flight", () => {
+  it("collects an entrance pin and complete address details before saving", () => {
     render(
       <SaveLocationModal
         {...baseProps}
-        address="Bengaluru, India"
-        saving
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        mapInitial={{ latitude: 28.6139, longitude: 77.209 }}
+        onPickExactLocation={vi.fn()}
+        startWithMapPicker
+        collectAddressDetails
+        deferredUntilVault
       />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Pin your entrance" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Add your address details" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Add your address details" }),
+    ).toHaveFocus();
+    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110001");
+    expect(
+      screen.getByText(/kept only for this setup session/i),
+    ).toBeInTheDocument();
+
+    const saveButton = screen.getByRole("button", { name: "Save location" });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: " Flat 4B, Tower 2 " },
+    });
+    fireEvent.change(screen.getByLabelText(/Building colour/), {
+      target: { value: "Blue gate" },
+    });
+    fireEvent.change(screen.getByLabelText(/Nearby landmark/), {
+      target: { value: "Opposite City Mall" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Other" }));
+    fireEvent.change(screen.getByLabelText(/Give it a name/i), {
+      target: { value: " Parents' home " },
+    });
+
+    expect(saveButton).toBeEnabled();
+    fireEvent.click(saveButton);
+
+    expect(baseProps.onSave).toHaveBeenCalledWith("other", "Parents' home", {
+      houseOrFlat: "Flat 4B, Tower 2",
+      buildingColor: "Blue gate",
+      landmark: "Opposite City Mall",
+      postalCode: "110001",
+    });
+  });
+
+  it("updates the dialog context and focus after renderer disclosure", async () => {
+    const acceptRenderer = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        mapInitial={{ latitude: 28.6139, longitude: 77.209 }}
+        onPickExactLocation={vi.fn()}
+        startWithMapPicker
+        collectAddressDetails
+        rendererDisclosureAccepted={false}
+        onAcceptRendererDisclosure={acceptRenderer}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Before Google Maps opens" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Before Google Maps opens" }),
+    ).toHaveFocus();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use Google Maps" }));
+
+    await waitFor(() => expect(acceptRenderer).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: "Pin your entrance" }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Pin your entrance" }),
+    ).toHaveFocus();
+  });
+
+  it("does not reset entered details when durable renderer consent arrives", () => {
+    const props = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      collectAddressDetails: true,
+    };
+    const { rerender } = render(
+      <SaveLocationModal {...props} rendererDisclosureAccepted={false} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Flat 4B" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+
+    rerender(<SaveLocationModal {...props} rendererDisclosureAccepted />);
+
+    expect(screen.getByLabelText("House, flat, floor or block")).toHaveValue(
+      "Flat 4B",
+    );
+    expect(screen.getByRole("button", { name: "Home" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("keeps an invalid postal code from being submitted", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Address without a postal code"
+        collectAddressDetails
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "12A" },
+    });
+    fireEvent.change(screen.getByLabelText("PIN / postal code"), {
+      target: { value: "!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+
+    expect(screen.getByLabelText("PIN / postal code")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Save location" }),
+    ).toBeDisabled();
+    expect(baseProps.onSave).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an inferred postal code when the confirmed pin moves", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        mapInitial={{ latitude: 28.6139, longitude: 77.209 }}
+        onPickExactLocation={vi.fn()}
+        startWithMapPicker
+        collectAddressDetails
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110001");
+
+    mapPickerMockState.picked = {
+      latitude: 12.9716,
+      longitude: 77.5946,
+      address: "Kasturba Road, Bengaluru, Karnataka 560001, India",
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Edit pin" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("560001");
+  });
+
+  it("preserves a manually corrected postal code when the pin moves", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="Kartavya Path, New Delhi, Delhi 110001, India"
+        mapInitial={{ latitude: 28.6139, longitude: 77.209 }}
+        onPickExactLocation={vi.fn()}
+        startWithMapPicker
+        collectAddressDetails
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    fireEvent.change(screen.getByLabelText("PIN / postal code"), {
+      target: { value: "110002" },
+    });
+
+    mapPickerMockState.picked = {
+      latitude: 12.9716,
+      longitude: 77.5946,
+      address: "Kasturba Road, Bengaluru, Karnataka 560001, India",
+    };
+    fireEvent.click(screen.getByRole("button", { name: "Edit pin" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+
+    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110002");
+  });
+
+  it("restores the inferred postal code when the same modal reopens", () => {
+    const props = {
+      ...baseProps,
+      address: "Kartavya Path, New Delhi, Delhi 110001, India",
+      collectAddressDetails: true,
+    };
+    const { rerender } = render(<SaveLocationModal {...props} />);
+
+    fireEvent.change(screen.getByLabelText("PIN / postal code"), {
+      target: { value: "110002" },
+    });
+    rerender(<SaveLocationModal {...props} open={false} />);
+    rerender(<SaveLocationModal {...props} open />);
+
+    expect(screen.getByLabelText("PIN / postal code")).toHaveValue("110001");
+  });
+
+  it("maps Escape to the same safe skip action on the map step", () => {
+    render(
+      <SaveLocationModal
+        {...baseProps}
+        address="New Delhi 110001, India"
+        mapInitial={{ latitude: 28.6139, longitude: 77.209 }}
+        onPickExactLocation={vi.fn()}
+        startWithMapPicker
+        collectAddressDetails
+      />,
+    );
+
+    fireEvent.keyDown(
+      screen.getByRole("dialog", { name: "Pin your entrance" }),
+      { key: "Escape" },
+    );
+
+    expect(baseProps.onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("prevents dismissal while an encrypted save is in flight", () => {
+    render(
+      <SaveLocationModal {...baseProps} address="Bengaluru, India" saving />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }));

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { Check, Crosshair, Loader2, MapPin, X } from "lucide-react";
+
+import { useGoogleMaps } from "@/lib/one-location/use-google-maps";
+import { cn } from "@/lib/utils";
+
+export type PickedLocation = {
+  latitude: number;
+  longitude: number;
+  address: string | null;
+};
+
+export interface LocationPickerMapProps {
+  /** Where the map centers when it first opens. */
+  initialLatitude: number;
+  initialLongitude: number;
+  /** Friendly address already resolved for the initial point (optional). */
+  initialAddress?: string | null;
+  /** Server-side reverse geocode used to keep the address in sync with the pin. */
+  reverseGeocode?: (lat: number, lng: number) => Promise<string | null>;
+  /** Re-center the map on the device GPS fix. */
+  onLocateMe?: () => Promise<{ latitude: number; longitude: number } | null>;
+  /** Emitted when the owner confirms the pin position. */
+  onConfirm: (picked: PickedLocation) => void;
+  /** Dismiss the map without changing the captured point. */
+  onCancel: () => void;
+  confirmLabel?: string;
+  className?: string;
+}
+
+const PIN_REVERSE_GEOCODE_DEBOUNCE_MS = 350;
+
+function isValidCoordinate(lat: number, lng: number): boolean {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+/**
+ * LocationPickerMap — an Uber/Zomato-style "drag the map, the pin stays centred"
+ * picker so the owner can place their EXACT home instead of trusting a coarse GPS
+ * fix. The centre pin marks the chosen coordinate; every time the map settles we
+ * reverse-geocode the centre so the address preview stays truthful. A "Use my
+ * location" control re-centres on the live GPS fix, and Confirm returns the
+ * precise coordinate + address to the caller.
+ */
+export function LocationPickerMap({
+  initialLatitude,
+  initialLongitude,
+  initialAddress = null,
+  reverseGeocode,
+  onLocateMe,
+  onConfirm,
+  onCancel,
+  confirmLabel = "Confirm location",
+  className,
+}: LocationPickerMapProps) {
+  const { status } = useGoogleMaps();
+  const { resolvedTheme } = useTheme();
+  const colorScheme = resolvedTheme === "dark" ? "DARK" : "LIGHT";
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<google.maps.Map | null>(null);
+  const resolveIdRef = useRef(0);
+  const debounceRef = useRef<number | null>(null);
+
+  const centerRef = useRef<{ lat: number; lng: number }>({
+    lat: initialLatitude,
+    lng: initialLongitude,
+  });
+  const [address, setAddress] = useState<string | null>(initialAddress);
+  const [resolving, setResolving] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [locating, setLocating] = useState(false);
+
+  const resolveAddressForCenter = useCallback(
+    (lat: number, lng: number) => {
+      if (!reverseGeocode) return;
+      const requestId = resolveIdRef.current + 1;
+      resolveIdRef.current = requestId;
+      setResolving(true);
+      void Promise.resolve(reverseGeocode(lat, lng))
+        .then((next) => {
+          if (resolveIdRef.current !== requestId) return;
+          setAddress((next && next.trim()) || null);
+        })
+        .catch(() => {
+          if (resolveIdRef.current !== requestId) return;
+          setAddress(null);
+        })
+        .finally(() => {
+          if (resolveIdRef.current === requestId) setResolving(false);
+        });
+    },
+    [reverseGeocode],
+  );
+
+  const scheduleResolve = useCallback(
+    (lat: number, lng: number) => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = window.setTimeout(() => {
+        resolveAddressForCenter(lat, lng);
+      }, PIN_REVERSE_GEOCODE_DEBOUNCE_MS);
+    },
+    [resolveAddressForCenter],
+  );
+
+  // Build the interactive map once the API is ready. Google applies colorScheme
+  // only at construction, so the container is keyed by scheme to force a fresh
+  // node when the theme flips.
+  useEffect(() => {
+    if (status !== "ready" || !containerRef.current || mapRef.current) return;
+    const start = centerRef.current;
+    const map = new google.maps.Map(containerRef.current, {
+      center: start,
+      zoom: 17,
+      disableDefaultUI: true,
+      clickableIcons: false,
+      gestureHandling: "greedy",
+      colorScheme,
+    });
+    mapRef.current = map;
+
+    const dragStart = map.addListener("dragstart", () => setDragging(true));
+    const idle = map.addListener("idle", () => {
+      const center = map.getCenter();
+      if (!center) return;
+      const lat = center.lat();
+      const lng = center.lng();
+      centerRef.current = { lat, lng };
+      setDragging(false);
+      scheduleResolve(lat, lng);
+    });
+    // Tapping the map recenters the pin on that spot (a second familiar gesture).
+    const click = map.addListener(
+      "click",
+      (event: google.maps.MapMouseEvent) => {
+        if (!event.latLng) return;
+        map.panTo(event.latLng);
+      },
+    );
+
+    return () => {
+      dragStart.remove();
+      idle.remove();
+      click.remove();
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      mapRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, colorScheme]);
+
+  const handleLocateMe = useCallback(async () => {
+    if (!onLocateMe || locating) return;
+    setLocating(true);
+    try {
+      const fix = await onLocateMe();
+      if (fix && isValidCoordinate(fix.latitude, fix.longitude)) {
+        centerRef.current = { lat: fix.latitude, lng: fix.longitude };
+        mapRef.current?.panTo({ lat: fix.latitude, lng: fix.longitude });
+        mapRef.current?.setZoom(17);
+      }
+    } catch {
+      // Best-effort recenter; the pin simply stays where it is.
+    } finally {
+      setLocating(false);
+    }
+  }, [locating, onLocateMe]);
+
+  const handleConfirm = useCallback(() => {
+    const { lat, lng } = centerRef.current;
+    if (!isValidCoordinate(lat, lng)) return;
+    onConfirm({ latitude: lat, longitude: lng, address });
+  }, [address, onConfirm]);
+
+  const unavailable = status === "error";
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+          Drag the map to pin your exact spot
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Close map"
+          className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+        >
+          <X className="h-4 w-4" strokeWidth={2.4} />
+        </button>
+      </div>
+
+      <div className="relative h-[min(48vh,340px)] w-full overflow-hidden rounded-2xl border border-black/[0.08] bg-[#eef2f7] dark:border-white/[0.1] dark:bg-[#10151d]">
+        {unavailable ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+            <MapPin
+              className="h-7 w-7 text-[#8b93a1]"
+              strokeWidth={2}
+              aria-hidden
+            />
+            <p className="text-[13px] font-medium text-[#5b6472] dark:text-[#9aa6b6]">
+              The map isn&apos;t available right now. Search for your address
+              instead, or keep your current location.
+            </p>
+          </div>
+        ) : status !== "ready" ? (
+          <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Loading map…
+          </div>
+        ) : (
+          <>
+            <div key={colorScheme} ref={containerRef} className="h-full w-full" />
+
+            {/* Fixed centre pin — the map moves beneath it, so the pin always
+                marks the chosen coordinate. */}
+            <div
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              aria-hidden="true"
+            >
+              {/* Offset up by half the pin height so the pin TIP (not its centre)
+                  marks the exact map centre; lift a little more while dragging. */}
+              <div
+                className={cn(
+                  "flex flex-col items-center transition-transform duration-150 ease-out",
+                  dragging ? "-translate-y-[26px]" : "-translate-y-[20px]",
+                )}
+              >
+                <MapPin
+                  className="h-9 w-9 text-[color:var(--app-accent,#087ff5)] drop-shadow-[0_6px_8px_rgba(8,127,245,0.35)]"
+                  strokeWidth={2.4}
+                  fill="currentColor"
+                  fillOpacity={0.18}
+                />
+                <span
+                  className={cn(
+                    "mt-0.5 h-2 w-2 rounded-full bg-black/40 blur-[1px] transition-all duration-150",
+                    dragging ? "scale-75 opacity-40" : "scale-100 opacity-60",
+                  )}
+                />
+              </div>
+            </div>
+
+            {onLocateMe ? (
+              <button
+                type="button"
+                onClick={() => void handleLocateMe()}
+                disabled={locating}
+                aria-label="Use my current location"
+                className="press-scale absolute bottom-3 right-3 flex h-11 w-11 items-center justify-center rounded-full bg-white text-[color:var(--app-accent-deep,#0b62c4)] shadow-[0_4px_14px_rgba(16,24,40,0.22)] disabled:opacity-60 dark:bg-[#1c2430] dark:text-[#9bc7f5]"
+              >
+                {locating ? (
+                  <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+                ) : (
+                  <Crosshair className="h-5 w-5" strokeWidth={2.2} aria-hidden />
+                )}
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-start gap-2 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
+        <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+          <MapPin className="h-4 w-4" strokeWidth={2.4} aria-hidden />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+            Selected spot
+          </p>
+          {resolving ? (
+            <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              Finding this address…
+            </span>
+          ) : (
+            <p className="mt-0.5 text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
+              {address || "Move the map to choose a place"}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={unavailable || status !== "ready" || resolving}
+          className={cn(
+            "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+            "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+          )}
+        >
+          <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
+          {confirmLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -29,10 +29,14 @@ export interface LocationPickerMapProps {
   onConfirm: (picked: PickedLocation) => void;
   /** Dismiss the map without changing the captured point. */
   onCancel: () => void;
-  /** Google Maps may initialize only after this explicit renderer disclosure. */
+  /**
+   * Retained for API compatibility with existing callers. The map now opens
+   * directly (no separate "Before the map opens" disclosure step), so these are
+   * optional and unused by the picker.
+   */
   rendererDisclosureAccepted?: boolean;
-  /** Persist or session-acknowledge the shared renderer disclosure. */
-  onAcceptRendererDisclosure: () => Promise<void>;
+  onAcceptRendererDisclosure?: () => Promise<void>;
+
   confirmLabel?: string;
   cancelLabel?: string;
   className?: string;
@@ -74,8 +78,13 @@ export function LocationPickerMap({
   cancelLabel = "Cancel",
   className,
 }: LocationPickerMapProps) {
-  const { status } = useGoogleMaps({ enabled: rendererDisclosureAccepted });
+  // The map opens directly now (no pre-map disclosure gate), so Google Maps
+  // initializes as soon as the picker mounts.
+  void rendererDisclosureAccepted;
+  void onAcceptRendererDisclosure;
+  const { status } = useGoogleMaps({ enabled: true });
   const { resolvedTheme } = useTheme();
+
   const colorScheme = resolvedTheme === "dark" ? "DARK" : "LIGHT";
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -96,24 +105,90 @@ export function LocationPickerMap({
   const [hasInteracted, setHasInteracted] = useState(false);
   const [locating, setLocating] = useState(false);
   const [locationError, setLocationError] = useState<string | null>(null);
-  const [acceptingRenderer, setAcceptingRenderer] = useState(false);
-  const [rendererError, setRendererError] = useState<string | null>(null);
+
 
   useEffect(() => {
     if (hasInteractedRef.current) return;
     setAddress((initialAddress && initialAddress.trim()) || null);
   }, [initialAddress]);
 
-  const reverseGeocodeInBrowser = useCallback(
+  // Resolve the pinned coordinate to a human address entirely in the browser.
+  // Primary path is google.maps.Geocoder (classic Geocoding API). Some Maps
+  // keys (like this project's) enable the Maps JavaScript API + Places API (New)
+  // but NOT the classic Geocoding API, which makes Geocoder return nothing. In
+  // that case we fall back to the Places nearest-place lookup — the SAME source
+  // the backend/Your Map uses — so the address still resolves instead of
+  // showing "Address not found".
+  const reverseGeocodeViaNearestPlace = useCallback(
     async (lat: number, lng: number): Promise<string | null> => {
-      if (typeof google === "undefined" || !google.maps.Geocoder) return null;
-      const geocoder = geocoderRef.current ?? new google.maps.Geocoder();
-      geocoderRef.current = geocoder;
-      const response = await geocoder.geocode({ location: { lat, lng } });
-      return response.results[0]?.formatted_address?.trim() || null;
+      const places = (
+        google.maps as unknown as {
+          places?: {
+            Place?: {
+              searchNearby: (request: unknown) => Promise<{
+                places: Array<{
+                  formattedAddress?: string | null;
+                  displayName?: string | null;
+                }>;
+              }>;
+            };
+            SearchNearbyRankPreference?: { DISTANCE?: unknown };
+          };
+        }
+      ).places;
+      if (!places?.Place?.searchNearby) return null;
+      try {
+        const { places: results } = await places.Place.searchNearby({
+          fields: ["formattedAddress", "displayName"],
+          locationRestriction: {
+            center: { lat, lng },
+            // Keep the fallback tightly bounded so a distant landmark is never
+            // presented as the user's pinned spot (mirrors the backend radius).
+            radius: 100,
+          },
+          maxResultCount: 1,
+          rankPreference: places.SearchNearbyRankPreference?.DISTANCE,
+        });
+        const nearest = results?.[0];
+        if (!nearest) return null;
+        const formatted =
+          typeof nearest.formattedAddress === "string"
+            ? nearest.formattedAddress.trim()
+            : "";
+        if (formatted) return formatted;
+        const name =
+          typeof nearest.displayName === "string"
+            ? nearest.displayName.trim()
+            : "";
+        return name || null;
+      } catch {
+        return null;
+      }
     },
     [],
   );
+
+  const reverseGeocodeInBrowser = useCallback(
+    async (lat: number, lng: number): Promise<string | null> => {
+      if (typeof google === "undefined") return null;
+      if (google.maps.Geocoder) {
+        try {
+          const geocoder = geocoderRef.current ?? new google.maps.Geocoder();
+          geocoderRef.current = geocoder;
+          const response = await geocoder.geocode({ location: { lat, lng } });
+          const formatted =
+            response.results[0]?.formatted_address?.trim() || null;
+          if (formatted) return formatted;
+        } catch {
+          // Geocoding API not enabled / denied for this key — fall through to
+          // the Places nearest-place lookup below.
+        }
+      }
+      return reverseGeocodeViaNearestPlace(lat, lng);
+    },
+    [reverseGeocodeViaNearestPlace],
+  );
+
 
   const scheduleResolve = useCallback(
     (lat: number, lng: number) => {
@@ -265,22 +340,8 @@ export function LocationPickerMap({
     onConfirm({ latitude: lat, longitude: lng, address });
   }, [address, onConfirm]);
 
-  const handleAcceptRendererDisclosure = useCallback(async () => {
-    if (acceptingRenderer) return;
-    setAcceptingRenderer(true);
-    setRendererError(null);
-    try {
-      await onAcceptRendererDisclosure();
-    } catch {
-      setRendererError(
-        "Google Maps could not be prepared. Try again or skip this step.",
-      );
-    } finally {
-      setAcceptingRenderer(false);
-    }
-  }, [acceptingRenderer, onAcceptRendererDisclosure]);
-
   const unavailable = status === "error";
+
   const accuracyHint = unavailable
     ? "Review the captured point, then complete the address details on the next step."
     : typeof initialAccuracyM === "number" && Number.isFinite(initialAccuracyM)
@@ -291,78 +352,8 @@ export function LocationPickerMap({
           : "GPS is approximate here. Move the pin carefully to your entrance."
       : "Move the map so the pin tip sits on your entrance.";
 
-  if (!rendererDisclosureAccepted) {
-    return (
-      <div
-        className={cn("flex flex-col gap-4", className)}
-        data-testid="saved-location-map-disclosure"
-      >
-        <div className="flex items-center justify-between">
-          <p className="text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
-            Before the map opens
-          </p>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close map"
-            className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:text-[#aeb8c7]"
-          >
-            <X className="h-4 w-4" strokeWidth={2.4} />
-          </button>
-        </div>
-
-        <section className="rounded-3xl border border-black/[0.07] bg-[#f4f6fa] p-5 dark:border-white/[0.08] dark:bg-white/[0.05]">
-          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
-            <MapPin className="h-5 w-5" strokeWidth={2.3} aria-hidden />
-          </span>
-          <h3 className="mt-4 text-[20px] font-bold leading-tight text-[#111827] dark:text-[#f4f7fb]">
-            Adjust your entrance with Google Maps
-          </h3>
-          <p className="mt-2 text-[14px] leading-6 text-[#5b6472] dark:text-[#9aa6b6]">
-            Google Maps receives the selected point after you continue so it can
-            draw the map and suggest an address. Opening the map does not share
-            this point with nearby people; any later location sharing still
-            needs your approval.
-          </p>
-        </section>
-
-        {rendererError ? (
-          <p
-            role="alert"
-            className="rounded-xl bg-[#fff1f0] px-3 py-2 text-[12px] font-medium text-[#b42318] dark:bg-[#7a271a]/20 dark:text-[#ff9b91]"
-          >
-            {rendererError}
-          </p>
-        ) : null}
-
-        <div className="flex flex-col gap-2.5">
-          <button
-            type="button"
-            onClick={() => void handleAcceptRendererDisclosure()}
-            disabled={acceptingRenderer}
-            className="press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full bg-[color:var(--app-accent,#087ff5)] text-[16px] font-bold text-[color:var(--app-accent-fg,#ffffff)] transition-colors hover:bg-[color:var(--app-accent-hover,#0b62c4)] disabled:cursor-not-allowed disabled:opacity-45"
-          >
-            {acceptingRenderer ? (
-              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
-            ) : (
-              <MapPin className="h-5 w-5" strokeWidth={2.4} aria-hidden />
-            )}
-            Use Google Maps
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={acceptingRenderer}
-            className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
-          >
-            {cancelLabel}
-          </button>
-        </div>
-      </div>
-    );
-  }
-
   return (
+
     <div className={cn("flex flex-col gap-3", className)}>
       <div className="flex items-center justify-between">
         <p className="text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
@@ -378,7 +369,8 @@ export function LocationPickerMap({
         </button>
       </div>
 
-      <div className="relative h-[min(48vh,340px)] w-full overflow-hidden rounded-2xl border border-black/[0.08] bg-[#eef2f7] dark:border-white/[0.1] dark:bg-[#10151d]">
+      <div className="relative h-[min(56vh,420px)] w-full overflow-hidden rounded-2xl border border-black/[0.08] bg-[#eef2f7] shadow-[0_8px_24px_rgba(16,24,40,0.12)] ring-1 ring-black/[0.02] dark:border-white/[0.1] dark:bg-[#10151d] dark:shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
+
         {unavailable ? (
           <div
             role="status"
@@ -412,34 +404,52 @@ export function LocationPickerMap({
               className="h-full w-full"
             />
 
-            {/* Fixed centre pin — the map moves beneath it, so the pin always
-                marks the chosen coordinate. */}
+            {/* Fixed centre marker — the map moves beneath it, so the pin
+                always marks the chosen coordinate. A polished Google-style
+                teardrop (accent fill + white ring) with a soft ground shadow
+                reads far better than a flat outline icon. */}
             <div
               className="pointer-events-none absolute inset-0 flex items-center justify-center"
               aria-hidden="true"
             >
-              {/* Offset up by half the pin height so the pin TIP (not its centre)
-                  marks the exact map centre; lift a little more while dragging. */}
               <div
                 className={cn(
-                  "flex flex-col items-center transition-transform duration-150 ease-out",
-                  dragging ? "-translate-y-[26px]" : "-translate-y-[20px]",
+                  "relative flex flex-col items-center transition-transform duration-150 ease-out",
+                  // Lift so the teardrop TIP sits exactly on the map centre.
+                  dragging ? "-translate-y-[30px]" : "-translate-y-[24px]",
                 )}
               >
-                <MapPin
-                  className="h-9 w-9 text-[color:var(--app-accent,#087ff5)] drop-shadow-[0_6px_8px_rgba(8,127,245,0.35)]"
-                  strokeWidth={2.4}
-                  fill="currentColor"
-                  fillOpacity={0.18}
-                />
+                <svg
+                  width="40"
+                  height="48"
+                  viewBox="0 0 40 48"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="drop-shadow-[0_6px_10px_rgba(16,24,40,0.35)]"
+                >
+                  {/* Teardrop body */}
+                  <path
+                    d="M20 1.5c-9.66 0-17.5 7.6-17.5 17 0 7.02 4.02 12.06 8.2 16.86 2.1 2.42 4.28 4.86 6.02 7.62.72 1.14 1.28 2.02 3.28 2.02s2.56-.88 3.28-2.02c1.74-2.76 3.92-5.2 6.02-7.62 4.18-4.8 8.2-9.84 8.2-16.86 0-9.4-7.84-17-17.5-17z"
+                    fill="var(--app-accent,#087ff5)"
+                    stroke="#ffffff"
+                    strokeWidth="2.5"
+                  />
+                  {/* Inner dot */}
+                  <circle cx="20" cy="18.5" r="6.2" fill="#ffffff" />
+                  <circle cx="20" cy="18.5" r="3" fill="var(--app-accent,#087ff5)" />
+                </svg>
+                {/* Ground shadow under the tip */}
                 <span
                   className={cn(
-                    "mt-0.5 h-2 w-2 rounded-full bg-black/40 blur-[1px] transition-all duration-150",
-                    dragging ? "scale-75 opacity-40" : "scale-100 opacity-60",
+                    "mt-[1px] rounded-full bg-black/45 blur-[2px] transition-all duration-150",
+                    dragging
+                      ? "h-[5px] w-[10px] opacity-35"
+                      : "h-[6px] w-[14px] opacity-55",
                   )}
                 />
               </div>
             </div>
+
 
             {onLocateMe ? (
               <button

--- a/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
+++ b/hushh-webapp/components/one-location/onboarding/location-picker-map.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Check, Crosshair, Loader2, MapPin, X } from "lucide-react";
 
@@ -19,6 +19,8 @@ export interface LocationPickerMapProps {
   initialLongitude: number;
   /** Friendly address already resolved for the initial point (optional). */
   initialAddress?: string | null;
+  /** Device accuracy for copy only; the chosen map centre remains authoritative. */
+  initialAccuracyM?: number | null;
   /** Server-side reverse geocode used to keep the address in sync with the pin. */
   reverseGeocode?: (lat: number, lng: number) => Promise<string | null>;
   /** Re-center the map on the device GPS fix. */
@@ -27,7 +29,12 @@ export interface LocationPickerMapProps {
   onConfirm: (picked: PickedLocation) => void;
   /** Dismiss the map without changing the captured point. */
   onCancel: () => void;
+  /** Google Maps may initialize only after this explicit renderer disclosure. */
+  rendererDisclosureAccepted?: boolean;
+  /** Persist or session-acknowledge the shared renderer disclosure. */
+  onAcceptRendererDisclosure: () => Promise<void>;
   confirmLabel?: string;
+  cancelLabel?: string;
   className?: string;
 }
 
@@ -45,32 +52,39 @@ function isValidCoordinate(lat: number, lng: number): boolean {
 }
 
 /**
- * LocationPickerMap — an Uber/Zomato-style "drag the map, the pin stays centred"
- * picker so the owner can place their EXACT home instead of trusting a coarse GPS
- * fix. The centre pin marks the chosen coordinate; every time the map settles we
+ * LocationPickerMap uses the familiar "drag the map, the pin stays centred"
+ * pattern so the owner can confirm their entrance instead of trusting a coarse
+ * GPS fix. The centre pin marks the chosen coordinate; when the map settles we
  * reverse-geocode the centre so the address preview stays truthful. A "Use my
  * location" control re-centres on the live GPS fix, and Confirm returns the
- * precise coordinate + address to the caller.
+ * owner-confirmed coordinate and resolved address to the caller.
  */
 export function LocationPickerMap({
   initialLatitude,
   initialLongitude,
   initialAddress = null,
+  initialAccuracyM = null,
   reverseGeocode,
   onLocateMe,
   onConfirm,
   onCancel,
+  rendererDisclosureAccepted = false,
+  onAcceptRendererDisclosure,
   confirmLabel = "Confirm location",
+  cancelLabel = "Cancel",
   className,
 }: LocationPickerMapProps) {
-  const { status } = useGoogleMaps();
+  const { status } = useGoogleMaps({ enabled: rendererDisclosureAccepted });
   const { resolvedTheme } = useTheme();
   const colorScheme = resolvedTheme === "dark" ? "DARK" : "LIGHT";
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
+  const geocoderRef = useRef<google.maps.Geocoder | null>(null);
   const resolveIdRef = useRef(0);
   const debounceRef = useRef<number | null>(null);
+  const hasInteractedRef = useRef(false);
+  const mapUnavailableDescriptionId = useId();
 
   const centerRef = useRef<{ lat: number; lng: number }>({
     lat: initialLatitude,
@@ -79,28 +93,26 @@ export function LocationPickerMap({
   const [address, setAddress] = useState<string | null>(initialAddress);
   const [resolving, setResolving] = useState(false);
   const [dragging, setDragging] = useState(false);
+  const [hasInteracted, setHasInteracted] = useState(false);
   const [locating, setLocating] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+  const [acceptingRenderer, setAcceptingRenderer] = useState(false);
+  const [rendererError, setRendererError] = useState<string | null>(null);
 
-  const resolveAddressForCenter = useCallback(
-    (lat: number, lng: number) => {
-      if (!reverseGeocode) return;
-      const requestId = resolveIdRef.current + 1;
-      resolveIdRef.current = requestId;
-      setResolving(true);
-      void Promise.resolve(reverseGeocode(lat, lng))
-        .then((next) => {
-          if (resolveIdRef.current !== requestId) return;
-          setAddress((next && next.trim()) || null);
-        })
-        .catch(() => {
-          if (resolveIdRef.current !== requestId) return;
-          setAddress(null);
-        })
-        .finally(() => {
-          if (resolveIdRef.current === requestId) setResolving(false);
-        });
+  useEffect(() => {
+    if (hasInteractedRef.current) return;
+    setAddress((initialAddress && initialAddress.trim()) || null);
+  }, [initialAddress]);
+
+  const reverseGeocodeInBrowser = useCallback(
+    async (lat: number, lng: number): Promise<string | null> => {
+      if (typeof google === "undefined" || !google.maps.Geocoder) return null;
+      const geocoder = geocoderRef.current ?? new google.maps.Geocoder();
+      geocoderRef.current = geocoder;
+      const response = await geocoder.geocode({ location: { lat, lng } });
+      return response.results[0]?.formatted_address?.trim() || null;
     },
-    [reverseGeocode],
+    [],
   );
 
   const scheduleResolve = useCallback(
@@ -108,11 +120,32 @@ export function LocationPickerMap({
       if (debounceRef.current !== null) {
         window.clearTimeout(debounceRef.current);
       }
+      // The map centre is now authoritative. Invalidate the old address before
+      // the debounce starts so Confirm cannot pair new coordinates with stale
+      // reverse-geocoded copy from the previous centre.
+      const requestId = resolveIdRef.current + 1;
+      resolveIdRef.current = requestId;
+      setAddress(null);
+      setResolving(true);
+      setLocationError(null);
       debounceRef.current = window.setTimeout(() => {
-        resolveAddressForCenter(lat, lng);
+        debounceRef.current = null;
+        const resolve = reverseGeocode ?? reverseGeocodeInBrowser;
+        void Promise.resolve(resolve(lat, lng))
+          .then((next) => {
+            if (resolveIdRef.current !== requestId) return;
+            setAddress((next && next.trim()) || null);
+          })
+          .catch(() => {
+            if (resolveIdRef.current !== requestId) return;
+            setAddress(null);
+          })
+          .finally(() => {
+            if (resolveIdRef.current === requestId) setResolving(false);
+          });
       }, PIN_REVERSE_GEOCODE_DEBOUNCE_MS);
     },
-    [resolveAddressForCenter],
+    [reverseGeocode, reverseGeocodeInBrowser],
   );
 
   // Build the interactive map once the API is ready. Google applies colorScheme
@@ -131,7 +164,18 @@ export function LocationPickerMap({
     });
     mapRef.current = map;
 
-    const dragStart = map.addListener("dragstart", () => setDragging(true));
+    const dragStart = map.addListener("dragstart", () => {
+      hasInteractedRef.current = true;
+      setHasInteracted(true);
+      resolveIdRef.current += 1;
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      setAddress(null);
+      setResolving(true);
+      setDragging(true);
+    });
     const idle = map.addListener("idle", () => {
       const center = map.getCenter();
       if (!center) return;
@@ -146,6 +190,8 @@ export function LocationPickerMap({
       "click",
       (event: google.maps.MapMouseEvent) => {
         if (!event.latLng) return;
+        hasInteractedRef.current = true;
+        setHasInteracted(true);
         map.panTo(event.latLng);
       },
     );
@@ -158,27 +204,60 @@ export function LocationPickerMap({
         window.clearTimeout(debounceRef.current);
         debounceRef.current = null;
       }
+      resolveIdRef.current += 1;
       mapRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status, colorScheme]);
 
+  useEffect(() => {
+    if (status !== "error") return;
+    resolveIdRef.current += 1;
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setDragging(false);
+    setResolving(false);
+  }, [status]);
+
   const handleLocateMe = useCallback(async () => {
     if (!onLocateMe || locating) return;
     setLocating(true);
+    setLocationError(null);
     try {
       const fix = await onLocateMe();
       if (fix && isValidCoordinate(fix.latitude, fix.longitude)) {
+        hasInteractedRef.current = true;
+        setHasInteracted(true);
+        resolveIdRef.current += 1;
+        if (debounceRef.current !== null) {
+          window.clearTimeout(debounceRef.current);
+          debounceRef.current = null;
+        }
+        setAddress(null);
+        setResolving(true);
         centerRef.current = { lat: fix.latitude, lng: fix.longitude };
-        mapRef.current?.panTo({ lat: fix.latitude, lng: fix.longitude });
-        mapRef.current?.setZoom(17);
+        const map = mapRef.current;
+        if (map) {
+          map.panTo({ lat: fix.latitude, lng: fix.longitude });
+          map.setZoom(17);
+        } else {
+          scheduleResolve(fix.latitude, fix.longitude);
+        }
+      } else {
+        setLocationError(
+          "Current location is unavailable. Keep the pin here or move the map manually.",
+        );
       }
     } catch {
-      // Best-effort recenter; the pin simply stays where it is.
+      setLocationError(
+        "Current location is unavailable. Keep the pin here or move the map manually.",
+      );
     } finally {
       setLocating(false);
     }
-  }, [locating, onLocateMe]);
+  }, [locating, onLocateMe, scheduleResolve]);
 
   const handleConfirm = useCallback(() => {
     const { lat, lng } = centerRef.current;
@@ -186,13 +265,108 @@ export function LocationPickerMap({
     onConfirm({ latitude: lat, longitude: lng, address });
   }, [address, onConfirm]);
 
+  const handleAcceptRendererDisclosure = useCallback(async () => {
+    if (acceptingRenderer) return;
+    setAcceptingRenderer(true);
+    setRendererError(null);
+    try {
+      await onAcceptRendererDisclosure();
+    } catch {
+      setRendererError(
+        "Google Maps could not be prepared. Try again or skip this step.",
+      );
+    } finally {
+      setAcceptingRenderer(false);
+    }
+  }, [acceptingRenderer, onAcceptRendererDisclosure]);
+
   const unavailable = status === "error";
+  const accuracyHint = unavailable
+    ? "Review the captured point, then complete the address details on the next step."
+    : typeof initialAccuracyM === "number" && Number.isFinite(initialAccuracyM)
+      ? initialAccuracyM <= 20
+        ? "GPS gave us a strong starting point. Confirm the entrance yourself."
+        : initialAccuracyM <= 75
+          ? "GPS is only a starting point. Check the pin before continuing."
+          : "GPS is approximate here. Move the pin carefully to your entrance."
+      : "Move the map so the pin tip sits on your entrance.";
+
+  if (!rendererDisclosureAccepted) {
+    return (
+      <div
+        className={cn("flex flex-col gap-4", className)}
+        data-testid="saved-location-map-disclosure"
+      >
+        <div className="flex items-center justify-between">
+          <p className="text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+            Before the map opens
+          </p>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close map"
+            className="press-scale flex h-8 w-8 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+          >
+            <X className="h-4 w-4" strokeWidth={2.4} />
+          </button>
+        </div>
+
+        <section className="rounded-3xl border border-black/[0.07] bg-[#f4f6fa] p-5 dark:border-white/[0.08] dark:bg-white/[0.05]">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+            <MapPin className="h-5 w-5" strokeWidth={2.3} aria-hidden />
+          </span>
+          <h3 className="mt-4 text-[20px] font-bold leading-tight text-[#111827] dark:text-[#f4f7fb]">
+            Adjust your entrance with Google Maps
+          </h3>
+          <p className="mt-2 text-[14px] leading-6 text-[#5b6472] dark:text-[#9aa6b6]">
+            Google Maps receives the selected point after you continue so it can
+            draw the map and suggest an address. Opening the map does not share
+            this point with nearby people; any later location sharing still
+            needs your approval.
+          </p>
+        </section>
+
+        {rendererError ? (
+          <p
+            role="alert"
+            className="rounded-xl bg-[#fff1f0] px-3 py-2 text-[12px] font-medium text-[#b42318] dark:bg-[#7a271a]/20 dark:text-[#ff9b91]"
+          >
+            {rendererError}
+          </p>
+        ) : null}
+
+        <div className="flex flex-col gap-2.5">
+          <button
+            type="button"
+            onClick={() => void handleAcceptRendererDisclosure()}
+            disabled={acceptingRenderer}
+            className="press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full bg-[color:var(--app-accent,#087ff5)] text-[16px] font-bold text-[color:var(--app-accent-fg,#ffffff)] transition-colors hover:bg-[color:var(--app-accent-hover,#0b62c4)] disabled:cursor-not-allowed disabled:opacity-45"
+          >
+            {acceptingRenderer ? (
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+            ) : (
+              <MapPin className="h-5 w-5" strokeWidth={2.4} aria-hidden />
+            )}
+            Use Google Maps
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={acceptingRenderer}
+            className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+          >
+            {cancelLabel}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
       <div className="flex items-center justify-between">
         <p className="text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
-          Drag the map to pin your exact spot
+          Pin your entrance on the map
         </p>
         <button
           type="button"
@@ -206,24 +380,37 @@ export function LocationPickerMap({
 
       <div className="relative h-[min(48vh,340px)] w-full overflow-hidden rounded-2xl border border-black/[0.08] bg-[#eef2f7] dark:border-white/[0.1] dark:bg-[#10151d]">
         {unavailable ? (
-          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center"
+          >
             <MapPin
               className="h-7 w-7 text-[#8b93a1]"
               strokeWidth={2}
               aria-hidden
             />
-            <p className="text-[13px] font-medium text-[#5b6472] dark:text-[#9aa6b6]">
-              The map isn&apos;t available right now. Search for your address
-              instead, or keep your current location.
+            <p
+              id={mapUnavailableDescriptionId}
+              className="text-[13px] font-medium text-[#5b6472] dark:text-[#9aa6b6]"
+            >
+              The interactive map isn&apos;t available right now. You can
+              continue with the captured point and complete the address
+              manually.
             </p>
           </div>
         ) : status !== "ready" ? (
           <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Loading map…
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> Loading
+            map…
           </div>
         ) : (
           <>
-            <div key={colorScheme} ref={containerRef} className="h-full w-full" />
+            <div
+              key={colorScheme}
+              ref={containerRef}
+              className="h-full w-full"
+            />
 
             {/* Fixed centre pin — the map moves beneath it, so the pin always
                 marks the chosen coordinate. */}
@@ -265,7 +452,11 @@ export function LocationPickerMap({
                 {locating ? (
                   <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
                 ) : (
-                  <Crosshair className="h-5 w-5" strokeWidth={2.2} aria-hidden />
+                  <Crosshair
+                    className="h-5 w-5"
+                    strokeWidth={2.2}
+                    aria-hidden
+                  />
                 )}
               </button>
             ) : null}
@@ -273,7 +464,23 @@ export function LocationPickerMap({
         )}
       </div>
 
-      <div className="flex items-start gap-2 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
+      <p className="text-[12px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]">
+        {accuracyHint}
+      </p>
+
+      {locationError ? (
+        <p
+          role="status"
+          className="rounded-xl bg-[#fff4ed] px-3 py-2 text-[12px] font-medium leading-[1.4] text-[#b54708] dark:bg-[#7a2e0e]/20 dark:text-[#fdb022]"
+        >
+          {locationError}
+        </p>
+      ) : null}
+
+      <div
+        aria-live="polite"
+        className="flex items-start gap-2 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]"
+      >
         <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
           <MapPin className="h-4 w-4" strokeWidth={2.4} aria-hidden />
         </span>
@@ -288,7 +495,12 @@ export function LocationPickerMap({
             </span>
           ) : (
             <p className="mt-0.5 text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
-              {address || "Move the map to choose a place"}
+              {address ||
+                (unavailable
+                  ? "Captured point ready"
+                  : hasInteracted
+                    ? "Address not found — add details on the next step"
+                    : "Move the map to choose a place")}
             </p>
           )}
         </div>
@@ -298,21 +510,24 @@ export function LocationPickerMap({
         <button
           type="button"
           onClick={handleConfirm}
-          disabled={unavailable || status !== "ready" || resolving}
+          disabled={status === "loading" || dragging || resolving || locating}
+          aria-describedby={
+            unavailable ? mapUnavailableDescriptionId : undefined
+          }
           className={cn(
             "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
             "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
           )}
         >
           <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
-          {confirmLabel}
+          {unavailable ? "Use captured point" : confirmLabel}
         </button>
         <button
           type="button"
           onClick={onCancel}
           className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
         >
-          Cancel
+          {cancelLabel}
         </button>
       </div>
     </div>

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   Home,
   Loader2,
+  Map as MapIcon,
   MapPin,
   Pencil,
   Search,
@@ -17,6 +18,10 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  LocationPickerMap,
+  type PickedLocation,
+} from "@/components/one-location/onboarding/location-picker-map";
 import { cn } from "@/lib/utils";
 import type { SavedLocationCategory } from "@/lib/one-location/saved-locations";
 
@@ -38,6 +43,18 @@ export type SaveLocationModalProps = {
     input: string,
   ) => Promise<SavedLocationPlaceSuggestion[]>;
   onSelectPlace?: (placeId: string) => Promise<void>;
+  /**
+   * Current captured coordinate used to seed the drag-to-pin map picker. When
+   * provided together with `onPickExactLocation`, an "Adjust on map" action lets
+   * the owner place their EXACT spot instead of trusting the coarse GPS fix.
+   */
+  mapInitial?: { latitude: number; longitude: number } | null;
+  /** Server reverse-geocode so the picker keeps the address synced to the pin. */
+  reverseGeocode?: (lat: number, lng: number) => Promise<string | null>;
+  /** Recenter the picker on the live device GPS fix. */
+  onLocateMe?: () => Promise<{ latitude: number; longitude: number } | null>;
+  /** Commit the precise coordinate + address chosen on the map. */
+  onPickExactLocation?: (picked: PickedLocation) => void;
   onSave: (category: SavedLocationCategory, label: string) => void;
   onSkip: () => void;
 };
@@ -55,9 +72,10 @@ const CATEGORY_OPTIONS: {
 /**
  * SaveLocationModal — a focused, responsive prompt shown during Location
  * onboarding after access is ready. The owner can correct the captured place
- * before tagging it as Home / Work / Other. The shared dialog primitive owns
- * focus trapping, focus restoration, Escape handling, and screen-reader
- * semantics.
+ * before tagging it as Home / Work / Other. Because a coarse GPS fix rarely lands
+ * on the exact doorstep, the owner can open a drag-to-pin map picker (like other
+ * apps) to place their precise spot. The shared dialog primitive owns focus
+ * trapping, focus restoration, Escape handling, and screen-reader semantics.
  */
 export function SaveLocationModal({
   open,
@@ -66,12 +84,17 @@ export function SaveLocationModal({
   saving = false,
   onSearchPlaces,
   onSelectPlace,
+  mapInitial,
+  reverseGeocode,
+  onLocateMe,
+  onPickExactLocation,
   onSave,
   onSkip,
 }: SaveLocationModalProps) {
   const [category, setCategory] = useState<SavedLocationCategory | null>(null);
   const [customLabel, setCustomLabel] = useState("");
   const [editingPlace, setEditingPlace] = useState(false);
+  const [pickingOnMap, setPickingOnMap] = useState(false);
   const [placeQuery, setPlaceQuery] = useState("");
   const [placeSuggestions, setPlaceSuggestions] = useState<
     SavedLocationPlaceSuggestion[]
@@ -87,6 +110,7 @@ export function SaveLocationModal({
       setCategory(null);
       setCustomLabel("");
       setEditingPlace(false);
+      setPickingOnMap(false);
       setPlaceQuery("");
       setPlaceSuggestions([]);
       setPlaceSearching(false);
@@ -137,11 +161,18 @@ export function SaveLocationModal({
   const changingPlace = selectingPlaceId !== null;
   const interactionBusy = saving || changingPlace;
   const canEditPlace = Boolean(onSearchPlaces && onSelectPlace);
+  const canPickOnMap = Boolean(
+    onPickExactLocation &&
+      mapInitial &&
+      Number.isFinite(mapInitial.latitude) &&
+      Number.isFinite(mapInitial.longitude),
+  );
   const canSave =
     category !== null &&
     !saving &&
     !loadingAddress &&
     !editingPlace &&
+    !pickingOnMap &&
     !changingPlace;
 
   const handleSelectPlace = async (placeId: string) => {
@@ -158,6 +189,11 @@ export function SaveLocationModal({
     } finally {
       setSelectingPlaceId(null);
     }
+  };
+
+  const handleConfirmMapPick = (picked: PickedLocation) => {
+    onPickExactLocation?.(picked);
+    setPickingOnMap(false);
   };
 
   const handleSave = () => {
@@ -181,10 +217,10 @@ export function SaveLocationModal({
         aria-describedby={descriptionId}
         overlayClassName="z-[559] bg-black/45 backdrop-blur-[6px]"
         onEscapeKeyDown={(event) => {
-          if (interactionBusy) event.preventDefault();
+          if (interactionBusy || pickingOnMap) event.preventDefault();
         }}
         onPointerDownOutside={(event) => {
-          if (interactionBusy) event.preventDefault();
+          if (interactionBusy || pickingOnMap) event.preventDefault();
         }}
         className={cn(
           "z-[560] bottom-0 top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
@@ -194,229 +230,272 @@ export function SaveLocationModal({
           "dark:border-white/[0.08] dark:bg-[#141922]",
         )}
       >
-        <button
-          type="button"
-          onClick={onSkip}
-          disabled={interactionBusy}
-          aria-label="Close"
-          className="press-scale absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
-        >
-          <X className="h-4.5 w-4.5" strokeWidth={2.4} />
-        </button>
-
-        <header className="pr-8">
-          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent,#087ff5)]">
-            <MapPin className="h-6 w-6" strokeWidth={2.2} />
-          </span>
-          <DialogTitle
-            className="mt-3.5 text-[22px] font-bold leading-[1.15] tracking-[-0.01em] text-[#0b1220] dark:text-[#f4f7fb]"
-          >
-            Save this place
-          </DialogTitle>
-          <p
-            id={descriptionId}
-            className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
-          >
-            Tag where you are so One can personalise your experience. It stays
-            encrypted in your vault and is shared only when you approve
-            location access.
-          </p>
-        </header>
-
-        <div className="flex items-center gap-2.5 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
-            <MapPin className="h-4 w-4" strokeWidth={2.4} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
-              Current location
+        {pickingOnMap && canPickOnMap ? (
+          <>
+            <DialogTitle className="sr-only">
+              Pin your exact location
+            </DialogTitle>
+            <p id={descriptionId} className="sr-only">
+              Drag the map so the centre pin sits on your exact spot, then
+              confirm.
             </p>
-            {loadingAddress ? (
-              <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" /> Finding your
-                address…
-              </span>
-            ) : (
-              <p className="mt-0.5 truncate text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
-                {resolvedAddress || "Address unavailable"}
-              </p>
-            )}
-          </div>
-          {canEditPlace && !loadingAddress ? (
+            <LocationPickerMap
+              initialLatitude={mapInitial!.latitude}
+              initialLongitude={mapInitial!.longitude}
+              initialAddress={resolvedAddress}
+              reverseGeocode={reverseGeocode}
+              onLocateMe={onLocateMe}
+              onConfirm={handleConfirmMapPick}
+              onCancel={() => setPickingOnMap(false)}
+            />
+          </>
+        ) : (
+          <>
             <button
               type="button"
-              onClick={() => {
-                setEditingPlace(true);
-                setPlaceQuery("");
-                setPlaceSuggestions([]);
-                setPlaceSearchError(null);
-              }}
+              onClick={onSkip}
               disabled={interactionBusy}
-              className="press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-white px-2.5 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] shadow-sm disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#9bc7f5]"
-              aria-label="Change captured location"
+              aria-label="Close"
+              className="press-scale absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
             >
-              <Pencil className="h-3.5 w-3.5" aria-hidden />
-              Change
+              <X className="h-4.5 w-4.5" strokeWidth={2.4} />
             </button>
-          ) : null}
-        </div>
 
-        {editingPlace ? (
-          <div className="space-y-2.5 [animation:saveLocFadeIn_.2s_ease-out_both]">
-            <label
-              htmlFor="saved-location-place-search"
-              className="block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
-            >
-              Search for another place
-            </label>
-            <div className="relative">
-              <Search
-                className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8b93a1]"
-                aria-hidden
-              />
-              <input
-                id="saved-location-place-search"
-                type="search"
-                value={placeQuery}
-                onChange={(event) => setPlaceQuery(event.target.value)}
-                disabled={interactionBusy}
-                autoComplete="off"
-                placeholder="Search address or place"
-                className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white pl-10 pr-10 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
-              />
-              {placeSearching || changingPlace ? (
-                <Loader2
-                  className="absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-[#8b93a1]"
-                  aria-label="Searching places"
-                />
+            <header className="pr-8">
+              <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent,#087ff5)]">
+                <MapPin className="h-6 w-6" strokeWidth={2.2} />
+              </span>
+              <DialogTitle className="mt-3.5 text-[22px] font-bold leading-[1.15] tracking-[-0.01em] text-[#0b1220] dark:text-[#f4f7fb]">
+                Save this place
+              </DialogTitle>
+              <p
+                id={descriptionId}
+                className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
+              >
+                Tag where you are so One can personalise your experience. It stays
+                encrypted in your vault and is shared only when you approve
+                location access.
+              </p>
+            </header>
+
+            <div className="flex items-center gap-2.5 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+                <MapPin className="h-4 w-4" strokeWidth={2.4} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+                  Current location
+                </p>
+                {loadingAddress ? (
+                  <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Finding your
+                    address…
+                  </span>
+                ) : (
+                  <p className="mt-0.5 truncate text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
+                    {resolvedAddress || "Address unavailable"}
+                  </p>
+                )}
+              </div>
+              {canEditPlace && !loadingAddress ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingPlace(true);
+                    setPlaceQuery("");
+                    setPlaceSuggestions([]);
+                    setPlaceSearchError(null);
+                  }}
+                  disabled={interactionBusy}
+                  className="press-scale inline-flex h-8 shrink-0 items-center gap-1 rounded-full bg-white px-2.5 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] shadow-sm disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#9bc7f5]"
+                  aria-label="Change captured location"
+                >
+                  <Pencil className="h-3.5 w-3.5" aria-hidden />
+                  Change
+                </button>
               ) : null}
             </div>
 
-            {placeSuggestions.length > 0 ? (
-              <div
-                className="max-h-40 overflow-y-auto rounded-2xl border border-black/[0.08] bg-white p-1 shadow-sm dark:border-white/[0.1] dark:bg-[#1b2230]"
-                aria-label="Location suggestions"
+            {canPickOnMap && !loadingAddress ? (
+              <button
+                type="button"
+                onClick={() => setPickingOnMap(true)}
+                disabled={interactionBusy}
+                data-testid="save-location-adjust-on-map"
+                className="press-scale flex w-full items-center gap-3 rounded-2xl border border-dashed border-[color:var(--app-accent,#087ff5)]/40 bg-[color:var(--app-accent-tint,#e7f0fd)]/50 px-3.5 py-3 text-left transition-colors hover:bg-[color:var(--app-accent-tint,#e7f0fd)] disabled:opacity-45 dark:border-[color:var(--app-accent,#087ff5)]/30 dark:bg-[color:var(--app-accent,#087ff5)]/10"
               >
-                {placeSuggestions.map((suggestion) => (
-                  <button
-                    key={suggestion.placeId}
-                    type="button"
-                    onClick={() => void handleSelectPlace(suggestion.placeId)}
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+                  <MapIcon className="h-4 w-4" strokeWidth={2.2} aria-hidden />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[14px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+                    Set exact location on map
+                  </span>
+                  <span className="block text-[12px] leading-[1.4] text-[#5b6472] dark:text-[#9aa6b6]">
+                    GPS can be off by a few meters — drag the pin to your door.
+                  </span>
+                </span>
+              </button>
+            ) : null}
+
+            {editingPlace ? (
+              <div className="space-y-2.5 [animation:saveLocFadeIn_.2s_ease-out_both]">
+                <label
+                  htmlFor="saved-location-place-search"
+                  className="block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  Search for another place
+                </label>
+                <div className="relative">
+                  <Search
+                    className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#8b93a1]"
+                    aria-hidden
+                  />
+                  <input
+                    id="saved-location-place-search"
+                    type="search"
+                    value={placeQuery}
+                    onChange={(event) => setPlaceQuery(event.target.value)}
                     disabled={interactionBusy}
-                    className="flex min-h-11 w-full items-start gap-2 rounded-xl px-3 py-2.5 text-left text-[14px] font-medium text-[#273142] hover:bg-black/[0.04] disabled:opacity-45 dark:text-[#dce5f2] dark:hover:bg-white/[0.06]"
-                  >
-                    <MapPin
-                      className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--app-accent,#087ff5)]"
-                      aria-hidden
+                    autoComplete="off"
+                    placeholder="Search address or place"
+                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white pl-10 pr-10 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  />
+                  {placeSearching || changingPlace ? (
+                    <Loader2
+                      className="absolute right-3.5 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-[#8b93a1]"
+                      aria-label="Searching places"
                     />
-                    <span>{suggestion.text}</span>
-                  </button>
-                ))}
+                  ) : null}
+                </div>
+
+                {placeSuggestions.length > 0 ? (
+                  <div
+                    className="max-h-40 overflow-y-auto rounded-2xl border border-black/[0.08] bg-white p-1 shadow-sm dark:border-white/[0.1] dark:bg-[#1b2230]"
+                    aria-label="Location suggestions"
+                  >
+                    {placeSuggestions.map((suggestion) => (
+                      <button
+                        key={suggestion.placeId}
+                        type="button"
+                        onClick={() => void handleSelectPlace(suggestion.placeId)}
+                        disabled={interactionBusy}
+                        className="flex min-h-11 w-full items-start gap-2 rounded-xl px-3 py-2.5 text-left text-[14px] font-medium text-[#273142] hover:bg-black/[0.04] disabled:opacity-45 dark:text-[#dce5f2] dark:hover:bg-white/[0.06]"
+                      >
+                        <MapPin
+                          className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--app-accent,#087ff5)]"
+                          aria-hidden
+                        />
+                        <span>{suggestion.text}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+
+                {placeSearchError ? (
+                  <p
+                    role="alert"
+                    className="text-[12px] font-medium text-[#b42318] dark:text-[#ff9b91]"
+                  >
+                    {placeSearchError}
+                  </p>
+                ) : null}
+
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingPlace(false);
+                    setPlaceQuery("");
+                    setPlaceSuggestions([]);
+                    setPlaceSearchError(null);
+                  }}
+                  disabled={interactionBusy}
+                  className="text-[13px] font-semibold text-[#5b6472] disabled:opacity-45 dark:text-[#9aa6b6]"
+                >
+                  Keep current location
+                </button>
               </div>
             ) : null}
 
-            {placeSearchError ? (
-              <p
-                role="alert"
-                className="text-[12px] font-medium text-[#b42318] dark:text-[#ff9b91]"
-              >
-                {placeSearchError}
+            <div>
+              <p className="mb-2 text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+                What kind of place is this?
               </p>
+              <div className="grid grid-cols-3 gap-2.5">
+                {CATEGORY_OPTIONS.map(({ category: value, label, Icon }) => {
+                  const selected = category === value;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => setCategory(value)}
+                      disabled={interactionBusy}
+                      className={cn(
+                        "press-scale flex flex-col items-center justify-center gap-2 rounded-2xl border-2 px-2 py-4 transition-colors disabled:opacity-45",
+                        selected
+                          ? "border-[color:var(--app-accent,#087ff5)] bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent-deep,#0b62c4)] dark:bg-[color:var(--app-accent,#087ff5)]/15"
+                          : "border-black/[0.08] bg-white text-[#4b5563] hover:border-black/20 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-[#aeb8c7]",
+                      )}
+                    >
+                      <Icon className="h-6 w-6" strokeWidth={2.1} />
+                      <span className="text-[13px] font-bold">{label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {category === "other" ? (
+              <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
+                <label
+                  htmlFor="saved-location-custom-label"
+                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  Give it a name
+                </label>
+                <input
+                  id="saved-location-custom-label"
+                  type="text"
+                  value={customLabel}
+                  onChange={(event) => setCustomLabel(event.target.value)}
+                  disabled={interactionBusy}
+                  maxLength={40}
+                  placeholder="e.g. Gym, Mom's house, Cafe"
+                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                />
+              </div>
             ) : null}
 
-            <button
-              type="button"
-              onClick={() => {
-                setEditingPlace(false);
-                setPlaceQuery("");
-                setPlaceSuggestions([]);
-                setPlaceSearchError(null);
-              }}
-              disabled={interactionBusy}
-              className="text-[13px] font-semibold text-[#5b6472] disabled:opacity-45 dark:text-[#9aa6b6]"
-            >
-              Keep current location
-            </button>
-          </div>
-        ) : null}
-
-        <div>
-          <p className="mb-2 text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
-            What kind of place is this?
-          </p>
-          <div className="grid grid-cols-3 gap-2.5">
-            {CATEGORY_OPTIONS.map(({ category: value, label, Icon }) => {
-              const selected = category === value;
-              return (
-                <button
-                  key={value}
-                  type="button"
-                  aria-pressed={selected}
-                  onClick={() => setCategory(value)}
-                  disabled={interactionBusy}
-                  className={cn(
-                    "press-scale flex flex-col items-center justify-center gap-2 rounded-2xl border-2 px-2 py-4 transition-colors disabled:opacity-45",
-                    selected
-                      ? "border-[color:var(--app-accent,#087ff5)] bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent-deep,#0b62c4)] dark:bg-[color:var(--app-accent,#087ff5)]/15"
-                      : "border-black/[0.08] bg-white text-[#4b5563] hover:border-black/20 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-[#aeb8c7]",
-                  )}
-                >
-                  <Icon className="h-6 w-6" strokeWidth={2.1} />
-                  <span className="text-[13px] font-bold">{label}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {category === "other" ? (
-          <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
-            <label
-              htmlFor="saved-location-custom-label"
-              className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
-            >
-              Give it a name
-            </label>
-            <input
-              id="saved-location-custom-label"
-              type="text"
-              value={customLabel}
-              onChange={(event) => setCustomLabel(event.target.value)}
-              disabled={interactionBusy}
-              maxLength={40}
-              placeholder="e.g. Gym, Mom's house, Cafe"
-              className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
-            />
-          </div>
-        ) : null}
-
-        <div className="mt-1 flex flex-col gap-2.5">
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={!canSave}
-            aria-busy={saving || undefined}
-            className={cn(
-              "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
-              "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
-            )}
-          >
-            {saving ? (
-              <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
-            ) : (
-              <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
-            )}
-            Save location
-          </button>
-          <button
-            type="button"
-            onClick={onSkip}
-            disabled={interactionBusy}
-            className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
-          >
-            Skip for now
-          </button>
-        </div>
+            <div className="mt-1 flex flex-col gap-2.5">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSave}
+                aria-busy={saving || undefined}
+                className={cn(
+                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+                  "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+                )}
+              >
+                {saving ? (
+                  <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+                ) : (
+                  <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
+                )}
+                Save location
+              </button>
+              <button
+                type="button"
+                onClick={onSkip}
+                disabled={interactionBusy}
+                className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+              >
+                Skip for now
+              </button>
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -61,8 +61,17 @@ export type SaveLocationModalProps = {
   startWithMapPicker?: boolean;
   /** Follow pin confirmation with the complete entrance/address detail step. */
   collectAddressDetails?: boolean;
+  /** Pre-select a category when editing an existing saved place. */
+  initialCategory?: SavedLocationCategory | null;
+  /** Pre-fill the custom label (for an "Other" place) when editing. */
+  initialCustomLabel?: string | null;
+  /** Pre-fill the structured address detail fields when editing. */
+  initialDetails?: SavedLocationAddressDetails | null;
+  /** Copy shown on the primary action button (e.g. "Save" vs "Update"). */
+  saveLabel?: string;
   /** Explain that a pre-vault draft is held only for the active setup session. */
   deferredUntilVault?: boolean;
+
   /** Accuracy reported for the initial device fix, never persisted or displayed raw. */
   initialAccuracyM?: number | null;
   /** Existing durable acceptance of the shared Google Maps renderer disclosure. */
@@ -151,8 +160,13 @@ export function SaveLocationModal({
   onPickExactLocation,
   startWithMapPicker = false,
   collectAddressDetails = false,
+  initialCategory = null,
+  initialCustomLabel = null,
+  initialDetails = null,
+  saveLabel = "Save location",
   deferredUntilVault = false,
   initialAccuracyM = null,
+
   rendererDisclosureAccepted = false,
   onAcceptRendererDisclosure,
   onSave,
@@ -182,15 +196,26 @@ export function SaveLocationModal({
   const detailsTitleRef = useRef<HTMLHeadingElement | null>(null);
   const postalCodeEditedRef = useRef(false);
 
-  // Reset internal selection each time the modal (re)opens.
+  // Reset internal selection each time the modal (re)opens. When editing an
+  // existing saved place, seed the category/label/detail fields from the
+  // provided initial values so the same add flow doubles as an update flow.
   useEffect(() => {
     if (open) {
-      postalCodeEditedRef.current = false;
-      setCategory(null);
-      setCustomLabel("");
+      // Treat provided initial details (edit mode) as already user-authored so
+      // the inferred-postal effect does not clobber them.
+      postalCodeEditedRef.current = Boolean(
+        initialDetails &&
+          (initialDetails.postalCode || initialDetails.houseOrFlat),
+      );
+      setCategory(initialCategory ?? null);
+      setCustomLabel(initialCustomLabel ?? "");
       setEditingPlace(false);
       setPickedAddress(null);
-      setAddressDetails({ ...EMPTY_SAVED_LOCATION_ADDRESS_DETAILS });
+      setAddressDetails(
+        initialDetails
+          ? { ...EMPTY_SAVED_LOCATION_ADDRESS_DETAILS, ...initialDetails }
+          : { ...EMPTY_SAVED_LOCATION_ADDRESS_DETAILS },
+      );
       setPlaceQuery("");
       setPlaceSuggestions([]);
       setPlaceSearching(false);
@@ -198,7 +223,11 @@ export function SaveLocationModal({
       setSelectingPlaceId(null);
       setRendererDisclosureReady(false);
     }
+    // Initial* props are read once per open; excluded to avoid mid-session
+    // resets while the modal is open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
 
   useEffect(() => {
     if (!open || !editingPlace || !onSearchPlaces) return;
@@ -645,7 +674,7 @@ export function SaveLocationModal({
                 ) : (
                   <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
                 )}
-                Save location
+                {saveLabel}
               </button>
               <button
                 type="button"
@@ -658,6 +687,7 @@ export function SaveLocationModal({
             </div>
           </>
         ) : (
+
           <>
             <button
               type="button"
@@ -870,7 +900,7 @@ export function SaveLocationModal({
                 ) : (
                   <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
                 )}
-                Save location
+                {saveLabel}
               </button>
               <button
                 type="button"
@@ -883,6 +913,7 @@ export function SaveLocationModal({
             </div>
           </>
         )}
+
       </DialogContent>
     </Dialog>
   );

--- a/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
+++ b/hushh-webapp/components/one-location/onboarding/save-location-modal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import {
+  ArrowLeft,
   Briefcase,
   Check,
   Home,
@@ -13,17 +14,20 @@ import {
   X,
 } from "lucide-react";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   LocationPickerMap,
   type PickedLocation,
 } from "@/components/one-location/onboarding/location-picker-map";
 import { cn } from "@/lib/utils";
 import type { SavedLocationCategory } from "@/lib/one-location/saved-locations";
+import {
+  EMPTY_SAVED_LOCATION_ADDRESS_DETAILS,
+  inferPostalCode,
+  isValidPostalCode,
+  normalizeSavedLocationAddressDetails,
+  type SavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
 
 export type SavedLocationPlaceSuggestion = {
   placeId: string;
@@ -39,25 +43,41 @@ export type SaveLocationModalProps = {
   /** True while a save is in flight. */
   saving?: boolean;
   /** Authenticated Maps search; selected place details replace point + copy. */
-  onSearchPlaces?: (
-    input: string,
-  ) => Promise<SavedLocationPlaceSuggestion[]>;
+  onSearchPlaces?: (input: string) => Promise<SavedLocationPlaceSuggestion[]>;
   onSelectPlace?: (placeId: string) => Promise<void>;
   /**
    * Current captured coordinate used to seed the drag-to-pin map picker. When
    * provided together with `onPickExactLocation`, an "Adjust on map" action lets
-   * the owner place their EXACT spot instead of trusting the coarse GPS fix.
+   * the owner confirm their entrance instead of trusting the coarse GPS fix.
    */
   mapInitial?: { latitude: number; longitude: number } | null;
   /** Server reverse-geocode so the picker keeps the address synced to the pin. */
   reverseGeocode?: (lat: number, lng: number) => Promise<string | null>;
   /** Recenter the picker on the live device GPS fix. */
   onLocateMe?: () => Promise<{ latitude: number; longitude: number } | null>;
-  /** Commit the precise coordinate + address chosen on the map. */
+  /** Commit the owner-confirmed coordinate + address chosen on the map. */
   onPickExactLocation?: (picked: PickedLocation) => void;
-  onSave: (category: SavedLocationCategory, label: string) => void;
+  /** Open directly on the map instead of making the owner find an extra CTA. */
+  startWithMapPicker?: boolean;
+  /** Follow pin confirmation with the complete entrance/address detail step. */
+  collectAddressDetails?: boolean;
+  /** Explain that a pre-vault draft is held only for the active setup session. */
+  deferredUntilVault?: boolean;
+  /** Accuracy reported for the initial device fix, never persisted or displayed raw. */
+  initialAccuracyM?: number | null;
+  /** Existing durable acceptance of the shared Google Maps renderer disclosure. */
+  rendererDisclosureAccepted?: boolean;
+  /** Persist renderer acceptance when vault authority exists. */
+  onAcceptRendererDisclosure?: () => Promise<void>;
+  onSave: (
+    category: SavedLocationCategory,
+    label: string,
+    details?: SavedLocationAddressDetails,
+  ) => void;
   onSkip: () => void;
 };
+
+type SaveLocationFlowStep = "summary" | "map" | "details";
 
 const CATEGORY_OPTIONS: {
   category: SavedLocationCategory;
@@ -68,6 +88,47 @@ const CATEGORY_OPTIONS: {
   { category: "work", label: "Work", Icon: Briefcase },
   { category: "other", label: "Other", Icon: MapPin },
 ];
+
+function SavedLocationCategoryPicker({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: SavedLocationCategory | null;
+  disabled: boolean;
+  onChange: (category: SavedLocationCategory) => void;
+}) {
+  return (
+    <div role="group" aria-label="Saved location category">
+      <p className="mb-2 text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
+        What kind of place is this?
+      </p>
+      <div className="grid grid-cols-3 gap-2.5">
+        {CATEGORY_OPTIONS.map(({ category, label, Icon }) => {
+          const selected = value === category;
+          return (
+            <button
+              key={category}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => onChange(category)}
+              disabled={disabled}
+              className={cn(
+                "press-scale flex min-h-[88px] flex-col items-center justify-center gap-2 rounded-2xl border-2 px-2 py-3 transition-colors disabled:opacity-45",
+                selected
+                  ? "border-[color:var(--app-accent,#087ff5)] bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent-deep,#0b62c4)] dark:bg-[color:var(--app-accent,#087ff5)]/15"
+                  : "border-black/[0.08] bg-white text-[#4b5563] hover:border-black/20 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-[#aeb8c7]",
+              )}
+            >
+              <Icon className="h-6 w-6" strokeWidth={2.1} aria-hidden />
+              <span className="text-[13px] font-bold">{label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 /**
  * SaveLocationModal — a focused, responsive prompt shown during Location
@@ -88,13 +149,22 @@ export function SaveLocationModal({
   reverseGeocode,
   onLocateMe,
   onPickExactLocation,
+  startWithMapPicker = false,
+  collectAddressDetails = false,
+  deferredUntilVault = false,
+  initialAccuracyM = null,
+  rendererDisclosureAccepted = false,
+  onAcceptRendererDisclosure,
   onSave,
   onSkip,
 }: SaveLocationModalProps) {
   const [category, setCategory] = useState<SavedLocationCategory | null>(null);
   const [customLabel, setCustomLabel] = useState("");
   const [editingPlace, setEditingPlace] = useState(false);
-  const [pickingOnMap, setPickingOnMap] = useState(false);
+  const [flowStep, setFlowStep] = useState<SaveLocationFlowStep>("summary");
+  const [pickedAddress, setPickedAddress] = useState<string | null>(null);
+  const [addressDetails, setAddressDetails] =
+    useState<SavedLocationAddressDetails>(EMPTY_SAVED_LOCATION_ADDRESS_DETAILS);
   const [placeQuery, setPlaceQuery] = useState("");
   const [placeSuggestions, setPlaceSuggestions] = useState<
     SavedLocationPlaceSuggestion[]
@@ -102,20 +172,31 @@ export function SaveLocationModal({
   const [placeSearching, setPlaceSearching] = useState(false);
   const [placeSearchError, setPlaceSearchError] = useState<string | null>(null);
   const [selectingPlaceId, setSelectingPlaceId] = useState<string | null>(null);
+  const [rendererDisclosureReady, setRendererDisclosureReady] = useState(
+    rendererDisclosureAccepted,
+  );
+  const rendererReady = rendererDisclosureReady || rendererDisclosureAccepted;
   const descriptionId = useId();
+  const postalCodeErrorId = useId();
+  const mapTitleRef = useRef<HTMLHeadingElement | null>(null);
+  const detailsTitleRef = useRef<HTMLHeadingElement | null>(null);
+  const postalCodeEditedRef = useRef(false);
 
   // Reset internal selection each time the modal (re)opens.
   useEffect(() => {
     if (open) {
+      postalCodeEditedRef.current = false;
       setCategory(null);
       setCustomLabel("");
       setEditingPlace(false);
-      setPickingOnMap(false);
+      setPickedAddress(null);
+      setAddressDetails({ ...EMPTY_SAVED_LOCATION_ADDRESS_DETAILS });
       setPlaceQuery("");
       setPlaceSuggestions([]);
       setPlaceSearching(false);
       setPlaceSearchError(null);
       setSelectingPlaceId(null);
+      setRendererDisclosureReady(false);
     }
   }, [open]);
 
@@ -163,16 +244,52 @@ export function SaveLocationModal({
   const canEditPlace = Boolean(onSearchPlaces && onSelectPlace);
   const canPickOnMap = Boolean(
     onPickExactLocation &&
-      mapInitial &&
-      Number.isFinite(mapInitial.latitude) &&
-      Number.isFinite(mapInitial.longitude),
+    mapInitial &&
+    Number.isFinite(mapInitial.latitude) &&
+    Number.isFinite(mapInitial.longitude),
   );
+  useEffect(() => {
+    if (!open) return;
+    if (startWithMapPicker && canPickOnMap) {
+      setFlowStep("map");
+      return;
+    }
+    setFlowStep(collectAddressDetails ? "details" : "summary");
+  }, [canPickOnMap, collectAddressDetails, open, startWithMapPicker]);
+
+  useEffect(() => {
+    if (!open) return;
+    const next = (address && address.trim()) || null;
+    if (next) setPickedAddress(next);
+    setAddressDetails((current) =>
+      postalCodeEditedRef.current
+        ? current
+        : { ...current, postalCode: inferPostalCode(next) },
+    );
+  }, [address, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const title =
+      flowStep === "map"
+        ? mapTitleRef.current
+        : flowStep === "details"
+          ? detailsTitleRef.current
+          : null;
+    title?.focus({ preventScroll: true });
+  }, [flowStep, open, rendererReady]);
+
+  const normalizedAddressDetails =
+    normalizeSavedLocationAddressDetails(addressDetails);
+  const detailsComplete =
+    normalizedAddressDetails.houseOrFlat.length > 0 &&
+    isValidPostalCode(normalizedAddressDetails.postalCode);
   const canSave =
     category !== null &&
     !saving &&
     !loadingAddress &&
     !editingPlace &&
-    !pickingOnMap &&
+    flowStep !== "map" &&
     !changingPlace;
 
   const handleSelectPlace = async (placeId: string) => {
@@ -193,14 +310,40 @@ export function SaveLocationModal({
 
   const handleConfirmMapPick = (picked: PickedLocation) => {
     onPickExactLocation?.(picked);
-    setPickingOnMap(false);
+    setPickedAddress(picked.address);
+    setAddressDetails((current) => ({
+      ...current,
+      postalCode: postalCodeEditedRef.current
+        ? current.postalCode
+        : inferPostalCode(picked.address),
+    }));
+    setFlowStep(collectAddressDetails ? "details" : "summary");
+  };
+
+  const handleAcceptRendererDisclosure = async () => {
+    await onAcceptRendererDisclosure?.();
+    setRendererDisclosureReady(true);
   };
 
   const handleSave = () => {
-    if (!category || !canSave) return;
+    if (!category || !canSave || (collectAddressDetails && !detailsComplete)) {
+      return;
+    }
     const label =
       category === "other" ? customLabel.trim() || "Other" : undefined;
+    if (collectAddressDetails) {
+      onSave(category, label ?? "", normalizedAddressDetails);
+      return;
+    }
     onSave(category, label ?? "");
+  };
+
+  const updateAddressDetail = (
+    key: keyof SavedLocationAddressDetails,
+    value: string,
+  ) => {
+    if (key === "postalCode") postalCodeEditedRef.current = true;
+    setAddressDetails((current) => ({ ...current, [key]: value }));
   };
 
   return (
@@ -217,37 +360,302 @@ export function SaveLocationModal({
         aria-describedby={descriptionId}
         overlayClassName="z-[559] bg-black/45 backdrop-blur-[6px]"
         onEscapeKeyDown={(event) => {
-          if (interactionBusy || pickingOnMap) event.preventDefault();
+          if (interactionBusy) event.preventDefault();
         }}
         onPointerDownOutside={(event) => {
-          if (interactionBusy || pickingOnMap) event.preventDefault();
+          if (interactionBusy || flowStep === "map") event.preventDefault();
         }}
         className={cn(
-          "z-[560] bottom-0 top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
+          "z-[560] bottom-[var(--kb-height,0px)] top-auto max-h-[min(92dvh,760px)] w-full max-w-[420px] translate-y-0 gap-5 overflow-y-auto",
           "rounded-b-none rounded-t-[28px] sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%] sm:rounded-[24px]",
           "border border-black/[0.06] bg-white p-6 pb-[calc(env(safe-area-inset-bottom,0px)+22px)] sm:pb-6",
           "shadow-[0_-8px_40px_rgba(16,24,40,0.18)] sm:shadow-[0_20px_60px_rgba(16,24,40,0.24)]",
           "dark:border-white/[0.08] dark:bg-[#141922]",
         )}
       >
-        {pickingOnMap && canPickOnMap ? (
+        {flowStep === "map" && canPickOnMap ? (
           <>
-            <DialogTitle className="sr-only">
-              Pin your exact location
+            <DialogTitle ref={mapTitleRef} tabIndex={-1} className="sr-only">
+              {rendererReady ? "Pin your entrance" : "Before Google Maps opens"}
             </DialogTitle>
             <p id={descriptionId} className="sr-only">
-              Drag the map so the centre pin sits on your exact spot, then
-              confirm.
+              {rendererReady
+                ? "Step one of two. Move the map so the centre pin sits on your entrance, then confirm it."
+                : "Review how Google Maps uses the selected point before opening the map."}
             </p>
+            {collectAddressDetails ? (
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+                Step 1 of 2
+              </p>
+            ) : null}
             <LocationPickerMap
               initialLatitude={mapInitial!.latitude}
               initialLongitude={mapInitial!.longitude}
-              initialAddress={resolvedAddress}
+              initialAddress={pickedAddress || resolvedAddress}
+              initialAccuracyM={initialAccuracyM}
               reverseGeocode={reverseGeocode}
               onLocateMe={onLocateMe}
               onConfirm={handleConfirmMapPick}
-              onCancel={() => setPickingOnMap(false)}
+              onCancel={() => {
+                if (startWithMapPicker) {
+                  onSkip();
+                  return;
+                }
+                setFlowStep("summary");
+              }}
+              rendererDisclosureAccepted={rendererReady}
+              onAcceptRendererDisclosure={handleAcceptRendererDisclosure}
+              confirmLabel={
+                collectAddressDetails ? "Confirm pin" : "Confirm location"
+              }
+              cancelLabel={startWithMapPicker ? "Skip for now" : "Cancel"}
             />
+          </>
+        ) : flowStep === "details" && collectAddressDetails ? (
+          <>
+            <button
+              type="button"
+              onClick={() =>
+                canPickOnMap ? setFlowStep("map") : setFlowStep("summary")
+              }
+              disabled={interactionBusy}
+              aria-label={canPickOnMap ? "Back to map" : "Back"}
+              className="press-scale absolute left-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+            >
+              <ArrowLeft className="h-4.5 w-4.5" strokeWidth={2.4} />
+            </button>
+            <button
+              type="button"
+              onClick={onSkip}
+              disabled={interactionBusy}
+              aria-label="Close"
+              className="press-scale absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-black/[0.05] text-[#4b5563] transition-colors hover:bg-black/[0.08] disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#aeb8c7]"
+            >
+              <X className="h-4.5 w-4.5" strokeWidth={2.4} />
+            </button>
+
+            <header className="px-9 text-center">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
+                Step 2 of 2
+              </p>
+              <DialogTitle
+                ref={detailsTitleRef}
+                tabIndex={-1}
+                className="mt-2 text-[22px] font-bold leading-[1.15] tracking-[-0.01em] text-[#0b1220] outline-none dark:text-[#f4f7fb]"
+              >
+                Add your address details
+              </DialogTitle>
+              <p
+                id={descriptionId}
+                className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
+              >
+                The pin tells One where. These details make the entrance easy to
+                recognise.
+              </p>
+            </header>
+
+            <div className="flex items-start gap-2.5 rounded-2xl bg-[#f4f6fa] px-3.5 py-3 dark:bg-white/[0.05]">
+              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-[color:var(--app-accent,#087ff5)] shadow-sm dark:bg-[#1c2430]">
+                <MapPin className="h-4 w-4" strokeWidth={2.4} aria-hidden />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.04em] text-[#8b93a1] dark:text-[#7f8a99]">
+                  Pinned location
+                </p>
+                <p className="mt-0.5 line-clamp-2 text-[13px] font-semibold leading-[1.35] text-[#111827] dark:text-[#e9eef7]">
+                  {pickedAddress ||
+                    resolvedAddress ||
+                    "Your selected map point"}
+                </p>
+              </div>
+              {canPickOnMap ? (
+                <button
+                  type="button"
+                  onClick={() => setFlowStep("map")}
+                  disabled={interactionBusy}
+                  className="press-scale shrink-0 rounded-full bg-white px-2.5 py-1.5 text-[12px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] shadow-sm disabled:opacity-45 dark:bg-white/[0.08] dark:text-[#9bc7f5]"
+                >
+                  Edit pin
+                </button>
+              ) : null}
+            </div>
+
+            <div className="space-y-3.5">
+              <div>
+                <label
+                  htmlFor="saved-location-house-or-flat"
+                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  House, flat, floor or block
+                </label>
+                <input
+                  id="saved-location-house-or-flat"
+                  type="text"
+                  value={addressDetails.houseOrFlat}
+                  onChange={(event) =>
+                    updateAddressDetail("houseOrFlat", event.target.value)
+                  }
+                  disabled={interactionBusy}
+                  required
+                  maxLength={80}
+                  autoComplete={deferredUntilVault ? "off" : "address-line1"}
+                  placeholder="e.g. Flat 4B, Tower 2"
+                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                />
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <label
+                    htmlFor="saved-location-building-color"
+                    className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  >
+                    Building colour{" "}
+                    <span className="font-normal">(optional)</span>
+                  </label>
+                  <input
+                    id="saved-location-building-color"
+                    type="text"
+                    value={addressDetails.buildingColor}
+                    onChange={(event) =>
+                      updateAddressDetail("buildingColor", event.target.value)
+                    }
+                    disabled={interactionBusy}
+                    maxLength={40}
+                    autoComplete="off"
+                    placeholder="e.g. Blue gate"
+                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  />
+                </div>
+                <div>
+                  <label
+                    htmlFor="saved-location-postal-code"
+                    className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                  >
+                    PIN / postal code
+                  </label>
+                  <input
+                    id="saved-location-postal-code"
+                    type="text"
+                    value={addressDetails.postalCode}
+                    onChange={(event) =>
+                      updateAddressDetail("postalCode", event.target.value)
+                    }
+                    disabled={interactionBusy}
+                    required
+                    maxLength={12}
+                    inputMode="text"
+                    autoComplete={deferredUntilVault ? "off" : "postal-code"}
+                    aria-describedby={
+                      addressDetails.postalCode.length > 0 &&
+                      !isValidPostalCode(addressDetails.postalCode)
+                        ? postalCodeErrorId
+                        : undefined
+                    }
+                    aria-invalid={
+                      addressDetails.postalCode.length > 0 &&
+                      !isValidPostalCode(addressDetails.postalCode)
+                    }
+                    placeholder="e.g. 560001"
+                    className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 aria-[invalid=true]:border-[#d92d20] dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                  />
+                  {addressDetails.postalCode.length > 0 &&
+                  !isValidPostalCode(addressDetails.postalCode) ? (
+                    <p
+                      id={postalCodeErrorId}
+                      role="alert"
+                      className="mt-1.5 text-[12px] font-medium text-[#b42318] dark:text-[#ff9b91]"
+                    >
+                      Enter a valid PIN or postal code.
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="saved-location-landmark"
+                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  Nearby landmark{" "}
+                  <span className="font-normal">(optional)</span>
+                </label>
+                <input
+                  id="saved-location-landmark"
+                  type="text"
+                  value={addressDetails.landmark}
+                  onChange={(event) =>
+                    updateAddressDetail("landmark", event.target.value)
+                  }
+                  disabled={interactionBusy}
+                  maxLength={100}
+                  autoComplete={deferredUntilVault ? "off" : "address-line2"}
+                  placeholder="e.g. Opposite City Mall"
+                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                />
+              </div>
+            </div>
+
+            <SavedLocationCategoryPicker
+              value={category}
+              disabled={interactionBusy}
+              onChange={setCategory}
+            />
+
+            {category === "other" ? (
+              <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
+                <label
+                  htmlFor="saved-location-details-custom-label"
+                  className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
+                >
+                  Give it a name <span className="font-normal">(optional)</span>
+                </label>
+                <input
+                  id="saved-location-details-custom-label"
+                  type="text"
+                  value={customLabel}
+                  onChange={(event) => setCustomLabel(event.target.value)}
+                  disabled={interactionBusy}
+                  maxLength={40}
+                  placeholder="e.g. Gym, parents' house"
+                  className="h-12 w-full rounded-2xl border border-black/[0.1] bg-white px-4 text-[15px] text-[#111827] outline-none transition-colors placeholder:text-[#9aa2b0] focus:border-[color:var(--app-accent,#087ff5)] focus:ring-2 focus:ring-[color:var(--app-accent,#087ff5)]/25 dark:border-white/[0.12] dark:bg-white/[0.05] dark:text-[#e9eef7]"
+                />
+              </div>
+            ) : null}
+
+            <p className="rounded-2xl bg-[#f4f6fa] px-3.5 py-3 text-[12px] leading-[1.45] text-[#5b6472] dark:bg-white/[0.05] dark:text-[#9aa6b6]">
+              {deferredUntilVault
+                ? "Kept only for this setup session. One encrypts and saves it after your private vault is ready."
+                : "Saved in your private vault and shared only when you approve location access."}
+            </p>
+
+            <div className="sticky bottom-0 z-20 -mx-3 mt-1 flex flex-col gap-2.5 rounded-t-2xl border-t border-black/[0.06] bg-white/95 px-3 pb-1 pt-3 backdrop-blur dark:border-white/[0.08] dark:bg-[#141922]/95">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={!canSave || !detailsComplete}
+                aria-busy={saving || undefined}
+                className={cn(
+                  "press-scale flex h-[52px] w-full items-center justify-center gap-2 rounded-full text-[16px] font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-45",
+                  "bg-[color:var(--app-accent,#087ff5)] text-[color:var(--app-accent-fg,#ffffff)] hover:bg-[color:var(--app-accent-hover,#0b62c4)]",
+                )}
+              >
+                {saving ? (
+                  <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+                ) : (
+                  <Check className="h-5 w-5" strokeWidth={2.6} aria-hidden />
+                )}
+                Save location
+              </button>
+              <button
+                type="button"
+                onClick={onSkip}
+                disabled={interactionBusy}
+                className="h-11 w-full rounded-full text-[15px] font-semibold text-[#6b7280] transition-colors hover:text-[#374151] disabled:opacity-50 dark:text-[#9aa6b6] dark:hover:text-[#c4cdda]"
+              >
+                Skip for now
+              </button>
+            </div>
           </>
         ) : (
           <>
@@ -272,9 +680,9 @@ export function SaveLocationModal({
                 id={descriptionId}
                 className="mt-1.5 text-[14px] leading-[1.45] text-[#5b6472] dark:text-[#9aa6b6]"
               >
-                Tag where you are so One can personalise your experience. It stays
-                encrypted in your vault and is shared only when you approve
-                location access.
+                Tag where you are so One can personalise your experience. It
+                stays encrypted in your vault and is shared only when you
+                approve location access.
               </p>
             </header>
 
@@ -288,8 +696,8 @@ export function SaveLocationModal({
                 </p>
                 {loadingAddress ? (
                   <span className="mt-0.5 flex items-center gap-1.5 text-[13px] text-[#5b6472] dark:text-[#9aa6b6]">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Finding your
-                    address…
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" /> Finding
+                    your address…
                   </span>
                 ) : (
                   <p className="mt-0.5 truncate text-[14px] font-semibold text-[#111827] dark:text-[#e9eef7]">
@@ -319,7 +727,7 @@ export function SaveLocationModal({
             {canPickOnMap && !loadingAddress ? (
               <button
                 type="button"
-                onClick={() => setPickingOnMap(true)}
+                onClick={() => setFlowStep("map")}
                 disabled={interactionBusy}
                 data-testid="save-location-adjust-on-map"
                 className="press-scale flex w-full items-center gap-3 rounded-2xl border border-dashed border-[color:var(--app-accent,#087ff5)]/40 bg-[color:var(--app-accent-tint,#e7f0fd)]/50 px-3.5 py-3 text-left transition-colors hover:bg-[color:var(--app-accent-tint,#e7f0fd)] disabled:opacity-45 dark:border-[color:var(--app-accent,#087ff5)]/30 dark:bg-[color:var(--app-accent,#087ff5)]/10"
@@ -329,7 +737,7 @@ export function SaveLocationModal({
                 </span>
                 <span className="min-w-0 flex-1">
                   <span className="block text-[14px] font-bold text-[color:var(--app-accent-deep,#0b62c4)] dark:text-[#9bc7f5]">
-                    Set exact location on map
+                    Pin your entrance on the map
                   </span>
                   <span className="block text-[12px] leading-[1.4] text-[#5b6472] dark:text-[#9aa6b6]">
                     GPS can be off by a few meters — drag the pin to your door.
@@ -378,7 +786,9 @@ export function SaveLocationModal({
                       <button
                         key={suggestion.placeId}
                         type="button"
-                        onClick={() => void handleSelectPlace(suggestion.placeId)}
+                        onClick={() =>
+                          void handleSelectPlace(suggestion.placeId)
+                        }
                         disabled={interactionBusy}
                         className="flex min-h-11 w-full items-start gap-2 rounded-xl px-3 py-2.5 text-left text-[14px] font-medium text-[#273142] hover:bg-black/[0.04] disabled:opacity-45 dark:text-[#dce5f2] dark:hover:bg-white/[0.06]"
                       >
@@ -417,34 +827,11 @@ export function SaveLocationModal({
               </div>
             ) : null}
 
-            <div>
-              <p className="mb-2 text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]">
-                What kind of place is this?
-              </p>
-              <div className="grid grid-cols-3 gap-2.5">
-                {CATEGORY_OPTIONS.map(({ category: value, label, Icon }) => {
-                  const selected = category === value;
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      aria-pressed={selected}
-                      onClick={() => setCategory(value)}
-                      disabled={interactionBusy}
-                      className={cn(
-                        "press-scale flex flex-col items-center justify-center gap-2 rounded-2xl border-2 px-2 py-4 transition-colors disabled:opacity-45",
-                        selected
-                          ? "border-[color:var(--app-accent,#087ff5)] bg-[color:var(--app-accent-tint,#e7f0fd)] text-[color:var(--app-accent-deep,#0b62c4)] dark:bg-[color:var(--app-accent,#087ff5)]/15"
-                          : "border-black/[0.08] bg-white text-[#4b5563] hover:border-black/20 dark:border-white/[0.1] dark:bg-white/[0.04] dark:text-[#aeb8c7]",
-                      )}
-                    >
-                      <Icon className="h-6 w-6" strokeWidth={2.1} />
-                      <span className="text-[13px] font-bold">{label}</span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
+            <SavedLocationCategoryPicker
+              value={category}
+              disabled={interactionBusy}
+              onChange={setCategory}
+            />
 
             {category === "other" ? (
               <div className="[animation:saveLocFadeIn_.2s_ease-out_both]">
@@ -452,7 +839,7 @@ export function SaveLocationModal({
                   htmlFor="saved-location-custom-label"
                   className="mb-1.5 block text-[13px] font-semibold text-[#374151] dark:text-[#c4cdda]"
                 >
-                  Give it a name
+                  Give it a name <span className="font-normal">(optional)</span>
                 </label>
                 <input
                   id="saved-location-custom-label"

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -6,6 +6,7 @@ import {
   Home,
   Loader2,
   MapPin,
+  Pencil,
   Plus,
   RefreshCw,
   ShieldCheck,
@@ -20,6 +21,7 @@ import { useAuth } from "@/lib/firebase/auth-context";
 import {
   addSavedLocation,
   duplicateSavedLocationMessage,
+
   DuplicateSavedLocationError,
   findDuplicateSavedLocation,
   loadSavedLocations,
@@ -27,8 +29,15 @@ import {
   sortSavedLocationsForDisplay,
   type SavedLocation,
   type SavedLocationCategory,
+  updateSavedLocation,
   updateSavedLocationAddress,
 } from "@/lib/one-location/saved-locations";
+import {
+  buildSavedLocationAddress,
+  inferPostalCode,
+  type SavedLocationAddressDetails,
+} from "@/lib/one-location/saved-location-address";
+
 import { readOneLocationControlState } from "@/lib/one-location/location-control-state";
 import { OneLocationService } from "@/lib/one-location/service";
 import type { PlainLocationPoint } from "@/lib/one-location/types";
@@ -79,8 +88,14 @@ export function SavedLocationsSection() {
   const [saveLocationAddressLoading, setSaveLocationAddressLoading] =
     useState(false);
   const [saveLocationSaving, setSaveLocationSaving] = useState(false);
+  // When set, the modal is editing an existing saved place (Settings edit flow)
+  // instead of adding a new one. Holds the id + pre-fill values for the modal.
+  const [editingLocation, setEditingLocation] = useState<SavedLocation | null>(
+    null,
+  );
   const [rendererDisclosureAccepted, setRendererDisclosureAccepted] =
     useState(false);
+
   const vaultSessionRef = useRef({ userId, vaultKey, vaultOwnerToken });
   const captureRequestIdRef = useRef(0);
   const addressResolutionIdRef = useRef(0);
@@ -298,14 +313,30 @@ export function SavedLocationsSection() {
   ]);
 
   const handleSave = useCallback(
-    async (category: SavedLocationCategory, label: string) => {
+    async (
+      category: SavedLocationCategory,
+      label: string,
+      details?: SavedLocationAddressDetails,
+    ) => {
       if (!userId || !vaultKey || !vaultOwnerToken || !saveLocationPoint) {
         toast.error("Unlock your vault and capture the location again.");
         return;
       }
 
+      // Fold the structured entrance details into the single encrypted address
+      // string (same contract onboarding uses), so Home/Work/Other saved from
+      // Settings carry the house/flat, landmark and postal code too.
+      const composedAddress = details
+        ? buildSavedLocationAddress(saveLocationAddress, details)
+        : saveLocationAddress;
+
+      const editing = editingLocation;
+      // Only guard against a *different* saved place occupying the same spot.
+      // When editing, re-saving the same place must not trip the duplicate gate.
       const duplicate = findDuplicateSavedLocation(
-        locations,
+        editing
+          ? locations.filter((location) => location.id !== editing.id)
+          : locations,
         saveLocationPoint,
       );
       if (duplicate) {
@@ -316,22 +347,30 @@ export function SavedLocationsSection() {
       setSaveLocationSaving(true);
       const session = { userId, vaultKey, vaultOwnerToken };
       try {
-        const next = await addSavedLocation({
-          context: { userId, vaultKey, vaultOwnerToken },
-          input: {
-            category,
-            label,
-            latitude: saveLocationPoint.latitude,
-            longitude: saveLocationPoint.longitude,
-            address: saveLocationAddress,
-          },
-        });
+        const input = {
+          category,
+          label,
+          latitude: saveLocationPoint.latitude,
+          longitude: saveLocationPoint.longitude,
+          address: composedAddress,
+        };
+        const next = editing
+          ? await updateSavedLocation({
+              context: { userId, vaultKey, vaultOwnerToken },
+              id: editing.id,
+              input,
+            })
+          : await addSavedLocation({
+              context: { userId, vaultKey, vaultOwnerToken },
+              input,
+            });
         if (!isCurrentVaultSession(session)) return;
         addressResolutionIdRef.current += 1;
         setLocations(sortSavedLocationsForDisplay(next));
         setSaveLocationModalOpen(false);
         setSaveLocationPoint(null);
-        toast.success("Location saved securely.");
+        setEditingLocation(null);
+        toast.success(editing ? "Location updated." : "Location saved securely.");
       } catch (error) {
         if (!isCurrentVaultSession(session)) return;
         toast.error(
@@ -346,6 +385,7 @@ export function SavedLocationsSection() {
       }
     },
     [
+      editingLocation,
       saveLocationAddress,
       saveLocationPoint,
       locations,
@@ -355,6 +395,31 @@ export function SavedLocationsSection() {
       vaultOwnerToken,
     ],
   );
+
+  // Open the same add/pin/details flow pre-filled to EDIT an existing place.
+  const handleEditSavedLocation = useCallback(
+    (location: SavedLocation) => {
+      if (!hasVaultAccess) {
+        toast.error("Unlock your vault before editing a saved location.");
+        return;
+      }
+      addressResolutionIdRef.current += 1;
+      captureRequestIdRef.current += 1;
+      setEditingLocation(location);
+      setSaveLocationPoint({
+        latitude: location.latitude,
+        longitude: location.longitude,
+        accuracyM: null,
+        capturedAt: new Date().toISOString(),
+        sourcePlatform: "web",
+      });
+      setSaveLocationAddress(location.address ?? null);
+      setSaveLocationAddressLoading(false);
+      setSaveLocationModalOpen(true);
+    },
+    [hasVaultAccess],
+  );
+
 
   const handleRemove = useCallback(
     async (id: string) => {
@@ -592,11 +657,27 @@ export function SavedLocationsSection() {
                 ) : null}
                 <button
                   type="button"
+                  aria-label={`Edit ${location.label}`}
+                  title="Edit place"
+                  onClick={() => handleEditSavedLocation(location)}
+                  disabled={
+                    removingId !== null ||
+                    repairingId !== null ||
+                    capturing ||
+                    locationControl.paused
+                  }
+                  className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-black/[0.05] hover:text-[#087ff5] disabled:opacity-45 dark:text-muted-foreground"
+                >
+                  <Pencil className="h-[17px] w-[17px]" strokeWidth={2} />
+                </button>
+                <button
+                  type="button"
                   aria-label={`Remove ${location.label}`}
                   onClick={() => void handleRemove(location.id)}
                   disabled={removingId !== null}
                   className="press-scale flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-[#8b93a1] transition-colors hover:bg-[#ff3b30]/10 hover:text-[#ff3b30] disabled:opacity-45 dark:text-muted-foreground"
                 >
+
                   {removingId === location.id ? (
                     <Loader2 className="h-[18px] w-[18px] animate-spin" />
                   ) : (
@@ -634,7 +715,25 @@ export function SavedLocationsSection() {
         onPickExactLocation={handlePickExactSavedLocation}
         rendererDisclosureAccepted={rendererDisclosureAccepted}
         onAcceptRendererDisclosure={acceptSavedLocationMapRenderer}
-        onSave={(category, label) => void handleSave(category, label)}
+        collectAddressDetails
+        initialCategory={editingLocation?.category ?? null}
+        initialCustomLabel={
+          editingLocation?.category === "other" ? editingLocation.label : null
+        }
+        initialDetails={
+          editingLocation
+            ? {
+                houseOrFlat: "",
+                buildingColor: "",
+                landmark: "",
+                postalCode: inferPostalCode(editingLocation.address),
+              }
+            : null
+        }
+        saveLabel={editingLocation ? "Update location" : "Save location"}
+        onSave={(category, label, details) =>
+          void handleSave(category, label, details)
+        }
         onSkip={() => {
           if (saveLocationSaving) return;
           addressResolutionIdRef.current += 1;
@@ -642,8 +741,10 @@ export function SavedLocationsSection() {
           setSaveLocationPoint(null);
           setSaveLocationAddress(null);
           setSaveLocationAddressLoading(false);
+          setEditingLocation(null);
         }}
       />
+
     </>
   );
 }

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -14,6 +14,8 @@ import {
 import { toast } from "sonner";
 
 import { SaveLocationModal } from "@/components/one-location/onboarding/save-location-modal";
+import type { PickedLocation } from "@/components/one-location/onboarding/location-picker-map";
+import { GOOGLE_MAPS_RENDERER_CONSENT_VERSION } from "@/lib/one-location/map-renderer-consent";
 import { useAuth } from "@/lib/firebase/auth-context";
 import {
   addSavedLocation,
@@ -77,9 +79,41 @@ export function SavedLocationsSection() {
   const [saveLocationAddressLoading, setSaveLocationAddressLoading] =
     useState(false);
   const [saveLocationSaving, setSaveLocationSaving] = useState(false);
+  const [rendererDisclosureAccepted, setRendererDisclosureAccepted] =
+    useState(false);
   const vaultSessionRef = useRef({ userId, vaultKey, vaultOwnerToken });
   const captureRequestIdRef = useRef(0);
-  vaultSessionRef.current = { userId, vaultKey, vaultOwnerToken };
+  const addressResolutionIdRef = useRef(0);
+
+  // Keep a "latest session" ref so async callbacks can detect when the vault
+  // session changed mid-flight. Updated in an effect (not during render) to
+  // satisfy the react-hooks/refs rule.
+  useEffect(() => {
+    vaultSessionRef.current = { userId, vaultKey, vaultOwnerToken };
+  }, [userId, vaultKey, vaultOwnerToken]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setRendererDisclosureAccepted(false);
+    if (!vaultOwnerToken) return () => undefined;
+
+    void OneLocationService.getMapState(vaultOwnerToken)
+      .then((state) => {
+        if (cancelled) return;
+        setRendererDisclosureAccepted(
+          state.preferences.rendererConsentVersion ===
+            GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
+        );
+      })
+      .catch(() => {
+        // Fail closed: show the disclosure again when canonical state cannot
+        // be read instead of assuming a prior acceptance.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [vaultOwnerToken]);
 
   const hasVaultAccess = Boolean(
     isVaultUnlocked && vaultKey && vaultOwnerToken,
@@ -144,6 +178,7 @@ export function SavedLocationsSection() {
   useEffect(() => {
     if (hasVaultAccess) return;
     captureRequestIdRef.current += 1;
+    addressResolutionIdRef.current += 1;
     setLocations([]);
     setSaveLocationModalOpen(false);
     setSaveLocationPoint(null);
@@ -159,6 +194,7 @@ export function SavedLocationsSection() {
   useEffect(() => {
     if (!locationControl.paused) return;
     captureRequestIdRef.current += 1;
+    addressResolutionIdRef.current += 1;
     setCapturing(false);
     setSaveLocationModalOpen(false);
     setSaveLocationPoint(null);
@@ -178,6 +214,7 @@ export function SavedLocationsSection() {
       return;
     }
 
+    addressResolutionIdRef.current += 1;
     setCapturing(true);
     const captureRequestId = captureRequestIdRef.current + 1;
     captureRequestIdRef.current = captureRequestId;
@@ -195,6 +232,8 @@ export function SavedLocationsSection() {
       setSaveLocationAddress(null);
       setSaveLocationAddressLoading(true);
       setSaveLocationModalOpen(true);
+      const addressResolutionId = addressResolutionIdRef.current + 1;
+      addressResolutionIdRef.current = addressResolutionId;
 
       try {
         const place = await OneLocationService.reverseGeocode({
@@ -204,6 +243,7 @@ export function SavedLocationsSection() {
         });
         if (
           captureRequestIdRef.current !== captureRequestId ||
+          addressResolutionIdRef.current !== addressResolutionId ||
           !isCurrentVaultSession(session) ||
           readOneLocationControlState(userId).paused
         ) {
@@ -215,6 +255,7 @@ export function SavedLocationsSection() {
       } catch {
         if (
           captureRequestIdRef.current !== captureRequestId ||
+          addressResolutionIdRef.current !== addressResolutionId ||
           !isCurrentVaultSession(session)
         ) {
           return;
@@ -223,6 +264,7 @@ export function SavedLocationsSection() {
       } finally {
         if (
           captureRequestIdRef.current === captureRequestId &&
+          addressResolutionIdRef.current === addressResolutionId &&
           isCurrentVaultSession(session)
         ) {
           setSaveLocationAddressLoading(false);
@@ -257,12 +299,7 @@ export function SavedLocationsSection() {
 
   const handleSave = useCallback(
     async (category: SavedLocationCategory, label: string) => {
-      if (
-        !userId ||
-        !vaultKey ||
-        !vaultOwnerToken ||
-        !saveLocationPoint
-      ) {
+      if (!userId || !vaultKey || !vaultOwnerToken || !saveLocationPoint) {
         toast.error("Unlock your vault and capture the location again.");
         return;
       }
@@ -290,6 +327,7 @@ export function SavedLocationsSection() {
           },
         });
         if (!isCurrentVaultSession(session)) return;
+        addressResolutionIdRef.current += 1;
         setLocations(sortSavedLocationsForDisplay(next));
         setSaveLocationModalOpen(false);
         setSaveLocationPoint(null);
@@ -340,13 +378,7 @@ export function SavedLocationsSection() {
         }
       }
     },
-    [
-      isCurrentVaultSession,
-      removingId,
-      userId,
-      vaultKey,
-      vaultOwnerToken,
-    ],
+    [isCurrentVaultSession, removingId, userId, vaultKey, vaultOwnerToken],
   );
 
   const handleRepairAddress = useCallback(
@@ -361,11 +393,7 @@ export function SavedLocationsSection() {
           lng: location.longitude,
         });
         if (!isCurrentVaultSession(session)) return;
-        const address = (
-          place.formattedAddress ||
-          place.name ||
-          ""
-        ).trim();
+        const address = (place.formattedAddress || place.name || "").trim();
         if (!address) {
           toast.error("No street address was found for this location.");
           return;
@@ -387,14 +415,64 @@ export function SavedLocationsSection() {
         }
       }
     },
-    [
-      isCurrentVaultSession,
-      repairingId,
-      userId,
-      vaultKey,
-      vaultOwnerToken,
-    ],
+    [isCurrentVaultSession, repairingId, userId, vaultKey, vaultOwnerToken],
   );
+
+  // Drag-to-pin confirm: adopt the owner-confirmed coordinate and address,
+  // replacing the coarse GPS fix for the Settings "Add place" flow.
+  const handlePickExactSavedLocation = useCallback((picked: PickedLocation) => {
+    addressResolutionIdRef.current += 1;
+    setSaveLocationPoint((current) => ({
+      latitude: picked.latitude,
+      longitude: picked.longitude,
+      accuracyM: null,
+      capturedAt: new Date().toISOString(),
+      sourcePlatform: current?.sourcePlatform ?? "web",
+    }));
+    setSaveLocationAddress(picked.address);
+    setSaveLocationAddressLoading(false);
+  }, []);
+
+  // "Locate me" inside the map picker — re-center on a fresh GPS fix.
+  const locateMeForSavedLocation = useCallback(async () => {
+    try {
+      const point = await OneLocationService.captureCurrentPosition();
+      return { latitude: point.latitude, longitude: point.longitude };
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Reverse-geocode wrapper the map picker calls on every settle.
+  const reverseGeocodeForSavedLocation = useCallback(
+    async (lat: number, lng: number): Promise<string | null> => {
+      if (!vaultOwnerToken) return null;
+      try {
+        const place = await OneLocationService.reverseGeocode({
+          vaultOwnerToken,
+          lat,
+          lng,
+        });
+        return place.formattedAddress || place.name || null;
+      } catch {
+        return null;
+      }
+    },
+    [vaultOwnerToken],
+  );
+
+  const acceptSavedLocationMapRenderer = useCallback(async () => {
+    if (!vaultOwnerToken) {
+      throw new Error("Unlock your vault before opening Google Maps.");
+    }
+    const next = await OneLocationService.updateMapPreferences({
+      vaultOwnerToken,
+      rendererConsentVersion: GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
+    });
+    setRendererDisclosureAccepted(
+      next.rendererConsentVersion === GOOGLE_MAPS_RENDERER_CONSENT_VERSION,
+    );
+  }, [vaultOwnerToken]);
 
   if (!userId || loadedUserId !== userId) return null;
 
@@ -522,10 +600,7 @@ export function SavedLocationsSection() {
                   {removingId === location.id ? (
                     <Loader2 className="h-[18px] w-[18px] animate-spin" />
                   ) : (
-                    <Trash2
-                      className="h-[18px] w-[18px]"
-                      strokeWidth={2}
-                    />
+                    <Trash2 className="h-[18px] w-[18px]" strokeWidth={2} />
                   )}
                 </button>
               </div>
@@ -546,11 +621,27 @@ export function SavedLocationsSection() {
         address={saveLocationAddress}
         loadingAddress={saveLocationAddressLoading}
         saving={saveLocationSaving}
+        mapInitial={
+          saveLocationPoint
+            ? {
+                latitude: saveLocationPoint.latitude,
+                longitude: saveLocationPoint.longitude,
+              }
+            : null
+        }
+        reverseGeocode={reverseGeocodeForSavedLocation}
+        onLocateMe={locateMeForSavedLocation}
+        onPickExactLocation={handlePickExactSavedLocation}
+        rendererDisclosureAccepted={rendererDisclosureAccepted}
+        onAcceptRendererDisclosure={acceptSavedLocationMapRenderer}
         onSave={(category, label) => void handleSave(category, label)}
         onSkip={() => {
           if (saveLocationSaving) return;
+          addressResolutionIdRef.current += 1;
           setSaveLocationModalOpen(false);
           setSaveLocationPoint(null);
+          setSaveLocationAddress(null);
+          setSaveLocationAddressLoading(false);
         }}
       />
     </>

--- a/hushh-webapp/components/one-location/saved-locations-section.tsx
+++ b/hushh-webapp/components/one-location/saved-locations-section.tsx
@@ -716,7 +716,9 @@ export function SavedLocationsSection() {
         rendererDisclosureAccepted={rendererDisclosureAccepted}
         onAcceptRendererDisclosure={acceptSavedLocationMapRenderer}
         collectAddressDetails
+        startWithMapPicker
         initialCategory={editingLocation?.category ?? null}
+
         initialCustomLabel={
           editingLocation?.category === "other" ? editingLocation.label : null
         }

--- a/hushh-webapp/docs/one-location-now-and-map.md
+++ b/hushh-webapp/docs/one-location-now-and-map.md
@@ -71,6 +71,25 @@ Approximate native permission and fixes worse than 100 m fail before
 publication with an app-settings recovery path. Active rosters refresh on a
 15-second, visible-app cadence without extending the server expiry.
 
+## Saved location onboarding
+
+Every Location onboarding run offers the saved-place flow after foreground
+permission is ready. The owner first confirms an entrance with a centre-pin map,
+then supplies the house/flat/floor or block and PIN/postal code; building colour,
+landmark, and a custom **Other** label remain optional. Google Maps never
+initializes until the owner accepts the same versioned renderer disclosure used
+by **Your Map**. Moving the map invalidates the previous address and disables
+confirmation until the selected centre has finished resolving, so coordinates
+cannot be paired with stale address copy.
+
+Root setup deliberately precedes vault creation. Its confirmed place therefore
+stays only in process memory, address autofill is disabled, reload/sign-out
+discards it, and Skip clears it. Once setup creates and unlocks the vault, the
+existing finalization transaction writes the place through encrypted Location
+PKM. No bootstrap database, browser-storage record, vault schema, or plaintext
+fallback is introduced. Home and Work retain their singleton behavior, and the
+existing 25-metre cross-category duplicate guard remains authoritative.
+
 ## Your Map
 
 `/one/location/map` is an immersive private map. It suppresses the app top

--- a/hushh-webapp/lib/capacitor/plugins/location-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/location-web.ts
@@ -89,36 +89,118 @@ export class HushhLocationWeb implements HushhLocationPlugin {
 
     const timeoutMs = options?.timeoutMs ?? 15_000;
 
-    const attempt = (enableHighAccuracy: boolean) =>
-      new Promise<{
-        latitude: number;
-        longitude: number;
-        accuracyM: number | null;
-        capturedAt: string;
-        sourcePlatform: "web";
-      }>((resolve, reject) => {
+    type WebFix = {
+      latitude: number;
+      longitude: number;
+      accuracyM: number | null;
+      capturedAt: string;
+      sourcePlatform: "web";
+    };
+
+    // Accuracy (meters) at which we stop sampling early — a confident fix.
+    const TARGET_ACCURACY_M = 35;
+
+    const toFix = (position: GeolocationPosition): WebFix => ({
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+      accuracyM: Number.isFinite(position.coords.accuracy)
+        ? position.coords.accuracy
+        : null,
+      capturedAt: new Date(position.timestamp || Date.now()).toISOString(),
+      sourcePlatform: "web",
+    });
+
+    const isBetter = (candidate: WebFix, current: WebFix | null): boolean => {
+      if (!current) return true;
+      // Prefer a fix that reports accuracy over one that does not.
+      if (candidate.accuracyM == null) return false;
+      if (current.accuracyM == null) return true;
+      return candidate.accuracyM < current.accuracyM;
+    };
+
+    // Single-shot reader (used for the low-accuracy desktop fallback). Always
+    // requests a FRESH fix (maximumAge: 0) so a stale cached position from a
+    // previous place is never returned as "current location".
+    const readOnce = (enableHighAccuracy: boolean) =>
+      new Promise<WebFix>((resolve, reject) => {
         navigator.geolocation.getCurrentPosition(
-          (position) => {
-            resolve({
-              latitude: position.coords.latitude,
-              longitude: position.coords.longitude,
-              accuracyM: Number.isFinite(position.coords.accuracy)
-                ? position.coords.accuracy
-                : null,
-              capturedAt: new Date(
-                position.timestamp || Date.now(),
-              ).toISOString(),
-              sourcePlatform: "web",
-            });
-          },
+          (position) => resolve(toFix(position)),
           (error) => reject(error),
-          {
-            enableHighAccuracy,
-            timeout: timeoutMs,
-            maximumAge: 30_000,
-          },
+          { enableHighAccuracy, timeout: timeoutMs, maximumAge: 0 },
         );
       });
+
+    // Best-of-samples reader: collect fresh fixes via watchPosition for a short
+    // budget and return the most accurate one. This prevents the occasional
+    // wildly-off first reading (coarse network/IP fix or a stale cache) from
+    // being shown as the user's current location. Resolves early once a fix is
+    // accurate enough; otherwise returns the best sample seen when the budget
+    // elapses.
+    const sampleBest = (enableHighAccuracy: boolean, budgetMs: number) =>
+      new Promise<WebFix>((resolve, reject) => {
+        let best: WebFix | null = null;
+        let settled = false;
+        let watchId: number | null = null;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+
+        const cleanup = () => {
+          if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          if (watchId !== null) {
+            navigator.geolocation.clearWatch(watchId);
+            watchId = null;
+          }
+        };
+        const finish = (value: WebFix | null, error?: unknown) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          if (value) resolve(value);
+          else reject(error);
+        };
+
+        try {
+          watchId = navigator.geolocation.watchPosition(
+            (position) => {
+              const fix = toFix(position);
+              if (isBetter(fix, best)) best = fix;
+              if (
+                best?.accuracyM != null &&
+                best.accuracyM <= TARGET_ACCURACY_M
+              ) {
+                finish(best);
+              }
+            },
+            (error) => {
+              // Only a hard permission denial should abort sampling; transient
+              // unavailable/timeout errors are ignored so a later fix can land.
+              if ((error as GeolocationPositionError)?.code === 1) {
+                finish(null, error);
+              }
+            },
+            { enableHighAccuracy, timeout: budgetMs, maximumAge: 0 },
+          );
+        } catch (error) {
+          finish(null, error);
+          return;
+        }
+
+        timer = setTimeout(() => {
+          if (best) finish(best);
+          else finish(null, { code: 3 } as GeolocationPositionError);
+        }, budgetMs);
+      });
+
+    const attempt = (enableHighAccuracy: boolean) => {
+      if (!enableHighAccuracy) return readOnce(false);
+      // Sample within a bounded window (cap at 9s) so the picker stays snappy
+      // while still rejecting a single jumpy reading.
+      const budgetMs = Math.min(Math.max(timeoutMs, 1_000), 9_000);
+      return sampleBest(true, budgetMs);
+    };
+
 
     // The browser GeolocationPositionError codes: 1 = PERMISSION_DENIED,
     // 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT. Many desktops have no GPS, so a

--- a/hushh-webapp/lib/one-location/map-renderer-consent.ts
+++ b/hushh-webapp/lib/one-location/map-renderer-consent.ts
@@ -1,0 +1,5 @@
+/**
+ * One consent version shared by every surface that initializes Google Maps.
+ * A renderer may receive coordinates only after the owner accepts this version.
+ */
+export const GOOGLE_MAPS_RENDERER_CONSENT_VERSION = "google-maps-renderer-v1";

--- a/hushh-webapp/lib/one-location/saved-location-address.ts
+++ b/hushh-webapp/lib/one-location/saved-location-address.ts
@@ -1,0 +1,122 @@
+export type SavedLocationAddressDetails = {
+  houseOrFlat: string;
+  buildingColor: string;
+  landmark: string;
+  postalCode: string;
+};
+
+export const EMPTY_SAVED_LOCATION_ADDRESS_DETAILS: SavedLocationAddressDetails =
+  {
+    houseOrFlat: "",
+    buildingColor: "",
+    landmark: "",
+    postalCode: "",
+  };
+
+const MAX_HOUSE_OR_FLAT_LENGTH = 80;
+const MAX_BUILDING_COLOR_LENGTH = 40;
+const MAX_LANDMARK_LENGTH = 100;
+const MAX_POSTAL_CODE_LENGTH = 12;
+const MAX_SAVED_ADDRESS_LENGTH = 300;
+
+function cleanText(value: string, maxLength: number): string {
+  return value.trim().replace(/\s+/g, " ").slice(0, maxLength);
+}
+
+function comparable(value: string): string {
+  return value.toLocaleLowerCase().replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+function landmarkSegment(value: string): string {
+  if (!value) return "";
+  return /^(near|opposite|beside|behind|next to)\b/i.test(value)
+    ? value
+    : `Near ${value}`;
+}
+
+function buildingColorSegment(value: string): string {
+  if (!value) return "";
+  return /\b(building|house|gate|door|tower|block)\b/i.test(value)
+    ? value
+    : `${value} building`;
+}
+
+/** Extract a likely PIN/postal code for a helpful, editable form prefill. */
+export function inferPostalCode(address: string | null | undefined): string {
+  const value = String(address || "");
+  return (
+    value.match(/\b\d{6}\b/)?.[0] ??
+    value.match(/\b\d{5}(?:-\d{4})?\b/)?.[0] ??
+    ""
+  );
+}
+
+/**
+ * Accept the common global PIN/postal-code shapes without pretending that all
+ * countries use India's six-digit format. The field remains human-editable.
+ */
+export function isValidPostalCode(value: string): boolean {
+  const normalized = cleanText(value, MAX_POSTAL_CODE_LENGTH);
+  return (
+    normalized.length >= 3 &&
+    normalized.length <= MAX_POSTAL_CODE_LENGTH &&
+    /^[\p{L}\p{N}][\p{L}\p{N}\s-]*[\p{L}\p{N}]$/u.test(normalized)
+  );
+}
+
+export function normalizeSavedLocationAddressDetails(
+  details: SavedLocationAddressDetails,
+): SavedLocationAddressDetails {
+  return {
+    houseOrFlat: cleanText(details.houseOrFlat, MAX_HOUSE_OR_FLAT_LENGTH),
+    buildingColor: cleanText(details.buildingColor, MAX_BUILDING_COLOR_LENGTH),
+    landmark: cleanText(details.landmark, MAX_LANDMARK_LENGTH),
+    postalCode: cleanText(details.postalCode, MAX_POSTAL_CODE_LENGTH),
+  };
+}
+
+/**
+ * Compose the structured onboarding answers into the existing encrypted
+ * saved-place address contract. This deliberately avoids a second schema or a
+ * plaintext pre-vault record. Required entrance and postal details stay ahead
+ * of optional overflow under the existing 300-character address contract.
+ */
+export function buildSavedLocationAddress(
+  mapAddress: string | null | undefined,
+  details: SavedLocationAddressDetails,
+): string | null {
+  const normalized = normalizeSavedLocationAddressDetails(details);
+  const baseAddress = cleanText(
+    String(mapAddress || ""),
+    MAX_SAVED_ADDRESS_LENGTH,
+  );
+  const rawSegments = [
+    normalized.houseOrFlat,
+    buildingColorSegment(normalized.buildingColor),
+    landmarkSegment(normalized.landmark),
+    baseAddress,
+  ].filter(Boolean);
+
+  const seen = new Set<string>();
+  const segments = rawSegments.filter((segment) => {
+    const key = comparable(segment);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const withoutPostal = segments.join(", ");
+  let composed = withoutPostal.slice(0, MAX_SAVED_ADDRESS_LENGTH);
+  const postalCode = normalized.postalCode;
+  if (
+    postalCode &&
+    !composed.toLocaleLowerCase().includes(postalCode.toLocaleLowerCase())
+  ) {
+    const suffix = `, ${postalCode}`;
+    const prefix = withoutPostal
+      .slice(0, Math.max(0, MAX_SAVED_ADDRESS_LENGTH - suffix.length))
+      .replace(/[,\s]+$/u, "");
+    composed = prefix ? `${prefix}${suffix}` : postalCode;
+  }
+  return composed || null;
+}

--- a/hushh-webapp/lib/one-location/saved-locations.ts
+++ b/hushh-webapp/lib/one-location/saved-locations.ts
@@ -332,11 +332,97 @@ export async function addSavedLocation(params: {
   return locations;
 }
 
+/**
+ * Update an existing saved place in place — its category, label, address, and
+ * (optionally) its pinned coordinate. Home and Work stay singletons, and the
+ * duplicate check excludes the entry being edited so re-saving the same place
+ * does not falsely trip the "already saved" guard. Used by the Settings edit
+ * flow so a place can be added OR updated with the same pin + details screens.
+ */
+export async function updateSavedLocation(params: {
+  context: SavedLocationVaultContext;
+  id: string;
+  input: {
+    category: SavedLocationCategory;
+    label?: string | null;
+    latitude: number;
+    longitude: number;
+    address?: string | null;
+  };
+}): Promise<SavedLocation[]> {
+  const { id, input } = params;
+  if (!id) {
+    throw new Error("This saved place could not be identified.");
+  }
+  if (
+    !Number.isFinite(input.latitude) ||
+    input.latitude < -90 ||
+    input.latitude > 90 ||
+    !Number.isFinite(input.longitude) ||
+    input.longitude < -180 ||
+    input.longitude > 180
+  ) {
+    throw new Error("The captured location is invalid. Try again.");
+  }
+
+  const label =
+    cleanText(input.label, MAX_LABEL_LENGTH) ||
+    defaultLabelForCategory(input.category);
+  // Home/Work use fixed ids; keep the existing id for "other" so identity and
+  // ordering are preserved across an edit.
+  const nextId =
+    input.category === "home" || input.category === "work"
+      ? input.category
+      : id;
+  const entry: SavedLocation = {
+    id: nextId,
+    category: input.category,
+    label,
+    latitude: input.latitude,
+    longitude: input.longitude,
+    address: cleanText(input.address, MAX_ADDRESS_LENGTH),
+    savedAt: new Date().toISOString(),
+  };
+
+  let duplicateLocation: SavedLocation | null = null;
+
+  const locations = await mutateSavedLocations({
+    context: params.context,
+    source: "one_location_saved_place_edit_confirm",
+    mutate: (existing) => {
+      // Drop the entry being edited (by its old id and its new id) so the
+      // duplicate check below never matches the place against itself.
+      const withoutSelf = existing.filter(
+        (location) => location.id !== id && location.id !== nextId,
+      );
+      const duplicate = findDuplicateSavedLocation(withoutSelf, entry);
+      duplicateLocation = duplicate;
+      if (duplicate) {
+        return existing;
+      }
+      if (input.category === "home" || input.category === "work") {
+        return [
+          entry,
+          ...withoutSelf.filter(
+            (location) => location.category !== input.category,
+          ),
+        ];
+      }
+      return [...withoutSelf, entry];
+    },
+  });
+  if (duplicateLocation) {
+    throw new DuplicateSavedLocationError(duplicateLocation);
+  }
+  return locations;
+}
+
 /** Remove a saved place from encrypted PKM. */
 export async function removeSavedLocation(params: {
   context: SavedLocationVaultContext;
   id: string;
 }): Promise<SavedLocation[]> {
+
   return mutateSavedLocations({
     context: params.context,
     source: "one_location_saved_place_remove_confirm",

--- a/hushh-webapp/lib/one-location/use-google-maps.ts
+++ b/hushh-webapp/lib/one-location/use-google-maps.ts
@@ -48,8 +48,14 @@ function loadGoogleMaps(): Promise<void> {
   loadPromise = Promise.all([
     loader.importLibrary("maps"),
     loader.importLibrary("marker"),
+    // "places" powers the reverse-geocode fallback in LocationPickerMap. This
+    // key has the Places API (New) enabled but NOT the classic Geocoding API,
+    // so the picker resolves the pinned address via Places nearest-place lookup
+    // (the same path the backend/Your Map uses) instead of google.maps.Geocoder.
+    loader.importLibrary("places"),
   ]).then(() => undefined);
   return loadPromise;
+
 }
 
 export function useGoogleMaps({ enabled = true }: { enabled?: boolean } = {}): {

--- a/hushh-webapp/lib/services/pre-vault-sensitive-draft-service.ts
+++ b/hushh-webapp/lib/services/pre-vault-sensitive-draft-service.ts
@@ -9,6 +9,13 @@ import {
   RUNTIME_CREDENTIAL_MODE_REF,
   type GeminiRuntimeTransport,
 } from "@/lib/services/personal-knowledge-model-service";
+import {
+  addSavedLocation,
+  defaultLabelForCategory,
+  DuplicateSavedLocationError,
+  loadSavedLocations,
+  type SavedLocationCategory,
+} from "@/lib/one-location/saved-locations";
 
 /**
  * Sensitive setup input has exactly one pre-vault home: process memory.
@@ -35,9 +42,30 @@ export type PreVaultFinanceIntent =
   | { kind: "plaid"; environment: string | null }
   | { kind: "sample" };
 
+export type PreVaultSavedLocationDraft = {
+  category: SavedLocationCategory;
+  label: string;
+  latitude: number;
+  longitude: number;
+  address: string | null;
+};
+
 const geminiDrafts = new Map<string, PreVaultGeminiRuntimeDraft>();
 const financeIntents = new Map<string, PreVaultFinanceIntent>();
+const savedLocationDrafts = new Map<string, PreVaultSavedLocationDraft>();
 const finalizeInFlight = new Map<string, Promise<void>>();
+const savedLocationGenerations = new Map<string, number>();
+const userClearEpochs = new Map<string, number>();
+
+function nextCounter(counter: Map<string, number>, userId: string): number {
+  const next = (counter.get(userId) ?? 0) + 1;
+  counter.set(userId, next);
+  return next;
+}
+
+function currentCounter(counter: Map<string, number>, userId: string): number {
+  return counter.get(userId) ?? 0;
+}
 
 function normalizeDraft(
   draft: PreVaultGeminiRuntimeDraft,
@@ -54,6 +82,46 @@ function assertStored(result: { success: boolean; conflict?: boolean }): void {
   if (!result.success) {
     throw new Error(result.conflict ? "PKM_CONFLICT" : "PKM_WRITE_FAILED");
   }
+}
+
+function normalizeSavedLocationDraft(
+  draft: PreVaultSavedLocationDraft,
+): PreVaultSavedLocationDraft {
+  if (
+    !Number.isFinite(draft.latitude) ||
+    draft.latitude < -90 ||
+    draft.latitude > 90 ||
+    !Number.isFinite(draft.longitude) ||
+    draft.longitude < -180 ||
+    draft.longitude > 180
+  ) {
+    throw new Error("Choose a valid location before continuing.");
+  }
+  return {
+    category: draft.category,
+    label: draft.label.trim().slice(0, 40),
+    latitude: draft.latitude,
+    longitude: draft.longitude,
+    address: draft.address?.trim().slice(0, 300) || null,
+  };
+}
+
+async function matchesPersistedSavedLocation(params: {
+  context: { userId: string; vaultKey: string; vaultOwnerToken: string };
+  draft: PreVaultSavedLocationDraft;
+}): Promise<boolean> {
+  const expectedLabel =
+    params.draft.label || defaultLabelForCategory(params.draft.category);
+  const expectedAddress = params.draft.address?.trim() || null;
+  const locations = await loadSavedLocations(params.context);
+  return locations.some(
+    (location) =>
+      location.category === params.draft.category &&
+      location.label === expectedLabel &&
+      location.latitude === params.draft.latitude &&
+      location.longitude === params.draft.longitude &&
+      (location.address?.trim() || null) === expectedAddress,
+  );
 }
 
 export class PreVaultSensitiveDraftService {
@@ -79,11 +147,19 @@ export class PreVaultSensitiveDraftService {
   }
 
   static clearForUser(userId: string): void {
+    // Invalidate captured snapshots before deleting them. A finalizer already
+    // awaiting another encrypted write must not dispatch this user's remaining
+    // sensitive drafts after sign-out/account switch.
+    nextCounter(userClearEpochs, userId);
     this.clearGeminiRuntime(userId);
     this.clearFinanceIntent(userId);
+    this.clearSavedLocation(userId);
   }
 
-  static stageFinanceIntent(userId: string, intent: PreVaultFinanceIntent): void {
+  static stageFinanceIntent(
+    userId: string,
+    intent: PreVaultFinanceIntent,
+  ): void {
     if (!userId) throw new Error("A signed-in user is required.");
     if (intent.kind === "statement" && !(intent.file instanceof File)) {
       throw new Error("A statement file is required.");
@@ -109,61 +185,171 @@ export class PreVaultSensitiveDraftService {
     financeIntents.delete(userId);
   }
 
+  static stageSavedLocation(
+    userId: string,
+    draft: PreVaultSavedLocationDraft,
+  ): void {
+    if (!userId) throw new Error("A signed-in user is required.");
+    nextCounter(savedLocationGenerations, userId);
+    savedLocationDrafts.set(userId, normalizeSavedLocationDraft(draft));
+  }
+
+  static hasSavedLocation(userId: string): boolean {
+    return savedLocationDrafts.has(userId);
+  }
+
+  static clearSavedLocation(userId: string): void {
+    nextCounter(savedLocationGenerations, userId);
+    savedLocationDrafts.delete(userId);
+  }
+
   /**
-   * Encrypt the complete runtime choice before clearing the volatile origin.
-   * All writes share the existing runtime-secret domain and are idempotent at
-   * the PKM commit layer; a failure retains the in-memory draft for retry.
+   * Commit every sensitive setup draft through its existing encrypted domain
+   * before clearing the volatile origin. A failed write retains only the
+   * unfinished in-memory draft for a safe retry.
    */
-  static async finalizeForVault(params: {
+  static finalizeForVault(params: {
     userId: string;
     vaultKey: string;
     vaultOwnerToken: string;
   }): Promise<void> {
-    const draft = geminiDrafts.get(params.userId);
-    if (!draft) return;
-
-    const existing = finalizeInFlight.get(params.userId);
-    if (existing) return existing;
-
+    const previous = finalizeInFlight.get(params.userId);
     const commit = (async () => {
-      const confirmation = {
-        confirmedByUser: true as const,
-        surface: "web" as const,
-        source: "one_setup_ai_access_finalize",
-      };
-      const secretRefs: Array<[string, string]> = [
-        [GEMINI_RUNTIME_CREDENTIAL_REF, draft.credential],
-        [GEMINI_RUNTIME_TRANSPORT_REF, draft.transport],
-        [RUNTIME_CREDENTIAL_MODE_REF, "byok"],
-      ];
-      if (draft.vertexProject) {
-        secretRefs.push([GEMINI_VERTEX_PROJECT_REF, draft.vertexProject]);
+      if (previous) {
+        // A later vault session must not inherit the earlier caller's result.
+        // Wait for that attempt (including cancellation/failure), then replay
+        // the still-current drafts with this caller's authority.
+        try {
+          await previous;
+        } catch {
+          // The previous caller receives its own failure. A queued caller is a
+          // deliberate retry and must still get a chance to persist the draft.
+        }
       }
-      if (draft.vertexLocation) {
-        secretRefs.push([GEMINI_VERTEX_LOCATION_REF, draft.vertexLocation]);
-      }
-
-      for (const [credentialRef, secret] of secretRefs) {
-        const result = await PersonalKnowledgeModelService.storeRuntimeSecret({
-          userId: params.userId,
-          vaultKey: params.vaultKey,
-          vaultOwnerToken: params.vaultOwnerToken,
-          credentialRef,
-          secret,
-          confirmation,
-        });
-        assertStored(result);
-      }
-
-      this.clearGeminiRuntime(params.userId);
+      await this.finalizeCurrentDrafts(params);
     })();
 
     finalizeInFlight.set(params.userId, commit);
-    try {
-      await commit;
-    } finally {
+    return commit.finally(() => {
       if (finalizeInFlight.get(params.userId) === commit) {
         finalizeInFlight.delete(params.userId);
+      }
+    });
+  }
+
+  private static async finalizeCurrentDrafts(params: {
+    userId: string;
+    vaultKey: string;
+    vaultOwnerToken: string;
+  }): Promise<void> {
+    if (
+      !geminiDrafts.has(params.userId) &&
+      !savedLocationDrafts.has(params.userId)
+    ) {
+      return;
+    }
+
+    const finalizationEpoch = currentCounter(userClearEpochs, params.userId);
+    const wasCancelled = () =>
+      currentCounter(userClearEpochs, params.userId) !== finalizationEpoch;
+
+    commitLoop: while (!wasCancelled()) {
+      const geminiDraft = geminiDrafts.get(params.userId);
+      if (geminiDraft) {
+        const confirmation = {
+          confirmedByUser: true as const,
+          surface: "web" as const,
+          source: "one_setup_ai_access_finalize",
+        };
+        const secretRefs: Array<[string, string]> = [
+          [GEMINI_RUNTIME_CREDENTIAL_REF, geminiDraft.credential],
+          [GEMINI_RUNTIME_TRANSPORT_REF, geminiDraft.transport],
+          [RUNTIME_CREDENTIAL_MODE_REF, "byok"],
+        ];
+        if (geminiDraft.vertexProject) {
+          secretRefs.push([
+            GEMINI_VERTEX_PROJECT_REF,
+            geminiDraft.vertexProject,
+          ]);
+        }
+        if (geminiDraft.vertexLocation) {
+          secretRefs.push([
+            GEMINI_VERTEX_LOCATION_REF,
+            geminiDraft.vertexLocation,
+          ]);
+        }
+
+        for (const [credentialRef, secret] of secretRefs) {
+          if (wasCancelled()) return;
+          if (geminiDrafts.get(params.userId) !== geminiDraft) {
+            continue commitLoop;
+          }
+          const result = await PersonalKnowledgeModelService.storeRuntimeSecret(
+            {
+              userId: params.userId,
+              vaultKey: params.vaultKey,
+              vaultOwnerToken: params.vaultOwnerToken,
+              credentialRef,
+              secret,
+              confirmation,
+            },
+          );
+          assertStored(result);
+        }
+
+        if (wasCancelled()) return;
+        if (geminiDrafts.get(params.userId) === geminiDraft) {
+          this.clearGeminiRuntime(params.userId);
+        } else {
+          continue;
+        }
+      }
+
+      if (wasCancelled()) return;
+      const savedLocationDraft = savedLocationDrafts.get(params.userId);
+      if (savedLocationDraft) {
+        const locationGeneration = currentCounter(
+          savedLocationGenerations,
+          params.userId,
+        );
+        if (
+          wasCancelled() ||
+          savedLocationDrafts.get(params.userId) !== savedLocationDraft
+        ) {
+          continue;
+        }
+        try {
+          await addSavedLocation({
+            context: params,
+            input: savedLocationDraft,
+          });
+        } catch (error) {
+          const exactRetry =
+            error instanceof DuplicateSavedLocationError &&
+            error.existingCategory === savedLocationDraft.category &&
+            (await matchesPersistedSavedLocation({
+              context: params,
+              draft: savedLocationDraft,
+            }));
+          if (!exactRetry) throw error;
+        }
+
+        if (wasCancelled()) return;
+        if (
+          currentCounter(savedLocationGenerations, params.userId) !==
+            locationGeneration ||
+          savedLocationDrafts.get(params.userId) !== savedLocationDraft
+        ) {
+          continue;
+        }
+        this.clearSavedLocation(params.userId);
+      }
+
+      if (
+        !geminiDrafts.has(params.userId) &&
+        !savedLocationDrafts.has(params.userId)
+      ) {
+        return;
       }
     }
   }


### PR DESCRIPTION
## Summary

Completes the One Location onboarding saved-place journey on top of the existing exact-map-pin branch:

- Always offers the save-place journey after Location access becomes ready during setup.
- Starts with an exact centre-pin map picker, then collects delivery-grade entrance details: house/flat/floor/block, building colour, landmark, postal/PIN code, and Home/Work/Other.
- Keeps setup vault-free: sensitive drafts remain memory-only and are finalized through the existing encrypted saved-location path after vault authority exists.
- Makes the same saved place visible in Location Settings after finalization.
- Extends the exact-pin experience to Settings > Saved locations.

## UX and behavior

- Two-step, responsive flow with mobile keyboard handling, sticky actions, validation, accessible dialog naming/focus, Escape/Skip behavior, and map-unavailable fallback.
- Google Maps is hard-gated behind an explicit renderer disclosure. Durable acceptance uses the existing map-preference service when vault authority exists; pre-vault acceptance lasts only for that modal session.
- The map guards out-of-order reverse-geocode responses and disables confirmation while a selected point is still resolving.
- Postal-code inference follows the pin until the owner edits it manually; manual values are then preserved.
- Duplicate coordinates remain blocked across Home/Work/Other instead of creating repeated saved places.
- Long structured addresses preserve the required house and postal details within the existing encrypted address limit.

## Security and lifecycle

- No vault schema, backend, migration, or vault-internal changes.
- No pre-vault location is written to local/session storage; the draft service is memory-only and scoped by user/session epochs.
- Account switches, vault locks, setup-route transitions, clear/restage races, and failed finalization retries cannot replay stale authority or clear a newer draft.
- The post-auth bridge revalidates authority between sensitive-draft finalization and ordinary post-unlock sync.
- Settings reverse-geocode generations prevent a late coarse lookup from overwriting an owner-confirmed exact pin.

## Verification

- Focused Location/onboarding/lifecycle suite: **109/109 passed** across 8 test files.
- `npm run typecheck`: passed.
- `npm run build`: passed; **141/141** static pages generated.
- `npm run verify:service-boundary`: passed.
- `npm run verify:design-system`: passed.
- Scoped Prettier and `git diff --check`: passed.
- Docs/runtime parity and data-model audit: passed (125/125 tables classified, 0 failures).
- DCO: passed for every commit in `origin/main..HEAD`.
- Gitleaks: 0 leaks; GitHub secret-scanning open alerts: 0.
- Independent UX, test-impact, and security reviews: no blockers.

## Local verification notes

- `verify:routes` requires the maintainer-only reviewer UID and vault passphrase, so it was not bypassed or faked locally.
- The Windows checkout reaches a known POSIX path-separator issue in the agent-governance checker even though the required markers exist unchanged; GitHub's Linux PR checks remain authoritative for that lane.

## Reviewer path

1. Start a fresh One setup journey and complete the Location intro/access step.
2. Accept the Google Maps renderer disclosure.
3. Move the centre pin to the entrance and confirm it.
4. Enter the address details, choose Home/Work/Other, and save or skip.
5. Complete setup/unlock the vault, then verify the saved place under Location > Settings > Saved locations.
6. Repeat from Settings > Add place and verify a duplicate coordinate is rejected.


---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)