### PR TITLE
Harden One Location onboarding contacts and completed re-entry

### DIFF
--- a/docs/reference/quality/one-onboarding-architecture.md
+++ b/docs/reference/quality/one-onboarding-architecture.md
@@ -236,11 +236,13 @@ compatibility-only and redirects known old links; `?finish=1` has no meaning.
   The final circle has no terminal completion button: after its four-second,
   reduced-motion-safe confirmation, it invokes
   the coordinator's durable finish action. While root setup remains active,
-  completion returns to `/one/setup`, and the completed Location tile can
-  replay the authored journey. After the master setup acknowledgement,
-  completed Location entry opens `/one/location`. Settlement retries
-  automatically on a transient failure. The first share remains optional. A
-  dismissed or failed vault setup leaves Location pending.
+  completion returns to `/one/setup`. Re-entering the completed Location tile
+  shows a brief completion acknowledgement and returns to the hub without
+  replaying permissions, contacts, saved-place capture, or circle confirmation.
+  After the master setup acknowledgement, completed Location entry opens
+  `/one/location`. Settlement retries automatically on a transient failure.
+  The first share remains optional. A dismissed or failed vault setup leaves
+  Location pending.
 - **KYC** reuses the email workspace; it becomes finishable after a verified
   identity and initialized client connector. Sending a draft remains optional.
 - **Finance** uses `/one/setup/finance` for preferences and

--- a/hushh-webapp/__tests__/app/one/setup/location-onboarding-completed-screen.test.tsx
+++ b/hushh-webapp/__tests__/app/one/setup/location-onboarding-completed-screen.test.tsx
@@ -77,6 +77,17 @@ describe("completed Location onboarding re-entry", () => {
         name: "Your Location onboarding is complete",
       }),
     ).toBeTruthy();
+    const completedScreen = screen.getByTestId(
+      "location-onboarding-completed",
+    );
+    expect(
+      completedScreen.getAttribute("data-fullscreen-flow-shell-width"),
+    ).toBe("reading");
+    const returnButton = screen.getByRole("button", {
+      name: "Back to setup",
+    });
+    expect(returnButton.className).toContain("min-h-14");
+    expect(returnButton.parentElement?.className).toContain("max-w-[30rem]");
     expect(screen.queryByTestId("location-cinematic-intro")).toBeNull();
     expect(screen.queryByTestId("location-onboarding-journey")).toBeNull();
 

--- a/hushh-webapp/__tests__/app/one/setup/location-onboarding-completed-screen.test.tsx
+++ b/hushh-webapp/__tests__/app/one/setup/location-onboarding-completed-screen.test.tsx
@@ -1,0 +1,118 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LOCATION_COMPLETION_RETURN_DELAY_MS,
+  LocationOnboardingSetupClient,
+} from "@/app/one/setup/location/location-onboarding-setup-client";
+
+const coordinatorMocks = vi.hoisted(() => ({
+  isAlreadyComplete: false,
+  returnToSetup: vi.fn(),
+  finish: vi.fn(),
+  skip: vi.fn(),
+}));
+
+vi.mock("@/app/one/location/page", () => ({
+  default: () => (
+    <div data-testid="location-onboarding-journey">Location onboarding</div>
+  ),
+}));
+
+vi.mock("@/components/onboarding/setup/capability-cinematic-intro", () => ({
+  CapabilityCinematicIntroGate: ({ children }: { children: ReactNode }) => (
+    <div data-testid="location-cinematic-intro">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/onboarding/setup/setup-capability-coordinator", () => ({
+  SetupCapabilityLoading: () => <div>Preparing location setup…</div>,
+  useSetupCapabilityCoordinator: () => ({
+    isReady: true,
+    isAlreadyComplete: coordinatorMocks.isAlreadyComplete,
+    returnToSetup: coordinatorMocks.returnToSetup,
+    operationallyReady: false,
+    isSettling: false,
+    finish: coordinatorMocks.finish,
+    skip: coordinatorMocks.skip,
+  }),
+}));
+
+vi.mock("@/lib/morphy-ux/morphy", () => ({
+  morphyToast: {},
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
+
+describe("completed Location onboarding re-entry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    coordinatorMocks.isAlreadyComplete = false;
+    coordinatorMocks.returnToSetup.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("keeps the full onboarding journey for an incomplete Location setup", () => {
+    render(<LocationOnboardingSetupClient />);
+
+    expect(screen.getByTestId("location-cinematic-intro")).toBeTruthy();
+    expect(screen.getByTestId("location-onboarding-journey")).toBeTruthy();
+    expect(screen.queryByTestId("location-onboarding-completed")).toBeNull();
+  });
+
+  it("shows only the completion screen and returns to setup after the delay", () => {
+    coordinatorMocks.isAlreadyComplete = true;
+
+    render(<LocationOnboardingSetupClient />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Your Location onboarding is complete",
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("location-cinematic-intro")).toBeNull();
+    expect(screen.queryByTestId("location-onboarding-journey")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(LOCATION_COMPLETION_RETURN_DELAY_MS - 1);
+    });
+    expect(coordinatorMocks.returnToSetup).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(coordinatorMocks.returnToSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the automatic return when the screen unmounts", () => {
+    coordinatorMocks.isAlreadyComplete = true;
+    const { unmount } = render(<LocationOnboardingSetupClient />);
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(LOCATION_COMPLETION_RETURN_DELAY_MS);
+    });
+
+    expect(coordinatorMocks.returnToSetup).not.toHaveBeenCalled();
+  });
+
+  it("lets the user return immediately without a second timer navigation", () => {
+    coordinatorMocks.isAlreadyComplete = true;
+    render(<LocationOnboardingSetupClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to setup" }));
+    expect(coordinatorMocks.returnToSetup).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(LOCATION_COMPLETION_RETURN_DELAY_MS);
+    });
+    expect(coordinatorMocks.returnToSetup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/__tests__/app/one/setup/location-onboarding-setup-route.contract.test.ts
+++ b/hushh-webapp/__tests__/app/one/setup/location-onboarding-setup-route.contract.test.ts
@@ -40,20 +40,27 @@ describe("Location setup route contract", () => {
     );
   });
 
-  it("redirects completed Location only after root setup is resolved", () => {
+  it("settles completed Location before its onboarding body can mount", () => {
     const coordinator = read(
       "components/onboarding/setup/setup-capability-coordinator.tsx",
+    );
+    const adapter = read(
+      "app/one/setup/location/location-onboarding-setup-client.tsx",
     );
 
     expect(coordinator).toContain(
       "completedCapabilityIds: initialJourney.setupCapabilityIds",
     );
+    expect(coordinator).toContain("resolveCompletedSetupCapabilityEntry({");
+    expect(coordinator).toContain('completedEntry.kind === "acknowledge"');
+    expect(coordinator).toContain("setConfirmedCompletionKey(`${userId}:${capabilityId}`)");
     expect(coordinator).toContain(
-      "resolveCompletedSetupCapabilityTarget({",
+      "enabled && routeReady && !settlementBlocked && !isAlreadyComplete",
     );
-    expect(coordinator).toContain(
-      "PreVaultUserStateService.isSetupResolved(initialJourney)",
+    expect(adapter).toContain("if (coordinator.isAlreadyComplete)");
+    expect(adapter).toContain("<LocationOnboardingCompletedScreen");
+    expect(adapter.indexOf("if (coordinator.isAlreadyComplete)")).toBeLessThan(
+      adapter.indexOf("<CapabilityCinematicIntroGate"),
     );
-    expect(coordinator).toContain("replaceRoute(completedTarget)");
   });
 });

--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -6,8 +6,15 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 
 import { OneLocationOnboardingFlow } from "@/components/one-location/onboarding/one-location-onboarding-flow";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
 
 const people = [
   {
@@ -99,6 +106,7 @@ function openPeopleScreen() {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.mocked(toast.error).mockClear();
 });
 
 describe("OneLocationOnboardingFlow", () => {
@@ -484,7 +492,7 @@ describe("OneLocationOnboardingFlow", () => {
     });
   });
 
-  it("lets the user continue without selecting anyone and sends no requests", () => {
+  it("keeps the user on contact selection and explains why one person is required", () => {
     const props = renderFlow({
       people: [people[1]!],
       connections: [],
@@ -496,16 +504,26 @@ describe("OneLocationOnboardingFlow", () => {
     const continueButton = screen.getByRole("button", { name: "Continue" });
     expect(continueButton).toBeEnabled();
     expect(
-      screen.getByText("Add anyone you'd like — or just continue"),
+      screen.getByText("Select at least one person to continue"),
     ).toBeTruthy();
 
     fireEvent.click(continueButton);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Choose at least one contact",
+      {
+        description:
+          "One Location works best with someone in your circle. You can update contacts later from the Connect tab.",
+      },
+    );
     expect(props.onSendConnectionRequests).not.toHaveBeenCalled();
-    expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
+    expect(screen.getByTestId("one-location-onboarding-people")).toBeTruthy();
+    expect(
+      screen.queryByTestId("one-location-onboarding-circle"),
+    ).toBeNull();
   });
 
-  it("keeps Continue enabled and counts people as they are selected", () => {
-    renderFlow({
+  it("allows the user to continue after selecting exactly one person", () => {
+    const props = renderFlow({
       people: [people[1]!],
       connections: [],
     });
@@ -517,9 +535,14 @@ describe("OneLocationOnboardingFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: "Add New Person" }));
     expect(continueButton).toBeEnabled();
     expect(screen.getByText("1 selected")).toBeTruthy();
+
+    fireEvent.click(continueButton);
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(props.onSendConnectionRequests).toHaveBeenCalledWith(["new_user"]);
+    expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
   });
 
-  it("advances the optional people step on Skip without ending onboarding", () => {
+  it("does not let people-screen Skip bypass the required contact", () => {
     const props = renderFlow({
       people: [people[1]!],
       connections: [],
@@ -528,7 +551,17 @@ describe("OneLocationOnboardingFlow", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Skip" }));
 
-    expect(screen.getByTestId("one-location-onboarding-circle")).toBeTruthy();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Choose at least one contact",
+      {
+        description:
+          "One Location works best with someone in your circle. You can update contacts later from the Connect tab.",
+      },
+    );
+    expect(screen.getByTestId("one-location-onboarding-people")).toBeTruthy();
+    expect(
+      screen.queryByTestId("one-location-onboarding-circle"),
+    ).toBeNull();
     expect(props.onSkip).not.toHaveBeenCalled();
     expect(props.onComplete).not.toHaveBeenCalled();
     expect(props.onSendConnectionRequests).not.toHaveBeenCalled();

--- a/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
+++ b/hushh-webapp/__tests__/components/one-setup-hub-terminal-action.contract.test.ts
@@ -4,15 +4,17 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("One setup hub terminal action contract", () => {
-  it("keeps completed capabilities replayable while the setup hub is active", () => {
+  it("routes completed rows through their canonical setup entry", () => {
     const source = readFileSync(
       join(process.cwd(), "components/onboarding/setup/one-setup-hub.tsx"),
       "utf8",
     );
 
     expect(source.match(/href=\{item\.copy\.href\}/g)).toHaveLength(2);
+    // The route coordinator owns durable completion. The hub must not invent a
+    // second target that would diverge for taps, voice navigation, or deep links.
     expect(source).not.toContain(
-      "resolveCompletedSetupCapabilityTarget(item.id)",
+      "resolveCompletedSetupCapabilityEntry(item.id)",
     );
   });
 
@@ -154,7 +156,9 @@ describe("One setup hub terminal action contract", () => {
     expect(emailSetup).toContain("settlementBlocked: saving");
     expect(coordinator).toContain("if (pending) return");
     expect(coordinator).toContain("disabled={pending}");
-    expect(coordinator).toContain("enabled: enabled && !settlementBlocked");
+    expect(coordinator).toMatch(
+      /enabled:\s*enabled && routeReady && !settlementBlocked && !isAlreadyComplete/,
+    );
   });
 
   it("never sends the master exit back onto a setup surface", () => {

--- a/hushh-webapp/__tests__/components/setup-capability-coordinator-completed-entry.test.tsx
+++ b/hushh-webapp/__tests__/components/setup-capability-coordinator-completed-entry.test.tsx
@@ -1,0 +1,177 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSetupCapabilityCoordinator } from "@/components/onboarding/setup/setup-capability-coordinator";
+
+const mocks = vi.hoisted(() => ({
+  cachedJourney: null as Record<string, unknown> | null,
+  bootstrapState: vi.fn(),
+  syncOnboardingJourney: vi.fn(),
+  replace: vi.fn(),
+  requestNavigation: vi.fn(() => false),
+  localActionHandler: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock("@/lib/firebase/auth-context", () => ({
+  useAuth: () => ({ user: { uid: "user-1" }, loading: false }),
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    getCachedBootstrapState: () => mocks.cachedJourney,
+    bootstrapState: (...args: unknown[]) => mocks.bootstrapState(...args),
+    isSetupResolved: (journey: { setupCompleted?: boolean } | null) =>
+      journey?.setupCompleted === true,
+    syncOnboardingJourney: (...args: unknown[]) =>
+      mocks.syncOnboardingJourney(...args),
+    syncSetupCapabilities: vi.fn(),
+    settleOnboardingCapability: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/agent/local-onboarding-actions", () => ({
+  useLocalOnboardingActionHandler: (...args: unknown[]) =>
+    mocks.localActionHandler(...args),
+}));
+
+vi.mock("@/lib/services/capability-tour-service", () => ({
+  CapabilityTourService: { markExplored: vi.fn() },
+}));
+
+vi.mock("@/lib/utils/browser-navigation", () => ({
+  requestInternalAppNavigation: (...args: unknown[]) =>
+    mocks.requestNavigation(...args),
+}));
+
+vi.mock("@/lib/voice/voice-surface-metadata", () => ({
+  usePublishVoiceSurfaceMetadata: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+function setupJourney(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    setupCompleted: false,
+    setupCapabilityIds: [],
+    onboardingPhase: "capability_setup",
+    onboardingActiveCapability: "location",
+    onboardingCallbackState: "none",
+    onboardingJourneyUpdatedAt: "journey-v1",
+    ...overrides,
+  };
+}
+
+function renderLocationCoordinator() {
+  return renderHook(() =>
+    useSetupCapabilityCoordinator({
+      capabilityId: "location",
+      isOperationallyReady: false,
+      finishActionId: "setup.finish_location",
+      skipActionId: "setup.skip_location",
+      terminalPresentation: "automatic",
+    }),
+  );
+}
+
+function expectTerminalActionsDisabled() {
+  const locationCalls = mocks.localActionHandler.mock.calls.filter(
+    ([actionId]) =>
+      actionId === "setup.finish_location" ||
+      actionId === "setup.skip_location",
+  );
+  expect(locationCalls.length).toBeGreaterThan(0);
+  expect(
+    locationCalls.every(([, , options]) => options.enabled === false),
+  ).toBe(true);
+}
+
+describe("setup coordinator completed Location entry", () => {
+  beforeEach(() => {
+    mocks.cachedJourney = null;
+    mocks.bootstrapState.mockReset();
+    mocks.syncOnboardingJourney.mockReset();
+    mocks.syncOnboardingJourney.mockResolvedValue(undefined);
+    mocks.replace.mockReset();
+    mocks.requestNavigation.mockReset();
+    mocks.requestNavigation.mockReturnValue(false);
+    mocks.localActionHandler.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it("acknowledges cached completion without reclaiming the onboarding journey", async () => {
+    mocks.cachedJourney = setupJourney({
+      setupCapabilityIds: ["location"],
+    });
+
+    const { result } = renderLocationCoordinator();
+
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.isAlreadyComplete).toBe(true);
+    await waitFor(() => expectTerminalActionsDisabled());
+    expect(mocks.bootstrapState).not.toHaveBeenCalled();
+    expect(mocks.syncOnboardingJourney).not.toHaveBeenCalled();
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges cold-bootstrap completion without exposing terminal actions", async () => {
+    mocks.bootstrapState.mockResolvedValue(
+      setupJourney({ setupCapabilityIds: ["location"] }),
+    );
+
+    const { result } = renderLocationCoordinator();
+
+    expect(result.current.isReady).toBe(false);
+    await waitFor(() => expect(result.current.isAlreadyComplete).toBe(true));
+    expect(result.current.isReady).toBe(true);
+    expect(mocks.bootstrapState).toHaveBeenCalledWith("user-1");
+    expect(mocks.syncOnboardingJourney).not.toHaveBeenCalled();
+    expectTerminalActionsDisabled();
+    expect(mocks.replace).not.toHaveBeenCalled();
+  });
+
+  it("keeps the resolved-root handoff to the Location workspace", async () => {
+    mocks.bootstrapState.mockResolvedValue(
+      setupJourney({
+        setupCompleted: true,
+        setupCapabilityIds: ["location"],
+      }),
+    );
+
+    const { result } = renderLocationCoordinator();
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/one/location"));
+    expect(result.current.isAlreadyComplete).toBe(false);
+    expect(mocks.syncOnboardingJourney).not.toHaveBeenCalled();
+    expectTerminalActionsDisabled();
+  });
+
+  it("continues the authored journey when Location is incomplete", async () => {
+    mocks.bootstrapState.mockResolvedValue(
+      setupJourney({
+        onboardingPhase: "hub",
+        onboardingActiveCapability: null,
+      }),
+    );
+
+    const { result } = renderLocationCoordinator();
+
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(result.current.isAlreadyComplete).toBe(false);
+    expect(mocks.syncOnboardingJourney).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        phase: "capability_setup",
+        activeCapability: "location",
+      }),
+    );
+  });
+});

--- a/hushh-webapp/__tests__/navigation/routes.test.ts
+++ b/hushh-webapp/__tests__/navigation/routes.test.ts
@@ -20,7 +20,7 @@ import {
   isPublicRoute,
   isRiaRoute,
   resolveCapabilityHandoffTarget,
-  resolveCompletedSetupCapabilityTarget,
+  resolveCompletedSetupCapabilityEntry,
   ROUTES,
 } from "@/lib/navigation/routes";
 import {
@@ -342,34 +342,34 @@ describe("navigation routes", () => {
     );
   });
 
-  it("keeps completed Location setup replayable until root setup resolves", () => {
+  it("acknowledges completed Location while root setup is still active", () => {
     expect(
-      resolveCompletedSetupCapabilityTarget({
+      resolveCompletedSetupCapabilityEntry({
         capabilityId: "location",
         completedCapabilityIds: ["location"],
         rootSetupResolved: false,
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "acknowledge", target: "/one/setup" });
     expect(
-      resolveCompletedSetupCapabilityTarget({
+      resolveCompletedSetupCapabilityEntry({
         capabilityId: "location",
         completedCapabilityIds: [],
         rootSetupResolved: true,
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "continue" });
     expect(
-      resolveCompletedSetupCapabilityTarget({
+      resolveCompletedSetupCapabilityEntry({
         capabilityId: "location",
         completedCapabilityIds: ["location"],
         rootSetupResolved: true,
       }),
-    ).toBe("/one/location");
+    ).toEqual({ kind: "redirect", target: "/one/location" });
     expect(
-      resolveCompletedSetupCapabilityTarget({
+      resolveCompletedSetupCapabilityEntry({
         capabilityId: "gmail",
         completedCapabilityIds: ["gmail"],
         rootSetupResolved: true,
       }),
-    ).toBeNull();
+    ).toEqual({ kind: "continue" });
   });
 });

--- a/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
@@ -1,14 +1,115 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CheckCircle2 } from "lucide-react";
 
 import OneLocationAgentPage from "@/app/one/location/page";
+import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
 import { CapabilityCinematicIntroGate } from "@/components/onboarding/setup/capability-cinematic-intro";
 import {
   SetupCapabilityLoading,
   useSetupCapabilityCoordinator,
 } from "@/components/onboarding/setup/setup-capability-coordinator";
+import { Button } from "@/lib/morphy-ux/button";
 import { morphyToast as toast } from "@/lib/morphy-ux/morphy";
+import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+
+export const LOCATION_COMPLETION_RETURN_DELAY_MS = 4_000;
+
+export function LocationOnboardingCompletedScreen({
+  onReturn,
+}: {
+  onReturn: () => void;
+}) {
+  const returnedRef = useRef(false);
+  const returnOnce = useCallback(() => {
+    if (returnedRef.current) return;
+    returnedRef.current = true;
+    onReturn();
+  }, [onReturn]);
+
+  useEffect(() => {
+    const returnTimer = window.setTimeout(
+      returnOnce,
+      LOCATION_COMPLETION_RETURN_DELAY_MS,
+    );
+    return () => window.clearTimeout(returnTimer);
+  }, [returnOnce]);
+
+  usePublishVoiceSurfaceMetadata({
+    screenId: "one_setup_location_complete",
+    title: "Location setup complete",
+    purpose: "Confirm Location is already set up before returning to setup.",
+    primaryEntity: "Location",
+    actions: [
+      {
+        id: "return_to_setup",
+        label: "Back to setup",
+        purpose: "Return to the One setup hub.",
+      },
+    ],
+    controls: [
+      {
+        id: "one_setup_location_complete_return",
+        label: "Back to setup",
+        type: "button",
+        purpose: "Return to the One setup hub.",
+      },
+    ],
+    availableActions: ["Back to setup"],
+  });
+
+  return (
+    <FullscreenFlowShell
+      width="reading"
+      className="min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-center px-[var(--page-inline-gutter-standard)] py-10"
+      data-testid="location-onboarding-completed"
+    >
+      <section
+        className="motion-step-enter mx-auto flex w-full max-w-[34rem] flex-col items-center text-center"
+        aria-labelledby="location-onboarding-completed-title"
+      >
+        <span className="flex size-16 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 sm:size-20">
+          <CheckCircle2 className="size-9 sm:size-11" aria-hidden="true" />
+        </span>
+        <p className="mt-6 type-subhead text-muted-foreground">
+          One · Location
+        </p>
+        <h1
+          id="location-onboarding-completed-title"
+          className="mt-3 max-w-[18ch] text-balance type-display text-foreground"
+        >
+          Your Location onboarding is complete
+        </h1>
+        <p className="mt-4 max-w-[34rem] text-pretty type-title3 text-muted-foreground">
+          Everything is ready. You can manage Location anytime from One.
+        </p>
+        <div className="mt-8 w-full max-w-[22rem]">
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="lg"
+            fullWidth
+            className="h-12 text-base"
+            onClick={returnOnce}
+            data-testid="location-onboarding-completed-return"
+            data-voice-control-id="one_setup_location_complete_return"
+          >
+            Back to setup
+          </Button>
+        </div>
+        <p
+          className="mt-3 text-sm text-muted-foreground"
+          role="status"
+          aria-live="polite"
+        >
+          Returning automatically in a few seconds.
+        </p>
+      </section>
+    </FullscreenFlowShell>
+  );
+}
 
 export function LocationOnboardingSetupClient() {
   const [ready, setReady] = useState(false);
@@ -22,6 +123,12 @@ export function LocationOnboardingSetupClient() {
 
   if (!coordinator.isReady)
     return <SetupCapabilityLoading label="Preparing location setup…" />;
+
+  if (coordinator.isAlreadyComplete) {
+    return (
+      <LocationOnboardingCompletedScreen onReturn={coordinator.returnToSetup} />
+    );
+  }
 
   return (
     <CapabilityCinematicIntroGate capabilityId="location">

--- a/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
@@ -84,14 +84,14 @@ export function LocationOnboardingCompletedScreen({
         <p className="mt-4 max-w-[34rem] text-pretty type-title3 text-muted-foreground">
           Everything is ready. You can manage Location anytime from One.
         </p>
-        <div className="mt-8 w-full max-w-[22rem]">
+        <div className="mt-8 w-full max-w-[30rem]">
           <Button
             type="button"
             variant="blue-gradient"
             effect="fill"
             size="lg"
             fullWidth
-            className="h-12 text-base"
+            className="min-h-14 justify-center text-center"
             onClick={returnOnce}
             data-testid="location-onboarding-completed-return"
             data-voice-control-id="one_setup_location_complete_return"

--- a/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
+++ b/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
@@ -12,7 +12,7 @@ import { requestInternalAppNavigation } from "@/lib/utils/browser-navigation";
 import {
   buildOneSetupCapabilityRoute,
   resolveCapabilityHandoffTarget,
-  resolveCompletedSetupCapabilityTarget,
+  resolveCompletedSetupCapabilityEntry,
   ROUTES,
 } from "@/lib/navigation/routes";
 import { type OneSetupCapabilityId } from "@/lib/onboarding/setup-capability-ids";
@@ -43,11 +43,15 @@ type SetupSettlementOptions = {
 
 export type SetupCapabilityCoordinator = {
   isReady: boolean;
+  /** Durable completion detected before the feature-owned setup body mounts. */
+  isAlreadyComplete: boolean;
   /** A verified feature result, optionally recovered from a typed callback. */
   operationallyReady: boolean;
   isSettling: boolean;
   finish: (options?: SetupSettlementOptions) => Promise<Settlement>;
   skip: (options?: SetupSettlementOptions) => Promise<Settlement>;
+  /** Idempotent return used by a completed-entry acknowledgement. */
+  returnToSetup: () => void;
 };
 
 export type SetupCapabilityJourneyMode = "auto" | "root" | "individual";
@@ -204,30 +208,44 @@ export function useSetupCapabilityCoordinator({
 }: UseSetupCapabilityCoordinatorParams): SetupCapabilityCoordinator {
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
+  const userId = user?.uid;
   const [isReady, setIsReady] = useState(false);
   const [isSettling, setIsSettling] = useState(false);
   const [callbackReadiness, setCallbackReadiness] = useState(false);
+  const [confirmedCompletionKey, setConfirmedCompletionKey] = useState<
+    string | null
+  >(null);
 
   const operationallyReady = isOperationallyReady || callbackReadiness;
   // Same-session setup transitions reuse the redacted bootstrap record already
   // hydrated by the app runtime. Cold entry waits once; explicit settlement
   // retains the force-refresh + version checks for durable correctness.
-  const cachedJourney = user?.uid
-    ? PreVaultUserStateService.getCachedBootstrapState?.(user.uid) ?? null
+  const cachedJourney = userId
+    ? PreVaultUserStateService.getCachedBootstrapState?.(userId) ?? null
     : null;
-  const cachedCompletedTarget = resolveCompletedSetupCapabilityTarget({
+  const cachedCompletedEntry = resolveCompletedSetupCapabilityEntry({
     capabilityId,
     completedCapabilityIds: cachedJourney?.setupCapabilityIds ?? [],
     rootSetupResolved:
       PreVaultUserStateService.isSetupResolved(cachedJourney),
   });
+  const cachedCompletedTarget =
+    cachedCompletedEntry.kind === "redirect"
+      ? cachedCompletedEntry.target
+      : null;
+  const completionKey = userId ? `${userId}:${capabilityId}` : null;
+  const isAlreadyComplete =
+    cachedCompletedEntry.kind === "acknowledge" ||
+    (cachedCompletedEntry.kind === "continue" &&
+      completionKey !== null &&
+      confirmedCompletionKey === completionKey);
   const hasUsableCachedJourney = Boolean(
     enabled &&
       cachedJourney &&
       !cachedCompletedTarget &&
       !PreVaultUserStateService.isSetupResolved(cachedJourney),
   );
-  const routeReady = isReady || hasUsableCachedJourney;
+  const routeReady = isReady || hasUsableCachedJourney || isAlreadyComplete;
 
   const canonicalRoute = useMemo(
     () => buildOneSetupCapabilityRoute(capabilityId),
@@ -247,11 +265,14 @@ export function useSetupCapabilityCoordinator({
     },
     [router],
   );
+  const returnToSetup = useCallback(() => {
+    replaceRoute(ROUTES.ONE_SETUP);
+  }, [replaceRoute]);
 
   useEffect(() => {
     if (!enabled) return;
     if (authLoading) return;
-    if (!user?.uid) {
+    if (!userId) {
       replaceRoute(`${ROUTES.LOGIN}?redirect=${encodeURIComponent(canonicalRoute)}`);
       return;
     }
@@ -262,17 +283,24 @@ export function useSetupCapabilityCoordinator({
       try {
         const initialJourney =
           cachedJourney ??
-          (await PreVaultUserStateService.bootstrapState(user.uid));
-        const completedTarget = resolveCompletedSetupCapabilityTarget({
+          (await PreVaultUserStateService.bootstrapState(userId));
+        if (cancelled) return;
+        const completedEntry = resolveCompletedSetupCapabilityEntry({
           capabilityId,
           completedCapabilityIds: initialJourney.setupCapabilityIds,
           rootSetupResolved:
             PreVaultUserStateService.isSetupResolved(initialJourney),
         });
-        if (completedTarget) {
-          replaceRoute(completedTarget);
+        if (completedEntry.kind === "redirect") {
+          replaceRoute(completedEntry.target);
           return;
         }
+        if (completedEntry.kind === "acknowledge") {
+          setConfirmedCompletionKey(`${userId}:${capabilityId}`);
+          setIsReady(true);
+          return;
+        }
+        setConfirmedCompletionKey(null);
         const prepare = async (
           journey: typeof initialJourney,
           retryConflict: boolean,
@@ -306,7 +334,7 @@ export function useSetupCapabilityCoordinator({
 
           try {
             await PreVaultUserStateService.syncOnboardingJourney({
-              userId: user.uid,
+              userId,
               phase: "capability_setup",
               activeCapability: capabilityId,
               callbackState: "none",
@@ -315,7 +343,7 @@ export function useSetupCapabilityCoordinator({
             if (!cancelled) setIsReady(true);
           } catch (error) {
             if (!retryConflict || !isOnboardingJourneyConflict(error)) throw error;
-            const fresh = await PreVaultUserStateService.bootstrapState(user.uid, {
+            const fresh = await PreVaultUserStateService.bootstrapState(userId, {
               force: true,
             });
             await prepare(fresh, false);
@@ -345,7 +373,7 @@ export function useSetupCapabilityCoordinator({
     journeyMode,
     resumeReadinessFromCallback,
     replaceRoute,
-    user?.uid,
+    userId,
   ]);
 
   const settle = useCallback(
@@ -353,7 +381,7 @@ export function useSetupCapabilityCoordinator({
       kind: "finish" | "skip",
       options: SetupSettlementOptions = {},
     ): Promise<Settlement> => {
-      if (!user?.uid) {
+      if (!userId) {
         return { status: "blocked", summary: "Sign in to continue setup." };
       }
       if (isSettling) {
@@ -374,7 +402,7 @@ export function useSetupCapabilityCoordinator({
 
       setIsSettling(true);
       try {
-        const journey = await PreVaultUserStateService.bootstrapState(user.uid, {
+        const journey = await PreVaultUserStateService.bootstrapState(userId, {
           force: true,
         });
         const resolvedJourneyMode = resolveSetupCapabilityJourneyMode(
@@ -400,26 +428,26 @@ export function useSetupCapabilityCoordinator({
               new Set([...journey.setupCapabilityIds, capabilityId]),
             ).sort();
             await PreVaultUserStateService.syncSetupCapabilities(
-              user.uid,
+              userId,
               completed,
             );
-            await CapabilityTourService.markExplored(user.uid, capabilityId);
+            await CapabilityTourService.markExplored(userId, capabilityId);
           }
         } else if (kind === "finish") {
           const completed = Array.from(
             new Set([...journey.setupCapabilityIds, capabilityId]),
           ).sort();
           await PreVaultUserStateService.settleOnboardingCapability({
-            userId: user.uid,
+            userId,
             capabilityId,
             completedCapabilityIds: completed,
             expectedJourneyUpdatedAt: journey.onboardingJourneyUpdatedAt,
             callbackState: "succeeded",
           });
-          await CapabilityTourService.markExplored(user.uid, capabilityId);
+          await CapabilityTourService.markExplored(userId, capabilityId);
         } else {
           await PreVaultUserStateService.settleOnboardingCapability({
-            userId: user.uid,
+            userId,
             capabilityId,
             expectedJourneyUpdatedAt: journey.onboardingJourneyUpdatedAt,
             callbackState: "none",
@@ -480,7 +508,7 @@ export function useSetupCapabilityCoordinator({
       replaceRoute,
       settlementBlocked,
       journeyMode,
-      user?.uid,
+      userId,
     ],
   );
 
@@ -493,10 +521,12 @@ export function useSetupCapabilityCoordinator({
     [settle],
   );
   useLocalOnboardingActionHandler(finishActionId, finish, {
-    enabled: enabled && !settlementBlocked,
+    enabled:
+      enabled && routeReady && !settlementBlocked && !isAlreadyComplete,
   });
   useLocalOnboardingActionHandler(skipActionId, skip, {
-    enabled: enabled && !settlementBlocked,
+    enabled:
+      enabled && routeReady && !settlementBlocked && !isAlreadyComplete,
   });
 
   const visibleActionId = operationallyReady ? finishActionId : skipActionId;
@@ -505,7 +535,7 @@ export function useSetupCapabilityCoordinator({
     : `Skip ${setupCapabilityLabel(capabilityId)} setup`;
   const routeSurfaceMetadata = useMemo(
     () =>
-      !enabled || !routeReady
+      !enabled || !routeReady || isAlreadyComplete
         ? null
         : {
             screenId: screenId || SETUP_CAPABILITY_SCREEN[capabilityId],
@@ -539,6 +569,7 @@ export function useSetupCapabilityCoordinator({
     [
       capabilityId,
       enabled,
+      isAlreadyComplete,
       routeReady,
       operationallyReady,
       settlementBlocked,
@@ -553,7 +584,15 @@ export function useSetupCapabilityCoordinator({
     routeSurfaceMetadata,
   );
 
-  return { isReady: routeReady, operationallyReady, isSettling, finish, skip };
+  return {
+    isReady: routeReady,
+    isAlreadyComplete,
+    operationallyReady,
+    isSettling,
+    finish,
+    skip,
+    returnToSetup,
+  };
 }
 
 type SetupCapabilityTerminalFooterProps = {

--- a/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
+++ b/hushh-webapp/components/one-location/onboarding/one-location-onboarding-flow.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { preload } from "react-dom";
 import { ArrowLeft, Check, Loader2, MapPin, UserPlus } from "lucide-react";
+import { toast } from "sonner";
 
 import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import type { ConsentNotificationDeliveryMode } from "@/components/consent/notification-provider";
@@ -1526,7 +1527,7 @@ function PeopleScreen({
         >
           {selectedIds.length > 0
             ? `${selectedIds.length} selected`
-            : "Add anyone you'd like — or just continue"}
+            : "Select at least one person to continue"}
         </p>
         <PrimaryButton
           onClick={() => onContinue(selectedIds)}
@@ -1857,10 +1858,21 @@ export function OneLocationOnboardingFlow({
   };
 
   const handlePeopleContinue = (selectedIds: string[]) => {
-    setSelectedPeopleIds(selectedIds);
-    const selectedPeople = people.filter((person) =>
-      selectedIds.includes(person.userId),
+    const selectedPeople = people.filter(
+      (person) =>
+        selectedIds.includes(person.userId) &&
+        person.relationship !== "pending_incoming" &&
+        person.relationship !== "pending_outgoing",
     );
+    if (selectedPeople.length === 0) {
+      toast.error("Choose at least one contact", {
+        description:
+          "One Location works best with someone in your circle. You can update contacts later from the Connect tab.",
+      });
+      return;
+    }
+
+    setSelectedPeopleIds(selectedPeople.map((person) => person.userId));
     const requestIds = selectedPeople
       .filter(
         (person) =>
@@ -1924,10 +1936,8 @@ export function OneLocationOnboardingFlow({
       });
   };
 
-  // People is an optional step: "Skip" advances into the flow without adding
-  // anyone (or without changing an existing selection) instead of tearing down
-  // onboarding. It reuses the Continue path, so no requests are sent for an
-  // empty/unchanged selection and all prior onboarding data is preserved.
+  // Keep the people-screen Skip path aligned with Continue so neither control
+  // can bypass the minimum-one-contact onboarding requirement.
   const handlePeopleSkip = () => {
     handlePeopleContinue(selectedPeopleIds);
   };

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -268,12 +268,21 @@ export function resolveCapabilityHandoffTarget(capabilityId: string): string {
   return CAPABILITY_HANDOFF_TARGETS[capabilityId] ?? ROUTES.ONE_SETUP;
 }
 
+export type CompletedSetupCapabilityEntry =
+  | { kind: "continue" }
+  | { kind: "acknowledge"; target: string }
+  | { kind: "redirect"; target: string };
+
 /**
- * Completed Location setup reopens its product workspace only after the root
- * setup journey is resolved. While `/one/setup` is still active, the authored
- * setup route remains replayable just like every other capability.
+ * Resolve a durable completion before a capability setup body mounts.
+ *
+ * Location is the only capability with a first-run flow that can finish while
+ * the root setup hub remains active. Re-entering that completed row briefly
+ * acknowledges the saved result and returns to the hub; it must never replay
+ * permissions, contacts, or the circle confirmation. Once root setup itself
+ * is resolved, the canonical Location workspace remains the handoff target.
  */
-export function resolveCompletedSetupCapabilityTarget({
+export function resolveCompletedSetupCapabilityEntry({
   capabilityId,
   completedCapabilityIds,
   rootSetupResolved,
@@ -281,11 +290,17 @@ export function resolveCompletedSetupCapabilityTarget({
   capabilityId: string;
   completedCapabilityIds: readonly string[];
   rootSetupResolved: boolean;
-}): string | null {
-  if (!rootSetupResolved || !completedCapabilityIds.includes(capabilityId)) {
-    return null;
+}): CompletedSetupCapabilityEntry {
+  if (
+    capabilityId !== "location" ||
+    !completedCapabilityIds.includes(capabilityId)
+  ) {
+    return { kind: "continue" };
   }
-  return capabilityId === "location" ? ROUTES.ONE_LOCATION : null;
+
+  return rootSetupResolved
+    ? { kind: "redirect", target: ROUTES.ONE_LOCATION }
+    : { kind: "acknowledge", target: ROUTES.ONE_SETUP };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Require at least one selectable contact before One Location onboarding can advance.
- Keep Continue available so a zero-selection attempt receives immediate guidance, and prevent Skip from bypassing the same rule.
- Detect durable Location completion before the onboarding body, permission prompts, contacts, saved-place capture, or circle confirmation can mount again.
- Show an accessible completed-onboarding screen with a manual **Back to setup** action and a guarded four-second automatic return.
- Align that acknowledgement with the shared One setup design language: `FullscreenFlowShell` reading geometry, Foundation typography, semantic success treatment, and the canonical full-width Morphy CTA (`30rem` cap and `min-h-14`).
- Preserve the existing post-master-setup handoff to the canonical Location workspace.

## Root cause

The contact step previously treated zero recipients as optional. Separately, completed Location setup intentionally reused the same setup route while the root setup hub was still active, so re-entering the completed row replayed the full authored onboarding journey.

## User impact

First-time Location onboarding still follows the existing screens and requires one valid contact. After Location is durably complete and the person reopens its completed row from `/one/setup`, they see **Your Location onboarding is complete** and return to the setup hub without repeating permissions or setup steps. The acknowledgement uses the same spacing, typography, control height, responsive reading width, motion, and semantic status language as the other One setup surfaces.

### Impact Map

- Routes touched: behavior of `/one/setup/location`; no new route or route identifier
- API/schema/type changes: none
- Runtime DB data-plane changes: none
- Cache keys touched: none
- PKM effects: none
- Mobile parity impacts: shared React setup behavior applies to web and Capacitor; no native plugin or bridge contract changed
- Trust boundary touched: none; completion reads the existing redacted setup capability projection
- Caller/proxy/backend pairing: frontend-only coordinator and presentation changes; no service, proxy, or backend contract changed
- Rollback or safe-failure behavior: revert the three branch commits to restore the previous optional-contact and replay behavior; loading/failed completion lookup stays contained to setup
- UI browser or Playwright proof: focused component and real-coordinator tests cover zero-contact validation, cached and cold completion, resolved-root redirect, handler suppression, shared shell/CTA geometry, manual return, automatic return, and timer cleanup. The protected signed-in route sweep was attempted locally but correctly refused to start without the maintainer-only reviewer UID and vault passphrase; no secret bypass was introduced.
- Docs updated: `docs/reference/quality/one-onboarding-architecture.md`

## Verification

- PR-focused Vitest suite: 70 passed across 7 files
- Cache contract suite: 55 passed across 7 files
- Targeted ESLint: passed with zero warnings
- `npm run typecheck`: passed
- `npm run verify:service-boundary`: passed
- `npm run verify:design-system`: passed
- `npm run verify:cache`: passed
- `npm run verify:docs`: passed
- `./bin/hushh docs verify`: passed
- DCO signoff check passed for all three PR commits

---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)