### PR TITLE
fix(one-location): stop returning SQL bound parameters in DB error details

### DIFF
--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -5548,11 +5548,36 @@ def location_error_detail(exc: OneLocationAgentError) -> dict[str, str]:
     return {"code": exc.code, "message": exc.message}
 
 
+_DB_UNAVAILABLE_HTTP_STATUS = 503
+_DB_UNAVAILABLE_MESSAGE = "Location storage is temporarily unavailable. Try again shortly."
+_DB_FAILED_MESSAGE = "Location request failed."
+
+
 def database_error_detail(exc: DatabaseExecutionError) -> dict[str, str]:
+    """Client-safe detail for a database failure.
+
+    `exc.details` is `str(<the DBAPI error>)`, and SQLAlchemy appends the failing
+    statement plus every bound value to that string (no engine here sets
+    `hide_parameters`). Location binds phone numbers, display labels, invite
+    tokens and coordinates, so the raw detail stays server-side: the caller gets
+    the stable code and the static hint, which is all it can act on anyway.
+    """
+    code = getattr(exc, "code", "DATABASE_EXECUTION_ERROR")
+    status_code = getattr(exc, "status_code", 500)
+    logger.error(
+        "one_location.database_error code=%s table=%s operation=%s",
+        code,
+        getattr(exc, "table_name", "unknown"),
+        getattr(exc, "operation", "unknown"),
+    )
     return {
-        "code": exc.code,
-        "message": exc.details,
-        "hint": exc.hint or "",
+        "code": code,
+        "message": (
+            _DB_UNAVAILABLE_MESSAGE
+            if status_code == _DB_UNAVAILABLE_HTTP_STATUS
+            else _DB_FAILED_MESSAGE
+        ),
+        "hint": getattr(exc, "hint", "") or "",
     }
 
 

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -33,3 +33,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_one_location_db_error_detail_cwe209.py

--- a/consent-protocol/tests/test_one_location_db_error_detail_cwe209.py
+++ b/consent-protocol/tests/test_one_location_db_error_detail_cwe209.py
@@ -1,0 +1,204 @@
+"""
+Regression tests: DatabaseExecutionError.details must not reach HTTP clients.
+
+CWE-209 - Information Exposure Through Error Messages.
+
+database_error_detail() in hushh_mcp/services/one_location_agent_service.py
+previously forwarded the raw exception detail into the HTTP response body:
+
+    return {
+        "code": exc.code,
+        "message": exc.details,      # <-- str(<the DBAPI error>)
+        "hint": exc.hint or "",
+    }
+
+db/db_client.py builds that `details` from `str(e)` on the SQLAlchemy error
+(raise sites for select/insert/update/delete). For a DBAPIError, SQLAlchemy
+appends the failing SQL statement AND every bound value to str(e) -- no engine
+in this service sets hide_parameters -- so the detail looks like:
+
+    (psycopg2.errors...) ...
+    [SQL: INSERT INTO one_location_recipients (...) VALUES (...)]
+    [parameters: {'phone': '+919812345678', 'email': '...', 'lat': 12.97, ...}]
+
+The Location plane binds phone numbers, display labels, invite tokens and
+coordinates, so those bound values are user PII.
+
+format_database_unavailable_details() does not sanitise -- it only appends a
+local-dev hint -- and local_database_unavailable_hint() returns None in
+production, so nothing upstream neutralises the leak.
+
+Fix: return a static message chosen by status code (503 vs 500); keep the
+stable `code` and the static `hint`; log the code/table/operation server-side.
+Same shape as the Wallet Profile routes, which duck-type the exception for the
+identical reason (routes may not import db.*).
+
+Attach point: database_error_detail() is called by _handle_error() in
+api/routes/one/location.py, which every /api/one/location/* handler raises
+through.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SENTINEL = "XK9_ONE_LOCATION_DB_PARAMS_SENTINEL_XK9"
+
+_FAKE_FIREBASE_UID = "test-one-location-cwe209"
+_FAKE_TOKEN_DATA = {
+    "user_id": _FAKE_FIREBASE_UID,
+    "token_type": "VAULT_OWNER",
+    "scope": "vault.owner",
+}
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+
+    from api.middleware import require_vault_owner_token
+    from server import app
+
+    app.dependency_overrides[require_vault_owner_token] = lambda: _FAKE_TOKEN_DATA
+    try:
+        with TestClient(app, raise_server_exceptions=False) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(require_vault_owner_token, None)
+
+
+def _make_db_error(sentinel: str, *, status_code: int = 500):
+    """A DatabaseExecutionError shaped exactly like the ones db_client raises."""
+    from db.db_client import DatabaseExecutionError
+
+    return DatabaseExecutionError(
+        table_name="one_location_recipients",
+        operation="insert",
+        details=(
+            "(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint\n"
+            "[SQL: INSERT INTO one_location_recipients (owner_user_id, phone) VALUES (%s, %s)]\n"
+            f"[parameters: {{'owner_user_id': 'user_a', 'phone': '{sentinel}'}}]"
+        ),
+        status_code=status_code,
+        code="DATABASE_UNAVAILABLE" if status_code == 503 else "DATABASE_EXECUTION_ERROR",
+        hint=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: database_error_detail directly
+# ---------------------------------------------------------------------------
+
+
+def test_bound_parameters_not_in_error_detail() -> None:
+    """The raw str(DBAPIError) must not appear in the client-facing detail."""
+    from hushh_mcp.services.one_location_agent_service import database_error_detail
+
+    detail = database_error_detail(_make_db_error(SENTINEL))
+
+    detail_str = str(detail)
+    assert SENTINEL not in detail_str, f"bound parameter leaked into detail: {detail_str}"
+    assert "[parameters:" not in detail_str
+    assert "[SQL:" not in detail_str
+    assert "psycopg2" not in detail_str
+
+
+def test_error_code_is_preserved() -> None:
+    """Error code must still be returned for client routing."""
+    from hushh_mcp.services.one_location_agent_service import database_error_detail
+
+    detail = database_error_detail(_make_db_error(SENTINEL))
+
+    assert detail["code"] == "DATABASE_EXECUTION_ERROR"
+    assert detail["message"] == "Location request failed."
+
+
+def test_unavailable_status_gets_its_own_static_message() -> None:
+    """A 503 must stay distinguishable from a 500 without echoing the detail."""
+    from hushh_mcp.services.one_location_agent_service import database_error_detail
+
+    detail = database_error_detail(_make_db_error(SENTINEL, status_code=503))
+
+    assert detail["code"] == "DATABASE_UNAVAILABLE"
+    assert detail["message"] == "Location storage is temporarily unavailable. Try again shortly."
+    assert SENTINEL not in str(detail)
+
+
+def test_static_local_hint_is_still_forwarded() -> None:
+    """The hint is static operator text (local dev only) and stays useful."""
+    from hushh_mcp.services.one_location_agent_service import database_error_detail
+
+    exc = _make_db_error(SENTINEL, status_code=503)
+    exc.hint = "Local backend database tunnel is unavailable."
+
+    detail = database_error_detail(exc)
+
+    assert detail["hint"] == "Local backend database tunnel is unavailable."
+    assert SENTINEL not in str(detail)
+
+
+def test_raw_detail_is_logged_server_side(caplog) -> None:
+    """The operator still gets the code/table/operation in the server log."""
+    import logging
+
+    from hushh_mcp.services.one_location_agent_service import database_error_detail
+
+    with caplog.at_level(logging.ERROR, logger="hushh_mcp.services.one_location_agent_service"):
+        database_error_detail(_make_db_error(SENTINEL))
+
+    assert "one_location.database_error" in caplog.text
+    assert "one_location_recipients" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Route-level: _handle_error
+# ---------------------------------------------------------------------------
+
+
+def test_handle_error_does_not_leak_bound_parameters() -> None:
+    """_handle_error is the single funnel for every /api/one/location/* handler."""
+    from api.routes.one.location import _handle_error
+
+    http_exc = _handle_error(_make_db_error(SENTINEL))
+
+    assert http_exc.status_code == 500
+    assert SENTINEL not in str(http_exc.detail)
+    assert http_exc.detail.get("code") == "DATABASE_EXECUTION_ERROR"
+
+
+def test_handle_error_preserves_unavailable_status() -> None:
+    from api.routes.one.location import _handle_error
+
+    http_exc = _handle_error(_make_db_error(SENTINEL, status_code=503))
+
+    assert http_exc.status_code == 503
+    assert SENTINEL not in str(http_exc.detail)
+
+
+# ---------------------------------------------------------------------------
+# HTTP proof: TestClient sentinel-injection
+# ---------------------------------------------------------------------------
+
+
+def test_http_location_state_db_error_does_not_leak_parameters(client) -> None:
+    """
+    GET /api/one/location/state with a failing DB layer must not return the
+    SQL statement or its bound values in the HTTP response body.
+
+    Attach point: get_location_state -> _service().list_state ->
+    DatabaseExecutionError -> _handle_error -> database_error_detail.
+    """
+    mock_svc = MagicMock()
+    mock_svc.list_state.side_effect = _make_db_error(SENTINEL, status_code=503)
+
+    with patch("api.routes.one.location._service", return_value=mock_svc):
+        resp = client.get("/api/one/location/state")
+
+    assert resp.status_code == 503
+    body = resp.text
+    assert SENTINEL not in body, f"bound parameter leaked into HTTP response: {body}"
+    assert "[parameters:" not in body
+    assert "[SQL:" not in body
+    assert resp.json().get("detail", {}).get("code") == "DATABASE_UNAVAILABLE"

--- a/consent-protocol/tests/test_one_location_routes.py
+++ b/consent-protocol/tests/test_one_location_routes.py
@@ -18,7 +18,13 @@ from tests.services.test_one_location_agent_service import (
 
 class DatabaseExecutionError(Exception):
     code = "DATABASE_UNAVAILABLE"
-    details = "Database temporarily unavailable."
+    # Shaped like the real thing: db_client passes str(<the DBAPI error>), and
+    # SQLAlchemy appends the statement plus every bound value to that.
+    details = (
+        "(psycopg2.OperationalError) connection failed\n"
+        "[SQL: SELECT * FROM one_location_recipients WHERE phone = %s]\n"
+        "[parameters: {'phone': '+919812345678'}]"
+    )
     hint = "Retry later."
     status_code = 503
 
@@ -675,9 +681,13 @@ def test_one_location_route_preserves_db_error_mapping_without_db_client_import(
     assert response.status_code == 503
     assert response.detail == {
         "code": "DATABASE_UNAVAILABLE",
-        "message": "Database temporarily unavailable.",
+        "message": "Location storage is temporarily unavailable. Try again shortly.",
         "hint": "Retry later.",
     }
+    # CWE-209: the raw SQLAlchemy detail carries the statement and its bound
+    # values; only the code and the static hint may cross the wire.
+    assert "[parameters:" not in str(response.detail)
+    assert "+919812345678" not in str(response.detail)
 
 
 def test_recipient_key_blob_is_returned_to_owner_and_never_leaks_to_others(monkeypatch) -> None:


### PR DESCRIPTION
## What

`database_error_detail()` in `consent-protocol/hushh_mcp/services/one_location_agent_service.py` forwarded `exc.details` straight into the HTTP response body.

`db/db_client.py` builds that string from `str(e)` on the SQLAlchemy error. For a `DBAPIError`, SQLAlchemy appends the failing statement **and every bound value** to `str(e)` — no engine on this path sets `hide_parameters` — so the detail looks like:

```
(psycopg2.OperationalError) connection failed
[SQL: SELECT * FROM one_location_recipients WHERE phone = %s]
[parameters: {'phone': '+91...'}]
```

The Location plane binds phone numbers, display labels, invite tokens and coordinates, so those bound values are user PII reaching an HTTP client. **CWE-209 — Information Exposure Through Error Messages.**

Nothing upstream neutralised it:
- `format_database_unavailable_details()` (`db/connection.py:140`) does not sanitize — it only appends a hint.
- `local_database_unavailable_hint()` (`db/connection.py:123`) returns `None` in production, so `format_...` returns the raw `str(e)` unchanged there.

## Fix

Return a **static** message chosen by status code (503 vs 500), keep the stable `code` and the static operator `hint`, and log `code`/`table`/`operation` server-side.

This is the same shape the Wallet Profile routes already use for this exact exception.

Fixed in the **shared helper** rather than at the call site: every `/api/one/location/*` handler raises through `_handle_error` in `api/routes/one/location.py`, which is the helper's only caller, so this covers the whole surface — present and future.

`hint` is still forwarded: it is static operator text about a local dev tunnel and is `None` in production.

## Tests

New `consent-protocol/tests/test_one_location_db_error_detail_cwe209.py` — 8 cases:
- helper: bound parameters absent, code preserved, 503 gets its own static message, static hint still forwarded, raw detail logged server-side
- route: `_handle_error` does not leak, and preserves the 503 status
- HTTP proof: TestClient sentinel-injection over `GET /api/one/location/state`

**All 8 fail against the pre-fix helper** (verified by reverting the service file and re-running) and pass after.

Registered in `consent-protocol/scripts/test-ci.manifest.txt` so the backend CI lane actually runs it, alongside the existing `*_cwe209.py` guards.

`tests/test_one_location_routes.py::test_one_location_route_preserves_db_error_mapping_without_db_client_import` was asserting the old passthrough. Its stub now carries a realistic leaky `details` and the test asserts that detail never crosses the wire — strengthened, not relaxed. Its original architecture assertion (routes must not import `db.*`) is untouched.

## Verification

Run locally on this branch, all exactly as CI invokes them:

| Gate | Result |
|---|---|
| `scripts/run-test-ci.sh` (backend CI manifest) | **455 passed** |
| `ruff check .` (pinned 0.15.11) | All checks passed |
| `ruff format --check` | 2 files already formatted |
| `mypy --config-file pyproject.toml` | Success, no issues in 92 source files |
| `bandit -ll` | exit 0 — High 0, Medium 0 |
| `verify-deployment-environment-governance.py` | exit 0 — matches documented contract |
| `pytest -k location` | 312 passed, 1 pre-existing failure (below) |

## Out of scope, reported not fixed

`tests/services/test_one_location_agent_service.py::test_kai_circle_recipient_directory_uses_safe_recommendation_signals` fails on unmodified `main` (`relationshipType` resolves to `Marketplace profile`, expected `Advisor relationship`). Verified pre-existing by stashing this change and re-running. CI stays green because that file is not in `scripts/test-ci.manifest.txt`. Not touched here — no test was skipped, deleted, or weakened to get this branch green.

## Risk

Behaviour change is limited to the error-response body on `/api/one/location/*` when the database fails: clients now get a static message instead of the raw driver string. The `code` field — the only part a client can branch on — is unchanged, as is the HTTP status.


---
Closes #4908
(retroactive board-linkage backfill, 2026-08-06)