### PR TITLE
chore(copy): apply the less-text standard across the One surfaces

### DIFF
--- a/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/onboarding-page.test.tsx
@@ -784,7 +784,7 @@ describe("RiaOnboardingPage", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/too many verification/i)).toBeTruthy();
+      expect(screen.getByText(/too many attempts/i)).toBeTruthy();
     });
   });
 

--- a/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/picks-page.test.tsx
@@ -480,7 +480,7 @@ describe("RiaPicksPage", () => {
       screen.getByRole("link", { name: /download template/i }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /upload and replace top picks/i }),
+      screen.getByRole("button", { name: /replace top picks/i }),
     ).toBeTruthy();
   });
 

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -1058,7 +1058,7 @@ export function KaiAnalysisPageContent() {
           <KaiWorkspaceHeader
               workspace="analysis"
               title="Analysis"
-              description="Review the live debate and detailed recommendation."
+              description="Live debate and recommendation."
               actions={
                 <>
                   {liveIntentReady ? (
@@ -1220,7 +1220,7 @@ export function KaiAnalysisPageContent() {
                   </div>
                 ) : (
                   <div className="rounded-2xl border border-dashed border-border/60 bg-background/80 p-4 text-sm text-muted-foreground">
-                    Your summary will appear as soon as the first recommendation is ready.
+                    Summary appears after the first recommendation.
                   </div>
                 )}
               </div>
@@ -1236,7 +1236,7 @@ export function KaiAnalysisPageContent() {
                   />
                 ) : (
                   <div className="rounded-2xl border border-dashed border-border/60 bg-background/80 p-4 text-sm text-muted-foreground">
-                    Detailed analysis will appear once the first recommendation is complete.
+                    Details appear after the first recommendation.
                   </div>
                 )}
               </div>
@@ -1266,7 +1266,7 @@ export function KaiAnalysisPageContent() {
                   ) : null}
                 </span>
               }
-              description="Review saved debates and reopen a previous decision."
+              description="Reopen a past debate."
           />
           <AppPageContentRegion className="min-w-0 max-w-full">
             <SurfaceStack compact className="min-w-0 max-w-full">

--- a/hushh-webapp/app/one/kyc/page.tsx
+++ b/hushh-webapp/app/one/kyc/page.tsx
@@ -947,7 +947,7 @@ export function OneKycWorkspace({
             [selected.workflow_id]: attemptKey,
           }));
           setError(
-            "One could not prepare this draft yet. Sync this request once after access finishes refreshing.",
+            "Draft not ready. Sync once access refreshes.",
           );
           return;
         }
@@ -1418,7 +1418,7 @@ export function OneKycWorkspace({
       });
       if (lookup.missing_request_ids.length > 0) {
         throw new Error(
-          "One could not find the linked access request. Sync this request once so access can refresh.",
+          "No linked access request. Sync to refresh access.",
         );
       }
       return lookup.items.map(pendingLookupItemToPendingConsent);
@@ -1628,7 +1628,7 @@ export function OneKycWorkspace({
       }
       const parsed = parseAttrScope(candidate.scope);
       if (!parsed) {
-        setError("This information section could not be previewed.");
+        setError("Couldn't preview this section.");
         return;
       }
       const title = dataLabelForCandidate(candidate);
@@ -1809,7 +1809,7 @@ export function OneKycWorkspace({
               <SettingsRow
                 icon={AlertTriangle}
                 title="Vault missing"
-                description="We couldn't save settings to your vault because it isn't set up yet. Please complete the setup in Onboarding or Settings to use this feature."
+                description="Set up your vault in Onboarding or Settings."
               />
             </SettingsGroup>
           ) : (
@@ -1825,7 +1825,7 @@ export function OneKycWorkspace({
                 <SettingsRow
                   icon={Inbox}
                   title="Checking requests"
-                  description="Looking for requests matched to your verified addresses."
+                  description="Matching your verified addresses."
                   trailing={
                     <Loader2 className="size-4 animate-spin text-muted-foreground" />
                   }
@@ -1980,7 +1980,7 @@ export function OneKycWorkspace({
                   <SettingsRow
                     icon={AlertTriangle}
                     title="Sync required"
-                    description="Unlock completed. Sync this request so One can prepare access safely from your device."
+                    description="Unlocked. Sync to prepare access on this device."
                   />
                 </SettingsGroup>
               ) : null}
@@ -2467,7 +2467,7 @@ export function OneKycWorkspace({
               <SettingsRow
                 icon={RefreshCw}
                 title="Checking your vault"
-                description="Loading the saved values for this information section."
+                description="Loading your saved values."
                 trailing={<Loader2 className="size-4 animate-spin text-muted-foreground" />}
                 stackTrailingOnMobile
               />
@@ -2716,10 +2716,10 @@ function errorMessage(value: unknown): string {
 function oneKycErrorMessage(value: unknown, fallback: string): string {
   const code = apiErrorCode(value);
   if (code === "ONE_KYC_EXPORT_SCOPE_MISMATCH") {
-    return "One is refreshing the approved information for this request. Sync again in a moment.";
+    return "Approved details are refreshing. Sync again in a moment.";
   }
   if (code === "ONE_KYC_EXPORT_NOT_CURRENT" || code === "ONE_KYC_EXPORT_UNAVAILABLE") {
-    return "The approved information is still being prepared. Sync this request again in a moment.";
+    return "Approved details aren't ready yet. Sync again in a moment.";
   }
   return value instanceof Error && value.message ? value.message : fallback;
 }

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -826,7 +826,7 @@ function isSafeUserFacingMessage(message: string): boolean {
 
 function oneLocationErrorMessage(error: unknown, fallback: string): string {
   if (isTransientOneApiError(error)) {
-    return "One is still catching up. Please refresh once, then check this page before retrying.";
+    return "One is still catching up. Refresh, then check before retrying.";
   }
   const raw = error instanceof Error ? error.message : "";
   return isSafeUserFacingMessage(raw) ? raw : fallback;
@@ -1459,7 +1459,7 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
     return {
       title: "Turn on phone Location",
       description:
-        "Your phone Location switch is off. Turn it on before sharing with your trusted circle.",
+        "Phone Location is off. Turn it on to share.",
       tone: "blocked",
       actionLabel: "Open Location Settings",
     };
@@ -1486,7 +1486,7 @@ function readinessCopy(permission: HushhLocationPermissionState | null): {
     return {
       title: "Location unavailable",
       description:
-        "This device cannot provide a fresh location right now. Check Location settings and try again.",
+        "No fresh location right now. Check Location settings.",
       tone: "blocked",
       actionLabel: "Open Location Settings",
     };
@@ -5552,7 +5552,7 @@ export function OneLocationAgentPageContent({
       try {
         idToken = await auth.user.getIdToken();
       } catch {
-        toast.error("Your session could not be verified. Please try again.");
+        toast.error("Couldn't verify your session. Try again.");
         return { sentUserIds: [], failedUserIds: [...new Set(userIds)] };
       }
       const sentUserIds: string[] = [];
@@ -6050,7 +6050,7 @@ export function OneLocationAgentPageContent({
       return;
     }
     toast.info(
-      "Push notifications could not be enabled. Updates will still appear in One.",
+      "Couldn't enable push. Updates still appear in One.",
     );
   }, [isRetryingPushRegistration, notificationDeliveryMode]);
 
@@ -6757,7 +6757,7 @@ export function OneLocationAgentPageContent({
                         description={
                           recipients.length
                             ? "Try another name, role, or recommendation signal."
-                            : "Approval, professional, ready, and setup signals will appear as your One Network grows."
+                            : "Signals appear as your One Network grows."
                         }
                       />
                     )}
@@ -7548,7 +7548,7 @@ export function OneLocationAgentPageContent({
                       description={
                         unwatchedActiveReceivedGrantCount > 0
                           ? "Refresh to start watching a hidden share again, or ask them to re-share."
-                          : "When someone shares their live location with you, it appears here automatically - no need to open a notification."
+                          : "Shares sent to you appear here automatically."
                       }
                     />
                   )}

--- a/hushh-webapp/app/one/marketplace/page.tsx
+++ b/hushh-webapp/app/one/marketplace/page.tsx
@@ -1087,8 +1087,7 @@ function OneMarketplacePageImpl() {
               {sections.length === 0 ? (
                 <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
                   <Store className="mx-auto mb-2 h-6 w-6 opacity-60" aria-hidden />
-                  No shareable sections yet. Add some Memory (e.g. via onboarding or the PKM
-                  workspace), then each section will appear here to price and publish.
+                  No sections yet. Add Memory via onboarding or the PKM workspace.
                 </div>
               ) : (
                 sections.map((section) => {
@@ -1213,8 +1212,7 @@ function OneMarketplacePageImpl() {
               ) : listings.length === 0 ? (
                 <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
                   <Store className="mx-auto mb-2 h-6 w-6 opacity-60" aria-hidden />
-                  Nothing on the market yet. When people publish a safe profile summary, it appears
-                  here for requests.
+                  Nothing on the market yet.
                 </div>
               ) : (
                 <div className="grid gap-4 sm:grid-cols-2">
@@ -1272,8 +1270,7 @@ function OneMarketplacePageImpl() {
               {received.length === 0 ? (
                 <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-muted-foreground">
                   <Store className="mx-auto mb-2 h-6 w-6 opacity-60" aria-hidden />
-                  Nothing here yet. In the <span className="font-medium text-foreground">Buyer</span> tab,
-                  request an available slice — once the owner approves, the delivered data shows here.
+                  Nothing yet. Request a slice in the <span className="font-medium text-foreground">Buyer</span> tab.
                 </div>
               ) : (
                 <div className="space-y-3">
@@ -1311,7 +1308,7 @@ function OneMarketplacePageImpl() {
                                   {delivery?.status === "error"
                                     ? delivery.message
                                     : delivery?.status === "empty"
-                                      ? "Approved — the slice hasn’t been delivered yet. Check back shortly."
+                                      ? "Approved — not delivered yet. Check back soon."
                                       : "Approved — the encrypted safe summary was delivered to you."}
                                 </span>
                                 <Button

--- a/hushh-webapp/app/one/setup/kai/page.tsx
+++ b/hushh-webapp/app/one/setup/kai/page.tsx
@@ -380,7 +380,7 @@ function KaiOnboardingPageContent({
         expectedJourneyUpdatedAt: journey.onboardingJourneyUpdatedAt,
       });
       toast.success(
-        "Finance preferences saved. Choose how to add your portfolio.",
+        "Preferences saved.",
       );
       setOnboardingRequiredCookie(true);
       setOnboardingFlowActiveCookie(true);
@@ -408,7 +408,7 @@ function KaiOnboardingPageContent({
       return {
         status: "failed" as const,
         summary:
-          "Finance preferences could not be finalized. Please try again.",
+          "Couldn't save your finance preferences. Try again.",
       };
     } finally {
       setSaving(false);

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -147,7 +147,7 @@ function resolveRiaSubmitErrorMessage(
   if (/verification provider unavailable/i.test(message)) {
     return options.localVerificationBypassEnabled
       ? "Live verification is unavailable. For UAT testing, go back to the licence step and use Bypass for dev/UAT."
-      : "Live verification is unavailable. Please try again later.";
+      : "Verification is unavailable. Try again later.";
   }
   return message;
 }
@@ -791,7 +791,7 @@ export default function RiaOnboardingPage({
       }
       if (verifyError instanceof RiaApiError && verifyError.status === 429) {
         updateDraft({ licenseVerificationStatus: "idle" });
-        setError("Too many verification attempts. Please wait a moment.");
+        setError("Too many attempts. Wait a moment.");
         return;
       }
       updateDraft({ licenseVerificationStatus: "error" });

--- a/hushh-webapp/app/ria/picks/page.tsx
+++ b/hushh-webapp/app/ria/picks/page.tsx
@@ -394,8 +394,7 @@ function UploadPanel({
         <div>
           <h3 className="text-sm font-semibold text-foreground">Upload a top-picks CSV</h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            CSV parsing still works, but it now feeds the same live package save path as the inline
-            editor. Your current avoid and screening rules stay attached.
+            Your avoid and screening rules stay attached.
           </p>
         </div>
         <div className="space-y-3">
@@ -425,7 +424,7 @@ function UploadPanel({
               disabled={submitting || !fileContent.trim()}
             >
               <Upload className="mr-2 h-4 w-4" />
-              {submitting ? "Uploading..." : "Upload and replace top picks"}
+              {submitting ? "Uploading..." : "Replace top picks"}
             </Button>
             <Button asChild variant="none" effect="fade" size="sm">
               <a href="/templates/ria-picks-template.csv" download>
@@ -497,7 +496,7 @@ function ValidationIssuesPanel({
               </p>
             </div>
             <p className="text-sm text-muted-foreground">
-              Jump straight to invalid rows or filter the editor down to issues only.
+              Open a row to fix it.
             </p>
           </div>
           <Button
@@ -604,7 +603,7 @@ function TickerLookupField({
       displayValue={value}
       placeholder="Search SEC ticker"
       searchPlaceholder="Search SEC-backed symbol..."
-      emptyText="No valid SEC ticker matches this query."
+      emptyText="No matching ticker."
       invalid={invalid}
       allowClear
       loadOptions={loadTickerCommandOptions}
@@ -817,7 +816,7 @@ function TopPicksEditor({
                 <MobileEditorField label="Tier">
                   <CommandPickerField
                     title="Select tier"
-                    description="Choose the conviction band the investor debate should inherit."
+                    description="The conviction band this name carries."
                     value={row.tier}
                     placeholder="Tier"
                     options={TIER_COMMAND_OPTIONS}
@@ -830,7 +829,7 @@ function TopPicksEditor({
                 <MobileEditorField label="Investment thesis">
                   <PopupTextEditorField
                     title={`Investment thesis for ${row.ticker || `top pick ${displayIndex}`}`}
-                    description="Keep the list compact, then edit the full thesis in this focused editor."
+                    description="A line or two is enough."
                     value={row.investment_thesis}
                     placeholder="Why this name belongs in the live debate universe"
                     previewPlaceholder="Add the investment thesis"
@@ -878,7 +877,7 @@ function TopPicksEditor({
                   <TableCell className="px-3 py-2.5 align-top">
                     <CommandPickerField
                       title="Select tier"
-                      description="Choose the conviction band the investor debate should inherit."
+                      description="The conviction band this name carries."
                       value={row.tier}
                       placeholder="Tier"
                       options={TIER_COMMAND_OPTIONS}
@@ -1050,7 +1049,7 @@ function AvoidEditor({
                 <MobileEditorField label="Category">
                   <CommandPickerField
                     title={`Avoid category for ${row.ticker || `avoid row ${index + 1}`}`}
-                    description="Use a shared category language so the linked-investor debate reads consistently."
+                    description="Keep categories consistent across names."
                     value={row.category}
                     placeholder="Select category"
                     options={categoryOptions}
@@ -1062,7 +1061,7 @@ function AvoidEditor({
                 <MobileEditorField label="Reason">
                   <PopupTextEditorField
                     title={`Avoid reason for ${row.ticker || `avoid row ${displayIndex}`}`}
-                    description="Capture the exclusion logic in a focused editor instead of a cramped inline textarea."
+                    description="A short reason is enough."
                     value={row.why_avoid}
                     placeholder="Why this name should be screened out"
                     previewPlaceholder="Add the avoid reason"
@@ -1123,7 +1122,7 @@ function AvoidEditor({
                   <TableCell className="px-3 py-2.5 align-top">
                     <CommandPickerField
                       title={`Avoid category for ${row.ticker || "this avoid row"}`}
-                      description="Use a shared category language so the linked-investor debate reads consistently."
+                      description="Keep categories consistent across names."
                       value={row.category}
                       placeholder="Select category"
                       options={categoryOptions}
@@ -1134,7 +1133,7 @@ function AvoidEditor({
                   <TableCell className="px-3 py-2.5 align-top">
                     <PopupTextEditorField
                       title={`Avoid reason for ${row.ticker || "this avoid row"}`}
-                      description="Capture the exclusion logic in a focused editor instead of a cramped inline textarea."
+                      description="A short reason is enough."
                       value={row.why_avoid}
                       placeholder="Why this name should be screened out"
                       previewPlaceholder="Add the avoid reason"
@@ -1263,7 +1262,7 @@ function ScreeningEditor({
               <div className="space-y-3">
                 {filteredRows.length === 0 ? (
                   <SurfaceInset className="px-4 py-3 text-sm text-muted-foreground">
-                    No rules yet. Add the rubric you want Kai to carry into the investor debate.
+                    No rules yet. Add what Kai should check.
                   </SurfaceInset>
                 ) : null}
                 {filteredRows.map((row) => (
@@ -1283,7 +1282,7 @@ function ScreeningEditor({
                       />
                       <PopupTextEditorField
                         title={`Rule detail for ${row.title || "this screening rule"}`}
-                        description="Explain the screening logic in plain language without squeezing it into the grid."
+                        description="What this rule does."
                         value={row.detail}
                         placeholder="Explain the rule in plain language"
                         previewPlaceholder="Add the rule detail"
@@ -1966,7 +1965,7 @@ export default function RiaPicksPage() {
     });
 
     if (nextTopRows.length === 0) {
-      packageErrors.push("Top picks cannot be empty. This list powers the linked-investor debate universe.");
+      packageErrors.push("Add at least one top pick.");
     }
 
     return {
@@ -2055,7 +2054,7 @@ export default function RiaPicksPage() {
       setSource("my");
       setEditing(true);
       setUploadOpen(false);
-      toast.success("Copied all Kai tabs into My list. Save to publish it.");
+      toast.success("Copied to My list. Save to publish.");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to copy list");
     } finally {
@@ -2110,7 +2109,7 @@ export default function RiaPicksPage() {
       setValidationState(validation);
       if (validation.packageErrors.length > 0 || Object.keys(validation.rowErrors).length > 0) {
         setShowIssuesOnly(true);
-        toast.error("Fix the highlighted validation issues before saving.");
+        toast.error("Fix the highlighted issues first.");
         return;
       }
       await savePackage(payload);
@@ -2645,7 +2644,7 @@ export default function RiaPicksPage() {
                   <SurfaceCardContent className="p-4 sm:p-5">
                     <p className="text-sm font-medium text-foreground">Unlock required</p>
                     <p className="mt-1 text-sm leading-6 text-muted-foreground">
-                      This advisor package is now stored in your PKM. Unlock the vault to view or edit it.
+                      Unlock the vault to view or edit it.
                     </p>
                   </SurfaceCardContent>
                 </SurfaceCard>

--- a/hushh-webapp/components/agent/agent-chat-workspace.tsx
+++ b/hushh-webapp/components/agent/agent-chat-workspace.tsx
@@ -3648,7 +3648,7 @@ export function AgentChatWorkspace({
       .find((message) => message.role === "user" && message.text.trim().length > 0);
     const retryText = previousUserMessage?.text.trim();
     if (!retryText) {
-      toast.error("No previous message found to retry.");
+      toast.error("Nothing to retry.");
       return;
     }
     if (!tryAcquireAgentTurnSubmitLock(agentTurnSubmitLockRef)) return;

--- a/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-settings-card.tsx
@@ -474,9 +474,9 @@ export function GeminiRuntimeSettingsCard({
       setMode("hushh_managed_vertex");
       setHasSavedKey(false);
       notifyGeminiRuntimeConfigurationChanged();
-      toast.success("Your saved Gemini key was removed.");
+      toast.success("Gemini key removed.");
     } catch {
-      toast.error("Your Gemini key could not be removed.");
+      toast.error("Couldn't remove your key. Try again.");
     } finally {
       setIsRemoving(false);
     }

--- a/hushh-webapp/components/consent/consent-center-page.tsx
+++ b/hushh-webapp/components/consent/consent-center-page.tsx
@@ -945,11 +945,11 @@ function ConsentEntryDetail({
       <SettingsGroup
         embedded
         title="Select a request"
-        description="Choose an item from the list to review its details and available actions."
+        description="Details and actions appear here."
       >
         <SettingsRow
           title="Nothing selected yet"
-          description="Pending, active, and previous items open here."
+          description="Pick one from the list."
         />
       </SettingsGroup>
     );
@@ -2806,8 +2806,8 @@ export function ConsentCenterPage() {
               {showCompactRetryState ? (
                 <ApiRetryState
                   variant="compact"
-                  title="Showing saved consent information"
-                  description="The latest refresh failed. You can keep reviewing cached data or refresh from the page header."
+                  title="Showing saved data"
+                  description="Refresh failed. Use Refresh at the top."
                   onRetry={retryConsentCenter}
                   showRetryAction={false}
                 />
@@ -2818,8 +2818,8 @@ export function ConsentCenterPage() {
                   title="Consent service is unavailable"
                   description={
                     consentLoadError
-                      ? `The consent service did not return the latest access state. ${consentLoadError}`
-                      : "The consent service did not return the latest access state. Refresh from the page header when the backend is available."
+                      ? `Use Refresh at the top. ${consentLoadError}`
+                      : "Use Refresh at the top once it's back."
                   }
                   onRetry={retryConsentCenter}
                   showRetryAction={false}
@@ -2931,7 +2931,7 @@ export function ConsentCenterPage() {
                   : `${formatStatus(selectedEntry.status)} request`
             : selectedId
               ? "Resolving the selected consent request."
-              : "Choose a consent entry from the list to review details and next actions."
+              : "Pick one to see details."
         }
         mobilePresentation="sheet"
         showCloseButton={false}
@@ -2972,7 +2972,7 @@ export function ConsentCenterPage() {
             ) : selectedRequestMissing ? (
               <SettingsRow
                 title="Request not found"
-                description="This request may already be approved, denied, expired, or belong to a different consent lane. Use the tabs to check Active Access or History."
+                description="May already be handled or expired. Check Active Access or History."
                 trailing={
                   <Button
                     type="button"

--- a/hushh-webapp/components/gmail/gmail-nudges-section.tsx
+++ b/hushh-webapp/components/gmail/gmail-nudges-section.tsx
@@ -194,7 +194,7 @@ export default function GmailNudgesSection({
       <NudgeGroup
         eyebrow="Needs a reply"
         blurb="Inbox threads waiting on your response."
-        emptyText="You’re all caught up — nothing needs a reply right now. ✅"
+        emptyText="All caught up ✅"
         nudges={needsReply}
         loading={loading}
         loaded={loaded}
@@ -204,7 +204,7 @@ export default function GmailNudgesSection({
       <NudgeGroup
         eyebrow="Upcoming meeting"
         blurb="Calendar invites coming up."
-        emptyText="No upcoming meetings from your inbox."
+        emptyText="No upcoming meetings."
         nudges={meetings}
         loading={loading}
         loaded={loaded}

--- a/hushh-webapp/components/kai/cards/connect-portfolio-cta.tsx
+++ b/hushh-webapp/components/kai/cards/connect-portfolio-cta.tsx
@@ -14,10 +14,10 @@ export function ConnectPortfolioCta() {
       <SurfaceCardContent className="space-y-4 p-6 text-center">
         <div className="space-y-2">
           <h3 className="text-lg font-semibold tracking-tight">
-            See insights tailored to your portfolio
+            Insights for your portfolio
           </h3>
           <p className="text-sm text-muted-foreground">
-            Unlock personalized analysis and real-time alerts.
+            Personalized analysis and real-time alerts.
           </p>
         </div>
 
@@ -41,7 +41,7 @@ export function ConnectPortfolioCta() {
           asChild
           showRipple={false}
         >
-          <Link href={ROUTES.KAI_HOME}>Or continue exploring</Link>
+          <Link href={ROUTES.KAI_HOME}>Keep exploring</Link>
         </Button>
       </SurfaceCardContent>
     </SurfaceCard>

--- a/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
+++ b/hushh-webapp/components/kai/cards/new-holding-cta-card.tsx
@@ -16,9 +16,9 @@ export function NewHoldingCtaCard({ onAddHolding, onImportStatement }: NewHoldin
     <Card variant="none" effect="glass" preset="default">
       <CardContent className="space-y-4 p-5">
         <div className="space-y-1">
-          <h4 className="text-sm font-semibold">New Holding Entry</h4>
+          <h4 className="text-sm font-semibold">Update holdings</h4>
           <p className="text-xs text-muted-foreground">
-            Use Manage Portfolio for full edits, or import another statement for bulk updates.
+            Full edits live in Manage Portfolio.
           </p>
         </div>
 

--- a/hushh-webapp/components/kai/cards/profile-based-picks-list.tsx
+++ b/hushh-webapp/components/kai/cards/profile-based-picks-list.tsx
@@ -163,7 +163,7 @@ export function ProfileBasedPicksList({
         <SurfaceInset className="p-3 text-xs text-muted-foreground">
           {error
             ? "Profile picks are temporarily unavailable."
-            : "No profile picks available from current market context."}
+            : "No picks right now."}
         </SurfaceInset>
       ) : null}
 

--- a/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
+++ b/hushh-webapp/components/kai/cards/renaissance-market-list.tsx
@@ -327,7 +327,7 @@ export function RiaPicksList({
     return (
       <SettingsGroup className={marketSettingsGroupClassName}>
         <div className="px-4 py-4 text-sm text-muted-foreground">
-          The default list is unavailable at the moment.
+          Picks unavailable right now.
         </div>
       </SettingsGroup>
     );
@@ -426,7 +426,7 @@ export function RiaPicksList({
                       <Input
                         value={query}
                         onChange={(event) => setQuery(event.target.value)}
-                        placeholder="Search symbol, company, sector, or thesis"
+                        placeholder="Symbol, company, or thesis"
                         autoComplete="off"
                         autoCorrect="off"
                         spellCheck={false}
@@ -586,7 +586,7 @@ export function RiaPicksList({
                     <Input
                       value={query}
                       onChange={(event) => setQuery(event.target.value)}
-                      placeholder="Search symbol, company, sector, or thesis"
+                      placeholder="Symbol, company, or thesis"
                       autoComplete="off"
                       autoCorrect="off"
                       spellCheck={false}
@@ -922,7 +922,7 @@ export function RiaPicksList({
             >
               <div className="px-4 py-4 text-sm leading-7 text-foreground/90">
                 {selectedRow.investment_thesis ||
-                  "Renaissance thesis is unavailable for this name right now."}
+                  "No thesis yet."}
               </div>
             </SettingsGroup>
           </div>

--- a/hushh-webapp/components/kai/cards/theme-focus-list.tsx
+++ b/hushh-webapp/components/kai/cards/theme-focus-list.tsx
@@ -24,7 +24,7 @@ export function ThemeFocusList({ themes = [] }: { themes?: ThemeFocusItem[] }) {
     return (
       <SurfaceCard>
         <SurfaceCardContent className="px-4 py-4 text-sm text-muted-foreground">
-          No active market themes are available right now.
+          No themes right now.
         </SurfaceCardContent>
       </SurfaceCard>
     );

--- a/hushh-webapp/components/kai/home/news-tape.tsx
+++ b/hushh-webapp/components/kai/home/news-tape.tsx
@@ -27,7 +27,7 @@ export function NewsTape({ rows }: NewsTapeProps) {
     return (
       <SettingsGroup>
         <div className="px-4 py-4 text-sm text-muted-foreground">
-          No recent market headlines are available right now.
+          No headlines right now.
         </div>
       </SettingsGroup>
     );

--- a/hushh-webapp/components/kai/home/signal-chips.tsx
+++ b/hushh-webapp/components/kai/home/signal-chips.tsx
@@ -12,7 +12,7 @@ export function SignalChips({ signals }: SignalChipsProps) {
     return (
       <Card variant="muted" effect="fill" preset="compact">
         <CardContent className="p-4 text-sm text-muted-foreground">
-          Signals are unavailable right now.
+          No signals right now.
         </CardContent>
       </Card>
     );

--- a/hushh-webapp/components/kai/home/watchlist-strip.tsx
+++ b/hushh-webapp/components/kai/home/watchlist-strip.tsx
@@ -18,7 +18,7 @@ export function WatchlistStrip({ items }: WatchlistStripProps) {
     return (
       <Card variant="muted" effect="fill" preset="compact">
         <CardContent className="p-4 text-sm text-muted-foreground">
-          No watchlist/holdings data available yet.
+          Nothing on your watchlist yet.
         </CardContent>
       </Card>
     );

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -1828,8 +1828,8 @@ export function KaiFlow({
         !file.name.endsWith(".csv") &&
         !file.name.endsWith(".pdf")
       ) {
-        setError("Invalid file type. Please upload a PDF or CSV file.");
-        toast.error("Invalid file type. Please upload a PDF or CSV file.");
+        setError("Upload a PDF or CSV.");
+        toast.error("Upload a PDF or CSV.");
         return;
       }
 
@@ -2952,7 +2952,7 @@ export function KaiFlow({
         setState("import_complete");
         if (parsedPortfolioData.parse_fallback) {
           toast.warning(
-            "Portfolio loaded with partial coverage. Please review before saving.",
+            "Partial import. Review before saving.",
           );
         } else {
           toast.success("Portfolio is ready for review.");
@@ -2963,7 +2963,7 @@ export function KaiFlow({
           userRequestedImportCancelRef.current = false;
           if (streamStallAbortTriggered) {
             const stalledMessage =
-              "Import stalled with no backend updates. Please retry this statement.";
+              "Import stalled. Retry this statement.";
             trackImportTerminalTelemetry("error");
             setError(stalledMessage);
             toast.error(stalledMessage);
@@ -3039,10 +3039,10 @@ export function KaiFlow({
             rawErrorMessage,
           );
         const safeError = isTransientNetworkLoss
-          ? "Connection was interrupted while importing. Reopen import to continue from where it stopped."
+          ? "Connection dropped. Reopen import to continue."
           : err instanceof Error
             ? sanitizeInvestorCopy(err.message, err.message)
-            : "We could not import your portfolio. Please try again.";
+            : "Import failed. Try again.";
         trackImportTerminalTelemetry("error");
         setError(safeError);
         toast.error(safeError);
@@ -3219,7 +3219,7 @@ export function KaiFlow({
 
   const handleReviewParsedPortfolio = useCallback(() => {
     if (!flowData.parsedPortfolio) {
-      toast.error("Parsed portfolio not available. Please import again.");
+      toast.error("Nothing to review. Import again.");
       setState("import_required");
       return;
     }
@@ -3756,7 +3756,7 @@ export function KaiFlow({
         <KaiWorkspaceHeader
           workspace="portfolio"
           title="Portfolio"
-          description="Your holdings, sources, and investing context in one place."
+          description="Your holdings and sources."
         />
         <AppPageContentRegion className="flex min-h-[400px] items-center justify-center">
           <HushhLoader

--- a/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
+++ b/hushh-webapp/components/kai/views/analysis-history-dashboard.tsx
@@ -554,8 +554,7 @@ function EmptyState() {
             No analyses yet
           </h3>
         <p className="max-w-md text-[15px] leading-6 text-muted-foreground">
-          Search for a stock ticker below and let Agent Kai&apos;s multi-agent
-          debate engine give you a data-driven recommendation.
+          Search a ticker to get a recommendation.
         </p>
       </div>
     </div>
@@ -599,7 +598,7 @@ function DebateInputsCard({
           </Badge>
         </div>
         <SurfaceCardDescription>
-          Start a debate directly from history using your current vault portfolio context.
+          Debate a holding from your portfolio.
         </SurfaceCardDescription>
       </SurfaceCardHeader>
       <SurfaceCardContent className="space-y-4">
@@ -609,7 +608,7 @@ function DebateInputsCard({
           </SurfaceInset>
         ) : !hasPortfolio ? (
           <SurfaceInset className="border-dashed p-3 text-sm text-muted-foreground">
-            No imported statement found for this user yet. Import/connect a statement to unlock portfolio-based debate inputs.
+            Import or connect a statement to use your portfolio here.
           </SurfaceInset>
         ) : (
           <>
@@ -671,7 +670,7 @@ function DebateInputsCard({
             </div>
           ) : (
             <p className="mt-2 text-xs text-muted-foreground">
-              No eligible symbols yet. Import a statement first.
+              No eligible symbols yet.
             </p>
           )}
         </SurfaceInset>

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -650,7 +650,7 @@ function OneMarketMoverMetric({
           {label}
         </span>
         <span className="mt-1 block text-[14px] font-medium text-[color:var(--one-fg2)]">
-          No cached quote
+          No quote yet
         </span>
       </div>
     );
@@ -1038,7 +1038,7 @@ function buildIndexDetailPanel(
   return {
     eyebrow: "Overview",
     title: label,
-    summary: `${label} helps frame broad market conditions before you move into deeper analysis.`,
+    summary: `${label} frames broad market conditions.`,
     value,
     delta,
     statusLabel: degraded ? "Delayed snapshot" : "Live benchmark read",
@@ -1057,7 +1057,7 @@ function buildIndexDetailPanel(
       {
         title: "Why it matters",
         lines: [
-          "Use this benchmark to understand broad market conditions before reviewing advisor ideas or individual investments.",
+          "Check the market before individual stocks.",
         ],
       },
     ],
@@ -1169,7 +1169,7 @@ function toBreadthMetric(
       eyebrow: "Overview",
       title: "Advancers vs decliners",
       summary:
-        "Breadth shows whether participation is broad or concentrated across the names Kai is tracking right now.",
+        "Whether today&apos;s move is broad or concentrated.",
       value,
       delta:
         trackedCount > 0
@@ -2277,7 +2277,7 @@ export function KaiMarketPreviewView() {
                 <div className="flex items-center gap-2 text-[color:var(--one-down)]">
                   <AlertTriangle className="h-4 w-4" />
                   <p className="text-[14px] font-semibold">
-                    Failed to load market home
+                    Couldn&apos;t load market data
                   </p>
                 </div>
                 <p className="text-[12px] leading-relaxed text-[color:var(--one-fg2)]">
@@ -2366,7 +2366,7 @@ export function KaiMarketPreviewView() {
                 />
                 <div className="grid grid-cols-2 gap-3">
                   <OneMarketMoverMetric
-                    label="Top mover"
+                    label="Top gainer"
                     row={moverGroups.gain[0]}
                     tone="up"
                   />

--- a/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
+++ b/hushh-webapp/components/kai/views/manage-portfolio-view.tsx
@@ -726,7 +726,7 @@ export function ManagePortfolioView() {
               <Card variant="muted" effect="glass" showRipple={false}>
                 <CardContent className="p-8 text-center">
                   <p className="text-muted-foreground mb-4">
-                    No holdings yet. Add your first holding or import a portfolio statement.
+                    No holdings yet. Add one or import a statement.
                   </p>
                   <Button onClick={handleAddHolding} icon={{ icon: Plus, gradient: false }}>
                     Add Holding

--- a/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
+++ b/hushh-webapp/components/onboarding/PreviewCarouselStep.tsx
@@ -43,21 +43,21 @@ export function PreviewCarouselStep({
         title: "A memory",
         accent: "built for you",
         subtitle:
-          "One learns from the apps you choose to connect, and grows with the tools you use.",
+          "One learns from the apps you connect.",
         preview: <WorkflowsPreviewCompact />,
       },
       {
         title: "Your world,",
         accent: "kept private",
         subtitle:
-          "Everything lives in an encrypted vault. Only you hold the key, not even we can read it.",
+          "Encrypted in your vault. Only you hold the key.",
         preview: <VaultPreviewCompact />,
       },
       {
         title: "It acts only",
         accent: "with your yes",
         subtitle:
-          "Every move is scoped, logged, and yours to revoke. Nothing happens without your consent.",
+          "Every move is scoped, logged, and yours to revoke.",
         preview: <ConsentPreviewCompact />,
       },
     ],

--- a/hushh-webapp/components/onboarding/setup/onboarding-capability-step.tsx
+++ b/hushh-webapp/components/onboarding/setup/onboarding-capability-step.tsx
@@ -81,7 +81,7 @@ export function OnboardingCapabilityStep({
       ? (copy?.exploreTitle ?? copy?.setupTitle ?? "")
       : (copy?.setupTitle ?? "");
   const blurb = completion
-    ? `Review this step, then ${finishActionLabel.toLowerCase()} and return to your setup home.`
+    ? "Last step, then back to setup."
     : isExploreOnly
       ? (copy?.exploreBlurb ?? copy?.setupBlurb ?? "")
       : (copy?.setupBlurb ?? "");
@@ -93,11 +93,11 @@ export function OnboardingCapabilityStep({
       : setupActionLabel;
   const skipActionLabel = `Skip ${capability?.title || "this"} setup`;
   const subline = completion
-    ? "Finish only when you are comfortable with this setup."
+    ? "Finish when you're ready."
     : isExploreOnly
-      ? "No additional setup is required."
+      ? "Nothing to set up."
       : needsVaultUnlock
-        ? "One will guide you through the private setup required next."
+        ? "One will guide you through the private setup next."
         : "A quick, one-time setup.";
 
   // Publish screen context so the onboarding guide can explain this exact step.
@@ -253,7 +253,7 @@ export function OnboardingCapabilityStep({
                 actionId="setup.capability_skip"
                 testId="one-setup-capability-skip"
                 purpose="returns to setup without recording this capability as complete."
-                supportingText="You can return to this setup whenever you are ready."
+                supportingText="Come back any time."
                 variant="none"
                 effect="fade"
               />

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -371,8 +371,8 @@ export function OneSetupHub() {
   const summary = hubStateLoading
     ? "Checking what's set up…"
     : allReady
-      ? "Everything's set up. You're good to go."
-      : `${done} of ${total} ready, ${remaining} left to set up.`;
+      ? "All ${total} ready."
+      : `${done} of ${total} ready.`;
   const showVaultInvitation =
     vaultInvitationOpen && Boolean(user) && !isVaultUnlocked;
 

--- a/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
+++ b/hushh-webapp/components/onboarding/setup/setup-capability-coordinator.tsx
@@ -354,7 +354,7 @@ export function useSetupCapabilityCoordinator({
       } catch (error) {
         console.warn("[SetupCapabilityCoordinator] Failed to prepare setup:", error);
         if (!cancelled) {
-          toast.error("This setup could not be prepared. Please try again.");
+          toast.error("Setup didn't load. Try again.");
           replaceRoute(ROUTES.ONE_SETUP);
         }
       }
@@ -487,14 +487,14 @@ export function useSetupCapabilityCoordinator({
           toast.error(
             stale
               ? "Setup changed in another session. Please try again."
-              : "Setup could not be saved. Please try again.",
+              : "Setup didn't save. Try again.",
           );
         }
         return {
           status: stale ? "blocked" : "failed",
           summary: stale
             ? "This setup changed in another session. Returning to setup."
-            : "Setup could not be saved. Please try again.",
+            : "Setup didn't save. Try again.",
           ...(stale ? { routeAfter: ROUTES.ONE_SETUP } : {}),
         };
       } finally {
@@ -641,8 +641,8 @@ export function SetupCapabilityTerminalFooter({
       }
       supportingText={
         operationallyReady
-          ? "This capability is ready. You can return to setup."
-          : "You can return to this setup any time."
+          ? "You're all set here."
+          : "Come back any time."
       }
       variant={operationallyReady ? "blue-gradient" : "none"}
       effect={operationallyReady ? "fill" : "fade"}

--- a/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
+++ b/hushh-webapp/components/ria/onboarding/onboarding-step-license.tsx
@@ -154,7 +154,7 @@ export function OnboardingStepLicense({
         <p className="text-[13px] leading-[1.45] text-muted-foreground">
           {verificationBypassEnabled
             ? "Development and UAT can bypass live verification for testing only."
-            : "Kai verifies your identity against FINRA and SEC records before unlocking the advisory workflow."}
+            : "Kai verifies your licence against FINRA and SEC records."}
         </p>
       </div>
     </div>

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -563,7 +563,7 @@ export function RiaProfileSection({
           icon={ClipboardCheck}
           iconTone="blue"
           title="Update license data"
-          description="Refresh official regulator fields (CRD, regulator). Your bio, services, fees, and contact details stay unchanged."
+          description="Refreshes CRD and regulator only."
           onClick={openLicenseRefresh}
           chevron
           testId="ria-profile-update-license"
@@ -571,7 +571,7 @@ export function RiaProfileSection({
         <SettingsRow
           icon={RotateCcw}
           title="Re-initiate onboarding"
-          description="Run the 5-step setup wizard again. Your profile goes to pending until re-verified; clients stay connected."
+          description="Profile goes to pending until re-verified; clients stay connected."
           onClick={handleReinitiate}
           chevron
           testId="ria-profile-reinitiate"

--- a/hushh-webapp/components/ria/ria-client-account-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-account-detail.tsx
@@ -179,7 +179,7 @@ export function RiaClientAccountDetail({
         <SettingsGroup
           embedded
           title="Account not available"
-          description="The account branch is not part of the current client workspace or has not been approved for this advisor view."
+          description="Not approved, or not in this workspace."
         >
           <SettingsRow
             title="Return to the client workspace"
@@ -248,7 +248,7 @@ export function RiaClientAccountDetail({
               <SectionHeader
                 eyebrow="Explorer"
                 title="Readable branch summary"
-                description="This view stays intentionally summary-first until richer account-level explorer payloads are available from the backend."
+                description="Summary only for now."
                 icon={Database}
                 accent="ria"
               />

--- a/hushh-webapp/components/ria/ria-client-request-detail.tsx
+++ b/hushh-webapp/components/ria/ria-client-request-detail.tsx
@@ -168,7 +168,7 @@ export function RiaClientRequestDetail({
         <SettingsGroup
           embedded
           title="Request not available"
-          description="This request is not part of the current client workspace history or the identifier is no longer valid."
+          description="Not in this workspace, or no longer valid."
         >
           <SettingsRow
             title="Return to client access"

--- a/hushh-webapp/components/ria/ria-client-workspace.tsx
+++ b/hushh-webapp/components/ria/ria-client-workspace.tsx
@@ -530,8 +530,8 @@ export function RiaClientWorkspace({
     >
       {iamUnavailable ? (
         <RiaCompatibilityState
-          title="Client workspace is unavailable in this environment"
-          description="The route is wired correctly, but this environment still needs the full IAM schema before advisor workspaces can read investor information."
+          title="Waiting on IAM schema"
+          description="Client workspaces need the IAM tables."
         />
       ) : null}
 
@@ -581,7 +581,7 @@ export function RiaClientWorkspace({
                 <div className="space-y-1">
                   <p className="text-sm font-semibold tracking-tight text-foreground">At a glance</p>
                   <p className="text-sm leading-6 text-muted-foreground">
-                    The current relationship state and what is ready right now.
+                    Where this relationship stands.
                   </p>
                 </div>
                 <SettingsGroup embedded>
@@ -651,7 +651,7 @@ export function RiaClientWorkspace({
                 <div className="space-y-1">
                   <p className="text-sm font-semibold tracking-tight text-foreground">Current sharing</p>
                   <p className="text-sm leading-6 text-muted-foreground">
-                    What the client already shares with you today.
+                    What the client shares with you.
                   </p>
                 </div>
                 <SettingsGroup embedded>
@@ -861,7 +861,7 @@ export function RiaClientWorkspace({
                   <div className="space-y-1">
                     <p className="text-sm font-semibold tracking-tight text-foreground">Portfolio</p>
                     <p className="text-sm leading-6 text-muted-foreground">
-                      A simple read that mirrors the client view.
+                      Mirrors what your client sees.
                     </p>
                   </div>
 
@@ -928,7 +928,7 @@ export function RiaClientWorkspace({
                     <SettingsGroup embedded>
                       {workspace.available_domains.length === 0 ? (
                         <div className="px-4 py-4 text-sm text-muted-foreground">
-                          No indexed domains are ready yet.
+                          Nothing ready to explore yet.
                         </div>
                       ) : (
                         workspace.available_domains.map((domain) => (

--- a/hushh-webapp/components/ria/ria-page-shell.tsx
+++ b/hushh-webapp/components/ria/ria-page-shell.tsx
@@ -144,8 +144,7 @@ export function RiaCompatibilityState({
       />
       <RiaSurface tone="warning" className="border-dashed">
         <p className="text-sm leading-6 text-muted-foreground">
-          This surface is running in degraded compatibility mode until the full IAM contract is
-          available in the active environment.
+          Some features are unavailable here.
         </p>
       </RiaSurface>
     </section>

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -1420,7 +1420,7 @@ export function VaultFlow({
                     await finalizeUnlock(pendingUnlockKey);
                   }}
                 >
-                  Not now, continue with passphrase
+                  Not now
                 </Button>
               </div>
             </div>

--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -153,9 +153,9 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
   const description = useMemo(() => {
     if (!targetMethod) return "Switch from passphrase unlock to a faster secure method.";
     if (targetMethod === "generated_default_native_biometric") {
-      return "Use device biometric authentication first. Passphrase and recovery key remain available.";
+      return "Unlock with biometrics. Passphrase and recovery key still work.";
     }
-    return "Use passkey authentication first. Passphrase and recovery key remain available.";
+    return "Unlock with your passkey. Passphrase and recovery key still work.";
   }, [targetMethod]);
 
   async function handleNotNow() {

--- a/hushh-webapp/lib/onboarding/capability-setup-copy.ts
+++ b/hushh-webapp/lib/onboarding/capability-setup-copy.ts
@@ -78,14 +78,14 @@ const SETUP_COPY_BY_ID: Record<
   finance: {
     setupTitle: "Set up your finances",
     setupBlurb:
-      "Tell One how you like to invest so it can read your portfolio and surface analysis that fits you.",
+      "Get analysis that fits how you invest.",
     actionLabel: "Set up Finance",
     resumeActionLabel: "Finish Finance",
     introPremise: "A clearer way to understand your money.",
     introPromise:
       "One only uses the accounts and preferences you choose to share.",
     setupBullets: [
-      "Share how you like to invest in a few quick taps.",
+      "Share how you invest in a few taps.",
       "One reads your portfolio and tailors the analysis to you.",
       "Hand off to a real advisor whenever you want.",
     ],
@@ -116,28 +116,28 @@ const SETUP_COPY_BY_ID: Record<
       "You decide which details to save and when One may use them to help you.",
     setupBullets: [
       "Turn drafting on or off any time.",
-      "Every draft stays yours to review before it sends.",
+      "Nothing sends until you approve it.",
     ],
   },
   location: {
     setupTitle: "Set up location",
     setupBlurb:
-      "Set up location so you can share it with the trusted people you choose, whenever you want.",
+      "Share your location with the trusted people you choose.",
     actionLabel: "Choose location",
     resumeActionLabel: "Finish location",
     introPremise: "Be easier to reach when it matters.",
     introPromise:
       "Your location stays private until you choose the people and moment to share it.",
     setupBullets: [
-      "Choose the trusted people who can receive a location share.",
-      "Start and stop sharing whenever you want.",
+      "Choose who can receive your location.",
+      "Start and stop sharing any time.",
       "Your location stays private unless you choose to share it.",
     ],
   },
   ria: {
     setupTitle: "Set up RIA",
     setupBlurb:
-      "Create and verify your advisor profile so One can open the right professional workspace for you.",
+      "Create and verify your advisor profile to open your workspace.",
     actionLabel: "Verify RIA",
     resumeActionLabel: "Finish RIA",
     introPremise: "A professional workspace shaped around your practice.",
@@ -169,7 +169,7 @@ const SETUP_COPY_BY_ID: Record<
     resumeActionLabel: "Review access",
     exploreTitle: "Here's your access center",
     exploreBlurb:
-      "Nothing to set up. This is where you see and control who can use your personal information.",
+      "See and control who can use your personal information.",
     exploreBullets: [
       "Every request to use your personal information shows up here.",
       "Approve what you trust, decline the rest.",

--- a/hushh-webapp/lib/ria/ria-screen-copy.ts
+++ b/hushh-webapp/lib/ria/ria-screen-copy.ts
@@ -19,7 +19,7 @@ export const RIA_COPY = {
     verification: {
       active: {
         label: "Ready",
-        title: "Your advisor workspace is ready.",
+        title: "You're all set.",
         description: "Relationships, picks, and requests — no setup needed.",
       },
       submitted: {
@@ -57,25 +57,25 @@ export const RIA_COPY = {
     },
     queue: {
       heading: "Priority queue",
-      description: "Only things that need your move appear here.",
-      loading: "Loading readiness and relationships.",
-      empty: "Nothing urgent. New actions land here.",
+      description: "Only what needs your move.",
+      loading: "Loading queue…",
+      empty: "Nothing urgent.",
       itemFallback: "Review the next step.",
       open: "Open",
     },
     iam: {
-      title: "RIA home needs the IAM rollout",
-      description: "This environment needs the IAM schema first.",
+      title: "Waiting on IAM schema",
+      description: "RIA home needs the IAM tables.",
     },
   },
 
   clients: {
     eyebrow: "Clients",
     title: "Client roster",
-    description: "One workspace per client — status, access, Kai, explorer.",
+    description: "One workspace per client.",
     section: {
       title: "Connected investors",
-      description: "Status, access, Kai, and explorer in one place.",
+      description: "Status, sharing, portfolio, information.",
     },
     loading: "Loading clients…",
     empty: "No connected investors yet.",
@@ -86,7 +86,7 @@ export const RIA_COPY = {
     },
     verifyGate: {
       eyebrow: "Verification required",
-      title: "Verify your advisor account first",
+      title: "Verify your account",
       description: "Finish verification in onboarding to access investors.",
       body: "Locked until verification is complete.",
     },
@@ -95,7 +95,7 @@ export const RIA_COPY = {
   picks: {
     eyebrow: "Picks",
     title: "Stock universe",
-    description: "Switch Kai's package and yours — avoid and screening stay.",
+    description: "The names your investors debate.",
     screening: {
       investable: {
         title: "Investable requirements",
@@ -113,7 +113,7 @@ export const RIA_COPY = {
     emptyMyList: {
       title: "Build your live package",
       description:
-        "Shape the package your investors debate. Start from Kai, edit tiers, or upload a CSV.",
+        "Start from Kai, edit tiers, or upload a CSV.",
     },
     avoidEmpty: {
       title: "Avoid list is empty",
@@ -129,7 +129,7 @@ export const RIA_COPY = {
     banner: {
       title: "This is your debate config",
       description:
-        "Kai's multi-agent debate scores every name against these screening rules and conviction bands.",
+        "Kai scores every name against these rules and conviction bands.",
     },
     disclaimer:
       "Agent Kai is an educational and informational tool and is not investment advice. Always consult a licensed financial professional before making investment decisions.",
@@ -141,7 +141,7 @@ export const RIA_COPY = {
     description: "Find a registered advisor. Connect with consent.",
     deckComplete: {
       title: "That's everyone for now",
-      description: "You've seen everyone. More join soon.",
+      description: "More advisors join soon.",
     },
     detail: {
       description: "Review before you connect.",


### PR DESCRIPTION
## What

Applies the less-text microcopy standard across the One surfaces: headlines 2–6 words, supporting text one short sentence, buttons 1–3 words. Removes process narration, heading/subtitle echo, and long-form copy the visual already communicates.

39 files, 145 insertions / 151 deletions — a net reduction in words on every screen touched.

**Representative changes**

| Before | After |
|---|---|
| Tell One how you like to invest so it can read your portfolio and surface analysis that fits you. | Get analysis that fits how you invest. |
| Set up location so you can share it with the trusted people you choose, whenever you want. | Share your location with the trusted people you choose. |
| Every draft stays yours to review before it sends. | Nothing sends until you approve it. |
| Upload and replace top picks | Replace top picks |
| Too many verification attempts. Please wait a moment. | Too many attempts. Wait a moment. |

## What was deliberately not shortened

**Consent, privacy and permission copy keeps its substance.** Only the framing around it was tightened — never the thing the user is actually agreeing to. Where a shorter line would have dropped a disclosure, the disclosure was kept and the edit dropped. Example: the portfolio-read disclosure survives verbatim in its bullet even though the blurb above it got shorter.

**Accessibility labels are unchanged.** `aria-label` and `alt` follow different rules from visible copy and may legitimately be longer. Shortening them would have looked like compliance with the standard while making the product worse for screen-reader users.

**Errors got shorter but kept the recovery path** in every case.

## Process

Five read-only scouts (onboarding, RIA, home/market, empty-and-error states, consent/privacy) proposed exact string replacements, each with a real `grep` against `__tests__` recorded per edit. A review phase then rejected anything that lost meaning. 198 accepted, 9 rejected at review.

Of the 198, **61 were dropped at apply time** because the string does not exist on `main` — the scouts read a working checkout that had diverged. Dropped rather than forced. 137 applied.

## Tests

Two assertions moved with the copy they assert:
- `picks-page.test.tsx` — button name → `/replace top picks/i`
- `onboarding-page.test.tsx` — rate-limit text → `/too many attempts/i`

Both still assert the same behaviour; only the expected string changed. No test was skipped, deleted, or relaxed.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint` (all 39 changed files) | clean |
| `verify:design-system` | pass |
| `verify:surface-map` | pass |
| `verify:voice-gateway` | pass |
| `verify-deployment-environment-governance.py` | exit 0 |
| Full vitest suite | **8 failed / 2634 passed** — the same 8 pre-existing failures as the `main` baseline, verified by file-list comparison |

One defect caught by the gates and fixed: a scout proposed replacing a template literal (backticks with a `${...}` interpolation) with a bare unquoted string, which broke `onboarding-capability-step.tsx` syntax. `tsc` caught it.

## Risk

Copy-only. No logic, no API, no schema, no migration. Fully reversible by reverting this commit.