### PR TITLE
feat(crm-registry): separate country code and phone number for MuleSoft updates

### DIFF
--- a/consent-protocol/api/developer_auth.py
+++ b/consent-protocol/api/developer_auth.py
@@ -164,7 +164,7 @@ def authenticate_developer_principal(
     )
     if principal is None:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
                 "error_code": "DEVELOPER_TOKEN_INVALID",
                 "message": "Developer token is invalid or revoked.",

--- a/consent-protocol/api/routes/session.py
+++ b/consent-protocol/api/routes/session.py
@@ -284,7 +284,7 @@ async def lookup_user(
     if not required_token:
         raise HTTPException(status_code=503, detail="Lookup endpoint not configured")
     if not x_mcp_developer_token or not hmac.compare_digest(x_mcp_developer_token, required_token):
-        raise HTTPException(status_code=403, detail="Forbidden")
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
     try:
         lookup_kind, lookup_value = resolve_lookup_identifier(

--- a/consent-protocol/hushh_mcp/services/connected_systems_service.py
+++ b/consent-protocol/hushh_mcp/services/connected_systems_service.py
@@ -168,6 +168,26 @@ def _clean_text(value: Any, *, max_length: int = 512) -> str:
     return text
 
 
+def _parse_crm_phone_parts(value: Any) -> tuple[str, str, str]:
+    """Parse E.164 phone string into (country_code, national_number, fallback)."""
+    raw = str(value or "").strip()
+    fallback = _normalize_crm_phone_for_mcp(raw)
+    if not raw.startswith("+"):
+        return "", fallback, fallback
+    try:
+        import phonenumbers
+
+        parsed = phonenumbers.parse(raw, None)
+        if not phonenumbers.is_valid_number(parsed):
+            return "", fallback, fallback
+
+        country_code = f"+{parsed.country_code}"
+        national_number = str(parsed.national_number)
+        return country_code, national_number, fallback
+    except Exception:
+        return "", fallback, fallback
+
+
 def _normalize_crm_phone_for_mcp(value: Any) -> str:
     clean = _clean_text(value, max_length=80)
     digits = re.sub(r"\D", "", clean)
@@ -2091,6 +2111,13 @@ class ConnectedSystemsService:
         aliases = {
             "email": ("email", "emailaddress", "email_address"),
             "phone": ("phone", "telephone", "phone_number", "mobilephone", "mobile_phone"),
+            "phoneCountryCode": (
+                "phonecountrycode",
+                "countrycode",
+                "dialcode",
+                "phone_country_code",
+                "mobilephonecountrycode",
+            ),
             "firstName": ("firstname", "first_name", "givenname", "given_name"),
             "lastName": ("lastname", "last_name", "surname", "familyname", "family_name"),
             "fullName": ("name", "fullname", "full_name", "displayname", "display_name"),
@@ -2191,6 +2218,11 @@ class ConnectedSystemsService:
                 "Verify your email before linking this CRM.",
                 code="CONNECTED_SYSTEM_EMAIL_VERIFICATION_REQUIRED",
             )
+
+        raw_phone = identity.get("phone_number")
+        phone_country_code, phone_national, phone_fallback = _parse_crm_phone_parts(raw_phone)
+        phone = phone_fallback
+
         if not identity.get("phone_verified") or not phone:
             raise ConnectedSystemBlockedError(
                 "Verify your phone before linking this CRM.",
@@ -2200,7 +2232,9 @@ class ConnectedSystemsService:
         parts = display_name.split()
         return {
             "email": email,
-            "phone": phone,
+            "phone": phone_national or phone,
+            "phoneCountryCode": phone_country_code,
+            "phoneFallback": phone,
             "displayName": display_name,
             "firstName": parts[0] if parts else "",
             "lastName": " ".join(parts[1:]) if len(parts) > 1 else (parts[0] if parts else ""),
@@ -2593,6 +2627,7 @@ class ConnectedSystemsService:
         fields: dict[str, Any] = {}
         for semantic, profile_key in (
             ("email", "email"),
+            ("phoneCountryCode", "phoneCountryCode"),
             ("phone", "phone"),
             ("firstName", "firstName"),
             ("lastName", "lastName"),
@@ -2601,6 +2636,14 @@ class ConnectedSystemsService:
             value = _clean_text(profile.get(profile_key), max_length=320)
             if field_name and value:
                 fields[field_name] = value
+
+        # If the schema didn't map a distinct phoneCountryCode but did map phone,
+        # fallback to the fully-constructed E.164-equivalent normalized value
+        # to ensure the single mapped field receives all necessary dial digits.
+        phone_field = _clean_text(mappings.get("phone"), max_length=80)
+        phone_cc_field = _clean_text(mappings.get("phoneCountryCode"), max_length=80)
+        if phone_field and not phone_cc_field:
+            fields[phone_field] = _clean_text(profile.get("phoneFallback"), max_length=320)
         # Salesforce-style `Name` fields are frequently derived and cannot be
         # written alongside FirstName/LastName. Use a full-name field only for
         # schemas that do not expose the split name pair.

--- a/consent-protocol/hushh_mcp/services/crm_schema_mapping_service.py
+++ b/consent-protocol/hushh_mcp/services/crm_schema_mapping_service.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 CRM_SCHEMA_MAPPER_ID = "crm_schema_mapper"
 CRM_SCHEMA_MAPPER_ENABLED_ENV = "CONNECTED_SYSTEMS_SCHEMA_MAPPER_ENABLED"
 CRM_SCHEMA_MAPPING_TTL = timedelta(hours=24)
-_SEMANTICS = ("email", "phone", "firstName", "lastName", "fullName", "address")
+_SEMANTICS = ("email", "phone", "phoneCountryCode", "firstName", "lastName", "fullName", "address")
 _REQUIRED_SEMANTICS = ("email", "phone")
 
 

--- a/consent-protocol/mcp_remote.py
+++ b/consent-protocol/mcp_remote.py
@@ -131,7 +131,7 @@ class AuthenticatedRemoteMCPApp:
         if principal is None:
             await _send_json(
                 send,
-                403,
+                401,
                 {
                     "error_code": "DEVELOPER_TOKEN_INVALID",
                     "message": "Developer token is invalid or revoked.",

--- a/consent-protocol/tests/test_connected_systems_service.py
+++ b/consent-protocol/tests/test_connected_systems_service.py
@@ -1032,6 +1032,104 @@ async def test_verified_profile_create_uses_server_identity_and_never_writes_der
 
 
 @pytest.mark.asyncio
+async def test_verified_profile_create_splits_phone_country_code_when_mapped():
+    class VerifiedIdentityService:
+        async def get_many(self, _user_ids):
+            return {
+                "user_123": {
+                    "display_name": "Bob Smith",
+                    "email": "bob@example.test",
+                    "email_verified": True,
+                    "phone_number": "+44 20 8366 1177",
+                    "phone_verified": True,
+                }
+            }
+
+    service, adapter = build_service()
+    service.identity_service = VerifiedIdentityService()
+
+    async def schema_with_country_code(payload: dict) -> dict:
+        adapter.calls.append(("object-schema", payload))
+        return {
+            "isError": False,
+            "payload": {
+                "fields": [
+                    {"name": "Email", "type": "email"},
+                    {"name": "Phone", "type": "phone"},
+                    {"name": "PhoneCountryCode", "type": "string"},
+                    {"name": "LastName", "type": "string", "required": True},
+                ]
+            },
+        }
+
+    adapter.object_schema = schema_with_country_code
+
+    intent = await service.create_record_intent_for_verified_user(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        profile_field_mappings={
+            "email": "Email",
+            "phone": "Phone",
+            "phoneCountryCode": "PhoneCountryCode",
+            "lastName": "LastName",
+        },
+    )
+
+    stored = service.store.intents[intent["intentId"]]["request_payload"]
+    assert stored.get("additionalFields", {}).get("PhoneCountryCode") == "+44"
+    assert stored.get("phone") == "2083661177"
+
+
+@pytest.mark.asyncio
+async def test_verified_profile_create_falls_back_to_full_phone_when_country_code_unmapped():
+    class VerifiedIdentityService:
+        async def get_many(self, _user_ids):
+            return {
+                "user_123": {
+                    "display_name": "Bob Smith",
+                    "email": "bob@example.test",
+                    "email_verified": True,
+                    "phone_number": "+44 20 8366 1177",
+                    "phone_verified": True,
+                }
+            }
+
+    service, adapter = build_service()
+    service.identity_service = VerifiedIdentityService()
+
+    async def schema_without_country_code(payload: dict) -> dict:
+        adapter.calls.append(("object-schema", payload))
+        return {
+            "isError": False,
+            "payload": {
+                "fields": [
+                    {"name": "Email", "type": "email"},
+                    {"name": "Phone", "type": "phone"},
+                    {"name": "LastName", "type": "string", "required": True},
+                ]
+            },
+        }
+
+    adapter.object_schema = schema_without_country_code
+
+    intent = await service.create_record_intent_for_verified_user(
+        user_id="user_123",
+        system_id=CONNECTED_SYSTEM_SALESFORCE_ID,
+        object_type=None,
+        profile_field_mappings={
+            "email": "Email",
+            "phone": "Phone",
+            "lastName": "LastName",
+        },
+    )
+
+    stored = service.store.intents[intent["intentId"]]["request_payload"]
+    assert "PhoneCountryCode" not in stored.get("additionalFields", {})
+    assert stored.get("phone") == "442083661177"
+
+
+@pytest.mark.asyncio
 async def test_verified_profile_create_accepts_required_derived_full_name_when_split_name_is_mapped():
     class VerifiedIdentityService:
         async def get_many(self, _user_ids):

--- a/consent-protocol/tests/test_developer_api_routes.py
+++ b/consent-protocol/tests/test_developer_api_routes.py
@@ -208,7 +208,7 @@ def test_user_scopes_accepts_authorization_bearer_header(monkeypatch):
     assert response.json()["app_id"] == "app_demo_123"
 
 
-def test_user_scopes_invalid_authorization_bearer_returns_403(monkeypatch):
+def test_user_scopes_invalid_authorization_bearer_returns_401(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("DEVELOPER_API_ENABLED", "true")
 
@@ -224,7 +224,7 @@ def test_user_scopes_invalid_authorization_bearer_returns_403(monkeypatch):
         headers={"Authorization": "Bearer not-a-real-token"},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 401
     detail = response.json()["detail"]
     assert detail["error_code"] == "DEVELOPER_TOKEN_INVALID"
 

--- a/consent-protocol/tests/test_mcp_remote_endpoint.py
+++ b/consent-protocol/tests/test_mcp_remote_endpoint.py
@@ -156,7 +156,7 @@ async def test_missing_token_returns_401(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_invalid_token_returns_403(monkeypatch):
+async def test_invalid_token_returns_401(monkeypatch):
     app, _inner = _build_app()
     monkeypatch.setattr(app._registry, "authenticate_token", lambda *a, **k: None)
 
@@ -164,7 +164,7 @@ async def test_invalid_token_returns_403(monkeypatch):
     headers = [(b"authorization", b"Bearer bad-token")]
     await app(_http_scope(headers=headers), _noop_receive, send)
 
-    assert send.status == 403
+    assert send.status == 401
     assert send.body_json["error_code"] == "DEVELOPER_TOKEN_INVALID"
 
 

--- a/consent-protocol/tests/test_session_developer_token_timing.py
+++ b/consent-protocol/tests/test_session_developer_token_timing.py
@@ -4,10 +4,10 @@ A plain ``!=`` string comparison leaks token length and prefix information via
 response timing (CWE-208).  The fix replaces it with ``hmac.compare_digest``.
 
 These tests assert the observable security properties:
-- Missing token => 403
-- Wrong token => 403
+- Missing token => 401
+- Wrong token => 401
 - Correct token => request proceeds past the auth gate (400 due to missing
-  lookup params, NOT 403)
+  lookup params, NOT 401)
 - Source code uses ``hmac.compare_digest`` for the comparison
 """
 
@@ -28,16 +28,16 @@ def _build_app() -> FastAPI:
     return app
 
 
-def test_missing_developer_token_returns_403(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_developer_token_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "correct-secret")
     client = TestClient(_build_app())
 
     response = client.get("/api/user/lookup")
 
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
-def test_wrong_developer_token_returns_403(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_wrong_developer_token_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HUSHH_DEVELOPER_TOKEN", "correct-secret")
     client = TestClient(_build_app())
 
@@ -46,7 +46,7 @@ def test_wrong_developer_token_returns_403(monkeypatch: pytest.MonkeyPatch) -> N
         headers={"X-MCP-Developer-Token": "wrong-secret"},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_correct_developer_token_passes_auth_gate(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Included fix: standardize MCP developer token status codes to 401

---
Closes #4904
(retroactive board-linkage backfill, 2026-08-06)