### PR TITLE
fix(deploy): bring the backend deploy step back under Cloud Build's arg limit

### DIFF
--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -34,3 +34,4 @@ tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
 tests/test_one_location_db_error_detail_cwe209.py
+tests/test_cloudbuild_step_arg_limit.py

--- a/consent-protocol/tests/test_cloudbuild_step_arg_limit.py
+++ b/consent-protocol/tests/test_cloudbuild_step_arg_limit.py
@@ -1,0 +1,163 @@
+"""No Cloud Build step arg may exceed 10,000 characters.
+
+This is the regression guard for a real, repeated outage. Cloud Build caps a single
+build-step arg at 10,000 characters. The `deploy-backend` step's inline bash body is
+ONE such arg, and it crossed the cap twice:
+
+  * 2026-07-28 (commit 363a9932d, 9,559 -> 10,569 raw) -- every backend deploy failed
+    at submission for roughly a week.
+  * 2026-08-04 (PR #4791, Wallet Profile, 10,657 -> 11,246 raw) -- the UAT deploy of
+    release ba39d0342 failed with:
+
+        INVALID_ARGUMENT: invalid build: invalid .steps field:
+        build step 1 arg 1 too long (max: 10000)
+
+`deploy/backend.cloudbuild.yaml` is invoked identically by deploy-dev.yml, deploy-uat.yml
+and deploy-production.yml, so one file breaks all three lanes at once -- including
+production. Nothing surfaces it, because gcloud enforces the cap client-side before any
+Build resource exists: there is no failed build to open and no log to read.
+
+WHAT IS ACTUALLY MEASURED. Cloud Build applies substitutions BEFORE enforcing the cap,
+so the raw YAML length is not the number that matters -- it is only an upper bound, and
+a loose one. The 2026-08-04 breach is the proof: the same raw body (10,657) was UNDER
+the cap once substituted for production but OVER it for UAT, because UAT passes longer
+substitution values. A raw-only assertion would therefore have called production healthy
+while UAT was broken. This module asserts both:
+
+  1. the raw body stays under the cap (cheap, catches gross growth), and
+  2. the SUBSTITUTED body stays under the cap for every deploy lane (the real check).
+
+WHERE TO PUT COMMENTS. Prose inside the bash body counts against the cap; prose at the
+YAML step level does not. Keep explanatory comments above the step, not inside `args`.
+If the body itself must grow past the cap, move it into a script the step invokes and
+pass substitutions through the step's `env:` field.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Cloud Build's hard cap on a single build-step arg.
+CLOUD_BUILD_MAX_ARG = 10_000
+
+# Refuse to land a change that leaves less than this much room. Without a margin the
+# suite goes green at 9,999 and the very next secret ref breaks all three deploy lanes.
+REQUIRED_HEADROOM = 500
+
+CLOUDBUILD_CONFIGS = [
+    "deploy/backend.cloudbuild.yaml",
+    "deploy/frontend.cloudbuild.yaml",
+    "deploy/dev.autodeploy.backend.cloudbuild.yaml",
+]
+
+# Workflows that invoke deploy/backend.cloudbuild.yaml, and the lane each one deploys.
+BACKEND_DEPLOY_WORKFLOWS = [
+    ".github/workflows/deploy-uat.yml",
+    ".github/workflows/deploy-production.yml",
+    ".github/workflows/deploy-dev.yml",
+]
+
+_SUBSTITUTION = re.compile(r"\$\{(_[A-Z0-9_]+)\}")
+# `SUBSTITUTIONS="..."` and `SUBSTITUTIONS="${SUBSTITUTIONS}..."` assignments.
+_SUBS_ASSIGNMENT = re.compile(
+    r'SUBSTITUTIONS="(?:\$\{SUBSTITUTIONS\})?(.*?)"\s*$', re.MULTILINE | re.DOTALL
+)
+# GitHub Actions expressions are resolved at runtime; stand in a worst-case-ish value.
+# 40 chars covers the longest common case, a full git SHA.
+_GHA_EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
+_GHA_PLACEHOLDER = "X" * 40
+
+
+def _load(config_path: str) -> dict | None:
+    path = REPO_ROOT / config_path
+    if not path.exists():  # a lane may not define every config
+        return None
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _backend_deploy_body() -> str:
+    config = _load("deploy/backend.cloudbuild.yaml")
+    assert config is not None, "deploy/backend.cloudbuild.yaml is missing"
+    for step in config.get("steps") or []:
+        if step.get("id") == "deploy-backend":
+            return step["args"][1]
+    raise AssertionError("no step with id 'deploy-backend' in backend.cloudbuild.yaml")
+
+
+def _default_substitutions() -> dict[str, str]:
+    config = _load("deploy/backend.cloudbuild.yaml") or {}
+    return {
+        key: ("" if value is None else str(value))
+        for key, value in (config.get("substitutions") or {}).items()
+    }
+
+
+def _workflow_substitutions(workflow_path: str) -> dict[str, str]:
+    path = REPO_ROOT / workflow_path
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for match in _SUBS_ASSIGNMENT.finditer(text):
+        for pair in match.group(1).split("##"):
+            if "=" not in pair:
+                continue
+            key, value = pair.split("=", 1)
+            key = key.strip()
+            if key.startswith("_"):
+                values[key] = _GHA_EXPRESSION.sub(_GHA_PLACEHOLDER, value)
+    return values
+
+
+@pytest.mark.parametrize("config_path", CLOUDBUILD_CONFIGS)
+def test_no_raw_cloud_build_step_arg_exceeds_the_limit(config_path: str) -> None:
+    """Upper bound: the un-substituted body must already fit."""
+    config = _load(config_path)
+    if config is None:
+        pytest.skip(f"{config_path} not present")
+
+    for index, step in enumerate(config.get("steps") or []):
+        for arg_index, arg in enumerate(step.get("args") or []):
+            size = len(arg)
+            assert size < CLOUD_BUILD_MAX_ARG, (
+                f"{config_path} step {index} ({step.get('id')}) arg {arg_index} is "
+                f"{size} chars, over Cloud Build's {CLOUD_BUILD_MAX_ARG} limit. gcloud "
+                f"rejects this config client-side, so NO build is created and every "
+                f"deploy lane using this file fails at submission with no log to read. "
+                f"Move comments above the step, or move the body into a script the "
+                f"step invokes."
+            )
+
+
+@pytest.mark.parametrize("workflow_path", BACKEND_DEPLOY_WORKFLOWS)
+def test_substituted_backend_deploy_body_fits_every_lane(workflow_path: str) -> None:
+    """The real check: what each lane actually submits must fit, with margin."""
+    if not (REPO_ROOT / workflow_path).exists():
+        pytest.skip(f"{workflow_path} not present")
+
+    body = _backend_deploy_body()
+    values = _default_substitutions()
+    values.update(_workflow_substitutions(workflow_path))
+
+    substituted = _SUBSTITUTION.sub(lambda m: values.get(m.group(1), ""), body)
+    size = len(substituted)
+    headroom = CLOUD_BUILD_MAX_ARG - size
+
+    assert size < CLOUD_BUILD_MAX_ARG, (
+        f"{workflow_path} would submit a deploy-backend arg of {size} chars after "
+        f"substitution, over Cloud Build's {CLOUD_BUILD_MAX_ARG} limit. This lane's "
+        f"deploys fail at submission. Note the raw body may still look fine -- lanes "
+        f"differ because they pass different substitution values."
+    )
+    assert headroom >= REQUIRED_HEADROOM, (
+        f"{workflow_path} would submit {size} chars, only {headroom} under Cloud "
+        f"Build's {CLOUD_BUILD_MAX_ARG} limit (need >= {REQUIRED_HEADROOM}). This is "
+        f"too close to ship: the next secret ref or env var breaks every deploy lane. "
+        f"Move prose above the step, or extract the body into a script."
+    )

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -20,7 +20,6 @@ steps:
       - "-c"
       - |
         set -euo pipefail
-        # Ensure gcr.io auth is available to the buildx container driver.
         gcloud auth configure-docker gcr.io --quiet || true
         docker buildx create --use --name hushh-builder --driver docker-container \
           >/dev/null 2>&1 || docker buildx use hushh-builder
@@ -36,6 +35,39 @@ steps:
     id: "build-backend-image"
 
   # Step 3: Deploy to Cloud Run
+  #
+  # NOTE ON COMMENTS IN THIS STEP: Cloud Build caps a single build-step arg at
+  # 10,000 characters, and this step's whole bash body is one arg. Comments
+  # placed *inside* the body count against that cap; comments here do not.
+  # Keep explanatory prose at this level. See
+  # consent-protocol/tests/test_cloudbuild_step_arg_limit.py for the CI guard.
+  #
+  # Apple Wallet pass signing material (WALLET_PASS_CERT_PEM / KEY_PEM /
+  # WWDR_PEM) is optional by construction: until the Pass Type ID certificate
+  # is minted these secrets do not exist, so append_optional_secret skips them
+  # and the signing service answers 503 instead of 500. They are defaulted to
+  # their canonical names so the first deploy after provisioning picks them up
+  # with no change to this file.
+  #
+  # Runtime identity may differ from deploy identity: the dev environment
+  # deploys with _DEPLOY_ENV=dev (labels, provenance) but runs with
+  # ENVIRONMENT=uat so behavior gates replicate UAT exactly.
+  #
+  # env_var_string joins with '|' (not ',') so env VALUES may themselves
+  # contain commas. Paired with gcloud's alternate-delimiter syntax on
+  # --set-env-vars below.
+  #
+  # Timeout 3600s: WebSocket voice sessions (/api/one/adk/live) are long-lived
+  # HTTP requests on Cloud Run; the previous 300s hard-killed any voice
+  # conversation at 5 minutes. Session affinity is best-effort per Google's
+  # WebSocket guidance; reconnects still re-mint a relay ticket, and
+  # cross-instance nonce single-use is Postgres-backed (migration 084). Billing
+  # note: instances with open WebSockets stay active for the connection's
+  # lifetime.
+  #
+  # --max/--min: service-level limits bound aggregate database fan-out across
+  # traffic splits. Revision min-instances=0 prevents no-traffic/retired
+  # revisions from pinning their own warm database pools.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
     args:
@@ -135,18 +167,10 @@ steps:
         append_optional_secret "${_REVIEWER_VAULT_PASSPHRASE_SECRET}" "REVIEWER_VAULT_PASSPHRASE"
         append_optional_secret "${_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET}" "RIA_INTELLIGENCE_VERIFY_BASE_URL"
         append_optional_secret "${_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET}" "ONE_EMAIL_WATCH_RENEW_TOKEN"
-        # Apple Wallet pass signing material. Optional by construction: until the
-        # Pass Type ID certificate is minted these secrets do not exist, so
-        # append_optional_secret skips them and the signing service answers 503
-        # instead of 500. Defaulted to their canonical names so the first deploy
-        # after provisioning picks them up with no change to this file.
         append_optional_secret "${_WALLET_PASS_CERT_PEM_SECRET}" "WALLET_PASS_CERT_PEM"
         append_optional_secret "${_WALLET_PASS_KEY_PEM_SECRET}" "WALLET_PASS_KEY_PEM"
         append_optional_secret "${_WALLET_PASS_WWDR_PEM_SECRET}" "WALLET_PASS_WWDR_PEM"
 
-        # Runtime identity may differ from deploy identity: the dev environment
-        # deploys with _DEPLOY_ENV=dev (labels, provenance) but runs with
-        # ENVIRONMENT=uat so behavior gates replicate UAT exactly.
         runtime_environment="${_RUNTIME_ENVIRONMENT}"
         if [[ -z "${runtime_environment}" ]]; then
           runtime_environment="${_DEPLOY_ENV}"
@@ -223,18 +247,9 @@ steps:
         append_optional_env "HUSHH_PROD_PHONE_TEST_ENABLED" "${_HUSHH_PROD_PHONE_TEST_ENABLED}"
         append_optional_env "KAI_ANALYZE_DURABLE_RUN_STORE" "${_KAI_ANALYZE_DURABLE_RUN_STORE}"
 
-        # Join with '|' (not ',') so env VALUES may themselves contain commas.
-        # Paired with gcloud's alternate-delimiter syntax on --set-env-vars below.
         env_var_string="$(IFS='|'; echo "${env_vars[*]}")"
         deploy_labels="managed-by=hushh-github-actions,deploy-env=${_DEPLOY_ENV},deploy-source=${_DEPLOY_SOURCE},deploy-sha=${_DEPLOY_SHA},github-run-id=${_GITHUB_RUN_ID}"
 
-        # Timeout 3600s: WebSocket voice sessions (/api/one/adk/live) are
-        # long-lived HTTP requests on Cloud Run; the previous 300s hard-killed
-        # any voice conversation at 5 minutes. Session affinity is best-effort
-        # per Google's WebSocket guidance; reconnects still re-mint a relay
-        # ticket, and cross-instance nonce single-use is Postgres-backed
-        # (migration 084). Billing note: instances with open WebSockets stay
-        # active for the connection's lifetime.
         cmd=(
           gcloud run deploy "${_BACKEND_SERVICE}"
           "--image=gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}"
@@ -247,9 +262,6 @@ steps:
           "--cpu=1"
           "--timeout=3600"
           "--session-affinity"
-          # Service-level limits bound aggregate database fan-out across traffic
-          # splits. Revision min=0 prevents no-traffic/retired revisions from
-          # pinning their own warm database pools.
           "--max=${_CLOUD_RUN_MAX_INSTANCES}"
           "--min=${_CLOUD_RUN_MIN_INSTANCES}"
           "--max-instances=${_CLOUD_RUN_MAX_INSTANCES}"


### PR DESCRIPTION
Unblocks the UAT deploy of release `ba39d0342` (PRs #4791 + #4792), which failed at submission and rolled back.

## What broke

Cloud Build caps a single build-step arg at **10,000 characters**. The `deploy-backend` step of `deploy/backend.cloudbuild.yaml` is one such arg. #4791 added three Wallet secret refs and a comment block, pushing it over:

```
INVALID_ARGUMENT: invalid build: invalid .steps field:
build step 1 arg 1 too long (max: 10000)
```

UAT auto-rolled back and stayed healthy; nothing was served broken.

## Why it went unnoticed

Substitutions are applied **before** the cap is enforced, so the same file measures differently per lane. At `ba39d0342`:

| lane | substituted | verdict |
| --- | --- | --- |
| deploy-uat | 10,282 | **over** |
| deploy-dev | 10,208 | **over** |
| deploy-production | 8,937 | under |

Production deployed successfully on 2026-08-04 while UAT and dev were already broken — and had been since `363a9932d` on 2026-07-28. `gcloud` rejects the config client-side, so no Build resource is created and there is no log to open.

## The fix

Comments **inside** the bash body count against the cap; comments at the YAML step level do not. Every comment is moved above the step rather than deleted — the Wallet optional-secret rationale, the dev runtime-identity note, the `|` env-delimiter note, the 3600s WebSocket timeout note and the Cloud Run fan-out note are preserved verbatim.

**The executable body is byte-identical.** Only comment lines moved; asserted mechanically before commit.

| lane | before | after | headroom |
| --- | --- | --- | --- |
| deploy-uat | 10,282 | 8,952 | +1,048 |
| deploy-dev | 10,208 | 8,878 | +1,122 |
| deploy-production | 8,937 | 7,607 | +2,393 |

## The guard

`consent-protocol/tests/test_cloudbuild_step_arg_limit.py` asserts both the raw body **and**, per lane, the substituted body stay under the cap with >= 500 chars of margin.

The per-lane substituted assertion is the one that matters: a raw-only check would have reported production healthy while UAT was broken. Verified to fail on `ba39d0342` and on `75452be4f`, and to pass here. The margin exists so the suite cannot go green at 9,999 and break every lane on the next secret ref.

Supersedes the unmerged `hotfix/cloudbuild-arg-limit` branch, which predates #4791 and would no longer be sufficient on its own.

Signed-off-by: Ankit Kumar Singh <ankit@hushh.ai>

---
Closes #4908
(retroactive board-linkage backfill, 2026-08-06)