### PR TITLE
fix(deploy): bring the backend deploy step back under Cloud Build's arg limit

### DIFF
--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -33,3 +33,4 @@ tests/test_stream_path_query_bounds_cwe400.py
 tests/performance/test_market_cache_instrumentation.py
 tests/test_llm_operon_stream_error_leak.py
 tests/test_stream_agent_thinking_gemini_error_cwe209.py
+tests/test_cloudbuild_step_arg_limit.py

--- a/consent-protocol/tests/test_cloudbuild_step_arg_limit.py
+++ b/consent-protocol/tests/test_cloudbuild_step_arg_limit.py
@@ -1,0 +1,56 @@
+"""No Cloud Build step arg may exceed 10,000 characters.
+
+This is the regression guard for a real, week-long outage. Cloud Build caps a single
+build-step arg at 10,000 characters. The `deploy-backend` step's inline body crossed that
+on 2026-07-28 (commit 363a9932d, 9,559 -> 10,569) and from that moment EVERY backend
+deploy failed at submission with:
+
+    INVALID_ARGUMENT: invalid build: invalid .steps field:
+    build step 2 arg 1 too long (max: 10000)
+
+`deploy/backend.cloudbuild.yaml` is invoked identically by deploy-dev.yml, deploy-uat.yml
+and deploy-production.yml, so one file broke all three lanes at once -- including
+production. Nothing surfaced it for a week, because gcloud enforces the cap client-side
+before any Build resource exists: there is no failed build to open, no log to read, and
+the lanes had simply not been dispatched in that window.
+
+Had this assertion existed, it would have failed on the commit that introduced the
+breach, in the PR that introduced it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Cloud Build's hard cap on a single build-step arg.
+CLOUD_BUILD_MAX_ARG = 10_000
+
+CLOUDBUILD_CONFIGS = [
+    "deploy/backend.cloudbuild.yaml",
+    "deploy/frontend.cloudbuild.yaml",
+    "deploy/dev.autodeploy.backend.cloudbuild.yaml",
+]
+
+
+@pytest.mark.parametrize("config_path", CLOUDBUILD_CONFIGS)
+def test_no_cloud_build_step_arg_exceeds_the_limit(config_path: str) -> None:
+    path = REPO_ROOT / config_path
+    if not path.exists():  # a lane may not define every config
+        pytest.skip(f"{config_path} not present")
+
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    for index, step in enumerate(config.get("steps") or []):
+        for arg_index, arg in enumerate(step.get("args") or []):
+            size = len(arg)
+            assert size < CLOUD_BUILD_MAX_ARG, (
+                f"{config_path} step {index} ({step.get('id')}) arg {arg_index} is "
+                f"{size} chars, over Cloud Build's {CLOUD_BUILD_MAX_ARG} limit. gcloud "
+                f"rejects this config client-side, so NO build is created and every "
+                f"deploy lane using this file fails at submission with no log to read. "
+                f"Move the body into a script the step invokes."
+            )

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -20,7 +20,6 @@ steps:
       - "-c"
       - |
         set -euo pipefail
-        # Ensure gcr.io auth is available to the buildx container driver.
         gcloud auth configure-docker gcr.io --quiet || true
         docker buildx create --use --name hushh-builder --driver docker-container \
           >/dev/null 2>&1 || docker buildx use hushh-builder
@@ -35,7 +34,6 @@ steps:
           consent-protocol
     id: "build-backend-image"
 
-  # Step 3: Deploy to Cloud Run
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     entrypoint: "bash"
     args:
@@ -136,9 +134,6 @@ steps:
         append_optional_secret "${_RIA_INTELLIGENCE_VERIFY_BASE_URL_SECRET}" "RIA_INTELLIGENCE_VERIFY_BASE_URL"
         append_optional_secret "${_ONE_EMAIL_WATCH_RENEW_TOKEN_SECRET}" "ONE_EMAIL_WATCH_RENEW_TOKEN"
 
-        # Runtime identity may differ from deploy identity: the dev environment
-        # deploys with _DEPLOY_ENV=dev (labels, provenance) but runs with
-        # ENVIRONMENT=uat so behavior gates replicate UAT exactly.
         runtime_environment="${_RUNTIME_ENVIRONMENT}"
         if [[ -z "${runtime_environment}" ]]; then
           runtime_environment="${_DEPLOY_ENV}"
@@ -215,18 +210,9 @@ steps:
         append_optional_env "HUSHH_PROD_PHONE_TEST_ENABLED" "${_HUSHH_PROD_PHONE_TEST_ENABLED}"
         append_optional_env "KAI_ANALYZE_DURABLE_RUN_STORE" "${_KAI_ANALYZE_DURABLE_RUN_STORE}"
 
-        # Join with '|' (not ',') so env VALUES may themselves contain commas.
-        # Paired with gcloud's alternate-delimiter syntax on --set-env-vars below.
         env_var_string="$(IFS='|'; echo "${env_vars[*]}")"
         deploy_labels="managed-by=hushh-github-actions,deploy-env=${_DEPLOY_ENV},deploy-source=${_DEPLOY_SOURCE},deploy-sha=${_DEPLOY_SHA},github-run-id=${_GITHUB_RUN_ID}"
 
-        # Timeout 3600s: WebSocket voice sessions (/api/one/adk/live) are
-        # long-lived HTTP requests on Cloud Run; the previous 300s hard-killed
-        # any voice conversation at 5 minutes. Session affinity is best-effort
-        # per Google's WebSocket guidance; reconnects still re-mint a relay
-        # ticket, and cross-instance nonce single-use is Postgres-backed
-        # (migration 084). Billing note: instances with open WebSockets stay
-        # active for the connection's lifetime.
         cmd=(
           gcloud run deploy "${_BACKEND_SERVICE}"
           "--image=gcr.io/$PROJECT_ID/consent-protocol:${_IMAGE_TAG}"
@@ -239,9 +225,6 @@ steps:
           "--cpu=1"
           "--timeout=3600"
           "--session-affinity"
-          # Service-level limits bound aggregate database fan-out across traffic
-          # splits. Revision min=0 prevents no-traffic/retired revisions from
-          # pinning their own warm database pools.
           "--max=${_CLOUD_RUN_MAX_INSTANCES}"
           "--min=${_CLOUD_RUN_MIN_INSTANCES}"
           "--max-instances=${_CLOUD_RUN_MAX_INSTANCES}"


### PR DESCRIPTION
# Superseded by #4796 — closing

`main` already carries this fix. #4796 landed `0fb82a033`, which brings the `deploy-backend` step to **9,916** characters, under Cloud Build's 10,000 cap. The deploy lanes are unblocked; this PR is a duplicate.

Closing rather than merging, because #4796's version is **strictly better** than this one on the point that matters:

**Cloud Build applies substitutions before enforcing the cap.** The raw YAML length is only an upper bound, and a loose one. #4796 proves it with a real case — the same raw body (10,657) was under the cap once substituted for production but over it for UAT, because UAT passes longer substitution values. This PR's guard asserts only the raw length, so it would have called production healthy while UAT was broken. #4796's guard asserts the substituted body per lane and requires 500 characters of headroom.

#4796 also records a second breach this PR does not know about: PR #4791 (Wallet Profile) took the body from 10,657 to 11,246 and broke the UAT deploy of release `ba39d0342`.

## What is still open

Both #4796 and this PR are comment-stripping stopgaps, and the step has now breached the cap **twice in eight days**. `main` is at 9,916 — 84 characters of raw headroom, less than one line of bash. The durable fix is to move the step body into a checked-in script invoked by the step, passing substitutions through the step's `env:` field, which removes the ceiling entirely. That work is prepared on `claude/hushh-infrastructure-analysis-7o991c` and will carry #4796's substituted-length guard forward unchanged.

## Description

- Routes touched: **None**
- API / schema / type changes: **None**
- Rollback or safe-failure behavior: not applicable — closing without merge.