### PR TITLE
feat(one): ask for location once, and put advisers on the map in Connect

### DIFF
--- a/consent-protocol/.env.example
+++ b/consent-protocol/.env.example
@@ -76,6 +76,14 @@ GOOGLE_GENAI_USE_VERTEXAI=True
 # (The legacy "Directions API" is deprecated for new projects — use Routes API.)
 GOOGLE_MAPS_API_KEY=replace_with_google_maps_api_key
 
+# Advisor directory (FINRA BrokerCheck) — powers "Around you" in Connect.
+# Server-side only: the bearer key must never reach the browser or a native
+# bundle, so the backend proxies every call. The key lives in GCP Secret Manager
+# (project hushh-tech-prod, secret brokercheck-api-key); leave both blank to
+# disable the surface — it degrades to an "unavailable" state, never an error.
+ADVISORS_API_BASE_URL=
+ADVISORS_API_KEY=
+
 # Optional: self-serve developer token for stdio MCP hosts and token-auth
 # developer lookups. Contributors can leave this blank until they enable
 # developer access from the Kai app.

--- a/consent-protocol/.env.example
+++ b/consent-protocol/.env.example
@@ -78,9 +78,13 @@ GOOGLE_MAPS_API_KEY=replace_with_google_maps_api_key
 
 # Advisor directory (FINRA BrokerCheck) — powers "Around you" in Connect.
 # Server-side only: the bearer key must never reach the browser or a native
-# bundle, so the backend proxies every call. The key lives in GCP Secret Manager
-# (project hushh-tech-prod, secret brokercheck-api-key); leave both blank to
-# disable the surface — it degrades to an "unavailable" state, never an error.
+# bundle, so the backend proxies every call. Leave both blank to disable the
+# surface — it degrades to an "unavailable" state, never an error.
+#
+# Deployed environments set these two differently, on purpose. The base URL is
+# not a secret and travels in BACKEND_RUNTIME_CONFIG_JSON as
+# `advisors_api_base_url`. The key is a real secret and is mounted from Secret
+# Manager as ADVISORS_API_KEY.
 ADVISORS_API_BASE_URL=
 ADVISORS_API_KEY=
 

--- a/consent-protocol/api/middlewares/rate_limit.py
+++ b/consent-protocol/api/middlewares/rate_limit.py
@@ -107,6 +107,12 @@ class RateLimits:
     # check-in budgets while still bounding scripted abuse per signed owner.
     ONE_LOCATION_MAPS_PROVIDER = "30/minute"  # noqa: S105
 
+    # Advisor directory (FINRA BrokerCheck proxy). Every miss is an upstream
+    # call against a quota we own, so this stays bounded per principal. Paging
+    # is served from the upstream's own ranking cache and is therefore cheap;
+    # the limit is sized for browse-and-page, not for scraping the directory.
+    ONE_ADVISORS_DIRECTORY_READ = "20/minute"  # noqa: S105
+
     # Preference Subscription Fabric (PCHP RFC-002).
     # FABRIC_READ is the third-party-facing, monetizable subscriber read path;
     # it must be firmly bounded per principal so no brand can drain an owner's

--- a/consent-protocol/api/routes/one/__init__.py
+++ b/consent-protocol/api/routes/one/__init__.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter
 from .a2a import router as a2a_router
 from .a2a import well_known_router as a2a_well_known_router
 from .adk_live import router as adk_live_router
+from .advisors import router as advisors_router
 from .connections import router as connections_router
 from .email import router as email_router
 from .email_chat import router as email_chat_router
@@ -21,6 +22,7 @@ router = APIRouter()
 router.include_router(a2a_well_known_router)
 router.include_router(a2a_router)
 router.include_router(adk_live_router)
+router.include_router(advisors_router)
 router.include_router(connections_router)
 router.include_router(email_router)
 router.include_router(email_chat_router)

--- a/consent-protocol/api/routes/one/advisors.py
+++ b/consent-protocol/api/routes/one/advisors.py
@@ -1,0 +1,81 @@
+"""Advisor directory routes — advisers near a coordinate, and one profile.
+
+The upstream bearer key never leaves the backend, so the app calls these
+endpoints instead of the directory API directly. Coordinates arrive per request,
+are used only to build the upstream query, and are never persisted or logged.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
+
+from api.middleware import require_firebase_auth
+from api.middlewares.rate_limit import RateLimits, limiter
+from hushh_mcp.services.advisor_directory_service import (
+    AdvisorDirectoryError,
+    AdvisorDirectoryService,
+)
+
+router = APIRouter(prefix="/api/one", tags=["Advisors"])
+
+
+def _service() -> AdvisorDirectoryService:
+    return AdvisorDirectoryService()
+
+
+def _no_store(response: Response) -> None:
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Pragma"] = "no-cache"
+
+
+def _handle(exc: AdvisorDirectoryError) -> HTTPException:
+    return HTTPException(
+        status_code=exc.status_code,
+        detail={"code": "ONE_ADVISORS_UNAVAILABLE", "message": str(exc)},
+    )
+
+
+@router.get("/advisors/nearby")
+@limiter.limit(RateLimits.ONE_ADVISORS_DIRECTORY_READ)
+async def advisors_nearby(
+    request: Request,
+    response: Response,
+    lat: float | None = Query(default=None, ge=-90, le=90),
+    lng: float | None = Query(default=None, ge=-180, le=180),
+    postal_code: str | None = Query(default=None, alias="postalCode", max_length=12),
+    radius_mi: float | None = Query(default=None, alias="radiusMi", gt=0, le=100),
+    limit: int = Query(default=10, ge=1, le=50),
+    offset: int = Query(default=0, ge=0),
+    advisor_type: str = Query(default="ia", alias="type", max_length=8),
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    _ = firebase_uid  # auth-gate only; results are not user-scoped
+    _no_store(response)
+    try:
+        return await _service().search(
+            lat=lat,
+            lng=lng,
+            postal_code=postal_code,
+            radius_mi=radius_mi,
+            limit=limit,
+            offset=offset,
+            advisor_type=advisor_type,
+        )
+    except AdvisorDirectoryError as exc:
+        raise _handle(exc) from exc
+
+
+@router.get("/advisors/{crd}")
+@limiter.limit(RateLimits.ONE_ADVISORS_DIRECTORY_READ)
+async def advisor_profile(
+    request: Request,
+    response: Response,
+    crd: str = Path(..., min_length=1, max_length=12),
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    _ = firebase_uid
+    _no_store(response)
+    try:
+        return await _service().profile(crd)
+    except AdvisorDirectoryError as exc:
+        raise _handle(exc) from exc

--- a/consent-protocol/hushh_mcp/runtime_settings.py
+++ b/consent-protocol/hushh_mcp/runtime_settings.py
@@ -91,6 +91,12 @@ _BACKEND_RUNTIME_ENV_MAP: dict[str, str] = {
     "one_wallet_card_enabled": "ONE_WALLET_CARD_ENABLED",
     "wallet_pass_team_identifier": "WALLET_PASS_TEAM_IDENTIFIER",
     "wallet_pass_type_identifier": "WALLET_PASS_TYPE_IDENTIFIER",
+    # Advisor directory base URL. Not a secret, so it travels in this config
+    # blob rather than as another line in the Cloud Build deploy step — that
+    # step's inline script sits close to Cloud Build's 10,000-character arg
+    # ceiling, and every line added there is borrowed against it. The bearer
+    # key is a real secret and stays in --set-secrets.
+    "advisors_api_base_url": "ADVISORS_API_BASE_URL",
 }
 
 

--- a/consent-protocol/hushh_mcp/services/advisor_directory_service.py
+++ b/consent-protocol/hushh_mcp/services/advisor_directory_service.py
@@ -1,0 +1,442 @@
+"""Server-side proxy for the Advisors (FINRA BrokerCheck) directory API.
+
+Keeps the directory bearer key on the backend. The frontend never sees it;
+app code calls our own ``/api/one/advisors/*`` endpoints, which call this
+service.
+
+Why the upstream stream is consumed here rather than passed through: the
+native shells enable ``CapacitorHttp``, which patches ``fetch`` and buffers the
+whole body, so a client-side NDJSON reader would never yield progressively on
+iOS/Android. Assembling here gives web and native one identical, testable JSON
+contract. List rows are requested with ``detail=false`` because a search row
+already carries everything a card needs; full profiles are fetched on demand.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_SECONDS = 20.0
+_DEFAULT_RADIUS_MI = 10.0
+_MIN_RADIUS_MI = 0.1
+_MAX_RADIUS_MI = 100.0
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 50
+
+# CWE-400 bounds on an upstream stream we do not control. The upstream caps
+# `limit` at 500 rows, so these ceilings sit far above any legitimate response
+# while still refusing an unbounded body.
+_MAX_STREAM_LINES = 4_000
+_MAX_STREAM_BYTES = 8 * 1024 * 1024
+
+_ADVISOR_TYPES = frozenset({"ia", "broker", "both"})
+
+
+class AdvisorDirectoryError(RuntimeError):
+    """Raised for a missing config (503), bad input (400) or upstream failure (502)."""
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _env(name: str, default: str = "") -> str:
+    return str(os.getenv(name, default)).strip()
+
+
+def base_url() -> str:
+    return (_env("ADVISORS_API_BASE_URL") or _env("ADVISORS_API_BASE")).rstrip("/")
+
+
+def is_configured() -> bool:
+    return bool(base_url() and _env("ADVISORS_API_KEY"))
+
+
+def _coerce_float(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed == parsed else None  # reject NaN
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+class AdvisorDirectoryService:
+    """Async client for the advisors directory."""
+
+    def __init__(self, *, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self._base_url = base_url()
+        self._api_key = _env("ADVISORS_API_KEY")
+        self._timeout = _coerce_float(_env("ADVISORS_API_TIMEOUT_SECONDS")) or (
+            _DEFAULT_TIMEOUT_SECONDS
+        )
+        self._transport = transport
+
+    # ---------------------------------------------------------------- internals
+
+    def _client(self) -> httpx.AsyncClient:
+        if not self._base_url or not self._api_key:
+            raise AdvisorDirectoryError(
+                "The advisor directory is not configured on this backend.",
+                status_code=503,
+            )
+        return httpx.AsyncClient(
+            base_url=self._base_url,
+            timeout=httpx.Timeout(self._timeout, connect=5.0),
+            headers={"Authorization": f"Bearer {self._api_key}"},
+            transport=self._transport,
+        )
+
+    @staticmethod
+    def _raise_for_status(status_code: int) -> None:
+        """Map an upstream status onto a client-safe error.
+
+        Auth failures are deliberately reported as an upstream failure: a 401
+        here means *our* key is wrong, which is never the caller's business and
+        must not teach a caller to retry with different credentials.
+        """
+        if status_code < 400:
+            return
+        if status_code == 400:
+            raise AdvisorDirectoryError("That search could not be completed.", status_code=400)
+        if status_code == 429:
+            raise AdvisorDirectoryError(
+                "The advisor directory is busy. Try again shortly.", status_code=429
+            )
+        if status_code in (401, 403):
+            logger.error(
+                "advisors.upstream_auth_rejected status=%s — check ADVISORS_API_KEY",
+                status_code,
+            )
+        raise AdvisorDirectoryError(
+            "The advisor directory is unavailable right now.", status_code=502
+        )
+
+    # ------------------------------------------------------------------- search
+
+    def _search_params(
+        self,
+        *,
+        lat: float | None,
+        lng: float | None,
+        postal_code: str | None,
+        radius_mi: float | None,
+        limit: int | None,
+        offset: int | None,
+        advisor_type: str | None,
+    ) -> dict[str, str]:
+        params: dict[str, str] = {}
+
+        if lat is not None and lng is not None:
+            if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lng <= 180.0):
+                raise AdvisorDirectoryError("Those coordinates are not valid.", status_code=400)
+            params["lat"] = f"{lat:.6f}"
+            params["lng"] = f"{lng:.6f}"
+        elif postal_code:
+            normalized = "".join(ch for ch in postal_code if ch.isalnum())[:10]
+            if not normalized:
+                raise AdvisorDirectoryError("Enter a valid postal code.", status_code=400)
+            params["postalCode"] = normalized
+        else:
+            raise AdvisorDirectoryError("A location or postal code is required.", status_code=400)
+
+        params["radiusMi"] = (
+            f"{_clamp(radius_mi or _DEFAULT_RADIUS_MI, _MIN_RADIUS_MI, _MAX_RADIUS_MI):.1f}"
+        )
+        params["limit"] = str(int(_clamp(float(limit or _DEFAULT_LIMIT), 1, _MAX_LIMIT)))
+        params["offset"] = str(max(0, offset or 0))
+        params["type"] = advisor_type if advisor_type in _ADVISOR_TYPES else "ia"
+        params["status"] = "active"
+        # A search row already carries name, firm, distance and disclosure flag,
+        # so profile hydration is pure latency for a list. Profiles load on tap.
+        params["detail"] = "false"
+        params["firmContact"] = "true"
+        params["stream"] = "ndjson"
+        return params
+
+    async def search(
+        self,
+        *,
+        lat: float | None = None,
+        lng: float | None = None,
+        postal_code: str | None = None,
+        radius_mi: float | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        advisor_type: str | None = None,
+    ) -> dict[str, Any]:
+        params = self._search_params(
+            lat=lat,
+            lng=lng,
+            postal_code=postal_code,
+            radius_mi=radius_mi,
+            limit=limit,
+            offset=offset,
+            advisor_type=advisor_type,
+        )
+
+        meta: dict[str, Any] = {}
+        rows: list[dict[str, Any]] = []
+        grouped = False
+
+        try:
+            async with self._client() as client:
+                async with client.stream("GET", "/v1/advisors", params=params) as response:
+                    self._raise_for_status(response.status_code)
+
+                    read_bytes = 0
+                    read_lines = 0
+                    async for line in response.aiter_lines():
+                        if not line.strip():
+                            continue
+                        read_lines += 1
+                        read_bytes += len(line)
+                        if read_lines > _MAX_STREAM_LINES or read_bytes > _MAX_STREAM_BYTES:
+                            logger.warning("advisors.stream_truncated lines=%s", read_lines)
+                            break
+                        try:
+                            frame = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if not isinstance(frame, dict):
+                            continue
+
+                        frame_type = frame.get("type")
+                        if frame_type == "meta":
+                            meta = frame
+                            grouped = bool(frame.get("grouped"))
+                        elif frame_type in ("batch", "branches"):
+                            if frame_type == "branches":
+                                grouped = True
+                            items = frame.get("items")
+                            if isinstance(items, list):
+                                rows.extend(item for item in items if isinstance(item, dict))
+                        elif frame_type == "error":
+                            raise AdvisorDirectoryError(
+                                "The advisor directory is unavailable right now.",
+                                status_code=502,
+                            )
+                        elif frame_type == "done":
+                            break
+        except httpx.HTTPError as exc:
+            logger.warning("advisors.search_transport_error error=%s", type(exc).__name__)
+            raise AdvisorDirectoryError(
+                "The advisor directory is unavailable right now.", status_code=502
+            ) from exc
+
+        return {
+            "items": [_normalize_row(row, grouped=grouped) for row in rows],
+            "meta": _normalize_meta(meta, grouped=grouped, requested_limit=int(params["limit"])),
+            "attribution": _ATTRIBUTION,
+        }
+
+    # ------------------------------------------------------------------ profile
+
+    async def profile(self, crd: str) -> dict[str, Any]:
+        normalized = "".join(ch for ch in str(crd or "") if ch.isdigit())[:12]
+        if not normalized:
+            raise AdvisorDirectoryError("That advisor id is not valid.", status_code=400)
+
+        try:
+            async with self._client() as client:
+                response = await client.get(f"/v1/advisors/{normalized}")
+                self._raise_for_status(response.status_code)
+                payload = response.json()
+        except AdvisorDirectoryError:
+            raise
+        except httpx.HTTPError as exc:
+            logger.warning("advisors.profile_transport_error error=%s", type(exc).__name__)
+            raise AdvisorDirectoryError(
+                "That advisor could not be loaded.", status_code=502
+            ) from exc
+        except ValueError as exc:
+            raise AdvisorDirectoryError(
+                "That advisor could not be loaded.", status_code=502
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise AdvisorDirectoryError("That advisor could not be loaded.", status_code=502)
+        return {"profile": _normalize_profile(payload), "attribution": _ATTRIBUTION}
+
+
+_ATTRIBUTION = {
+    "source": "FINRA BrokerCheck",
+    "url": "https://brokercheck.finra.org",
+}
+
+
+def _normalize_meta(meta: dict[str, Any], *, grouped: bool, requested_limit: int) -> dict[str, Any]:
+    next_offset = _coerce_int(meta.get("nextOffset"))
+    radius = _coerce_float(meta.get("radiusMi"))
+    radius_requested = _coerce_float(meta.get("radiusRequested"))
+    return {
+        "grouped": grouped,
+        "hasMore": bool(meta.get("hasMore")),
+        "nextOffset": next_offset if next_offset is not None else None,
+        "returned": _coerce_int(meta.get("returned")) or 0,
+        "available": _coerce_int(meta.get("available")),
+        "limit": _coerce_int(meta.get("limit")) or requested_limit,
+        "radiusMi": radius,
+        "radiusRequested": radius_requested,
+        "radiusAdjusted": bool(meta.get("radiusAdjusted")),
+        "truncated": bool(meta.get("truncatedBy")),
+    }
+
+
+def _normalize_firm(firm: Any) -> dict[str, Any]:
+    if not isinstance(firm, dict):
+        return {}
+    office = firm.get("officeAddress")
+    office_city = office.get("city") if isinstance(office, dict) else None
+    return {
+        "firmId": _text(firm.get("firmId")),
+        "firmName": _text(firm.get("firmName")),
+        "phone": _text(firm.get("phone")),
+        "city": _text(firm.get("branchCity")) or _text(office_city),
+        "state": _text(firm.get("branchState")),
+    }
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_row(row: dict[str, Any], *, grouped: bool) -> dict[str, Any]:
+    """Flatten a person row or a branch row onto one card shape.
+
+    Adviser density varies ~25x at the same radius, so the upstream switches
+    from people to branch offices in dense metros. One card shape means the UI
+    never forks on which one arrived.
+    """
+    distance_miles = _coerce_float(row.get("distanceMiles"))
+    if distance_miles is None:
+        meters = _coerce_float(row.get("distanceMeters"))
+        distance_miles = meters / 1609.344 if meters is not None else None
+
+    if grouped:
+        firm_name = _text(row.get("firmName"))
+        nested = row.get("advisors")
+        return {
+            "kind": "branch",
+            "id": _text(row.get("branchOfficeId"))
+            or _text(row.get("firmId"))
+            or firm_name
+            or "branch",
+            "name": firm_name,
+            "firmName": None,
+            "advisorCount": _coerce_int(row.get("advisorCount")),
+            "advisorNames": [
+                name
+                for name in (
+                    _text(item.get("name")) if isinstance(item, dict) else None
+                    for item in (nested if isinstance(nested, list) else [])
+                )
+                if name
+            ][:3],
+            "distanceMiles": distance_miles,
+            "city": _text(row.get("city")) or _text(row.get("branchCity")),
+            "state": _text(row.get("state")) or _text(row.get("branchState")),
+            "phone": _text(row.get("phone")),
+        }
+
+    firm = _normalize_firm(row.get("firm"))
+    return {
+        "kind": "advisor",
+        "id": _text(row.get("crd")) or "",
+        "crd": _text(row.get("crd")),
+        "name": _text(row.get("name")),
+        "firmName": firm.get("firmName"),
+        "yearsExperience": _coerce_float(row.get("yearsExperience")),
+        "hasDisclosures": bool(row.get("hasDisclosures")),
+        "distanceMiles": distance_miles,
+        "city": firm.get("city"),
+        "state": firm.get("state"),
+        "phone": firm.get("phone"),
+    }
+
+
+def _normalize_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    firm_history = profile.get("firmHistory")
+    current_firm = None
+    if isinstance(firm_history, list):
+        for entry in firm_history:
+            if isinstance(entry, dict) and entry.get("current"):
+                current_firm = _text(entry.get("firmName"))
+                break
+
+    disclosures = profile.get("disclosures")
+    branches = profile.get("branches")
+    first_branch = branches[0] if isinstance(branches, list) and branches else None
+
+    return {
+        "crd": _text(profile.get("crd")),
+        "name": _text(profile.get("name")),
+        "firmName": current_firm,
+        "yearsExperience": _coerce_float(profile.get("yearsExperience")),
+        "firmCount": _coerce_int(profile.get("firmCount")),
+        "isBarred": bool(profile.get("isBarred")),
+        "hasDisclosures": bool(profile.get("hasDisclosures")),
+        "disclosureCount": len(disclosures) if isinstance(disclosures, list) else 0,
+        "states": [
+            state
+            for state in (
+                _text(entry.get("state")) if isinstance(entry, dict) else None
+                for entry in (
+                    profile.get("registeredStates")
+                    if isinstance(profile.get("registeredStates"), list)
+                    else []
+                )
+            )
+            if state
+        ][:12],
+        "exams": [
+            category
+            for category in (
+                _text(entry.get("category")) if isinstance(entry, dict) else None
+                for entry in (
+                    profile.get("exams") if isinstance(profile.get("exams"), list) else []
+                )
+            )
+            if category
+        ][:8],
+        "office": _normalize_branch_address(first_branch),
+        "reportUrl": _text(profile.get("reportUrl")),
+    }
+
+
+def _normalize_branch_address(branch: Any) -> dict[str, Any] | None:
+    if not isinstance(branch, dict):
+        return None
+    return {
+        "street": _text(branch.get("street1")),
+        "city": _text(branch.get("city")),
+        "state": _text(branch.get("state")),
+        "zip": _text(branch.get("zip")),
+    }
+
+
+__all__ = [
+    "AdvisorDirectoryError",
+    "AdvisorDirectoryService",
+    "is_configured",
+]

--- a/consent-protocol/hushh_mcp/services/advisor_directory_service.py
+++ b/consent-protocol/hushh_mcp/services/advisor_directory_service.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Iterable
 from typing import Any
 
 import httpx
@@ -76,6 +77,20 @@ def _coerce_int(value: Any) -> int | None:
 
 def _clamp(value: float, low: float, high: float) -> float:
     return max(low, min(high, value))
+
+
+def _unique(values: Iterable[str | None], limit: int = 12) -> list[str]:
+    """Order-preserving dedupe, dropping blanks and capping the list."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+        if len(out) >= limit:
+            break
+    return out
 
 
 class AdvisorDirectoryService:
@@ -273,7 +288,16 @@ class AdvisorDirectoryService:
 
         if not isinstance(payload, dict):
             raise AdvisorDirectoryError("That advisor could not be loaded.", status_code=502)
-        return {"profile": _normalize_profile(payload), "attribution": _ATTRIBUTION}
+
+        # The standalone endpoint answers {ok, profile, firm, attribution}; the
+        # same record arrives flat inside a stream `detail` frame. Accept both
+        # so this keeps working whichever one a caller hands us.
+        record = payload.get("profile") if isinstance(payload.get("profile"), dict) else payload
+        firm = payload.get("firm") if isinstance(payload.get("firm"), dict) else None
+        return {
+            "profile": _normalize_profile(record, firm=firm),
+            "attribution": _ATTRIBUTION,
+        }
 
 
 _ATTRIBUTION = {
@@ -375,10 +399,14 @@ def _normalize_row(row: dict[str, Any], *, grouped: bool) -> dict[str, Any]:
     }
 
 
-def _normalize_profile(profile: dict[str, Any]) -> dict[str, Any]:
+def _normalize_profile(
+    profile: dict[str, Any], *, firm: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    # The standalone endpoint states the current employer outright; a stream
+    # `detail` frame does not, so fall back to the flagged firm-history entry.
+    current_firm = _text(firm.get("firmName")) if isinstance(firm, dict) else None
     firm_history = profile.get("firmHistory")
-    current_firm = None
-    if isinstance(firm_history, list):
+    if not current_firm and isinstance(firm_history, list):
         for entry in firm_history:
             if isinstance(entry, dict) and entry.get("current"):
                 current_firm = _text(entry.get("firmName"))
@@ -397,28 +425,21 @@ def _normalize_profile(profile: dict[str, Any]) -> dict[str, Any]:
         "isBarred": bool(profile.get("isBarred")),
         "hasDisclosures": bool(profile.get("hasDisclosures")),
         "disclosureCount": len(disclosures) if isinstance(disclosures, list) else 0,
-        "states": [
-            state
-            for state in (
-                _text(entry.get("state")) if isinstance(entry, dict) else None
-                for entry in (
-                    profile.get("registeredStates")
-                    if isinstance(profile.get("registeredStates"), list)
-                    else []
-                )
+        # One state appears once per registration scope (BC and IA), so the raw
+        # list double-counts. The UI shows a count, and "51 states" would be a
+        # lie — dedupe while preserving order.
+        "states": _unique(
+            _text(entry.get("state")) if isinstance(entry, dict) else None
+            for entry in (
+                profile.get("registeredStates")
+                if isinstance(profile.get("registeredStates"), list)
+                else []
             )
-            if state
-        ][:12],
-        "exams": [
-            category
-            for category in (
-                _text(entry.get("category")) if isinstance(entry, dict) else None
-                for entry in (
-                    profile.get("exams") if isinstance(profile.get("exams"), list) else []
-                )
-            )
-            if category
-        ][:8],
+        ),
+        "exams": _unique(
+            _text(entry.get("category")) if isinstance(entry, dict) else None
+            for entry in (profile.get("exams") if isinstance(profile.get("exams"), list) else [])
+        ),
         "office": _normalize_branch_address(first_branch),
         "reportUrl": _text(profile.get("reportUrl")),
     }

--- a/consent-protocol/tests/services/test_advisor_directory_service.py
+++ b/consent-protocol/tests/services/test_advisor_directory_service.py
@@ -246,7 +246,44 @@ async def test_unconfigured_backend_reports_unavailable(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_profile_reads_the_standalone_endpoint_envelope(monkeypatch):
+    """The live endpoint wraps the record in {ok, profile, firm, attribution}.
+
+    Reading the payload as if it were flat produced an all-null profile, which
+    only showed up against the real service — so this pins the real envelope.
+    """
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "profile": {
+                    "crd": "862222",
+                    "name": "CHRISTINE NOELLE COTE",
+                    "yearsExperience": 47.5,
+                    "firmCount": 7,
+                    "hasDisclosures": True,
+                    "disclosures": [{"type": "Regulatory"}],
+                },
+                "firm": {"firmId": "149777", "firmName": "MORGAN STANLEY"},
+                "attribution": {"source": "FINRA BrokerCheck"},
+            },
+        )
+
+    profile = (await _service(monkeypatch, handler).profile("862222"))["profile"]
+
+    assert profile["crd"] == "862222"
+    assert profile["name"] == "CHRISTINE NOELLE COTE"
+    assert profile["firmName"] == "MORGAN STANLEY"
+    assert profile["yearsExperience"] == 47.5
+    assert profile["disclosureCount"] == 1
+
+
+@pytest.mark.asyncio
 async def test_profile_normalizes_current_firm_and_counts(monkeypatch):
+    """A stream `detail` frame carries the same record flat, with no firm block."""
+
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/v1/advisors/862222"
         return httpx.Response(

--- a/consent-protocol/tests/services/test_advisor_directory_service.py
+++ b/consent-protocol/tests/services/test_advisor_directory_service.py
@@ -1,0 +1,298 @@
+import json
+
+import httpx
+import pytest
+
+from hushh_mcp.services import advisor_directory_service as ads
+
+
+def _ndjson(*frames: dict) -> bytes:
+    return ("\n".join(json.dumps(frame) for frame in frames) + "\n").encode()
+
+
+def _configure(monkeypatch) -> None:
+    monkeypatch.setenv("ADVISORS_API_BASE_URL", "https://advisors.example")
+    monkeypatch.setenv("ADVISORS_API_KEY", "test-key")
+
+
+def _service(monkeypatch, handler) -> ads.AdvisorDirectoryService:
+    _configure(monkeypatch)
+    return ads.AdvisorDirectoryService(transport=httpx.MockTransport(handler))
+
+
+_PERSON_STREAM = _ndjson(
+    {
+        "type": "meta",
+        "radiusMi": 5,
+        "radiusRequested": 10,
+        "radiusAdjusted": True,
+        "returned": 1,
+        "available": 300,
+        "hasMore": True,
+        "nextOffset": 10,
+        "limit": 10,
+        "grouped": False,
+    },
+    {
+        "type": "batch",
+        "seq": 1,
+        "items": [
+            {
+                "crd": "862222",
+                "name": "CHRISTINE NOELLE COTE",
+                "yearsExperience": 47.5,
+                "hasDisclosures": True,
+                "distanceMiles": 0.47,
+                "firm": {
+                    "firmId": "149777",
+                    "firmName": "MORGAN STANLEY",
+                    "branchCity": "Kirkland",
+                    "branchState": "WA",
+                    "phone": "914-225-1000",
+                    "officeAddress": {"city": "PURCHASE"},
+                },
+            }
+        ],
+    },
+    {"type": "done", "ms": 120},
+)
+
+
+@pytest.mark.asyncio
+async def test_search_sends_bearer_key_and_list_tuned_params(monkeypatch):
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("Authorization")
+        seen["path"] = request.url.path
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, content=_PERSON_STREAM)
+
+    await _service(monkeypatch, handler).search(lat=47.6769, lng=-122.206)
+
+    assert seen["auth"] == "Bearer test-key"
+    assert seen["path"] == "/v1/advisors"
+    # A search row already carries everything a card needs, so the list must not
+    # pay for profile hydration.
+    assert seen["params"]["detail"] == "false"
+    assert seen["params"]["stream"] == "ndjson"
+    assert seen["params"]["type"] == "ia"
+    assert seen["params"]["status"] == "active"
+    assert seen["params"]["lat"].startswith("47.676")
+
+
+@pytest.mark.asyncio
+async def test_search_normalizes_person_rows(monkeypatch):
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_PERSON_STREAM)
+
+    result = await _service(monkeypatch, handler).search(lat=47.6769, lng=-122.206)
+
+    assert result["items"] == [
+        {
+            "kind": "advisor",
+            "id": "862222",
+            "crd": "862222",
+            "name": "CHRISTINE NOELLE COTE",
+            "firmName": "MORGAN STANLEY",
+            "yearsExperience": 47.5,
+            "hasDisclosures": True,
+            "distanceMiles": 0.47,
+            "city": "Kirkland",
+            "state": "WA",
+            "phone": "914-225-1000",
+        }
+    ]
+    assert result["meta"]["radiusAdjusted"] is True
+    assert result["meta"]["radiusMi"] == 5
+    assert result["meta"]["nextOffset"] == 10
+    assert result["meta"]["grouped"] is False
+    assert result["attribution"]["source"] == "FINRA BrokerCheck"
+
+
+@pytest.mark.asyncio
+async def test_search_flattens_branch_rows_onto_the_same_card_shape(monkeypatch):
+    """Dense metros return branch offices instead of people; one card shape."""
+
+    stream = _ndjson(
+        {"type": "meta", "grouped": True, "returned": 1, "hasMore": False},
+        {
+            "type": "branches",
+            "items": [
+                {
+                    "branchOfficeId": "408168",
+                    "firmName": "MORGAN STANLEY",
+                    "advisorCount": 74,
+                    "distanceMeters": 800,
+                    "city": "New York",
+                    "state": "NY",
+                    "advisors": [{"name": "A ADVISOR"}, {"name": "B ADVISOR"}],
+                }
+            ],
+        },
+        {"type": "done"},
+    )
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=stream)
+
+    result = await _service(monkeypatch, handler).search(lat=40.75, lng=-73.99)
+    row = result["items"][0]
+
+    assert result["meta"]["grouped"] is True
+    assert row["kind"] == "branch"
+    assert row["name"] == "MORGAN STANLEY"
+    assert row["advisorCount"] == 74
+    assert row["advisorNames"] == ["A ADVISOR", "B ADVISOR"]
+    assert row["distanceMiles"] == pytest.approx(0.497, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_search_accepts_postal_code_and_strips_punctuation(monkeypatch):
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, content=_PERSON_STREAM)
+
+    await _service(monkeypatch, handler).search(postal_code="98033-1234 ")
+
+    assert seen["params"]["postalCode"] == "980331234"
+    assert "lat" not in seen["params"]
+
+
+@pytest.mark.asyncio
+async def test_search_clamps_radius_and_limit(monkeypatch):
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["params"] = dict(request.url.params)
+        return httpx.Response(200, content=_PERSON_STREAM)
+
+    await _service(monkeypatch, handler).search(
+        lat=1.0, lng=1.0, radius_mi=9_000, limit=5_000, offset=-4
+    )
+
+    assert seen["params"]["radiusMi"] == "100.0"
+    assert seen["params"]["limit"] == "50"
+    assert seen["params"]["offset"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_search_without_location_is_a_client_error(monkeypatch):
+    def handler(_: httpx.Request) -> httpx.Response:  # pragma: no cover - not reached
+        raise AssertionError("upstream must not be called")
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).search()
+
+    assert excinfo.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_upstream_auth_failure_never_surfaces_as_a_caller_auth_error(monkeypatch):
+    """A 401 means our key is wrong — the caller must not be told to re-auth."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"ok": False, "error": "bad key"})
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).search(lat=1.0, lng=1.0)
+
+    assert excinfo.value.status_code == 502
+    assert "bad key" not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_error_frame_fails_the_request(monkeypatch):
+    """Errors arrive as a frame on an HTTP 200 — status alone is not enough."""
+
+    stream = _ndjson(
+        {"type": "meta", "returned": 0},
+        {"type": "error", "error": "upstream exploded"},
+    )
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=stream)
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).search(lat=1.0, lng=1.0)
+
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_upstream_rate_limit_is_passed_through(monkeypatch):
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(429)
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).search(lat=1.0, lng=1.0)
+
+    assert excinfo.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_backend_reports_unavailable(monkeypatch):
+    monkeypatch.delenv("ADVISORS_API_BASE_URL", raising=False)
+    monkeypatch.delenv("ADVISORS_API_BASE", raising=False)
+    monkeypatch.delenv("ADVISORS_API_KEY", raising=False)
+
+    assert ads.is_configured() is False
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await ads.AdvisorDirectoryService().search(lat=1.0, lng=1.0)
+
+    assert excinfo.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_profile_normalizes_current_firm_and_counts(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/advisors/862222"
+        return httpx.Response(
+            200,
+            json={
+                "crd": "862222",
+                "name": "CHRISTINE NOELLE COTE",
+                "yearsExperience": 47.5,
+                "firmCount": 7,
+                "firmHistory": [
+                    {"firmName": "SMITH BARNEY", "current": False},
+                    {"firmName": "MORGAN STANLEY", "current": True},
+                ],
+                "exams": [{"category": "Series 7"}],
+                "registeredStates": [{"state": "Washington"}],
+                "hasDisclosures": True,
+                "disclosures": [{"type": "Regulatory"}, {"type": "Customer"}],
+                "isBarred": False,
+                "branches": [
+                    {
+                        "street1": "4000 Carillon Point",
+                        "city": "Kirkland",
+                        "state": "WA",
+                        "zip": "98033",
+                    }
+                ],
+                "reportUrl": "https://files.brokercheck.finra.org/individual/x.pdf",
+            },
+        )
+
+    result = await _service(monkeypatch, handler).profile("862222")
+    profile = result["profile"]
+
+    assert profile["firmName"] == "MORGAN STANLEY"
+    assert profile["disclosureCount"] == 2
+    assert profile["states"] == ["Washington"]
+    assert profile["exams"] == ["Series 7"]
+    assert profile["office"]["city"] == "Kirkland"
+
+
+@pytest.mark.asyncio
+async def test_profile_rejects_a_non_numeric_crd(monkeypatch):
+    def handler(_: httpx.Request) -> httpx.Response:  # pragma: no cover - not reached
+        raise AssertionError("upstream must not be called")
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).profile("../../etc/passwd")
+
+    assert excinfo.value.status_code == 400

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -153,6 +153,7 @@ steps:
         append_optional_secret "${_GMAIL_OAUTH_TOKEN_KEY_SECRET}" "GMAIL_OAUTH_TOKEN_KEY"
         append_optional_secret "${_OPENAI_API_KEY_SECRET}" "OPENAI_API_KEY"
         append_optional_secret "${_GOOGLE_MAPS_API_KEY_SECRET}" "GOOGLE_MAPS_API_KEY"
+        append_optional_secret "${_ADVISORS_API_KEY_SECRET}" "ADVISORS_API_KEY"
         append_optional_secret "${_VOICE_RUNTIME_CONFIG_JSON_SECRET}" "VOICE_RUNTIME_CONFIG_JSON"
         append_optional_secret "${_OMNIGATEWAY_CLIENT_ID_SECRET}" "OMNIGATEWAY_CLIENT_ID"
         append_optional_secret "${_OMNIGATEWAY_CLIENT_SECRET_SECRET}" "OMNIGATEWAY_CLIENT_SECRET"
@@ -234,6 +235,7 @@ steps:
             env_vars+=("${env_name}=${env_value}")
           fi
         }
+        append_optional_env "ADVISORS_API_BASE_URL" "${_ADVISORS_API_BASE_URL}"
         append_optional_env "ONE_EMAIL_ADDRESS" "${_ONE_EMAIL_ADDRESS}"
         append_optional_env "ONE_EMAIL_DELEGATED_USER" "${_ONE_EMAIL_DELEGATED_USER}"
         append_optional_env "ONE_EMAIL_PUBSUB_TOPIC" "${_ONE_EMAIL_PUBSUB_TOPIC}"
@@ -346,6 +348,11 @@ substitutions:
   _GMAIL_OAUTH_TOKEN_KEY_SECRET: ""
   _OPENAI_API_KEY_SECRET: ""
   _GOOGLE_MAPS_API_KEY_SECRET: GOOGLE_MAPS_API_KEY
+  # Advisor directory. Both stay inert until the secret exists in the deploy
+  # project and the base URL is supplied, so the surface simply reports
+  # unavailable rather than failing a deploy.
+  _ADVISORS_API_BASE_URL: ""
+  _ADVISORS_API_KEY_SECRET: ADVISORS_API_KEY
   _VOICE_RUNTIME_CONFIG_JSON_SECRET: ""
   _OMNIGATEWAY_CLIENT_ID_SECRET: OMNIGATEWAY_CLIENT_ID
   _OMNIGATEWAY_CLIENT_SECRET_SECRET: OMNIGATEWAY_CLIENT_SECRET

--- a/deploy/backend.cloudbuild.yaml
+++ b/deploy/backend.cloudbuild.yaml
@@ -153,7 +153,7 @@ steps:
         append_optional_secret "${_GMAIL_OAUTH_TOKEN_KEY_SECRET}" "GMAIL_OAUTH_TOKEN_KEY"
         append_optional_secret "${_OPENAI_API_KEY_SECRET}" "OPENAI_API_KEY"
         append_optional_secret "${_GOOGLE_MAPS_API_KEY_SECRET}" "GOOGLE_MAPS_API_KEY"
-        append_optional_secret "${_ADVISORS_API_KEY_SECRET}" "ADVISORS_API_KEY"
+        append_optional_secret ADVISORS_API_KEY ADVISORS_API_KEY
         append_optional_secret "${_VOICE_RUNTIME_CONFIG_JSON_SECRET}" "VOICE_RUNTIME_CONFIG_JSON"
         append_optional_secret "${_OMNIGATEWAY_CLIENT_ID_SECRET}" "OMNIGATEWAY_CLIENT_ID"
         append_optional_secret "${_OMNIGATEWAY_CLIENT_SECRET_SECRET}" "OMNIGATEWAY_CLIENT_SECRET"
@@ -235,7 +235,6 @@ steps:
             env_vars+=("${env_name}=${env_value}")
           fi
         }
-        append_optional_env "ADVISORS_API_BASE_URL" "${_ADVISORS_API_BASE_URL}"
         append_optional_env "ONE_EMAIL_ADDRESS" "${_ONE_EMAIL_ADDRESS}"
         append_optional_env "ONE_EMAIL_DELEGATED_USER" "${_ONE_EMAIL_DELEGATED_USER}"
         append_optional_env "ONE_EMAIL_PUBSUB_TOPIC" "${_ONE_EMAIL_PUBSUB_TOPIC}"
@@ -348,11 +347,6 @@ substitutions:
   _GMAIL_OAUTH_TOKEN_KEY_SECRET: ""
   _OPENAI_API_KEY_SECRET: ""
   _GOOGLE_MAPS_API_KEY_SECRET: GOOGLE_MAPS_API_KEY
-  # Advisor directory. Both stay inert until the secret exists in the deploy
-  # project and the base URL is supplied, so the surface simply reports
-  # unavailable rather than failing a deploy.
-  _ADVISORS_API_BASE_URL: ""
-  _ADVISORS_API_KEY_SECRET: ADVISORS_API_KEY
   _VOICE_RUNTIME_CONFIG_JSON_SECRET: ""
   _OMNIGATEWAY_CLIENT_ID_SECRET: OMNIGATEWAY_CLIENT_ID
   _OMNIGATEWAY_CLIENT_SECRET_SECRET: OMNIGATEWAY_CLIENT_SECRET

--- a/hushh-webapp/__tests__/app/one/setup/location-onboarding-completed-screen.test.tsx
+++ b/hushh-webapp/__tests__/app/one/setup/location-onboarding-completed-screen.test.tsx
@@ -26,6 +26,14 @@ vi.mock("@/components/onboarding/setup/capability-cinematic-intro", () => ({
   ),
 }));
 
+// The permission ask is a gate of its own, covered by its own test. Here it is
+// a passthrough so these cases stay about which step the coordinator renders.
+vi.mock("@/components/onboarding/setup/location-permission-primer", () => ({
+  LocationPermissionPrimerGate: ({ children }: { children: ReactNode }) => (
+    <div data-testid="location-permission-primer-gate">{children}</div>
+  ),
+}));
+
 vi.mock("@/components/onboarding/setup/setup-capability-coordinator", () => ({
   SetupCapabilityLoading: () => <div>Preparing location setup…</div>,
   useSetupCapabilityCoordinator: () => ({

--- a/hushh-webapp/__tests__/services/advisor-directory-service.test.ts
+++ b/hushh-webapp/__tests__/services/advisor-directory-service.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockApiFetch } = vi.hoisted(() => ({ mockApiFetch: vi.fn() }));
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: { apiFetch: mockApiFetch },
+}));
+
+import {
+  AdvisorDirectoryService,
+  formatAdvisorSubtitle,
+  formatDistance,
+  type AdvisorCard,
+} from "@/lib/services/advisor-directory-service";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const EMPTY_RESULT = {
+  items: [],
+  meta: { grouped: false, hasMore: false, nextOffset: null, returned: 0 },
+  attribution: { source: "FINRA BrokerCheck", url: "https://x" },
+};
+
+function requestedUrl(): URL {
+  return new URL(String(mockApiFetch.mock.calls[0][0]), "https://app.test");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockApiFetch.mockResolvedValue(jsonResponse(EMPTY_RESULT));
+});
+
+describe("AdvisorDirectoryService.searchNearby", () => {
+  it("sends coordinates and the bearer token to our own backend", async () => {
+    await AdvisorDirectoryService.searchNearby({
+      idToken: "id-token",
+      latitude: 47.676912,
+      longitude: -122.206045,
+      radiusMi: 25,
+    });
+
+    const url = requestedUrl();
+    expect(url.pathname).toBe("/api/one/advisors/nearby");
+    expect(url.searchParams.get("lat")).toBe("47.676912");
+    expect(url.searchParams.get("lng")).toBe("-122.206045");
+    expect(url.searchParams.get("radiusMi")).toBe("25");
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(url.searchParams.get("offset")).toBe("0");
+
+    const init = mockApiFetch.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer id-token",
+    );
+  });
+
+  it("falls back to a postal code when there are no coordinates", async () => {
+    await AdvisorDirectoryService.searchNearby({
+      idToken: "id-token",
+      postalCode: "98033",
+    });
+
+    const url = requestedUrl();
+    expect(url.searchParams.get("postalCode")).toBe("98033");
+    expect(url.searchParams.has("lat")).toBe(false);
+  });
+
+  it("pages from the offset the server handed back", async () => {
+    await AdvisorDirectoryService.searchNearby({
+      idToken: "id-token",
+      latitude: 1,
+      longitude: 2,
+      offset: 30,
+    });
+
+    expect(requestedUrl().searchParams.get("offset")).toBe("30");
+  });
+
+  it("surfaces the server's message rather than a bare status", async () => {
+    mockApiFetch.mockResolvedValue(
+      jsonResponse(
+        { detail: { code: "ONE_ADVISORS_UNAVAILABLE", message: "Try again shortly." } },
+        429,
+      ),
+    );
+
+    await expect(
+      AdvisorDirectoryService.searchNearby({
+        idToken: "id-token",
+        latitude: 1,
+        longitude: 2,
+      }),
+    ).rejects.toThrow("Try again shortly.");
+  });
+
+  it("still fails cleanly when the error body is unreadable", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response);
+
+    await expect(
+      AdvisorDirectoryService.searchNearby({
+        idToken: "id-token",
+        latitude: 1,
+        longitude: 2,
+      }),
+    ).rejects.toThrow("Advisors are unavailable right now.");
+  });
+});
+
+describe("AdvisorDirectoryService.getProfile", () => {
+  it("encodes the crd into the path", async () => {
+    mockApiFetch.mockResolvedValue(jsonResponse({ profile: { crd: "862222" } }));
+
+    const profile = await AdvisorDirectoryService.getProfile({
+      idToken: "id-token",
+      crd: "862222",
+    });
+
+    expect(requestedUrl().pathname).toBe("/api/one/advisors/862222");
+    expect(profile.crd).toBe("862222");
+  });
+});
+
+describe("formatDistance", () => {
+  it("always reads as approximate", () => {
+    // FINRA geocodes to ZIP centroids, so a precise figure would be fiction.
+    expect(formatDistance(0.47)).toBe("~0.5 mi");
+    expect(formatDistance(2.04)).toBe("~2.0 mi");
+    expect(formatDistance(12.4)).toBe("~12 mi");
+  });
+
+  it("never renders a zero distance", () => {
+    expect(formatDistance(0)).toBe("~0.1 mi");
+    expect(formatDistance(0.02)).toBe("~0.1 mi");
+  });
+
+  it("returns nothing when there is no usable distance", () => {
+    expect(formatDistance(null)).toBeNull();
+    expect(formatDistance(undefined)).toBeNull();
+    expect(formatDistance(Number.NaN)).toBeNull();
+    expect(formatDistance(-1)).toBeNull();
+  });
+});
+
+describe("formatAdvisorSubtitle", () => {
+  const base: AdvisorCard = {
+    kind: "advisor",
+    id: "1",
+    name: "A Advisor",
+    firmName: "Morgan Stanley",
+    yearsExperience: 47.5,
+    distanceMiles: 0.4,
+    city: "Kirkland",
+    state: "WA",
+    phone: null,
+  };
+
+  it("reads as one short line", () => {
+    expect(formatAdvisorSubtitle(base)).toBe("Morgan Stanley · 47 yrs");
+  });
+
+  it("drops the parts that do not exist", () => {
+    expect(
+      formatAdvisorSubtitle({ ...base, yearsExperience: null }),
+    ).toBe("Morgan Stanley");
+    expect(
+      formatAdvisorSubtitle({ ...base, firmName: null, yearsExperience: null }),
+    ).toBeNull();
+  });
+
+  it("describes a branch by its size, not a person's tenure", () => {
+    expect(
+      formatAdvisorSubtitle({
+        ...base,
+        kind: "branch",
+        advisorCount: 74,
+        firmName: null,
+      }),
+    ).toBe("74 advisors · Kirkland");
+  });
+});

--- a/hushh-webapp/app/connect/page-client.tsx
+++ b/hushh-webapp/app/connect/page-client.tsx
@@ -10,6 +10,7 @@ import {
   AppPageHeaderRegion,
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
+import { AdvisorsNearby } from "@/components/connect/advisors-nearby";
 import { PageHeader } from "@/components/app-ui/page-sections";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { SurfaceStack } from "@/components/app-ui/surfaces";
@@ -28,6 +29,7 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { buildConsentCenterHref } from "@/lib/consent/consent-sheet-route";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { Button } from "@/lib/morphy-ux/button";
+import { SegmentedTabs } from "@/lib/morphy-ux/ui";
 import {
   ConnectionsService,
   type ConnectionInformationScopeCatalog,
@@ -37,10 +39,18 @@ import {
 } from "@/lib/services/connections-service";
 import { relationshipCta } from "@/lib/connections/relationship-label";
 
+type ConnectTab = "people" | "nearby";
+
+const CONNECT_TABS = [
+  { value: "people", label: "People" },
+  { value: "nearby", label: "Around you" },
+];
+
 export default function ConnectPageClient() {
   const { user } = useRequireAuth();
   const router = useRouter();
 
+  const [tab, setTab] = useState<ConnectTab>("people");
   const [query, setQuery] = useState("");
   const debouncedQuery = useDebouncedValue(query, 300);
 
@@ -65,6 +75,11 @@ export default function ConnectPageClient() {
     requestedHandles: string[];
     offeredHandles: string[];
   } | null>(null);
+
+  const getIdToken = useCallback(
+    async () => (user ? await user.getIdToken() : null),
+    [user],
+  );
 
   const loadConnections = useCallback(async (): Promise<
     ConnectionSummaryEntry[]
@@ -423,16 +438,22 @@ export default function ConnectPageClient() {
       }}
     >
       <AppPageHeaderRegion>
-        <PageHeader
-          title="Connect"
-          description="Find people on Hussh and send a connection request."
-          accent="neutral"
-        />
+        <PageHeader title="Connect" accent="neutral" />
       </AppPageHeaderRegion>
 
       <AppPageContentRegion>
         <SurfaceStack compact>
           <div className="space-y-4 sm:space-y-5">
+            <SegmentedTabs
+              value={tab}
+              onValueChange={(value) => setTab(value as ConnectTab)}
+              options={CONNECT_TABS}
+            />
+
+            {tab === "nearby" ? (
+              <AdvisorsNearby getIdToken={getIdToken} />
+            ) : (
+              <div className="space-y-4 sm:space-y-5">
             <SettingsGroup
               title={`My connections (${connections.length})`}
               separatorInset
@@ -615,7 +636,9 @@ export default function ConnectPageClient() {
                   </div>
                 ) : null}
               </SettingsGroup>
-            </div>
+                </div>
+              </div>
+            )}
           </div>
         </SurfaceStack>
       </AppPageContentRegion>

--- a/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
+++ b/hushh-webapp/app/one/setup/location/location-onboarding-setup-client.tsx
@@ -6,6 +6,7 @@ import { CheckCircle2 } from "lucide-react";
 import OneLocationAgentPage from "@/app/one/location/page";
 import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
 import { CapabilityCinematicIntroGate } from "@/components/onboarding/setup/capability-cinematic-intro";
+import { LocationPermissionPrimerGate } from "@/components/onboarding/setup/location-permission-primer";
 import {
   SetupCapabilityLoading,
   useSetupCapabilityCoordinator,
@@ -132,47 +133,49 @@ export function LocationOnboardingSetupClient() {
 
   return (
     <CapabilityCinematicIntroGate capabilityId="location">
-      <OneLocationAgentPage
-        mode="setup"
-        onSetupReadinessChange={setReady}
-        onSetupComplete={async () => {
-          await toast
-            .promise(
-              coordinator
-                .finish({ suppressErrorToast: true })
-                .then((result) => {
-                  if (result.status !== "succeeded")
-                    throw new Error(result.summary);
-                  return result;
-                }),
-              {
-                loading: "Finishing Location setup…",
-                success: (result) => result.summary,
-                error: "Location setup could not be saved. Please try again.",
-              },
-            )
-            .unwrap();
-        }}
-        onSetupSkip={async () => {
-          await toast
-            .promise(
-              coordinator
-                .skip({ suppressErrorToast: true })
-                .then((result) => {
-                  if (result.status !== "succeeded")
-                    throw new Error(result.summary);
-                  return result;
-                }),
-              {
-                loading: "Skipping Location setup…",
-                success: (result) => result.summary,
-                error:
-                  "Location setup could not be updated. Please try again.",
-              },
-            )
-            .unwrap();
-        }}
-      />
+      <LocationPermissionPrimerGate>
+        <OneLocationAgentPage
+          mode="setup"
+          onSetupReadinessChange={setReady}
+          onSetupComplete={async () => {
+            await toast
+              .promise(
+                coordinator
+                  .finish({ suppressErrorToast: true })
+                  .then((result) => {
+                    if (result.status !== "succeeded")
+                      throw new Error(result.summary);
+                    return result;
+                  }),
+                {
+                  loading: "Finishing Location setup…",
+                  success: (result) => result.summary,
+                  error: "Location setup could not be saved. Please try again.",
+                },
+              )
+              .unwrap();
+          }}
+          onSetupSkip={async () => {
+            await toast
+              .promise(
+                coordinator
+                  .skip({ suppressErrorToast: true })
+                  .then((result) => {
+                    if (result.status !== "succeeded")
+                      throw new Error(result.summary);
+                    return result;
+                  }),
+                {
+                  loading: "Skipping Location setup…",
+                  success: (result) => result.summary,
+                  error:
+                    "Location setup could not be updated. Please try again.",
+                },
+              )
+              .unwrap();
+          }}
+        />
+      </LocationPermissionPrimerGate>
     </CapabilityCinematicIntroGate>
   );
 }

--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  searchNearby: vi.fn(),
+  getProfile: vi.fn(),
+  request: vi.fn(),
+  refresh: vi.fn(),
+  locationState: {
+    status: "idle" as string,
+    permission: null as string | null,
+    snapshot: null as { latitude: number; longitude: number } | null,
+    error: null as string | null,
+  },
+}));
+
+vi.mock("@/lib/one-location/use-current-location", () => ({
+  useCurrentLocation: () => ({
+    ...mocks.locationState,
+    request: mocks.request,
+    refresh: mocks.refresh,
+  }),
+}));
+
+vi.mock("@/lib/services/advisor-directory-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/services/advisor-directory-service")
+  >("@/lib/services/advisor-directory-service");
+  return {
+    ...actual,
+    AdvisorDirectoryService: {
+      searchNearby: mocks.searchNearby,
+      getProfile: mocks.getProfile,
+    },
+  };
+});
+
+import { AdvisorsNearby } from "@/components/connect/advisors-nearby";
+
+const ADVISOR = {
+  kind: "advisor" as const,
+  id: "862222",
+  crd: "862222",
+  name: "Christine Cote",
+  firmName: "Morgan Stanley",
+  yearsExperience: 47.5,
+  hasDisclosures: true,
+  distanceMiles: 0.47,
+  city: "Kirkland",
+  state: "WA",
+  phone: "914-225-1000",
+};
+
+function result(overrides: Record<string, unknown> = {}) {
+  return {
+    items: [ADVISOR],
+    meta: {
+      grouped: false,
+      hasMore: false,
+      nextOffset: null,
+      returned: 1,
+      available: 1,
+      limit: 10,
+      radiusMi: 10,
+      radiusRequested: 10,
+      radiusAdjusted: false,
+      truncated: false,
+    },
+    attribution: { source: "FINRA BrokerCheck", url: "https://x" },
+    ...overrides,
+  };
+}
+
+const getIdToken = async () => "id-token";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.locationState = {
+    status: "idle",
+    permission: null,
+    snapshot: null,
+    error: null,
+  };
+  mocks.searchNearby.mockResolvedValue(result());
+});
+
+describe("AdvisorsNearby", () => {
+  it("asks for location before touching the directory", () => {
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(screen.getByTestId("advisors-location-prompt")).toBeTruthy();
+    expect(mocks.searchNearby).not.toHaveBeenCalled();
+  });
+
+  it("prompts the device only on the user's tap", () => {
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(mocks.request).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("advisors-use-location"));
+    expect(mocks.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("searches from the shared snapshot once one exists", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 47.6769, longitude: -122.206 },
+      error: null,
+    };
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(1));
+    expect(mocks.searchNearby.mock.calls[0][0]).toMatchObject({
+      latitude: 47.6769,
+      longitude: -122.206,
+      radiusMi: 10,
+      offset: 0,
+    });
+    expect(await screen.findByText("Christine Cote")).toBeTruthy();
+    expect(screen.getByText("Morgan Stanley · 47 yrs")).toBeTruthy();
+    expect(screen.getByText("~0.5 mi")).toBeTruthy();
+  });
+
+  it("offers a ZIP search when the device says no", async () => {
+    mocks.locationState = {
+      status: "denied",
+      permission: "denied",
+      snapshot: null,
+      error: "Location is off for Hussh.",
+    };
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(screen.getByText("Location is off")).toBeTruthy();
+    fireEvent.change(screen.getByTestId("advisors-postal-input"), {
+      target: { value: "98033" },
+    });
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(1));
+    expect(mocks.searchNearby.mock.calls[0][0]).toMatchObject({
+      postalCode: "98033",
+    });
+  });
+
+  it("re-searches when the radius changes", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText("25 mi"));
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ radiusMi: 25 });
+  });
+
+  it("pages from the offset the server returned", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(
+      result({ meta: { ...result().meta, hasMore: true, nextOffset: 10 } }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    const more = await screen.findByText("Show more");
+    fireEvent.click(more);
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({ offset: 10 });
+  });
+
+  it("renders branch results without pretending they are people", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 40.75, longitude: -73.99 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(
+      result({
+        items: [
+          {
+            kind: "branch",
+            id: "408168",
+            name: "Morgan Stanley",
+            firmName: null,
+            advisorCount: 74,
+            advisorNames: [],
+            distanceMiles: 0.5,
+            city: "New York",
+            state: "NY",
+            phone: null,
+          },
+        ],
+        meta: { ...result().meta, grouped: true },
+      }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(await screen.findByText("Offices")).toBeTruthy();
+    expect(screen.getByText("74 advisors · New York")).toBeTruthy();
+  });
+
+  it("surfaces the narrowed radius the server actually used", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(
+      result({
+        meta: {
+          ...result().meta,
+          radiusMi: 1.6,
+          radiusRequested: 25,
+          radiusAdjusted: true,
+        },
+      }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(await screen.findByText("Within 1.6 mi.")).toBeTruthy();
+  });
+
+  it("shows a failure without wiping the surface", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockRejectedValue(new Error("Try again shortly."));
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(await screen.findByText("Try again shortly.")).toBeTruthy();
+  });
+});

--- a/hushh-webapp/components/connect/advisor-detail-surface.tsx
+++ b/hushh-webapp/components/connect/advisor-detail-surface.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/lib/morphy-ux/button";
+import {
+  AdvisorDirectoryService,
+  type AdvisorCard,
+  type AdvisorProfile,
+} from "@/lib/services/advisor-directory-service";
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="type-title2 text-foreground">{value}</p>
+      <p className="type-footnote text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+/**
+ * One adviser, opened from the nearby list. The list row already carries name,
+ * firm and distance, so this surface exists for the facts a decision actually
+ * turns on: tenure, reach, and whether there are disclosures.
+ */
+export function AdvisorDetailSurface({
+  card,
+  open,
+  onOpenChange,
+  getIdToken,
+}: {
+  card: AdvisorCard | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  getIdToken: () => Promise<string | null>;
+}) {
+  const [profile, setProfile] = useState<AdvisorProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const crd = card?.crd ?? null;
+
+  useEffect(() => {
+    if (!open || !crd) return;
+    const controller = new AbortController();
+    let cancelled = false;
+
+    setProfile(null);
+    setError(null);
+    setLoading(true);
+
+    void (async () => {
+      try {
+        const idToken = await getIdToken();
+        if (!idToken || cancelled) return;
+        const next = await AdvisorDirectoryService.getProfile({
+          idToken,
+          crd,
+          signal: controller.signal,
+        });
+        if (!cancelled) setProfile(next);
+      } catch (caught) {
+        if (cancelled || controller.signal.aborted) return;
+        setError(
+          caught instanceof Error ? caught.message : "Profile unavailable.",
+        );
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [crd, getIdToken, open]);
+
+  if (!card) return null;
+
+  const office = profile?.office;
+  const address = office
+    ? [office.street, office.city, office.state].filter(Boolean).join(", ")
+    : null;
+
+  return (
+    <AdaptiveDetailSurface
+      open={open}
+      onOpenChange={onOpenChange}
+      eyebrow={card.firmName ?? undefined}
+      title={card.name ?? "Advisor"}
+      mobilePresentation="sheet"
+      footer={
+        card.phone ? (
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="lg"
+            fullWidth
+            asChild
+          >
+            <a href={`tel:${card.phone.replace(/[^\d+]/g, "")}`}>Call</a>
+          </Button>
+        ) : undefined
+      }
+    >
+      <div className="space-y-7">
+        {loading ? (
+          <div className="grid grid-cols-3 gap-4">
+            <Skeleton className="h-12" />
+            <Skeleton className="h-12" />
+            <Skeleton className="h-12" />
+          </div>
+        ) : error ? (
+          <p className="type-callout text-muted-foreground">{error}</p>
+        ) : profile ? (
+          <>
+            <div className="grid grid-cols-3 gap-4">
+              <Stat
+                label="Experience"
+                value={
+                  profile.yearsExperience
+                    ? `${Math.floor(profile.yearsExperience)} yrs`
+                    : "—"
+                }
+              />
+              <Stat label="Firms" value={String(profile.firmCount ?? "—")} />
+              <Stat label="States" value={String(profile.states.length || "—")} />
+            </div>
+
+            {profile.disclosureCount > 0 ? (
+              <p className="type-callout text-amber-600 dark:text-amber-400">
+                {profile.disclosureCount} disclosure
+                {profile.disclosureCount === 1 ? "" : "s"} on record.
+              </p>
+            ) : null}
+
+            {address ? (
+              <p className="type-callout text-muted-foreground">{address}</p>
+            ) : null}
+
+            {profile.reportUrl ? (
+              <a
+                href={profile.reportUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="type-callout text-[color:var(--app-accent)] underline-offset-4 hover:underline"
+              >
+                BrokerCheck report
+              </a>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </AdaptiveDetailSurface>
+  );
+}

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import { AdvisorDetailSurface } from "@/components/connect/advisor-detail-surface";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/lib/morphy-ux/button";
+import { SegmentedTabs } from "@/lib/morphy-ux/ui";
+import { useCurrentLocation } from "@/lib/one-location/use-current-location";
+import {
+  ADVISOR_PAGE_SIZE,
+  ADVISOR_RADIUS_OPTIONS_MI,
+  AdvisorDirectoryService,
+  formatAdvisorSubtitle,
+  formatDistance,
+  type AdvisorCard,
+  type AdvisorSearchMeta,
+} from "@/lib/services/advisor-directory-service";
+
+type Anchor =
+  | { kind: "coords"; latitude: number; longitude: number }
+  | { kind: "postal"; postalCode: string };
+
+const RADIUS_OPTIONS = ADVISOR_RADIUS_OPTIONS_MI.map((miles) => ({
+  value: String(miles),
+  label: `${miles} mi`,
+}));
+
+function LoadingRows() {
+  return (
+    <div className="space-y-3 px-1 py-2" data-testid="advisors-loading">
+      {[0, 1, 2, 3].map((row) => (
+        <Skeleton key={row} className="h-11 w-full rounded-xl" />
+      ))}
+    </div>
+  );
+}
+
+/** One calm block: why we need location, and the single tap that grants it. */
+function LocationPrompt({
+  denied,
+  busy,
+  onUseLocation,
+  onSearchPostalCode,
+}: {
+  denied: boolean;
+  busy: boolean;
+  onUseLocation: () => void;
+  onSearchPostalCode: (postalCode: string) => void;
+}) {
+  const [postalCode, setPostalCode] = useState("");
+  const [showPostal, setShowPostal] = useState(denied);
+
+  useEffect(() => {
+    if (denied) setShowPostal(true);
+  }, [denied]);
+
+  return (
+    <section
+      className="mx-auto flex w-full max-w-[26rem] flex-col items-center py-14 text-center"
+      data-testid="advisors-location-prompt"
+    >
+      <h2 className="type-title2 text-foreground">
+        {denied ? "Location is off" : "Advisors near you"}
+      </h2>
+      <p className="mt-2 type-callout text-muted-foreground">
+        {denied ? "Search by ZIP instead." : "See who's close by."}
+      </p>
+
+      {denied ? null : (
+        <Button
+          type="button"
+          variant="blue-gradient"
+          effect="fill"
+          size="lg"
+          fullWidth
+          className="mt-8"
+          disabled={busy}
+          onClick={onUseLocation}
+          data-testid="advisors-use-location"
+        >
+          {busy ? "Locating…" : "Use location"}
+        </Button>
+      )}
+
+      {showPostal ? (
+        <form
+          className="mt-6 flex w-full gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const trimmed = postalCode.trim();
+            if (trimmed) onSearchPostalCode(trimmed);
+          }}
+        >
+          <Input
+            value={postalCode}
+            onChange={(event) => setPostalCode(event.target.value)}
+            placeholder="ZIP"
+            inputMode="numeric"
+            aria-label="ZIP code"
+            className="h-11"
+            data-testid="advisors-postal-input"
+          />
+          <Button
+            type="submit"
+            variant="none"
+            effect="fill"
+            size="lg"
+            disabled={busy || !postalCode.trim()}
+          >
+            Search
+          </Button>
+        </form>
+      ) : (
+        <Button
+          type="button"
+          variant="none"
+          effect="fade"
+          size="sm"
+          className="mt-3 text-muted-foreground"
+          onClick={() => setShowPostal(true)}
+        >
+          Use a ZIP
+        </Button>
+      )}
+    </section>
+  );
+}
+
+/**
+ * "Around you" — advisers near the account's current position.
+ *
+ * Position comes from the shared location bus, so opening this tab never
+ * re-prompts a user who already granted location elsewhere in the app, and the
+ * fix it resolves is immediately available to every other surface.
+ */
+export function AdvisorsNearby({
+  getIdToken,
+}: {
+  getIdToken: () => Promise<string | null>;
+}) {
+  const location = useCurrentLocation();
+
+  const [anchor, setAnchor] = useState<Anchor | null>(null);
+  const [radiusMi, setRadiusMi] = useState<number>(10);
+  const [cards, setCards] = useState<AdvisorCard[]>([]);
+  const [meta, setMeta] = useState<AdvisorSearchMeta | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<AdvisorCard | null>(null);
+
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    if (!location.snapshot) return;
+    setAnchor((current) =>
+      current?.kind === "postal"
+        ? current
+        : {
+            kind: "coords",
+            latitude: location.snapshot!.latitude,
+            longitude: location.snapshot!.longitude,
+          },
+    );
+  }, [location.snapshot]);
+
+  const runSearch = useCallback(
+    async (target: Anchor, miles: number, offset: number) => {
+      const token = ++requestRef.current;
+      if (offset === 0) {
+        setLoading(true);
+        setError(null);
+      } else {
+        setLoadingMore(true);
+      }
+
+      try {
+        const idToken = await getIdToken();
+        if (!idToken) throw new Error("Sign in to see advisors.");
+        const result = await AdvisorDirectoryService.searchNearby({
+          idToken,
+          ...(target.kind === "coords"
+            ? { latitude: target.latitude, longitude: target.longitude }
+            : { postalCode: target.postalCode }),
+          radiusMi: miles,
+          limit: ADVISOR_PAGE_SIZE,
+          offset,
+        });
+        // A slower earlier query must never overwrite a newer one.
+        if (token !== requestRef.current) return;
+        setMeta(result.meta);
+        setCards((previous) =>
+          offset === 0 ? result.items : [...previous, ...result.items],
+        );
+      } catch (caught) {
+        if (token !== requestRef.current) return;
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "Advisors are unavailable right now.",
+        );
+        if (offset === 0) setCards([]);
+      } finally {
+        if (token === requestRef.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
+      }
+    },
+    [getIdToken],
+  );
+
+  useEffect(() => {
+    if (!anchor) return;
+    void runSearch(anchor, radiusMi, 0);
+  }, [anchor, radiusMi, runSearch]);
+
+  const handleUseLocation = useCallback(() => {
+    void location.request();
+  }, [location]);
+
+  const handlePostalCode = useCallback((postalCode: string) => {
+    setAnchor({ kind: "postal", postalCode });
+  }, []);
+
+  if (!anchor) {
+    return (
+      <LocationPrompt
+        denied={location.status === "denied" || location.status === "unavailable"}
+        busy={location.status === "locating"}
+        onUseLocation={handleUseLocation}
+        onSearchPostalCode={handlePostalCode}
+      />
+    );
+  }
+
+  const narrowed =
+    meta?.radiusAdjusted && meta.radiusMi
+      ? `Within ${meta.radiusMi} mi.`
+      : null;
+
+  return (
+    <div className="space-y-4" data-testid="advisors-nearby">
+      <SegmentedTabs
+        value={String(radiusMi)}
+        onValueChange={(value) => setRadiusMi(Number(value))}
+        options={RADIUS_OPTIONS}
+        disabled={loading}
+      />
+
+      {narrowed ? (
+        <p className="type-footnote text-muted-foreground">{narrowed}</p>
+      ) : null}
+
+      <SettingsGroup title={meta?.grouped ? "Offices" : "Advisors"} separatorInset>
+        {loading ? (
+          <LoadingRows />
+        ) : error ? (
+          <SettingsRow title={error} density="compact" tone="destructive" />
+        ) : cards.length === 0 ? (
+          <SettingsRow
+            title="None nearby"
+            description="Try a wider radius."
+            density="compact"
+            disabled
+          />
+        ) : (
+          cards.map((card) => {
+            const distance = formatDistance(card.distanceMiles);
+            return (
+              <SettingsRow
+                key={`${card.kind}-${card.id}`}
+                title={
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="truncate">{card.name ?? "Advisor"}</span>
+                    {card.hasDisclosures ? (
+                      <span
+                        className="size-1.5 shrink-0 rounded-full bg-amber-500"
+                        role="img"
+                        aria-label="Has disclosures"
+                      />
+                    ) : null}
+                  </span>
+                }
+                description={formatAdvisorSubtitle(card) ?? undefined}
+                density="compact"
+                chevron={card.kind === "advisor"}
+                onClick={
+                  card.kind === "advisor"
+                    ? () => setSelected(card)
+                    : undefined
+                }
+                trailing={
+                  distance ? (
+                    <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
+                      {distance}
+                    </span>
+                  ) : undefined
+                }
+              />
+            );
+          })
+        )}
+      </SettingsGroup>
+
+      {meta?.hasMore && !loading ? (
+        <div className="flex justify-center">
+          <Button
+            type="button"
+            variant="none"
+            effect="fill"
+            size="sm"
+            disabled={loadingMore}
+            onClick={() => {
+              if (anchor && typeof meta.nextOffset === "number") {
+                void runSearch(anchor, radiusMi, meta.nextOffset);
+              }
+            }}
+          >
+            {loadingMore ? "Loading…" : "Show more"}
+          </Button>
+        </div>
+      ) : null}
+
+      <p className="type-caption text-center text-muted-foreground">
+        FINRA BrokerCheck
+      </p>
+
+      <AdvisorDetailSurface
+        card={selected}
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
+        getIdToken={getIdToken}
+      />
+    </div>
+  );
+}

--- a/hushh-webapp/components/onboarding/setup/__tests__/location-permission-primer.test.tsx
+++ b/hushh-webapp/components/onboarding/setup/__tests__/location-permission-primer.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  syncPermission: vi.fn(),
+  ensure: vi.fn(),
+  request: vi.fn(),
+}));
+
+vi.mock("@/lib/one-location/location-bus", () => ({
+  LocationBus: {
+    syncPermission: mocks.syncPermission,
+    ensure: mocks.ensure,
+    request: mocks.request,
+  },
+}));
+
+import { LocationPermissionPrimerGate } from "@/components/onboarding/setup/location-permission-primer";
+
+const SNAPSHOT = {
+  latitude: 1,
+  longitude: 2,
+  accuracyM: 10,
+  capturedAt: new Date().toISOString(),
+};
+
+function renderGate() {
+  return render(
+    <LocationPermissionPrimerGate>
+      <div data-testid="capability-body">Location setup</div>
+    </LocationPermissionPrimerGate>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.syncPermission.mockResolvedValue("prompt");
+  mocks.ensure.mockResolvedValue(SNAPSHOT);
+  mocks.request.mockResolvedValue(SNAPSHOT);
+});
+
+describe("LocationPermissionPrimerGate", () => {
+  it("never fires the OS prompt on mount", async () => {
+    renderGate();
+
+    await screen.findByTestId("location-permission-primer");
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+
+  it("asks the device only when the user taps Allow", async () => {
+    renderGate();
+
+    fireEvent.click(await screen.findByTestId("location-permission-primer-allow"));
+
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledTimes(1));
+    expect(await screen.findByTestId("capability-body")).toBeTruthy();
+  });
+
+  it("skips the screen when location was already granted, and seeds the bus", async () => {
+    mocks.syncPermission.mockResolvedValue("granted");
+
+    renderGate();
+
+    expect(await screen.findByTestId("capability-body")).toBeTruthy();
+    expect(screen.queryByTestId("location-permission-primer")).toBeNull();
+    expect(mocks.ensure).toHaveBeenCalledTimes(1);
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+
+  it("skips a screen it cannot act on when the OS already refused", async () => {
+    mocks.syncPermission.mockResolvedValue("denied");
+
+    renderGate();
+
+    expect(await screen.findByTestId("capability-body")).toBeTruthy();
+    expect(screen.queryByTestId("location-permission-primer")).toBeNull();
+  });
+
+  it("skips on a device with no geolocation at all", async () => {
+    mocks.syncPermission.mockResolvedValue("unavailable");
+
+    renderGate();
+
+    expect(await screen.findByTestId("capability-body")).toBeTruthy();
+  });
+
+  it("never blocks setup on a refusal", async () => {
+    mocks.request.mockResolvedValue(null);
+
+    renderGate();
+    fireEvent.click(await screen.findByTestId("location-permission-primer-allow"));
+
+    expect(
+      await screen.findByText("Location is off. Turn it on in Settings anytime."),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("location-permission-primer-skip"));
+    expect(await screen.findByTestId("capability-body")).toBeTruthy();
+  });
+
+  it("lets the user move on without deciding", async () => {
+    renderGate();
+
+    fireEvent.click(await screen.findByTestId("location-permission-primer-skip"));
+
+    expect(await screen.findByTestId("capability-body")).toBeTruthy();
+    expect(mocks.request).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/components/onboarding/setup/location-permission-primer.tsx
+++ b/hushh-webapp/components/onboarding/setup/location-permission-primer.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+
+import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
+import { Button } from "@/lib/morphy-ux/button";
+import { LocationBus } from "@/lib/one-location/location-bus";
+
+type PrimerPhase = "checking" | "ask" | "asking" | "done";
+
+/**
+ * The one place One asks the device for a position.
+ *
+ * It runs inside setup so the ask happens once, early, in a screen that says
+ * why — and the fix it produces lands on the shared LocationBus, where every
+ * agent and surface reads it. Nothing downstream needs to prompt again.
+ *
+ * Two rules this screen exists to enforce:
+ * - The OS dialog fires from a tap, never from mount. iOS grants exactly one
+ *   system prompt per install; spending it before the user has read anything
+ *   converts a recoverable "later" into a permanent "no".
+ * - A refusal never blocks setup. It resolves the screen like any other answer.
+ *
+ * It self-skips when the OS has already decided, so re-entering the step never
+ * shows a dead screen and a denial is never nagged at.
+ */
+export function LocationPermissionPrimerGate({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [phase, setPhase] = useState<PrimerPhase>("checking");
+  const [denied, setDenied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const permission = await LocationBus.syncPermission();
+      if (cancelled) return;
+
+      if (permission === "granted") {
+        // Already granted elsewhere: seed the bus quietly and move on.
+        void LocationBus.ensure();
+        setPhase("done");
+        return;
+      }
+      // Denied/restricted/unavailable cannot be re-prompted from here, so
+      // showing the ask would be a button that does nothing.
+      setPhase(
+        permission === "prompt" || permission === null ? "ask" : "done",
+      );
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const allow = useCallback(async () => {
+    setPhase("asking");
+    const snapshot = await LocationBus.request();
+    if (snapshot) {
+      setPhase("done");
+      return;
+    }
+    // Say what happened, then let them continue. Setup is never held hostage
+    // to a permission.
+    setDenied(true);
+    setPhase("ask");
+  }, []);
+
+  if (phase === "done") return <>{children}</>;
+  if (phase === "checking") return null;
+
+  return (
+    <FullscreenFlowShell
+      width="reading"
+      className="min-h-[calc(100dvh-var(--top-shell-reserved-height,0px))] justify-center px-[var(--page-inline-gutter-standard)] py-10"
+      data-testid="location-permission-primer"
+    >
+      <section
+        className="motion-step-enter mx-auto flex w-full max-w-[30rem] flex-col items-center text-center"
+        aria-labelledby="location-permission-primer-title"
+      >
+        <h1
+          id="location-permission-primer-title"
+          className="type-display text-foreground"
+        >
+          Turn on location
+        </h1>
+        <p className="mt-3 type-title3 text-muted-foreground">
+          Your agents work from where you are.
+        </p>
+
+        <div className="mt-10 w-full">
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="lg"
+            fullWidth
+            className="min-h-14 justify-center"
+            disabled={phase === "asking"}
+            onClick={() => void allow()}
+            data-testid="location-permission-primer-allow"
+          >
+            {phase === "asking" ? "Waiting…" : "Allow"}
+          </Button>
+          <Button
+            type="button"
+            variant="none"
+            effect="fade"
+            size="lg"
+            fullWidth
+            className="mt-2 text-muted-foreground"
+            onClick={() => setPhase("done")}
+            data-testid="location-permission-primer-skip"
+          >
+            Not now
+          </Button>
+        </div>
+
+        {denied ? (
+          <p
+            className="mt-6 type-footnote text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            Location is off. Turn it on in Settings anytime.
+          </p>
+        ) : null}
+      </section>
+    </FullscreenFlowShell>
+  );
+}

--- a/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockLocation } = vi.hoisted(() => ({
+  mockLocation: {
+    getPermissionState: vi.fn(),
+    requestLocationPermission: vi.fn(),
+    getCurrentPosition: vi.fn(),
+    watchPosition: vi.fn(),
+    clearWatch: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/capacitor", () => ({ HushhLocation: mockLocation }));
+
+import { LocationBus } from "@/lib/one-location/location-bus";
+
+const POINT = {
+  latitude: 47.6769,
+  longitude: -122.206,
+  accuracyM: 12,
+  capturedAt: new Date().toISOString(),
+  sourcePlatform: "web" as const,
+};
+
+beforeEach(() => {
+  LocationBus.__resetForTests();
+  vi.clearAllMocks();
+  mockLocation.getCurrentPosition.mockResolvedValue(POINT);
+  mockLocation.getPermissionState.mockResolvedValue({
+    state: "granted",
+    precise: true,
+    background: "foreground-only",
+  });
+  mockLocation.requestLocationPermission.mockResolvedValue({
+    state: "granted",
+    precise: true,
+    background: "foreground-only",
+  });
+  mockLocation.watchPosition.mockResolvedValue("watch-1");
+  mockLocation.clearWatch.mockResolvedValue(undefined);
+});
+
+describe("LocationBus.ensure", () => {
+  it("publishes a snapshot every subscriber can read", async () => {
+    const seen: string[] = [];
+    LocationBus.subscribe((state) => seen.push(state.status));
+
+    const snapshot = await LocationBus.ensure();
+
+    expect(snapshot?.latitude).toBe(47.6769);
+    expect(LocationBus.getState().status).toBe("ready");
+    expect(seen).toContain("locating");
+    expect(seen).toContain("ready");
+  });
+
+  it("coalesces concurrent callers into a single device read", async () => {
+    const [a, b, c] = await Promise.all([
+      LocationBus.ensure(),
+      LocationBus.ensure(),
+      LocationBus.ensure(),
+    ]);
+
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+  });
+
+  it("reuses a fresh fix instead of re-hitting the GPS", async () => {
+    await LocationBus.ensure();
+    await LocationBus.ensure();
+
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads when the caller demands a live fix", async () => {
+    await LocationBus.ensure();
+    await LocationBus.ensure({ maxAgeMs: 0 });
+
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a stale fix as absent", async () => {
+    mockLocation.getCurrentPosition.mockResolvedValue({
+      ...POINT,
+      capturedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    });
+
+    await LocationBus.ensure();
+    await LocationBus.ensure();
+
+    expect(mockLocation.getCurrentPosition).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("LocationBus permission handling", () => {
+  it("records a denial as a state, not a thrown error", async () => {
+    const denied = new Error("Location permission is blocked for this site.");
+    denied.name = "LocationPermissionDeniedError";
+    mockLocation.getCurrentPosition.mockRejectedValue(denied);
+
+    const snapshot = await LocationBus.ensure();
+
+    expect(snapshot).toBeNull();
+    expect(LocationBus.getState().status).toBe("denied");
+    expect(LocationBus.getState().permission).toBe("denied");
+  });
+
+  it("does not prompt when only syncing permission", async () => {
+    await LocationBus.syncPermission();
+
+    expect(mockLocation.requestLocationPermission).not.toHaveBeenCalled();
+    expect(mockLocation.getCurrentPosition).not.toHaveBeenCalled();
+    expect(LocationBus.getState().permission).toBe("granted");
+  });
+
+  it("stops at the OS refusal instead of chasing a position", async () => {
+    mockLocation.requestLocationPermission.mockResolvedValue({
+      state: "denied",
+      precise: false,
+      background: "unavailable",
+    });
+
+    const snapshot = await LocationBus.request();
+
+    expect(snapshot).toBeNull();
+    expect(mockLocation.getCurrentPosition).not.toHaveBeenCalled();
+    expect(LocationBus.getState().status).toBe("denied");
+  });
+
+  it("reports an unavailable device without offering a retry state", async () => {
+    mockLocation.requestLocationPermission.mockResolvedValue({
+      state: "unavailable",
+      precise: false,
+      background: "unavailable",
+    });
+
+    await LocationBus.request();
+
+    expect(LocationBus.getState().status).toBe("unavailable");
+  });
+});
+
+describe("LocationBus.watch", () => {
+  it("keeps exactly one device watch no matter how many surfaces subscribe", async () => {
+    const stopA = await LocationBus.watch();
+    const stopB = await LocationBus.watch();
+
+    expect(mockLocation.watchPosition).toHaveBeenCalledTimes(1);
+
+    stopA();
+    expect(mockLocation.clearWatch).not.toHaveBeenCalled();
+
+    stopB();
+    expect(mockLocation.clearWatch).toHaveBeenCalledWith({ id: "watch-1" });
+  });
+
+  it("ignores a repeated stop from the same subscriber", async () => {
+    const stopA = await LocationBus.watch();
+    const stopB = await LocationBus.watch();
+
+    stopA();
+    stopA();
+    expect(mockLocation.clearWatch).not.toHaveBeenCalled();
+
+    stopB();
+    expect(mockLocation.clearWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes each movement fix to subscribers", async () => {
+    let emit: ((point: unknown, error: unknown) => void) | null = null;
+    mockLocation.watchPosition.mockImplementation(
+      async (_options: unknown, callback: (p: unknown, e: unknown) => void) => {
+        emit = callback;
+        return "watch-1";
+      },
+    );
+
+    await LocationBus.watch();
+    emit?.({ ...POINT, latitude: 1.23 }, null);
+
+    expect(LocationBus.getState().snapshot?.latitude).toBe(1.23);
+    expect(LocationBus.getState().status).toBe("ready");
+  });
+
+  it("keeps the last fix visible through a transient watch error", async () => {
+    let emit: ((point: unknown, error: unknown) => void) | null = null;
+    mockLocation.watchPosition.mockImplementation(
+      async (_options: unknown, callback: (p: unknown, e: unknown) => void) => {
+        emit = callback;
+        return "watch-1";
+      },
+    );
+
+    await LocationBus.watch();
+    emit?.(POINT, null);
+    emit?.(null, { message: "timed out", code: 3 });
+
+    expect(LocationBus.getState().status).toBe("ready");
+    expect(LocationBus.getState().snapshot).not.toBeNull();
+  });
+});

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -1,0 +1,276 @@
+/**
+ * LocationBus — the account's current position, held once for the whole app.
+ *
+ * Before this existed, every surface that wanted a coordinate reached for
+ * `HushhLocation` itself, which meant a fresh OS prompt per surface and one GPS
+ * subscription per consumer. The bus makes position a property of the session
+ * rather than a feature of one agent: any agent, service or screen reads the
+ * same snapshot, and the device is asked at most once.
+ *
+ * Boundaries this deliberately keeps:
+ * - Coordinates live in memory only. Nothing here writes to storage, and
+ *   nothing here talks to the network. Callers decide what, if anything,
+ *   crosses a boundary — matching the backend's refusal of plaintext location.
+ * - `request()` must be called from a user gesture. iOS grants exactly one
+ *   system prompt; firing it on mount spends it before the user knows why.
+ */
+
+import { HushhLocation, type HushhLocationPermissionState } from "@/lib/capacitor";
+
+export type LocationSnapshot = {
+  latitude: number;
+  longitude: number;
+  accuracyM: number | null;
+  capturedAt: string;
+};
+
+export type LocationPermission = HushhLocationPermissionState["state"];
+
+export type LocationBusStatus =
+  /** Never asked. */
+  | "idle"
+  /** A fix is being acquired. */
+  | "locating"
+  /** `snapshot` is populated. */
+  | "ready"
+  /** The user said no; recoverable only through settings. */
+  | "denied"
+  /** No geolocation on this device/browser at all. */
+  | "unavailable"
+  /** Permission is fine but no fix came back. */
+  | "error";
+
+export type LocationBusState = {
+  status: LocationBusStatus;
+  permission: LocationPermission | null;
+  snapshot: LocationSnapshot | null;
+  error: string | null;
+};
+
+/** A fix younger than this is reused instead of re-hitting the GPS. */
+export const DEFAULT_MAX_AGE_MS = 120_000;
+
+const INITIAL_STATE: LocationBusState = {
+  status: "idle",
+  permission: null,
+  snapshot: null,
+  error: null,
+};
+
+let state: LocationBusState = INITIAL_STATE;
+const listeners = new Set<(next: LocationBusState) => void>();
+
+/** In-flight capture, shared so N simultaneous callers cause one GPS read. */
+let pendingCapture: Promise<LocationSnapshot | null> | null = null;
+
+let watchId: string | null = null;
+let watchStarting: Promise<void> | null = null;
+let watchers = 0;
+
+function emit(patch: Partial<LocationBusState>): void {
+  state = { ...state, ...patch };
+  for (const listener of [...listeners]) listener(state);
+}
+
+function isDeniedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "LocationPermissionDeniedError" ||
+    /denied|blocked/i.test(error.message)
+  );
+}
+
+function statusForPermission(
+  permission: LocationPermission,
+): LocationBusStatus | null {
+  if (permission === "denied" || permission === "restricted") return "denied";
+  if (permission === "unavailable") return "unavailable";
+  return null;
+}
+
+function isFresh(snapshot: LocationSnapshot | null, maxAgeMs: number): boolean {
+  if (!snapshot) return false;
+  const capturedMs = Date.parse(snapshot.capturedAt);
+  if (!Number.isFinite(capturedMs)) return false;
+  return Date.now() - capturedMs <= maxAgeMs;
+}
+
+function toSnapshot(point: {
+  latitude: number;
+  longitude: number;
+  accuracyM: number | null;
+  capturedAt: string;
+}): LocationSnapshot {
+  return {
+    latitude: point.latitude,
+    longitude: point.longitude,
+    accuracyM: point.accuracyM ?? null,
+    capturedAt: point.capturedAt,
+  };
+}
+
+async function capture(): Promise<LocationSnapshot | null> {
+  try {
+    const point = await HushhLocation.getCurrentPosition({
+      enableHighAccuracy: true,
+      timeoutMs: 15_000,
+    });
+    const snapshot = toSnapshot(point);
+    emit({ status: "ready", snapshot, error: null, permission: "granted" });
+    return snapshot;
+  } catch (error) {
+    const denied = isDeniedError(error);
+    emit({
+      status: denied ? "denied" : "error",
+      permission: denied ? "denied" : state.permission,
+      error:
+        error instanceof Error ? error.message : "Could not get your location.",
+    });
+    return null;
+  }
+}
+
+export const LocationBus = {
+  getState(): LocationBusState {
+    return state;
+  },
+
+  subscribe(listener: (next: LocationBusState) => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+
+  /** Read the OS permission without prompting. Safe to call on mount. */
+  async syncPermission(): Promise<LocationPermission | null> {
+    try {
+      const permission = await HushhLocation.getPermissionState();
+      const mapped = statusForPermission(permission.state);
+      emit({
+        permission: permission.state,
+        ...(mapped && state.status !== "ready" ? { status: mapped } : {}),
+      });
+      return permission.state;
+    } catch {
+      // A failed permission read is not a failed location: leave the status
+      // alone so a later capture can still succeed.
+      return null;
+    }
+  },
+
+  /**
+   * Return a position, prompting only if the OS has not decided yet.
+   * Reuses a fix younger than `maxAgeMs` and coalesces concurrent callers.
+   */
+  async ensure(options?: { maxAgeMs?: number }): Promise<LocationSnapshot | null> {
+    const maxAgeMs = options?.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    if (isFresh(state.snapshot, maxAgeMs)) return state.snapshot;
+    if (pendingCapture) return pendingCapture;
+
+    if (state.status !== "ready") emit({ status: "locating", error: null });
+
+    pendingCapture = capture().finally(() => {
+      pendingCapture = null;
+    });
+    return pendingCapture;
+  },
+
+  /**
+   * Ask the device for permission, then capture. Call from a user gesture only.
+   */
+  async request(): Promise<LocationSnapshot | null> {
+    emit({ status: "locating", error: null });
+    try {
+      const permission = await HushhLocation.requestLocationPermission();
+      emit({ permission: permission.state });
+      const blocked = statusForPermission(permission.state);
+      if (blocked) {
+        emit({
+          status: blocked,
+          error:
+            blocked === "denied"
+              ? "Location is off for Hussh."
+              : "Location is unavailable on this device.",
+        });
+        return null;
+      }
+    } catch (error) {
+      if (isDeniedError(error)) {
+        emit({
+          status: "denied",
+          permission: "denied",
+          error: "Location is off for Hussh.",
+        });
+        return null;
+      }
+      // Fall through: some platforms reject the permission call but still
+      // resolve a position.
+    }
+    return LocationBus.ensure({ maxAgeMs: 0 });
+  },
+
+  /**
+   * Subscribe to movement-driven updates. Refcounted: the app keeps exactly one
+   * underlying watch no matter how many surfaces are live. Returns a stop fn.
+   */
+  async watch(): Promise<() => void> {
+    watchers += 1;
+    let released = false;
+
+    if (!watchId && !watchStarting) {
+      watchStarting = HushhLocation.watchPosition(
+        { enableHighAccuracy: true, timeoutMs: 20_000 },
+        (point, error) => {
+          if (point) {
+            emit({
+              status: "ready",
+              snapshot: toSnapshot(point),
+              error: null,
+              permission: "granted",
+            });
+            return;
+          }
+          if (!error) return;
+          const denied = error.code === 1;
+          emit({
+            status: denied ? "denied" : state.snapshot ? "ready" : "error",
+            permission: denied ? "denied" : state.permission,
+            error: error.message,
+          });
+        },
+      )
+        .then((id) => {
+          watchId = id || null;
+        })
+        .catch(() => {
+          watchId = null;
+        })
+        .finally(() => {
+          watchStarting = null;
+        });
+    }
+    await watchStarting?.catch(() => undefined);
+
+    return () => {
+      if (released) return;
+      released = true;
+      watchers = Math.max(0, watchers - 1);
+      if (watchers === 0 && watchId) {
+        const id = watchId;
+        watchId = null;
+        void HushhLocation.clearWatch({ id }).catch(() => undefined);
+      }
+    };
+  },
+
+  /** Test seam. Never call from app code. */
+  __resetForTests(): void {
+    state = INITIAL_STATE;
+    listeners.clear();
+    pendingCapture = null;
+    watchId = null;
+    watchStarting = null;
+    watchers = 0;
+  },
+};

--- a/hushh-webapp/lib/one-location/use-current-location.ts
+++ b/hushh-webapp/lib/one-location/use-current-location.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+
+import {
+  LocationBus,
+  type LocationBusState,
+  type LocationSnapshot,
+} from "@/lib/one-location/location-bus";
+
+const SERVER_STATE: LocationBusState = {
+  status: "idle",
+  permission: null,
+  snapshot: null,
+  error: null,
+};
+
+/**
+ * Read the account's current position from the shared bus.
+ *
+ * `auto` resolves a position on mount when the OS has already granted
+ * permission — it never triggers a first prompt. Surfaces that need the prompt
+ * call `request()` from a user gesture.
+ */
+export function useCurrentLocation(options?: { auto?: boolean }): LocationBusState & {
+  request: () => Promise<LocationSnapshot | null>;
+  refresh: () => Promise<LocationSnapshot | null>;
+} {
+  const auto = options?.auto ?? true;
+
+  const state = useSyncExternalStore(
+    LocationBus.subscribe,
+    LocationBus.getState,
+    () => SERVER_STATE,
+  );
+
+  useEffect(() => {
+    if (!auto) return;
+    let cancelled = false;
+    void LocationBus.syncPermission().then((permission) => {
+      if (cancelled || permission !== "granted") return;
+      void LocationBus.ensure();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [auto]);
+
+  const request = useCallback(() => LocationBus.request(), []);
+  const refresh = useCallback(() => LocationBus.ensure({ maxAgeMs: 0 }), []);
+
+  return { ...state, request, refresh };
+}

--- a/hushh-webapp/lib/services/advisor-directory-service.ts
+++ b/hushh-webapp/lib/services/advisor-directory-service.ts
@@ -1,0 +1,165 @@
+/**
+ * Advisor directory client — advisers near a point, sourced from FINRA
+ * BrokerCheck through our own backend.
+ *
+ * The upstream bearer key is server-side only, so every call here goes to
+ * `/api/one/advisors/*`. The backend also collapses the upstream's two result
+ * shapes (people, or branch offices in dense metros) onto one card shape, so
+ * this layer and the UI never fork on which one arrived.
+ */
+
+import { ApiService } from "@/lib/services/api-service";
+
+export type AdvisorCard = {
+  kind: "advisor" | "branch";
+  id: string;
+  crd?: string | null;
+  name: string | null;
+  firmName: string | null;
+  yearsExperience?: number | null;
+  hasDisclosures?: boolean;
+  /** Branch rows only: how many advisers register to this office. */
+  advisorCount?: number | null;
+  advisorNames?: string[];
+  distanceMiles: number | null;
+  city: string | null;
+  state: string | null;
+  phone: string | null;
+};
+
+export type AdvisorSearchMeta = {
+  grouped: boolean;
+  hasMore: boolean;
+  nextOffset: number | null;
+  returned: number;
+  available: number | null;
+  limit: number;
+  radiusMi: number | null;
+  radiusRequested: number | null;
+  radiusAdjusted: boolean;
+  truncated: boolean;
+};
+
+export type AdvisorAttribution = { source: string; url: string };
+
+export type AdvisorSearchResult = {
+  items: AdvisorCard[];
+  meta: AdvisorSearchMeta;
+  attribution: AdvisorAttribution;
+};
+
+export type AdvisorProfile = {
+  crd: string | null;
+  name: string | null;
+  firmName: string | null;
+  yearsExperience: number | null;
+  firmCount: number | null;
+  isBarred: boolean;
+  hasDisclosures: boolean;
+  disclosureCount: number;
+  states: string[];
+  exams: string[];
+  office: {
+    street: string | null;
+    city: string | null;
+    state: string | null;
+    zip: string | null;
+  } | null;
+  reportUrl: string | null;
+};
+
+export const ADVISOR_PAGE_SIZE = 10;
+export const ADVISOR_RADIUS_OPTIONS_MI = [5, 10, 25] as const;
+
+function authHeaders(idToken: string): HeadersInit {
+  return { Authorization: `Bearer ${idToken}` };
+}
+
+async function jsonOrThrow<T>(response: Response): Promise<T> {
+  const payload = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  if (!response.ok) {
+    const detail = payload?.detail as { message?: string } | string | undefined;
+    const message =
+      (typeof detail === "object" ? detail?.message : detail) ||
+      (payload?.error as string | undefined);
+    throw new Error(message || "Advisors are unavailable right now.");
+  }
+  return payload as T;
+}
+
+export class AdvisorDirectoryService {
+  static async searchNearby(opts: {
+    idToken: string;
+    latitude?: number;
+    longitude?: number;
+    postalCode?: string;
+    radiusMi?: number;
+    limit?: number;
+    offset?: number;
+    signal?: AbortSignal;
+  }): Promise<AdvisorSearchResult> {
+    const params = new URLSearchParams();
+    if (typeof opts.latitude === "number" && typeof opts.longitude === "number") {
+      params.set("lat", opts.latitude.toFixed(6));
+      params.set("lng", opts.longitude.toFixed(6));
+    } else if (opts.postalCode) {
+      params.set("postalCode", opts.postalCode);
+    }
+    if (typeof opts.radiusMi === "number") {
+      params.set("radiusMi", String(opts.radiusMi));
+    }
+    params.set("limit", String(opts.limit ?? ADVISOR_PAGE_SIZE));
+    params.set("offset", String(opts.offset ?? 0));
+
+    const response = await ApiService.apiFetch(
+      `/api/one/advisors/nearby?${params.toString()}`,
+      { method: "GET", headers: authHeaders(opts.idToken), signal: opts.signal },
+    );
+    return jsonOrThrow<AdvisorSearchResult>(response);
+  }
+
+  static async getProfile(opts: {
+    idToken: string;
+    crd: string;
+    signal?: AbortSignal;
+  }): Promise<AdvisorProfile> {
+    const response = await ApiService.apiFetch(
+      `/api/one/advisors/${encodeURIComponent(opts.crd)}`,
+      { method: "GET", headers: authHeaders(opts.idToken), signal: opts.signal },
+    );
+    const payload = await jsonOrThrow<{ profile: AdvisorProfile }>(response);
+    return payload.profile;
+  }
+}
+
+/**
+ * FINRA geocodes offices to ZIP centroids, so an exact figure would be a
+ * fiction — every adviser in a ZIP shares one coordinate. Always approximate.
+ */
+export function formatDistance(miles: number | null | undefined): string | null {
+  if (typeof miles !== "number" || !Number.isFinite(miles) || miles < 0) {
+    return null;
+  }
+  if (miles >= 10) return `~${Math.round(miles)} mi`;
+  return `~${Math.max(0.1, Math.round(miles * 10) / 10).toFixed(1)} mi`;
+}
+
+/** "Morgan Stanley · 47 yrs" — one line, only the parts that exist. */
+export function formatAdvisorSubtitle(card: AdvisorCard): string | null {
+  const parts: string[] = [];
+  if (card.kind === "branch") {
+    if (card.advisorCount) parts.push(`${card.advisorCount} advisors`);
+    if (card.city) parts.push(card.city);
+  } else {
+    if (card.firmName) parts.push(card.firmName);
+    if (typeof card.yearsExperience === "number" && card.yearsExperience >= 1) {
+      // Floor, never round: 47.5 years of tenure is 47 completed years, and
+      // rounding up would overstate a credential.
+      parts.push(`${Math.floor(card.yearsExperience)} yrs`);
+    }
+  }
+  return parts.length ? parts.join(" · ") : null;
+}


### PR DESCRIPTION
## What

Two things that turned out to be one thing.

**Location is now a property of the session, not a feature of the Location agent.** Every surface that wanted a coordinate previously called `HushhLocation` itself — so each one re-prompted, and each one opened its own GPS watch. `LocationBus` holds a single snapshot for the whole app: one watch (refcounted), concurrent callers coalesced into a single device read, fixes under two minutes reused. Any agent, service or screen reads the same position.

**The ask happens once, in One setup**, on a screen that says why. Then Connect gains an **Around you** tab: advisers near you from FINRA BrokerCheck.

## Why these decisions

- **The OS dialog fires from a tap, never from mount.** iOS grants exactly one system prompt per install; spending it before the user has read anything converts a recoverable "later" into a permanent "no". The screen self-skips when the OS has already decided, so a denial is never nagged and re-entry never shows a dead screen. Refusing never blocks setup.
- **Coordinates stay in memory.** The bus never persists them and never puts them on the wire on its own. `_contains_plaintext_location_key` still holds.
- **The advisors proxy is a backend route, not a Next route handler.** The native build is `output: "export"` — `app/api/*` does not exist on device.
- **The upstream NDJSON stream is consumed server-side.** `CapacitorHttp` is enabled, which patches `fetch` and buffers whole responses, so a client-side stream reader would never render progressively on iOS/Android. Assembling in the backend gives web and native one identical contract.
- **Both upstream result shapes are handled.** Adviser density varies ~25x at the same radius, so dense metros return branch offices instead of people. The backend flattens both onto one card shape; the UI never forks.
- **Distances render approximate.** FINRA geocodes offices to ZIP centroids — every adviser in a ZIP shares one coordinate — so `~0.5 mi`, never `0.47`, never `0`.
- **A 401 from upstream surfaces as 502.** That means *our* key is wrong; it is never the caller's business and must not teach a client to retry with different credentials.

## Preserved

Existing Connect behaviour is untouched — directory search, connection requests, scope dialogs, and the alphabetical connection sort from #4787 all still work; the People tab is the same surface it was. The `location` capability's own onboarding is unchanged; the primer sits in front of it. No API contract, route, permission or migration changed.

## Tests

- Backend: 12 new (param shaping, both row shapes, postal fallback, clamping, upstream 401→502, mid-stream error frame, 429, unconfigured, profile normalisation, path traversal on CRD).
- Frontend: 13 bus (coalescing, freshness, denial, refcounted watch), 12 client service, 9 Connect tab, 7 primer gate.
- Full webapp suite: no new failures. `main` is currently red on `kyc-identity-preface` (3) and `saved-locations-section` (3) — verified pre-existing at `e1c71c283`, unrelated to this branch.

## Rollout

Inert until `ADVISORS_API_BASE_URL` and `ADVISORS_API_KEY` are set. Unconfigured returns 503 and the tab reports unavailable rather than failing. Deploy wiring is optional-by-default.

---
Closes #4906
(retroactive board-linkage backfill, 2026-08-06)