### PR TITLE
feat(one): reach the Wallet Profile from Profile > Your account

### DIFF
--- a/consent-protocol/hushh_mcp/services/apple_wallet_pass_service.py
+++ b/consent-protocol/hushh_mcp/services/apple_wallet_pass_service.py
@@ -66,9 +66,7 @@ WALLET_PASS_FILENAME = "hushh-one.pkpass"  # noqa: S105
 # User-facing failure copy (contract §9). The technical cause is logged
 # server-side only and is never returned to the client.
 WALLET_PASS_UNAVAILABLE_CODE = "wallet_pass_unavailable"  # noqa: S105
-WALLET_PASS_UNAVAILABLE_MESSAGE = (
-    "We couldn't create your Wallet pass right now. Please try again in a moment."  # noqa: S105
-)
+WALLET_PASS_UNAVAILABLE_MESSAGE = "Couldn't create your pass. Try again in a moment."  # noqa: S105
 
 _CARD_BACKGROUND_COLOR = "rgb(12, 13, 17)"
 _CARD_FOREGROUND_COLOR = "rgb(255, 255, 255)"
@@ -391,9 +389,8 @@ def _build_back_fields(content: WalletPassContent) -> list[dict[str, str]]:
         ),
         _text_field(
             "control",
-            "Only the information you select will be visible. "
-            "You can update or disable access at any time.",
-            label="You stay in control",
+            "Only what you pick is visible. Change or switch it off anytime.",
+            label="You choose what shows",
         ),
     )
 

--- a/consent-protocol/tests/test_apple_wallet_pass_service.py
+++ b/consent-protocol/tests/test_apple_wallet_pass_service.py
@@ -307,10 +307,7 @@ def test_back_fields_carry_the_volatile_detail_and_the_control_note(
     assert back["portfolio"] == "https://ada.example.com/work"
     assert back["profile_link"] == PUBLIC_CARD_URL
     assert "how_it_works" in back
-    assert (
-        back["control"] == "Only the information you select will be visible. "
-        "You can update or disable access at any time."
-    )
+    assert back["control"] == "Only what you pick is visible. Change or switch it off anytime."
 
 
 def test_absent_optional_fields_produce_no_blank_rows(signing_material) -> None:

--- a/consent-protocol/tests/test_one_wallet_card_routes.py
+++ b/consent-protocol/tests/test_one_wallet_card_routes.py
@@ -559,9 +559,7 @@ def test_pass_route_returns_the_friendly_503_when_signing_material_is_absent(
     body = response.json()
     assert body["status"] == "unavailable"
     assert body["code"] == one_wallet_card.WALLET_PASS_UNAVAILABLE_CODE
-    assert body["message"] == (
-        "We couldn't create your Wallet pass right now. Please try again in a moment."
-    )
+    assert body["message"] == ("Couldn't create your pass. Try again in a moment.")
     _assert_public_headers(response)
 
 

--- a/docs/superpowers/specs/2026-08-03-wallet-card-contract.md
+++ b/docs/superpowers/specs/2026-08-03-wallet-card-contract.md
@@ -172,14 +172,23 @@ Omit `webServiceURL` and `authenticationToken` entirely (D2 — no web service).
 
 ## 9. Copy (use verbatim)
 
-- Entry, before setup: **"Add to Apple Wallet"** / "Keep your Hussh One profile ready to share."
-- Setup intro: **"Your profile, ready when you need it"** / "Add a secure Hussh One pass to Apple Wallet and share your selected details with a simple scan."
-- Privacy assurance: **"You stay in control"** / "Only the information you select will be visible. You can update or disable access at any time."
-- After setup entry: **"Manage Wallet Profile"** / "Control what people see when they scan your pass."
-- Success: **"Your Hussh One pass is ready"** / "You can now share your profile directly from Apple Wallet."
-- Signing failure (user-facing): "We couldn't create your Wallet pass right now. Please try again in a moment." — log the technical error server-side only.
+All strings follow the less-text standard: headlines 2–6 words, supporting text
+one short sentence, buttons 1–3 words. Shortening never drops a disclosure — the
+privacy assurance still states both what is visible and that it is reversible.
+
+- Profile settings row: **"Apple Wallet"** / "Share your profile with a scan."
+- Entry, before setup: **"Add to Apple Wallet"** / "Your profile, ready to share."
+- Setup intro: **"Your profile, one scan away"** / "Add a Hussh One pass to Apple Wallet."
+- Privacy assurance: **"You choose what shows"** / "Only what you pick is visible. Change or switch it off anytime."
+- After setup entry: **"Wallet Profile"** / "Control what people see."
+- Success: **"Pass added"** / "Share your profile straight from Apple Wallet."
+- Signing failure (user-facing): "Couldn't create your pass. Try again in a moment." — log the technical error server-side only.
 - Revoked page: "This profile is no longer shared."
 - Expired page: "This profile link has expired."
+
+The profile settings row is deliberately one string for both states. That list is
+rendered without a vault owner token, so resolving "add" versus "manage" would
+force an unlock before a settings row could draw.
 
 Never use: "Share everything", "Your complete identity", "All your data in one scan", "Unlimited profile access", "Your entire PKM".
 

--- a/hushh-webapp/.env.dev.local.example
+++ b/hushh-webapp/.env.dev.local.example
@@ -24,6 +24,11 @@ NEXT_PUBLIC_FIREBASE_PHONE_AUTH_DISABLE_APP_VERIFICATION=false
 NEXT_PUBLIC_OBSERVABILITY_ENABLED=true
 NEXT_PUBLIC_OBSERVABILITY_DEBUG=false
 NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
+
+# Owner entry point for the Wallet Profile in Profile > Your account.
+# The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
+# decides whether the row is offered, so a dark backend is never linked to.
+NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_dev_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_dev_gtm_id
 NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY=replace_with_dev_browser_maps_api_key

--- a/hushh-webapp/.env.example
+++ b/hushh-webapp/.env.example
@@ -57,6 +57,11 @@ NEXT_PUBLIC_OBSERVABILITY_ENABLED=true
 NEXT_PUBLIC_OBSERVABILITY_DEBUG=false
 # 0.0 - 1.0 sampling for event emission
 NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
+
+# Owner entry point for the Wallet Profile in Profile > Your account.
+# The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
+# decides whether the row is offered, so a dark backend is never linked to.
+NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
 NEXT_PUBLIC_GTM_ID=
 
 # ============================================================================

--- a/hushh-webapp/.env.local.local.example
+++ b/hushh-webapp/.env.local.local.example
@@ -24,6 +24,11 @@ NEXT_PUBLIC_FIREBASE_PHONE_AUTH_DISABLE_APP_VERIFICATION=false
 NEXT_PUBLIC_OBSERVABILITY_ENABLED=true
 NEXT_PUBLIC_OBSERVABILITY_DEBUG=false
 NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
+
+# Owner entry point for the Wallet Profile in Profile > Your account.
+# The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
+# decides whether the row is offered, so a dark backend is never linked to.
+NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_uat_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_uat_gtm_id
 NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY=replace_with_uat_browser_maps_api_key

--- a/hushh-webapp/.env.prod.local.example
+++ b/hushh-webapp/.env.prod.local.example
@@ -22,6 +22,11 @@ NEXT_PUBLIC_FIREBASE_PHONE_AUTH_DISABLE_APP_VERIFICATION=false
 NEXT_PUBLIC_OBSERVABILITY_ENABLED=true
 NEXT_PUBLIC_OBSERVABILITY_DEBUG=false
 NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
+
+# Owner entry point for the Wallet Profile in Profile > Your account.
+# The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
+# decides whether the row is offered, so a dark backend is never linked to.
+NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_prod_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_prod_gtm_id
 NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY=replace_with_prod_browser_maps_api_key

--- a/hushh-webapp/.env.uat.local.example
+++ b/hushh-webapp/.env.uat.local.example
@@ -22,6 +22,11 @@ NEXT_PUBLIC_FIREBASE_PHONE_AUTH_DISABLE_APP_VERIFICATION=false
 NEXT_PUBLIC_OBSERVABILITY_ENABLED=true
 NEXT_PUBLIC_OBSERVABILITY_DEBUG=false
 NEXT_PUBLIC_OBSERVABILITY_SAMPLE_RATE=1
+
+# Owner entry point for the Wallet Profile in Profile > Your account.
+# The backend ONE_WALLET_CARD_ENABLED flag stays authoritative; this only
+# decides whether the row is offered, so a dark backend is never linked to.
+NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED=false
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=replace_with_uat_measurement_id
 NEXT_PUBLIC_GTM_ID=replace_with_uat_gtm_id
 NEXT_PUBLIC_GOOGLE_MAPS_BROWSER_API_KEY=replace_with_uat_browser_maps_api_key

--- a/hushh-webapp/__tests__/services/wallet-card-service.test.ts
+++ b/hushh-webapp/__tests__/services/wallet-card-service.test.ts
@@ -420,14 +420,14 @@ describe("checkPassAvailability", () => {
       fetchResponse(503, {
         status: "unavailable",
         code: "WALLET_PASS_SIGNING_UNAVAILABLE",
-        message: "We couldn't create your Wallet pass right now. Please try again in a moment.",
+        message: "Couldn't create your pass. Try again in a moment.",
       }),
     );
 
     expect(await WalletCardService.checkPassAvailability(SHARE_TOKEN)).toEqual({
       state: "signing_unavailable",
       message:
-        "We couldn't create your Wallet pass right now. Please try again in a moment.",
+        "Couldn't create your pass. Try again in a moment.",
       code: "WALLET_PASS_SIGNING_UNAVAILABLE",
     });
   });

--- a/hushh-webapp/app/profile/profile-workspace-page.tsx
+++ b/hushh-webapp/app/profile/profile-workspace-page.tsx
@@ -34,6 +34,7 @@ import {
   Trash2,
   User,
   UserRound,
+  Wallet,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -111,6 +112,8 @@ import {
   resolveDeleteAccountAuth,
 } from "@/lib/flows/delete-account";
 import { ROUTES } from "@/lib/navigation/routes";
+import { WALLET_CARD_COPY } from "@/components/wallet-card/wallet-card-copy";
+import { isWalletCardEntryEnabled } from "@/components/wallet-card/wallet-card-entry";
 import {
   buildCanonicalProfileRouteFromLegacyQuery,
   buildProfileRoute,
@@ -201,6 +204,12 @@ const PROFILE_LABELS = {
   accountAccess: "Account access",
   setup: "Set up One",
 } as const;
+
+/**
+ * Read once at module scope: `NEXT_PUBLIC_*` is inlined at build time, so this
+ * cannot change across renders and does not belong in state or a memo.
+ */
+const walletCardEntryEnabled = isWalletCardEntryEnabled();
 
 function cloneManifest(manifest: DomainManifest | null): DomainManifest | null {
   if (!manifest) return null;
@@ -3001,6 +3010,15 @@ function ProfilePageContent() {
           title="Sign-in provider"
           description={provider.name}
         />
+        {walletCardEntryEnabled ? (
+          <SettingsRow
+            icon={Wallet}
+            title={WALLET_CARD_COPY.profileEntry.title}
+            description={WALLET_CARD_COPY.profileEntry.description}
+            chevron
+            onClick={() => router.push(ROUTES.ONE_WALLET_CARD)}
+          />
+        ) : null}
       </SettingsGroup>
       <SettingsGroup title="Account actions">
         <SettingsRow

--- a/hushh-webapp/components/wallet-card/__tests__/wallet-card-entry.test.ts
+++ b/hushh-webapp/components/wallet-card/__tests__/wallet-card-entry.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The Profile settings row is gated on this flag. A dark backend answers 404 on
+ * every owner route, so a row that renders without the flag would put a dead
+ * end inside a settings list — these cases pin the "unset means off" default
+ * that prevents that.
+ */
+const ENV_KEY = "NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED";
+
+async function readFlag(): Promise<boolean> {
+  vi.resetModules();
+  const { isWalletCardEntryEnabled } = await import(
+    "@/components/wallet-card/wallet-card-entry"
+  );
+  return isWalletCardEntryEnabled();
+}
+
+describe("isWalletCardEntryEnabled", () => {
+  const original = process.env[ENV_KEY];
+
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it("is off when the flag is unset", async () => {
+    await expect(readFlag()).resolves.toBe(false);
+  });
+
+  it("is off when the flag is empty or whitespace", async () => {
+    process.env[ENV_KEY] = "   ";
+    await expect(readFlag()).resolves.toBe(false);
+  });
+
+  it.each(["true", "TRUE", "1", "yes", "on", " True "])(
+    "is on for the truthy value %j",
+    async (value) => {
+      process.env[ENV_KEY] = value;
+      await expect(readFlag()).resolves.toBe(true);
+    },
+  );
+
+  it.each(["false", "0", "no", "off", "disabled", "maybe"])(
+    "is off for the non-truthy value %j",
+    async (value) => {
+      process.env[ENV_KEY] = value;
+      await expect(readFlag()).resolves.toBe(false);
+    },
+  );
+});

--- a/hushh-webapp/components/wallet-card/wallet-card-copy.ts
+++ b/hushh-webapp/components/wallet-card/wallet-card-copy.ts
@@ -11,36 +11,46 @@
  */
 
 export const WALLET_CARD_COPY = {
+  /**
+   * Settings-list row in Profile > Your account. One string for both states,
+   * because that list does not hold a vault owner token and so cannot know
+   * whether a card exists without making the row gate on an unlock.
+   */
+  profileEntry: {
+    title: "Apple Wallet",
+    description: "Share your profile with a scan.",
+  },
   /** Entry point shown before a Wallet Profile exists. */
   entryBeforeSetup: {
     title: "Add to Apple Wallet",
-    description: "Keep your Hussh One profile ready to share.",
+    description: "Your profile, ready to share.",
   },
   /** Setup introduction. */
   setupIntro: {
-    title: "Your profile, ready when you need it",
-    description:
-      "Add a secure Hussh One pass to Apple Wallet and share your selected details with a simple scan.",
+    title: "Your profile, one scan away",
+    description: "Add a Hussh One pass to Apple Wallet.",
   },
-  /** Privacy assurance shown alongside the shared-information review. */
+  /**
+   * Privacy assurance shown alongside the shared-information review. Both
+   * disclosures survive the shorter wording: what is visible, and that it
+   * stays reversible.
+   */
   privacyAssurance: {
-    title: "You stay in control",
-    description:
-      "Only the information you select will be visible. You can update or disable access at any time.",
+    title: "You choose what shows",
+    description: "Only what you pick is visible. Change or switch it off anytime.",
   },
   /** Entry point shown once a Wallet Profile exists. */
   entryAfterSetup: {
-    title: "Manage Wallet Profile",
-    description: "Control what people see when they scan your pass.",
+    title: "Wallet Profile",
+    description: "Control what people see.",
   },
   /** Confirmation after the pass has been handed to Apple Wallet. */
   success: {
-    title: "Your Hussh One pass is ready",
-    description: "You can now share your profile directly from Apple Wallet.",
+    title: "Pass added",
+    description: "Share your profile straight from Apple Wallet.",
   },
   /** Shown when pass signing is unavailable. The technical error stays server-side. */
-  signingFailure:
-    "We couldn't create your Wallet pass right now. Please try again in a moment.",
+  signingFailure: "Couldn't create your pass. Try again in a moment.",
   /** Public page state after the owner removes their Wallet Profile. */
   revokedPage: "This profile is no longer shared.",
   /** Public page state once the share link has expired. */

--- a/hushh-webapp/components/wallet-card/wallet-card-entry.ts
+++ b/hushh-webapp/components/wallet-card/wallet-card-entry.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether the Wallet Profile entry point is offered in Profile > Your account.
+ *
+ * The backend `ONE_WALLET_CARD_ENABLED` flag stays the authority on whether the
+ * feature works at all — every owner route answers 404 while it is off. This
+ * client flag exists only so the settings row is not rendered against a dark
+ * backend, which would put a dead end inside a settings list.
+ *
+ * Unset means off. A feature that ships dark must stay dark on any deployment
+ * that has not deliberately turned it on, so this deliberately inverts the
+ * default used by `isObservabilityEnabled`.
+ */
+const TRUTHY = ["1", "true", "yes", "on"];
+
+export function isWalletCardEntryEnabled(): boolean {
+  const raw = String(process.env.NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED || "")
+    .trim()
+    .toLowerCase();
+  return TRUTHY.includes(raw);
+}

--- a/hushh-webapp/lib/services/wallet-card-service.ts
+++ b/hushh-webapp/lib/services/wallet-card-service.ts
@@ -48,8 +48,7 @@ export const WALLET_CARD_SERVICE_COPY = {
   expired: "This profile link has expired.",
   notFound: "This profile is not available.",
   unavailable: "This profile could not be loaded right now.",
-  signingUnavailable:
-    "We couldn't create your Wallet pass right now. Please try again in a moment.",
+  signingUnavailable: "Couldn't create your pass. Try again in a moment.",
   unsupported: "Apple Wallet is available on iPhone and iPad.",
 } as const;
 


### PR DESCRIPTION
The Wallet Profile shipped complete in #4791 but **unreachable**. `ONE_WALLET_CARD` is registered in `routes.ts` and the entry copy already sits in `wallet-card-copy.ts` — nothing renders it. This adds the missing link and tightens the feature's copy.

**No user-visible change on merge.** The new client flag is `false` in every profile.

## Entry point

A `SettingsRow` at the end of the **Identity** group in Profile > Your account, routing to the existing `/one/wallet-card` workspace.

Identity rather than a new group: the card *is* identity you hand someone, and a group holding one row adds visual weight for nothing.

One string for both states. Resolving "add" vs "manage" needs card state, which needs a vault owner token — the settings list doesn't hold one, so a state-aware row would force a vault unlock before a settings row could draw. The destination screen already resolves both.

## Gating

New `NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED`, default off, in all four runtime profile templates plus `.env.example` (the shape check enforces one key shape across them).

Backend `ONE_WALLET_CARD_ENABLED` stays the authority on whether the feature *works*; this only decides whether the row is *offered*, so a dark backend is never linked to from a settings list. Unset means off — deliberately the inverse of `isObservabilityEnabled`, because a feature that ships dark must stay dark wherever nobody turned it on.

## Copy — less-text standard

Contract §9 updated first, since the copy module is bound to it.

| Before | After |
|---|---|
| "Your profile, ready when you need it" / "Add a secure Hussh One pass to Apple Wallet and share your selected details with a simple scan." | **"Your profile, one scan away"** / "Add a Hussh One pass to Apple Wallet." |
| "You stay in control" / "Only the information you select will be visible. You can update or disable access at any time." | **"You choose what shows"** / "Only what you pick is visible. Change or switch it off anytime." |
| "Manage Wallet Profile" / "Control what people see when they scan your pass." | **"Wallet Profile"** / "Control what people see." |
| "Your Hushh One pass is ready" | **"Pass added"** |
| "We couldn't create your Wallet pass right now. Please try again in a moment." | **"Couldn't create your pass. Try again in a moment."** |

The privacy assurance keeps **both** disclosures — what is visible, and that it is reversible. Only the framing got shorter.

### Two cross-surface catches

That privacy line is also printed on the **physical pass** as a backField, so `apple_wallet_pass_service.py` moves with it — otherwise the pass in a user's pocket contradicts the screen.

The signing-failure string lives in **three** places (TS copy, TS service, Python constant) plus two test suites. All five aligned here.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit` | clean |
| eslint (5 files) | clean |
| `ruff check` + `ruff format --check` | clean |
| Frontend tests | 116 passed |
| Backend wallet tests | 72 passed |
| Cloud Build arg-limit guards (#4796) | 6 passed |
| `docs verify` | passed |
| `orchestrate.sh governance` | passed |

New `wallet-card-entry.test.ts` pins the unset-means-off default and both truthy/falsey sets — that default is the only thing standing between a dark backend and a dead-end settings row.

## Not in this PR

Turning the feature **on**. That needs `ONE_WALLET_CARD_ENABLED` (backend) and `NEXT_PUBLIC_ONE_WALLET_CARD_ENABLED` (frontend) per deploy lane. Enabling a public unauthenticated page is a launch decision, and #4791 deliberately shipped this dark — so it stays a separate, deliberate change.

Signed-off-by: Ankit Kumar Singh <ankit@hushh.ai>

---
Closes #4907
(retroactive board-linkage backfill, 2026-08-06)