### PR TITLE
fix(advisors): offer a ZIP when there is nothing nearby, and stop leaking our plumbing

### DIFF
--- a/hushh-webapp/__tests__/services/advisor-directory-service.test.ts
+++ b/hushh-webapp/__tests__/services/advisor-directory-service.test.ts
@@ -98,6 +98,30 @@ describe("AdvisorDirectoryService.searchNearby", () => {
     ).rejects.toThrow("Try again shortly.");
   });
 
+  it("never shows the reader our own plumbing", async () => {
+    // A 503 means this deployment has no directory wired up. "not configured
+    // on this backend" is a sentence no user should be made to read.
+    mockApiFetch.mockResolvedValue(
+      jsonResponse(
+        {
+          detail: {
+            code: "ONE_ADVISORS_UNAVAILABLE",
+            message: "The advisor directory is not configured on this backend.",
+          },
+        },
+        503,
+      ),
+    );
+
+    await expect(
+      AdvisorDirectoryService.searchNearby({
+        idToken: "id-token",
+        latitude: 1,
+        longitude: 2,
+      }),
+    ).rejects.toThrow("Not available yet.");
+  });
+
   it("still fails cleanly when the error body is unreadable", async () => {
     mockApiFetch.mockResolvedValue({
       ok: false,

--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -237,6 +237,83 @@ describe("AdvisorsNearby", () => {
     expect(await screen.findByText("Within 1.6 mi.")).toBeTruthy();
   });
 
+  it("offers a ZIP when the coordinates are fine but match nobody", async () => {
+    // Someone in India has working GPS and an empty list — FINRA is US-only.
+    // A dead-end "none nearby" row leaves them with nothing to do.
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 19.076, longitude: 72.8777 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(result({ items: [] }));
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(await screen.findByTestId("advisors-empty")).toBeTruthy();
+    expect(screen.getByText("Nothing nearby")).toBeTruthy();
+
+    fireEvent.change(screen.getByTestId("advisors-postal-input"), {
+      target: { value: "98033" },
+    });
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => expect(mocks.searchNearby).toHaveBeenCalledTimes(2));
+    expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({
+      postalCode: "98033",
+    });
+  });
+
+  it("does not credit a source it showed nothing from", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 19.076, longitude: 72.8777 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(result({ items: [] }));
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    await screen.findByTestId("advisors-empty");
+    expect(screen.queryByText("FINRA BrokerCheck")).toBeNull();
+  });
+
+  it("lets the user retry a failure instead of stranding them", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockRejectedValueOnce(new Error("Not available yet."));
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    expect(await screen.findByTestId("advisors-error")).toBeTruthy();
+    expect(screen.getByText("Not available yet.")).toBeTruthy();
+
+    mocks.searchNearby.mockResolvedValue(result());
+    fireEvent.click(screen.getByText("Try again"));
+
+    expect(await screen.findByText("Christine Cote")).toBeTruthy();
+  });
+
+  it("keeps the radius control available when nothing came back", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(result({ items: [] }));
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    await screen.findByTestId("advisors-empty");
+    expect(screen.getByText("25 mi")).toBeTruthy();
+  });
+
   it("shows a failure without wiping the surface", async () => {
     mocks.locationState = {
       status: "ready",

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -38,6 +38,80 @@ function LoadingRows() {
   );
 }
 
+/**
+ * The one way in when coordinates cannot answer the question — location was
+ * refused, or the coordinates are real but the directory covers nobody there.
+ * FINRA is a US register, so anyone outside the US has working GPS and an
+ * empty list; a ZIP is the only thing that helps them.
+ */
+function PostalCodeForm({
+  busy,
+  initialValue = "",
+  onSearch,
+}: {
+  busy: boolean;
+  initialValue?: string;
+  onSearch: (postalCode: string) => void;
+}) {
+  const [postalCode, setPostalCode] = useState(initialValue);
+
+  return (
+    <form
+      className="flex w-full gap-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const trimmed = postalCode.trim();
+        if (trimmed) onSearch(trimmed);
+      }}
+    >
+      <Input
+        value={postalCode}
+        onChange={(event) => setPostalCode(event.target.value)}
+        placeholder="ZIP"
+        inputMode="numeric"
+        aria-label="ZIP code"
+        className="h-11"
+        data-testid="advisors-postal-input"
+      />
+      <Button
+        type="submit"
+        variant="none"
+        effect="fill"
+        size="lg"
+        disabled={busy || !postalCode.trim()}
+      >
+        Search
+      </Button>
+    </form>
+  );
+}
+
+/** A centred non-result: one line, and the single thing worth doing next. */
+function QuietBlock({
+  title,
+  subtitle,
+  testId,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  testId: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <section
+      className="mx-auto flex w-full max-w-[26rem] flex-col items-center py-12 text-center"
+      data-testid={testId}
+    >
+      <h2 className="type-title3 text-foreground">{title}</h2>
+      {subtitle ? (
+        <p className="mt-2 type-callout text-muted-foreground">{subtitle}</p>
+      ) : null}
+      {children ? <div className="mt-6 w-full">{children}</div> : null}
+    </section>
+  );
+}
+
 /** One calm block: why we need location, and the single tap that grants it. */
 function LocationPrompt({
   denied,
@@ -50,7 +124,6 @@ function LocationPrompt({
   onUseLocation: () => void;
   onSearchPostalCode: (postalCode: string) => void;
 }) {
-  const [postalCode, setPostalCode] = useState("");
   const [showPostal, setShowPostal] = useState(denied);
 
   useEffect(() => {
@@ -86,33 +159,9 @@ function LocationPrompt({
       )}
 
       {showPostal ? (
-        <form
-          className="mt-6 flex w-full gap-2"
-          onSubmit={(event) => {
-            event.preventDefault();
-            const trimmed = postalCode.trim();
-            if (trimmed) onSearchPostalCode(trimmed);
-          }}
-        >
-          <Input
-            value={postalCode}
-            onChange={(event) => setPostalCode(event.target.value)}
-            placeholder="ZIP"
-            inputMode="numeric"
-            aria-label="ZIP code"
-            className="h-11"
-            data-testid="advisors-postal-input"
-          />
-          <Button
-            type="submit"
-            variant="none"
-            effect="fill"
-            size="lg"
-            disabled={busy || !postalCode.trim()}
-          >
-            Search
-          </Button>
-        </form>
+        <div className="mt-6 w-full">
+          <PostalCodeForm busy={busy} onSearch={onSearchPostalCode} />
+        </div>
       ) : (
         <Button
           type="button"
@@ -229,7 +278,9 @@ export function AdvisorsNearby({
   if (!anchor) {
     return (
       <LocationPrompt
-        denied={location.status === "denied" || location.status === "unavailable"}
+        denied={
+          location.status === "denied" || location.status === "unavailable"
+        }
         busy={location.status === "locating"}
         onUseLocation={handleUseLocation}
         onSearchPostalCode={handlePostalCode}
@@ -255,56 +306,83 @@ export function AdvisorsNearby({
         <p className="type-footnote text-muted-foreground">{narrowed}</p>
       ) : null}
 
-      <SettingsGroup title={meta?.grouped ? "Offices" : "Advisors"} separatorInset>
-        {loading ? (
-          <LoadingRows />
-        ) : error ? (
-          <SettingsRow title={error} density="compact" tone="destructive" />
-        ) : cards.length === 0 ? (
-          <SettingsRow
-            title="None nearby"
-            description="Try a wider radius."
-            density="compact"
-            disabled
+      {error && !loading ? (
+        <QuietBlock title={error} testId="advisors-error">
+          <Button
+            type="button"
+            variant="none"
+            effect="fill"
+            size="lg"
+            onClick={() => void runSearch(anchor, radiusMi, 0)}
+          >
+            Try again
+          </Button>
+        </QuietBlock>
+      ) : null}
+
+      {!error && !loading && cards.length === 0 ? (
+        // Coordinates can be perfectly good and still match nobody — FINRA is a
+        // US register. Offer the one input that can actually help rather than a
+        // dead end.
+        <QuietBlock
+          title="Nothing nearby"
+          subtitle="Try a US ZIP."
+          testId="advisors-empty"
+        >
+          <PostalCodeForm
+            busy={loading}
+            initialValue={anchor.kind === "postal" ? anchor.postalCode : ""}
+            onSearch={handlePostalCode}
           />
-        ) : (
-          cards.map((card) => {
-            const distance = formatDistance(card.distanceMiles);
-            return (
-              <SettingsRow
-                key={`${card.kind}-${card.id}`}
-                title={
-                  <span className="flex min-w-0 items-center gap-2">
-                    <span className="truncate">{card.name ?? "Advisor"}</span>
-                    {card.hasDisclosures ? (
-                      <span
-                        className="size-1.5 shrink-0 rounded-full bg-amber-500"
-                        role="img"
-                        aria-label="Has disclosures"
-                      />
-                    ) : null}
-                  </span>
-                }
-                description={formatAdvisorSubtitle(card) ?? undefined}
-                density="compact"
-                chevron={card.kind === "advisor"}
-                onClick={
-                  card.kind === "advisor"
-                    ? () => setSelected(card)
-                    : undefined
-                }
-                trailing={
-                  distance ? (
-                    <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
-                      {distance}
+        </QuietBlock>
+      ) : null}
+
+      {error || (!loading && cards.length === 0) ? null : (
+        <SettingsGroup
+          title={meta?.grouped ? "Offices" : "Advisors"}
+          separatorInset
+        >
+          {loading ? (
+            <LoadingRows />
+          ) : (
+            cards.map((card) => {
+              const distance = formatDistance(card.distanceMiles);
+              return (
+                <SettingsRow
+                  key={`${card.kind}-${card.id}`}
+                  title={
+                    <span className="flex min-w-0 items-center gap-2">
+                      <span className="truncate">{card.name ?? "Advisor"}</span>
+                      {card.hasDisclosures ? (
+                        <span
+                          className="size-1.5 shrink-0 rounded-full bg-amber-500"
+                          role="img"
+                          aria-label="Has disclosures"
+                        />
+                      ) : null}
                     </span>
-                  ) : undefined
-                }
-              />
-            );
-          })
-        )}
-      </SettingsGroup>
+                  }
+                  description={formatAdvisorSubtitle(card) ?? undefined}
+                  density="compact"
+                  chevron={card.kind === "advisor"}
+                  onClick={
+                    card.kind === "advisor"
+                      ? () => setSelected(card)
+                      : undefined
+                  }
+                  trailing={
+                    distance ? (
+                      <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
+                        {distance}
+                      </span>
+                    ) : undefined
+                  }
+                />
+              );
+            })
+          )}
+        </SettingsGroup>
+      )}
 
       {meta?.hasMore && !loading ? (
         <div className="flex justify-center">
@@ -325,9 +403,11 @@ export function AdvisorsNearby({
         </div>
       ) : null}
 
-      <p className="type-caption text-center text-muted-foreground">
-        FINRA BrokerCheck
-      </p>
+      {cards.length > 0 ? (
+        <p className="type-caption text-center text-muted-foreground">
+          FINRA BrokerCheck
+        </p>
+      ) : null}
 
       <AdvisorDetailSurface
         card={selected}

--- a/hushh-webapp/lib/services/advisor-directory-service.ts
+++ b/hushh-webapp/lib/services/advisor-directory-service.ts
@@ -81,6 +81,11 @@ async function jsonOrThrow<T>(response: Response): Promise<T> {
     unknown
   >;
   if (!response.ok) {
+    // A 503 means this deployment has no directory wired up. That is our
+    // plumbing, not the reader's problem — "not configured on this backend" is
+    // a sentence no user should ever be shown.
+    if (response.status === 503) throw new Error("Not available yet.");
+
     const detail = payload?.detail as { message?: string } | string | undefined;
     const message =
       (typeof detail === "object" ? detail?.message : detail) ||


### PR DESCRIPTION
Two things found by looking at the actual UAT screen, not the tests.

## Nothing nearby was a dead end

Coordinates can be perfectly good and still match nobody — FINRA is a **US** register, so anyone outside the US gets working GPS and an empty list. The empty state was a disabled `None nearby / Try a wider radius` row, which is a dead end for exactly the people who most need the alternative.

It now offers the ZIP field right there, prefilled when a ZIP was already used, with the radius control still in reach. Attribution no longer appears under a list that showed nothing.

## We were showing the user our plumbing

An unconfigured deployment answered **"The advisor directory is not configured on this backend."** straight into the UI. A 503 now reads **"Not available yet."** and comes with **Try again**, so a transient failure is recoverable rather than terminal.

## Tests

Four new component tests and one service test:
- coordinates that match nobody surface the ZIP field, and searching by it works
- a 503 never reaches the reader as backend wording
- Try again recovers into a real list
- the radius control stays available when nothing came back
- no source credit under an empty list

26 passing across the two files; typecheck and lint clean.

---
Closes #4906
(retroactive board-linkage backfill, 2026-08-06)