### PR TITLE
fix(advisors): stop writing user coordinates to the logs

### DIFF
--- a/consent-protocol/api/routes/one/advisors.py
+++ b/consent-protocol/api/routes/one/advisors.py
@@ -1,13 +1,19 @@
 """Advisor directory routes — advisers near a coordinate, and one profile.
 
 The upstream bearer key never leaves the backend, so the app calls these
-endpoints instead of the directory API directly. Coordinates arrive per request,
-are used only to build the upstream query, and are never persisted or logged.
+endpoints instead of the directory API directly. Coordinates arrive per
+request, are used only to build the upstream query, and are never persisted.
+
+The search is a POST even though it reads nothing: a GET would put the user's
+exact position in the request line, which the access log records verbatim, and
+which also lands in browser history and any Referer. The Maps proxy endpoints
+in api/routes/one/location.py are POST for the same reason.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
+from pydantic import BaseModel, ConfigDict, Field
 
 from api.middleware import require_firebase_auth
 from api.middlewares.rate_limit import RateLimits, limiter
@@ -17,6 +23,20 @@ from hushh_mcp.services.advisor_directory_service import (
 )
 
 router = APIRouter(prefix="/api/one", tags=["Advisors"])
+
+
+class AdvisorSearchRequest(BaseModel):
+    """A location to search around, or a postal code when there is none."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    lat: float | None = Field(default=None, ge=-90, le=90)
+    lng: float | None = Field(default=None, ge=-180, le=180)
+    postal_code: str | None = Field(default=None, alias="postalCode", max_length=12)
+    radius_mi: float | None = Field(default=None, alias="radiusMi", gt=0, le=100)
+    limit: int = Field(default=10, ge=1, le=50)
+    offset: int = Field(default=0, ge=0)
+    advisor_type: str = Field(default="ia", alias="type", max_length=8)
 
 
 def _service() -> AdvisorDirectoryService:
@@ -35,31 +55,25 @@ def _handle(exc: AdvisorDirectoryError) -> HTTPException:
     )
 
 
-@router.get("/advisors/nearby")
+@router.post("/advisors/search")
 @limiter.limit(RateLimits.ONE_ADVISORS_DIRECTORY_READ)
-async def advisors_nearby(
+async def advisors_search(
     request: Request,
     response: Response,
-    lat: float | None = Query(default=None, ge=-90, le=90),
-    lng: float | None = Query(default=None, ge=-180, le=180),
-    postal_code: str | None = Query(default=None, alias="postalCode", max_length=12),
-    radius_mi: float | None = Query(default=None, alias="radiusMi", gt=0, le=100),
-    limit: int = Query(default=10, ge=1, le=50),
-    offset: int = Query(default=0, ge=0),
-    advisor_type: str = Query(default="ia", alias="type", max_length=8),
+    payload: AdvisorSearchRequest,
     firebase_uid: str = Depends(require_firebase_auth),
 ):
     _ = firebase_uid  # auth-gate only; results are not user-scoped
     _no_store(response)
     try:
         return await _service().search(
-            lat=lat,
-            lng=lng,
-            postal_code=postal_code,
-            radius_mi=radius_mi,
-            limit=limit,
-            offset=offset,
-            advisor_type=advisor_type,
+            lat=payload.lat,
+            lng=payload.lng,
+            postal_code=payload.postal_code,
+            radius_mi=payload.radius_mi,
+            limit=payload.limit,
+            offset=payload.offset,
+            advisor_type=payload.advisor_type,
         )
     except AdvisorDirectoryError as exc:
         raise _handle(exc) from exc
@@ -73,6 +87,7 @@ async def advisor_profile(
     crd: str = Path(..., min_length=1, max_length=12),
     firebase_uid: str = Depends(require_firebase_auth),
 ):
+    # A CRD is a public FINRA identifier, not a location, so it is safe in a path.
     _ = firebase_uid
     _no_store(response)
     try:

--- a/consent-protocol/hushh_mcp/services/advisor_directory_service.py
+++ b/consent-protocol/hushh_mcp/services/advisor_directory_service.py
@@ -79,8 +79,13 @@ def _clamp(value: float, low: float, high: float) -> float:
     return max(low, min(high, value))
 
 
-def _unique(values: Iterable[str | None], limit: int = 12) -> list[str]:
-    """Order-preserving dedupe, dropping blanks and capping the list."""
+def _unique(values: Iterable[str | None], limit: int | None = None) -> list[str]:
+    """Order-preserving dedupe, dropping blanks.
+
+    ``limit`` is opt-in because the caller decides whether the list is being
+    shown or counted. Truncating a list the UI reports as a count turns it into
+    a wrong number: an adviser registered in 51 states rendered as "12".
+    """
     seen: set[str] = set()
     out: list[str] = []
     for value in values:
@@ -88,7 +93,7 @@ def _unique(values: Iterable[str | None], limit: int = 12) -> list[str]:
             continue
         seen.add(value)
         out.append(value)
-        if len(out) >= limit:
+        if limit is not None and len(out) >= limit:
             break
     return out
 
@@ -426,8 +431,8 @@ def _normalize_profile(
         "hasDisclosures": bool(profile.get("hasDisclosures")),
         "disclosureCount": len(disclosures) if isinstance(disclosures, list) else 0,
         # One state appears once per registration scope (BC and IA), so the raw
-        # list double-counts. The UI shows a count, and "51 states" would be a
-        # lie — dedupe while preserving order.
+        # list double-counts. The UI reports the length of this list, so it is
+        # deduped but never truncated — a cap here would render as a wrong count.
         "states": _unique(
             _text(entry.get("state")) if isinstance(entry, dict) else None
             for entry in (

--- a/consent-protocol/mcp_modules/log_redaction.py
+++ b/consent-protocol/mcp_modules/log_redaction.py
@@ -17,7 +17,13 @@ _TOKEN_PREFIXES = ("HCT:", "Bearer ")
 _TOKEN_VALUE_RE = re.compile(r"\b(?:Bearer\s+|HCT:)[A-Za-z0-9._~+/=-]+")
 _QUERY_SECRET_RE = re.compile(
     r"([?&](?:access_token|api[_-]?key|apikey|auth|client_secret|key|"
-    r"private_key|refresh_token|secret|signature|token)=)([^&\s\"'<>]+)",
+    r"private_key|refresh_token|secret|signature|token|"
+    # A person's position is as sensitive as a credential and leaks the same
+    # way. httpx logs every outbound request URL at INFO, so any provider call
+    # that carries coordinates in its query string — the advisor directory, the
+    # Maps geocoder — would otherwise write a home address to a retained log.
+    r"lat|latitude|latlng|lng|lon|longitude|coords|coordinates|postal_?code|zip)=)"
+    r"([^&\s\"'<>]+)",
     flags=re.IGNORECASE,
 )
 

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -37,3 +37,4 @@ tests/test_one_location_db_error_detail_cwe209.py
 tests/test_cloudbuild_step_arg_limit.py
 tests/services/test_advisor_directory_service.py
 tests/test_advisors_runtime_config_wiring.py
+tests/test_advisors_coordinate_privacy.py

--- a/consent-protocol/tests/test_advisors_coordinate_privacy.py
+++ b/consent-protocol/tests/test_advisors_coordinate_privacy.py
@@ -1,0 +1,87 @@
+"""A user's position must never reach a log line or a URL.
+
+Two independent sinks leaked it before this was pinned:
+
+1. The inbound request line. ``GET /api/one/advisors/nearby?lat=..&lng=..`` is
+   recorded verbatim by the access log, and also lands in browser history and
+   any Referer header. The search is a POST so there is no query string.
+
+2. The outbound provider call. httpx logs every request URL at INFO, and the
+   upstream directory requires coordinates as query parameters, so the only
+   lever there is redaction.
+
+Coordinates are treated as credential-grade here on purpose: a home address is
+not less sensitive than an API key.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from api.routes.one import advisors as advisors_routes
+from mcp_modules.log_redaction import SensitiveLogFilter
+
+
+def _redact(message: str) -> str:
+    record = logging.LogRecord("httpx", logging.INFO, "", 0, "%s", (message,), None)
+    SensitiveLogFilter().filter(record)
+    args = record.args
+    return args[0] if isinstance(args, tuple) else str(args)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "https://x/v1/advisors?lat=47.676900&lng=-122.206000&radiusMi=10.0",
+        "https://x/v1/advisors?latitude=47.6769&longitude=-122.206",
+        "https://maps.googleapis.com/maps/api/geocode/json?latlng=47.67,-122.20&key=k",
+        "https://x/v1/advisors?postalCode=98033&limit=10",
+    ],
+)
+def test_coordinates_are_redacted_from_outbound_request_logs(query: str) -> None:
+    redacted = _redact(f"HTTP Request: GET {query}")
+
+    assert "[REDACTED]" in redacted
+    for leak in ("47.676900", "47.6769", "-122.206000", "-122.206", "98033"):
+        assert leak not in redacted
+
+
+def test_redaction_leaves_harmless_parameters_readable() -> None:
+    """Over-redacting would make production logs useless for debugging."""
+    redacted = _redact("HTTP Request: GET https://x/v1/advisors?lat=1.0&radiusMi=10.0&limit=5")
+
+    assert "radiusMi=10.0" in redacted
+    assert "limit=5" in redacted
+
+
+def _routes() -> list[tuple[str, frozenset[str]]]:
+    return [(route.path, frozenset(route.methods or ())) for route in advisors_routes.router.routes]
+
+
+def test_the_search_is_a_post_so_no_position_reaches_the_request_line() -> None:
+    paths = dict(_routes())
+
+    assert "POST" in paths["/api/one/advisors/search"]
+    # The GET this replaced must be gone, not merely unused.
+    assert "/api/one/advisors/nearby" not in paths
+
+
+def test_no_advisor_route_accepts_a_location_as_a_query_parameter() -> None:
+    """A GET route on this router would put coordinates back in the URL."""
+    import inspect
+
+    for route in advisors_routes.router.routes:
+        if "GET" not in (route.methods or ()):
+            continue
+        params = inspect.signature(route.endpoint).parameters
+        for name in ("lat", "lng", "latitude", "longitude", "postal_code", "postalCode"):
+            assert name not in params, f"{route.path} takes {name} on a GET"
+
+
+def test_the_profile_route_carries_only_a_public_identifier() -> None:
+    """A CRD is a public FINRA id, so it is safe in a path; nothing else is."""
+    paths = dict(_routes())
+
+    assert "GET" in paths["/api/one/advisors/{crd}"]

--- a/hushh-webapp/__tests__/services/advisor-directory-service.test.ts
+++ b/hushh-webapp/__tests__/services/advisor-directory-service.test.ts
@@ -31,13 +31,20 @@ function requestedUrl(): URL {
   return new URL(String(mockApiFetch.mock.calls[0][0]), "https://app.test");
 }
 
+function requestedBody(): Record<string, unknown> {
+  const init = mockApiFetch.mock.calls[0][1] as RequestInit;
+  return JSON.parse(String(init.body));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockApiFetch.mockResolvedValue(jsonResponse(EMPTY_RESULT));
 });
 
 describe("AdvisorDirectoryService.searchNearby", () => {
-  it("sends coordinates and the bearer token to our own backend", async () => {
+  it("never puts the user's position in a URL", async () => {
+    // A query string lands in the server access log, browser history and any
+    // Referer. Coordinates travel in the request body instead.
     await AdvisorDirectoryService.searchNearby({
       idToken: "id-token",
       latitude: 47.676912,
@@ -46,17 +53,22 @@ describe("AdvisorDirectoryService.searchNearby", () => {
     });
 
     const url = requestedUrl();
-    expect(url.pathname).toBe("/api/one/advisors/nearby");
-    expect(url.searchParams.get("lat")).toBe("47.676912");
-    expect(url.searchParams.get("lng")).toBe("-122.206045");
-    expect(url.searchParams.get("radiusMi")).toBe("25");
-    expect(url.searchParams.get("limit")).toBe("10");
-    expect(url.searchParams.get("offset")).toBe("0");
+    expect(url.pathname).toBe("/api/one/advisors/search");
+    expect(url.search).toBe("");
+    expect(String(mockApiFetch.mock.calls[0][0])).not.toMatch(/47\.67|122\.20/);
 
     const init = mockApiFetch.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
     expect((init.headers as Record<string, string>).Authorization).toBe(
       "Bearer id-token",
     );
+    expect(requestedBody()).toMatchObject({
+      lat: 47.676912,
+      lng: -122.206045,
+      radiusMi: 25,
+      limit: 10,
+      offset: 0,
+    });
   });
 
   it("falls back to a postal code when there are no coordinates", async () => {
@@ -65,9 +77,10 @@ describe("AdvisorDirectoryService.searchNearby", () => {
       postalCode: "98033",
     });
 
-    const url = requestedUrl();
-    expect(url.searchParams.get("postalCode")).toBe("98033");
-    expect(url.searchParams.has("lat")).toBe(false);
+    const body = requestedBody();
+    expect(body.postalCode).toBe("98033");
+    expect(body.lat).toBeUndefined();
+    expect(requestedUrl().search).toBe("");
   });
 
   it("pages from the offset the server handed back", async () => {
@@ -78,7 +91,7 @@ describe("AdvisorDirectoryService.searchNearby", () => {
       offset: 30,
     });
 
-    expect(requestedUrl().searchParams.get("offset")).toBe("30");
+    expect(requestedBody().offset).toBe(30);
   });
 
   it("surfaces the server's message rather than a bare status", async () => {
@@ -163,8 +176,11 @@ describe("formatDistance", () => {
     expect(formatDistance(12.4)).toBe("~12 mi");
   });
 
-  it("never renders a zero distance", () => {
-    expect(formatDistance(0)).toBe("~0.1 mi");
+  it("renders nothing rather than inventing a distance", () => {
+    // A ZIP search measures from the centroid it was given, so every row comes
+    // back at exactly 0. "~0.1 mi" would be a number we made up.
+    expect(formatDistance(0)).toBeNull();
+    // A real, tiny coordinate distance still rounds up to the floor.
     expect(formatDistance(0.02)).toBe("~0.1 mi");
   });
 

--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -314,6 +314,55 @@ describe("AdvisorsNearby", () => {
     expect(screen.getByText("25 mi")).toBeTruthy();
   });
 
+  it("keeps the page on screen when Show more fails", async () => {
+    // A failed extra page must not take the results the user is already
+    // reading with it.
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValueOnce(
+      result({ meta: { ...result().meta, hasMore: true, nextOffset: 10 } }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    expect(await screen.findByText("Christine Cote")).toBeTruthy();
+
+    mocks.searchNearby.mockRejectedValueOnce(new Error("Try again shortly."));
+    fireEvent.click(screen.getByText("Show more"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Try again shortly.")).toBeTruthy(),
+    );
+    expect(screen.getByText("Christine Cote")).toBeTruthy();
+    expect(screen.queryByTestId("advisors-error")).toBeNull();
+  });
+
+  it("drops a stale paging cursor when a fresh search fails", async () => {
+    // Otherwise "Show more" survives the failure and pages into a list that no
+    // longer exists.
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 1, longitude: 2 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValueOnce(
+      result({ meta: { ...result().meta, hasMore: true, nextOffset: 10 } }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    expect(await screen.findByText("Show more")).toBeTruthy();
+
+    mocks.searchNearby.mockRejectedValueOnce(new Error("Not available yet."));
+    fireEvent.click(screen.getByText("25 mi"));
+
+    expect(await screen.findByTestId("advisors-error")).toBeTruthy();
+    expect(screen.queryByText("Show more")).toBeNull();
+  });
+
   it("shows a failure without wiping the surface", async () => {
     mocks.locationState = {
       status: "ready",

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -199,6 +199,8 @@ export function AdvisorsNearby({
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** A failed extra page. Kept apart from `error` so it never hides the list. */
+  const [pageError, setPageError] = useState<string | null>(null);
   const [selected, setSelected] = useState<AdvisorCard | null>(null);
 
   const requestRef = useRef(0);
@@ -225,6 +227,7 @@ export function AdvisorsNearby({
       } else {
         setLoadingMore(true);
       }
+      setPageError(null);
 
       try {
         const idToken = await getIdToken();
@@ -246,12 +249,20 @@ export function AdvisorsNearby({
         );
       } catch (caught) {
         if (token !== requestRef.current) return;
-        setError(
+        const message =
           caught instanceof Error
             ? caught.message
-            : "Advisors are unavailable right now.",
-        );
-        if (offset === 0) setCards([]);
+            : "Advisors are unavailable right now.";
+        if (offset === 0) {
+          // A fresh search that failed has nothing to show, and its old paging
+          // cursor now points into a list that no longer exists.
+          setError(message);
+          setCards([]);
+          setMeta(null);
+        } else {
+          // A failed page must not take the page already on screen with it.
+          setPageError(message);
+        }
       } finally {
         if (token === requestRef.current) {
           setLoading(false);
@@ -384,8 +395,13 @@ export function AdvisorsNearby({
         </SettingsGroup>
       )}
 
-      {meta?.hasMore && !loading ? (
-        <div className="flex justify-center">
+      {meta?.hasMore && typeof meta.nextOffset === "number" && !loading ? (
+        <div className="flex flex-col items-center gap-2">
+          {pageError ? (
+            <p className="type-footnote text-muted-foreground" role="status">
+              {pageError}
+            </p>
+          ) : null}
           <Button
             type="button"
             variant="none"
@@ -398,7 +414,7 @@ export function AdvisorsNearby({
               }
             }}
           >
-            {loadingMore ? "Loading…" : "Show more"}
+            {loadingMore ? "Loading…" : pageError ? "Try again" : "Show more"}
           </Button>
         </div>
       ) : null}

--- a/hushh-webapp/lib/services/advisor-directory-service.ts
+++ b/hushh-webapp/lib/services/advisor-directory-service.ts
@@ -106,23 +106,33 @@ export class AdvisorDirectoryService {
     offset?: number;
     signal?: AbortSignal;
   }): Promise<AdvisorSearchResult> {
-    const params = new URLSearchParams();
-    if (typeof opts.latitude === "number" && typeof opts.longitude === "number") {
-      params.set("lat", opts.latitude.toFixed(6));
-      params.set("lng", opts.longitude.toFixed(6));
+    // POST, not GET: a query string puts the user's exact position in the
+    // request line, which the server access log records verbatim and which also
+    // lands in browser history and any Referer header.
+    const body: Record<string, unknown> = {
+      limit: opts.limit ?? ADVISOR_PAGE_SIZE,
+      offset: opts.offset ?? 0,
+    };
+    if (
+      typeof opts.latitude === "number" &&
+      typeof opts.longitude === "number"
+    ) {
+      body.lat = Number(opts.latitude.toFixed(6));
+      body.lng = Number(opts.longitude.toFixed(6));
     } else if (opts.postalCode) {
-      params.set("postalCode", opts.postalCode);
+      body.postalCode = opts.postalCode;
     }
-    if (typeof opts.radiusMi === "number") {
-      params.set("radiusMi", String(opts.radiusMi));
-    }
-    params.set("limit", String(opts.limit ?? ADVISOR_PAGE_SIZE));
-    params.set("offset", String(opts.offset ?? 0));
+    if (typeof opts.radiusMi === "number") body.radiusMi = opts.radiusMi;
 
-    const response = await ApiService.apiFetch(
-      `/api/one/advisors/nearby?${params.toString()}`,
-      { method: "GET", headers: authHeaders(opts.idToken), signal: opts.signal },
-    );
+    const response = await ApiService.apiFetch("/api/one/advisors/search", {
+      method: "POST",
+      headers: {
+        ...authHeaders(opts.idToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: opts.signal,
+    });
     return jsonOrThrow<AdvisorSearchResult>(response);
   }
 
@@ -133,7 +143,11 @@ export class AdvisorDirectoryService {
   }): Promise<AdvisorProfile> {
     const response = await ApiService.apiFetch(
       `/api/one/advisors/${encodeURIComponent(opts.crd)}`,
-      { method: "GET", headers: authHeaders(opts.idToken), signal: opts.signal },
+      {
+        method: "GET",
+        headers: authHeaders(opts.idToken),
+        signal: opts.signal,
+      },
     );
     const payload = await jsonOrThrow<{ profile: AdvisorProfile }>(response);
     return payload.profile;
@@ -144,10 +158,17 @@ export class AdvisorDirectoryService {
  * FINRA geocodes offices to ZIP centroids, so an exact figure would be a
  * fiction — every adviser in a ZIP shares one coordinate. Always approximate.
  */
-export function formatDistance(miles: number | null | undefined): string | null {
+export function formatDistance(
+  miles: number | null | undefined,
+): string | null {
   if (typeof miles !== "number" || !Number.isFinite(miles) || miles < 0) {
     return null;
   }
+  // A postal-code search measures from the ZIP centroid, which *is* the query
+  // point, so every row comes back at exactly 0. Showing "~0.1 mi" there would
+  // invent a number. A coordinate search never yields 0 — the upstream floors
+  // those at 500 m — so treating 0 as "no usable distance" is safe.
+  if (miles === 0) return null;
   if (miles >= 10) return `~${Math.round(miles)} mi`;
   return `~${Math.max(0.1, Math.round(miles * 10) / 10).toFixed(1)} mi`;
 }


### PR DESCRIPTION
Found by an adversarial review of the already-merged feature (#4799, #4802, #4803). 50 candidate findings, 9 survived independent refutation. This fixes the high-severity one and three others.

## The module docstring was false

`advisor_directory_service.py` and `advisors.py` both claim coordinates are *"never persisted or logged"*. They were, twice per request. Confirmed in a captured local backend log holding a real home position at six decimal places — roughly 11 cm.

**Sink 1 — the inbound request line.** `GET /api/one/advisors/nearby?lat=..&lng=..` is recorded verbatim by the access log, and also lands in browser history and any `Referer`. The search is now `POST /api/one/advisors/search` with the position in the body. The Maps proxy endpoints in `api/routes/one/location.py` are POST for exactly this reason — this route should have followed that precedent from the start.

**Sink 2 — the outbound provider call.** httpx logs every request URL at INFO, and the upstream directory requires coordinates as query parameters, so redaction is the only lever. `SensitiveLogFilter` was already installed on the `httpx` logger and already handled URL objects; its query rule just had no coordinate terms. Adding them **also closes the same leak in the Maps geocoder**, which has been writing `latlng` to the log since long before this feature.

Coordinates are treated as credential-grade deliberately. A home address is not less sensitive than an API key, and this codebase already refuses plaintext location elsewhere (`_contains_plaintext_location_key`).

Verified against a running backend: **13 log lines carrying raw coordinates before, 0 after.**

## Three correctness defects from the same review

- **A failed "Show more" erased the page you were reading.** The error block replaced the list. A failed page now reports next to the button and leaves the results alone.
- **A failed fresh search kept its paging cursor**, so "Show more" survived and paged into a list that no longer existed.
- **A ZIP search rendered a fabricated distance.** It measures from the centroid it was handed, so every row is exactly 0 miles and displayed as "~0.1 mi". Distance is omitted at zero; a coordinate search never returns zero because the upstream floors those at 500 m.

## One from a live run

`_unique` capped registered states at 12 while the detail sheet renders that list's *length* as a count — an adviser licensed in 51 states read as "12". The cap is now opt-in and unused for counted lists.

## Tests

8 new backend tests pinning the privacy invariant: coordinates redacted from outbound logs (including the Maps case), harmless params still readable, the search is POST, the removed GET is gone rather than merely unused, and no GET route on this router accepts a location parameter.

2 new frontend tests for the pagination defects. Backend CI suite 488 passed; frontend 46 passed across the affected files.

## Not fixed here, reported instead

- **Rate limiting is keyed by IP, not principal.** `get_rate_limit_key` only decodes HCT consent tokens; these routes authenticate with Firebase, so they fall back to the IP bucket. Fixing it means teaching shared middleware about Firebase tokens — real blast radius, deserves its own change.
- **`wallet_pass_team_identifier` has no producer**, so pkpass signing cannot complete in any environment. Different feature, different owner.
- **The Cloud Build arg-ceiling guard does not measure the production lane** — the same guard that caught my regression earlier only checks some files.

---
Closes #4906
(retroactive board-linkage backfill, 2026-08-06)