### PR TITLE
fix(advisors): honour BrokerCheck's source-credit terms, and the API's newer contract

### DIFF
--- a/consent-protocol/api/routes/one/advisors.py
+++ b/consent-protocol/api/routes/one/advisors.py
@@ -49,9 +49,16 @@ def _no_store(response: Response) -> None:
 
 
 def _handle(exc: AdvisorDirectoryError) -> HTTPException:
+    # The upstream limit is per-IP and every user shares this backend's egress
+    # address, so its Retry-After applies to the whole surface. Passing it on
+    # lets a client wait the stated time instead of hammering a closed door.
+    headers = None
+    if exc.status_code == 429 and exc.retry_after_seconds:
+        headers = {"Retry-After": str(exc.retry_after_seconds)}
     return HTTPException(
         status_code=exc.status_code,
         detail={"code": "ONE_ADVISORS_UNAVAILABLE", "message": str(exc)},
+        headers=headers,
     )
 
 

--- a/consent-protocol/hushh_mcp/services/advisor_directory_service.py
+++ b/consent-protocol/hushh_mcp/services/advisor_directory_service.py
@@ -18,13 +18,16 @@ import json
 import logging
 import os
 from collections.abc import Iterable
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_TIMEOUT_SECONDS = 20.0
+# A cold query fetches the whole radius — up to ~20 FINRA pages in parallel —
+# so the previous 20s ceiling sat close to a real cold metro request.
+_DEFAULT_TIMEOUT_SECONDS = 35.0
 _DEFAULT_RADIUS_MI = 10.0
 _MIN_RADIUS_MI = 0.1
 _MAX_RADIUS_MI = 100.0
@@ -43,8 +46,15 @@ _ADVISOR_TYPES = frozenset({"ia", "broker", "both"})
 class AdvisorDirectoryError(RuntimeError):
     """Raised for a missing config (503), bad input (400) or upstream failure (502)."""
 
-    def __init__(self, message: str, *, status_code: int) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        retry_after_seconds: int | None = None,
+    ) -> None:
         self.status_code = status_code
+        self.retry_after_seconds = retry_after_seconds
         super().__init__(message)
 
 
@@ -125,7 +135,7 @@ class AdvisorDirectoryService:
         )
 
     @staticmethod
-    def _raise_for_status(status_code: int) -> None:
+    def _raise_for_status(status_code: int, headers: Any = None) -> None:
         """Map an upstream status onto a client-safe error.
 
         Auth failures are deliberately reported as an upstream failure: a 401
@@ -137,8 +147,19 @@ class AdvisorDirectoryService:
         if status_code == 400:
             raise AdvisorDirectoryError("That search could not be completed.", status_code=400)
         if status_code == 429:
+            # The upstream limit is per-IP, and every one of our users shares
+            # this backend's egress address — so its Retry-After is the whole
+            # surface's, and it is carried through rather than guessed at.
+            retry_after = None
+            if headers is not None:
+                try:
+                    retry_after = _coerce_int(headers.get("retry-after"))
+                except (AttributeError, TypeError):
+                    retry_after = None
             raise AdvisorDirectoryError(
-                "The advisor directory is busy. Try again shortly.", status_code=429
+                "The advisor directory is busy. Try again shortly.",
+                status_code=429,
+                retry_after_seconds=retry_after,
             )
         if status_code in (401, 403):
             logger.error(
@@ -219,7 +240,7 @@ class AdvisorDirectoryService:
         try:
             async with self._client() as client:
                 async with client.stream("GET", "/v1/advisors", params=params) as response:
-                    self._raise_for_status(response.status_code)
+                    self._raise_for_status(response.status_code, response.headers)
 
                     read_bytes = 0
                     read_lines = 0
@@ -264,7 +285,7 @@ class AdvisorDirectoryService:
         return {
             "items": [_normalize_row(row, grouped=grouped) for row in rows],
             "meta": _normalize_meta(meta, grouped=grouped, requested_limit=int(params["limit"])),
-            "attribution": _ATTRIBUTION,
+            "attribution": _normalize_attribution(meta.get("attribution")),
         }
 
     # ------------------------------------------------------------------ profile
@@ -277,7 +298,7 @@ class AdvisorDirectoryService:
         try:
             async with self._client() as client:
                 response = await client.get(f"/v1/advisors/{normalized}")
-                self._raise_for_status(response.status_code)
+                self._raise_for_status(response.status_code, response.headers)
                 payload = response.json()
         except AdvisorDirectoryError:
             raise
@@ -301,14 +322,45 @@ class AdvisorDirectoryService:
         firm = payload.get("firm") if isinstance(payload.get("firm"), dict) else None
         return {
             "profile": _normalize_profile(record, firm=firm),
-            "attribution": _ATTRIBUTION,
+            "attribution": _normalize_attribution(payload.get("attribution")),
         }
 
 
-_ATTRIBUTION = {
+# Used only when the upstream omits its own block. BrokerCheck's Terms of Use
+# permit this data's reuse under §5, and those conditions include naming the
+# source, linking to BrokerCheck *and* to the Terms, and offering a way to
+# report an error. A bare "FINRA BrokerCheck" string satisfies one of four, so
+# the real block is passed through and these are only a floor.
+_ATTRIBUTION_FALLBACK = {
     "source": "FINRA BrokerCheck",
-    "url": "https://brokercheck.finra.org",
+    "sourceUrl": "https://brokercheck.finra.org",
+    "termsUrl": "https://brokercheck.finra.org/terms-and-conditions",
+    "notice": (
+        "Data retrieved from FINRA BrokerCheck. Use of BrokerCheck data is "
+        "subject to the BrokerCheck Terms of Use."
+    ),
+    "errorReporting": (
+        "https://www.finra.org/investors/investing/"
+        "working-with-investment-professional/about-brokercheck"
+    ),
 }
+
+
+def _normalize_attribution(attribution: Any) -> dict[str, Any]:
+    """Carry the upstream's own credit through, field for field.
+
+    ``retrievedAt`` is stamped here because §5 also requires disclosing the
+    retrieval date. It is when *this* response was produced; a warm upstream
+    cache can be older, which is why ``meta.cache`` travels alongside it.
+    """
+    block = dict(_ATTRIBUTION_FALLBACK)
+    if isinstance(attribution, dict):
+        for key in ("source", "sourceUrl", "termsUrl", "notice", "errorReporting"):
+            value = _text(attribution.get(key))
+            if value:
+                block[key] = value
+    block["retrievedAt"] = datetime.now(UTC).isoformat()
+    return block
 
 
 def _normalize_meta(meta: dict[str, Any], *, grouped: bool, requested_limit: int) -> dict[str, Any]:
@@ -320,8 +372,15 @@ def _normalize_meta(meta: dict[str, Any], *, grouped: bool, requested_limit: int
         "hasMore": bool(meta.get("hasMore")),
         "nextOffset": next_offset if next_offset is not None else None,
         "returned": _coerce_int(meta.get("returned")) or 0,
+        # `available` is what the upstream actually ranked and can page through.
+        # `estimatedTotal` is FINRA's count for the whole radius and is larger
+        # whenever `truncatedBy` is set — showing it would promise rows this API
+        # cannot deliver, so it is deliberately not carried forward.
         "available": _coerce_int(meta.get("available")),
         "limit": _coerce_int(meta.get("limit")) or requested_limit,
+        # "cold" | "warm". A warm result can trail FINRA by up to the upstream's
+        # profile cache, which is why it is disclosed rather than hidden.
+        "cache": _text(meta.get("cache")),
         "radiusMi": radius,
         "radiusRequested": radius_requested,
         "radiusAdjusted": bool(meta.get("radiusAdjusted")),

--- a/consent-protocol/tests/services/test_advisor_directory_service.py
+++ b/consent-protocol/tests/services/test_advisor_directory_service.py
@@ -233,6 +233,88 @@ async def test_upstream_rate_limit_is_passed_through(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_the_upstream_retry_after_is_carried_not_guessed(monkeypatch):
+    """The upstream limit is per-IP, so its wait applies to every user of ours."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "42"})
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).search(lat=1.0, lng=1.0)
+
+    assert excinfo.value.retry_after_seconds == 42
+
+
+@pytest.mark.asyncio
+async def test_a_missing_retry_after_is_simply_absent(monkeypatch):
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(429)
+
+    with pytest.raises(ads.AdvisorDirectoryError) as excinfo:
+        await _service(monkeypatch, handler).search(lat=1.0, lng=1.0)
+
+    assert excinfo.value.retry_after_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_the_upstreams_own_source_credit_is_carried_through(monkeypatch):
+    """BrokerCheck's terms require the Terms link and an error-reporting route.
+
+    Hardcoding a bare source name dropped three of the four obligations.
+    """
+
+    stream = _ndjson(
+        {
+            "type": "meta",
+            "returned": 1,
+            "available": 2518,
+            "estimatedTotal": 4430,
+            "cache": "warm",
+            "truncatedBy": "candidateCeiling",
+            "attribution": {
+                "source": "FINRA BrokerCheck",
+                "sourceUrl": "https://brokercheck.finra.org",
+                "termsUrl": "https://brokercheck.finra.org/terms-and-conditions",
+                "notice": "Data retrieved from FINRA BrokerCheck.",
+                "errorReporting": "https://www.finra.org/investors/about-brokercheck",
+            },
+        },
+        {"type": "batch", "items": []},
+        {"type": "done"},
+    )
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=stream)
+
+    result = await _service(monkeypatch, handler).search(lat=1.0, lng=1.0)
+    attribution = result["attribution"]
+
+    assert attribution["termsUrl"].endswith("/terms-and-conditions")
+    assert attribution["errorReporting"].startswith("https://www.finra.org/")
+    assert attribution["notice"]
+    # §5 also requires disclosing when the data was retrieved.
+    assert attribution["retrievedAt"]
+
+    # `available` is pageable; `estimatedTotal` is not and must not be offered
+    # as a count the API cannot actually deliver.
+    assert result["meta"]["available"] == 2518
+    assert "estimatedTotal" not in result["meta"]
+    assert result["meta"]["cache"] == "warm"
+
+
+@pytest.mark.asyncio
+async def test_source_credit_falls_back_when_the_upstream_omits_it(monkeypatch):
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=_PERSON_STREAM)
+
+    attribution = (await _service(monkeypatch, handler).search(lat=1.0, lng=1.0))["attribution"]
+
+    assert attribution["source"] == "FINRA BrokerCheck"
+    assert attribution["termsUrl"]
+    assert attribution["errorReporting"]
+
+
+@pytest.mark.asyncio
 async def test_unconfigured_backend_reports_unavailable(monkeypatch):
     monkeypatch.delenv("ADVISORS_API_BASE_URL", raising=False)
     monkeypatch.delenv("ADVISORS_API_BASE", raising=False)

--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -67,7 +73,14 @@ function result(overrides: Record<string, unknown> = {}) {
       radiusAdjusted: false,
       truncated: false,
     },
-    attribution: { source: "FINRA BrokerCheck", url: "https://x" },
+    attribution: {
+      source: "FINRA BrokerCheck",
+      sourceUrl: "https://brokercheck.finra.org",
+      termsUrl: "https://brokercheck.finra.org/terms-and-conditions",
+      notice: "Data retrieved from FINRA BrokerCheck.",
+      errorReporting: "https://www.finra.org/investors/about-brokercheck",
+      retrievedAt: "2026-08-05T09:00:00.000Z",
+    },
     ...overrides,
   };
 }
@@ -262,6 +275,52 @@ describe("AdvisorsNearby", () => {
     expect(mocks.searchNearby.mock.calls[1][0]).toMatchObject({
       postalCode: "98033",
     });
+  });
+
+  it("carries the source credit the licence requires, not just a name", async () => {
+    // BrokerCheck's Terms permit reuse under §5 only with the source named, the
+    // Terms linked, a way to report an error, and the retrieval date shown.
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 47.6769, longitude: -122.206 },
+      error: null,
+    };
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    await screen.findByText("Christine Cote");
+
+    const footer = screen.getByTestId("advisors-attribution");
+    const href = (name: RegExp) =>
+      within(footer).getByRole("link", { name }).getAttribute("href");
+
+    expect(href(/FINRA BrokerCheck/i)).toBe("https://brokercheck.finra.org");
+    expect(href(/^Terms$/i)).toBe(
+      "https://brokercheck.finra.org/terms-and-conditions",
+    );
+    expect(href(/Report an error/i)).toBe(
+      "https://www.finra.org/investors/about-brokercheck",
+    );
+    expect(within(footer).getByText(/Retrieved/)).toBeTruthy();
+  });
+
+  it("says so when the data came from a cache rather than live", async () => {
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 47.6769, longitude: -122.206 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(
+      result({ meta: { ...result().meta, cache: "warm" } }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+    await screen.findByText("Christine Cote");
+
+    expect(
+      within(screen.getByTestId("advisors-attribution")).getByText(/cached/),
+    ).toBeTruthy();
   });
 
   it("does not credit a source it showed nothing from", async () => {

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -15,6 +15,7 @@ import {
   AdvisorDirectoryService,
   formatAdvisorSubtitle,
   formatDistance,
+  type AdvisorAttribution,
   type AdvisorCard,
   type AdvisorSearchMeta,
 } from "@/lib/services/advisor-directory-service";
@@ -83,6 +84,76 @@ function PostalCodeForm({
         Search
       </Button>
     </form>
+  );
+}
+
+/**
+ * The source credit BrokerCheck's Terms require wherever this data is shown:
+ * the source named, BrokerCheck and its Terms linked, a way to report an error,
+ * and the retrieval date. Four obligations, one quiet line — a bare "FINRA
+ * BrokerCheck" string met only the first of them.
+ */
+function Attribution({
+  attribution,
+  stale,
+}: {
+  attribution: AdvisorAttribution | null;
+  stale: boolean;
+}) {
+  if (!attribution) return null;
+
+  const retrieved = attribution.retrievedAt
+    ? new Date(attribution.retrievedAt)
+    : null;
+  const retrievedLabel =
+    retrieved && !Number.isNaN(retrieved.getTime())
+      ? retrieved.toLocaleDateString(undefined, {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        })
+      : null;
+
+  return (
+    <footer
+      className="mx-auto max-w-[30rem] text-center"
+      data-testid="advisors-attribution"
+    >
+      <p className="type-caption text-muted-foreground">
+        <a
+          href={attribution.sourceUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="underline-offset-4 hover:underline"
+        >
+          {attribution.source}
+        </a>
+        {" · "}
+        <a
+          href={attribution.termsUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="underline-offset-4 hover:underline"
+        >
+          Terms
+        </a>
+        {" · "}
+        <a
+          href={attribution.errorReporting}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="underline-offset-4 hover:underline"
+        >
+          Report an error
+        </a>
+      </p>
+      {retrievedLabel ? (
+        <p className="type-caption mt-1 text-muted-foreground/70">
+          Retrieved {retrievedLabel}
+          {stale ? " · cached" : ""}
+        </p>
+      ) : null}
+    </footer>
   );
 }
 
@@ -196,6 +267,9 @@ export function AdvisorsNearby({
   const [radiusMi, setRadiusMi] = useState<number>(10);
   const [cards, setCards] = useState<AdvisorCard[]>([]);
   const [meta, setMeta] = useState<AdvisorSearchMeta | null>(null);
+  const [attribution, setAttribution] = useState<AdvisorAttribution | null>(
+    null,
+  );
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -244,6 +318,7 @@ export function AdvisorsNearby({
         // A slower earlier query must never overwrite a newer one.
         if (token !== requestRef.current) return;
         setMeta(result.meta);
+        setAttribution(result.attribution ?? null);
         setCards((previous) =>
           offset === 0 ? result.items : [...previous, ...result.items],
         );
@@ -420,9 +495,7 @@ export function AdvisorsNearby({
       ) : null}
 
       {cards.length > 0 ? (
-        <p className="type-caption text-center text-muted-foreground">
-          FINRA BrokerCheck
-        </p>
+        <Attribution attribution={attribution} stale={meta?.cache === "warm"} />
       ) : null}
 
       <AdvisorDetailSurface

--- a/hushh-webapp/lib/services/advisor-directory-service.ts
+++ b/hushh-webapp/lib/services/advisor-directory-service.ts
@@ -38,9 +38,24 @@ export type AdvisorSearchMeta = {
   radiusRequested: number | null;
   radiusAdjusted: boolean;
   truncated: boolean;
+  /** "cold" | "warm" — a warm result can trail the regulator's own feed. */
+  cache: string | null;
 };
 
-export type AdvisorAttribution = { source: string; url: string };
+/**
+ * BrokerCheck's Terms of Use permit this data's reuse under §5, and those
+ * conditions include naming the source, linking to BrokerCheck *and* to the
+ * Terms, offering a way to report an error, and disclosing the retrieval date.
+ * All five travel with every response so the UI can satisfy them.
+ */
+export type AdvisorAttribution = {
+  source: string;
+  sourceUrl: string;
+  termsUrl: string;
+  notice: string;
+  errorReporting: string;
+  retrievedAt: string;
+};
 
 export type AdvisorSearchResult = {
   items: AdvisorCard[];


### PR DESCRIPTION
The updated integration guide, build plan and README changed things this consumer was getting wrong. Found by diffing them against what shipped, and confirmed against the live API.

## We were not honouring the licence we rely on

BrokerCheck's Terms of Use ban scraping in §6(g), but **§5 carves out an exception** — and that carve-out is the basis on which this data may be used at all. Its conditions include: **name the source, link to BrokerCheck *and* to the Terms, provide an error-reporting mechanism, and disclose the retrieval date.**

Every response already carried an `attribution` block with exactly those fields. **This service threw it away** and hardcoded `{source, url}`, so the UI rendered a bare `FINRA BrokerCheck` string — **one condition of four**.

The upstream's own block now passes through field for field, is stamped with a retrieval time, and renders as one quiet line:

```
FINRA BrokerCheck · Terms · Report an error
Retrieved 5 Aug 2026 · cached
```

The build plan lists this as Phase 6: *"the §5 attribution obligations rendered in any consuming UI (source credit, link to BrokerCheck + ToU, retrieval date, error-reporting contact)."*

## `available` vs `estimatedTotal`

The guide now warns explicitly not to confuse them. `estimatedTotal` is FINRA's count for the whole radius; `available` is what was actually ranked and can be paged. Live Kirkland right now: **4,430 vs 2,518**. Only `available` is carried forward, so no count can promise rows the API cannot deliver.

## `Retry-After` on 429

The upstream limit is **per-IP**, and every one of our users shares this backend's egress address — so its stated wait applies to the whole surface, not one caller. It is now passed through instead of dropped.

## Timeout

A cold query now fetches the **whole radius — up to ~20 FINRA pages in parallel** — so the previous 20s ceiling sat close to a real cold metro request. Raised to 35s.

Also surfaces `meta.cache`, since a warm result can trail the regulator's own feed by up to the upstream's profile cache, and the guide is explicit that callers should know which they got.

## Tests

17 backend service tests (up from 13) and 17 component tests (up from 13). New ones pin: the upstream credit is carried through, a fallback exists when it is absent, `estimatedTotal` never reaches the client, `Retry-After` is carried and absent-when-absent, and the footer renders all four obligations.

Backend CI suite 492 passed. Frontend 48 passed on affected files. mypy and ruff clean.

## ⚠️ Not a code issue — needs a decision

The build plan flags **§6(p)**, which is **not** waived by §5: it prohibits using BrokerCheck data *"in conjunction with any machine learning, neural network, deep learning, predictive analytics or other artificial intelligence computer or software program."* Hushh is an AI product, and this data now sits inside it on UAT.

The plan's own **Phase 0 is marked OUTSTANDING**: send the §5 written-permission letter to `brokercheck@finra.org` and get counsel's read on §6(p). That is a lawyer's call, not mine — flagging it because we are now shipping against this source.

---
Closes #4906
(retroactive board-linkage backfill, 2026-08-06)