### PR TITLE
fix(advisors): mirror the directory key instead of copying it once

### DIFF
--- a/consent-protocol/tests/test_advisors_runtime_config_wiring.py
+++ b/consent-protocol/tests/test_advisors_runtime_config_wiring.py
@@ -33,7 +33,8 @@ _CONFIG_ARGS = (
     "plaid_redirect_uri plaid_tx_history_days one_location_read_only_state_enabled "
     "consent_center_summary_v2_enabled db_bulk_batching_enabled "
     "hushh_trusted_device_enabled hushh_trusted_device_uat_allowlist "
-    "advisors_api_base_url"
+    "advisors_api_base_url advisors_api_key_source_project "
+    "advisors_api_key_source_secret"
 ).split()
 
 
@@ -84,6 +85,81 @@ def test_the_service_reports_unavailable_without_a_key(monkeypatch):
     monkeypatch.delenv("ADVISORS_API_KEY", raising=False)
 
     assert ads.is_configured() is False
+
+
+def test_the_directory_key_is_mirrored_from_its_home_project(monkeypatch):
+    """A hand-copied key does not follow a rotation; a mirrored one does.
+
+    The source rotated and disabled the old version while UAT still held the
+    copy, so the surface answered 502 with a revoked credential.
+    """
+    module = _load_sync_module()
+    reads: list[tuple[str, str]] = []
+    writes: list[tuple[str, str, str]] = []
+
+    def fake_read(project: str, secret: str) -> str:
+        reads.append((project, secret))
+        if (project, secret) == ("hushh-tech-prod", "brokercheck-api-key"):
+            return "rotated-key"
+        return "stale-key"
+
+    monkeypatch.setattr(module, "_read_secret", fake_read)
+    monkeypatch.setattr(module, "_upsert_secret", lambda p, s, v: writes.append((p, s, v)))
+
+    status = module._sync_advisors_api_key(
+        _namespace(
+            advisors_api_key_source_project="hushh-tech-prod",
+            # noqa comment: this is a secret *name*, not a credential value.
+            advisors_api_key_source_secret="brokercheck-api-key",  # noqa: S106
+        )
+    )
+
+    assert ("hushh-tech-prod", "brokercheck-api-key") in reads
+    assert writes == [("hushh-pda-uat", "ADVISORS_API_KEY", "rotated-key")]
+    assert status and "rotated" in status
+
+
+def test_an_unchanged_key_does_not_mint_a_secret_version(monkeypatch):
+    """The shared upsert helper adds a version unconditionally."""
+    module = _load_sync_module()
+    writes: list = []
+
+    monkeypatch.setattr(module, "_read_secret", lambda project, secret: "same-key")
+    monkeypatch.setattr(module, "_upsert_secret", lambda p, s, v: writes.append(s))
+
+    status = module._sync_advisors_api_key(
+        _namespace(
+            advisors_api_key_source_project="hushh-tech-prod",
+            # noqa comment: this is a secret *name*, not a credential value.
+            advisors_api_key_source_secret="brokercheck-api-key",  # noqa: S106
+        )
+    )
+
+    assert writes == []
+    assert status and "unchanged" in status
+
+
+def test_a_lane_without_access_to_the_source_is_left_inert(monkeypatch):
+    """A dev lane with no cross-project read must not fail its deploy."""
+    module = _load_sync_module()
+
+    monkeypatch.setattr(module, "_read_secret", lambda project, secret: "")
+    monkeypatch.setattr(
+        module,
+        "_upsert_secret",
+        lambda *a: pytest.fail("must not write without a source value"),
+    )
+
+    assert (
+        module._sync_advisors_api_key(
+            _namespace(
+                advisors_api_key_source_project="hushh-tech-prod",
+                # noqa comment: this is a secret *name*, not a credential value.
+                advisors_api_key_source_secret="brokercheck-api-key",  # noqa: S106
+            )
+        )
+        is None
+    )
 
 
 def test_the_deploy_workflows_pass_the_flag_they_configure():

--- a/scripts/ops/sync_backend_runtime_secrets.py
+++ b/scripts/ops/sync_backend_runtime_secrets.py
@@ -37,7 +37,9 @@ LEGACY_SECRET_FALLBACKS: dict[str, tuple[str, ...]] = {
 }
 
 
-def _run(cmd: list[str], *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+def _run(
+    cmd: list[str], *, input_text: str | None = None, check: bool = True
+) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         cmd,
         input=input_text,
@@ -189,6 +191,36 @@ def _build_backend_runtime_config(args: argparse.Namespace) -> dict[str, Any]:
     return _drop_empty(config)
 
 
+def _sync_advisors_api_key(args: argparse.Namespace) -> str | None:
+    """Mirror the advisor-directory key from its home project into this lane.
+
+    The key lives in one project and is consumed by several. Copying it by hand
+    is exactly what broke UAT: the source rotated and disabled the old version,
+    the hand-made copy did not follow, and the surface began answering 502 with
+    a revoked credential. Re-mirroring on every deploy bounds that drift to a
+    single release instead of forever.
+
+    A lane without read access to the source simply gets nothing, and the
+    feature stays inert there rather than failing the deploy.
+    """
+    source_project = str(args.advisors_api_key_source_project or "").strip()
+    source_secret = str(args.advisors_api_key_source_secret or "").strip()
+    if not (source_project and source_secret):
+        return None
+
+    value = _read_secret(source_project, source_secret)
+    if not value:
+        return None
+
+    if _read_secret(args.project, "ADVISORS_API_KEY") == value:
+        # The shared upsert helper adds a version unconditionally; skipping the
+        # write keeps a no-op deploy from minting a secret version each time.
+        return "ADVISORS_API_KEY (unchanged)"
+
+    _upsert_secret(args.project, "ADVISORS_API_KEY", value)
+    return "ADVISORS_API_KEY (rotated)"
+
+
 def _upsert_secret(project: str, secret: str, value: str) -> None:
     _run(
         [
@@ -238,12 +270,24 @@ def main() -> int:
     # Build's arg ceiling. Blank leaves it out entirely and the surface reports
     # unavailable; the bearer key is a real secret and is mounted separately.
     parser.add_argument("--advisors-api-base-url", default="")
+    # The directory key is owned by one project and consumed by several, so it
+    # is mirrored rather than copied by hand — see _sync_advisors_api_key.
+    parser.add_argument("--advisors-api-key-source-project", default="hushh-tech-prod")
+    parser.add_argument("--advisors-api-key-source-secret", default="brokercheck-api-key")
     args = parser.parse_args()
 
     sync_summary: list[str] = []
 
+    advisors_key_status = _sync_advisors_api_key(args)
+    if advisors_key_status:
+        sync_summary.append(advisors_key_status)
+
     for canonical_name, fallback_names in LEGACY_SECRET_FALLBACKS.items():
-        if canonical_name in {"APP_FRONTEND_ORIGIN", "BACKEND_RUNTIME_CONFIG_JSON", "VOICE_RUNTIME_CONFIG_JSON"}:
+        if canonical_name in {
+            "APP_FRONTEND_ORIGIN",
+            "BACKEND_RUNTIME_CONFIG_JSON",
+            "VOICE_RUNTIME_CONFIG_JSON",
+        }:
             continue
         value = _resolve_secret(args.project, fallback_names)
         if not value:


### PR DESCRIPTION
Found while verifying the previous change: **UAT was silently broken.**

## What happened

`brokercheck-api-key` rotated at 20:21 and its previous version was **disabled**. UAT was still holding a hand-made copy of that version, so the directory answered `502` against a **revoked credential** — and nothing surfaced it, because from the outside a dead key is indistinguishable from an unreachable provider.

That copy was mine, and the service's own README warns against exactly it:

> anything pinned to `:latest` picks the new key up on its next restart; **anything holding a copied literal breaks** — which is the reason to mount rather than copy.

UAT and local have already been re-synced by hand, so the surface is serving again. This PR stops it recurring.

## The fix

The deploy now mirrors the key from its home project on every release, so drift is bounded by one deploy rather than lasting until someone notices.

- A lane with no read access to the source gets nothing and stays **inert**, rather than failing its deploy.
- An unchanged key is **not rewritten** — the shared upsert helper mints a version unconditionally, which would otherwise add one per deploy forever.

## This is a floor, not the ceiling

The README's actual recommendation is to **mount** the source secret cross-project, so a rotation is picked up on restart with no deploy at all. That needs the Cloud Build deploy step's inline script extracted to a file first: the full cross-project resource path does not fit in the **27 characters** of headroom left under the 10,000-character arg ceiling.

That ceiling has now caused three separate problems in this feature's life — it is worth its own change.

## ⚠️ One manual step before this does anything

The mirror needs the deploy identity to read the source secret. This is a CI identity reaching into a production project, so I have not granted it:

```bash
gcloud secrets add-iam-policy-binding brokercheck-api-key \
  --member="serviceAccount:github-actions-uat-deployer@hushh-pda-uat.iam.gserviceaccount.com" \
  --role="roles/secretmanager.secretAccessor" --project hushh-tech-prod
```

Until that binding exists the mirror is a no-op and UAT runs on the refreshed copy.

## Tests

3 new: the key is mirrored when the source differs, an unchanged key mints no version, and a lane without access is left inert without failing. Backend CI suite 495 passed.

---
Closes #4906
(retroactive board-linkage backfill, 2026-08-06)