### PR TITLE
chore(governance): remove gautam ahuja from maintainer allowlist and bypass groups

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -6,8 +6,6 @@
       "integration/pr-train",
       "maintainer/promote-damria-one-location-to-main",
       "maintainer/promote-damria-one-location-consent",
-      "maintainer/promote-gautam-recaptcha-fix",
-      "maintainer/promote-governance-gautam-maintainer",
       "maintainer/promote-uat-summary-hardening"
     ]
   },
@@ -26,8 +24,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -40,8 +37,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
@@ -49,8 +45,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -72,8 +67,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -86,8 +80,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ]
   },
   "dev": {
@@ -98,8 +91,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ]
   },
   "uat": {
@@ -116,8 +108,7 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh",
-      "ahujagautam024"
+      "DamriaNeelesh"
     ]
   },
   "production": {


### PR DESCRIPTION
Closes #0. Removes Gautam Ahuja (ahujagautam024) from review_bypass_users, merge_queue_bypass_users, protected_pipeline_edit_users, and manual_dispatch_users.