### PR TITLE
Fix map and SMS contact UI contrast issues

### DIFF
--- a/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
+++ b/hushh-webapp/__tests__/components/location-immersive-map.test.tsx
@@ -318,6 +318,7 @@ describe("LocationImmersiveMap demo experience", () => {
     const jordanButton = screen.getByRole("button", {
       name: "Show Jordan Lee on the map",
     });
+    expect(screen.getAllByRole("button", { name: /everyone/i })).toHaveLength(1);
     fireEvent.click(jordanButton);
     expect(jordanButton).toHaveClass(
       "bg-[var(--app-accent)]",

--- a/hushh-webapp/components/one-location/location-immersive-map.tsx
+++ b/hushh-webapp/components/one-location/location-immersive-map.tsx
@@ -1570,13 +1570,6 @@ export function LocationImmersiveMap() {
                         : "Sharing privately now"}
                     </p>
                   </div>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => void showEveryone()}
-                  >
-                    Show everyone
-                  </Button>
                 </div>
               ) : null}
 

--- a/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sms-contacts-flow.test.tsx
@@ -64,9 +64,24 @@ describe("SmsContactsFlow", () => {
     const onRemove = vi.fn().mockResolvedValue(true);
     render(<SmsContactsFlow {...baseProps} onRemove={onRemove} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    const removeButton = screen.getByRole("button", { name: "Remove" });
+    expect(removeButton).toHaveClass(
+      "bg-[#ffe9e9]",
+      "text-[#d70015]",
+      "border-[#ff3b30]/35",
+    );
+    fireEvent.click(removeButton);
     expect(onRemove).not.toHaveBeenCalled();
     expect(screen.getByText("Remove Kushal?")).toBeInTheDocument();
+
+    const title = screen.getByRole("heading", { name: /Remove Kushal\?/i });
+    expect(title.querySelector("span")).toHaveClass("text-[#17171c]");
+    expect(
+      screen.getByText(
+        "They'll no longer be alerted with your live location when you trigger SMS.",
+      ),
+    ).toHaveClass("!text-[#17171c]");
+
     const removeButtons = screen.getAllByRole("button", {
       name: "Remove",
       hidden: true,

--- a/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
+++ b/hushh-webapp/components/one-location/redesign/sms-contacts-flow.tsx
@@ -88,7 +88,7 @@ function ContactRow({
           type="button"
           onClick={onAskRemove}
           disabled={busy}
-          className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full border border-[#ff3b30]/35 px-3 text-[13px] font-semibold text-[#ff3b30] disabled:opacity-45"
+          className="press-scale flex h-8 min-w-[76px] items-center justify-center rounded-full border border-[#ff3b30]/35 bg-[#ffe9e9] px-3 text-[13px] font-semibold text-[#d70015] disabled:opacity-45 disabled:bg-[#f8f8f8]"
         >
           {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Remove"}
         </button>
@@ -256,12 +256,14 @@ export function SmsContactsFlow({
               {pendingRemoval ? initials(recipientLabel(pendingRemoval)) : "?"}
             </span>
             <AlertDialogTitle className="mt-1 !text-center !text-[20px] !font-bold !leading-tight">
-              Remove{" "}
-              {pendingRemoval
-                ? `${recipientLabel(pendingRemoval).split(/\s+/)[0]}?`
-                : "contact?"}
+              <span className="text-[#17171c]">
+                Remove{" "}
+                {pendingRemoval
+                  ? `${recipientLabel(pendingRemoval).split(/\s+/)[0]}?`
+                  : "contact?"}
+              </span>
             </AlertDialogTitle>
-            <AlertDialogDescription className="mt-1 !max-w-[290px] !text-center !text-[13px] !leading-[1.45]">
+            <AlertDialogDescription className="mt-1 !max-w-[290px] !text-center !text-[13px] !leading-[1.45] !text-[#17171c]">
               They&apos;ll no longer be alerted with your live location when you
               trigger SMS.
             </AlertDialogDescription>


### PR DESCRIPTION
## What changed
- Removed duplicated 'Show everyone' button from selected-person row on One Location map to avoid redundant action.
- Updated SMS contact remove row/button styling and confirmation dialog copy colors for readable text on light backgrounds.

## Validation
- npm run test -- location-immersive-map.test.tsx sms-contacts-flow.test.tsx (passed)
- npm run lint for touched files: existing pre-existing eact-hooks/refs errors in location-immersive-map.tsx remain untouched (not introduced by this change).

---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)