### PR TITLE
fix(one/location): calm envelope-wait state, tab-preserving Back, SMS-contact SOS guard

### DIFF
--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -590,6 +590,38 @@ describe("top shell breadcrumbs", () => {
     expect(resolveTopShellBreadcrumb("/one/location")?.backHref).toBe("/one");
   });
 
+  it("returns a focused flow to the hub TAB it was opened from (Links/People/Settings)", () => {
+    // Regression: opening "Create a new link" from Links, "Invite trusted
+    // person" from People, or "SMS contacts" from Settings must return Back to
+    // that ORIGINATING tab — not the default "Now" tab. `openFlow` keeps the
+    // current `?view=` tab in the URL alongside `?action=`, so the breadcrumb
+    // resolver retraces to it.
+
+    // Links → Create a new link (temp-link) → back to Links.
+    const fromLinks = new URLSearchParams();
+    fromLinks.set("view", "links");
+    fromLinks.set("action", "temp-link");
+    expect(
+      resolveTopShellBreadcrumb("/one/location", fromLinks)?.backHref,
+    ).toBe("/one/location?view=links");
+
+    // People → Invite trusted person (invite) → back to People.
+    const fromPeople = new URLSearchParams();
+    fromPeople.set("view", "people");
+    fromPeople.set("action", "invite");
+    expect(
+      resolveTopShellBreadcrumb("/one/location", fromPeople)?.backHref,
+    ).toBe("/one/location?view=people");
+
+    // Settings → SMS contacts → back to the Settings flow (not "Now").
+    const fromSettings = new URLSearchParams();
+    fromSettings.set("action", "sms-contacts");
+    expect(
+      resolveTopShellBreadcrumb("/one/location", fromSettings)?.backHref,
+    ).toBe("/one/location?action=settings");
+  });
+
+
   it("retraces setup-hub-opened capabilities through their terminal acknowledgement", () => {
     // From the Set up One hub, capability handoffs carry ?from=/one/setup so the
     // top-bar back returns to the hub (not Profile/dashboard) — "jaise aaya waise

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -117,7 +117,9 @@ function BodyPortal({ children }: { children: ReactNode }) {
 
 import type { HushhLocationPermissionState } from "@/lib/capacitor";
 import { isWeb } from "@/lib/capacitor/platform";
+import { apiErrorCode } from "@/lib/services/api-client";
 import { appInteractionCoordinator } from "@/lib/interaction/interaction-intent-coordinator";
+
 
 import {
   RECIPIENT_KEY_UNAVAILABLE_MESSAGE,
@@ -3538,6 +3540,21 @@ export function OneLocationAgentPageContent({
         const keyUnavailable =
           error instanceof Error &&
           error.message === RECIPIENT_KEY_UNAVAILABLE_MESSAGE;
+        // The grant is active ("Live") but the owner has not published any
+        // encrypted point yet — e.g. they JUST started sharing, or haven't
+        // moved / re-opened One since. The backend returns a 404
+        // LOCATION_ENVELOPE_MISSING for this. It's a normal "not ready yet"
+        // state on the happy path, NOT a failure, so we must never surface the
+        // raw backend string ("The owner has not published an encrypted
+        // location envelope yet.") as a scary red error toast the moment the
+        // recipient lands on the page.
+        const envelopeMissing =
+          !keyUnavailable &&
+          (apiErrorCode(error) === "LOCATION_ENVELOPE_MISSING" ||
+            (error instanceof Error &&
+              /has not published an encrypted location envelope/i.test(
+                error.message,
+              )));
         if (keyUnavailable) {
           // The recipient's device key rotated / was lost, so this envelope was
           // encrypted for a key we no longer hold. Self-heal: re-register our
@@ -3560,6 +3577,23 @@ export function OneLocationAgentPageContent({
               grant,
             )}'s live location — the secure key changed. Ask them to share again.`,
           }));
+        } else if (envelopeMissing) {
+          // Calm, reassuring "waiting for their first update" state. The share
+          // is genuinely active; the point simply hasn't arrived yet and will
+          // appear automatically on the next poll once the owner publishes.
+          const waitingMessage = `${receivedGrantOwnerLabel(
+            grant,
+          )} is sharing, but hasn't sent a live location update yet. It will appear here automatically as soon as they move or open One.`;
+          setGrantViewErrors((current) =>
+            current[grant.id] === waitingMessage
+              ? current
+              : { ...current, [grant.id]: waitingMessage },
+          );
+          // Only nudge with a gentle (non-error) toast on an explicit tap, and
+          // never on the background poll, so the page stays quiet while waiting.
+          if (!silent) {
+            toast.message(waitingMessage);
+          }
         } else if (!silent) {
           toast.error(
             error instanceof Error
@@ -3573,6 +3607,7 @@ export function OneLocationAgentPageContent({
           );
         }
       } finally {
+
         if (!silent) setBusy(null);
       }
     },

--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -7,6 +7,12 @@ import {
   SosPanel,
 } from "@/components/one-location/redesign/sos-panel";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() },
+}));
+const toastError = vi.mocked(toast.error);
 
 const recipient = (
   overrides: Partial<OneLocationRecipient>,
@@ -55,7 +61,78 @@ describe("SosPanel", () => {
     ).toBe(true);
   });
 
+  it("supports fallback for Windows user agents that do not include the word windows", () => {
+    expect(
+      isWindowsDesktopEmCallUnsupported({
+        userAgent: "Mozilla/5.0 (X11; Win32; x64) Chrome/140.0.0.0",
+        platform: "Win32",
+      }),
+    ).toBe(true);
+  });
+
+  it("shows emergency copy fallback on Windows desktop and confirms copy status", async () => {
+    vi.useRealTimers();
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+    const navigatorUserAgent = vi
+      .spyOn(window.navigator, "userAgent", "get")
+      .mockReturnValue("Mozilla/5.0 (X11; Win32; x64) Chrome/140.0.0.0");
+    const navigatorPlatform = vi
+      .spyOn(window.navigator, "platform", "get")
+      .mockReturnValue("Win32");
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      "clipboard",
+    );
+
+    try {
+      Object.defineProperty(window.navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: clipboardWriteText,
+        },
+      });
+
+      render(<SosPanel {...baseProps} />);
+
+      const copyButton = screen.getByRole("button", {
+        name: "Copy 112 emergency services (India)",
+      });
+      expect(copyButton).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /call 112 emergency services/i }),
+      ).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+
+      expect(clipboardWriteText).toHaveBeenCalledWith("112");
+      await waitFor(() =>
+        expect(screen.getByText("Number copied to clipboard.")).toBeInTheDocument(),
+      );
+    } finally {
+      navigatorUserAgent.mockRestore();
+      navigatorPlatform.mockRestore();
+      if (clipboardDescriptor) {
+        Object.defineProperty(window.navigator, "clipboard", clipboardDescriptor);
+      } else {
+        delete (window.navigator as unknown as { clipboard?: unknown }).clipboard;
+      }
+      vi.useFakeTimers();
+    }
+
+  });
+
   it("renders the Save My Soul UI, selected recipients, and local dialer", () => {
+    const navigatorUserAgent = vi
+      .spyOn(window.navigator, "userAgent", "get")
+      .mockReturnValue("Mozilla/5.0 (X11; Linux x86_64)");
+    const navigatorPlatform = vi
+      .spyOn(window.navigator, "platform", "get")
+      .mockReturnValue("Linux x86_64");
+
+    try {
     render(<SosPanel {...baseProps} />);
 
     expect(screen.getByText("SMS · Save my Soul")).toBeInTheDocument();
@@ -76,6 +153,10 @@ describe("SosPanel", () => {
       "inset-0",
       "bg-black",
     );
+    } finally {
+      navigatorUserAgent.mockRestore();
+      navigatorPlatform.mockRestore();
+    }
   });
 
   it("does not expose a dial link before the local number resolves", () => {
@@ -236,15 +317,30 @@ describe("SosPanel", () => {
     );
   });
 
-  it("fails closed when no selected recipient is ready", () => {
+  it("fails closed and prompts to add a contact when none are ready", () => {
     const onTrigger = vi.fn();
     render(<SosPanel {...baseProps} recipients={[]} onTrigger={onTrigger} />);
     const hold = screen.getByRole("button", {
       name: /press and hold for two seconds/i,
     });
-    expect(hold).toBeDisabled();
+    // The button stays pressable so the press can EXPLAIN what's missing, but a
+    // full hold must never actually send an SMS with zero recipients.
+    expect(hold).toBeEnabled();
     fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
     act(() => vi.advanceTimersByTime(3_000));
     expect(onTrigger).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      "Please add at least one contact in your SMS emergency contact list.",
+    );
+  });
+
+  it("does not prompt to add a contact when at least one is ready", () => {
+    render(<SosPanel {...baseProps} />);
+    const hold = screen.getByRole("button", {
+      name: /press and hold for two seconds/i,
+    });
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(toastError).not.toHaveBeenCalled();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -717,8 +717,12 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
             recipients={vm.smsContactCandidates}
             selectedUserIds={vm.smsContactUserIds}
             busyKey={vm.busy}
-            onBack={() => closeFlow("now")}
+            // SMS contacts is only ever opened from Settings, so its in-content
+            // back arrow returns to Settings (not the default "Now" tab), which
+            // matches the chrome/OS back button behavior.
+            onBack={() => openFlow("settings")}
             onAdd={vm.onAddSmsContact}
+
             onRemove={vm.onRemoveSmsContact}
             recipientLabel={vm.recipientLabel}
             recipientSubtitle={vm.recipientSubtitle}

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -10,6 +10,7 @@ import {
   type PointerEvent,
 } from "react";
 import { ChevronLeft, Loader2, Phone } from "lucide-react";
+import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 import type { OneLocationRecipient } from "@/lib/one-location/types";
@@ -33,7 +34,9 @@ export function isWindowsDesktopEmCallUnsupported(
 ) {
   const userAgent = (options?.userAgent ?? navigator.userAgent).toLowerCase();
   const platform = (options?.platform ?? navigator.platform).toLowerCase();
-  const isWindows = /windows/.test(platform) || /windows/i.test(userAgent);
+  const isWindows =
+    /windows|win32|win64|wow64|win16/.test(platform) ||
+    /windows nt|win64|wow64|win32/.test(userAgent);
   const isMobileOrTablet =
     /mobile|mobi|iphone|ipad|ipod|android/.test(userAgent) ||
     /phone|tablet|touch/.test(userAgent);
@@ -115,8 +118,17 @@ export function SosPanel({
   const customMessageInvalid =
     messageSelection === "custom" &&
     (!selectedMessage || customMessageLimitExceeded);
-  const disabled =
-    busy || active || readyRecipients.length === 0 || customMessageInvalid;
+  // True when the owner has not added any share-ready SMS contact yet. In this
+  // case we keep the button PRESSABLE (see `hardDisabled` below) so the hold
+  // handler can surface an actionable toast instead of silently doing nothing.
+  const noReadyRecipients = readyRecipients.length === 0;
+  // Blockers that must keep the button truly inert (sending in progress, already
+  // live, or an invalid custom message). Missing contacts is intentionally NOT
+  // here so the press can explain what to do.
+  const hardDisabled = busy || active || customMessageInvalid;
+  // Full guard used by the hold-completion path so a hold can never actually
+  // send an SMS while there are no ready recipients.
+  const disabled = hardDisabled || noReadyRecipients;
   const shouldFallbackWindowsEmergencyCall = isWindowsDesktopEmCallUnsupported();
   // Radar pulse is active the moment the user starts pressing, and keeps
   // emanating continuously while the SMS is sending and after it goes live.
@@ -150,12 +162,18 @@ export function SosPanel({
   }, []);
 
   const startHold = useCallback(() => {
-    if (disabled || holdStartedAtRef.current || firedRef.current) return;
+    if (hardDisabled || holdStartedAtRef.current || firedRef.current) return;
+    if (noReadyRecipients) {
+      toast.error(
+        "Please add at least one contact in your SMS emergency contact list.",
+      );
+      return;
+    }
     holdStartedAtRef.current = performance.now();
     setProgress(0);
     frameRef.current = requestAnimationFrame(updateProgress);
     timeoutRef.current = setTimeout(completeHold, HOLD_DURATION_MS);
-  }, [completeHold, disabled, updateProgress]);
+  }, [completeHold, hardDisabled, noReadyRecipients, updateProgress]);
 
   const cancelHold = useCallback(() => clearHold(true), [clearHold]);
 
@@ -278,7 +296,11 @@ export function SosPanel({
 
             <button
               type="button"
-              disabled={disabled}
+              // Only HARD blockers (sending, already live, invalid message)
+              // disable the control. When the sole blocker is "no SMS contacts
+              // added", the button stays pressable so the hold handler can show
+              // an actionable toast instead of the press doing nothing.
+              disabled={hardDisabled}
               aria-label={
                 active
                   ? "SMS sharing is active"

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -713,12 +713,26 @@ function resolveTopShellBreadcrumbInner(
         searchParams?.get("source") === "nearby";
       const nearbyReturnToken =
         searchParams?.get(NEARBY_PRIVATE_RETURN_TOKEN_PARAM) ?? null;
+      // Preserve the originating hub tab so the single top-bar (and OS/hardware)
+      // back button returns the user to the tab the flow was opened FROM —
+      // "Create a new link" from Links returns to Links, "Invite trusted person"
+      // from People returns to People — instead of always dropping to the
+      // default "Now" tab. `openFlow` keeps the current `?view=` tab in the URL
+      // when it appends `?action=`, so it is available here. SMS contacts is
+      // only ever reached from Settings, so it retraces to the Settings flow.
+      const hubView = String(searchParams?.get("view") || "").trim();
+      const hubBackHref =
+        action === "sms-contacts"
+          ? `${ROUTES.ONE_LOCATION}?action=settings`
+          : hubView
+            ? `${ROUTES.ONE_LOCATION}?view=${encodeURIComponent(hubView)}`
+            : ROUTES.ONE_LOCATION;
       return {
         backHref: returnToNearbyCheckIn
           ? isNearbyPrivateReturnToken(nearbyReturnToken)
             ? buildNearbyCheckInResumeHref(nearbyReturnToken)
             : `${ROUTES.ONE_LOCATION_MAP}?action=check-in`
-          : ROUTES.ONE_LOCATION,
+          : hubBackHref,
         width: "profile",
         align: "center",
         items: [
@@ -730,6 +744,7 @@ function resolveTopShellBreadcrumbInner(
         ],
       };
     }
+
     return {
       backHref:
         resolveCapabilitySetupBackHref(pathname, originHref) || ROUTES.ONE_HOME,


### PR DESCRIPTION
# Description

Fixes three One Location UX bugs reported by QA. All three are presentation/
view-routing only — no API, schema, consent, crypto, or data-plane changes.

1. **Calm "waiting for their first update" state (no scary toast).**
   A recipient opening an active ("Live") share whose owner has not yet
   published a first encrypted point saw the raw backend error
   *"The owner has not published an encrypted location envelope yet."* as a red
   error toast the moment the page loaded. This is a normal not-ready-yet edge
   case (owner just started sharing, hasn't moved, or hasn't re-opened One), not
   a failure. `viewGrantEnvelope` now detects the backend
   `LOCATION_ENVELOPE_MISSING` code and shows a calm inline "…is sharing, but
   hasn't sent a live location update yet…" message plus a gentle non-error
   toast only on an explicit tap — and stays silent on the background poll. The
   point appears automatically once the owner publishes.

2. **Back button preserves the originating tab.**
   Opening a focused flow from a hub tab and pressing the single top-bar / OS
   Back button always returned to the default "Now" tab because the breadcrumb
   hard-coded `/one/location`. It now retraces to the tab the flow was opened
   from — `?view=links` for "Create a new link", `?view=people` for "Invite
   trusted person" — and, since SMS contacts is only reachable from Settings, to
   `?action=settings`. The in-content SMS-contacts back arrow was aligned to the
   same target.

3. **SMS "Save my Soul" guard with zero contacts.**
   The hold button was silently disabled with no SMS contacts. It now stays
   pressable when the only blocker is missing contacts and surfaces the toast
   *"Please add at least one contact in your SMS emergency contact list."* while
   still preventing an SMS from being sent with zero recipients.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location` (focused-flow Back behavior + in-flow toasts). No new routes.
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared React presentation used by web + Capacitor webview; no native plugin change.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — surfaces an existing backend error more gently; no auth/consent/vault/PKM logic changed.
- Caller / proxy / backend pairing:
  - [x] Not applicable — consumes the existing `GET /api/one/location/grants/:id/envelope` contract; the new branch only maps its existing `LOCATION_ENVELOPE_MISSING` code to friendlier UI.
- Rollback or safe-failure behavior:
  - [x] Listed below: purely additive UI guards; reverting the commit restores prior behavior. Bug 3 keeps the send fully guarded (never fires with zero recipients); Bug 1 never blocks the map.
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `components/one-location/redesign/__tests__/sos-panel.test.tsx` and `__tests__/utils/top-shell-breadcrumbs.test.ts`.
- Verification commands executed:
  - [x] `cd hushh-webapp && npx vitest run __tests__/utils/top-shell-breadcrumbs.test.ts components/one-location/redesign/__tests__/sos-panel.test.tsx` → 41 passed

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate them.
- [x] This PR changes a current reachable app surface (`/one/location`).
- [x] Reachable production attach point: `LocationRedesignHub` (rendered by `app/one/location/page.tsx`), the shared `resolveTopShellBreadcrumb` back resolver, and `SosPanel`.
- [x] New tests import and exercise production code (`SosPanel`, `resolveTopShellBreadcrumb`), not test-only mocks.
- [x] Required checks are current on this head; commit is signed off (DCO); branch is rebased on latest `origin/main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`app/one/location`, shared navigation lib)
- [x] **iOS**: N/A — no Swift plugin change; the shared web UI runs in the Capacitor webview.
- [x] **Android**: N/A — no Kotlin plugin change; the shared web UI runs in the Capacitor webview.

## 🧪 Testing

- [x] Tested on Web (Chrome) via vitest/jsdom component + unit suites (41 passing).
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

UI-visible behavior is covered by the two vitest suites above (breadcrumb Back
targets + SOS toast/guard). No visual redesign; copy/behavior only.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No new access — it only reframes an
      existing backend error and adds a client-side guard toast.
- [x] `checkConsentToken()` not applicable (no new data access path).
- [x] Sensitive surface touched: none.
- [x] Error path / safe-failure proved: Bug 1 stays silent on background poll;
      Bug 3 never sends an SMS with zero recipients.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes; third-party notices unaffected.

---
Signed-off-by: Neelesh Meena <66689602+DamriaNeelesh@users.noreply.github.com>


---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)