### PR TITLE
feat(one/location): cancel a live SMS/SOS session from the SMS screen, synced both ways

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -30,6 +30,8 @@ const baseProps = {
   active: false,
   busy: false,
   onTrigger: vi.fn(),
+  onStopSos: vi.fn(),
+  stopBusy: false,
   onClose: vi.fn(),
   onEditContacts: vi.fn(),
   recipientLabel: (value: OneLocationRecipient) => value.displayName,
@@ -342,5 +344,49 @@ describe("SosPanel", () => {
     fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
     act(() => vi.advanceTimersByTime(2_000));
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows 'Cancel SMS Alert' only while a session is active and calls onStopSos", () => {
+    const onStopSos = vi.fn();
+    const { rerender } = render(
+      <SosPanel {...baseProps} active={false} onStopSos={onStopSos} />,
+    );
+    // Idle state: no cancel affordance, core reads "SMS".
+    expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
+    expect(screen.getByText("SMS")).toBeInTheDocument();
+
+    // Active ("SENT · Live now") state: the cancel button appears.
+    rerender(<SosPanel {...baseProps} active onStopSos={onStopSos} />);
+    expect(screen.getByText("SENT")).toBeInTheDocument();
+    expect(screen.getByText("Live now")).toBeInTheDocument();
+    const cancel = screen.getByRole("button", {
+      name: "Cancel SMS alert and stop sharing your location",
+    });
+    expect(cancel).toHaveTextContent("Cancel SMS Alert");
+    fireEvent.click(cancel);
+    expect(onStopSos).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables 'Cancel SMS Alert' and shows a spinner while stopping", () => {
+    const onStopSos = vi.fn();
+    render(
+      <SosPanel {...baseProps} active stopBusy onStopSos={onStopSos} />,
+    );
+    const cancel = screen.getByTestId("sos-cancel-alert");
+    expect(cancel).toBeDisabled();
+    expect(cancel).toHaveTextContent("Cancelling…");
+    fireEvent.click(cancel);
+    expect(onStopSos).not.toHaveBeenCalled();
+  });
+
+  it("resets the core to 'SMS' once the session is no longer active (external revoke sync)", () => {
+    const { rerender } = render(<SosPanel {...baseProps} active />);
+    expect(screen.getByText("SENT")).toBeInTheDocument();
+    // Simulate the incident being cleared elsewhere (e.g. Active shares → Stop),
+    // which flips `active` back to false and must reset the SMS screen.
+    rerender(<SosPanel {...baseProps} active={false} />);
+    expect(screen.getByText("SMS")).toBeInTheDocument();
+    expect(screen.queryByText("Live now")).toBeNull();
+    expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
   });
 });

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -1656,6 +1656,8 @@ function SosFlow({
       active={vm.sosActive}
       busy={vm.sosBusy}
       onTrigger={vm.onTriggerSos}
+      onStopSos={vm.onStopSos}
+      stopBusy={vm.sosBusy}
       onClose={onClose}
       onEditContacts={onEditContacts}
       recipientLabel={vm.recipientLabel}

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -49,8 +49,17 @@ export type SosPanelProps = {
   active: boolean;
   busy: boolean;
   onTrigger: (message?: string | null) => void;
+  /**
+   * Stop a live SMS/SOS session: revokes the location grants created by the
+   * alert AND clears the incident, so "SENT · Live now" resets. Kept separate
+   * from `onClose` (which only closes the screen without stopping sharing).
+   */
+  onStopSos: () => void;
+  /** True while the stop request is in flight (shows a spinner on Cancel). */
+  stopBusy: boolean;
   onClose: () => void;
   onEditContacts: () => void;
+
   recipientLabel: (recipient: OneLocationRecipient) => string;
   isRecipientShareReady: (recipient: OneLocationRecipient) => boolean;
   emergency: EmergencyInfo | null;
@@ -76,6 +85,8 @@ export function SosPanel({
   active,
   busy,
   onTrigger,
+  onStopSos,
+  stopBusy,
   onClose,
   onEditContacts,
   recipientLabel,
@@ -84,6 +95,7 @@ export function SosPanel({
   emergencyStatus,
   onResolveEmergencyNumber,
 }: SosPanelProps) {
+
   const [messageSelection, setMessageSelection] =
     useState<SmsMessageSelection>(null);
   const [customMessage, setCustomMessage] = useState("");
@@ -359,6 +371,26 @@ export function SosPanel({
 
 
         <div className="mt-auto">
+          {/* While an SMS/SOS session is live, the primary action becomes
+              stopping it. Cancelling here revokes the location grants created by
+              the alert AND clears the incident, so "SENT · Live now" resets and
+              the change is mirrored in Active shares (and vice-versa). */}
+          {active ? (
+            <button
+              type="button"
+              onClick={onStopSos}
+              disabled={stopBusy}
+              aria-label="Cancel SMS alert and stop sharing your location"
+              data-testid="sos-cancel-alert"
+              className="press-scale mb-3 flex h-12 w-full items-center justify-center gap-2 rounded-full bg-white text-[15px] font-semibold text-[#d70015] disabled:opacity-60"
+            >
+              {stopBusy ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : null}
+              {stopBusy ? "Cancelling…" : "Cancel SMS Alert"}
+            </button>
+          ) : null}
+
           <p className="truncate px-2 text-center text-[13px] text-white/70">
             {names ? `SMS goes to ${names}` : "No SMS contacts selected"} ·{" "}
             <button


### PR DESCRIPTION
# Description

Two related One Location items reported by QA.

**Task 2 — SOS Cancel state (the substantive change in this PR).** After
cancelling an SMS/SOS session the SMS "Save my Soul" screen kept showing
"SENT · Live now" with no way to stop it, and cancelling a share from Active
shares was not reflected on the SMS screen. This PR:

- Adds a **"Cancel SMS Alert"** button on the SMS screen, shown only while a
  session is active. It calls the existing `onStopSos` handler, which **revokes
  every location grant the alert created and clears the incident** — so the
  shared location is revoked and the core resets from "SENT · Live now" back to
  "SMS".
- Shows a "Cancelling…" spinner and disables the button while the stop is in
  flight (new `onStopSos` + `stopBusy` props on `SosPanel`, wired through
  `SosFlow`).
- **Bidirectional sync:** the panel is driven purely by the `active` prop, which
  the page derives from the SOS incident. Stopping a share from **Active shares**
  already runs `reconcileSosIncident`, which drops the incident and flips
  `active` to `false` — so the SMS screen resets too. Cancelling from the SMS
  screen revokes the grants, so Active shares updates as well.

**Task 1 — Back navigation.** The reported Back-button cases (Settings → SMS
Contacts → Back to Settings, Links → Create New Link → Back to Links, People →
Invite Trusted Person → Back to the originating tab) are already fixed on `main`
by the tab-preserving top-shell breadcrumb resolver and its regression suite
(`__tests__/utils/top-shell-breadcrumbs.test.ts`). This PR keeps that behavior
intact and green (verified in the same test run).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/location` (SMS "Save my Soul" flow only). No new routes.
- API / schema / type changes:
  - [x] None (adds two component props; consumes existing `onStopSos`).
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared React presentation used by web + Capacitor webview; no native plugin change.
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — reuses the existing consent-gated revoke path (`onStopSos` → revoke grants); adds no new data access.
- Caller / proxy / backend pairing:
  - [x] Not applicable — reuses the existing grant-revoke handler; no new backend contract.
- Rollback or safe-failure behavior:
  - [x] Listed below: additive UI only. Reverting restores prior behavior. The Cancel button is disabled while stopping; the reset is driven by the reconciled `active` flag, so a failed stop leaves the session visibly active.
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `components/one-location/redesign/__tests__/sos-panel.test.tsx` (new Cancel/reset/sync cases) + `__tests__/utils/top-shell-breadcrumbs.test.ts`.
- Verification commands executed:
  - [x] `cd hushh-webapp && npx vitest run components/one-location/redesign/__tests__/sos-panel.test.tsx __tests__/utils/top-shell-breadcrumbs.test.ts` → 44 passed
  - [x] `cd hushh-webapp && npm run typecheck` → clean

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate the merged back-navigation work.
- [x] This PR changes a current reachable app surface (SMS "Save my Soul" on `/one/location`).
- [x] Reachable production attach point: `SosPanel` (rendered by `SosFlow` in `LocationRedesignHub`, which `app/one/location/page.tsx` renders).
- [x] New tests import and exercise production code (`SosPanel`), not test-only mocks.
- [x] Required checks are current on this head; commit is signed off (DCO); branch is rebased on latest `origin/main`.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation (`components/one-location/redesign`)
- [x] **iOS**: N/A — no Swift plugin change; the shared web UI runs in the Capacitor webview.
- [x] **Android**: N/A — no Kotlin plugin change; the shared web UI runs in the Capacitor webview.

## 🧪 Testing

- [x] Tested on Web (Chrome) via vitest/jsdom (44 passing) + typecheck.
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

## 📸 Screenshots / Video

Behavior is covered by the new `sos-panel` tests: Cancel button visibility gated
on `active`, `onStopSos` invocation, "Cancelling…" busy state, and reset of the
core to "SMS" when `active` flips false (external revoke sync). No visual
redesign beyond the added Cancel button.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No new access — it stops sharing and
      revokes grants via the existing consent-gated handler.
- [x] `checkConsentToken()` not applicable (no new data access path).
- [x] Sensitive surface touched: location sharing stop/revoke (uses the existing,
      already-gated revoke flow).
- [x] Error path / safe-failure proved: Cancel is disabled while stopping; the
      screen only resets once the incident is actually cleared (`active` false).

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes; third-party notices unaffected.

---
Signed-off-by: Neelesh Meena <66689602+DamriaNeelesh@users.noreply.github.com>


---
Closes #4910
(retroactive board-linkage backfill, 2026-08-06)