### PR TITLE
feat(auth): send One's welcome, sign-in and phone-conflict mail

### DIFF
--- a/contracts/architecture/runtime-topology-index.v1.json
+++ b/contracts/architecture/runtime-topology-index.v1.json
@@ -4451,7 +4451,7 @@
     "one_specialist_tools": "95be4db6c1c4b999a3e542711c6b902fce7639ca5c166a3dd7cfeb39e3b57a14",
     "route_index": "a9aa3bdab7af5e90ba1b58e246d53d89425eb29f9e46eab33064204ae1cc6c7c",
     "route_layout": "bc33f99445d51fd79b22a7d42f364a87509b9b5c90699c5a86566ac8b9e67a64",
-    "surface_map": "eb4a313f290454c68c06554b4b179659396d049b40fabfec238e79ae085d7c42",
+    "surface_map": "ec77c5fc41b64c11ed0a40fe1ddb97591c245b6f8bfff161a125761111a92bbb",
     "topology_contract": "3515551e0cd42c3d17c767dd922111b1bf29f7ac1521d47e2d16ced39c6c1b6a",
     "world_model_compat": "10fc27eefad30ff56c69ef71a8953b727ab323a6e982ec783711fbbe1c1ee425"
   },

--- a/deploy/frontend.cloudbuild.yaml
+++ b/deploy/frontend.cloudbuild.yaml
@@ -86,6 +86,19 @@ steps:
       - "-c"
       - |
         set -euo pipefail
+
+        secrets="BACKEND_URL=BACKEND_URL:latest,DEVELOPER_API_URL=BACKEND_URL:latest,FIREBASE_ADMIN_CREDENTIALS_JSON=FIREBASE_ADMIN_CREDENTIALS_JSON:latest,APPLE_TEAM_ID=APPLE_TEAM_ID:latest,NEXT_PUBLIC_IOS_BUNDLE_ID=NEXT_PUBLIC_IOS_BUNDLE_ID:latest,NEXT_PUBLIC_ANDROID_APP_ID=NEXT_PUBLIC_ANDROID_APP_ID:latest,ANDROID_SHA256_CERT_FINGERPRINTS=ANDROID_SHA256_CERT_FINGERPRINTS:latest"
+
+        # `hushh-mail-api` key for One's lifecycle mail. Optional on purpose, the
+        # same way backend.cloudbuild.yaml treats its add-on secrets: binding a
+        # secret that does not exist yet would fail the whole deploy. While it is
+        # absent the webapp reports `not_configured` and sign-in is unaffected.
+        if gcloud secrets describe MAIL_API_KEY --project="$PROJECT_ID" >/dev/null 2>&1; then
+          secrets="${secrets},MAIL_API_KEY=MAIL_API_KEY:latest"
+        else
+          echo "Skipping optional secret MAIL_API_KEY; not found in project ${PROJECT_ID}."
+        fi
+
         cmd=(
           gcloud run deploy "${_FRONTEND_SERVICE}"
           "--image=gcr.io/$PROJECT_ID/hushh-webapp:${_IMAGE_TAG}"
@@ -99,8 +112,8 @@ steps:
           "--max-instances=10"
           "--min-instances=1"
           "--labels=managed-by=hushh-github-actions,deploy-env=${_DEPLOY_ENV},deploy-source=${_DEPLOY_SOURCE},deploy-sha=${_DEPLOY_SHA},github-run-id=${_GITHUB_RUN_ID}"
-          "--set-env-vars=NEXT_PUBLIC_APP_ENV=${_APP_ENV},HUSHH_DEPLOY_ENV=${_DEPLOY_ENV},HUSHH_DEPLOY_SOURCE=${_DEPLOY_SOURCE},HUSHH_DEPLOY_SHA=${_DEPLOY_SHA},HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID},RIA_ONBOARDING_PROXY_TIMEOUT_MS=90000"
-          "--set-secrets=BACKEND_URL=BACKEND_URL:latest,DEVELOPER_API_URL=BACKEND_URL:latest,FIREBASE_ADMIN_CREDENTIALS_JSON=FIREBASE_ADMIN_CREDENTIALS_JSON:latest,APPLE_TEAM_ID=APPLE_TEAM_ID:latest,NEXT_PUBLIC_IOS_BUNDLE_ID=NEXT_PUBLIC_IOS_BUNDLE_ID:latest,NEXT_PUBLIC_ANDROID_APP_ID=NEXT_PUBLIC_ANDROID_APP_ID:latest,ANDROID_SHA256_CERT_FINGERPRINTS=ANDROID_SHA256_CERT_FINGERPRINTS:latest"
+          "--set-env-vars=NEXT_PUBLIC_APP_ENV=${_APP_ENV},HUSHH_DEPLOY_ENV=${_DEPLOY_ENV},HUSHH_DEPLOY_SOURCE=${_DEPLOY_SOURCE},HUSHH_DEPLOY_SHA=${_DEPLOY_SHA},HUSHH_DEPLOY_RUN_ID=${_GITHUB_RUN_ID},RIA_ONBOARDING_PROXY_TIMEOUT_MS=90000,MAIL_API_ENDPOINT=${_MAIL_API_ENDPOINT}"
+          "--set-secrets=${secrets}"
         )
 
         if [[ "${_CLOUD_RUN_NO_TRAFFIC}" == "true" ]]; then
@@ -124,6 +137,9 @@ substitutions:
   # Wallet Profile owner entry point. Empty/false keeps the Profile row hidden;
   # the backend ONE_WALLET_CARD_ENABLED flag still decides whether it works.
   _ONE_WALLET_CARD_ENABLED: "false"
+  # `hushh-mail-api` in hushh-tech-prod. One key per consuming project, so this
+  # single endpoint serves UAT and production.
+  _MAIL_API_ENDPOINT: "https://hushh-mail-api-646258530541.us-central1.run.app"
   _CLOUD_RUN_NO_TRAFFIC: "false"
   _IMAGE_TAG: v2.1.2
   _DEPLOY_ENV: manual

--- a/docs/reference/operations/env-and-secrets.md
+++ b/docs/reference/operations/env-and-secrets.md
@@ -448,7 +448,7 @@ These are used by MCP modules (`mcp_modules/`) for MCP server functionality, not
 | `SESSION_SECRET` | If using session API | Yes | Server env only | Not in client |
 | `FIREBASE_ADMIN_CREDENTIALS_JSON` | Server-side Firebase | Yes | Server env only | |
 | `MAIL_API_ENDPOINT` | For lifecycle mail | No | Cloud Run runtime env from `_MAIL_API_ENDPOINT` | Public `hushh-mail-api` URL |
-| `MAIL_API_KEY` | For lifecycle mail | Yes | Secret Manager `MAIL_API_KEY`, bound only when present | Never `NEXT_PUBLIC_`; a browser-reachable key would be an open relay under Hushh SPF/DKIM |
+| `MAIL_API_KEY` | For lifecycle mail | Yes | Secret Manager `MAIL_API_KEY`, bound only when present | Never `NEXT_PUBLIC_`; a browser-reachable key would be an open relay under the Hussh Workspace SPF/DKIM identity |
 | `NEXT_PUBLIC_CONSENT_TIMEOUT_SECONDS` | No | No | Optional; sync with backend | |
 
 **CI:** Frontend build uses dummy Firebase vars and `NEXT_PUBLIC_BACKEND_URL=https://api.example.com`; no `.env.local` required.

--- a/docs/reference/operations/env-and-secrets.md
+++ b/docs/reference/operations/env-and-secrets.md
@@ -315,6 +315,8 @@ Used by:
 | `BACKEND_URL` | Server-side api routes | Hosted runtime required | Canonical runtime backend origin for Next.js route handlers |
 | `SESSION_SECRET` | `lib/auth/session.ts` | If session API | Server-only |
 | `FIREBASE_ADMIN_CREDENTIALS_JSON` | `lib/firebase/admin.ts` | Server-side Firebase | Server-only |
+| `MAIL_API_ENDPOINT` | `lib/runtime/settings.ts` → `lib/mail/mail-client.ts` | For lifecycle mail | `hushh-mail-api` origin. Plain env var, set from `_MAIL_API_ENDPOINT` in `deploy/frontend.cloudbuild.yaml` |
+| `MAIL_API_KEY` | `lib/runtime/settings.ts` → `lib/mail/mail-client.ts` | For lifecycle mail | Server-only. Bound from Secret Manager only when the secret exists; absent means welcome/sign-in/phone-conflict mail stays off and sign-in is unaffected |
 
 ---
 
@@ -445,6 +447,8 @@ These are used by MCP modules (`mcp_modules/`) for MCP server functionality, not
 | `BACKEND_URL` | Server-side | Hosted runtime required | Cloud Run runtime env or local profile value; do not leave unset in hosted environments | |
 | `SESSION_SECRET` | If using session API | Yes | Server env only | Not in client |
 | `FIREBASE_ADMIN_CREDENTIALS_JSON` | Server-side Firebase | Yes | Server env only | |
+| `MAIL_API_ENDPOINT` | For lifecycle mail | No | Cloud Run runtime env from `_MAIL_API_ENDPOINT` | Public `hushh-mail-api` URL |
+| `MAIL_API_KEY` | For lifecycle mail | Yes | Secret Manager `MAIL_API_KEY`, bound only when present | Never `NEXT_PUBLIC_`; a browser-reachable key would be an open relay under Hushh SPF/DKIM |
 | `NEXT_PUBLIC_CONSENT_TIMEOUT_SECONDS` | No | No | Optional; sync with backend | |
 
 **CI:** Frontend build uses dummy Firebase vars and `NEXT_PUBLIC_BACKEND_URL=https://api.example.com`; no `.env.local` required.

--- a/hushh-webapp/.env.example
+++ b/hushh-webapp/.env.example
@@ -85,5 +85,10 @@ FIREBASE_ADMIN_CREDENTIALS_JSON=
 # SESSION_SECRET=     # If using session API
 # BACKEND_URL=        # Server-side fallback
 # NEXT_PUBLIC_CONSENT_TIMEOUT_SECONDS=120
+# hushh-mail-api, for welcome / sign-in / phone-conflict mail. Leave both unset
+# locally and the mail is skipped; sign-in is unaffected either way. The key is
+# server-side by definition — a browser-reachable one would be an open relay.
+# MAIL_API_ENDPOINT=https://hushh-mail-api-646258530541.us-central1.run.app
+# MAIL_API_KEY=
 # Maintainer-only overlay values such as app-review, native signing,
 # REVIEWER_UID / REVIEWER_VAULT_PASSPHRASE, and rehearsal toggles should live in an untracked overlay file.

--- a/hushh-webapp/__tests__/mail/auth-mail-route.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-route.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const validateFirebaseToken = vi.fn();
+const getUser = vi.fn();
+const getUserByPhoneNumber = vi.fn();
+const setCustomUserClaims = vi.fn();
+const sendSignInMail = vi.fn();
+const sendPhoneConflictMail = vi.fn();
+
+vi.mock("@/lib/auth/validate", () => ({
+  validateFirebaseToken: (...args: unknown[]) => validateFirebaseToken(...args),
+}));
+
+vi.mock("@/lib/firebase/admin", () => ({
+  auth: {
+    getUser: (...args: unknown[]) => getUser(...args),
+    getUserByPhoneNumber: (...args: unknown[]) => getUserByPhoneNumber(...args),
+    setCustomUserClaims: (...args: unknown[]) => setCustomUserClaims(...args),
+  },
+}));
+
+vi.mock("@/lib/mail/auth-mail-service", () => ({
+  WELCOME_MAIL_CLAIM: "hushhWelcomeMailAt",
+  sendSignInMail: (...args: unknown[]) => sendSignInMail(...args),
+  sendPhoneConflictMail: (...args: unknown[]) => sendPhoneConflictMail(...args),
+}));
+
+const ROUTE = "@/app/api/auth/mail/route";
+const CONFLICT_NUMBER = "+919876543210";
+
+function request(body: unknown, authorization = "Bearer good-token") {
+  return new Request("https://uat.one.hushh.ai/api/auth/mail", {
+    method: "POST",
+    headers: { Authorization: authorization, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+// A fresh module per test: the duplicate and quota guards are module state.
+async function loadRoute() {
+  vi.resetModules();
+  return (await import(ROUTE)) as typeof import("@/app/api/auth/mail/route");
+}
+
+describe("POST /api/auth/mail", () => {
+  beforeEach(() => {
+    validateFirebaseToken.mockReset().mockResolvedValue({ valid: true, userId: "uid-1" });
+    getUser.mockReset().mockResolvedValue({
+      uid: "uid-1",
+      email: "ankit@hushh.ai",
+      displayName: "Ankit",
+      customClaims: {},
+      metadata: { creationTime: "", lastSignInTime: "Wed, 05 Aug 2026 09:12:00 GMT" },
+    });
+    getUserByPhoneNumber.mockReset();
+    setCustomUserClaims.mockReset().mockResolvedValue(undefined);
+    sendSignInMail.mockReset().mockResolvedValue({ status: "sent", kind: "welcome", messageId: "<a>" });
+    sendPhoneConflictMail.mockReset().mockResolvedValue({
+      status: "sent",
+      kind: "phone_conflict",
+      messageId: "<b>",
+    });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("rejects an unauthenticated caller before touching anything", async () => {
+    validateFirebaseToken.mockResolvedValue({ valid: false });
+    const { POST } = await loadRoute();
+
+    const response = await POST(request({ event: "signed_in" }));
+
+    expect(response.status).toBe(401);
+    expect(getUser).not.toHaveBeenCalled();
+    expect(sendSignInMail).not.toHaveBeenCalled();
+  });
+
+  it("rejects an event it does not know", async () => {
+    const { POST } = await loadRoute();
+    const response = await POST(request({ event: "password_reset" }));
+    expect(response.status).toBe(400);
+    expect(sendSignInMail).not.toHaveBeenCalled();
+  });
+
+  it("collapses a repeated request for the same sign-in", async () => {
+    const { POST } = await loadRoute();
+
+    await POST(request({ event: "signed_in" }));
+    const second = await POST(request({ event: "signed_in" }));
+
+    expect(await second.json()).toEqual({ status: "skipped", reason: "duplicate_request" });
+    expect(sendSignInMail).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a phone number that is not E.164", async () => {
+    const { POST } = await loadRoute();
+    const response = await POST(request({ event: "phone_conflict", phoneNumber: "9876543210" }));
+    expect(response.status).toBe(400);
+    expect(getUserByPhoneNumber).not.toHaveBeenCalled();
+  });
+
+  it("does not mail when no other account holds the number", async () => {
+    getUserByPhoneNumber.mockRejectedValue(new Error("user not found"));
+    const { POST } = await loadRoute();
+
+    const response = await POST(request({ event: "phone_conflict", phoneNumber: CONFLICT_NUMBER }));
+
+    expect(await response.json()).toEqual({ status: "skipped", reason: "no_conflicting_account" });
+    expect(sendPhoneConflictMail).not.toHaveBeenCalled();
+  });
+
+  it("does not mail when the number is already the caller's own", async () => {
+    getUserByPhoneNumber.mockResolvedValue({ uid: "uid-1", email: "ankit@hushh.ai" });
+    const { POST } = await loadRoute();
+
+    const response = await POST(request({ event: "phone_conflict", phoneNumber: CONFLICT_NUMBER }));
+
+    expect(await response.json()).toEqual({ status: "skipped", reason: "no_conflicting_account" });
+    expect(sendPhoneConflictMail).not.toHaveBeenCalled();
+  });
+
+  it("mails a genuine conflict and passes the owner's address for masking", async () => {
+    getUserByPhoneNumber.mockResolvedValue({ uid: "uid-2", email: "ankit.old@gmail.com" });
+    const { POST } = await loadRoute();
+
+    const response = await POST(request({ event: "phone_conflict", phoneNumber: CONFLICT_NUMBER }));
+
+    expect(await response.json()).toMatchObject({ status: "sent", kind: "phone_conflict" });
+    expect(sendPhoneConflictMail.mock.calls[0][1]).toMatchObject({
+      attemptedPhoneNumber: CONFLICT_NUMBER,
+      linkedAccountEmail: "ankit.old@gmail.com",
+    });
+  });
+
+  it("still mails a phone-only owner, with no address to hint at", async () => {
+    getUserByPhoneNumber.mockResolvedValue({ uid: "uid-2", email: undefined });
+    const { POST } = await loadRoute();
+
+    await POST(request({ event: "phone_conflict", phoneNumber: CONFLICT_NUMBER }));
+
+    expect(sendPhoneConflictMail.mock.calls[0][1]).toMatchObject({ linkedAccountEmail: null });
+  });
+
+  it("caps conflict mail per account so it cannot be walked or used to burn quota", async () => {
+    getUserByPhoneNumber.mockResolvedValue({ uid: "uid-2", email: "other@gmail.com" });
+    const { POST } = await loadRoute();
+
+    // Distinct numbers, so the duplicate guard is not what stops this.
+    const numbers = ["+919876543210", "+919876543211", "+919876543212", "+919876543213"];
+    const outcomes = [];
+    for (const phoneNumber of numbers) {
+      outcomes.push(await (await POST(request({ event: "phone_conflict", phoneNumber }))).json());
+    }
+
+    expect(sendPhoneConflictMail).toHaveBeenCalledTimes(3);
+    expect(outcomes[3]).toEqual({ status: "skipped", reason: "rate_limited" });
+  });
+
+  it("merges the welcome marker into existing claims rather than replacing them", async () => {
+    getUser.mockResolvedValue({
+      uid: "uid-1",
+      email: "ankit@hushh.ai",
+      displayName: "Ankit",
+      customClaims: { somethingElse: true },
+      metadata: { creationTime: "", lastSignInTime: "Wed, 05 Aug 2026 09:12:00 GMT" },
+    });
+    sendSignInMail.mockImplementation(async (_user, _ctx, deps) => {
+      await deps.markWelcomeSent("uid-1", 1_754_000_000);
+      return { status: "sent", kind: "welcome", messageId: "<a>" };
+    });
+    const { POST } = await loadRoute();
+
+    await POST(request({ event: "signed_in" }));
+
+    expect(setCustomUserClaims).toHaveBeenCalledWith("uid-1", {
+      somethingElse: true,
+      hushhWelcomeMailAt: 1_754_000_000,
+    });
+  });
+
+  it("reports a dispatch failure instead of throwing at the caller", async () => {
+    getUser.mockRejectedValue(new Error("admin unavailable"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { POST } = await loadRoute();
+
+    const response = await POST(request({ event: "signed_in" }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "failed", reason: "dispatch_error" });
+    warn.mockRestore();
+  });
+});

--- a/hushh-webapp/__tests__/mail/auth-mail-route.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-route.test.ts
@@ -166,7 +166,7 @@ describe("POST /api/auth/mail", () => {
       customClaims: { somethingElse: true },
       metadata: { creationTime: "", lastSignInTime: "Wed, 05 Aug 2026 09:12:00 GMT" },
     });
-    sendSignInMail.mockImplementation(async (_user, _ctx, deps) => {
+    sendSignInMail.mockImplementation(async (_user, deps) => {
       await deps.markWelcomeSent("uid-1", 1_754_000_000);
       return { status: "sent", kind: "welcome", messageId: "<a>" };
     });

--- a/hushh-webapp/__tests__/mail/auth-mail-service.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-service.test.ts
@@ -81,6 +81,22 @@ describe("sign-in mail", () => {
     expect(markWelcomeSent).not.toHaveBeenCalled();
   });
 
+  it("still reports the send when the marker fails to persist", async () => {
+    const { sendSignInMail } = await loadService();
+    const markWelcomeSent = vi.fn().mockRejectedValue(new Error("claims unavailable"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+      markWelcomeSent,
+    });
+
+    // The mail was delivered; calling that a failure would be the opposite of
+    // what happened.
+    expect(outcome).toMatchObject({ status: "sent", kind: "welcome" });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("never sends a second welcome, even if the account looks new again", async () => {
     const { sendSignInMail, WELCOME_MAIL_CLAIM } = await loadService();
     const user = makeUser({ customClaims: { [WELCOME_MAIL_CLAIM]: 1_754_000_000 } });

--- a/hushh-webapp/__tests__/mail/auth-mail-service.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-service.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/mail/mail-client", () => ({
 }));
 
 const MODULE_PATH = "@/lib/mail/auth-mail-service";
-const APP_URL = "https://uat.one.hushh.ai";
+const APP_URL = "https://one.hushh.ai";
 
 type FakeUser = {
   uid: string;
@@ -54,7 +54,7 @@ describe("sign-in mail", () => {
     const { sendSignInMail } = await loadService();
     const markWelcomeSent = vi.fn().mockResolvedValue(undefined);
 
-    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(makeUser()), {
       markWelcomeSent,
     });
 
@@ -73,7 +73,7 @@ describe("sign-in mail", () => {
     const { sendSignInMail } = await loadService();
     const markWelcomeSent = vi.fn();
 
-    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(makeUser()), {
       markWelcomeSent,
     });
 
@@ -86,7 +86,7 @@ describe("sign-in mail", () => {
     const markWelcomeSent = vi.fn().mockRejectedValue(new Error("claims unavailable"));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(makeUser()), {
       markWelcomeSent,
     });
 
@@ -101,7 +101,7 @@ describe("sign-in mail", () => {
     const { sendSignInMail, WELCOME_MAIL_CLAIM } = await loadService();
     const user = makeUser({ customClaims: { [WELCOME_MAIL_CLAIM]: 1_754_000_000 } });
 
-    const outcome = await sendSignInMail(asRecord(user), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(user), {
       markWelcomeSent: vi.fn(),
     });
 
@@ -118,7 +118,7 @@ describe("sign-in mail", () => {
       },
     });
 
-    const outcome = await sendSignInMail(asRecord(user), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(user), {
       markWelcomeSent: vi.fn(),
     });
 
@@ -134,7 +134,7 @@ describe("sign-in mail", () => {
   it("skips an account with no email rather than failing", async () => {
     const { sendSignInMail } = await loadService();
 
-    const outcome = await sendSignInMail(asRecord(makeUser({ email: null })), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(makeUser({ email: null })), {
       markWelcomeSent: vi.fn(),
     });
 
@@ -146,7 +146,7 @@ describe("sign-in mail", () => {
     sendMail.mockResolvedValue({ status: "not_configured" });
     const { sendSignInMail } = await loadService();
 
-    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+    const outcome = await sendSignInMail(asRecord(makeUser()), {
       markWelcomeSent: vi.fn(),
     });
 
@@ -191,7 +191,6 @@ describe("phone conflict mail", () => {
     const { sendPhoneConflictMail } = await loadService();
 
     const outcome = await sendPhoneConflictMail(asRecord(makeUser()), {
-      appUrl: APP_URL,
       attemptedPhoneNumber: "+919876543210",
       linkedAccountEmail: "ankit.old@gmail.com",
     });
@@ -208,7 +207,6 @@ describe("phone conflict mail", () => {
     const { sendPhoneConflictMail } = await loadService();
 
     const outcome = await sendPhoneConflictMail(asRecord(makeUser()), {
-      appUrl: APP_URL,
       attemptedPhoneNumber: "+12",
       linkedAccountEmail: null,
     });

--- a/hushh-webapp/__tests__/mail/auth-mail-service.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-service.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMail = vi.fn();
+vi.mock("@/lib/mail/mail-client", () => ({
+  sendMail: (...args: unknown[]) => sendMail(...args),
+  isMailConfigured: () => true,
+}));
+
+const MODULE_PATH = "@/lib/mail/auth-mail-service";
+const APP_URL = "https://uat.one.hushh.ai";
+
+type FakeUser = {
+  uid: string;
+  email?: string | null;
+  displayName?: string | null;
+  customClaims?: Record<string, unknown>;
+  metadata: { creationTime?: string; lastSignInTime?: string };
+};
+
+function makeUser(overrides: Partial<FakeUser> = {}): FakeUser {
+  return {
+    uid: "uid-1",
+    email: "ankit@hushh.ai",
+    displayName: "Ankit Kumar Singh",
+    metadata: {
+      creationTime: "Wed, 05 Aug 2026 09:12:00 GMT",
+      lastSignInTime: "Wed, 05 Aug 2026 09:12:01 GMT",
+    },
+    ...overrides,
+  };
+}
+
+// The service only reads a subset of the Admin SDK UserRecord.
+async function loadService() {
+  return (await import(MODULE_PATH)) as typeof import("@/lib/mail/auth-mail-service");
+}
+
+const asRecord = (user: FakeUser) =>
+  user as unknown as Parameters<
+    typeof import("@/lib/mail/auth-mail-service").sendSignInMail
+  >[0];
+
+describe("sign-in mail", () => {
+  beforeEach(() => {
+    sendMail.mockReset();
+    sendMail.mockResolvedValue({ status: "sent", messageId: "<id@hushh.ai>", deduplicated: false });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("sends the welcome mail on the sign-in that created the account", async () => {
+    const { sendSignInMail } = await loadService();
+    const markWelcomeSent = vi.fn().mockResolvedValue(undefined);
+
+    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+      markWelcomeSent,
+    });
+
+    expect(outcome).toEqual({ status: "sent", kind: "welcome", messageId: "<id@hushh.ai>" });
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail.mock.calls[0][0]).toMatchObject({
+      to: "ankit@hushh.ai",
+      subject: "Welcome to One",
+      idempotencyKey: "one-welcome:uid-1",
+    });
+    expect(markWelcomeSent).toHaveBeenCalledWith("uid-1", expect.any(Number));
+  });
+
+  it("does not mark the welcome mail as sent when the send failed", async () => {
+    sendMail.mockResolvedValue({ status: "failed", reason: "http_503" });
+    const { sendSignInMail } = await loadService();
+    const markWelcomeSent = vi.fn();
+
+    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+      markWelcomeSent,
+    });
+
+    expect(outcome).toEqual({ status: "failed", reason: "http_503" });
+    expect(markWelcomeSent).not.toHaveBeenCalled();
+  });
+
+  it("never sends a second welcome, even if the account looks new again", async () => {
+    const { sendSignInMail, WELCOME_MAIL_CLAIM } = await loadService();
+    const user = makeUser({ customClaims: { [WELCOME_MAIL_CLAIM]: 1_754_000_000 } });
+
+    const outcome = await sendSignInMail(asRecord(user), { appUrl: APP_URL }, {
+      markWelcomeSent: vi.fn(),
+    });
+
+    expect(outcome).toEqual({ status: "skipped", reason: "welcome_already_sent" });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("sends welcome back on a later sign-in, keyed on that sign-in", async () => {
+    const { sendSignInMail } = await loadService();
+    const user = makeUser({
+      metadata: {
+        creationTime: "Wed, 05 Aug 2026 09:12:00 GMT",
+        lastSignInTime: "Fri, 07 Aug 2026 11:30:00 GMT",
+      },
+    });
+
+    const outcome = await sendSignInMail(asRecord(user), { appUrl: APP_URL }, {
+      markWelcomeSent: vi.fn(),
+    });
+
+    expect(outcome).toMatchObject({ status: "sent", kind: "welcome_back" });
+    const payload = sendMail.mock.calls[0][0];
+    expect(payload.subject).toBe("Welcome back to One");
+    expect(payload.idempotencyKey).toBe(
+      `one-signin:uid-1:${new Date("Fri, 07 Aug 2026 11:30:00 GMT").getTime()}`,
+    );
+    expect(payload.html).toContain("7 August 2026 at 11:30 UTC");
+  });
+
+  it("skips an account with no email rather than failing", async () => {
+    const { sendSignInMail } = await loadService();
+
+    const outcome = await sendSignInMail(asRecord(makeUser({ email: null })), { appUrl: APP_URL }, {
+      markWelcomeSent: vi.fn(),
+    });
+
+    expect(outcome).toEqual({ status: "skipped", reason: "no_email" });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing binding instead of pretending it sent", async () => {
+    sendMail.mockResolvedValue({ status: "not_configured" });
+    const { sendSignInMail } = await loadService();
+
+    const outcome = await sendSignInMail(asRecord(makeUser()), { appUrl: APP_URL }, {
+      markWelcomeSent: vi.fn(),
+    });
+
+    expect(outcome).toEqual({ status: "not_configured" });
+  });
+});
+
+describe("first sign-in detection", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("treats timestamps within a minute of each other as the first sign-in", async () => {
+    const { isFirstSignIn } = await loadService();
+    expect(
+      isFirstSignIn({
+        creationTime: "Wed, 05 Aug 2026 09:12:00 GMT",
+        lastSignInTime: "Wed, 05 Aug 2026 09:12:03 GMT",
+      }),
+    ).toBe(true);
+    expect(
+      isFirstSignIn({
+        creationTime: "Wed, 05 Aug 2026 09:12:00 GMT",
+        lastSignInTime: "Wed, 05 Aug 2026 09:20:00 GMT",
+      }),
+    ).toBe(false);
+    expect(isFirstSignIn({})).toBe(false);
+  });
+});
+
+describe("phone conflict mail", () => {
+  beforeEach(() => {
+    sendMail.mockReset();
+    sendMail.mockResolvedValue({ status: "sent", messageId: "<id@hushh.ai>", deduplicated: false });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("mails the signed-in person, keyed to the number so a retry does not repeat", async () => {
+    const { sendPhoneConflictMail } = await loadService();
+
+    const outcome = await sendPhoneConflictMail(asRecord(makeUser()), {
+      appUrl: APP_URL,
+      attemptedPhoneNumber: "+919876543210",
+      linkedAccountEmail: "ankit.old@gmail.com",
+    });
+
+    expect(outcome).toMatchObject({ status: "sent", kind: "phone_conflict" });
+    const payload = sendMail.mock.calls[0][0];
+    expect(payload.to).toBe("ankit@hushh.ai");
+    expect(payload.idempotencyKey).toBe("one-phone-conflict:uid-1:919876543210");
+    expect(payload.html).toContain("an•••@gmail.com");
+    expect(payload.html).toContain(`href="${APP_URL}/login"`);
+  });
+
+  it("refuses an unusable phone number", async () => {
+    const { sendPhoneConflictMail } = await loadService();
+
+    const outcome = await sendPhoneConflictMail(asRecord(makeUser()), {
+      appUrl: APP_URL,
+      attemptedPhoneNumber: "+12",
+      linkedAccountEmail: null,
+    });
+
+    expect(outcome).toEqual({ status: "skipped", reason: "invalid_phone" });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/__tests__/mail/auth-mail-templates.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-templates.test.ts
@@ -10,7 +10,7 @@ import {
   maskEmail,
 } from "@/lib/mail/auth-mail-templates";
 
-const APP_URL = "https://uat.one.hushh.ai";
+const APP_URL = "https://one.hushh.ai";
 
 describe("email shell primitives", () => {
   it("escapes markup so caller data cannot inject HTML", () => {
@@ -28,7 +28,7 @@ describe("email shell primitives", () => {
   });
 
   it("uses the vendor font stack and never a webfont", () => {
-    const { html } = buildWelcomeMail({ appUrl: APP_URL, displayName: "Ankit" });
+    const { html } = buildWelcomeMail({ displayName: "Ankit" });
     expect(html).toContain(FONT_STACK);
     expect(html).not.toContain("fonts.googleapis.com");
     expect(html).not.toContain("@font-face");
@@ -62,7 +62,7 @@ describe("masking", () => {
 
 describe("welcome mail", () => {
   it("greets by first name and offers one action", () => {
-    const mail = buildWelcomeMail({ appUrl: APP_URL, displayName: "Ankit Kumar Singh" });
+    const mail = buildWelcomeMail({ displayName: "Ankit Kumar Singh" });
     expect(mail.subject).toBe("Welcome to One");
     expect(mail.html).toContain("Ankit, you&#39;re in.");
     expect(mail.html).toContain(`href="${APP_URL}/"`);
@@ -71,7 +71,7 @@ describe("welcome mail", () => {
   });
 
   it("falls back to a neutral greeting without a name", () => {
-    const mail = buildWelcomeMail({ appUrl: APP_URL, displayName: null });
+    const mail = buildWelcomeMail({ displayName: null });
     expect(mail.html).toContain("You&#39;re in.");
     expect(mail.text).toContain("You're in.");
   });
@@ -80,7 +80,6 @@ describe("welcome mail", () => {
 describe("welcome back mail", () => {
   it("states when the sign-in happened", () => {
     const mail = buildWelcomeBackMail({
-      appUrl: APP_URL,
       displayName: "Ankit",
       signedInAt: new Date("2026-08-05T09:12:00Z"),
     });
@@ -92,45 +91,62 @@ describe("welcome back mail", () => {
 });
 
 describe("phone conflict mail", () => {
-  it("names the other account only as a masked address", () => {
+  it("shows the number in full and the other account only masked", () => {
     const mail = buildPhoneConflictMail({
-      appUrl: APP_URL,
       displayName: "Ankit",
       attemptedPhoneNumber: "+919876543210",
       linkedAccountEmail: "ankit.old@gmail.com",
-      signInUrl: `${APP_URL}/login`,
     });
     expect(mail.subject).toBe("That number is on another account");
-    expect(mail.html).toContain("an•••@gmail.com");
-    expect(mail.html).not.toContain("ankit.old@gmail.com");
-    // The full number never appears, even though the recipient typed it.
-    expect(mail.html).not.toContain("9876543210");
-    expect(mail.text).toContain("Number: 919876 •• •• 3210");
+    // The recipient typed this number a moment ago, so masking it would hide
+    // nothing from them and only make the mail harder to act on.
+    expect(mail.text).toContain("Number: +919876543210");
+    expect(mail.html).toContain("+919876543210");
+    // The other account is somebody else's, and stays a hint.
     expect(mail.text).toContain("Account: an•••@gmail.com");
+    expect(mail.html).not.toContain("ankit.old@gmail.com");
     expect(mail.html).toContain(`href="${APP_URL}/login"`);
   });
 
-  it("omits the account row when the owning account cannot be resolved", () => {
+  it("omits the account row for a phone-only owner with no address to show", () => {
     const mail = buildPhoneConflictMail({
-      appUrl: APP_URL,
       displayName: null,
       attemptedPhoneNumber: "+919876543210",
       linkedAccountEmail: null,
-      signInUrl: `${APP_URL}/login`,
     });
     expect(mail.text).not.toContain("Account:");
-    expect(mail.text).toContain("Number: 919876 •• •• 3210");
+    expect(mail.text).toContain("Number: +919876543210");
   });
+});
 
-  it("refuses a javascript: sign-in URL rather than rendering it", () => {
-    const mail = buildPhoneConflictMail({
-      appUrl: APP_URL,
-      displayName: null,
+describe("every link points at the product", () => {
+  // The regression this guards: a UAT deploy mails real inboxes, and a link
+  // built from the sending origin lands them on uat.one.hushh.ai.
+  const mails = [
+    buildWelcomeMail({ displayName: "Ankit" }),
+    buildWelcomeBackMail({ displayName: "Ankit", signedInAt: new Date("2026-08-05T09:12:00Z") }),
+    buildPhoneConflictMail({
+      displayName: "Ankit",
       attemptedPhoneNumber: "+919876543210",
-      linkedAccountEmail: null,
-      signInUrl: "javascript:alert(1)",
-    });
-    expect(mail.html).not.toContain("javascript:");
-    expect(mail.html).not.toContain("Sign in to that account");
+      linkedAccountEmail: "ankit.old@gmail.com",
+    }),
+  ];
+
+  it.each(mails.map((mail, index) => [index, mail] as const))(
+    "mail %i links only to one.hushh.ai",
+    (_index, mail) => {
+      const hrefs = [...mail.html.matchAll(/href="([^"]+)"/g)].map((match) => match[1]);
+      expect(hrefs.length).toBeGreaterThan(0);
+      for (const href of hrefs) {
+        expect(href.startsWith("https://one.hushh.ai") || href.startsWith("mailto:")).toBe(true);
+      }
+      expect(mail.html).not.toContain("uat.");
+      expect(mail.text).not.toContain("uat.");
+    },
+  );
+
+  it("loads the One app icon, not another product's logo", () => {
+    expect(mails[0].html).toContain('src="https://one.hushh.ai/quiet-emoji-icon.png"');
+    expect(mails[0].html).not.toContain("hushhtech.com");
   });
 });

--- a/hushh-webapp/__tests__/mail/auth-mail-templates.test.ts
+++ b/hushh-webapp/__tests__/mail/auth-mail-templates.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeHtml, FONT_STACK, safeUrl } from "@/lib/mail/email-shell";
+import {
+  buildPhoneConflictMail,
+  buildWelcomeBackMail,
+  buildWelcomeMail,
+  firstNameOf,
+  formatSignInMoment,
+  maskEmail,
+} from "@/lib/mail/auth-mail-templates";
+
+const APP_URL = "https://uat.one.hushh.ai";
+
+describe("email shell primitives", () => {
+  it("escapes markup so caller data cannot inject HTML", () => {
+    expect(escapeHtml('<script>"x"&\'y\'</script>')).toBe(
+      "&lt;script&gt;&quot;x&quot;&amp;&#39;y&#39;&lt;/script&gt;",
+    );
+  });
+
+  it("drops any scheme that is not http, https or mailto", () => {
+    expect(safeUrl("javascript:alert(1)")).toBe("");
+    expect(safeUrl("data:text/html,<b>x</b>")).toBe("");
+    expect(safeUrl("https://one.hushh.ai/login")).toBe("https://one.hushh.ai/login");
+    expect(safeUrl("mailto:support@hushh.ai")).toBe("mailto:support@hushh.ai");
+    expect(safeUrl("not a url", "https://fallback.test/")).toBe("https://fallback.test/");
+  });
+
+  it("uses the vendor font stack and never a webfont", () => {
+    const { html } = buildWelcomeMail({ appUrl: APP_URL, displayName: "Ankit" });
+    expect(html).toContain(FONT_STACK);
+    expect(html).not.toContain("fonts.googleapis.com");
+    expect(html).not.toContain("@font-face");
+    // Gmail strips <style> blocks and classes; everything must be inline.
+    expect(html).not.toContain("<style");
+    expect(html).not.toContain("class=");
+  });
+});
+
+describe("masking", () => {
+  it("keeps an email recognisable without disclosing it", () => {
+    expect(maskEmail("ankit.singh@gmail.com")).toBe("an•••@gmail.com");
+    expect(maskEmail("a@hushh.ai")).toBe("a•••@hushh.ai");
+    expect(maskEmail("not-an-email")).toBe("");
+    expect(maskEmail(null)).toBe("");
+  });
+
+  it("takes only a plausible first name from a display name", () => {
+    expect(firstNameOf("Ankit Kumar Singh")).toBe("Ankit");
+    expect(firstNameOf("ankit@hushh.ai")).toBe("");
+    expect(firstNameOf("A")).toBe("");
+    expect(firstNameOf(null)).toBe("");
+  });
+
+  it("stamps the sign-in moment in UTC so it is unambiguous", () => {
+    expect(formatSignInMoment(new Date("2026-08-05T09:12:00Z"))).toBe(
+      "5 August 2026 at 09:12 UTC",
+    );
+  });
+});
+
+describe("welcome mail", () => {
+  it("greets by first name and offers one action", () => {
+    const mail = buildWelcomeMail({ appUrl: APP_URL, displayName: "Ankit Kumar Singh" });
+    expect(mail.subject).toBe("Welcome to One");
+    expect(mail.html).toContain("Ankit, you&#39;re in.");
+    expect(mail.html).toContain(`href="${APP_URL}/"`);
+    // One CTA, not two.
+    expect(mail.html.match(/display:inline-block;padding:14px 32px/g)).toHaveLength(1);
+  });
+
+  it("falls back to a neutral greeting without a name", () => {
+    const mail = buildWelcomeMail({ appUrl: APP_URL, displayName: null });
+    expect(mail.html).toContain("You&#39;re in.");
+    expect(mail.text).toContain("You're in.");
+  });
+});
+
+describe("welcome back mail", () => {
+  it("states when the sign-in happened", () => {
+    const mail = buildWelcomeBackMail({
+      appUrl: APP_URL,
+      displayName: "Ankit",
+      signedInAt: new Date("2026-08-05T09:12:00Z"),
+    });
+    expect(mail.subject).toBe("Welcome back to One");
+    expect(mail.html).toContain("Welcome back, Ankit.");
+    expect(mail.html).toContain("5 August 2026 at 09:12 UTC");
+    expect(mail.text).toContain("Signed in: 5 August 2026 at 09:12 UTC");
+  });
+});
+
+describe("phone conflict mail", () => {
+  it("names the other account only as a masked address", () => {
+    const mail = buildPhoneConflictMail({
+      appUrl: APP_URL,
+      displayName: "Ankit",
+      attemptedPhoneNumber: "+919876543210",
+      linkedAccountEmail: "ankit.old@gmail.com",
+      signInUrl: `${APP_URL}/login`,
+    });
+    expect(mail.subject).toBe("That number is on another account");
+    expect(mail.html).toContain("an•••@gmail.com");
+    expect(mail.html).not.toContain("ankit.old@gmail.com");
+    // The full number never appears, even though the recipient typed it.
+    expect(mail.html).not.toContain("9876543210");
+    expect(mail.text).toContain("Number: 919876 •• •• 3210");
+    expect(mail.text).toContain("Account: an•••@gmail.com");
+    expect(mail.html).toContain(`href="${APP_URL}/login"`);
+  });
+
+  it("omits the account row when the owning account cannot be resolved", () => {
+    const mail = buildPhoneConflictMail({
+      appUrl: APP_URL,
+      displayName: null,
+      attemptedPhoneNumber: "+919876543210",
+      linkedAccountEmail: null,
+      signInUrl: `${APP_URL}/login`,
+    });
+    expect(mail.text).not.toContain("Account:");
+    expect(mail.text).toContain("Number: 919876 •• •• 3210");
+  });
+
+  it("refuses a javascript: sign-in URL rather than rendering it", () => {
+    const mail = buildPhoneConflictMail({
+      appUrl: APP_URL,
+      displayName: null,
+      attemptedPhoneNumber: "+919876543210",
+      linkedAccountEmail: null,
+      signInUrl: "javascript:alert(1)",
+    });
+    expect(mail.html).not.toContain("javascript:");
+    expect(mail.html).not.toContain("Sign in to that account");
+  });
+});

--- a/hushh-webapp/__tests__/mail/mail-client.test.ts
+++ b/hushh-webapp/__tests__/mail/mail-client.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const MODULE_PATH = "@/lib/mail/mail-client";
+const ENDPOINT = "https://hushh-mail-api.example.run.app";
+
+describe("hushh-mail-api client", () => {
+  const originalEndpoint = process.env.MAIL_API_ENDPOINT;
+  const originalKey = process.env.MAIL_API_KEY;
+
+  beforeEach(() => {
+    process.env.MAIL_API_ENDPOINT = ENDPOINT;
+    process.env.MAIL_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    if (originalEndpoint === undefined) delete process.env.MAIL_API_ENDPOINT;
+    else process.env.MAIL_API_ENDPOINT = originalEndpoint;
+    if (originalKey === undefined) delete process.env.MAIL_API_KEY;
+    else process.env.MAIL_API_KEY = originalKey;
+  });
+
+  it("posts to /v1/send with the key in the header, never the body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, messageId: "<a@hushh.ai>" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { sendMail } = await import(MODULE_PATH);
+    const result = await sendMail({
+      to: "ankit@hushh.ai",
+      subject: "Welcome to One",
+      html: "<p>hi</p>",
+      text: "hi",
+      idempotencyKey: "one-welcome:uid-1",
+    });
+
+    expect(result).toEqual({ status: "sent", messageId: "<a@hushh.ai>", deduplicated: false });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${ENDPOINT}/v1/send`);
+    expect((init.headers as Record<string, string>)["x-api-key"]).toBe("test-key");
+    expect(init.body).not.toContain("test-key");
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      to: "ankit@hushh.ai",
+      subject: "Welcome to One",
+      idempotencyKey: "one-welcome:uid-1",
+    });
+  });
+
+  it("reports a de-duplicated send rather than claiming a fresh one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ success: true, messageId: "<a@hushh.ai>", deduplicated: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const { sendMail } = await import(MODULE_PATH);
+    const result = await sendMail({ to: "a@b.com", subject: "s", html: "<p>x</p>" });
+
+    expect(result).toEqual({ status: "sent", messageId: "<a@hushh.ai>", deduplicated: true });
+  });
+
+  it("does not send when the binding is missing", async () => {
+    delete process.env.MAIL_API_KEY;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { sendMail, isMailConfigured } = await import(MODULE_PATH);
+
+    expect(isMailConfigured()).toBe(false);
+    expect(await sendMail({ to: "a@b.com", subject: "s", html: "<p>x</p>" })).toEqual({
+      status: "not_configured",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the service's own error text on a rejected request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Unknown template" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    const { sendMail } = await import(MODULE_PATH);
+    expect(await sendMail({ to: "a@b.com", subject: "s", html: "<p>x</p>" })).toEqual({
+      status: "failed",
+      reason: "Unknown template",
+    });
+  });
+
+  it("turns a transport failure into a result instead of throwing", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("fetch failed")));
+
+    const { sendMail } = await import(MODULE_PATH);
+    expect(await sendMail({ to: "a@b.com", subject: "s", html: "<p>x</p>" })).toEqual({
+      status: "failed",
+      reason: "fetch failed",
+    });
+  });
+});

--- a/hushh-webapp/app/api/auth/mail/route.ts
+++ b/hushh-webapp/app/api/auth/mail/route.ts
@@ -23,7 +23,6 @@ import {
   sendSignInMail,
   WELCOME_MAIL_CLAIM,
 } from "@/lib/mail/auth-mail-service";
-import { resolveRuntimeFrontendUrl } from "@/lib/runtime/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -95,8 +94,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unsupported event" }, { status: 400 });
   }
 
-  const appUrl = resolveRuntimeFrontendUrl() || new URL(request.url).origin;
-
   try {
     const { auth } = await import("@/lib/firebase/admin");
     const user = await auth.getUser(identity.userId);
@@ -107,7 +104,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ status: "skipped", reason: "duplicate_request" });
       }
 
-      const outcome = await sendSignInMail(user, { appUrl }, {
+      const outcome = await sendSignInMail(user, {
         markWelcomeSent: async (uid, atEpochSeconds) => {
           // Merge: replacing the claim set would drop anything another feature
           // adds later.
@@ -144,7 +141,6 @@ export async function POST(request: NextRequest) {
     }
 
     const outcome = await sendPhoneConflictMail(user, {
-      appUrl,
       attemptedPhoneNumber: phoneNumber,
       linkedAccountEmail: owner.email ?? null,
     });

--- a/hushh-webapp/app/api/auth/mail/route.ts
+++ b/hushh-webapp/app/api/auth/mail/route.ts
@@ -47,6 +47,39 @@ function seenRecently(key: string): boolean {
   return false;
 }
 
+/**
+ * Per-account ceiling on conflict mail.
+ *
+ * The client only asks for this after a real Firebase conflict, but the route
+ * is reachable directly by anyone signed in, and it will happily look up any
+ * number. Two things follow from that and both are capped here: the mail names
+ * a masked address, so an unbounded caller could walk numbers to learn which
+ * ones are registered; and every send spends from a Workspace daily quota
+ * shared with the welcome mail, so a loop could starve real signups.
+ *
+ * Per instance, so the true ceiling is this times the instance count. That is
+ * a backstop against a runaway or casual prober, not a strict global quota —
+ * an exact one needs shared state the frontend does not have today.
+ */
+const CONFLICT_SENDS = new Map<string, number[]>();
+const CONFLICT_WINDOW_MS = 60 * 60_000;
+const CONFLICT_MAX_PER_WINDOW = 3;
+
+function conflictQuotaExhausted(uid: string): boolean {
+  const now = Date.now();
+  const recent = (CONFLICT_SENDS.get(uid) ?? []).filter(
+    (at) => now - at < CONFLICT_WINDOW_MS,
+  );
+  if (recent.length >= CONFLICT_MAX_PER_WINDOW) {
+    CONFLICT_SENDS.set(uid, recent);
+    return true;
+  }
+  recent.push(now);
+  if (CONFLICT_SENDS.size >= RECENT_MAX_ENTRIES) CONFLICT_SENDS.clear();
+  CONFLICT_SENDS.set(uid, recent);
+  return false;
+}
+
 export async function POST(request: NextRequest) {
   const identity = await validateFirebaseToken(request.headers.get("Authorization"));
   if (!identity.valid || !identity.userId) {
@@ -95,18 +128,25 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ status: "skipped", reason: "duplicate_request" });
     }
 
-    // Resolve the account that actually holds the number. Absent is normal —
-    // the number may sit on a just-deleted account — and the mail still goes
-    // out, only without the account hint.
-    const linkedAccountEmail = await auth
-      .getUserByPhoneNumber(phoneNumber)
-      .then((owner) => (owner.uid === user.uid ? null : owner.email ?? null))
-      .catch(() => null);
+    // Only mail when a different account genuinely holds the number. Sending
+    // otherwise would be both wrong — "that number is taken" when it is not —
+    // and an invitation to walk the number space. The owner may legitimately
+    // have no email of its own (a phone-only account), which is a real
+    // conflict with no hint to offer, so absence of an owner and absence of an
+    // address are kept apart.
+    const owner = await auth.getUserByPhoneNumber(phoneNumber).catch(() => null);
+    if (!owner || owner.uid === user.uid) {
+      return NextResponse.json({ status: "skipped", reason: "no_conflicting_account" });
+    }
+
+    if (conflictQuotaExhausted(user.uid)) {
+      return NextResponse.json({ status: "skipped", reason: "rate_limited" });
+    }
 
     const outcome = await sendPhoneConflictMail(user, {
       appUrl,
       attemptedPhoneNumber: phoneNumber,
-      linkedAccountEmail,
+      linkedAccountEmail: owner.email ?? null,
     });
     return NextResponse.json(outcome);
   } catch (error) {

--- a/hushh-webapp/app/api/auth/mail/route.ts
+++ b/hushh-webapp/app/api/auth/mail/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/auth/mail
+ *
+ * The one place One asks `hushh-mail-api` for a lifecycle mail.
+ *
+ *   { "event": "signed_in" }
+ *     Welcome on the first sign-in, welcome back on every later one.
+ *
+ *   { "event": "phone_conflict", "phoneNumber": "+9198…" }
+ *     Sent when the phone step reports that the number is verified on another
+ *     account. The mail names that account only as a masked address, and only
+ *     to the signed-in person's own verified inbox.
+ *
+ * A mail failure never fails the caller: the response reports the outcome and
+ * the sign-in continues either way.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { validateFirebaseToken } from "@/lib/auth/validate";
+import {
+  sendPhoneConflictMail,
+  sendSignInMail,
+  WELCOME_MAIL_CLAIM,
+} from "@/lib/mail/auth-mail-service";
+import { resolveRuntimeFrontendUrl } from "@/lib/runtime/settings";
+
+export const dynamic = "force-dynamic";
+
+const E164_PATTERN = /^\+[1-9]\d{6,14}$/;
+
+/**
+ * Guards against a client loop turning into a mail loop. This is per instance
+ * and therefore a backstop, not a quota — the durable guarantees live in
+ * auth-mail-service.
+ */
+const RECENT_REQUESTS = new Map<string, number>();
+const RECENT_WINDOW_MS = 60_000;
+const RECENT_MAX_ENTRIES = 5_000;
+
+function seenRecently(key: string): boolean {
+  const now = Date.now();
+  const previous = RECENT_REQUESTS.get(key);
+  if (previous !== undefined && now - previous < RECENT_WINDOW_MS) return true;
+  if (RECENT_REQUESTS.size >= RECENT_MAX_ENTRIES) RECENT_REQUESTS.clear();
+  RECENT_REQUESTS.set(key, now);
+  return false;
+}
+
+export async function POST(request: NextRequest) {
+  const identity = await validateFirebaseToken(request.headers.get("Authorization"));
+  if (!identity.valid || !identity.userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    event?: string;
+    phoneNumber?: string;
+  };
+  const event = String(body.event ?? "").trim();
+  if (event !== "signed_in" && event !== "phone_conflict") {
+    return NextResponse.json({ error: "Unsupported event" }, { status: 400 });
+  }
+
+  const appUrl = resolveRuntimeFrontendUrl() || new URL(request.url).origin;
+
+  try {
+    const { auth } = await import("@/lib/firebase/admin");
+    const user = await auth.getUser(identity.userId);
+
+    if (event === "signed_in") {
+      const signInStamp = user.metadata?.lastSignInTime ?? "";
+      if (seenRecently(`signed_in:${user.uid}:${signInStamp}`)) {
+        return NextResponse.json({ status: "skipped", reason: "duplicate_request" });
+      }
+
+      const outcome = await sendSignInMail(user, { appUrl }, {
+        markWelcomeSent: async (uid, atEpochSeconds) => {
+          // Merge: replacing the claim set would drop anything another feature
+          // adds later.
+          await auth.setCustomUserClaims(uid, {
+            ...(user.customClaims ?? {}),
+            [WELCOME_MAIL_CLAIM]: atEpochSeconds,
+          });
+        },
+      });
+      return NextResponse.json(outcome);
+    }
+
+    const phoneNumber = String(body.phoneNumber ?? "").trim();
+    if (!E164_PATTERN.test(phoneNumber)) {
+      return NextResponse.json({ error: "Invalid phone number" }, { status: 400 });
+    }
+    if (seenRecently(`phone_conflict:${user.uid}:${phoneNumber}`)) {
+      return NextResponse.json({ status: "skipped", reason: "duplicate_request" });
+    }
+
+    // Resolve the account that actually holds the number. Absent is normal —
+    // the number may sit on a just-deleted account — and the mail still goes
+    // out, only without the account hint.
+    const linkedAccountEmail = await auth
+      .getUserByPhoneNumber(phoneNumber)
+      .then((owner) => (owner.uid === user.uid ? null : owner.email ?? null))
+      .catch(() => null);
+
+    const outcome = await sendPhoneConflictMail(user, {
+      appUrl,
+      attemptedPhoneNumber: phoneNumber,
+      linkedAccountEmail,
+    });
+    return NextResponse.json(outcome);
+  } catch (error) {
+    console.warn("[API] Auth mail dispatch failed:", error);
+    return NextResponse.json({ status: "failed", reason: "dispatch_error" });
+  }
+}

--- a/hushh-webapp/components/auth/phone-verification-flow.tsx
+++ b/hushh-webapp/components/auth/phone-verification-flow.tsx
@@ -46,6 +46,7 @@ import {
   type CountryPhoneOption,
 } from "@/lib/constants/country-phone-options";
 import { morphyToast } from "@/lib/morphy-ux/morphy";
+import { ApiService } from "@/lib/services/api-service";
 import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
 import { trackEvent } from "@/lib/observability/client";
 import {
@@ -55,6 +56,25 @@ import {
 import { cn } from "@/lib/utils";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
+
+/**
+ * Firebase reports a number that is verified on a *different* account with one
+ * of these. It is the case where somebody made an account earlier, forgot it,
+ * and is now blocked on a number they own — so the server mails them the
+ * masked address of the account that holds it.
+ */
+const PHONE_TAKEN_ERROR_CODES = new Set([
+  "credential-already-in-use",
+  "phone-number-already-exists",
+]);
+
+function isPhoneTakenByAnotherAccount(error: unknown): boolean {
+  const code = String((error as { code?: unknown })?.code ?? "").replace(
+    /^auth\//,
+    "",
+  );
+  return PHONE_TAKEN_ERROR_CODES.has(code);
+}
 
 // Country metadata owns national-number length and validity.
 const E164_PHONE_PATTERN = /^\+[1-9]\d{1,14}$/;
@@ -671,6 +691,11 @@ export function PhoneVerificationFlow({
           action: mode,
           result: "error",
         });
+        if (isPhoneTakenByAnotherAccount(error)) {
+          void ApiService.notifyAuthMail("phone_conflict", {
+            phoneNumber: normalizedPhone,
+          });
+        }
         morphyToast.error(
           error instanceof Error
             ? error.message
@@ -795,6 +820,13 @@ export function PhoneVerificationFlow({
           action: mode,
           result: "error",
         });
+        // The link only fails on the code step, so this is where the conflict
+        // usually surfaces.
+        if (isPhoneTakenByAnotherAccount(error) && submittedPhoneNumber) {
+          void ApiService.notifyAuthMail("phone_conflict", {
+            phoneNumber: submittedPhoneNumber,
+          });
+        }
         if (options.notify) {
           morphyToast.error(
             error instanceof Error
@@ -808,7 +840,7 @@ export function PhoneVerificationFlow({
         setBusy(false);
       }
     },
-    [busy, confirmVerification, mode, onCompleted],
+    [busy, confirmVerification, mode, onCompleted, submittedPhoneNumber],
   );
 
   const handleConfirmVerification = useCallback(async () => {

--- a/hushh-webapp/components/developers/developer-docs-hub.tsx
+++ b/hushh-webapp/components/developers/developer-docs-hub.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useAuth } from "@/hooks/use-auth";
+import { ApiService } from "@/lib/services/api-service";
 import { AuthService } from "@/lib/services/auth-service";
 import { AppleIcon, GoogleIcon } from "@/lib/morphy-ux/social-icons";
 import { Button as MorphyButton } from "@/lib/morphy-ux/button";
@@ -1196,6 +1197,8 @@ export function DeveloperDocsHub({
           ? await AuthService.signInWithGoogle()
           : await AuthService.signInWithApple();
       setNativeUser(authResult.user);
+      // Same sign-in, same mail as the main auth surface.
+      void ApiService.notifyAuthMail("signed_in");
       await checkAuth();
       await refreshAccess(authResult.user);
     } catch (error) {

--- a/hushh-webapp/components/onboarding/AuthStep.tsx
+++ b/hushh-webapp/components/onboarding/AuthStep.tsx
@@ -693,6 +693,10 @@ export function AuthStep({
               action: provider,
               result: "success",
             });
+            // Welcome on the first sign-in, welcome back afterwards. The server
+            // decides which; this is the one point per sign-in that asks. It is
+            // never awaited — navigation must not wait on a mail.
+            void ApiService.notifyAuthMail("signed_in", { idToken });
             if (growthJourney) {
               trackGrowthFunnelStepCompleted({
                 journey: growthJourney,

--- a/hushh-webapp/eslint.config.mjs
+++ b/hushh-webapp/eslint.config.mjs
@@ -133,6 +133,8 @@ export default [
       "lib/services/**/*",
       "lib/api/**/*",
       "lib/auth/**/*",
+      // Server-only transport to hushh-mail-api; never reachable from a browser
+      "lib/mail/**/*",
       // SSE streaming components use fetch() for EventSource polyfill
       "components/kai/debate-stream-view.tsx",
     ],

--- a/hushh-webapp/frontend-native-surface-map.generated.json
+++ b/hushh-webapp/frontend-native-surface-map.generated.json
@@ -36,6 +36,10 @@
       "file": "app/api/app-config/review-mode/session/route.ts"
     },
     {
+      "template": "/api/auth/mail",
+      "file": "app/api/auth/mail/route.ts"
+    },
+    {
       "template": "/api/auth/session",
       "file": "app/api/auth/session/route.ts"
     },
@@ -7936,5 +7940,5 @@
       "thread_and_consent_contract": null
     }
   ],
-  "content_sha256": "d375354425f66ebe9e6da2e5a38ac51e63f62c7122ffcc203f016a64fb8abca9"
+  "content_sha256": "f9ce08c33eeea46cd638055f70b91759798f45e49afb6d46c30ae33419c7cb94"
 }

--- a/hushh-webapp/lib/mail/auth-mail-service.ts
+++ b/hushh-webapp/lib/mail/auth-mail-service.ts
@@ -128,7 +128,16 @@ export async function sendSignInMail(
       `one-welcome:${user.uid}`,
     );
     if (outcome.status === "sent") {
-      await deps.markWelcomeSent(user.uid, Math.floor(Date.now() / 1000));
+      // The mail is already delivered at this point. A claim-write failure must
+      // not be reported as a failed send — the caller would read that as "no
+      // mail went out", which is the opposite of what happened. `isFirstSignIn`
+      // stops being true once the next real sign-in advances lastSignInTime, so
+      // a lost marker risks at most one repeat, not an unbounded loop.
+      try {
+        await deps.markWelcomeSent(user.uid, Math.floor(Date.now() / 1000));
+      } catch (error) {
+        console.warn("[AuthMail] Welcome mail sent but its marker did not persist:", error);
+      }
     }
     return outcome;
   }

--- a/hushh-webapp/lib/mail/auth-mail-service.ts
+++ b/hushh-webapp/lib/mail/auth-mail-service.ts
@@ -1,0 +1,183 @@
+/**
+ * Decides which auth mail to send, and whether to send one at all.
+ *
+ * The route handler stays thin; the judgement lives here so it is testable
+ * without a request.
+ *
+ * Not sending twice
+ * -----------------
+ * The client fires one call per real sign-in, so there is normally exactly one
+ * request per mail. Three backstops sit under that:
+ *
+ *   - `lastSignInTime` keys the idempotency. Firebase advances it on a sign-in
+ *     and not on a token refresh, so every retry inside one sign-in collapses
+ *     onto the same key.
+ *   - `hushhWelcomeMailAt`, a custom claim, makes the welcome mail
+ *     once-per-account for good. It is the only durable store this service has
+ *     — the Firebase project has no Firestore — and it survives instance
+ *     recycling, which an in-memory guard does not.
+ *   - the mail service's own `idempotencyKey`, which is per-instance and
+ *     therefore a backstop rather than a guarantee.
+ */
+
+import "server-only";
+
+import type { auth as adminAuth } from "firebase-admin";
+
+import {
+  buildPhoneConflictMail,
+  buildWelcomeBackMail,
+  buildWelcomeMail,
+  type BuiltAuthMail,
+} from "@/lib/mail/auth-mail-templates";
+import { sendMail, type SendMailResult } from "@/lib/mail/mail-client";
+
+/** A first sign-in lands within a second or two of account creation. */
+const FIRST_SIGN_IN_TOLERANCE_MS = 60_000;
+
+export const WELCOME_MAIL_CLAIM = "hushhWelcomeMailAt";
+
+type AuthMailKind = "welcome" | "welcome_back" | "phone_conflict";
+
+export type AuthMailOutcome =
+  | { status: "sent"; kind: AuthMailKind; messageId: string | null }
+  | { status: "skipped"; reason: string }
+  | { status: "not_configured" }
+  | { status: "failed"; reason: string };
+
+type UserRecord = adminAuth.UserRecord;
+
+function parseTime(value: string | undefined | null): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * True when this sign-in is the one that created the account. Firebase sets
+ * both timestamps in the same operation, so they agree within a second; the
+ * tolerance only absorbs clock jitter between the two writes.
+ */
+export function isFirstSignIn(record: {
+  creationTime?: string;
+  lastSignInTime?: string;
+}): boolean {
+  const created = parseTime(record.creationTime);
+  const lastSignIn = parseTime(record.lastSignInTime);
+  if (!created) return false;
+  if (!lastSignIn) return true;
+  return lastSignIn.getTime() - created.getTime() <= FIRST_SIGN_IN_TOLERANCE_MS;
+}
+
+function toOutcome(kind: AuthMailKind, sent: SendMailResult): AuthMailOutcome {
+  if (sent.status === "sent") return { status: "sent", kind, messageId: sent.messageId };
+  if (sent.status === "not_configured") return { status: "not_configured" };
+  return { status: "failed", reason: sent.reason };
+}
+
+async function deliver(
+  kind: AuthMailKind,
+  to: string,
+  mail: BuiltAuthMail,
+  idempotencyKey: string,
+): Promise<AuthMailOutcome> {
+  const sent = await sendMail({
+    to,
+    subject: mail.subject,
+    html: mail.html,
+    text: mail.text,
+    idempotencyKey,
+  });
+  return toOutcome(kind, sent);
+}
+
+export interface SignInMailDeps {
+  /** Marks the welcome mail as sent, durably. Failures must not resend. */
+  markWelcomeSent: (uid: string, atEpochSeconds: number) => Promise<void>;
+}
+
+/**
+ * Welcome on the first sign-in, welcome back on every later one.
+ */
+export async function sendSignInMail(
+  user: UserRecord,
+  context: { appUrl: string },
+  deps: SignInMailDeps,
+): Promise<AuthMailOutcome> {
+  const to = String(user.email ?? "").trim();
+  if (!to) return { status: "skipped", reason: "no_email" };
+
+  const lastSignInTime = user.metadata?.lastSignInTime;
+  const signedInAt = parseTime(lastSignInTime) ?? new Date();
+  const signInStamp = String(signedInAt.getTime());
+
+  if (isFirstSignIn(user.metadata ?? {})) {
+    const alreadySent = Number(
+      (user.customClaims as Record<string, unknown> | undefined)?.[WELCOME_MAIL_CLAIM] ?? 0,
+    );
+    if (alreadySent > 0) {
+      // The account exists and was already welcomed — a repeat here means a
+      // retry, not a second signup.
+      return { status: "skipped", reason: "welcome_already_sent" };
+    }
+
+    const outcome = await deliver(
+      "welcome",
+      to,
+      buildWelcomeMail({ appUrl: context.appUrl, displayName: user.displayName }),
+      `one-welcome:${user.uid}`,
+    );
+    if (outcome.status === "sent") {
+      await deps.markWelcomeSent(user.uid, Math.floor(Date.now() / 1000));
+    }
+    return outcome;
+  }
+
+  return deliver(
+    "welcome_back",
+    to,
+    buildWelcomeBackMail({
+      appUrl: context.appUrl,
+      displayName: user.displayName,
+      signedInAt,
+    }),
+    `one-signin:${user.uid}:${signInStamp}`,
+  );
+}
+
+/**
+ * The number entered on the phone step is verified on a different account.
+ *
+ * The mail goes to the signed-in person's own verified address and names the
+ * other account only as a masked hint, so it helps someone recover an account
+ * they forgot without telling anyone who owns a number.
+ */
+export async function sendPhoneConflictMail(
+  user: UserRecord,
+  context: {
+    appUrl: string;
+    attemptedPhoneNumber: string;
+    linkedAccountEmail: string | null;
+  },
+): Promise<AuthMailOutcome> {
+  const to = String(user.email ?? "").trim();
+  if (!to) return { status: "skipped", reason: "no_email" };
+
+  const digits = context.attemptedPhoneNumber.replace(/\D/g, "");
+  if (digits.length < 5) return { status: "skipped", reason: "invalid_phone" };
+
+  return deliver(
+    "phone_conflict",
+    to,
+    buildPhoneConflictMail({
+      appUrl: context.appUrl,
+      displayName: user.displayName,
+      attemptedPhoneNumber: context.attemptedPhoneNumber,
+      linkedAccountEmail: context.linkedAccountEmail,
+      signInUrl: `${context.appUrl}/login`,
+    }),
+    // One mail per person per number: a repeated attempt on the same number is
+    // the same fact, and re-sending it would be noise.
+    `one-phone-conflict:${user.uid}:${digits}`,
+  );
+}

--- a/hushh-webapp/lib/mail/auth-mail-service.ts
+++ b/hushh-webapp/lib/mail/auth-mail-service.ts
@@ -101,7 +101,6 @@ export interface SignInMailDeps {
  */
 export async function sendSignInMail(
   user: UserRecord,
-  context: { appUrl: string },
   deps: SignInMailDeps,
 ): Promise<AuthMailOutcome> {
   const to = String(user.email ?? "").trim();
@@ -124,7 +123,7 @@ export async function sendSignInMail(
     const outcome = await deliver(
       "welcome",
       to,
-      buildWelcomeMail({ appUrl: context.appUrl, displayName: user.displayName }),
+      buildWelcomeMail({ displayName: user.displayName }),
       `one-welcome:${user.uid}`,
     );
     if (outcome.status === "sent") {
@@ -146,7 +145,6 @@ export async function sendSignInMail(
     "welcome_back",
     to,
     buildWelcomeBackMail({
-      appUrl: context.appUrl,
       displayName: user.displayName,
       signedInAt,
     }),
@@ -164,7 +162,6 @@ export async function sendSignInMail(
 export async function sendPhoneConflictMail(
   user: UserRecord,
   context: {
-    appUrl: string;
     attemptedPhoneNumber: string;
     linkedAccountEmail: string | null;
   },
@@ -179,11 +176,9 @@ export async function sendPhoneConflictMail(
     "phone_conflict",
     to,
     buildPhoneConflictMail({
-      appUrl: context.appUrl,
       displayName: user.displayName,
       attemptedPhoneNumber: context.attemptedPhoneNumber,
       linkedAccountEmail: context.linkedAccountEmail,
-      signInUrl: `${context.appUrl}/login`,
     }),
     // One mail per person per number: a repeated attempt on the same number is
     // the same fact, and re-sending it would be noise.

--- a/hushh-webapp/lib/mail/auth-mail-templates.ts
+++ b/hushh-webapp/lib/mail/auth-mail-templates.ts
@@ -15,11 +15,10 @@
 
 import {
   buildEmailShell,
+  ONE_APP_URL,
   type DetailRow,
   type RenderedEmail,
 } from "@/lib/mail/email-shell";
-// The same masking the phone screen shows, so the mail and the screen agree.
-import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
 
 export type AuthMailEvent = "welcome" | "welcome_back" | "phone_conflict";
 
@@ -68,8 +67,6 @@ export function formatSignInMoment(at: Date): string {
 }
 
 export interface AuthMailContext {
-  /** Origin of the app the mail links back to, e.g. https://one.hushh.ai */
-  appUrl: string;
   displayName?: string | null;
 }
 
@@ -82,7 +79,7 @@ export function buildWelcomeMail(context: AuthMailContext): BuiltAuthMail {
       eyebrow: "Welcome",
       heading: name ? `${name}, you're in.` : "You're in.",
       paragraphs: ["One is your private agent. Your data stays yours."],
-      cta: { label: "Open One", url: context.appUrl },
+      cta: { label: "Open One", url: ONE_APP_URL },
       footNote: "You received this because a Hussh account was just created with this address.",
     }),
   };
@@ -102,28 +99,31 @@ export function buildWelcomeBackMail(context: WelcomeBackContext): BuiltAuthMail
       heading: name ? `Welcome back, ${name}.` : "Welcome back.",
       paragraphs: ["Good to see you again."],
       details: [{ label: "Signed in", value: formatSignInMoment(context.signedInAt) }],
-      cta: { label: "Open One", url: context.appUrl },
+      cta: { label: "Open One", url: ONE_APP_URL },
       footNote: "Not you? Reply to this email and we will secure the account.",
     }),
   };
 }
 
 export interface PhoneConflictContext extends AuthMailContext {
-  /** The number that was entered, in E.164. Masked before it is rendered. */
+  /**
+   * The number that was entered, in E.164. Shown in full: the recipient typed
+   * it a moment ago on their own screen, so masking it hides nothing from them
+   * and only makes the mail harder to act on. The account that holds it is a
+   * different matter and stays masked.
+   */
   attemptedPhoneNumber: string;
   /** Address on the account that already holds the number. Masked before use. */
   linkedAccountEmail?: string | null;
-  /** Where the person signs in to the other account. */
-  signInUrl: string;
 }
 
 export function buildPhoneConflictMail(context: PhoneConflictContext): BuiltAuthMail {
   const name = firstNameOf(context.displayName);
-  const maskedPhone = maskPhoneNumber(context.attemptedPhoneNumber);
+  const phoneNumber = String(context.attemptedPhoneNumber ?? "").trim();
   const maskedEmail = maskEmail(context.linkedAccountEmail);
 
   const details: DetailRow[] = [];
-  if (maskedPhone) details.push({ label: "Number", value: maskedPhone });
+  if (phoneNumber) details.push({ label: "Number", value: phoneNumber });
   if (maskedEmail) details.push({ label: "Account", value: maskedEmail });
 
   return {
@@ -138,7 +138,7 @@ export function buildPhoneConflictMail(context: PhoneConflictContext): BuiltAuth
           : "It is already verified on another Hussh account.",
       ],
       details,
-      cta: { label: "Sign in to that account", url: context.signInUrl },
+      cta: { label: "Sign in to that account", url: `${ONE_APP_URL}/login` },
       footNote: "Didn't try this? Ignore this email — nothing changed.",
     }),
   };

--- a/hushh-webapp/lib/mail/auth-mail-templates.ts
+++ b/hushh-webapp/lib/mail/auth-mail-templates.ts
@@ -83,7 +83,7 @@ export function buildWelcomeMail(context: AuthMailContext): BuiltAuthMail {
       heading: name ? `${name}, you're in.` : "You're in.",
       paragraphs: ["One is your private agent. Your data stays yours."],
       cta: { label: "Open One", url: context.appUrl },
-      footNote: "You received this because a Hushh account was just created with this address.",
+      footNote: "You received this because a Hussh account was just created with this address.",
     }),
   };
 }
@@ -134,8 +134,8 @@ export function buildPhoneConflictMail(context: PhoneConflictContext): BuiltAuth
       heading: name ? `${name}, that number is taken.` : "That number is taken.",
       paragraphs: [
         maskedEmail
-          ? "It is already verified on another Hushh account — often one you made earlier and forgot."
-          : "It is already verified on another Hushh account.",
+          ? "It is already verified on another Hussh account — often one you made earlier and forgot."
+          : "It is already verified on another Hussh account.",
       ],
       details,
       cta: { label: "Sign in to that account", url: context.signInUrl },

--- a/hushh-webapp/lib/mail/auth-mail-templates.ts
+++ b/hushh-webapp/lib/mail/auth-mail-templates.ts
@@ -1,0 +1,145 @@
+/**
+ * One's transactional auth mail.
+ *
+ * Three moments, three mails, one design family with the `invitation` template
+ * that `hushh-mail-api` already sends:
+ *
+ *   welcome        first sign-in — the account now exists
+ *   welcome_back   a later sign-in — also the "was this you?" signal
+ *   phone_conflict the number entered on the phone step is verified on a
+ *                  different account, which the person has usually forgotten
+ *
+ * Copy rules: one headline, at most one supporting line, one action. Anything
+ * the panel already states is not repeated in prose.
+ */
+
+import {
+  buildEmailShell,
+  type DetailRow,
+  type RenderedEmail,
+} from "@/lib/mail/email-shell";
+// The same masking the phone screen shows, so the mail and the screen agree.
+import { maskPhoneNumber } from "@/lib/services/phone-mandate-service";
+
+export type AuthMailEvent = "welcome" | "welcome_back" | "phone_conflict";
+
+export interface BuiltAuthMail extends RenderedEmail {
+  subject: string;
+}
+
+/** First name only. A full legal name in a greeting reads like a form letter. */
+export function firstNameOf(displayName?: string | null): string {
+  const first = String(displayName ?? "")
+    .trim()
+    .split(/\s+/)[0];
+  // Reject anything that is not a plain name: emails, handles, single letters.
+  if (!first || first.length < 2 || /[@<>"]/.test(first)) return "";
+  return first;
+}
+
+/**
+ * `ankit.singh@gmail.com` → `an•••@gmail.com`.
+ *
+ * The other account's address is a recovery hint, never a disclosure: enough to
+ * recognise an inbox you own, not enough to learn one you do not.
+ */
+export function maskEmail(email?: string | null): string {
+  const raw = String(email ?? "").trim();
+  const at = raw.lastIndexOf("@");
+  if (at <= 0) return "";
+  const local = raw.slice(0, at);
+  const domain = raw.slice(at + 1);
+  if (!domain) return "";
+  const head = local.slice(0, local.length > 2 ? 2 : 1);
+  return `${head}•••@${domain}`;
+}
+
+/** Unambiguous across time zones, which a local-time string would not be. */
+export function formatSignInMoment(at: Date): string {
+  return `${new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "UTC",
+  }).format(at)} UTC`;
+}
+
+export interface AuthMailContext {
+  /** Origin of the app the mail links back to, e.g. https://one.hushh.ai */
+  appUrl: string;
+  displayName?: string | null;
+}
+
+export function buildWelcomeMail(context: AuthMailContext): BuiltAuthMail {
+  const name = firstNameOf(context.displayName);
+  return {
+    subject: "Welcome to One",
+    ...buildEmailShell({
+      previewText: "Your One account is ready.",
+      eyebrow: "Welcome",
+      heading: name ? `${name}, you're in.` : "You're in.",
+      paragraphs: ["One is your private agent. Your data stays yours."],
+      cta: { label: "Open One", url: context.appUrl },
+      footNote: "You received this because a Hushh account was just created with this address.",
+    }),
+  };
+}
+
+export interface WelcomeBackContext extends AuthMailContext {
+  signedInAt: Date;
+}
+
+export function buildWelcomeBackMail(context: WelcomeBackContext): BuiltAuthMail {
+  const name = firstNameOf(context.displayName);
+  return {
+    subject: "Welcome back to One",
+    ...buildEmailShell({
+      previewText: "You just signed in to One.",
+      eyebrow: "Sign-in",
+      heading: name ? `Welcome back, ${name}.` : "Welcome back.",
+      paragraphs: ["Good to see you again."],
+      details: [{ label: "Signed in", value: formatSignInMoment(context.signedInAt) }],
+      cta: { label: "Open One", url: context.appUrl },
+      footNote: "Not you? Reply to this email and we will secure the account.",
+    }),
+  };
+}
+
+export interface PhoneConflictContext extends AuthMailContext {
+  /** The number that was entered, in E.164. Masked before it is rendered. */
+  attemptedPhoneNumber: string;
+  /** Address on the account that already holds the number. Masked before use. */
+  linkedAccountEmail?: string | null;
+  /** Where the person signs in to the other account. */
+  signInUrl: string;
+}
+
+export function buildPhoneConflictMail(context: PhoneConflictContext): BuiltAuthMail {
+  const name = firstNameOf(context.displayName);
+  const maskedPhone = maskPhoneNumber(context.attemptedPhoneNumber);
+  const maskedEmail = maskEmail(context.linkedAccountEmail);
+
+  const details: DetailRow[] = [];
+  if (maskedPhone) details.push({ label: "Number", value: maskedPhone });
+  if (maskedEmail) details.push({ label: "Account", value: maskedEmail });
+
+  return {
+    subject: "That number is on another account",
+    ...buildEmailShell({
+      previewText: "The number you entered is verified on a different account.",
+      eyebrow: "Account check",
+      heading: name ? `${name}, that number is taken.` : "That number is taken.",
+      paragraphs: [
+        maskedEmail
+          ? "It is already verified on another Hushh account — often one you made earlier and forgot."
+          : "It is already verified on another Hushh account.",
+      ],
+      details,
+      cta: { label: "Sign in to that account", url: context.signInUrl },
+      footNote: "Didn't try this? Ignore this email — nothing changed.",
+    }),
+  };
+}

--- a/hushh-webapp/lib/mail/email-shell.ts
+++ b/hushh-webapp/lib/mail/email-shell.ts
@@ -1,0 +1,269 @@
+/**
+ * Gmail-safe email shell for One's transactional mail.
+ *
+ * The rendered markup deliberately mirrors the `invitation` template shipped by
+ * `hushh-mail-api`, so a welcome mail and an invitation read as one family:
+ *
+ *   - table layout with `bgcolor` attributes, because Gmail strips background
+ *     shorthand from some containers
+ *   - inline styles only; no <style> block, no classes, no Tailwind
+ *   - no webfonts — Gmail does not load them, so this uses the same vendor font
+ *     stack the invitation mail uses
+ *   - every URL is scheme-checked, because some values reach here from client
+ *     supplied request bodies
+ *
+ * Copy discipline lives in the templates, not here: one headline, at most one
+ * supporting line, one primary action.
+ */
+
+/** Same stack as the invitation mail. Vendor fonts only — never a webfont. */
+export const FONT_STACK =
+  "'Google Sans','Roboto','Trebuchet MS',Arial,Helvetica,sans-serif";
+
+export const PALETTE = {
+  accent: "#0088cc",
+  bg: "#f5f7f8",
+  card: "#ffffff",
+  border: "#e5e7eb",
+  ink: "#111827",
+  body: "#374151",
+  muted: "#6b7280",
+  faint: "#9ca3af",
+} as const;
+
+export const BRAND = {
+  name: "Hushh",
+  logoUrl: "https://www.hushhtech.com/images/hushh-logo-email.png",
+  siteUrl: "https://hushh.ai/",
+  supportEmail: "support@hushh.ai",
+  address: "HushOne, Inc.",
+} as const;
+
+export interface DetailRow {
+  label: string;
+  value: string;
+}
+
+export interface EmailCallToAction {
+  label: string;
+  url: string;
+}
+
+export interface EmailShellOptions {
+  /** Inbox preview line shown next to the subject. */
+  previewText?: string;
+  /** Small uppercase label above the headline. */
+  eyebrow?: string;
+  /** The single headline. Two to six words. */
+  heading: string;
+  /** Supporting copy. One short line is the norm; two is the ceiling. */
+  paragraphs?: string[];
+  /** Key/value panel. Omitted entirely when empty. */
+  details?: DetailRow[];
+  /** The one primary action. */
+  cta?: EmailCallToAction | null;
+  /** Small print under the action. */
+  footNote?: string;
+}
+
+export interface RenderedEmail {
+  html: string;
+  text: string;
+}
+
+export function escapeHtml(value: string): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Only http(s) and mailto survive. Some values reach a template from a request
+ * body, so a raw `javascript:` or `data:` href must never be rendered.
+ */
+export function safeUrl(value: string | undefined | null, fallback = ""): string {
+  const raw = String(value ?? "").trim();
+  if (!raw) return fallback;
+  try {
+    const parsed = new URL(raw);
+    if (!["http:", "https:", "mailto:"].includes(parsed.protocol)) return fallback;
+    return parsed.toString();
+  } catch {
+    return fallback;
+  }
+}
+
+function preheader(text: string): string {
+  if (!text) return "";
+  return `
+      <div style="display:none;font-size:1px;color:${PALETTE.card};line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden;">
+        ${escapeHtml(text)}${"&nbsp;&zwnj;".repeat(60)}
+      </div>`;
+}
+
+function paragraph(text: string): string {
+  return `
+              <p style="margin:0 0 16px;font-family:${FONT_STACK};font-size:15px;line-height:24px;color:${PALETTE.body};">
+                ${escapeHtml(text)}
+              </p>`;
+}
+
+function detailPanel(rows: DetailRow[]): string {
+  const cells = rows
+    .filter((row) => row && row.label && row.value)
+    .map(
+      (row) => `
+                  <tr>
+                    <td style="padding:6px 0;font-family:${FONT_STACK};font-size:13px;line-height:20px;color:${PALETTE.muted};width:38%;vertical-align:top;">
+                      ${escapeHtml(row.label)}
+                    </td>
+                    <td style="padding:6px 0;font-family:${FONT_STACK};font-size:14px;line-height:20px;color:${PALETTE.ink};font-weight:600;vertical-align:top;">
+                      ${escapeHtml(row.value)}
+                    </td>
+                  </tr>`,
+    )
+    .join("");
+
+  if (!cells) return "";
+
+  return `
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f8fafc" style="background-color:#f8fafc;border:1px solid ${PALETTE.border};border-radius:12px;margin:0 0 24px;">
+                <tr>
+                  <td style="padding:18px 20px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                      ${cells}
+                    </table>
+                  </td>
+                </tr>
+              </table>`;
+}
+
+/**
+ * Table-based CTA. `bgcolor` on the <td> is what makes the fill survive Gmail
+ * and Outlook; the inline background-color covers every other client.
+ */
+function ctaButton(cta: EmailCallToAction | null | undefined): string {
+  if (!cta?.label || !cta?.url) return "";
+  const url = safeUrl(cta.url);
+  if (!url) return "";
+
+  return `
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 28px;">
+                <tr>
+                  <td align="center" bgcolor="${PALETTE.accent}" style="background-color:${PALETTE.accent};border-radius:10px;">
+                    <a href="${escapeHtml(url)}"
+                       style="display:inline-block;padding:14px 32px;font-family:${FONT_STACK};font-size:15px;font-weight:600;line-height:20px;color:#ffffff;text-decoration:none;border-radius:10px;">
+                      ${escapeHtml(cta.label)}
+                    </a>
+                  </td>
+                </tr>
+              </table>`;
+}
+
+/** Build a complete Gmail-safe HTML document plus its plain-text alternative. */
+export function buildEmailShell({
+  previewText = "",
+  eyebrow = "",
+  heading,
+  paragraphs = [],
+  details = [],
+  cta = null,
+  footNote = "",
+}: EmailShellOptions): RenderedEmail {
+  const bodyCopy = paragraphs.filter(Boolean).map(paragraph).join("");
+  const logoUrl = safeUrl(BRAND.logoUrl);
+  const siteUrl = safeUrl(BRAND.siteUrl);
+
+  const html = `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <title>${escapeHtml(heading || BRAND.name)}</title>
+  </head>
+  <body style="margin:0;padding:0;background-color:${PALETTE.bg};">
+${preheader(previewText || heading)}
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="${PALETTE.bg}" style="background-color:${PALETTE.bg};">
+      <tr>
+        <td align="center" style="padding:32px 16px;">
+          <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:600px;max-width:100%;">
+
+            <tr>
+              <td align="left" style="padding:0 0 20px;">
+                <a href="${escapeHtml(siteUrl)}" style="text-decoration:none;">
+                  <img src="${escapeHtml(logoUrl)}" alt="${escapeHtml(BRAND.name)}" width="112" height="32"
+                       style="display:block;border:0;outline:none;height:32px;width:auto;max-width:160px;" />
+                </a>
+              </td>
+            </tr>
+
+            <tr>
+              <td bgcolor="${PALETTE.card}" style="background-color:${PALETTE.card};border:1px solid ${PALETTE.border};border-radius:16px;padding:36px 32px;">
+                ${
+                  eyebrow
+                    ? `<p style="margin:0 0 10px;font-family:${FONT_STACK};font-size:11px;line-height:16px;letter-spacing:1.2px;text-transform:uppercase;color:${PALETTE.accent};font-weight:700;">${escapeHtml(
+                        eyebrow,
+                      )}</p>`
+                    : ""
+                }
+                <h1 style="margin:0 0 18px;font-family:${FONT_STACK};font-size:24px;line-height:32px;color:${PALETTE.ink};font-weight:700;">
+                  ${escapeHtml(heading)}
+                </h1>
+${bodyCopy}
+${detailPanel(details)}
+${ctaButton(cta)}
+                ${
+                  footNote
+                    ? `<p style="margin:0;font-family:${FONT_STACK};font-size:13px;line-height:20px;color:${PALETTE.muted};">${escapeHtml(
+                        footNote,
+                      )}</p>`
+                    : ""
+                }
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:24px 8px 0;">
+                <p style="margin:0 0 6px;font-family:${FONT_STACK};font-size:12px;line-height:18px;color:${PALETTE.faint};">
+                  ${escapeHtml(BRAND.address)} &middot;
+                  <a href="${escapeHtml(siteUrl)}" style="color:${PALETTE.muted};text-decoration:underline;">${escapeHtml(
+                    BRAND.name,
+                  )}</a>
+                </p>
+                <p style="margin:0;font-family:${FONT_STACK};font-size:12px;line-height:18px;color:${PALETTE.faint};">
+                  Questions? Reply to this email or write to
+                  <a href="mailto:${escapeHtml(BRAND.supportEmail)}" style="color:${PALETTE.muted};text-decoration:underline;">${escapeHtml(
+                    BRAND.supportEmail,
+                  )}</a>.
+                </p>
+              </td>
+            </tr>
+
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const textLines: string[] = [heading, "", ...paragraphs.filter(Boolean)];
+  const detailLines = details
+    .filter((row) => row && row.label && row.value)
+    .map((row) => `${row.label}: ${row.value}`);
+  if (detailLines.length > 0) textLines.push("", ...detailLines);
+  if (cta?.label && cta?.url) {
+    const url = safeUrl(cta.url);
+    if (url) textLines.push("", `${cta.label}: ${url}`);
+  }
+  if (footNote) textLines.push("", footNote);
+  textLines.push("", `${BRAND.address} — ${BRAND.siteUrl}`);
+
+  return {
+    html,
+    text: textLines.join("\n").replace(/\n{3,}/g, "\n\n").trim(),
+  };
+}

--- a/hushh-webapp/lib/mail/email-shell.ts
+++ b/hushh-webapp/lib/mail/email-shell.ts
@@ -31,10 +31,20 @@ export const PALETTE = {
   faint: "#9ca3af",
 } as const;
 
+/**
+ * Every link in an auth mail points at the product, never at the origin that
+ * happened to send it. A UAT deploy mails real inboxes, and "Open One" landing
+ * on uat.one.hushh.ai is a dead end for the person who receives it.
+ */
+export const ONE_APP_URL = "https://one.hushh.ai";
+
 export const BRAND = {
-  name: "Hussh",
-  logoUrl: "https://www.hushhtech.com/images/hushh-logo-email.png",
-  siteUrl: "https://hushh.ai/",
+  name: "One",
+  // The app's own icon — the same mark as the browser tab and the home screen.
+  // A PNG because Gmail and Outlook do not render SVG, and served from the
+  // product origin so it resolves for every recipient.
+  logoUrl: `${ONE_APP_URL}/quiet-emoji-icon.png`,
+  siteUrl: ONE_APP_URL,
   supportEmail: "support@hushh.ai",
   address: "HushOne, Inc.",
 } as const;
@@ -194,10 +204,22 @@ ${preheader(previewText || heading)}
 
             <tr>
               <td align="left" style="padding:0 0 20px;">
-                <a href="${escapeHtml(siteUrl)}" style="text-decoration:none;">
-                  <img src="${escapeHtml(logoUrl)}" alt="${escapeHtml(BRAND.name)}" width="112" height="32"
-                       style="display:block;border:0;outline:none;height:32px;width:auto;max-width:160px;" />
-                </a>
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td style="padding:0 10px 0 0;line-height:0;">
+                      <a href="${escapeHtml(siteUrl)}" style="text-decoration:none;">
+                        <img src="${escapeHtml(logoUrl)}" alt="${escapeHtml(BRAND.name)}" width="36" height="36"
+                             style="display:block;border:0;outline:none;width:36px;height:36px;border-radius:9px;" />
+                      </a>
+                    </td>
+                    <td style="vertical-align:middle;">
+                      <a href="${escapeHtml(siteUrl)}"
+                         style="font-family:${FONT_STACK};font-size:19px;font-weight:700;letter-spacing:-0.01em;color:${PALETTE.ink};text-decoration:none;">
+                        ${escapeHtml(BRAND.name)}
+                      </a>
+                    </td>
+                  </tr>
+                </table>
               </td>
             </tr>
 

--- a/hushh-webapp/lib/mail/email-shell.ts
+++ b/hushh-webapp/lib/mail/email-shell.ts
@@ -32,7 +32,7 @@ export const PALETTE = {
 } as const;
 
 export const BRAND = {
-  name: "Hushh",
+  name: "Hussh",
   logoUrl: "https://www.hushhtech.com/images/hushh-logo-email.png",
   siteUrl: "https://hushh.ai/",
   supportEmail: "support@hushh.ai",

--- a/hushh-webapp/lib/mail/mail-client.ts
+++ b/hushh-webapp/lib/mail/mail-client.ts
@@ -1,7 +1,7 @@
 /**
  * Server-side client for `hushh-mail-api`.
  *
- * The API key authorises sending under Hushh's SPF and DKIM, so it stays on the
+ * The API key authorises sending under the Hussh Workspace SPF and DKIM identity, so it stays on the
  * server: this module must never be imported from a client component, and the
  * route handlers that use it never echo the key or the endpoint back.
  *

--- a/hushh-webapp/lib/mail/mail-client.ts
+++ b/hushh-webapp/lib/mail/mail-client.ts
@@ -1,0 +1,93 @@
+/**
+ * Server-side client for `hushh-mail-api`.
+ *
+ * The API key authorises sending under Hushh's SPF and DKIM, so it stays on the
+ * server: this module must never be imported from a client component, and the
+ * route handlers that use it never echo the key or the endpoint back.
+ *
+ * One sends rendered `subject` + `html` rather than a registered template id.
+ * The registry covers cross-project shapes (invitation, notification,
+ * verification); One's lifecycle copy is product-specific and lives with the
+ * product, while the transport, key model, idempotency and rate limiting stay
+ * with the service.
+ */
+
+import "server-only";
+
+import { resolveMailApiEndpoint, resolveMailApiKey } from "@/lib/runtime/settings";
+
+const SEND_TIMEOUT_MS = 10_000;
+
+export interface SendMailInput {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  /** A retry with the same key does not send twice. */
+  idempotencyKey?: string;
+}
+
+export type SendMailResult =
+  | { status: "sent"; messageId: string | null; deduplicated: boolean }
+  | { status: "not_configured" }
+  | { status: "failed"; reason: string };
+
+/** True when both the endpoint and a key are bound. Never logs either value. */
+export function isMailConfigured(): boolean {
+  return Boolean(resolveMailApiEndpoint() && resolveMailApiKey());
+}
+
+export async function sendMail(input: SendMailInput): Promise<SendMailResult> {
+  const endpoint = resolveMailApiEndpoint();
+  const apiKey = resolveMailApiKey();
+
+  // Fail open, not closed: a missing binding must never break a sign-in. The
+  // caller decides how loudly to report it.
+  if (!endpoint || !apiKey) return { status: "not_configured" };
+
+  const to = String(input.to ?? "").trim();
+  if (!to) return { status: "failed", reason: "missing_recipient" };
+
+  try {
+    const response = await fetch(`${endpoint}/v1/send`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body: JSON.stringify({
+        to,
+        subject: input.subject,
+        html: input.html,
+        ...(input.text ? { text: input.text } : {}),
+        ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+      }),
+      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+    });
+
+    const payload = (await response.json().catch(() => ({}))) as {
+      messageId?: string;
+      deduplicated?: boolean;
+      error?: string;
+    };
+
+    if (!response.ok) {
+      // `error` from the mail service describes the request, not the key.
+      return {
+        status: "failed",
+        reason: payload?.error ? String(payload.error) : `http_${response.status}`,
+      };
+    }
+
+    return {
+      status: "sent",
+      messageId: payload?.messageId ?? null,
+      deduplicated: payload?.deduplicated === true,
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      reason: error instanceof Error ? error.message : "send_failed",
+    };
+  }
+}

--- a/hushh-webapp/lib/runtime/settings.ts
+++ b/hushh-webapp/lib/runtime/settings.ts
@@ -30,6 +30,19 @@ export function resolveRuntimeFrontendUrl(): string {
   return normalizeUrl(process.env.NEXT_PUBLIC_APP_URL);
 }
 
+/**
+ * `hushh-mail-api` binding. Both values are server-only: the key authorises
+ * sending under Hushh's SPF and DKIM, so neither is ever exposed with a
+ * `NEXT_PUBLIC_` prefix.
+ */
+export function resolveMailApiEndpoint(): string {
+  return normalizeUrl(process.env.MAIL_API_ENDPOINT);
+}
+
+export function resolveMailApiKey(): string {
+  return normalizeText(process.env.MAIL_API_KEY);
+}
+
 export function resolveVoiceFailFastPolicy(): boolean {
   return false;
 }

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -52,7 +52,10 @@ import {
   REQUEST_TIMESTAMP_HEADER,
 } from "@/lib/observability/request-id";
 import { resolveRouteId } from "@/lib/observability/route-map";
-import { resolveRuntimeBackendUrl } from "@/lib/runtime/settings";
+import {
+  resolveRuntimeBackendUrl,
+  resolveRuntimeFrontendUrl,
+} from "@/lib/runtime/settings";
 import { sanitizeErrorMessage } from "@/lib/services/error-sanitizer";
 
 const AUTH_REFRESH_RETRY_HEADER = "X-Hushh-Auth-Refresh-Retry";
@@ -350,7 +353,10 @@ async function apiFetch(
   options: RequestInit = {},
 ): Promise<Response> {
   const apiBase = getApiBaseUrl();
-  const url = `${apiBase}${path}`;
+  // An absolute path is already fully resolved. Native builds use this to reach
+  // a Next.js-only route on the web origin, which `apiBase` (the Python
+  // backend) does not host.
+  const url = /^https?:\/\//i.test(path) ? path : `${apiBase}${path}`;
   const requestStartedAt = Date.now();
   const httpMethod = (options.method || "GET").toUpperCase();
   const routeId =
@@ -1733,6 +1739,38 @@ export class ApiService {
       method: "POST",
       body: JSON.stringify(data),
     });
+  }
+
+  /**
+   * Ask the server to send a lifecycle mail through `hushh-mail-api`.
+   *
+   * Fire and forget by contract: the caller is a sign-in or a phone step, and
+   * neither may be delayed or failed by a mail. Every error resolves to `false`.
+   *
+   * `/api/auth/mail` is a Next.js route, so a native build — where `apiFetch`
+   * resolves against the Python backend — targets the web origin explicitly.
+   */
+  static async notifyAuthMail(
+    event: "signed_in" | "phone_conflict",
+    options?: { phoneNumber?: string; idToken?: string },
+  ): Promise<boolean> {
+    try {
+      const idToken = options?.idToken || (await this.getFirebaseToken());
+      if (!idToken) return false;
+
+      const origin = Capacitor.isNativePlatform() ? resolveRuntimeFrontendUrl() : "";
+      const response = await apiFetch(`${origin}/api/auth/mail`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${idToken}` },
+        body: JSON.stringify({
+          event,
+          ...(options?.phoneNumber ? { phoneNumber: options.phoneNumber } : {}),
+        }),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
   }
 
   static async refreshAccountIdentityShadow(


### PR DESCRIPTION
## What

Three moments in One had no mail behind them:

| Moment | Mail |
|---|---|
| First sign-in | **Welcome to One** — *"Ankit, you're in."* |
| Every later sign-in | **Welcome back to One** — with the sign-in stamp, so it doubles as the "was this you?" signal |
| Phone step reports the number is on another account | **That number is on another account** — with the other account's *masked* address |

All three go through `hushh-mail-api`, which already sends Hushh mail under one Workspace identity and one SPF/DKIM reputation.

## Why raw `subject` + `html` rather than a registered template id

The registry (`invitation`, `notification`, `verification`) covers cross-project shapes. One's lifecycle copy is product-specific, so it lives with the product while the transport, key model, idempotency and rate limiting stay with the service — the path the service's own handover documents for this case.

The markup mirrors the `invitation` template: table layout with `bgcolor`, inline styles only, the same vendor font stack, no webfont. Copy is one headline, one supporting line, one action.

## Not sending twice

Three layers, weakest last:

1. The client fires **once per real sign-in**, so there is normally one request per mail.
2. `lastSignInTime` keys the idempotency. Firebase advances it on a sign-in and not on a token refresh, so retries inside one sign-in collapse onto one key.
3. `hushhWelcomeMailAt`, a merged custom claim, makes the welcome mail once-per-account **for good**. It is the only durable store available — the Firebase project has no Firestore — and it survives instance recycling as an in-memory guard does not.

## The phone-conflict case

The mail goes to the signed-in person's **own verified address** and names the other account only as `an•••@gmail.com`. Enough to recognise an inbox you own, not enough to learn one you do not — so it recovers a forgotten account without turning the phone step into a way to ask who owns a number. The full phone number never appears either, even though the recipient typed it.

## Nothing here can fail a sign-in

- Every send resolves to a result, never a throw; the client never awaits it.
- `MAIL_API_KEY` is bound **only when the secret exists** in the project, the way `backend.cloudbuild.yaml` already treats its add-on secrets. Binding a secret that has not been provisioned would fail the whole deploy. While it is absent the route reports `not_configured` and sign-in is untouched.

## Verification

- `npm run lint` — clean, `--max-warnings=0`
- `npm run typecheck` — clean
- 26 new tests (`__tests__/mail/`) — escaping, scheme rejection, masking, no-webfont, idempotency keys, claim guard, transport failure modes
- `npm run verify:design-system`, `verify:docs`, `verify:phone-verification` (22), `verify:surface-map` — pass
- CI-equivalent build — passes; `/api/auth/mail` registered as ƒ (dynamic)
- Pre-existing unrelated failures in the wider vitest run were baselined against `origin/main` and are identical there

## Remaining

`MAIL_API_KEY` is not yet provisioned — see the PR discussion. Until it is, the feature ships inert and safe.

---
Closes #4905
(retroactive board-linkage backfill, 2026-08-06)