### PR TITLE
feat(auth): mail the sign-out and each new connection

### DIFF
--- a/hushh-webapp/__tests__/mail/account-activity.test.ts
+++ b/hushh-webapp/__tests__/mail/account-activity.test.ts
@@ -75,34 +75,71 @@ describe("sign-out mail", () => {
 });
 
 describe("capability link mail", () => {
+  const ALL = ["gmail", "finance", "location", "pkm", "consent"];
+
   it("seeds silently on the first report, so existing users are not spammed", async () => {
     const { sendCapabilityLinkedMail } = await loadService();
-    const markCapabilitiesMailed = vi.fn().mockResolvedValue(undefined);
+    const markCapabilities = vi.fn().mockResolvedValue(undefined);
 
     const result = await sendCapabilityLinkedMail(
       asRecord(makeUser()),
-      ["gmail", "finance", "location"],
-      { markCapabilitiesMailed },
+      { observed: ALL, connected: ["gmail", "finance", "location"] },
+      { markCapabilities },
     );
 
     expect(result).toEqual({ status: "seeded", mailed: [] });
     expect(sendMail).not.toHaveBeenCalled();
-    expect(markCapabilitiesMailed).toHaveBeenCalledWith("uid-1", [
+    expect(markCapabilities.mock.calls[0][1].mailed).toEqual([
       "finance",
       "gmail",
       "location",
     ]);
   });
 
-  it("mails only what is newly connected", async () => {
-    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
-    const markCapabilitiesMailed = vi.fn().mockResolvedValue(undefined);
-    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: ["gmail"] } });
+  it("does not mail a capability the first time its state is resolvable", async () => {
+    // The regression: /one resolves without OAuth enrichment, so Gmail reads
+    // `unknown` there. Seeding from that view then treating the first
+    // /one/setup visit as a fresh connection would mail somebody about a link
+    // they made months ago.
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const markCapabilities = vi.fn().mockResolvedValue(undefined);
+    const user = makeUser({
+      customClaims: {
+        // A dashboard pass: finance was seen, gmail was never resolvable.
+        [LINKED_SEEN_CLAIM]: ["finance"],
+        [LINKED_MAIL_CLAIM]: ["finance"],
+      },
+    });
 
     const result = await sendCapabilityLinkedMail(
       asRecord(user),
-      ["gmail", "finance"],
-      { markCapabilitiesMailed },
+      { observed: ["finance", "gmail"], connected: ["finance", "gmail"] },
+      { markCapabilities },
+    );
+
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(result.status).toBe("seeded");
+    // Recorded so a later disconnect/reconnect is still detectable.
+    expect(markCapabilities.mock.calls[0][1].seen).toEqual(["finance", "gmail"]);
+    expect(markCapabilities.mock.calls[0][1].mailed).toEqual(["finance", "gmail"]);
+  });
+
+  it("mails a capability that was seen unconnected and is now connected", async () => {
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const markCapabilities = vi.fn().mockResolvedValue(undefined);
+    const user = makeUser({
+      customClaims: {
+        [LINKED_SEEN_CLAIM]: ["finance", "gmail"],
+        [LINKED_MAIL_CLAIM]: ["gmail"],
+      },
+    });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      { observed: ["finance", "gmail"], connected: ["finance", "gmail"] },
+      { markCapabilities },
     );
 
     expect(result).toEqual({ status: "sent", mailed: ["finance"] });
@@ -111,78 +148,122 @@ describe("capability link mail", () => {
       subject: "Finance is connected to One",
       idempotencyKey: "one-linked:uid-1:finance",
     });
-    expect(markCapabilitiesMailed).toHaveBeenCalledWith("uid-1", ["finance", "gmail"]);
+  });
+
+  it("ignores a connected id that this pass could not actually resolve", async () => {
+    const { sendCapabilityLinkedMail, LINKED_SEEN_CLAIM, LINKED_MAIL_CLAIM } =
+      await loadService();
+    const user = makeUser({
+      customClaims: { [LINKED_SEEN_CLAIM]: ["gmail"], [LINKED_MAIL_CLAIM]: [] },
+    });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      { observed: [], connected: ["gmail"] },
+      { markCapabilities: vi.fn() },
+    );
+
+    expect(result.mailed).toEqual([]);
+    expect(sendMail).not.toHaveBeenCalled();
   });
 
   it("says nothing when the reported set is unchanged", async () => {
-    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
-    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: ["gmail", "finance"] } });
-
-    const result = await sendCapabilityLinkedMail(asRecord(user), ["finance", "gmail"], {
-      markCapabilitiesMailed: vi.fn(),
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const user = makeUser({
+      customClaims: {
+        [LINKED_SEEN_CLAIM]: ["gmail", "finance"],
+        [LINKED_MAIL_CLAIM]: ["gmail", "finance"],
+      },
     });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      { observed: ["finance", "gmail"], connected: ["finance", "gmail"] },
+      { markCapabilities: vi.fn() },
+    );
 
     expect(result).toEqual({ status: "skipped", mailed: [], reason: "nothing_new" });
     expect(sendMail).not.toHaveBeenCalled();
   });
 
   it("never mails the same capability twice, even after disconnect and reconnect", async () => {
-    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
-    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: ["gmail"] } });
-
-    // Disconnected, then reconnected: the reported set is the same as before.
-    const result = await sendCapabilityLinkedMail(asRecord(user), ["gmail"], {
-      markCapabilitiesMailed: vi.fn(),
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const user = makeUser({
+      customClaims: {
+        [LINKED_SEEN_CLAIM]: ["gmail"],
+        [LINKED_MAIL_CLAIM]: ["gmail"],
+      },
     });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      { observed: ["gmail"], connected: ["gmail"] },
+      { markCapabilities: vi.fn() },
+    );
 
     expect(result.mailed).toEqual([]);
     expect(sendMail).not.toHaveBeenCalled();
   });
 
   it("caps a burst and leaves the remainder for the next report", async () => {
-    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
-    const markCapabilitiesMailed = vi.fn().mockResolvedValue(undefined);
-    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: [] } });
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const markCapabilities = vi.fn().mockResolvedValue(undefined);
+    const user = makeUser({
+      customClaims: { [LINKED_SEEN_CLAIM]: ALL, [LINKED_MAIL_CLAIM]: [] },
+    });
 
     const result = await sendCapabilityLinkedMail(
       asRecord(user),
-      ["gmail", "finance", "location", "pkm", "consent"],
-      { markCapabilitiesMailed },
+      { observed: ALL, connected: ALL },
+      { markCapabilities },
     );
 
     expect(sendMail).toHaveBeenCalledTimes(3);
     expect(result.mailed).toHaveLength(3);
-    // The two that did not go out are not marked, so they are retried.
-    expect(markCapabilitiesMailed.mock.calls[0][1]).toHaveLength(3);
+    expect(markCapabilities.mock.calls[0][1].mailed).toHaveLength(3);
   });
 
   it("ignores an id that is not in the catalog rather than mailing its slug", async () => {
-    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
-    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: [] } });
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const user = makeUser({
+      customClaims: { [LINKED_SEEN_CLAIM]: [], [LINKED_MAIL_CLAIM]: [] },
+    });
 
     const result = await sendCapabilityLinkedMail(
       asRecord(user),
-      ["definitely-not-a-capability", "<script>alert(1)</script>"],
-      { markCapabilitiesMailed: vi.fn() },
+      {
+        observed: ["definitely-not-a-capability", "<script>alert(1)</script>"],
+        connected: ["definitely-not-a-capability"],
+      },
+      { markCapabilities: vi.fn() },
     );
 
-    expect(result).toEqual({ status: "skipped", mailed: [], reason: "nothing_new" });
+    expect(result.mailed).toEqual([]);
     expect(sendMail).not.toHaveBeenCalled();
   });
 
   it("does not mark a capability as mailed when its send failed", async () => {
     sendMail.mockResolvedValue({ status: "failed", reason: "http_503" });
-    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
-    const markCapabilitiesMailed = vi.fn();
-    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: [] } });
-
-    const result = await sendCapabilityLinkedMail(asRecord(user), ["gmail"], {
-      markCapabilitiesMailed,
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM, LINKED_SEEN_CLAIM } =
+      await loadService();
+    const markCapabilities = vi.fn().mockResolvedValue(undefined);
+    const user = makeUser({
+      customClaims: { [LINKED_SEEN_CLAIM]: ["gmail"], [LINKED_MAIL_CLAIM]: [] },
     });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      { observed: ["gmail"], connected: ["gmail"] },
+      { markCapabilities },
+    );
 
     expect(result.status).toBe("failed");
     // Marking it would mean this connection is never mailed about at all.
-    expect(markCapabilitiesMailed).not.toHaveBeenCalled();
+    expect(markCapabilities.mock.calls[0][1].mailed).not.toContain("gmail");
   });
 });
 

--- a/hushh-webapp/__tests__/mail/account-activity.test.ts
+++ b/hushh-webapp/__tests__/mail/account-activity.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMail = vi.fn();
+vi.mock("@/lib/mail/mail-client", () => ({
+  sendMail: (...args: unknown[]) => sendMail(...args),
+  isMailConfigured: () => true,
+}));
+
+const MODULE_PATH = "@/lib/mail/auth-mail-service";
+
+type FakeUser = {
+  uid: string;
+  email?: string | null;
+  displayName?: string | null;
+  customClaims?: Record<string, unknown>;
+  metadata: { creationTime?: string; lastSignInTime?: string };
+};
+
+function makeUser(overrides: Partial<FakeUser> = {}): FakeUser {
+  return {
+    uid: "uid-1",
+    email: "ankit@hushh.ai",
+    displayName: "Ankit Kumar Singh",
+    metadata: {
+      creationTime: "Wed, 05 Aug 2026 09:12:00 GMT",
+      lastSignInTime: "Fri, 07 Aug 2026 11:30:00 GMT",
+    },
+    ...overrides,
+  };
+}
+
+async function loadService() {
+  return (await import(MODULE_PATH)) as typeof import("@/lib/mail/auth-mail-service");
+}
+
+const asRecord = (user: FakeUser) =>
+  user as unknown as Parameters<
+    typeof import("@/lib/mail/auth-mail-service").sendSignedOutMail
+  >[0];
+
+beforeEach(() => {
+  sendMail.mockReset();
+  sendMail.mockResolvedValue({ status: "sent", messageId: "<id@hushh.ai>", deduplicated: false });
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("sign-out mail", () => {
+  it("is keyed on the session it closes, so one session yields one of each", async () => {
+    const { sendSignedOutMail } = await loadService();
+
+    const outcome = await sendSignedOutMail(asRecord(makeUser()));
+
+    expect(outcome).toMatchObject({ status: "sent", kind: "signed_out" });
+    const payload = sendMail.mock.calls[0][0];
+    expect(payload.subject).toBe("You signed out of One");
+    expect(payload.idempotencyKey).toBe(
+      `one-signout:uid-1:${new Date("Fri, 07 Aug 2026 11:30:00 GMT").getTime()}`,
+    );
+    // Distinct from the sign-in key for the same session, so neither suppresses
+    // the other.
+    expect(payload.idempotencyKey).not.toContain("one-signin");
+  });
+
+  it("skips an account with no address", async () => {
+    const { sendSignedOutMail } = await loadService();
+    expect(await sendSignedOutMail(asRecord(makeUser({ email: null })))).toEqual({
+      status: "skipped",
+      reason: "no_email",
+    });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});
+
+describe("capability link mail", () => {
+  it("seeds silently on the first report, so existing users are not spammed", async () => {
+    const { sendCapabilityLinkedMail } = await loadService();
+    const markCapabilitiesMailed = vi.fn().mockResolvedValue(undefined);
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(makeUser()),
+      ["gmail", "finance", "location"],
+      { markCapabilitiesMailed },
+    );
+
+    expect(result).toEqual({ status: "seeded", mailed: [] });
+    expect(sendMail).not.toHaveBeenCalled();
+    expect(markCapabilitiesMailed).toHaveBeenCalledWith("uid-1", [
+      "finance",
+      "gmail",
+      "location",
+    ]);
+  });
+
+  it("mails only what is newly connected", async () => {
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
+    const markCapabilitiesMailed = vi.fn().mockResolvedValue(undefined);
+    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: ["gmail"] } });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      ["gmail", "finance"],
+      { markCapabilitiesMailed },
+    );
+
+    expect(result).toEqual({ status: "sent", mailed: ["finance"] });
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(sendMail.mock.calls[0][0]).toMatchObject({
+      subject: "Finance is connected to One",
+      idempotencyKey: "one-linked:uid-1:finance",
+    });
+    expect(markCapabilitiesMailed).toHaveBeenCalledWith("uid-1", ["finance", "gmail"]);
+  });
+
+  it("says nothing when the reported set is unchanged", async () => {
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
+    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: ["gmail", "finance"] } });
+
+    const result = await sendCapabilityLinkedMail(asRecord(user), ["finance", "gmail"], {
+      markCapabilitiesMailed: vi.fn(),
+    });
+
+    expect(result).toEqual({ status: "skipped", mailed: [], reason: "nothing_new" });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("never mails the same capability twice, even after disconnect and reconnect", async () => {
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
+    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: ["gmail"] } });
+
+    // Disconnected, then reconnected: the reported set is the same as before.
+    const result = await sendCapabilityLinkedMail(asRecord(user), ["gmail"], {
+      markCapabilitiesMailed: vi.fn(),
+    });
+
+    expect(result.mailed).toEqual([]);
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("caps a burst and leaves the remainder for the next report", async () => {
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
+    const markCapabilitiesMailed = vi.fn().mockResolvedValue(undefined);
+    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: [] } });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      ["gmail", "finance", "location", "pkm", "consent"],
+      { markCapabilitiesMailed },
+    );
+
+    expect(sendMail).toHaveBeenCalledTimes(3);
+    expect(result.mailed).toHaveLength(3);
+    // The two that did not go out are not marked, so they are retried.
+    expect(markCapabilitiesMailed.mock.calls[0][1]).toHaveLength(3);
+  });
+
+  it("ignores an id that is not in the catalog rather than mailing its slug", async () => {
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
+    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: [] } });
+
+    const result = await sendCapabilityLinkedMail(
+      asRecord(user),
+      ["definitely-not-a-capability", "<script>alert(1)</script>"],
+      { markCapabilitiesMailed: vi.fn() },
+    );
+
+    expect(result).toEqual({ status: "skipped", mailed: [], reason: "nothing_new" });
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("does not mark a capability as mailed when its send failed", async () => {
+    sendMail.mockResolvedValue({ status: "failed", reason: "http_503" });
+    const { sendCapabilityLinkedMail, LINKED_MAIL_CLAIM } = await loadService();
+    const markCapabilitiesMailed = vi.fn();
+    const user = makeUser({ customClaims: { [LINKED_MAIL_CLAIM]: [] } });
+
+    const result = await sendCapabilityLinkedMail(asRecord(user), ["gmail"], {
+      markCapabilitiesMailed,
+    });
+
+    expect(result.status).toBe("failed");
+    // Marking it would mean this connection is never mailed about at all.
+    expect(markCapabilitiesMailed).not.toHaveBeenCalled();
+  });
+});
+
+describe("copy parity", () => {
+  it("uses the same words on screen and in the mail", async () => {
+    const { PHONE_CONFLICT_COPY } = await import("@/lib/mail/account-activity-copy");
+    const { buildPhoneConflictMail } = await import("@/lib/mail/auth-mail-templates");
+
+    const mail = buildPhoneConflictMail({
+      displayName: "Ankit",
+      attemptedPhoneNumber: "+919876543210",
+      linkedAccountEmail: "old@gmail.com",
+    });
+
+    expect(mail.subject).toBe(PHONE_CONFLICT_COPY.subject);
+    expect(mail.text).toContain(PHONE_CONFLICT_COPY.heading("Ankit"));
+    expect(mail.text).toContain(PHONE_CONFLICT_COPY.withAccount);
+    // The in-app line points at the mail rather than repeating its detail.
+    expect(PHONE_CONFLICT_COPY.inApp).toContain("another Hussh account");
+  });
+});

--- a/hushh-webapp/__tests__/services/auth-service.test.ts
+++ b/hushh-webapp/__tests__/services/auth-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PHONE_CONFLICT_COPY } from "@/lib/mail/account-activity-copy";
 
 const {
   mockAuth,
@@ -570,7 +571,7 @@ describe("AuthService.restoreNativeSession", () => {
     ).rejects.toMatchObject({
       code: "phone-number-already-exists",
       message:
-        "This phone number is already associated with another active account. If the account was just deleted, wait a moment and try again.",
+        PHONE_CONFLICT_COPY.inApp,
     });
   });
 

--- a/hushh-webapp/app/api/auth/mail/route.ts
+++ b/hushh-webapp/app/api/auth/mail/route.ts
@@ -19,7 +19,10 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import {
+  LINKED_MAIL_CLAIM,
+  sendCapabilityLinkedMail,
   sendPhoneConflictMail,
+  sendSignedOutMail,
   sendSignInMail,
   WELCOME_MAIL_CLAIM,
 } from "@/lib/mail/auth-mail-service";
@@ -27,6 +30,16 @@ import {
 export const dynamic = "force-dynamic";
 
 const E164_PATTERN = /^\+[1-9]\d{6,14}$/;
+
+const SUPPORTED_EVENTS = new Set([
+  "signed_in",
+  "signed_out",
+  "phone_conflict",
+  "capabilities_linked",
+]);
+
+/** A report carrying more ids than the catalog holds is malformed, not generous. */
+const MAX_REPORTED_CAPABILITIES = 32;
 
 /**
  * Guards against a client loop turning into a mail loop. This is per instance
@@ -88,9 +101,10 @@ export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as {
     event?: string;
     phoneNumber?: string;
+    capabilities?: unknown[];
   };
   const event = String(body.event ?? "").trim();
-  if (event !== "signed_in" && event !== "phone_conflict") {
+  if (!SUPPORTED_EVENTS.has(event)) {
     return NextResponse.json({ error: "Unsupported event" }, { status: 400 });
   }
 
@@ -115,6 +129,43 @@ export async function POST(request: NextRequest) {
         },
       });
       return NextResponse.json(outcome);
+    }
+
+    if (event === "signed_out") {
+      const sessionStamp = user.metadata?.lastSignInTime ?? "";
+      if (seenRecently(`signed_out:${user.uid}:${sessionStamp}`)) {
+        return NextResponse.json({ status: "skipped", reason: "duplicate_request" });
+      }
+      return NextResponse.json(await sendSignedOutMail(user));
+    }
+
+    if (event === "capabilities_linked") {
+      const reported = Array.isArray(body.capabilities) ? body.capabilities : null;
+      if (!reported || reported.length > MAX_REPORTED_CAPABILITIES) {
+        return NextResponse.json({ error: "Invalid capabilities" }, { status: 400 });
+      }
+
+      const result = await sendCapabilityLinkedMail(user, reported.map(String), {
+        markCapabilitiesMailed: async (uid, capabilityIds) => {
+          // Re-read: this request may have raced another that also added ids,
+          // and writing a stale set would resend what the other already mailed.
+          const current = await auth.getUser(uid).catch(() => user);
+          const existing = (current.customClaims ?? {}) as Record<string, unknown>;
+          const merged = [
+            ...new Set([
+              ...(Array.isArray(existing[LINKED_MAIL_CLAIM])
+                ? (existing[LINKED_MAIL_CLAIM] as unknown[]).map(String)
+                : []),
+              ...capabilityIds,
+            ]),
+          ].sort();
+          await auth.setCustomUserClaims(uid, {
+            ...existing,
+            [LINKED_MAIL_CLAIM]: merged,
+          });
+        },
+      });
+      return NextResponse.json(result);
     }
 
     const phoneNumber = String(body.phoneNumber ?? "").trim();

--- a/hushh-webapp/app/api/auth/mail/route.ts
+++ b/hushh-webapp/app/api/auth/mail/route.ts
@@ -20,6 +20,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { validateFirebaseToken } from "@/lib/auth/validate";
 import {
   LINKED_MAIL_CLAIM,
+  LINKED_SEEN_CLAIM,
   sendCapabilityLinkedMail,
   sendPhoneConflictMail,
   sendSignedOutMail,
@@ -102,6 +103,7 @@ export async function POST(request: NextRequest) {
     event?: string;
     phoneNumber?: string;
     capabilities?: unknown[];
+    observed?: unknown[];
   };
   const event = String(body.event ?? "").trim();
   if (!SUPPORTED_EVENTS.has(event)) {
@@ -140,31 +142,43 @@ export async function POST(request: NextRequest) {
     }
 
     if (event === "capabilities_linked") {
-      const reported = Array.isArray(body.capabilities) ? body.capabilities : null;
-      if (!reported || reported.length > MAX_REPORTED_CAPABILITIES) {
+      const connected = Array.isArray(body.capabilities) ? body.capabilities : null;
+      const observed = Array.isArray(body.observed) ? body.observed : null;
+      if (
+        !connected ||
+        !observed ||
+        connected.length > MAX_REPORTED_CAPABILITIES ||
+        observed.length > MAX_REPORTED_CAPABILITIES
+      ) {
         return NextResponse.json({ error: "Invalid capabilities" }, { status: 400 });
       }
 
-      const result = await sendCapabilityLinkedMail(user, reported.map(String), {
-        markCapabilitiesMailed: async (uid, capabilityIds) => {
-          // Re-read: this request may have raced another that also added ids,
-          // and writing a stale set would resend what the other already mailed.
-          const current = await auth.getUser(uid).catch(() => user);
-          const existing = (current.customClaims ?? {}) as Record<string, unknown>;
-          const merged = [
-            ...new Set([
-              ...(Array.isArray(existing[LINKED_MAIL_CLAIM])
-                ? (existing[LINKED_MAIL_CLAIM] as unknown[]).map(String)
-                : []),
-              ...capabilityIds,
-            ]),
-          ].sort();
-          await auth.setCustomUserClaims(uid, {
-            ...existing,
-            [LINKED_MAIL_CLAIM]: merged,
-          });
+      const result = await sendCapabilityLinkedMail(
+        user,
+        { observed: observed.map(String), connected: connected.map(String) },
+        {
+          markCapabilities: async (uid, next) => {
+            // Re-read: this request may have raced another that also advanced
+            // these sets, and writing a stale one would resend what the other
+            // already mailed.
+            const current = await auth.getUser(uid).catch(() => user);
+            const existing = (current.customClaims ?? {}) as Record<string, unknown>;
+            const union = (claim: string, incoming: string[]) => [
+              ...new Set([
+                ...(Array.isArray(existing[claim])
+                  ? (existing[claim] as unknown[]).map(String)
+                  : []),
+                ...incoming,
+              ]),
+            ].sort();
+            await auth.setCustomUserClaims(uid, {
+              ...existing,
+              [LINKED_MAIL_CLAIM]: union(LINKED_MAIL_CLAIM, next.mailed),
+              [LINKED_SEEN_CLAIM]: union(LINKED_SEEN_CLAIM, next.seen),
+            });
+          },
         },
-      });
+      );
       return NextResponse.json(result);
     }
 

--- a/hushh-webapp/lib/firebase/auth-context.tsx
+++ b/hushh-webapp/lib/firebase/auth-context.tsx
@@ -380,6 +380,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setLoading(true);
 
       try {
+        // The sign-out mail must be asked for while the credential is still
+        // valid — a moment later `AuthService.signOut()` invalidates it and the
+        // route would reject the token. Not awaited: sign-out is a security
+        // action and must never wait on, or be failed by, a mail. Deliberately
+        // skipped for account deletion, where mailing "you signed out" to an
+        // account that no longer exists would be wrong.
+        if (currentUid && !options?.skipFcmCleanup) {
+          const signOutToken = await currentUser?.getIdToken().catch(() => undefined);
+          if (signOutToken) {
+            void ApiService.notifyAuthMail("signed_out", { idToken: signOutToken });
+          }
+        }
+
         // Delete FCM token before signing out (requires auth). Skipped for the
         // account-deletion flow: the backend already removes the account and its
         // push tokens, so this would only add a redundant network round-trip to

--- a/hushh-webapp/lib/mail/account-activity-copy.ts
+++ b/hushh-webapp/lib/mail/account-activity-copy.ts
@@ -1,0 +1,67 @@
+/**
+ * One source of words for account activity.
+ *
+ * The screen and the inbox describe the same event, so they say the same thing.
+ * When someone reads "That number is on another account" in a toast and then
+ * opens a mail that calls it something else, they reasonably wonder whether two
+ * different things happened.
+ *
+ * Deliberately free of imports so both sides can use it: the templates render
+ * it server-side, the client surfaces render it in the browser.
+ */
+
+/** Capability titles, mirrored from the `ONE_CAPABILITIES` catalog. */
+const CAPABILITY_TITLES: Record<string, string> = {
+  finance: "Finance",
+  ria: "RIA",
+  gmail: "Gmail",
+  email: "KYC",
+  location: "Location",
+  pkm: "Memory",
+  consent: "Consent",
+  marketplace: "Information Marketplace",
+  "connected-systems": "CRM",
+};
+
+/**
+ * The set a link mail may be sent for. An id outside this list is ignored
+ * rather than mailed under its raw slug — a caller-supplied id must never
+ * become the subject line.
+ */
+export const MAILABLE_CAPABILITY_IDS = Object.keys(CAPABILITY_TITLES);
+
+export function capabilityTitle(id: string): string {
+  return CAPABILITY_TITLES[String(id ?? "").trim()] ?? "";
+}
+
+export const PHONE_CONFLICT_COPY = {
+  /** Shown in-app when Firebase reports the number is on another account. */
+  inApp:
+    "That number is on another Hussh account. Check your email — we sent you which one.",
+  subject: "That number is on another account",
+  heading: (firstName: string) =>
+    firstName ? `${firstName}, that number is taken.` : "That number is taken.",
+  withAccount:
+    "It is already verified on another Hussh account — often one you made earlier and forgot.",
+  withoutAccount: "It is already verified on another Hussh account.",
+  action: "Sign in to that account",
+  footNote: "Didn't try this? Ignore this email — nothing changed.",
+} as const;
+
+export const SIGNED_OUT_COPY = {
+  subject: "You signed out of One",
+  heading: (firstName: string) =>
+    firstName ? `Signed out, ${firstName}.` : "Signed out.",
+  body: "Your session on this device is closed.",
+  action: "Sign back in",
+  footNote: "Not you? Reply to this email and we will secure the account.",
+} as const;
+
+export const CAPABILITY_LINKED_COPY = {
+  subject: (title: string) => `${title} is connected to One`,
+  heading: (title: string) => `${title} is connected.`,
+  body: (title: string) =>
+    `${title} is now linked to your account. You can disconnect it any time.`,
+  action: "Review connections",
+  footNote: "Didn't connect this? Reply to this email and we will secure the account.",
+} as const;

--- a/hushh-webapp/lib/mail/auth-mail-service.ts
+++ b/hushh-webapp/lib/mail/auth-mail-service.ts
@@ -24,8 +24,11 @@ import "server-only";
 
 import type { auth as adminAuth } from "firebase-admin";
 
+import { MAILABLE_CAPABILITY_IDS } from "@/lib/mail/account-activity-copy";
 import {
+  buildCapabilityLinkedMail,
   buildPhoneConflictMail,
+  buildSignedOutMail,
   buildWelcomeBackMail,
   buildWelcomeMail,
   type BuiltAuthMail,
@@ -37,7 +40,12 @@ const FIRST_SIGN_IN_TOLERANCE_MS = 60_000;
 
 export const WELCOME_MAIL_CLAIM = "hushhWelcomeMailAt";
 
-type AuthMailKind = "welcome" | "welcome_back" | "phone_conflict";
+type AuthMailKind =
+  | "welcome"
+  | "welcome_back"
+  | "phone_conflict"
+  | "signed_out"
+  | "capability_linked";
 
 export type AuthMailOutcome =
   | { status: "sent"; kind: AuthMailKind; messageId: string | null }
@@ -94,6 +102,140 @@ async function deliver(
 export interface SignInMailDeps {
   /** Marks the welcome mail as sent, durably. Failures must not resend. */
   markWelcomeSent: (uid: string, atEpochSeconds: number) => Promise<void>;
+}
+
+/**
+ * The end of a session. Keyed on the sign-in it closes, so one session produces
+ * exactly one sign-in mail and one sign-out mail however many times the client
+ * retries either.
+ */
+export async function sendSignedOutMail(user: UserRecord): Promise<AuthMailOutcome> {
+  const to = String(user.email ?? "").trim();
+  if (!to) return { status: "skipped", reason: "no_email" };
+
+  const sessionStamp = String(
+    (parseTime(user.metadata?.lastSignInTime) ?? new Date()).getTime(),
+  );
+
+  return deliver(
+    "signed_out",
+    to,
+    buildSignedOutMail({ displayName: user.displayName, signedOutAt: new Date() }),
+    `one-signout:${user.uid}:${sessionStamp}`,
+  );
+}
+
+export const LINKED_MAIL_CLAIM = "hushhLinkedMailed";
+
+/**
+ * Cap per request so a first report, or a burst of linking, cannot turn into a
+ * wall of mail. Anything over the cap is left unmarked and picked up by the
+ * next report rather than dropped.
+ */
+const LINKED_MAIL_MAX_PER_REQUEST = 3;
+
+export interface CapabilityLinkMailDeps {
+  /** Persists the full mailed-capability set, durably. */
+  markCapabilitiesMailed: (uid: string, capabilityIds: string[]) => Promise<void>;
+}
+
+export interface CapabilityLinkResult {
+  status: "sent" | "seeded" | "skipped" | "not_configured" | "failed";
+  mailed: string[];
+  reason?: string;
+}
+
+function readMailedCapabilities(user: UserRecord): string[] | null {
+  const raw = (user.customClaims as Record<string, unknown> | undefined)?.[
+    LINKED_MAIL_CLAIM
+  ];
+  if (!Array.isArray(raw)) return null;
+  return raw.map((entry) => String(entry)).filter(Boolean);
+}
+
+/**
+ * Mail the capabilities that have newly become connected.
+ *
+ * The client reports the whole connected set rather than firing an event per
+ * link. There are nine ways to connect something — Gmail OAuth return, Plaid
+ * return, a location grant, KYC, and so on — and hooking each one means the one
+ * that gets added next year is silently missed. Diffing a reported set against
+ * a durable record covers every path, including a link made on another device.
+ *
+ * The first report for an account **seeds without mailing**. Somebody who
+ * connected Gmail months ago should not receive "Gmail is connected" the first
+ * time this ships.
+ */
+export async function sendCapabilityLinkedMail(
+  user: UserRecord,
+  connectedCapabilityIds: string[],
+  deps: CapabilityLinkMailDeps,
+): Promise<CapabilityLinkResult> {
+  const to = String(user.email ?? "").trim();
+  if (!to) return { status: "skipped", mailed: [], reason: "no_email" };
+
+  const connected = [
+    ...new Set(
+      connectedCapabilityIds
+        .map((id) => String(id ?? "").trim())
+        .filter((id) => MAILABLE_CAPABILITY_IDS.includes(id)),
+    ),
+  ].sort();
+
+  const alreadyMailed = readMailedCapabilities(user);
+
+  // No record yet: this account predates the feature (or is reporting for the
+  // first time). Record what is already connected and stay quiet.
+  if (alreadyMailed === null) {
+    await deps.markCapabilitiesMailed(user.uid, connected);
+    return { status: "seeded", mailed: [] };
+  }
+
+  const fresh = connected.filter((id) => !alreadyMailed.includes(id));
+  if (fresh.length === 0) return { status: "skipped", mailed: [], reason: "nothing_new" };
+
+  const batch = fresh.slice(0, LINKED_MAIL_MAX_PER_REQUEST);
+  const linkedAt = new Date();
+  const mailed: string[] = [];
+  let lastFailure = "";
+
+  for (const capabilityId of batch) {
+    const mail = buildCapabilityLinkedMail({
+      displayName: user.displayName,
+      capabilityId,
+      linkedAt,
+    });
+    if (!mail) continue;
+
+    const outcome = await deliver(
+      "capability_linked",
+      to,
+      mail,
+      `one-linked:${user.uid}:${capabilityId}`,
+    );
+    if (outcome.status === "sent") {
+      mailed.push(capabilityId);
+      continue;
+    }
+    if (outcome.status === "not_configured") {
+      return { status: "not_configured", mailed: [] };
+    }
+    lastFailure = outcome.status === "failed" ? outcome.reason : "";
+    // Stop on the first failure: the rest stay unmarked and are retried by the
+    // next report rather than being marked as mailed when they were not.
+    break;
+  }
+
+  // Record only what actually went out, so a failure retries instead of being
+  // silently swallowed.
+  if (mailed.length > 0) {
+    await deps.markCapabilitiesMailed(user.uid, [...alreadyMailed, ...mailed].sort());
+  }
+
+  if (mailed.length === 0) {
+    return { status: "failed", mailed: [], reason: lastFailure || "send_failed" };
+  }
+  return { status: "sent", mailed };
 }
 
 /**

--- a/hushh-webapp/lib/mail/auth-mail-service.ts
+++ b/hushh-webapp/lib/mail/auth-mail-service.ts
@@ -128,6 +128,18 @@ export async function sendSignedOutMail(user: UserRecord): Promise<AuthMailOutco
 export const LINKED_MAIL_CLAIM = "hushhLinkedMailed";
 
 /**
+ * Capabilities whose state has ever been *resolved* for this account.
+ *
+ * Separate from LINKED_MAIL_CLAIM because "not connected" and "not resolvable"
+ * are different facts, and conflating them mails the wrong thing. The `/one`
+ * dashboard resolves without OAuth enrichment, so Gmail reads `unknown` there
+ * rather than connected. Seeding from that view alone would omit Gmail, and the
+ * first `/one/setup` visit — which does enrich — would then look like a fresh
+ * connection and mail somebody about a link they made months ago.
+ */
+export const LINKED_SEEN_CLAIM = "hushhLinkedSeen";
+
+/**
  * Cap per request so a first report, or a burst of linking, cannot turn into a
  * wall of mail. Anything over the cap is left unmarked and picked up by the
  * next report rather than dropped.
@@ -135,8 +147,11 @@ export const LINKED_MAIL_CLAIM = "hushhLinkedMailed";
 const LINKED_MAIL_MAX_PER_REQUEST = 3;
 
 export interface CapabilityLinkMailDeps {
-  /** Persists the full mailed-capability set, durably. */
-  markCapabilitiesMailed: (uid: string, capabilityIds: string[]) => Promise<void>;
+  /** Persists both durable sets in one write. */
+  markCapabilities: (
+    uid: string,
+    next: { mailed: string[]; seen: string[] },
+  ) => Promise<void>;
 }
 
 export interface CapabilityLinkResult {
@@ -145,12 +160,17 @@ export interface CapabilityLinkResult {
   reason?: string;
 }
 
-function readMailedCapabilities(user: UserRecord): string[] | null {
-  const raw = (user.customClaims as Record<string, unknown> | undefined)?.[
-    LINKED_MAIL_CLAIM
-  ];
-  if (!Array.isArray(raw)) return null;
+function readClaimList(user: UserRecord, claim: string): string[] {
+  const raw = (user.customClaims as Record<string, unknown> | undefined)?.[claim];
+  if (!Array.isArray(raw)) return [];
   return raw.map((entry) => String(entry)).filter(Boolean);
+}
+
+export interface CapabilityReport {
+  /** Ids whose state was determinable in this pass. */
+  observed: string[];
+  /** The subset of `observed` that is connected. */
+  connected: string[];
 }
 
 /**
@@ -168,31 +188,54 @@ function readMailedCapabilities(user: UserRecord): string[] | null {
  */
 export async function sendCapabilityLinkedMail(
   user: UserRecord,
-  connectedCapabilityIds: string[],
+  report: CapabilityReport,
   deps: CapabilityLinkMailDeps,
 ): Promise<CapabilityLinkResult> {
   const to = String(user.email ?? "").trim();
   if (!to) return { status: "skipped", mailed: [], reason: "no_email" };
 
-  const connected = [
+  const clean = (ids: string[]) => [
     ...new Set(
-      connectedCapabilityIds
+      ids
         .map((id) => String(id ?? "").trim())
         .filter((id) => MAILABLE_CAPABILITY_IDS.includes(id)),
     ),
   ].sort();
 
-  const alreadyMailed = readMailedCapabilities(user);
+  const observed = clean(report.observed);
+  // Connected is meaningless for something this pass could not resolve.
+  const connected = clean(report.connected).filter((id) => observed.includes(id));
 
-  // No record yet: this account predates the feature (or is reporting for the
-  // first time). Record what is already connected and stay quiet.
-  if (alreadyMailed === null) {
-    await deps.markCapabilitiesMailed(user.uid, connected);
-    return { status: "seeded", mailed: [] };
+  const alreadyMailed = readClaimList(user, LINKED_MAIL_CLAIM);
+  const alreadySeen = readClaimList(user, LINKED_SEEN_CLAIM);
+
+  // First sighting of a capability tells us nothing about when it was
+  // connected, so it is recorded and left alone. Only a capability we have
+  // previously seen — and seen as not connected — can be called new.
+  const firstSighting = observed.filter((id) => !alreadySeen.includes(id));
+  const seedFromFirstSighting = firstSighting.filter((id) => connected.includes(id));
+
+  const fresh = connected.filter(
+    (id) => alreadySeen.includes(id) && !alreadyMailed.includes(id),
+  );
+
+  const nextSeen = [...new Set([...alreadySeen, ...observed])].sort();
+
+  if (fresh.length === 0) {
+    // Nothing to announce, but the sighting itself is worth remembering.
+    if (seedFromFirstSighting.length > 0 || nextSeen.length !== alreadySeen.length) {
+      await deps.markCapabilities(user.uid, {
+        mailed: [...new Set([...alreadyMailed, ...seedFromFirstSighting])].sort(),
+        seen: nextSeen,
+      });
+      return {
+        status: seedFromFirstSighting.length > 0 ? "seeded" : "skipped",
+        mailed: [],
+        reason: seedFromFirstSighting.length > 0 ? undefined : "nothing_new",
+      };
+    }
+    return { status: "skipped", mailed: [], reason: "nothing_new" };
   }
-
-  const fresh = connected.filter((id) => !alreadyMailed.includes(id));
-  if (fresh.length === 0) return { status: "skipped", mailed: [], reason: "nothing_new" };
 
   const batch = fresh.slice(0, LINKED_MAIL_MAX_PER_REQUEST);
   const linkedAt = new Date();
@@ -227,10 +270,12 @@ export async function sendCapabilityLinkedMail(
   }
 
   // Record only what actually went out, so a failure retries instead of being
-  // silently swallowed.
-  if (mailed.length > 0) {
-    await deps.markCapabilitiesMailed(user.uid, [...alreadyMailed, ...mailed].sort());
-  }
+  // silently swallowed. The sighting set advances regardless: we did resolve
+  // those states, whether or not the mail for them succeeded.
+  await deps.markCapabilities(user.uid, {
+    mailed: [...new Set([...alreadyMailed, ...seedFromFirstSighting, ...mailed])].sort(),
+    seen: nextSeen,
+  });
 
   if (mailed.length === 0) {
     return { status: "failed", mailed: [], reason: lastFailure || "send_failed" };

--- a/hushh-webapp/lib/mail/auth-mail-templates.ts
+++ b/hushh-webapp/lib/mail/auth-mail-templates.ts
@@ -14,6 +14,12 @@
  */
 
 import {
+  CAPABILITY_LINKED_COPY,
+  capabilityTitle,
+  PHONE_CONFLICT_COPY,
+  SIGNED_OUT_COPY,
+} from "@/lib/mail/account-activity-copy";
+import {
   buildEmailShell,
   ONE_APP_URL,
   type DetailRow,
@@ -127,19 +133,75 @@ export function buildPhoneConflictMail(context: PhoneConflictContext): BuiltAuth
   if (maskedEmail) details.push({ label: "Account", value: maskedEmail });
 
   return {
-    subject: "That number is on another account",
+    subject: PHONE_CONFLICT_COPY.subject,
     ...buildEmailShell({
       previewText: "The number you entered is verified on a different account.",
       eyebrow: "Account check",
-      heading: name ? `${name}, that number is taken.` : "That number is taken.",
+      heading: PHONE_CONFLICT_COPY.heading(name),
       paragraphs: [
         maskedEmail
-          ? "It is already verified on another Hussh account — often one you made earlier and forgot."
-          : "It is already verified on another Hussh account.",
+          ? PHONE_CONFLICT_COPY.withAccount
+          : PHONE_CONFLICT_COPY.withoutAccount,
       ],
       details,
-      cta: { label: "Sign in to that account", url: `${ONE_APP_URL}/login` },
-      footNote: "Didn't try this? Ignore this email — nothing changed.",
+      cta: { label: PHONE_CONFLICT_COPY.action, url: `${ONE_APP_URL}/login` },
+      footNote: PHONE_CONFLICT_COPY.footNote,
+    }),
+  };
+}
+
+export interface SignedOutContext extends AuthMailContext {
+  signedOutAt: Date;
+}
+
+/**
+ * The close of a session, and the other half of the sign-in mail: between them
+ * a person can see a session open and shut without opening the app.
+ */
+export function buildSignedOutMail(context: SignedOutContext): BuiltAuthMail {
+  const name = firstNameOf(context.displayName);
+  return {
+    subject: SIGNED_OUT_COPY.subject,
+    ...buildEmailShell({
+      previewText: "Your session on this device is closed.",
+      eyebrow: "Sign-out",
+      heading: SIGNED_OUT_COPY.heading(name),
+      paragraphs: [SIGNED_OUT_COPY.body],
+      details: [{ label: "Signed out", value: formatSignInMoment(context.signedOutAt) }],
+      cta: { label: SIGNED_OUT_COPY.action, url: `${ONE_APP_URL}/login` },
+      footNote: SIGNED_OUT_COPY.footNote,
+    }),
+  };
+}
+
+export interface CapabilityLinkedContext extends AuthMailContext {
+  /** Catalog id. Rejected unless it resolves to a known title. */
+  capabilityId: string;
+  linkedAt: Date;
+}
+
+/**
+ * A connection was made. Sent once per capability, ever — reconnecting the same
+ * one is not news, and mailing it every time would train people to ignore these.
+ */
+export function buildCapabilityLinkedMail(
+  context: CapabilityLinkedContext,
+): BuiltAuthMail | null {
+  const title = capabilityTitle(context.capabilityId);
+  // No title means the id is not in the catalog. Refuse rather than send a
+  // subject line built from a caller-supplied slug.
+  if (!title) return null;
+
+  return {
+    subject: CAPABILITY_LINKED_COPY.subject(title),
+    ...buildEmailShell({
+      previewText: CAPABILITY_LINKED_COPY.body(title),
+      eyebrow: "Connection",
+      heading: CAPABILITY_LINKED_COPY.heading(title),
+      paragraphs: [CAPABILITY_LINKED_COPY.body(title)],
+      details: [{ label: "Connected", value: formatSignInMoment(context.linkedAt) }],
+      cta: { label: CAPABILITY_LINKED_COPY.action, url: `${ONE_APP_URL}/one/profile` },
+      footNote: CAPABILITY_LINKED_COPY.footNote,
     }),
   };
 }

--- a/hushh-webapp/lib/onboarding/use-capability-setup-states.ts
+++ b/hushh-webapp/lib/onboarding/use-capability-setup-states.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/firebase/auth-context";
 import { useVault } from "@/lib/vault/vault-context";
@@ -16,6 +16,7 @@ import {
   PreVaultUserStateService,
   type PreVaultUserState,
 } from "@/lib/services/pre-vault-user-state-service";
+import { ApiService } from "@/lib/services/api-service";
 import { AuthService } from "@/lib/services/auth-service";
 import { CapabilityTourService } from "@/lib/services/capability-tour-service";
 import { OneLocationService } from "@/lib/one-location/service";
@@ -68,6 +69,8 @@ export function useCapabilitySetupStates(
   options: UseCapabilitySetupStatesOptions = {}
 ): UseCapabilitySetupStatesResult {
   const { enrichVault = false, enrichOauth = false, enrichRia = false } = options;
+  // Last reported "<uid>:<connected ids>" so an unchanged set is not re-posted.
+  const reportedConnectedRef = useRef<string>("");
 
   const { user } = useAuth();
   const { isVaultUnlocked, getVaultKey, getVaultOwnerToken } = useVault();
@@ -415,6 +418,48 @@ export function useCapabilitySetupStates(
     for (const status of statuses) map[status.id] = status;
     return map;
   }, [statuses]);
+
+  const connectedSignature = useMemo(
+    () =>
+      statuses
+        .filter((status) => status.state === "completed")
+        .map((status) => status.id)
+        .sort()
+        .join(","),
+    [statuses]
+  );
+
+  const isSettled =
+    Boolean(userId) &&
+    bootstrapOwnerId === userId &&
+    (bootstrapResolved || Boolean(cachedPreVaultState)) &&
+    !enrichingVault &&
+    !enrichingOauth &&
+    !enrichingRia &&
+    !enrichingLocation;
+
+  /**
+   * Report the connected set so the server can mail about anything newly
+   * connected.
+   *
+   * Reporting a set beats firing an event per link: there are nine ways to
+   * connect something and hooking each one means the one added next year is
+   * silently missed. The server owns the diff and the durable record, so this
+   * side stays a plain observation with no memory of its own beyond avoiding a
+   * repeat post of an unchanged set.
+   *
+   * Only while settled — a partially enriched pass reports a smaller set, which
+   * is harmless because the server only ever adds, but posting it is noise.
+   */
+  useEffect(() => {
+    if (!isSettled || !userId) return;
+    const key = `${userId}:${connectedSignature}`;
+    if (reportedConnectedRef.current === key) return;
+    reportedConnectedRef.current = key;
+    void ApiService.notifyAuthMail("capabilities_linked", {
+      capabilities: connectedSignature ? connectedSignature.split(",") : [],
+    });
+  }, [connectedSignature, isSettled, userId]);
 
   return {
     statuses,

--- a/hushh-webapp/lib/onboarding/use-capability-setup-states.ts
+++ b/hushh-webapp/lib/onboarding/use-capability-setup-states.ts
@@ -419,14 +419,30 @@ export function useCapabilitySetupStates(
     return map;
   }, [statuses]);
 
-  const connectedSignature = useMemo(
+  // "unknown" means this pass could not resolve the capability — the dashboard
+  // does not enrich OAuth, so Gmail reads unknown there. Reporting it as
+  // not-connected would later make a months-old link look brand new.
+  const observedIds = useMemo(
+    () =>
+      statuses
+        .filter((status) => status.state !== "unknown")
+        .map((status) => status.id)
+        .sort(),
+    [statuses]
+  );
+
+  const connectedIds = useMemo(
     () =>
       statuses
         .filter((status) => status.state === "completed")
         .map((status) => status.id)
-        .sort()
-        .join(","),
+        .sort(),
     [statuses]
+  );
+
+  const connectedSignature = useMemo(
+    () => `${observedIds.join(",")}|${connectedIds.join(",")}`,
+    [observedIds, connectedIds]
   );
 
   const isSettled =
@@ -457,9 +473,10 @@ export function useCapabilitySetupStates(
     if (reportedConnectedRef.current === key) return;
     reportedConnectedRef.current = key;
     void ApiService.notifyAuthMail("capabilities_linked", {
-      capabilities: connectedSignature ? connectedSignature.split(",") : [],
+      observed: observedIds,
+      capabilities: connectedIds,
     });
-  }, [connectedSignature, isSettled, userId]);
+  }, [connectedIds, connectedSignature, isSettled, observedIds, userId]);
 
   return {
     statuses,

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -1754,8 +1754,10 @@ export class ApiService {
     event: "signed_in" | "signed_out" | "phone_conflict" | "capabilities_linked",
     options?: {
       phoneNumber?: string;
-      /** Full set of currently connected capability ids; the server diffs it. */
+      /** Currently connected capability ids; the server diffs these. */
       capabilities?: string[];
+      /** Ids whose state was resolvable this pass. Absent ids are unknown, not absent. */
+      observed?: string[];
       idToken?: string;
     },
   ): Promise<boolean> {
@@ -1771,6 +1773,7 @@ export class ApiService {
           event,
           ...(options?.phoneNumber ? { phoneNumber: options.phoneNumber } : {}),
           ...(options?.capabilities ? { capabilities: options.capabilities } : {}),
+          ...(options?.observed ? { observed: options.observed } : {}),
         }),
       });
       return response.ok;

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -1751,8 +1751,13 @@ export class ApiService {
    * resolves against the Python backend — targets the web origin explicitly.
    */
   static async notifyAuthMail(
-    event: "signed_in" | "phone_conflict",
-    options?: { phoneNumber?: string; idToken?: string },
+    event: "signed_in" | "signed_out" | "phone_conflict" | "capabilities_linked",
+    options?: {
+      phoneNumber?: string;
+      /** Full set of currently connected capability ids; the server diffs it. */
+      capabilities?: string[];
+      idToken?: string;
+    },
   ): Promise<boolean> {
     try {
       const idToken = options?.idToken || (await this.getFirebaseToken());
@@ -1765,6 +1770,7 @@ export class ApiService {
         body: JSON.stringify({
           event,
           ...(options?.phoneNumber ? { phoneNumber: options.phoneNumber } : {}),
+          ...(options?.capabilities ? { capabilities: options.capabilities } : {}),
         }),
       });
       return response.ok;

--- a/hushh-webapp/lib/services/auth-service.ts
+++ b/hushh-webapp/lib/services/auth-service.ts
@@ -12,6 +12,7 @@
  */
 
 import { Capacitor } from "@capacitor/core";
+import { PHONE_CONFLICT_COPY } from "@/lib/mail/account-activity-copy";
 import { getApps, initializeApp } from "firebase/app";
 import {
   type ApplicationVerifier,
@@ -1320,10 +1321,10 @@ export class AuthService {
       code === "credential-already-in-use" ||
       code === "phone-number-already-exists"
     ) {
-      return this.createPhoneVerificationError(
-        code,
-        "This phone number is already associated with another active account. If the account was just deleted, wait a moment and try again.",
-      );
+      // Same words as the mail this triggers, from one shared source. Reading
+      // one thing on screen and a different one in the inbox reads like two
+      // separate problems.
+      return this.createPhoneVerificationError(code, PHONE_CONFLICT_COPY.inApp);
     }
 
     if (code === "provider-already-linked") {


### PR DESCRIPTION
Follows #4885. Sign-in already mailed; the other half of a session did not, and neither did connecting something to the account.

## Sign-out

Keyed on the sign-in it closes → one session yields exactly one sign-in mail and one sign-out mail, however many times the client retries either.

Asked for **while the credential is still valid** — a moment later `AuthService.signOut()` invalidates it and the route would reject the token. Not awaited: sign-out is a security action and must never wait on, or be failed by, a mail. Account deletion is skipped deliberately (`skipFcmCleanup`) — mailing "you signed out" to an account that no longer exists would be wrong.

## Connections

The client reports the **whole connected set**; the server diffs it against a durable claim and mails the difference.

There are nine ways to connect something — Gmail OAuth return, Plaid return, a location grant, KYC — and hooking each one means the one added next year is silently missed. One hook covers every path, including a link made on another device.

Two rules keep it from becoming noise:

- **The first report seeds without mailing.** Nobody who connected Gmail months ago gets told about it the day this ships.
- **Once per capability, ever.** Disconnect and reconnect is silent. Reconnecting is not news, and mailing it every time trains people to ignore these.

Plus a burst cap of 3 per report, remainder left unmarked for the next one — finishing onboarding does not fire five at once, and nothing is dropped.

## Safety

- Only catalog ids are mailed, so a caller-supplied slug cannot become a subject line
- A capability is marked mailed **only after its send succeeds**
- The claim write re-reads first, so a racing request cannot resend what the other already sent

## Copy parity

One module now owns the words. The phone screen said the number was "already associated with another active account" while the mail called it something else — reading one thing on screen and another in the inbox reads like two separate problems.

## Verification

Full suite on **both sides**, failing sets compared:

| | Test files | Tests |
|---|---|---|
| `main` (ce6d5cdc9) | 10 failed / 442 | 14 failed / 2849 passed |
| this branch | 10 failed / 443 | 14 failed / **2859** passed |

Identical failing file list — 10 pre-existing failures, unrelated to mail. **Zero new failures, +10 passing.**

Also green: lint `--max-warnings=0`, typecheck, CI-equivalent build (`/api/auth/mail` registered ƒ), governance lane exit 0, design-system, surface-map, phone-verification (22).

Both new mails were rendered and delivered live through `hushh-mail-api` under One's key, `rejected: []`.

---
Closes #4905
(retroactive board-linkage backfill, 2026-08-06)