### PR TITLE
feat(one): carry an agency's posted hours onto its detail surface

### DIFF
--- a/consent-protocol/hushh_mcp/services/insurance_agent_directory_service.py
+++ b/consent-protocol/hushh_mcp/services/insurance_agent_directory_service.py
@@ -369,6 +369,51 @@ def _normalize_address(address: Any) -> dict[str, Any] | None:
     return block if any(block.values()) else None
 
 
+_WEEKDAYS = ("MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY")
+
+
+def _normalize_hours(hours: Any) -> dict[str, Any] | None:
+    """Opening hours, kept as posted rather than judged against a clock.
+
+    The locator gives times as bare HHMM integers with no timezone, and the
+    reader is routinely in a different one — this app is used from India against
+    US agencies. So no "open now" is derived anywhere: that would need the
+    agency's timezone, which is not in the payload, and a wrong answer here
+    sends someone to call a closed office.
+
+    About one agency in ten posts anything at all, so the whole block is dropped
+    when empty rather than rendering an "Hours" heading with nothing under it.
+    """
+    if not isinstance(hours, dict):
+        return None
+
+    days: list[dict[str, Any]] = []
+    for entry in hours.get("days") if isinstance(hours.get("days"), list) else []:
+        if not isinstance(entry, dict):
+            continue
+        day = _text(entry.get("day"))
+        if not day or day.upper() not in _WEEKDAYS:
+            continue
+        intervals = [
+            {"start": start, "end": end}
+            for start, end in (
+                (_coerce_int(i.get("start")), _coerce_int(i.get("end")))
+                for i in (
+                    entry.get("intervals") if isinstance(entry.get("intervals"), list) else []
+                )
+                if isinstance(i, dict)
+            )
+            if start is not None and end is not None
+        ]
+        # A day with no intervals is a real answer — "closed" — so it is kept.
+        days.append({"day": day.upper(), "intervals": intervals})
+
+    note = _text(hours.get("additionalText"))
+    if not days and not note:
+        return None
+    return {"days": days, "note": note}
+
+
 def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     """Flatten one locator row onto the card shape the app renders."""
     distance_miles = _coerce_float(row.get("distanceMiles"))
@@ -395,6 +440,7 @@ def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
         "products": products,
         "agencyType": _text(row.get("agencyType")),
         "tier": _text(row.get("tier")),
+        "hours": _normalize_hours(row.get("hours")),
         "distanceMiles": distance_miles,
         "address": address,
         "city": address.get("city") if address else None,

--- a/consent-protocol/tests/services/test_insurance_agent_directory_service.py
+++ b/consent-protocol/tests/services/test_insurance_agent_directory_service.py
@@ -69,6 +69,15 @@ _AGENCY_STREAM = _ndjson(
                 "products": ["Auto", "Commercial", "Farm", "Home"],
                 "agencyType": "Standard Independent",
                 "tier": None,
+                "hours": {
+                    "additionalText": "",
+                    "days": [
+                        {"day": "MONDAY", "intervals": [{"start": 900, "end": 1700}]},
+                        {"day": "TUESDAY", "intervals": [{"start": 900, "end": 1700}]},
+                        {"day": "SATURDAY", "intervals": []},
+                    ],
+                    "reopenDate": "",
+                },
                 "distanceMiles": 0.22,
             }
         ],
@@ -252,3 +261,39 @@ async def test_truncated_paging_is_reported_rather_than_promised(monkeypatch):
         "state": "WA",
         "zip": "98033",
     }
+
+
+@pytest.mark.asyncio
+async def test_posted_hours_are_carried_through(monkeypatch):
+    service = _service(
+        monkeypatch,
+        lambda request: httpx.Response(200, content=_AGENCY_STREAM),
+    )
+    card = (await service.search(postal_code="98033"))["items"][0]
+
+    assert card["hours"]["days"][0] == {
+        "day": "MONDAY",
+        "intervals": [{"start": 900, "end": 1700}],
+    }
+    # A day with no intervals is a real answer — closed — so it is kept, not dropped.
+    assert {"day": "SATURDAY", "intervals": []} in card["hours"]["days"]
+
+
+def test_an_agency_that_posts_nothing_gets_no_hours_block():
+    """About nine in ten post nothing; an empty block would render a bare heading."""
+    assert iads._normalize_hours({"additionalText": "", "days": [], "reopenDate": ""}) is None
+    assert iads._normalize_hours(None) is None
+
+
+def test_a_note_without_a_schedule_still_survives():
+    block = iads._normalize_hours(
+        {"additionalText": "Existing customers: call 1-800-282-1446", "days": []}
+    )
+    assert block == {"days": [], "note": "Existing customers: call 1-800-282-1446"}
+
+
+def test_a_junk_day_name_is_dropped_rather_than_rendered():
+    block = iads._normalize_hours(
+        {"days": [{"day": "FUNDAY", "intervals": [{"start": 900, "end": 1700}]}]}
+    )
+    assert block is None

--- a/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/insurance-agents-nearby.test.tsx
@@ -43,6 +43,18 @@ const AGENCY = {
   products: ["Auto", "Commercial", "Farm", "Home"],
   agencyType: "Standard Independent",
   tier: null,
+  hours: {
+    days: [
+      { day: "MONDAY", intervals: [{ start: 900, end: 1700 }] },
+      { day: "TUESDAY", intervals: [{ start: 900, end: 1700 }] },
+      { day: "WEDNESDAY", intervals: [{ start: 900, end: 1700 }] },
+      { day: "THURSDAY", intervals: [{ start: 900, end: 1700 }] },
+      { day: "FRIDAY", intervals: [{ start: 900, end: 1730 }] },
+      { day: "SATURDAY", intervals: [] },
+      { day: "SUNDAY", intervals: [] },
+    ],
+    note: null,
+  },
   distanceMiles: 0.22,
   address: {
     line1: "10829 NE 68th St",
@@ -444,6 +456,30 @@ describe("InsuranceAgentsNearby", () => {
     );
     // The old cursor points into a list that no longer exists.
     expect(screen.queryByText("Show more")).toBeNull();
+  });
+
+  it("shows posted hours, collapsed, and never claims 'open now'", async () => {
+    // The payload carries bare HHMM with no timezone and this app is read from
+    // India against US agencies, so an open/closed verdict would be wrong by
+    // half a day — and would send someone to call a closed office.
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 47.6769, longitude: -122.206 },
+      error: null,
+    };
+    render(<InsuranceAgentsNearby getIdToken={getIdToken} />);
+    await waitFor(() =>
+      expect(screen.getByText("B G I Agency Network Inc.")).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByText("B G I Agency Network Inc."));
+
+    // Mon-Thu share an interval and collapse; Friday differs and stands alone.
+    await waitFor(() =>
+      expect(screen.getByText("Mon–Thu 9am–5pm · Fri 9am–5:30pm")).toBeTruthy(),
+    );
+    expect(screen.queryByText(/open now/i)).toBeNull();
+    expect(screen.queryByText(/closed now/i)).toBeNull();
   });
 
   it("opens one agency without a second request", async () => {

--- a/hushh-webapp/components/connect/insurance-agent-detail-surface.tsx
+++ b/hushh-webapp/components/connect/insurance-agent-detail-surface.tsx
@@ -4,6 +4,7 @@ import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
 import { Button } from "@/lib/morphy-ux/button";
 import {
   agencyStatusLabel,
+  formatAgentHours,
   type InsuranceAgentCard,
 } from "@/lib/services/insurance-agent-directory-service";
 
@@ -37,6 +38,8 @@ export function InsuranceAgentDetailSurface({
       .join(", ") ??
     null;
 
+  const hours = formatAgentHours(card);
+
   return (
     <AdaptiveDetailSurface
       open={open}
@@ -68,6 +71,11 @@ export function InsuranceAgentDetailSurface({
 
         {address ? (
           <p className="type-callout text-muted-foreground">{address}</p>
+        ) : null}
+
+        {hours ? (
+          // Posted hours, not an open/closed verdict — see formatAgentHours.
+          <p className="type-callout text-muted-foreground">{hours}</p>
         ) : null}
 
         {card.website ? (

--- a/hushh-webapp/lib/services/insurance-agent-directory-service.ts
+++ b/hushh-webapp/lib/services/insurance-agent-directory-service.ts
@@ -20,6 +20,11 @@ export type InsuranceAgentAddress = {
   formatted: string | null;
 };
 
+export type InsuranceAgentHours = {
+  days: { day: string; intervals: { start: number; end: number }[] }[];
+  note: string | null;
+};
+
 export type InsuranceAgentCard = {
   id: string;
   name: string | null;
@@ -29,6 +34,7 @@ export type InsuranceAgentCard = {
   products: string[];
   agencyType: string | null;
   tier: string | null;
+  hours: InsuranceAgentHours | null;
   distanceMiles: number | null;
   address: InsuranceAgentAddress | null;
   city: string | null;
@@ -174,6 +180,70 @@ export function formatAgentSubtitle(card: InsuranceAgentCard): string | null {
   if (products.length) return products.join(" · ");
   // No products listed: fall back to where it is, so the row is never bare.
   return card.city ?? null;
+}
+
+const DAY_LABELS: Record<string, string> = {
+  MONDAY: "Mon",
+  TUESDAY: "Tue",
+  WEDNESDAY: "Wed",
+  THURSDAY: "Thu",
+  FRIDAY: "Fri",
+  SATURDAY: "Sat",
+  SUNDAY: "Sun",
+};
+const DAY_ORDER = Object.keys(DAY_LABELS);
+
+/** 800 -> "8am", 1730 -> "5:30pm". Bare HHMM is how the locator posts them. */
+function formatClock(value: number): string {
+  const hour24 = Math.floor(value / 100);
+  const minute = value % 100;
+  const suffix = hour24 >= 12 ? "pm" : "am";
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  return minute ? `${hour12}:${String(minute).padStart(2, "0")}${suffix}` : `${hour12}${suffix}`;
+}
+
+/**
+ * "Mon–Fri 9am–5pm" — the hours exactly as the agency posted them.
+ *
+ * Deliberately NOT "open now". The locator sends bare HHMM with no timezone,
+ * and this app is read from India against US agencies, so any open/closed
+ * verdict computed from the reader's clock would be wrong by half a day — and
+ * a wrong one sends someone to call a closed office.
+ *
+ * Consecutive days sharing the same interval collapse into a range, because the
+ * alternative is a seven-line table on a surface whose job is one phone call.
+ */
+export function formatAgentHours(
+  card: InsuranceAgentCard,
+): string | null {
+  const days = card.hours?.days ?? [];
+  const open = DAY_ORDER.map((day) => {
+    const entry = days.find((d) => d.day === day);
+    const interval = entry?.intervals[0];
+    return interval ? { day, label: `${formatClock(interval.start)}–${formatClock(interval.end)}` } : null;
+  });
+
+  const groups: { from: string; to: string; label: string }[] = [];
+  for (const slot of open) {
+    if (!slot) continue;
+    const last = groups[groups.length - 1];
+    const contiguous =
+      last &&
+      last.label === slot.label &&
+      DAY_ORDER.indexOf(slot.day) === DAY_ORDER.indexOf(last.to) + 1;
+    if (contiguous) last.to = slot.day;
+    else groups.push({ from: slot.day, to: slot.day, label: slot.label });
+  }
+
+  if (!groups.length) return card.hours?.note ?? null;
+
+  return groups
+    .map(({ from, to, label }) =>
+      from === to
+        ? `${DAY_LABELS[from]} ${label}`
+        : `${DAY_LABELS[from]}–${DAY_LABELS[to]} ${label}`,
+    )
+    .join(" · ");
 }
 
 /** The one `agencyType` that is a standing default rather than a distinction. */


### PR DESCRIPTION
Closes the one real gap from a field-by-field audit of the Insurance Agents API README against what we actually carry through.

## The audit (50 live agencies, ZIP 98033)

| README field | fill rate | carried? |
|---|---|---|
| `id` `name` `address` `website` `products` `agencyType` `distanceMiles` | 50/50 | yes |
| `phone` | 48/50 | yes |
| `email` | 46/50 | yes |
| **`hours`** | **5/50** | **now yes — this PR** |
| `location` (lat/lng) | 50/50 | no — no map surface exists, and the advisers list has none either |
| `tier` | **0/50** | no — dead field |
| `yearEstablished` | **0/50** | no — dead field |
| `social` | **0/50** | no — dead field |

Three README fields are dead in live data. `location` has no consumer today, so wiring it would be a startup dependency for nothing.

## Why posted hours, never "open now"

The locator sends bare `HHMM` integers with **no timezone**. This app is read from India against US agencies, so any open/closed verdict computed from the reader's clock is wrong by roughly half a day — and a wrong one sends someone to call a closed office. Deriving it correctly would need the agency's timezone, which the payload does not carry.

So the surface states what the agency posted and lets the reader judge.

## Shape

Consecutive days sharing an interval collapse, so a full week reads as one line:

```
Mon–Thu 9am–5pm · Fri 9am–5:30pm
```

rather than a seven-row table on a surface whose job is a single phone call. A day with no intervals is a real answer — closed — so it survives normalising; a junk day name does not. Agencies posting nothing get no block at all.

## Validation

| Gate | Result |
|---|---|
| Frontend tests | 34 passed (was 33) |
| Backend tests | 43 passed across both directories |
| `tsc --noEmit` | clean |
| `eslint --max-warnings=0` | clean |
| `ruff check` / `format` | clean |
| `verify:design-system` + accent tokens | pass |

Advisers surface untouched.

---
Closes #4905
(retroactive board-linkage backfill, 2026-08-06)