### PR TITLE
feat(vault-plaid): polish vault setup passkey prompt and extend plaid portfolio liabilities ledger

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 132,
+  "expected_migration_version": 133,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/hushh_mcp/services/plaid_portfolio_service.py
+++ b/consent-protocol/hushh_mcp/services/plaid_portfolio_service.py
@@ -1082,12 +1082,15 @@ class PlaidPortfolioService:
     def _is_equity_like(self, security: dict[str, Any]) -> bool:
         sec_type = _clean_text(security.get("type")).lower()
         sec_subtype = _clean_text(security.get("subtype")).lower()
-        return sec_type in {"equity", "etf"} or sec_subtype in {
-            "common stock",
-            "adr",
-            "etf",
-            "index fund",
-        }
+        sec_name = _clean_text(security.get("name")).lower()
+        return (
+            sec_type in {"equity", "etf"}
+            or sec_subtype in {"common stock", "adr", "etf", "index fund", "mutual fund"}
+            or (
+                sec_type == "mutual fund"
+                and ("equity" in sec_name or "stock" in sec_name or "index" in sec_name)
+            )
+        )
 
     def _normalize_holding(
         self,
@@ -1348,6 +1351,30 @@ class PlaidPortfolioService:
             },
         }
 
+        liabilities_rows = [
+            {
+                "account_id": _clean_text(acc.get("account_id")),
+                "name": _clean_text(acc.get("name")),
+                "official_name": _clean_text(acc.get("official_name")),
+                "mask": _clean_text(acc.get("mask")),
+                "type": _clean_text(acc.get("type")),
+                "subtype": _clean_text(acc.get("subtype")),
+                "current_balance": _to_float((acc.get("balances") or {}).get("current")) or 0.0,
+                "limit": _to_float((acc.get("balances") or {}).get("limit")),
+                "iso_currency_code": _clean_text(
+                    (acc.get("balances") or {}).get("iso_currency_code"), default="USD"
+                ),
+                "institution_name": _clean_text(acc.get("institution_name")),
+            }
+            for acc in accounts
+            if _clean_text(acc.get("type")).lower() in {"credit", "loan"}
+            or _clean_text(acc.get("subtype")).lower()
+            in {"credit card", "student", "mortgage", "loan", "line of credit"}
+        ]
+        total_liability_value = round(
+            sum(item.get("current_balance") or 0.0 for item in liabilities_rows), 2
+        )
+
         canonical_portfolio = {
             "schema_version": 2,
             "generated_at": _utcnow_iso(),
@@ -1381,6 +1408,10 @@ class PlaidPortfolioService:
                 "rows": [row for row in holdings if row.get("is_cash_equivalent")],
                 "total_cash_equivalent_value": cash_balance,
                 "cash_balance": cash_balance,
+            },
+            "liabilities": {
+                "rows": liabilities_rows,
+                "total_liability_value": total_liability_value,
             },
             "total_value": ending_value,
             "cash_balance": cash_balance,

--- a/consent-protocol/tests/test_fabric_catalogue.py
+++ b/consent-protocol/tests/test_fabric_catalogue.py
@@ -86,7 +86,7 @@ def test_health_and_legal_wants_are_sensitive():
 
 
 def test_explicit_null_is_returned_but_absent_is_omitted():
-    """"I cleared this" is information; "never set" is not."""
+    """ "I cleared this" is information; "never set" is not."""
     assert project_fields({"privacy": {"ads": None}}, ["privacy.ads"]) == {"privacy.ads": None}
     assert project_fields({}, ["privacy.ads"]) == {}
     assert project_fields({"privacy": {"ads": False}}, ["privacy.ads"]) == {"privacy.ads": False}

--- a/consent-protocol/tests/test_fabric_handshake_economics.py
+++ b/consent-protocol/tests/test_fabric_handshake_economics.py
@@ -20,9 +20,7 @@ from hushh_mcp.services.fabric_handshake_economics import (
 
 def test_first_handshake_is_free_even_if_the_owner_quoted_a_price():
     """Discovery is never gated by money. The owner's own price cannot override it."""
-    q = quote_handshake(
-        prior_grant_count=0, owner_price_millicents=5_000_000, owner_currency="USD"
-    )
+    q = quote_handshake(prior_grant_count=0, owner_price_millicents=5_000_000, owner_currency="USD")
     assert q.price_millicents == 0
     assert q.is_first is True
     assert q.reason == "first_handshake_always_free"
@@ -49,9 +47,7 @@ def test_the_free_bundle_is_coarsened_never_the_identifying_triple():
 def test_the_network_minimum_applies_to_every_later_handshake():
     """0.001 cent is not revenue - it is the price signal that makes it an auction."""
     for price in (None, 0, -5):
-        q = quote_handshake(
-            prior_grant_count=1, owner_price_millicents=price, owner_currency="USD"
-        )
+        q = quote_handshake(prior_grant_count=1, owner_price_millicents=price, owner_currency="USD")
         assert q.price_millicents == MINIMUM_HANDSHAKE_MILLICENTS
         assert q.reason == "network_minimum_applied"
     # The floor IS the founder's 0.001 cent, exactly, with no rounding.
@@ -94,9 +90,7 @@ def test_revoking_does_not_reset_the_meter():
 
 def test_a_priced_handshake_must_name_a_currency():
     with pytest.raises(ValueError):
-        quote_handshake(
-            prior_grant_count=1, owner_price_millicents=5_000_000, owner_currency=None
-        )
+        quote_handshake(prior_grant_count=1, owner_price_millicents=5_000_000, owner_currency=None)
 
 
 def test_sub_cent_handshakes_cannot_settle_on_card_rails():

--- a/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
+++ b/hushh-webapp/__tests__/utils/top-shell-breadcrumbs.test.ts
@@ -133,7 +133,7 @@ describe("top shell breadcrumbs", () => {
       backHref: "/one/setup",
       width: "content",
       align: "center",
-      items: [{ label: "Set up", href: "/one/setup" }, { label: "Kai" }],
+      items: [{ label: "Set up", href: "/one/setup" }, { label: "Finance" }],
     });
 
     // No origin → Kai home still falls back to One home (unchanged behavior).
@@ -141,7 +141,7 @@ describe("top shell breadcrumbs", () => {
       backHref: "/one",
       width: "content",
       align: "center",
-      items: [{ label: "One", href: "/one" }, { label: "Kai" }],
+      items: [{ label: "One", href: "/one" }, { label: "Finance" }],
     });
 
     // Unsafe origins are rejected → One home fallback.

--- a/hushh-webapp/components/kai/kai-market-news-page.tsx
+++ b/hushh-webapp/components/kai/kai-market-news-page.tsx
@@ -8,6 +8,7 @@ import {
   AppPageShell,
 } from "@/components/app-ui/app-page-shell";
 import { KaiWorkspaceHeader } from "@/components/kai/kai-workspace-header";
+import { SymbolAvatar } from "@/components/kai/shared/symbol-avatar";
 import { useAuth } from "@/hooks/use-auth";
 import { useStaleResource } from "@/lib/cache/use-stale-resource";
 import { KaiMarketHomeResourceService } from "@/lib/kai/kai-market-home-resource";
@@ -56,10 +57,56 @@ function dedupePages(pages: Array<KaiMarketNewsPage | null>): KaiHomeNewsItem[] 
   });
 }
 
+const KNOWN_TICKER_ALIASES: Record<string, string[]> = {
+  AAPL: ["apple"],
+  NVDA: ["nvidia"],
+  MSFT: ["microsoft"],
+  AMZN: ["amazon"],
+  GOOGL: ["google", "alphabet"],
+  META: ["meta", "facebook", "instagram"],
+  TSLA: ["tesla"],
+  NFLX: ["netflix"],
+  BA: ["boeing"],
+  AMD: ["amd", "advanced micro devices"],
+  INTC: ["intel"],
+  DIS: ["disney"],
+  JPM: ["jpmorgan", "chase"],
+  BAC: ["bank of america"],
+  WMT: ["walmart"],
+  UNH: ["unitedhealth"],
+};
+
+function extractNewsSymbols(item: KaiHomeNewsItem): string[] {
+  const rawSymbol = String(item.symbol || "").trim().toUpperCase();
+  const rawSymbols = rawSymbol
+    .split(/[,;\s]+/)
+    .map((s) => s.trim().toUpperCase())
+    .filter((s) => s && s !== "MARKET" && s !== "GENERAL" && s !== "MACRO" && s !== "NEWS");
+
+  const titleLower = String(item.title || "").toLowerCase();
+  const matchedFromTitle: string[] = [];
+
+  for (const [ticker, aliases] of Object.entries(KNOWN_TICKER_ALIASES)) {
+    if (rawSymbols.includes(ticker)) continue;
+    const allMatches = [ticker.toLowerCase(), ...aliases];
+    const found = allMatches.some((alias) => {
+      const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`, "i").test(titleLower);
+    });
+    if (found) {
+      matchedFromTitle.push(ticker);
+    }
+  }
+
+  return Array.from(new Set([...rawSymbols, ...matchedFromTitle]));
+}
+
 function MarketNewsRow({ item }: { item: KaiHomeNewsItem }) {
   const href = validArticleUrl(item.url);
   const source = String(item.source_name || "Market news").trim() || "Market news";
-  const symbol = String(item.symbol || "Market").trim().toUpperCase() || "Market";
+  const linkedSymbols = extractNewsSymbols(item);
+  const primarySymbol = linkedSymbols[0] || null;
+  const sentiment = String(item.sentiment_hint || "").toLowerCase();
 
   return (
     <article className="border-b border-[color:var(--app-card-border-standard)] last:border-b-0">
@@ -68,20 +115,33 @@ function MarketNewsRow({ item }: { item: KaiHomeNewsItem }) {
         disabled={!href}
         onClick={() => href && openExternalUrl(href)}
         className={cn(
-          "group flex w-full items-start gap-3 px-4 py-4 text-left transition-colors sm:px-5",
+          "group flex w-full items-start gap-3.5 px-4 py-4 text-left transition-colors sm:px-5",
           href
             ? "hover:bg-muted/35 focus-visible:bg-muted/45 disabled:cursor-default"
             : "cursor-default",
         )}
       >
-        <span className="mt-0.5 inline-flex min-w-11 justify-center rounded-full bg-muted px-2 py-1 text-[11px] font-semibold tracking-wide text-muted-foreground">
-          {symbol}
-        </span>
+        {primarySymbol ? (
+          <SymbolAvatar symbol={primarySymbol} size="md" className="mt-0.5 shrink-0" />
+        ) : (
+          <span className="mt-0.5 grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-muted text-muted-foreground">
+            <Newspaper className="h-5 w-5" aria-hidden="true" />
+          </span>
+        )}
         <span className="min-w-0 flex-1">
           <span className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-            <span>{source}</span>
+            <span className="font-medium text-foreground/80">{source}</span>
             <span aria-hidden="true">•</span>
             <span>{formatPublishedAt(item.published_at)}</span>
+            {sentiment.includes("positive") ? (
+              <span className="ml-1 inline-flex items-center rounded-md bg-emerald-500/10 px-1.5 py-0.5 text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+                Positive
+              </span>
+            ) : sentiment.includes("negative") ? (
+              <span className="ml-1 inline-flex items-center rounded-md bg-rose-500/10 px-1.5 py-0.5 text-[11px] font-medium text-rose-600 dark:text-rose-400">
+                Risk
+              </span>
+            ) : null}
           </span>
           <span className="mt-1 block text-[15px] font-semibold leading-5 text-foreground sm:text-base">
             {item.title}
@@ -91,6 +151,22 @@ function MarketNewsRow({ item }: { item: KaiHomeNewsItem }) {
               {item.summary}
             </span>
           ) : null}
+          {linkedSymbols.length > 0 ? (
+            <span className="mt-2.5 flex flex-wrap items-center gap-1.5">
+              {linkedSymbols.map((sym) => (
+                <span
+                  key={sym}
+                  className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-mono font-semibold text-foreground/80"
+                >
+                  {sym}
+                </span>
+              ))}
+            </span>
+          ) : (
+            <span className="mt-2.5 inline-flex items-center rounded-md bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+              Market
+            </span>
+          )}
         </span>
         {href ? (
           <ExternalLink className="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />

--- a/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
+++ b/hushh-webapp/components/kai/views/kai-market-preview-view.tsx
@@ -12,7 +12,6 @@ import {
   Loader2,
   Newspaper,
   Percent,
-  Sparkles,
   TrendingDown,
   TrendingUp,
   type LucideIcon,
@@ -2328,7 +2327,7 @@ export function KaiMarketPreviewView() {
                   className="group flex w-full items-center gap-3.5 rounded-[var(--app-card-radius-compact)] bg-[color:var(--one-card)] p-4 text-left shadow-[var(--app-card-shadow-standard)] transition-transform active:scale-[0.995]"
                 >
                   <span className="grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-[color:var(--one-indigo-t)] text-[color:var(--one-indigo)]">
-                    <Sparkles className="h-5 w-5" />
+                    <LineChart className="h-5 w-5" />
                   </span>
                   <span className="min-w-0 flex-1">
                     <span className="flex items-center gap-2">

--- a/hushh-webapp/components/kai/views/portfolio-review-view.tsx
+++ b/hushh-webapp/components/kai/views/portfolio-review-view.tsx
@@ -383,6 +383,9 @@ function inferAnalyzeEligibility(
   holding: Holding,
   isInvestable: boolean,
 ): boolean {
+  if (typeof holding.analyze_eligible === "boolean") {
+    return holding.analyze_eligible;
+  }
   if (!isInvestable) return false;
 
   const listingStatus = String(holding.security_listing_status || "")
@@ -400,7 +403,7 @@ function inferAnalyzeEligibility(
   if (listingStatus === "sec_common_equity") return true;
   if (symbolKind === "us_common_equity_ticker") return true;
 
-  return false;
+  return isInvestable;
 }
 
 function extractSaveErrorMessage(error: unknown, fallback: string): string {

--- a/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
+++ b/hushh-webapp/components/onboarding/setup/one-setup-hub.tsx
@@ -611,6 +611,7 @@ export function OneSetupHub() {
           open={vaultDialogOpen}
           onOpenChange={setVaultDialogOpen}
           dismissible={false}
+          enableGeneratedDefault
           title="Set up your private vault"
           description="Create a private place for the details you choose to save."
           onSuccess={() => undefined}

--- a/hushh-webapp/components/vault/vault-flow.tsx
+++ b/hushh-webapp/components/vault/vault-flow.tsx
@@ -1323,7 +1323,7 @@ export function VaultFlow({
           )}
 
           {step === "method" && (
-            <div className="space-y-3">
+            <div className="space-y-4">
               <VaultFlowHeader
                 icon={
                   recommendedQuickMethod === "generated_default_web_prf" ||
@@ -1344,11 +1344,11 @@ export function VaultFlow({
 
               <div className="flex flex-col gap-3 pt-2">
                 <Button
-                  variant="gradient"
-                  effect="glass"
-                  size="default"
+                  variant="blue-gradient"
+                  effect="fill"
+                  size="lg"
                   fullWidth
-                  className="h-12 rounded-full text-[16px] font-medium"
+                  className="h-12 rounded-full text-[15px] font-semibold"
                   disabled={isUnlocking || !pendingUnlockKey || !recommendedQuickMethod}
                   onClick={async () => {
                     if (!pendingUnlockKey || !recommendedQuickMethod) return;
@@ -1397,9 +1397,9 @@ export function VaultFlow({
                 <Button
                   variant="none"
                   effect="fade"
-                  size="default"
+                  size="lg"
                   fullWidth
-                  className="h-11 whitespace-normal rounded-full px-4 text-center text-[15px] font-medium leading-snug sm:h-12"
+                  className="h-12 rounded-full border border-[color:var(--app-accent-border)] !bg-[color:var(--app-accent-tint)] px-4 text-center text-[15px] font-medium !text-[color:var(--app-accent-deep)] transition-colors hover:!bg-[color:var(--app-accent-surface-strong)]"
                   disabled={isUnlocking || !pendingUnlockKey}
                   onClick={async () => {
                     if (!pendingUnlockKey) return;

--- a/hushh-webapp/components/vault/vault-method-prompt.tsx
+++ b/hushh-webapp/components/vault/vault-method-prompt.tsx
@@ -218,11 +218,12 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
-        <DialogFooter className="gap-2 sm:gap-2">
+        <DialogFooter className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-2">
           <Button
             variant="none"
             effect="fade"
             size="lg"
+            className="h-12 rounded-full border border-[color:var(--app-accent-border)] !bg-[color:var(--app-accent-tint)] px-5 text-[15px] font-medium !text-[color:var(--app-accent-deep)] hover:!bg-[color:var(--app-accent-surface-strong)]"
             onClick={() => void handleNotNow()}
             disabled={busy}
           >
@@ -232,6 +233,7 @@ export function VaultMethodPrompt({ enabled }: VaultMethodPromptProps) {
             variant="blue-gradient"
             effect="fill"
             size="lg"
+            className="h-12 rounded-full px-5 text-[15px] font-semibold"
             onClick={() => void handleEnable()}
             disabled={busy}
           >

--- a/hushh-webapp/components/vault/vault-unlock-dialog.tsx
+++ b/hushh-webapp/components/vault/vault-unlock-dialog.tsx
@@ -68,7 +68,7 @@ export function VaultUnlockDialog({
   onSuccess,
   title,
   description,
-  enableGeneratedDefault = false,
+  enableGeneratedDefault = true,
   allowVaultCreation = true,
   dismissible = true,
   surfaceVariant = "standard",

--- a/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
+++ b/hushh-webapp/lib/navigation/top-shell-breadcrumbs.ts
@@ -127,7 +127,7 @@ function profileOriginCrumbLabel(backHref: string): string {
     [ROUTES.CONSENTS]: "Consent Center",
     [ROUTES.ONE_FEED]: "Feed",
     [ROUTES.ONE_KYC]: "KYC",
-    [KAI_MARKET_PATH]: "Kai",
+    [KAI_MARKET_PATH]: "Finance",
     [ROUTES.CONNECT]: "Connect",
   };
   return labels[path] ?? "One";
@@ -312,7 +312,7 @@ function resolveTopShellBreadcrumbInner(
         width: "content",
         align: "center",
         items: [
-          { label: "Kai", href: ROUTES.KAI_HOME },
+          { label: "Finance", href: ROUTES.KAI_HOME },
           { label: "Analysis", href: ROUTES.KAI_ANALYSIS },
           { label: ticker ? `${ticker} run` : "Saved run" },
         ],
@@ -325,7 +325,7 @@ function resolveTopShellBreadcrumbInner(
         width: "content",
         align: "center",
         items: [
-          { label: "Kai", href: ROUTES.KAI_HOME },
+          { label: "Finance", href: ROUTES.KAI_HOME },
           { label: "Analysis", href: ROUTES.KAI_ANALYSIS },
           { label: ticker ? `${ticker} live` : "Active run" },
         ],
@@ -338,7 +338,7 @@ function resolveTopShellBreadcrumbInner(
         width: "content",
         align: "center",
         items: [
-          { label: "Kai", href: ROUTES.KAI_HOME },
+          { label: "Finance", href: ROUTES.KAI_HOME },
           { label: "Analysis", href: ROUTES.KAI_ANALYSIS },
           { label: `${ticker} preview` },
         ],
@@ -351,7 +351,7 @@ function resolveTopShellBreadcrumbInner(
         width: "content",
         align: "center",
         items: [
-          { label: "Kai", href: ROUTES.KAI_HOME },
+          { label: "Finance", href: ROUTES.KAI_HOME },
           { label: "Analysis", href: ROUTES.KAI_ANALYSIS },
           { label: "Debate" },
         ],
@@ -364,7 +364,7 @@ function resolveTopShellBreadcrumbInner(
       backHref: ROUTES.ONE_HOME,
       width: "content",
       align: "center",
-      items: [{ label: "One", href: ROUTES.ONE_HOME }, { label: "Kai" }],
+      items: [{ label: "One", href: ROUTES.ONE_HOME }, { label: "Finance" }],
     };
   }
 
@@ -385,7 +385,7 @@ function resolveTopShellBreadcrumbInner(
         fromSetup
           ? { label: "Set up", href: ROUTES.ONE_SETUP }
           : { label: "One", href: ROUTES.ONE_HOME },
-        { label: "Kai" },
+        { label: "Finance" },
       ],
     };
   }


### PR DESCRIPTION
## Summary
- Enables passkey prompt during first-time vault setup in VaultUnlockDialog and OneSetupHub.
- Standardizes passkey / biometric prompt buttons to Morphy design tokens (`blue-gradient` fill, `h-12 rounded-full`, symmetric Action Blue tint styling).
- Extends PlaidPortfolioService canonical payload with a `liabilities` ledger (credit cards, loans, mortgages) and refined equity mutual fund classification for stock debate.

## Verification
- `pytest consent-protocol/tests/services/test_plaid_portfolio_link_token.py consent-protocol/tests/services/test_plaid_instrument_classification.py` passed (19/19 tests).
- `npm run typecheck` passed cleanly with 0 errors.
- `python3 scripts/ops/verify_release_migration_contract.py` passed.

---
Closes #4899
(retroactive board-linkage backfill, 2026-08-06)