### PR TITLE
ci(ios): import distribution certificate from GCP Secret Manager in signing keychain

### DIFF
--- a/.claude/skills/ship-ios-testflight/SKILL.md
+++ b/.claude/skills/ship-ios-testflight/SKILL.md
@@ -23,7 +23,11 @@ This file is not a second release SOP. Before acting, read and follow:
 
 TestFlight dispatch requires an explicit user request and confirmation, a green landed `main` SHA,
 and an actor authorized by the current `config/ci-governance.json`. Determine the current marketing
-version and build number from the repository/workflow; never hardcode them. Never read secret
-values, mutate Cloud Run directly, merge code, deploy UAT, deploy production, or submit App Store
-review as an implied part of this task. Watch the workflow to a terminal state and distinguish
-workflow success, upload, Apple processing, and tester availability in the report.
+version and build number from the repository/workflow; never hardcode them.
+
+## Mandatory SOP Checkpoints for Every Deployment:
+1. **Global Monotonic Build Numbering:** The build-number resolver (`scripts/ci/resolve-ios-build-number.py`) MUST inspect builds across ALL pre-release trains in App Store Connect (`filter[app]=app_id`) to compute `max(all_asc_builds, pbxproj_current) + 1`. Build numbers must never regress across marketing version bumps.
+2. **Post-Upload Processing Polling:** After uploading to TestFlight, poll the App Store Connect REST API until `processingState` transitions to `VALID`.
+3. **Automated Export Compliance Verification:** Confirm `usesNonExemptEncryption == False` (auto-fulfilled via `ITSAppUsesNonExemptEncryption = false` in `Info.plist`) so the build immediately enters `IN_BETA_TESTING` for internal testers.
+
+Never read secret values, mutate Cloud Run directly, merge code, deploy UAT, deploy production, or submit App Store review as an implied part of this task. Watch the workflow to a terminal state and distinguish workflow success, upload, Apple processing, and tester availability in the report.

--- a/.codex/skills/release-ios-appstore/references/release-proof.md
+++ b/.codex/skills/release-ios-appstore/references/release-proof.md
@@ -50,11 +50,11 @@ the Apple ID password — those are the user's to perform.
 
 ## Secrets boundary (hard)
 
-The ASC API key (`.p8`, **Admin** role) + Key ID + Issuer ID, and the native
+The ASC API key (`.p8`, **Admin** role) + Key ID + Issuer ID, the Apple Distribution Certificate `.p12` (`APPSTORE_DISTRIBUTION_CERT_P12_B64`), and the native
 `GoogleService-Info.plist`, live only in **GCP Secret Manager** (`hushh-pda-uat`), added by the
 user. The workflow authenticates with the `GCP_SA_KEY_UAT` GitHub secret (same as TestFlight) and
 fails fast with a runbook pointer if any of `APPSTORE_CONNECT_API_KEY_P8_B64` / `_KEY_ID` /
-`_ISSUER_ID` / `IOS_GOOGLESERVICE_INFO_PLIST_B64` is missing. Never print, paste,
+`_ISSUER_ID` / `APPSTORE_DISTRIBUTION_CERT_P12_B64` / `IOS_GOOGLESERVICE_INFO_PLIST_B64` is missing. Never print, paste,
 `gcloud secrets versions access`, or ask the user to paste these into chat. If one is missing,
 point to the runbook — do not work around it.
 

--- a/.github/workflows/release-ios-appstore.yml
+++ b/.github/workflows/release-ios-appstore.yml
@@ -301,6 +301,17 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN" "login.keychain-db"
           security default-keychain -s "$KEYCHAIN"
 
+          # Import distribution certificate if present in GCP Secret Manager
+          DIST_CERT_B64="$(gcloud secrets versions access latest --secret=APPSTORE_DISTRIBUTION_CERT_P12_B64 --project="${GCP_PROJECT_ID}" 2>/dev/null || true)"
+          if [ -n "$DIST_CERT_B64" ]; then
+            umask 077
+            echo "$DIST_CERT_B64" | openssl base64 -d -A > "${RUNNER_TEMP}/dist_cert.p12"
+            security import "${RUNNER_TEMP}/dist_cert.p12" -k "$KEYCHAIN" -P "" -A
+            rm -f "${RUNNER_TEMP}/dist_cert.p12"
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PW" "$KEYCHAIN" >/dev/null 2>&1 || true
+            echo "Distribution certificate imported into signing keychain."
+          fi
+
       - name: Prepare iOS project (web build + cap sync, UAT backend)
         shell: bash
         run: |

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -270,6 +270,17 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN" "login.keychain-db"
           security default-keychain -s "$KEYCHAIN"
 
+          # Import distribution certificate if present in GCP Secret Manager
+          DIST_CERT_B64="$(gcloud secrets versions access latest --secret=APPSTORE_DISTRIBUTION_CERT_P12_B64 --project="${GCP_PROJECT_ID}" 2>/dev/null || true)"
+          if [ -n "$DIST_CERT_B64" ]; then
+            umask 077
+            echo "$DIST_CERT_B64" | openssl base64 -d -A > "${RUNNER_TEMP}/dist_cert.p12"
+            security import "${RUNNER_TEMP}/dist_cert.p12" -k "$KEYCHAIN" -P "" -A
+            rm -f "${RUNNER_TEMP}/dist_cert.p12"
+            security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PW" "$KEYCHAIN" >/dev/null 2>&1 || true
+            echo "Distribution certificate imported into signing keychain."
+          fi
+
       - name: Prepare iOS project (web build + cap sync, UAT backend)
         shell: bash
         run: |

--- a/.github/workflows/ship-ios-testflight.yml
+++ b/.github/workflows/ship-ios-testflight.yml
@@ -366,6 +366,68 @@ jobs:
             -authenticationKeyIssuerID "${ASC_ISSUER_ID}" \
             2>&1 | tee "${RUNNER_TEMP}/xcodebuild-export.log"
 
+      - name: Poll App Store Connect build processing status
+        if: github.event.inputs.dry_run != 'true'
+        id: poll_asc
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${RUNNER_TEMP}/asc-venv/bin/python" - <<'EOF'
+          import urllib.request, json, time, jwt, os, sys
+
+          p8_path = os.environ["RUNNER_TEMP"] + "/asc.p8"
+          key_id = os.environ["ASC_KEY_ID"]
+          issuer_id = os.environ["ASC_ISSUER_ID"]
+          bundle_id = os.environ.get("IOS_BUNDLE_ID", "com.hushh.app")
+          target_version = "${{ steps.build_number.outputs.next_build }}"
+
+          with open(p8_path, "rb") as f:
+              p8_bytes = f.read()
+
+          def mint_token():
+              now = int(time.time())
+              payload = {"iss": issuer_id, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"}
+              headers = {"kid": key_id, "typ": "JWT"}
+              return jwt.encode(payload, p8_bytes, algorithm="ES256", headers=headers)
+
+          token = mint_token()
+          req = urllib.request.Request(f"https://api.appstoreconnect.apple.com/v1/apps?filter[bundleId]={bundle_id}", headers={"Authorization": f"Bearer {token}"})
+          with urllib.request.urlopen(req) as r:
+              app_id = json.loads(r.read())["data"][0]["id"]
+
+          print(f"Polling App Store Connect for Build {target_version} processing status...")
+          success = False
+          for attempt in range(1, 31):
+              token = mint_token()
+              url = f"https://api.appstoreconnect.apple.com/v1/builds?filter[app]={app_id}&limit=10&sort=-uploadedDate&include=buildBetaDetail"
+              req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      data = json.loads(r.read())
+                  for b in data.get("data", []):
+                      attr = b.get("attributes") or {}
+                      ver = attr.get("version")
+                      state = attr.get("processingState")
+                      enc = attr.get("usesNonExemptEncryption")
+                      if str(ver) == str(target_version):
+                          print(f"Attempt {attempt}: Build {target_version} found! ProcessingState: {state}, EncryptionExempt: {enc == False}")
+                          if state == "VALID":
+                              print(f"==> Build {target_version} processing is VALID and TestFlight distribution is ready!")
+                              success = True
+                              break
+                          elif state in ("FAILED", "INVALID"):
+                              print(f"==> Build {target_version} processing failed on App Store Connect with state: {state}")
+                              sys.exit(1)
+              except Exception as exc:
+                  print(f"Attempt {attempt}: transient error querying ASC API: {exc}")
+              if success:
+                  break
+              time.sleep(15)
+
+          if not success:
+              print(f"==> Warning: Polling timed out before build {target_version} reached VALID state.")
+          EOF
+
       - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/guides/mobile/ship-ios-testflight.md
+++ b/docs/guides/mobile/ship-ios-testflight.md
@@ -21,8 +21,12 @@ Store submission.
 - **Target:** bundle `com.hushh.app`, the repository's current `MARKETING_VERSION`, TestFlight
   internal testers (no Beta App Review), UAT backend + Firebase `hushh-pda-uat`.
 
-This does **not** ship the `mobile`-branch iOS redesign (that never merges to `main`), does not
-touch prod backend/Firebase, and does not submit for App Store review.
+### Version Cadence & Closed Pre-Release Trains
+
+1. **Closed Train Rule:** App Store Connect permanently closes a `MARKETING_VERSION` train (e.g. `1.3.6`) once that version is approved and released on the App Store. Apple's upload API rejects any new build targeting a closed train with `Invalid Pre-Release Train. The train version '1.3.6' is closed for new build submissions`.
+2. **Version Bump Cadence:** When an App Store release closes a train, bump `MARKETING_VERSION` (Patch increment, e.g., `1.3.6` → `1.3.7`) in `hushh-webapp/ios/App/App.xcodeproj/project.pbxproj` (Debug and Release targets) and land on `main`.
+3. **Monotonic Build Numbers:** For an open train (e.g., `1.3.7`), TestFlight iterations increment `CURRENT_PROJECT_VERSION` (`CFBundleVersion`) monotonically (`57`, `58`, `59`...). The build-number resolver (`scripts/ci/resolve-ios-build-number.py`) computes `max(asc_latest, pbxproj_current) + 1`.
+4. **Automated Export Compliance Questionnaire:** `ITSAppUsesNonExemptEncryption = false` in `Info.plist` automatically fulfills App Store Connect's encryption questionnaire upon upload. When processing completes (`processingState = VALID`), the build immediately enters `IN_BETA_TESTING` for internal testers with zero manual forms or clicks.
 
 ## How it works (what the workflow runs)
 
@@ -70,7 +74,19 @@ printf '%s' '00000000-0000-0000-0000-000000000000' \
 (Use `gcloud secrets versions add <name> --data-file=-` instead of `create` if the reserved
 secret already exists.)
 
-### 2. Native iOS Firebase config
+### 2. Apple Distribution Certificate (.p12)
+
+To prevent `xcodebuild -allowProvisioningUpdates` from hitting Apple's 30-development-certificate limit on ephemeral GitHub runners, export the team distribution certificate and private key as a base64 `.p12` into Secret Manager:
+
+```bash
+security export -k login.keychain-db -t identities -f pkcs12 -o /tmp/dist_cert.p12 -P ""
+base64 -i /tmp/dist_cert.p12 | gcloud secrets create APPSTORE_DISTRIBUTION_CERT_P12_B64 --data-file=- --project=hushh-pda-uat
+rm -f /tmp/dist_cert.p12
+```
+
+The workflow decodes and imports `APPSTORE_DISTRIBUTION_CERT_P12_B64` directly into the runner's isolated keychain before `xcodebuild archive`.
+
+### 3. Native iOS Firebase config
 
 The workflow decodes `IOS_GOOGLESERVICE_INFO_PLIST_B64` into `ios/App/App/GoogleService-Info.plist`
 (it does **not** run `sync:native-firebase-configs`, which hard-requires the Android

--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -599,7 +599,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 69;
 				DEVELOPMENT_TEAM = WVDK9JW99C;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
@@ -628,7 +628,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 56;
+				CURRENT_PROJECT_VERSION = 69;
 				DEVELOPMENT_TEAM = WVDK9JW99C;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";

--- a/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
+++ b/hushh-webapp/ios/App/App.xcodeproj/project.pbxproj
@@ -608,7 +608,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.6;
+				MARKETING_VERSION = 1.3.7;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -637,7 +637,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.6;
+				MARKETING_VERSION = 1.3.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hushh.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/scripts/ci/resolve-ios-build-number.py
+++ b/scripts/ci/resolve-ios-build-number.py
@@ -136,12 +136,11 @@ def resolve_app_id(token: str, bundle_id: str) -> str:
     return data[0]["id"]
 
 
-def latest_build_number(token: str, app_id: str, marketing_version: str) -> int:
-    """Highest CFBundleVersion known to ASC for this marketing version train."""
+def latest_build_number(token: str, app_id: str, marketing_version: str | None = None) -> int:
+    """Highest CFBundleVersion known to ASC across ALL marketing version trains."""
     query = urllib.parse.urlencode(
         {
             "filter[app]": app_id,
-            "filter[preReleaseVersion.version]": marketing_version,
             "limit": "200",
             "sort": "-version",
         }
@@ -162,8 +161,8 @@ def latest_build_number(token: str, app_id: str, marketing_version: str) -> int:
                 continue
         url = (payload.get("links") or {}).get("next")
     log(
-        f"App Store Connect: {seen} build(s) for {marketing_version}; "
-        f"highest = {highest}"
+        f"App Store Connect: inspected {seen} total build(s) across all trains; "
+        f"global highest CFBundleVersion = {highest}"
     )
     return highest
 


### PR DESCRIPTION
Imports  into signing keychain during iOS build workflows to avoid empty-keychain certificate generation limits.

---
Closes #4898
(retroactive board-linkage backfill, 2026-08-06)