### PR TITLE
fix(connect): dial US directory numbers as E.164 so calls work from any region

### DIFF
--- a/hushh-webapp/__tests__/services/us-tel-href.test.ts
+++ b/hushh-webapp/__tests__/services/us-tel-href.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { usTelHref } from "@/lib/services/us-tel-href";
+
+describe("usTelHref", () => {
+  it("adds +1 to the bare ten-digit numbers US directories serve", () => {
+    expect(usTelHref("612-3712811")).toBe("tel:+16123712811");
+    expect(usTelHref("(425) 803-8300")).toBe("tel:+14258038300");
+  });
+
+  it("adds only the + when the country code is already there", () => {
+    expect(usTelHref("1-612-371-2811")).toBe("tel:+16123712811");
+    expect(usTelHref("+1 612 371 2811")).toBe("tel:+16123712811");
+  });
+
+  it("passes a foreign country code through instead of forcing +1", () => {
+    expect(usTelHref("+44 20 7946 0958")).toBe("tel:+442079460958");
+  });
+
+  it("leaves a shape it does not recognize alone rather than guessing", () => {
+    expect(usTelHref("371-2811")).toBe("tel:3712811");
+  });
+});

--- a/hushh-webapp/components/connect/advisor-detail-surface.tsx
+++ b/hushh-webapp/components/connect/advisor-detail-surface.tsx
@@ -10,6 +10,7 @@ import {
   type AdvisorCard,
   type AdvisorProfile,
 } from "@/lib/services/advisor-directory-service";
+import { usTelHref } from "@/lib/services/us-tel-href";
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
@@ -101,7 +102,7 @@ export function AdvisorDetailSurface({
             fullWidth
             asChild
           >
-            <a href={`tel:${card.phone.replace(/[^\d+]/g, "")}`}>Call</a>
+            <a href={usTelHref(card.phone)}>Call</a>
           </Button>
         ) : undefined
       }

--- a/hushh-webapp/components/connect/insurance-agent-detail-surface.tsx
+++ b/hushh-webapp/components/connect/insurance-agent-detail-surface.tsx
@@ -7,6 +7,7 @@ import {
   formatAgentHours,
   type InsuranceAgentCard,
 } from "@/lib/services/insurance-agent-directory-service";
+import { usTelHref } from "@/lib/services/us-tel-href";
 
 /**
  * One agency, opened from the nearby list.
@@ -57,7 +58,7 @@ export function InsuranceAgentDetailSurface({
             fullWidth
             asChild
           >
-            <a href={`tel:${card.phone.replace(/[^\d+]/g, "")}`}>Call</a>
+            <a href={usTelHref(card.phone)}>Call</a>
           </Button>
         ) : undefined
       }

--- a/hushh-webapp/lib/services/us-tel-href.ts
+++ b/hushh-webapp/lib/services/us-tel-href.ts
@@ -1,0 +1,15 @@
+/**
+ * US directory feeds (BrokerCheck advisers, Nationwide agencies) serve phones
+ * as bare ten-digit strings, so a raw `tel:` link dials as a local number and
+ * misroutes from any non-US region. Emit E.164 (`tel:+1…`); a number already
+ * carrying a `+` passes through as-is; any other shape stays bare digits
+ * rather than guessing a country.
+ */
+export function usTelHref(phone: string): string {
+  const trimmed = phone.trim();
+  const digits = trimmed.replace(/\D/g, "");
+  if (trimmed.startsWith("+")) return `tel:+${digits}`;
+  if (digits.length === 10) return `tel:+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `tel:+${digits}`;
+  return `tel:${digits}`;
+}


### PR DESCRIPTION
## What

The Connect page's adviser and insurance-agency Call buttons built `tel:` links from the raw directory phone strings. BrokerCheck and Nationwide serve bare ten-digit US numbers (`612-3712811`), so the link carried no country code — a device set to any non-US region (Ankit tests from India) misdials or fails the call.

## Change

- New shared `usTelHref` helper (`hushh-webapp/lib/services/us-tel-href.ts`): emits E.164 — `+1` for bare ten-digit US shapes, `+` for eleven digits leading with 1, passthrough for numbers already carrying `+`, bare digits otherwise rather than guessing a country.
- Both Connect detail surfaces (`advisor-detail-surface.tsx`, `insurance-agent-detail-surface.tsx`) now route their Call hrefs through it.
- Unit tests for all four shapes.

Wallet-card and SOS `tel:` builders are deliberately untouched — wallet phones are user-entered international numbers, and SOS short codes must never gain `+1`.

## Verification

- Targeted: 34/34 tests pass (new file + adjacent suites); `tsc --noEmit` and eslint clean on touched files.
- Full suite branch vs clean `origin/main` baseline: failing sets byte-identical (15 pre-existing failures in 11 files on both); branch adds exactly its new passing tests.

---
Closes #4905
(retroactive board-linkage backfill, 2026-08-06)