### PR TITLE
copy(onboarding): plain-language rewrite of welcome tagline, motions, and description

### DIFF
--- a/hushh-webapp/components/onboarding/IntroStep.tsx
+++ b/hushh-webapp/components/onboarding/IntroStep.tsx
@@ -19,7 +19,7 @@ import styles from "./IntroStep.module.css";
 
 // One's four motions, shown as a quiet typographic rhythm — never as chips,
 // never labeled "framework". Matches docs/vision/agent-ontology.md.
-const MOTIONS = ["Listens", "Remembers", "Decides", "Acts"];
+const MOTIONS = ["Listens", "Remembers", "Acts"];
 
 export function IntroStep({ onLogin }: { onLogin?: () => void }) {
   const claimOne = useCallback(() => {
@@ -117,7 +117,7 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
           {/* Approved durable product line (docs/vision/agent-ontology.md
               Founder Copy Rules; brand punchline). Not ad-hoc copy. */}
           <p className={styles.tagline}>
-            Your agents. Yours to own.
+          Made just for you.
           </p>
 
           {/* Quiet rhythm line: the four motions, typographic not chip-like. */}
@@ -135,7 +135,7 @@ export function IntroStep({ onLogin }: { onLogin?: () => void }) {
           </div>
 
           <p className={styles.description}>
-            Everything stays encrypted in your vault.
+            All data is encrypted.
             <br />
             Nothing moves without your consent.
           </p>


### PR DESCRIPTION
# Description

Simplifies the onboarding welcome screen (`IntroStep`) copy to plain, everyday language — removing repetitive framing in favor of wording a non-technical person would use.

**Changes:**
- Tagline: "Your agents. Yours to own." → "Made just for you."
- Motions row: dropped "Decides" → "Listens · Remembers · Acts" (The term "decides" at first glance might scare a user away from the app because they might be worried about losing their autonomy)
- Description: "Everything stays encrypted in your vault." → "All data is encrypted." (User might be confused by what a vault is)

⚠️ **Flag for reviewer:** This PR diverges from the documented Founder Copy Rules in `docs/vision/agent-ontology.md` (line 137: `Your agents. Yours to own.` is listed as approved founder-facing copy; the motions line maps 1:1
to `One listens, remembers, decides, and acts under consent.` on line 133). Opening this PR for visibility and reviewer discretion rather than assuming approval — please route to whoever owns brand/copy decisions if this needs
sign-off before merging.

**Note on base branch:** this PR targets `integration/pr-train` per repo policy — direct PRs into `main` are blocked for non-maintainers.

Before requesting review, read
[`docs/reference/quality/pr-contributor-readiness.md`](docs/reference/quality/pr-contributor-readiness.md).

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/` (onboarding welcome screen — `IntroStep`)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [ ] Listed below: Not yet verified on iOS/Android; copy-only change, low risk.
- Docs updated (exact files):
  - [ ] Listed below: `docs/vision/agent-ontology.md` NOT updated — see flag above.
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None (copy-only change)
- Caller / proxy / backend pairing:
  - [x] Not applicable
- Rollback or safe-failure behavior:
  - [x] Not applicable (copy-only; worst case is prior wording persists)
- UI browser or Playwright proof:
  - [ ] Route/spec/command listed below: Manually verified on `/` locally via `npm run dev`; screenshots pending.
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — clean
  - [x] `cd hushh-webapp && npx vitest run intro-step` — 4/5 passing; 1 pre-existing failure, unrelated (see note above)
  - [ ] `./bin/hushh codex pre-pr`
  - [ ] `cd hushh-webapp && npm test` (full suite)
  - [ ] `cd hushh-webapp && npm run build`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py --api-base http://localhost:8000 --web-base http://localhost:3000`

I cannot test this because I don't have maintainer access. 

## ✅ Review-Ready Contract

- [ ] Title, body, changed files, and tests