### PR TITLE
fix(ci): make the post-merge smoke gate recoverable

### DIFF
--- a/.github/workflows/main-post-merge-smoke.yml
+++ b/.github/workflows/main-post-merge-smoke.yml
@@ -4,12 +4,29 @@ on:
   push:
     branches:
       - main
+  # Recovery trigger. A push-only gate is unrecoverable when its run is lost:
+  # on 2026-08-06 a run sat queued for five hours holding the concurrency group,
+  # the next merge to main never got a run at all, and because every deploy lane
+  # requires a green "Main Post-Merge Smoke Gate" on the exact SHA, that commit
+  # could never be deployed. The push event cannot be replayed, and a check-run
+  # cannot be published by hand because that API is GitHub-App-only. Being able
+  # to re-run this for a specific SHA is the only way out that does not involve
+  # weakening the gate.
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Exact main SHA to smoke-test (blank = current main)"
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: smoke-${{ github.workflow }}-${{ github.ref }}
+  # Keyed by the SHA under test, not just the ref. With a ref-only key a stuck
+  # run blocks every later commit; keyed by SHA, a wedged run can only ever
+  # block re-runs of its own commit.
+  group: smoke-${{ github.workflow }}-${{ github.event.inputs.sha || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -25,6 +42,23 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # On a dispatch this MUST be the requested SHA. Checking out the ref
+          # would publish a "Main Post-Merge Smoke Gate" result attributed to a
+          # different commit than the one actually tested, which is worse than
+          # no result at all.
+          ref: ${{ github.event.inputs.sha || github.sha }}
+
+      - name: Assert the dispatched SHA is on main
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.sha != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "${{ github.event.inputs.sha }}" origin/main; then
+            echo "Refusing: ${{ github.event.inputs.sha }} is not an ancestor of origin/main." >&2
+            exit 1
+          fi
+          echo "Confirmed ${{ github.event.inputs.sha }} is on main."
 
       - uses: actions/setup-node@v6
         with:

--- a/deploy/ci.cloudbuild.yaml
+++ b/deploy/ci.cloudbuild.yaml
@@ -181,11 +181,21 @@ steps:
 
   # Step 4: publish the verdict back to GitHub as a check-run.
   #
-  # This is the step that actually unblocks a release. Every deploy and release
-  # workflow gates on a check named exactly "Main Post-Merge Smoke Gate" via
-  # scripts/ci/require-deploy-sha-on-main.sh, so a green Cloud Build that is
-  # never reported to GitHub does not unblock anything. Runs only when
-  # _PUBLISH_CHECK=true and a token secret is available.
+  # Every deploy and release workflow gates on a check named exactly
+  # "Main Post-Merge Smoke Gate" via scripts/ci/require-deploy-sha-on-main.sh,
+  # which reads /commits/<sha>/check-runs. A green Cloud Build that is never
+  # reported to GitHub therefore unblocks nothing.
+  #
+  # IMPORTANT LIMITATION, PROVEN 2026-08-06: the create-check-run API is
+  # GitHub-App-only. A personal access token returns
+  #   403 "You must authenticate via a GitHub App."
+  # no matter its scopes. The commit-status API does accept a PAT, but the
+  # deploy gate does not read statuses, so a status will not satisfy it.
+  #
+  # So _GITHUB_TOKEN_SECRET must hold an INSTALLATION token for a GitHub App
+  # with checks:write. If you do not have one, do not fight this step -- the
+  # supported recovery is to dispatch main-post-merge-smoke.yml for the SHA,
+  # which publishes the real check under the real name.
   - name: "python:3.13-bookworm"
     id: "publish-github-check"
     entrypoint: "bash"
@@ -232,8 +242,21 @@ steps:
             },
             method="POST",
         )
-        with urllib.request.urlopen(req) as resp:
-            print(f"Published check-run '{name}' for {sha}: HTTP {resp.status}")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                print(f"Published check-run '{name}' for {sha}: HTTP {resp.status}")
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", "replace")
+            print(f"Could not publish the check-run: HTTP {exc.code} {body}", flush=True)
+            if exc.code == 403 and "GitHub App" in body:
+                print(
+                    "The token is not a GitHub App installation token. Check-runs "
+                    "cannot be created with a personal access token at any scope.\n"
+                    "Recover instead by dispatching the smoke workflow for this SHA:\n"
+                    f"  gh workflow run main-post-merge-smoke.yml --ref main -f sha={sha}",
+                    flush=True,
+                )
+            raise SystemExit(1)
         PY
     env:
       - "_CHECK_NAME=${_CHECK_NAME}"


### PR DESCRIPTION
## The deadlock this fixes, which happened today

A `Main Post-Merge Smoke` run sat **queued for five hours** holding the concurrency group `smoke-<workflow>-refs/heads/main`. The next merge to `main` (`fa1d2bf09`, PR #4915) then got **no run at all** — zero check-runs on the commit.

Every deploy and release lane requires a green `Main Post-Merge Smoke Gate` on the exact SHA. So that commit became undeployable by any route:

- The push event cannot be replayed, and this workflow had no other trigger.
- The check cannot be published by hand: `create-check-run` is **GitHub-App-only** and returns `403 You must authenticate via a GitHub App` for a personal access token at any scope. Verified today.
- A commit status does not help either, because `require-deploy-sha-on-main.sh` reads `/commits/<sha>/check-runs`.

The only ways out were to weaken the gate or to land another commit and hope. Neither is acceptable for a control that guards production.

## Changes

**1. `workflow_dispatch` with a `sha` input.** The gate can now be re-run for a specific commit. Two safeguards, because a recovery trigger on a release gate is exactly where a mistake is expensive:
- the checkout uses `inputs.sha`, so the result belongs to the commit actually tested;
- a new step asserts that SHA is an ancestor of `origin/main` before anything runs.

Publishing a gate result attributed to a different commit than the one tested would be worse than publishing none.

**2. Concurrency keyed by SHA, not ref.** With a ref-only key, one wedged run blocks every later commit. Keyed by SHA, a wedged run can only block re-runs of its own commit. This is what turned a single stuck run into a repo-wide deploy freeze.

**3. Honest correction to `deploy/ci.cloudbuild.yaml`.** Its optional `_PUBLISH_CHECK` step (added in #4915) claimed it could report the verdict back to GitHub. It cannot with a PAT. The step now fails with the explicit reason and points at the dispatch recovery, rather than implying a capability that does not exist.

## Verification

- Workflow YAML parses; job name `Main Post-Merge Smoke Gate` is unchanged, so every lane referencing it by name keeps working.
- Both triggers present, `sha` input declared.
- `deploy/ci.cloudbuild.yaml` passes the substitution audit and `test_cloudbuild_step_arg_limit.py` (7 passed) after the step body grew.
- The behaviour of the checks themselves is untouched — this PR is purely about recoverability.

## Recovery command, once this lands

```bash
gh workflow run main-post-merge-smoke.yml --ref main -f sha=<SHA>
```