### PR TITLE
fix(ci): activate uat profile for Android ship

### DIFF
--- a/.github/workflows/ship-android-playstore.yml
+++ b/.github/workflows/ship-android-playstore.yml
@@ -200,6 +200,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          bash scripts/env/use_profile.sh uat
           cd hushh-webapp
           npm run sync:native-firebase-configs
           npm run cap:build


### PR DESCRIPTION
Runs use_profile.sh uat to hydrate UAT frontend environment variables before cap:build.