### PR TITLE
fix(ci): bootstrap runtime profiles for Android ship

### DIFF
--- a/.github/workflows/ship-android-playstore.yml
+++ b/.github/workflows/ship-android-playstore.yml
@@ -200,6 +200,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          bash scripts/env/bootstrap_profiles.sh
           bash scripts/env/use_profile.sh uat
           cd hushh-webapp
           npm run sync:native-firebase-configs


### PR DESCRIPTION
Runs bootstrap_profiles.sh to hydrate .env.uat.local before activating UAT profile.