### PR TITLE
feat(ria): recognise an adviser from the number they already gave us

### DIFF
--- a/hushh-webapp/__tests__/services/ria-claim-entry.test.ts
+++ b/hushh-webapp/__tests__/services/ria-claim-entry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRiaClaimRoute,
+  isClaimableLookupOutcome,
+  toNanpDigits,
+} from "@/lib/ria/ria-claim-entry";
+
+const firm = { crd: 283040, name: "OLYMPUS PEAKS FINANCIAL, LLC" } as never;
+
+describe("recognising an adviser from the number they typed at sign-up", () => {
+  it("claims on every outcome where the SEC has something at the number", () => {
+    for (const outcome of [
+      "single_person",
+      "few_candidates",
+      "large_firm",
+      "ambiguous_firm",
+    ]) {
+      expect(
+        isClaimableLookupOutcome({ outcome, firm, firms: [] }),
+        `${outcome} should route to claim`,
+      ).toBe(true);
+    }
+  });
+
+  it("stays out of the way when the number is not an adviser's", () => {
+    // The overwhelming majority of sign-ups: normal people. They must never be
+    // detoured into a claim screen.
+    expect(isClaimableLookupOutcome({ outcome: "no_match", firm: null, firms: [] })).toBe(false);
+    expect(isClaimableLookupOutcome({ outcome: "invalid_phone", firm: null, firms: [] })).toBe(false);
+    expect(isClaimableLookupOutcome(null)).toBe(false);
+  });
+
+  it("does not route to a claim screen it cannot render", () => {
+    // A claimable outcome with no firm attached would render an empty screen.
+    expect(isClaimableLookupOutcome({ outcome: "single_person", firm: null, firms: [] })).toBe(false);
+  });
+
+  it("accepts an ambiguous outcome carried only by the firms list", () => {
+    expect(
+      isClaimableLookupOutcome({
+        outcome: "ambiguous_firm",
+        firm: null,
+        firms: [{ crd: 159042, name: "PENSERRA CAPITAL MANAGEMENT LLC" } as never],
+      }),
+    ).toBe(true);
+  });
+
+  it("normalises whatever shape the verified number arrives in", () => {
+    expect(toNanpDigits("+18015663510")).toBe("8015663510");
+    expect(toNanpDigits("(801) 566-3510")).toBe("8015663510");
+    expect(toNanpDigits("18015663510")).toBe("8015663510");
+    expect(toNanpDigits("+44 20 7946 0958")).toBe("");
+    expect(toNanpDigits(null)).toBe("");
+  });
+
+  it("carries the number and the original destination into the claim route", () => {
+    expect(buildRiaClaimRoute("+18015663510")).toBe("/ria/claim?phone=8015663510");
+    expect(buildRiaClaimRoute("+18015663510", { returnTo: "/one/setup" })).toBe(
+      "/ria/claim?phone=8015663510&return_to=%2Fone%2Fsetup",
+    );
+  });
+});

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -29,6 +29,8 @@ import {
 } from "@/lib/services/onboarding-route-cookie";
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
+import { RiaService } from "@/lib/services/ria-service";
+import { buildRiaClaimRoute, isClaimableLookupOutcome } from "@/lib/ria/ria-claim-entry";
 import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-mandate-service";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { resolvePostPhoneOnboardingPhase } from "@/lib/onboarding/onboarding-journey-phase";
@@ -106,7 +108,32 @@ export function PhoneMandatePageContent() {
           return false;
         });
       const idToken = await activeUser.getIdToken().catch(() => undefined);
-      const nextPath = setupResolved
+
+      // The number they just verified is the trigger for claiming: if the SEC
+      // lists a firm or advisers at it, show that instead of the generic next
+      // screen. Fails open — any error, timeout or miss continues as normal.
+      const claimRoute = await (async () => {
+        const verifiedPhone = activeUser.phoneNumber;
+        if (!idToken || !verifiedPhone) return null;
+        try {
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), 12_000);
+          const lookup = await RiaService.claimLookup(
+            idToken,
+            { phone: verifiedPhone },
+            { signal: controller.signal },
+          ).finally(() => clearTimeout(timer));
+          return isClaimableLookupOutcome(lookup)
+            ? buildRiaClaimRoute(verifiedPhone, { returnTo: redirectPath })
+            : null;
+        } catch {
+          return null;
+        }
+      })();
+
+      const nextPath = claimRoute
+        ? claimRoute
+        : setupResolved
         ? await PostAuthRouteService.resolveAfterLogin({
             userId: activeUser.uid,
             redirectPath,

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -19,7 +19,7 @@ import {
   ShieldCheck,
   UserRound,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
@@ -27,6 +27,7 @@ import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
 import { useAuth } from "@/hooks/use-auth";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
+import { toNanpDigits } from "@/lib/ria/ria-claim-entry";
 import { Button } from "@/lib/morphy-ux/button";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
@@ -173,8 +174,11 @@ function CodeCells({
 
 export default function RiaClaimPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user, loading: authLoading } = useAuth();
   const { refresh: refreshPersonaState } = usePersonaState();
+  // Arrives pre-filled when the sign-up phone screen recognised this number.
+  const seededPhone = toNanpDigits(searchParams.get("phone"));
 
   const [step, setStep] = useState<ClaimStep>("phone");
   const [phoneDigits, setPhoneDigits] = useState("");
@@ -224,13 +228,14 @@ export default function RiaClaimPage() {
     return "Something went wrong. Try again.";
   };
 
-  const handleLookup = useCallback(async () => {
-    if (phoneDigits.length !== 10 || busy) return;
+  const handleLookup = useCallback(async (phoneOverride?: string) => {
+    const phone = phoneOverride ?? phoneDigits;
+    if (phone.length !== 10 || busy) return;
     setBusy(true);
     setError(null);
     try {
       const idToken = await getIdToken();
-      const result = await RiaService.claimLookup(idToken, { phone: phoneDigits });
+      const result = await RiaService.claimLookup(idToken, { phone });
       if (result.outcome === "invalid_phone") {
         setError("Enter a valid US phone number.");
         return;
@@ -254,6 +259,16 @@ export default function RiaClaimPage() {
       setBusy(false);
     }
   }, [phoneDigits, busy, getIdToken]);
+
+  // Recognised at sign-up: run the lookup immediately so the person lands on
+  // their firm instead of retyping the number they just verified.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || !seededPhone || !user || authLoading) return;
+    seededRef.current = true;
+    setPhoneDigits(seededPhone);
+    void handleLookup(seededPhone);
+  }, [seededPhone, user, authLoading, handleLookup]);
 
   const beginClaim = useCallback(
     async (type: ClaimType, candidateCrd: number | null) => {

--- a/hushh-webapp/lib/ria/ria-claim-entry.ts
+++ b/hushh-webapp/lib/ria/ria-claim-entry.ts
@@ -1,0 +1,51 @@
+/**
+ * Recognising an adviser from the number they already typed.
+ *
+ * The number a user enters at sign-up IS the trigger for claiming: if the SEC
+ * lists a firm or advisers at it, we surface the claim instead of making the
+ * person discover a "claim" feature on their own. These helpers keep that
+ * decision in one testable place, shared by the phone-mandate screen and the
+ * claim screen.
+ */
+
+import { ROUTES } from "@/lib/navigation/routes";
+import type { RiaClaimLookupResult } from "@/lib/services/ria-service";
+
+/** Outcomes that mean "the SEC has something at this number worth claiming". */
+const CLAIMABLE_OUTCOMES = new Set([
+  "single_person",
+  "few_candidates",
+  "large_firm",
+  "ambiguous_firm",
+]);
+
+export function isClaimableLookupOutcome(
+  result: Pick<RiaClaimLookupResult, "outcome" | "firm" | "firms"> | null,
+): boolean {
+  if (!result) return false;
+  const outcome = String(result.outcome ?? "");
+  if (!CLAIMABLE_OUTCOMES.has(outcome)) return false;
+  // An outcome without any firm attached is not something we can render.
+  return Boolean(result.firm?.crd) || (result.firms?.length ?? 0) > 0;
+}
+
+/** Reduce any phone formatting to the 10-digit NANP number, or "". */
+export function toNanpDigits(raw: string | null | undefined): string {
+  let digits = String(raw ?? "").replace(/\D/g, "");
+  if (digits.length === 11 && digits.startsWith("1")) digits = digits.slice(1);
+  if (digits.length !== 10 || digits[0] === "0" || digits[0] === "1") return "";
+  return digits;
+}
+
+export function buildRiaClaimRoute(
+  phone: string,
+  options?: { returnTo?: string | null },
+): string {
+  const digits = toNanpDigits(phone);
+  const params = new URLSearchParams();
+  if (digits) params.set("phone", digits);
+  const returnTo = String(options?.returnTo ?? "").trim();
+  if (returnTo) params.set("return_to", returnTo);
+  const query = params.toString();
+  return query ? `${ROUTES.RIA_CLAIM}?${query}` : ROUTES.RIA_CLAIM;
+}


### PR DESCRIPTION
## The problem this fixes

The claim feature was **invisible in the journey it was built for**. An adviser signed in with Google, verified their office number on the normal phone screen, and was shown nothing — the claim screen only existed if you already knew to navigate to `/ria/claim`. Caught by walking the real flow on UAT.

## What changes

The number typed at sign-up becomes the trigger. After the phone mandate verifies a number, we ask the RIA identity service whether the SEC lists a firm or advisers at it. If yes, the person lands directly on **"Listed at this number"** with their firm and colleagues already loaded — no retyping, no hunting for a feature.

## Safety: it fails open

The 99% of users who are not advisers must see zero change. The probe is wrapped so that **any** error, a 12s timeout, or a non-adviser number continues down the existing path untouched. `no_match` and `invalid_phone` never route to claim, and neither does a claimable outcome with no firm attached (which would render an empty screen).

## Files (4, additive)

- `lib/ria/ria-claim-entry.ts` — the recognition rule in one testable place: claimable outcomes, NANP normalisation, and the route builder that preserves the original destination via `return_to`.
- `app/register-phone/page.tsx` — the probe, after verification.
- `app/ria/claim/page.tsx` — accepts `?phone=` and runs the lookup on arrival.
- `__tests__/services/ria-claim-entry.test.ts` — 6 tests locking the rule, including the must-not-detour-normal-users cases.

## Validation

typecheck, lint clean; 11 claim tests pass; post-auth routing, observability route map, voice playbook contract, and phone-verification interaction suites all pass. The one failure in `setup-warm-transition.contract.test.ts` reproduces identically on merged main without this change (proven in a separate worktree).