### PR TITLE
fix(ria): recognise a returning adviser, not just a first-time signup

### DIFF
--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -178,7 +178,11 @@ export default function RiaClaimPage() {
   const { user, loading: authLoading } = useAuth();
   const { refresh: refreshPersonaState } = usePersonaState();
   // Arrives pre-filled when the sign-up phone screen recognised this number.
-  const seededPhone = toNanpDigits(searchParams.get("phone"));
+  // Someone who verified their phone on an earlier visit never sees that
+  // screen again, so fall back to the number already on their account — they
+  // should be recognised whenever they reach here, not only on first sign-up.
+  const seededPhone =
+    toNanpDigits(searchParams.get("phone")) || toNanpDigits(user?.phoneNumber);
 
   const [step, setStep] = useState<ClaimStep>("phone");
   const [phoneDigits, setPhoneDigits] = useState("");


### PR DESCRIPTION
Follow-up to #4926, found by tracing the guard rather than the happy path.

`shouldRequirePhoneMandate` returns `false` once a phone is verified. So the sign-up phone screen — where #4926 puts the recognition hook — **never renders again** for anyone who verified on an earlier visit. That is most real advisers after their first session, and it reproduces exactly the "I typed my number and nothing happened" failure this work exists to fix.

The claim screen now falls back to the verified number already on the account when no `?phone=` is supplied. Reaching it by any route — the RIA setup row, a direct link, a voice action — recognises you immediately instead of asking you to retype a number the app already has.

One file, five lines. typecheck, lint, and the 11 claim tests pass.