### PR TITLE
fix(ci): bootstrap runtime profiles in Android ship workflow

### DIFF
--- a/.github/workflows/ship-android-playstore.yml
+++ b/.github/workflows/ship-android-playstore.yml
@@ -250,6 +250,7 @@ EOF
         shell: bash
         run: |
           set -euo pipefail
+          bash scripts/env/bootstrap_profiles.sh
           bash scripts/env/use_profile.sh uat
           cd hushh-webapp
           npm run sync:native-firebase-configs


### PR DESCRIPTION
Runs bootstrap_profiles.sh before use_profile.sh uat so .env.uat.local exists.