### PR TITLE
fix(ci): remove push trigger from ship-android-playstore.yml

### DIFF
--- a/.github/workflows/ship-android-playstore.yml
+++ b/.github/workflows/ship-android-playstore.yml
@@ -29,11 +29,6 @@ on:
         description: "Optional release notes / summary of changes"
         required: false
         type: string
-  push:
-    branches:
-      - main
-    paths:
-      - .github/workflows/ship-android-playstore.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes push trigger so workflow_dispatch inputs resolve cleanly.