### PR TITLE
feat(ria): recognise the adviser when they open RIA setup

### DIFF
--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -31,6 +31,7 @@ import { toNanpDigits } from "@/lib/ria/ria-claim-entry";
 import { Button } from "@/lib/morphy-ux/button";
 import { ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
+import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import {
   RiaApiError,
   RiaService,
@@ -322,6 +323,20 @@ export default function RiaClaimPage() {
       // adviser back into the onboarding wizard off a 30-min-TTL cache hit.
       if (user) {
         CacheSyncService.onPersonaStateChanged(user.uid);
+        // Claiming completes RIA setup just as the wizard does, so the Setup
+        // hub must stop listing it as remaining. syncSetupCapabilities REPLACES
+        // the stored set, so pass the union.
+        try {
+          const current = await PreVaultUserStateService.bootstrapState(user.uid);
+          if (!current.setupCapabilityIds.includes("ria")) {
+            await PreVaultUserStateService.syncSetupCapabilities(
+              user.uid,
+              Array.from(new Set([...current.setupCapabilityIds, "ria"])).sort(),
+            );
+          }
+        } catch {
+          // best-effort; the dashboard reconciles the count on next load.
+        }
       }
       await refreshPersonaState({ force: true });
     },

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -50,6 +50,11 @@ import {
   type RiaLicenseVerificationResult,
   type RiaOnboardingStatus,
 } from "@/lib/services/ria-service";
+import {
+  buildRiaClaimRoute,
+  isClaimableLookupOutcome,
+  toNanpDigits,
+} from "@/lib/ria/ria-claim-entry";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { trackEvent } from "@/lib/observability/client";
 import { trackGrowthFunnelStepCompleted } from "@/lib/observability/growth";
@@ -503,6 +508,35 @@ export default function RiaOnboardingPage({
     onboardingEntryHandledRef.current = true;
     router.replace(ROUTES.RIA_PROFILE);
   }, [entryMode, router]);
+
+  // Recognise before asking. An adviser opening RIA setup has usually already
+  // given us the number the SEC lists them at, so check it before showing a
+  // blank wizard. Fails open: any miss, error or timeout leaves the wizard
+  // exactly as it was.
+  const claimProbeRef = useRef(false);
+  useEffect(() => {
+    if (entryMode !== "wizard" || claimProbeRef.current || !user) return;
+    const phone = toNanpDigits(user.phoneNumber);
+    if (!phone) return;
+    claimProbeRef.current = true;
+    void (async () => {
+      try {
+        const idToken = await user.getIdToken();
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 12_000);
+        const lookup = await RiaService.claimLookup(
+          idToken,
+          { phone },
+          { signal: controller.signal },
+        ).finally(() => clearTimeout(timer));
+        if (isClaimableLookupOutcome(lookup)) {
+          router.replace(buildRiaClaimRoute(phone));
+        }
+      } catch {
+        /* stay in the wizard */
+      }
+    })();
+  }, [entryMode, user, router]);
 
   useEffect(() => {
     if (!user || !draftReady || iamUnavailable || !shouldPersistDraft) return;


### PR DESCRIPTION
Third gap in the same journey, found by walking it on UAT rather than reading config.

**Observed:** signed in with an account that already has a verified phone → the sign-up phone screen never renders (`shouldRequirePhoneMandate` returns false once verified) → landed on `/one/setup` → "Set up RIA" opens the blank manual wizard. The claim is a row you have to notice. That is discovery, not recognition.

**Change:** RIA setup now checks the number already on the account before showing the wizard. If the SEC lists a firm or advisers at it, the person goes straight to the claim with their firm already loaded.

**Fails open**, same as the other entry points: any miss, error, or 12-second timeout leaves the wizard exactly as it was, so a non-adviser sees no change.

**Also fixed:** completing a claim now marks the RIA capability as set up, the same way submitting the wizard does — otherwise the Setup hub would keep listing "Set up RIA" as remaining after you had already claimed.

Two files. typecheck, lint, and 17 tests (claim entry, claim service, onboarding flow) pass.