### PR TITLE
fix(android): place signingConfigs before buildTypes in app/build.gradle

### DIFF
--- a/hushh-webapp/android/app/build.gradle
+++ b/hushh-webapp/android/app/build.gradle
@@ -37,15 +37,6 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (hasReleaseSigning) {
-                signingConfig signingConfigs.release
-            }
-        }
-    }
     signingConfigs {
         release {
             if (hasEnvReleaseSigning) {
@@ -58,6 +49,15 @@ android {
                 keyPassword releaseSigningProperties['keyPassword']
                 storeFile releaseSigningProperties['storeFile'] ? file(releaseSigningProperties['storeFile']) : null
                 storePassword releaseSigningProperties['storePassword']
+            }
+        }
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (hasReleaseSigning) {
+                signingConfig signingConfigs.release
             }
         }
     }


### PR DESCRIPTION
Fixes MissingPropertyException by declaring signingConfigs before buildTypes in app/build.gradle.