### PR TITLE
fix(ria): make recognition actually reach the adviser

### DIFF
--- a/hushh-webapp/__tests__/services/ria-claim-admission.test.ts
+++ b/hushh-webapp/__tests__/services/ria-claim-admission.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isCapabilityOnboardingRoute,
+  isOnboardingAdmissionExemptRoute,
+  ROUTES,
+} from "@/lib/navigation/routes";
+
+/**
+ * The claim screen is reached by REDIRECT from three places (the phone mandate,
+ * RIA setup, and the setup hub). An app-wide journey guard bounces any route it
+ * does not admit back to /one/setup, which silently reverts every one of those
+ * redirects and leaves the adviser staring at the setup hub. These assertions
+ * exist so that regression cannot return unnoticed.
+ */
+describe("the journey guard must admit the claim screen", () => {
+  it("admits /ria/claim while the ria capability is being set up", () => {
+    // Redirected here from /one/setup/ria after recognising the adviser.
+    expect(isCapabilityOnboardingRoute("ria", ROUTES.RIA_CLAIM)).toBe(true);
+  });
+
+  it("still admits the RIA setup surface itself", () => {
+    expect(isCapabilityOnboardingRoute("ria", ROUTES.ONE_SETUP_RIA)).toBe(true);
+  });
+
+  it("admits /ria/claim before any capability is active", () => {
+    // Redirected here straight from the phone mandate, where onboarding has no
+    // active capability yet, so capability admission cannot be what saves it.
+    expect(isOnboardingAdmissionExemptRoute(ROUTES.RIA_CLAIM)).toBe(true);
+  });
+
+  it("does not widen admission to the rest of the RIA workspace", () => {
+    // Only the claim screen is reachable mid-setup; clients/picks/profile must
+    // still be gated behind completed onboarding.
+    expect(isOnboardingAdmissionExemptRoute(ROUTES.RIA_CLIENTS)).toBe(false);
+    expect(isOnboardingAdmissionExemptRoute(ROUTES.RIA_PICKS)).toBe(false);
+    expect(isCapabilityOnboardingRoute("ria", ROUTES.RIA_CLIENTS)).toBe(false);
+  });
+
+  it("does not admit the claim screen under an unrelated capability", () => {
+    expect(isCapabilityOnboardingRoute("finance", ROUTES.RIA_CLAIM)).toBe(false);
+    expect(isCapabilityOnboardingRoute("location", ROUTES.RIA_CLAIM)).toBe(false);
+  });
+});

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -176,14 +176,15 @@ function CodeCells({
 export default function RiaClaimPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { user, loading: authLoading } = useAuth();
+  const { user, phoneNumber: accountPhone, loading: authLoading } = useAuth();
   const { refresh: refreshPersonaState } = usePersonaState();
   // Arrives pre-filled when the sign-up phone screen recognised this number.
   // Someone who verified their phone on an earlier visit never sees that
   // screen again, so fall back to the number already on their account — they
   // should be recognised whenever they reach here, not only on first sign-up.
   const seededPhone =
-    toNanpDigits(searchParams.get("phone")) || toNanpDigits(user?.phoneNumber);
+    toNanpDigits(searchParams.get("phone")) ||
+    toNanpDigits(accountPhone || user?.phoneNumber);
 
   const [step, setStep] = useState<ClaimStep>("phone");
   const [phoneDigits, setPhoneDigits] = useState("");

--- a/hushh-webapp/app/ria/onboarding/page.tsx
+++ b/hushh-webapp/app/ria/onboarding/page.tsx
@@ -516,7 +516,10 @@ export default function RiaOnboardingPage({
   const claimProbeRef = useRef(false);
   useEffect(() => {
     if (entryMode !== "wizard" || claimProbeRef.current || !user) return;
-    const phone = toNanpDigits(user.phoneNumber);
+    // The account's verified number lives on the auth context; the Firebase
+    // user object is null here for anyone who signed in with Google and for
+    // native sessions that rehydrate before the phone hydrates.
+    const phone = toNanpDigits(phoneNumber || user.phoneNumber);
     if (!phone) return;
     claimProbeRef.current = true;
     void (async () => {
@@ -536,7 +539,9 @@ export default function RiaOnboardingPage({
         /* stay in the wizard */
       }
     })();
-  }, [entryMode, user, router]);
+    // phoneNumber is in the deps so the probe re-runs once the backend phone
+    // hydrates, which happens after the first render for a Google sign-in.
+  }, [entryMode, user, phoneNumber, router]);
 
   useEffect(() => {
     if (!user || !draftReady || iamUnavailable || !shouldPersistDraft) return;

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -343,7 +343,10 @@ export const CAPABILITY_ONBOARDING_ROUTE_PREFIXES: Readonly<
   gmail: [ROUTES.ONE_SETUP_GMAIL, ROUTES.PROFILE_GMAIL_OAUTH_RETURN],
   email: [ROUTES.ONE_SETUP_EMAIL],
   location: [ROUTES.ONE_SETUP_LOCATION],
-  ria: [ROUTES.ONE_SETUP_RIA],
+  // RIA_CLAIM belongs to the ria capability: recognising an adviser from their
+  // filed number routes here from setup, and the journey guard must admit it
+  // or the redirect is bounced straight back to the hub.
+  ria: [ROUTES.ONE_SETUP_RIA, ROUTES.RIA_CLAIM],
   "connected-systems": [ROUTES.ONE_SETUP_CONNECTED_SYSTEMS],
 };
 
@@ -408,6 +411,9 @@ export function isOnboardingAdmissionExemptRoute(pathname: string): boolean {
     normalizedPathname === ROUTES.LOGIN ||
     normalizedPathname === ROUTES.GETTING_STARTED ||
     normalizedPathname === ROUTES.PHONE_MANDATE ||
+    // Reached straight from the phone mandate when the number the adviser just
+    // verified is on an SEC filing, before any capability is active.
+    normalizedPathname === ROUTES.RIA_CLAIM ||
     normalizedPathname === ROUTES.LOGOUT ||
     normalizedPathname === ROUTES.PROFILE ||
     normalizedPathname.startsWith(`${ROUTES.PROFILE}/`) ||


### PR DESCRIPTION
An independent audit of every entry door into RIA setup found **two defects that each silently defeated all three recognition wirings**. Both confirmed against the code by separate reviewers.

## 1. The journey guard was ejecting the claim screen

`OnboardingJourneyGuard` admits a route only if it is a setup surface or belongs to the *active capability*. `CAPABILITY_ONBOARDING_ROUTE_PREFIXES.ria` listed only `/one/setup/ria`, and `/ria/claim` was not admission-exempt either.

So **every** redirect to the claim screen was bounced back to `/one/setup`. Observable symptom: tap "Set up RIA" → "Preparing RIA setup…" → the intro → back on the hub with RIA still listed as not done. The recognition code ran correctly and its result was thrown away.

Fixed by adding `RIA_CLAIM` to the `ria` capability, and to the exempt list for the phone-mandate leg where no capability is active yet.

## 2. The probes read a phone number that is null for Google sign-ins

All three probes read `user.phoneNumber` from the Firebase user object. For anyone who signed in with Google — which is the entire demo path — that is **null**. The account's verified number lives on the auth context, hydrated from the backend precisely because the Firebase object lacks it ( carries the same note).

This is the root cause of *"I put my number and nothing happened"*: the probe returned before it ever called the lookup. Now reads the context value first, with `phoneNumber` in the effect deps so it re-runs once the backend phone hydrates.

## Tests

New `ria-claim-admission.test.ts` locks the guard behaviour, including the negative cases — that this does **not** widen access to the rest of the RIA workspace (, ) or admit the claim screen under an unrelated capability.

typecheck, lint clean; 37 tests pass across claim admission, claim entry, claim service, onboarding flow, and the existing journey-guard suite.