### PR TITLE
fix(ci): update upload-google-play action to use tracks key

### DIFF
--- a/.github/workflows/ship-android-playstore-v1.yml
+++ b/.github/workflows/ship-android-playstore-v1.yml
@@ -272,6 +272,7 @@ jobs:
           packageName: ${{ env.ANDROID_PACKAGE_NAME }}
           releaseFiles: hushh-webapp/android/app/build/outputs/bundle/release/app-release.aab
           track: ${{ inputs.track }}
+          tracks: ${{ inputs.track }}
           status: completed
 
       - name: Publish job summary


### PR DESCRIPTION
Update r0adkll/upload-google-play step to supply `tracks` parameter.