### PR TITLE
fix(ci): pass tracks only to upload-google-play action step

### DIFF
--- a/.github/workflows/ship-android-playstore-v1.yml
+++ b/.github/workflows/ship-android-playstore-v1.yml
@@ -271,7 +271,6 @@ jobs:
           serviceAccountJson: ${{ env.PLAY_SERVICE_ACCOUNT_PATH }}
           packageName: ${{ env.ANDROID_PACKAGE_NAME }}
           releaseFiles: hushh-webapp/android/app/build/outputs/bundle/release/app-release.aab
-          track: ${{ inputs.track }}
           tracks: ${{ inputs.track }}
           status: completed
 


### PR DESCRIPTION
Remove deprecated track parameter in favor of tracks only in upload-google-play action step.