### PR TITLE
fix(kai): portfolio-save dead end and Analysis pager glitch

### DIFF
--- a/hushh-webapp/__tests__/components/swipe-views.test.tsx
+++ b/hushh-webapp/__tests__/components/swipe-views.test.tsx
@@ -148,8 +148,21 @@ describe("SwipeViews", () => {
     expect(embla.options).toMatchObject({
       duration: 16,
       dragThreshold: 6,
-      watchResize: false,
     });
+
+    // Resize watching stays ON so a stale container measurement can correct
+    // itself, but is scoped to the container: per-slide entries (streaming
+    // content changing height) must not re-trigger the horizontal engine.
+    const watchResize = embla.options?.watchResize as (
+      api: { containerNode: () => Element },
+      entries: { target: Element }[],
+    ) => boolean;
+    expect(typeof watchResize).toBe("function");
+    const containerNode = document.createElement("div");
+    const slideNode = document.createElement("div");
+    const apiStub = { containerNode: () => containerNode };
+    expect(watchResize(apiStub, [{ target: containerNode }])).toBe(true);
+    expect(watchResize(apiStub, [{ target: slideNode }])).toBe(false);
   });
 
   it("starts pane motion immediately when the shared top tab is pressed", () => {

--- a/hushh-webapp/app/one/kai/analysis/page.tsx
+++ b/hushh-webapp/app/one/kai/analysis/page.tsx
@@ -508,13 +508,29 @@ export function KaiAnalysisPageContent() {
     setHistoryFallbackEntry(entry);
     setShowHistoryWhileActive(false);
     setWorkspaceTab((prev) => (prev === "debate" ? "summary" : prev));
-    setDebateIdParam(extractDebateId(entry));
+    // Unlike the fresh-context callers of setDebateIdParam (new ticker,
+    // close), this fires mid-view while the user is still looking at the
+    // run that just finished -- rebuilding params from scratch here wiped
+    // out `focus`/`run_id`/`view` and, lacking `{ scroll: false }`, forced
+    // an unflagged scroll-to-top right as the workspace pager was still
+    // animating to the summary pane, producing the stuck/glitched layout.
+    const params = new URLSearchParams(searchParamsRef.current.toString());
+    const nextDebateId = extractDebateId(entry);
+    if (nextDebateId) {
+      params.set("debate_id", nextDebateId);
+    } else {
+      params.delete("debate_id");
+    }
+    router.replace(
+      buildKaiMarketRoute("analysis", Object.fromEntries(params.entries())),
+      { scroll: false },
+    );
     if (summaryLoadingToastIdRef.current !== null) {
       toast.dismiss(summaryLoadingToastIdRef.current);
       summaryLoadingToastIdRef.current = null;
     }
     toast.success("Analysis saved to history.");
-  }, [setDebateIdParam]);
+  }, [router]);
 
   const hasFocusedRun = Boolean(focusedRunTask && !focusedRunTask.dismissedAt);
   const activeEntry = liveEntry || resolvedEntry;

--- a/hushh-webapp/components/kai/kai-flow.tsx
+++ b/hushh-webapp/components/kai/kai-flow.tsx
@@ -721,7 +721,8 @@ export function KaiFlow({
       if (
         newState === "import_required" ||
         newState === "reviewing" ||
-        newState === "importing"
+        newState === "importing" ||
+        newState === "import_complete"
       ) {
         const params = new URLSearchParams(searchParams?.toString());
         params.set("stage", newState);

--- a/hushh-webapp/lib/consent/use-consent-pending-summary-count.ts
+++ b/hushh-webapp/lib/consent/use-consent-pending-summary-count.ts
@@ -85,5 +85,9 @@ export function useConsentPendingSummaryCount(): number | null {
     summaryResource.data ??
     (retainedSummary?.key === cacheKey ? retainedSummary.data : null);
 
-  return summaryData?.counts.pending ?? null;
+  // `counts` is optional-chained too: a partial/error payload from the summary
+  // endpoint would otherwise throw here, and this hook runs in the Navbar --
+  // inside the root shell -- so that throw takes down the entire app rather
+  // than just hiding a pending-consent badge.
+  return summaryData?.counts?.pending ?? null;
 }

--- a/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
@@ -44,6 +44,106 @@ function isNestedSwipeViewsTarget(
   return Boolean(closestSwipeViewsRoot && closestSwipeViewsRoot !== rootNode);
 }
 
+/**
+ * Embla's own `scrollSnaps` can desync from its `slideRects` after certain
+ * reInit/resize sequences: slideRects correctly reports N uniform-width
+ * slides, but scrollSnaps keeps a shorter array from an earlier measurement
+ * (observed directly: slideRects = [792, 792, 792], scrollSnaps = [0, -168]).
+ * Patching scrollSnaps back in sync (used below, and by Embla's own drag
+ * snapping) is necessary but not sufficient: `scrollTo(index)` resolves an
+ * index through `indexCurrent.clone().set(index)` first, and that Counter's
+ * upper bound is captured once at construction from the *original* (stale)
+ * scrollSnaps length. It has no public setter, so a request for an index
+ * beyond that stale bound is silently clamped down before the distance is
+ * even computed -- observed directly: scrollTo(2) on a carousel whose Counter
+ * still thinks max=1 computed a target of -792 (index 1's snap) instead of
+ * -1584 (index 2's), because byIndex() only ever saw the clamped index.
+ * There is no way to fix that bound from outside, so after asking Embla to
+ * scroll, force the actual position to the correct absolute pixel computed
+ * independently from slideRects, which we've confirmed stays accurate.
+ */
+function scrollToIndexSafely(
+  api: EmblaCarouselType,
+  index: number,
+  jump?: boolean,
+) {
+  const engine = api.internalEngine?.();
+  const slideRects = engine?.slideRects;
+  const slideWidth = slideRects?.[0]?.width;
+  const hasReliableWidth =
+    typeof slideWidth === "number" && slideWidth > 0 && Boolean(slideRects?.length);
+
+  // The engine's `limit` (its scroll bounds) is captured at construction from
+  // the same stale measurement as scrollSnaps, and has no public setter. Its
+  // rubber-band edge logic (ScrollBounds.constrain, run every animation
+  // frame) treats any position beyond that stale limit as an out-of-bounds
+  // overscroll and pulls the target back toward it -- observed directly:
+  // forcing target to index 2's real position still settled back near 0,
+  // because the animation loop kept fighting it back within the old bound.
+  // Disabling it is safe here: the bound it would otherwise protect is wrong
+  // for the carousel's real content, not a legitimate edge.
+  engine?.scrollBounds?.toggleActive?.(false);
+
+  if (engine && hasReliableWidth) {
+    const expected = slideRects.map((_, i) => -(i * slideWidth));
+    const current = engine.scrollSnaps;
+    const isStale =
+      current.length !== expected.length ||
+      expected.some((value, i) => Math.abs((current[i] ?? NaN) - value) > 1);
+    if (isStale) {
+      current.splice(0, current.length, ...expected);
+    }
+  }
+
+  if (jump) {
+    api.scrollTo(index, jump);
+  } else {
+    api.scrollTo(index);
+  }
+
+  if (engine && hasReliableWidth) {
+    const correctTarget = -(index * slideWidth);
+    engine.target.set(correctTarget);
+    if (jump) {
+      engine.location.set(correctTarget);
+      engine.offsetLocation.set(correctTarget);
+      engine.previousLocation.set(correctTarget);
+      engine.translate.to(correctTarget);
+    } else {
+      engine.animation.start();
+    }
+  }
+}
+
+/**
+ * Embla's own `selectedScrollSnap()` reads through the same stale-bounded
+ * Counter documented above, so it can misreport the current pane even after
+ * `scrollToIndexSafely` has corrected the actual rendered position --
+ * observed directly: forcing a scroll to index 2 lands the pane on the
+ * correct pixel, but the 'settle' event that follows still reports index 1,
+ * which this component then propagated upward as a silent revert of the
+ * user's own selection back to index 1. Resolve the effective index from the
+ * real rendered position instead, which we've confirmed stays accurate; only
+ * fall back to Embla's own counter when the geometry isn't available yet
+ * (e.g. before first layout).
+ */
+function resolveVisualIndex(api: EmblaCarouselType, optionsLength: number): number {
+  const engine = api.internalEngine?.();
+  const slideWidth = engine?.slideRects?.[0]?.width;
+  const rendered = engine?.offsetLocation?.get?.();
+  if (
+    engine &&
+    typeof slideWidth === "number" &&
+    slideWidth > 0 &&
+    typeof rendered === "number" &&
+    optionsLength > 0
+  ) {
+    const rawIndex = Math.round(-rendered / slideWidth);
+    return Math.min(Math.max(rawIndex, 0), optionsLength - 1);
+  }
+  return api.selectedScrollSnap();
+}
+
 interface SwipeViewsProps {
   children: React.ReactNode;
   options: readonly { label: string; value: string }[];
@@ -96,10 +196,22 @@ export function SwipeViews({
     dragThreshold: 6,
     skipSnaps: false,
     // Pane content streams, charts, and cached resources change height often.
-    // Embla's default ResizeObserver re-initialized the horizontal engine for
-    // those vertical-only changes, producing a visible hitch on Finance.
-    // Viewport-width changes are handled explicitly below.
-    watchResize: false,
+    // Embla's default ResizeObserver reacts to every observed target -- the
+    // container AND each individual slide -- so that frequent per-slide
+    // height churn re-triggered the horizontal engine and produced a visible
+    // hitch on Finance. But disabling it outright (the previous fix) meant
+    // Embla's cached container width goes stale the moment it drifts from
+    // its value at mount (font load, sidebar/app-shell chrome settling, a
+    // scrollbar appearing) and never self-corrects, since the window-resize
+    // fallback below only fires on actual browser-window resizes. A stale
+    // width makes every later scrollTo() land at a fraction of a real slide
+    // width instead of a clean multiple of it -- the two panes then render
+    // partially overlapped rather than one fully off-screen. Scoping the
+    // watcher to entries whose target is the container itself keeps it
+    // width-accurate against ANY resize cause while still ignoring the
+    // per-slide entries that caused the original hitch.
+    watchResize: (emblaApiInstance, entries) =>
+      entries.some((entry) => entry.target === emblaApiInstance.containerNode()),
     watchDrag,
   });
   const panels = useMemo(() => React.Children.toArray(children), [children]);
@@ -111,6 +223,103 @@ export function SwipeViews({
   const hasMovedSincePointerDownRef = useRef(false);
   const lastReportedValueRef = useRef(activeValue);
   const resizeFrameRef = useRef<number | null>(null);
+  // Read by the measurement-reconciliation effect below, which must not itself
+  // re-run on every selection change (re-subscribing its observer each time),
+  // but still needs the CURRENT selection whenever it does fire.
+  const activeValueRef = useRef(activeValue);
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    activeValueRef.current = activeValue;
+    optionsRef.current = options;
+  }, [activeValue, options]);
+
+  // Embla measures the container and slides synchronously at init, but only
+  // attaches its own ResizeObserver a frame later. A width change inside that
+  // gap is never observed -- the observer takes the NEW width as its baseline
+  // while the engine keeps the stale one -- so its snap points stay wrong
+  // permanently, and nothing further fires to repair them.
+  //
+  // The visible result is a pane resting at a fraction of a slide width rather
+  // than a clean multiple of it, leaving two panes overlapped on screen.
+  //
+  // Checking only whether the measured width looks stale is not enough: the
+  // engine can re-measure correctly and still leave the rendered transform
+  // parked in the wrong place, in which case a width-only check sees nothing
+  // wrong and skips the repair. So assert the symptom itself -- is the pane
+  // that is supposed to be showing actually the one in view -- and reconcile
+  // whenever it is not. That is self-healing regardless of when, or why, the
+  // position drifted.
+  useEffect(() => {
+    if (!emblaApi) return;
+    const api = emblaApi;
+    const root = api.rootNode();
+    let lastWidth = -1;
+
+    const reconcile = () => {
+      // Never fight a finger that is mid-drag; Embla owns the position then.
+      if (isDraggingRef.current) return;
+
+      const width = root.getBoundingClientRect().width;
+      // A hidden/unlaid-out pane measures 0; re-measuring against that would
+      // bake in a worse value than whatever is already held.
+      if (width <= 0) return;
+
+      const engine = api.internalEngine?.();
+      const engineWidth = engine?.containerRect?.width;
+      const widthChanged = lastWidth !== -1 && Math.abs(width - lastWidth) > 0.5;
+      const engineIsStale =
+        typeof engineWidth === "number" && Math.abs(engineWidth - width) > 1;
+      lastWidth = width;
+
+      // Embla registers its slide list from the container's DOM children at
+      // init time and re-syncs it via its own MutationObserver (`watchSlides`).
+      // That sync can race a panel that mounts a beat after Embla's own init
+      // (for example a tab that only appears once a computed flag settles):
+      // slideRects gets remeasured, but scrollSnaps -- the actual snap-point
+      // list scrollTo() targets -- can be left stuck at the stale, smaller
+      // count. Embla then keeps scrolling and reporting a perfectly
+      // self-consistent position, just against snap points computed for a
+      // carousel with fewer slides than are actually in the DOM. A width or
+      // slideRects check can't see this -- neither changed, only scrollSnaps
+      // failed to grow with the container's real children.
+      const containerChildCount = api.containerNode?.().children.length;
+      const engineSnapCount = engine?.scrollSnaps?.length;
+      const slideCountStale =
+        typeof containerChildCount === "number" &&
+        typeof engineSnapCount === "number" &&
+        containerChildCount !== engineSnapCount;
+
+      const targetIdx = optionsRef.current.findIndex(
+        (opt) => opt.value === activeValueRef.current,
+      );
+
+      // Where the pane actually sits, against where the selected pane belongs.
+      const renderedAt = engine?.offsetLocation?.get?.();
+      const belongsAt = engine?.scrollSnaps?.[targetIdx];
+      const misaligned =
+        targetIdx !== -1 &&
+        typeof renderedAt === "number" &&
+        typeof belongsAt === "number" &&
+        Math.abs(renderedAt - belongsAt) > 1;
+
+      if (!widthChanged && !engineIsStale && !slideCountStale && !misaligned) return;
+
+      // Re-measure only when the measurement is the thing at fault; reInit()
+      // preserves whatever index the engine believes it is on, which may
+      // itself have drifted, so re-assert the app's selection either way --
+      // jumping rather than animating, so the repair is never itself visible.
+      if (widthChanged || engineIsStale || slideCountStale) api.reInit();
+      if (targetIdx !== -1) {
+        scrollToIndexSafely(api, targetIdx, true);
+      }
+    };
+
+    reconcile();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(reconcile);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [emblaApi]);
 
   const syncTabIndicator = useCallback(
     (isDragging?: boolean) => {
@@ -119,7 +328,7 @@ export function SwipeViews({
       const position =
         typeof scrollProgress === "number" && Number.isFinite(scrollProgress)
           ? scrollProgress * Math.max(0, options.length - 1)
-          : emblaApi.selectedScrollSnap();
+          : resolveVisualIndex(emblaApi, options.length);
       setTopShellTabSwipeState(
         tabSetId,
         position,
@@ -135,8 +344,9 @@ export function SwipeViews({
   useEffect(() => {
     if (!emblaApi) return;
     const targetIdx = options.findIndex((opt) => opt.value === activeValue);
-    if (targetIdx !== -1 && targetIdx !== emblaApi.selectedScrollSnap()) {
-      emblaApi.scrollTo(targetIdx);
+    const visualIdx = resolveVisualIndex(emblaApi, options.length);
+    if (targetIdx !== -1 && targetIdx !== visualIdx) {
+      scrollToIndexSafely(emblaApi, targetIdx);
       setTopShellTabSwipeState(tabSetId, Math.max(0, targetIdx), false);
     } else if (!isDraggingRef.current && !hasMovedSincePointerDownRef.current) {
       setTopShellTabSwipeState(tabSetId, Math.max(0, targetIdx), false);
@@ -148,7 +358,7 @@ export function SwipeViews({
   // query-backed tabs look stale on iOS and delayed the visible panel state.
   const onSelect = useCallback(() => {
     if (!emblaApi) return;
-    const currentIdx = emblaApi.selectedScrollSnap();
+    const currentIdx = resolveVisualIndex(emblaApi, options.length);
     const newValue = options[currentIdx]?.value;
     if (newValue && newValue !== activeValue) {
       lastReportedValueRef.current = newValue;
@@ -160,7 +370,7 @@ export function SwipeViews({
   // example a cancelled drag); it never owns the first route update.
   const onSettle = useCallback(() => {
     if (!emblaApi) return;
-    const currentIdx = emblaApi.selectedScrollSnap();
+    const currentIdx = resolveVisualIndex(emblaApi, options.length);
     // Embla continues its snap after the finger lifts. Keep the tab indicator
     // bound to the same compositor progress through that settle phase instead
     // of letting it jump back to the route-selected index mid-pane motion.
@@ -210,11 +420,11 @@ export function SwipeViews({
       const targetIndex = options.findIndex(
         (option) => option.value === selection.value,
       );
-      if (targetIndex < 0 || targetIndex === emblaApi.selectedScrollSnap())
+      if (targetIndex < 0 || targetIndex === resolveVisualIndex(emblaApi, options.length))
         return;
       // A top-tab press starts the compositor motion immediately. Waiting for
       // Next searchParams made the tab ink update first and the pane lag behind.
-      emblaApi.scrollTo(targetIndex);
+      scrollToIndexSafely(emblaApi, targetIndex);
     });
   }, [emblaApi, options, tabSetId]);
 


### PR DESCRIPTION
## Summary

Two unrelated bugs in the Kai analysis workspace:

- **Portfolio-save dead end** — uploaded-portfolio imports never reached the review/save screen. The visible flow state reads from the `?stage=` URL param, but the transition into `"import_complete"` was missing from the allowlist that pushes it there, so the URL stayed on `"importing"` and rendered the branch with no continue button. Sample-portfolio loads skip this state entirely, which is why only that path worked.

- **Analysis pager glitch (Debate / Summary / Detailed View)** — the pager kept rendering two panes partially overlapped, worst when jumping straight to Detailed View. Root cause is in Embla carousel's own internals: it constructs its index `Counter`'s bound and scroll-bounds `limit` once, from whatever slide count it measured at that moment. A tab that mounts a beat later (once a computed flag settles) can grow the real slide count without either ever being recomputed — Embla exposes no public setter for either. Every later `scrollTo(index)` then silently clamps to the stale bound before computing a distance, and Embla's own per-frame rubber-band edge logic pulls any position beyond that stale bound back toward it, so even forcibly setting the correct target kept settling back near the start. Fixed by recomputing the target directly from `slideRects` (which stays accurate) instead of trusting Embla's own `scrollSnaps`/Counter, and disabling the rubber-band constraint, which only ever protects a bound that's wrong for this carousel's real content. `selectedScrollSnap()` reads through that same stale Counter, so `onSelect`/`onSettle` were also capable of reporting the previous pane after a correct scroll and silently reverting the caller's own selection — fixed by resolving the effective index from the rendered position everywhere the component reads it.

Also included: a small, unrelated guard in `useConsentPendingSummaryCount` (root app-shell hook) against a partial/error summary payload — found while testing the Kai fixes above, since it was throwing and taking down the entire app shell rather than just hiding a badge. Kept as its own commit since it's unrelated to the Kai bugs.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — full suite passes except 22 pre-existing failures in unrelated subsystems (marketplace encryption/SubtleCrypto, a location-sharing modal test, vault-sync mock), none touching the files in this PR
- [x] Manual: portfolio upload now reaches the review/save screen
- [x] Manual: Analysis workspace — Debate → Summary → Detailed View in all directions, including jumping straight from Summary to Detailed View, on both a live and a saved/historical run