### PR TITLE
fix(ci): publish Android .aab as workflow artifact

### DIFF
--- a/.github/workflows/ship-android-playstore-v1.yml
+++ b/.github/workflows/ship-android-playstore-v1.yml
@@ -264,6 +264,14 @@ jobs:
           cd hushh-webapp/android
           ./gradlew bundleRelease --stacktrace
 
+      - name: Publish .aab as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hushh-one-android-release-aab
+          path: hushh-webapp/android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 14
+          if-no-files-found: error
+
       - name: Upload .aab to Google Play Console
         if: ${{ inputs.dry_run != true }}
         uses: r0adkll/upload-google-play@v1


### PR DESCRIPTION
## Summary
- Google Play Developer API refuses `edits.insert` for `com.hushh.app` because the app is still `Draft` in Play Console with zero prior uploads (confirmed via Play Console screenshot + Google's own docs: "you will have to upload at least one APK through the Play Console before you can use this API").
- CI cannot bootstrap that first upload. This adds an `actions/upload-artifact` step so the built `.aab` is downloadable from the run, to be uploaded once by hand through Play Console's UI. Every dispatch after that bootstrap upload will use the existing API path unchanged.

## Test plan
- [x] Dispatch with `dry_run=true` after merge, confirm artifact `hushh-one-android-release-aab` is attached to the run