### PR TITLE
chore(governance): grant parthmawai + abdulbeast4-creator main/UAT access

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -25,7 +25,9 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "parthmawai",
+      "abdulbeast4-creator"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -38,7 +40,9 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "parthmawai",
+      "abdulbeast4-creator"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
@@ -68,7 +72,9 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "parthmawai",
+      "abdulbeast4-creator"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -81,7 +87,9 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "parthmawai",
+      "abdulbeast4-creator"
     ]
   },
   "dev": {
@@ -109,7 +117,9 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "parthmawai",
+      "abdulbeast4-creator"
     ]
   },
   "production": {


### PR DESCRIPTION
## Summary
- Parth (\`parthmawai\`) and Abdul (\`abdulbeast4-creator\`) were previously forced through \`integration/pr-train\` for every PR and had no UAT deploy access.
- Adds both to \`main\`/\`pr_train\` \`review_bypass_users\` + \`merge_queue_bypass_users\` in \`config/ci-governance.json\` — together these make \`verify-pr-base-policy.py\` treat them as governed maintainers, so their PRs can target \`main\` directly through the normal merge queue.
- Adds both to \`uat.manual_dispatch_users\` — can dispatch \`deploy-uat.yml\`.
- **Deliberately NOT** added to \`production.manual_dispatch_users\` or \`main.protected_pipeline_edit_users\` — production dispatch and CI/CD pipeline file edits stay restricted to the existing maintainer set.
- This edits \`config/ci-governance.json\`, itself a \`protected_pipeline_path\`.

## Test plan
- [x] \`verify-pr-base-policy.py\` self-test passes; directly verified both new logins now evaluate as governed maintainers, unrelated actors remain blocked
- [ ] After merge, run \`python3 scripts/ci/apply-governance.py --apply\` to sync branch protection bypass lists and the \`allowed-maintainers-to-approve\` team membership to GitHub (JSON alone does not change live GitHub state for those two)