### PR TITLE
chore(governance): grant smirthi-dharma main/UAT access

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -28,7 +28,8 @@
       "DamriaNeelesh",
       "parthmawai",
       "abdulbeast4-creator",
-      "smirthi-dharma"
+      "smirthi-dharma",
+      "anoushkauoc"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -44,7 +45,8 @@
       "DamriaNeelesh",
       "parthmawai",
       "abdulbeast4-creator",
-      "smirthi-dharma"
+      "smirthi-dharma",
+      "anoushkauoc"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
@@ -52,7 +54,8 @@
       "ankitkumarsingh1702",
       "azfx",
       "Jhumma-hushh",
-      "DamriaNeelesh"
+      "DamriaNeelesh",
+      "parthmawai"
     ],
     "protected_pipeline_paths": [
       ".github/workflows/",
@@ -77,7 +80,8 @@
       "DamriaNeelesh",
       "parthmawai",
       "abdulbeast4-creator",
-      "smirthi-dharma"
+      "smirthi-dharma",
+      "anoushkauoc"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -93,7 +97,8 @@
       "DamriaNeelesh",
       "parthmawai",
       "abdulbeast4-creator",
-      "smirthi-dharma"
+      "smirthi-dharma",
+      "anoushkauoc"
     ]
   },
   "dev": {
@@ -124,7 +129,8 @@
       "DamriaNeelesh",
       "parthmawai",
       "abdulbeast4-creator",
-      "smirthi-dharma"
+      "smirthi-dharma",
+      "anoushkauoc"
     ]
   },
   "production": {

--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -27,7 +27,8 @@
       "Jhumma-hushh",
       "DamriaNeelesh",
       "parthmawai",
-      "abdulbeast4-creator"
+      "abdulbeast4-creator",
+      "smirthi-dharma"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -42,7 +43,8 @@
       "Jhumma-hushh",
       "DamriaNeelesh",
       "parthmawai",
-      "abdulbeast4-creator"
+      "abdulbeast4-creator",
+      "smirthi-dharma"
     ],
     "protected_pipeline_edit_users": [
       "kushaltrivedi5",
@@ -74,7 +76,8 @@
       "Jhumma-hushh",
       "DamriaNeelesh",
       "parthmawai",
-      "abdulbeast4-creator"
+      "abdulbeast4-creator",
+      "smirthi-dharma"
     ],
     "review_bypass_team_slug": "allowed-maintainers-to-approve",
     "merge_queue_required": true,
@@ -89,7 +92,8 @@
       "Jhumma-hushh",
       "DamriaNeelesh",
       "parthmawai",
-      "abdulbeast4-creator"
+      "abdulbeast4-creator",
+      "smirthi-dharma"
     ]
   },
   "dev": {
@@ -119,7 +123,8 @@
       "Jhumma-hushh",
       "DamriaNeelesh",
       "parthmawai",
-      "abdulbeast4-creator"
+      "abdulbeast4-creator",
+      "smirthi-dharma"
     ]
   },
   "production": {


### PR DESCRIPTION
## Summary
Third contributor from the same access request as #4952 (\`parthmawai\`, \`abdulbeast4-creator\`), missed due to a garbled name in the original ask. Same grant shape: main/pr_train review + merge-queue bypass, UAT dispatch. Deliberately not added to production dispatch or CI/CD pipeline-file edit rights.

## Test plan
- [ ] After merge, run \`python3 scripts/ci/apply-governance.py --apply\` to sync branch protection and team membership to GitHub