### PR TITLE
fix(ria): read the verified number the backend recorded, not Firebase's

### DIFF
--- a/hushh-webapp/__tests__/services/ria-claim-entry.test.ts
+++ b/hushh-webapp/__tests__/services/ria-claim-entry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildRiaClaimRoute,
   isClaimableLookupOutcome,
+  resolveVerifiedPhone,
   toNanpDigits,
 } from "@/lib/ria/ria-claim-entry";
 
@@ -52,6 +53,40 @@ describe("recognising an adviser from the number they typed at sign-up", () => {
     expect(toNanpDigits("18015663510")).toBe("8015663510");
     expect(toNanpDigits("+44 20 7946 0958")).toBe("");
     expect(toNanpDigits(null)).toBe("");
+  });
+
+  it("finds the number when only the backend recorded it", () => {
+    // The exact demo path: the adviser confirms with the fixed test code, which
+    // records the phone server-side and returns the UNCHANGED Firebase user.
+    // Reading the Firebase phone here skips recognition entirely — this is the
+    // defect that made "I entered my number and nothing happened" reproduce.
+    expect(
+      resolveVerifiedPhone({
+        identityPhone: "+18015663510",
+        contextPhone: null,
+        firebasePhone: null,
+      }),
+    ).toBe("8015663510");
+  });
+
+  it("prefers the backend number over a stale Firebase one", () => {
+    expect(
+      resolveVerifiedPhone({
+        identityPhone: "+18015663510",
+        contextPhone: null,
+        firebasePhone: "+12125550000",
+      }),
+    ).toBe("8015663510");
+  });
+
+  it("falls back through context then Firebase when the backend has none", () => {
+    expect(
+      resolveVerifiedPhone({ identityPhone: null, contextPhone: "+16036768813" }),
+    ).toBe("6036768813");
+    expect(
+      resolveVerifiedPhone({ identityPhone: null, firebasePhone: "+12243262044" }),
+    ).toBe("2243262044");
+    expect(resolveVerifiedPhone({})).toBe("");
   });
 
   it("carries the number and the original destination into the claim route", () => {

--- a/hushh-webapp/app/register-phone/page.tsx
+++ b/hushh-webapp/app/register-phone/page.tsx
@@ -30,7 +30,11 @@ import {
 import { PostAuthRouteService } from "@/lib/services/post-auth-route-service";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import { RiaService } from "@/lib/services/ria-service";
-import { buildRiaClaimRoute, isClaimableLookupOutcome } from "@/lib/ria/ria-claim-entry";
+import {
+  buildRiaClaimRoute,
+  isClaimableLookupOutcome,
+  resolveVerifiedPhone,
+} from "@/lib/ria/ria-claim-entry";
 import { shouldBypassPhoneMandateForLocalhost } from "@/lib/services/phone-mandate-service";
 import { usePublishVoiceSurfaceMetadata } from "@/lib/voice/voice-surface-metadata";
 import { resolvePostPhoneOnboardingPhase } from "@/lib/onboarding/onboarding-journey-phase";
@@ -113,7 +117,17 @@ export function PhoneMandatePageContent() {
       // lists a firm or advisers at it, show that instead of the generic next
       // screen. Fails open — any error, timeout or miss continues as normal.
       const claimRoute = await (async () => {
-        const verifiedPhone = activeUser.phoneNumber;
+        // identity.phone_number is the authoritative verified number. The
+        // Firebase user object is null here whenever the phone was confirmed
+        // through the backend test-code path or any non-Firebase channel --
+        // that path returns the unchanged user and only records the phone
+        // server-side, so reading activeUser.phoneNumber skips recognition
+        // exactly when it is needed.
+        const verifiedPhone = resolveVerifiedPhone({
+          identityPhone: identity?.phone_number,
+          contextPhone: phoneNumber,
+          firebasePhone: activeUser.phoneNumber,
+        });
         if (!idToken || !verifiedPhone) return null;
         try {
           const controller = new AbortController();
@@ -158,7 +172,7 @@ export function PhoneMandatePageContent() {
       });
       router.replace(nextPath);
     },
-    [redirectPath, refreshUser, router, user],
+    [redirectPath, refreshUser, router, user, phoneNumber],
   );
 
   const [shouldBypassLocalPhoneMandate, setShouldBypassLocalPhoneMandate] =

--- a/hushh-webapp/lib/ria/ria-claim-entry.ts
+++ b/hushh-webapp/lib/ria/ria-claim-entry.ts
@@ -29,6 +29,27 @@ export function isClaimableLookupOutcome(
   return Boolean(result.firm?.crd) || (result.firms?.length ?? 0) > 0;
 }
 
+/**
+ * The account's verified number, in the order the sources are trustworthy.
+ *
+ * `identity.phone_number` is authoritative: it is what the backend recorded.
+ * The auth context's `phoneNumber` is the hydrated copy of it. The Firebase
+ * user object comes LAST because it is null in two common cases — a Google
+ * sign-in (no phone credential is ever linked) and the backend test-code
+ * confirmation path (which returns the unchanged user and only records the
+ * phone server-side). Reading it first skips recognition exactly when an
+ * adviser has just told us their number.
+ */
+export function resolveVerifiedPhone(sources: {
+  identityPhone?: string | null;
+  contextPhone?: string | null;
+  firebasePhone?: string | null;
+}): string {
+  return toNanpDigits(
+    sources.identityPhone || sources.contextPhone || sources.firebasePhone,
+  );
+}
+
 /** Reduce any phone formatting to the 10-digit NANP number, or "". */
 export function toNanpDigits(raw: string | null | undefined): string {
   let digits = String(raw ?? "").replace(/\D/g, "");


### PR DESCRIPTION
Reproduced from the user's own run on UAT: fresh account, entered `801-566-3510`, code `000000`, landed on "Finish setting up One" with no list.

## Root cause

The demo code path (`AccountIdentityService.confirmUatTestPhoneVerification`) records the phone **server-side** and returns `userRef.current` — the unchanged Firebase user. For a Google sign-in that object never carries a phone at all.

So `activeUser.phoneNumber` was `null` at exactly the moment the adviser had just told us their number. The probe returned before ever calling the lookup, and the generic setup route won.

`continueToNextRoute` already had the answer on the line above: `identity`, whose `phone_number` is what the backend actually stored, and which is also what `AccountIdentityService.hasVerifiedPhone(identity)` is read from two lines later.

## Fix

One shared `resolveVerifiedPhone()` — identity first, then the hydrated auth context, then Firebase last — so the three entry points cannot drift apart again. The other two probes already read the context value (which hydrates from identity), so this closes the last one.

## Tests

New cases pin the exact demo scenario: a backend-only phone must still be recognised, the backend value wins over a stale Firebase one, and the fallback order holds.

typecheck and lint clean; 64 tests pass across claim entry, claim admission, claim service, journey guard, and post-auth routing.