### PR TITLE
fix(one-location): send SMS from the message box, and unstick the ring

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -224,6 +224,71 @@ describe("SosPanel", () => {
     expect(onTrigger).toHaveBeenCalledWith(null);
   });
 
+  it("stays pressable when the trigger bails out without ever going busy", async () => {
+    // Regression: handleTriggerSos returns early on a blocked permission, an
+    // empty SMS contact list, or an incident that is already live -- all before
+    // it sets `busy`. The panel's reset effect only runs on a busy true -> false
+    // edge, so nothing released the fired latch: `progress` stayed at 1, the
+    // ring showed a frozen countdown with the radar pulse running, and every
+    // later press was silently ignored until the screen was remounted.
+    const onTrigger = vi.fn().mockResolvedValue(undefined);
+    render(<SosPanel {...baseProps} onTrigger={onTrigger} />);
+    const hold = screen.getByRole("button", {
+      name: /press and hold for two seconds/i,
+    });
+
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 1 });
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.pointerUp(hold, { pointerId: 1 });
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+
+    // Let the trigger promise settle so the latch is released.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The ring must be back to its resting label, not a stuck countdown.
+    expect(hold).toHaveTextContent("Hold 2 s");
+
+    fireEvent.pointerDown(hold, { button: 0, pointerId: 2 });
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.pointerUp(hold, { pointerId: 2 });
+
+    expect(onTrigger).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends a typed message straight from the send button in the message box", () => {
+    const onTrigger = vi.fn();
+    render(<SosPanel {...baseProps} onTrigger={onTrigger} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Short text message" }));
+    fireEvent.change(screen.getByLabelText("Short text message"), {
+      target: { value: "Emergency" },
+    });
+    fireEvent.click(screen.getByTestId("sos-send-custom-message"));
+
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+    expect(onTrigger).toHaveBeenCalledWith("Emergency");
+  });
+
+  it("keeps the send button inert until the message box has text", () => {
+    const onTrigger = vi.fn();
+    render(<SosPanel {...baseProps} onTrigger={onTrigger} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Short text message" }));
+    const send = screen.getByTestId("sos-send-custom-message");
+    expect(send).toBeDisabled();
+
+    // Whitespace alone is not a message.
+    fireEvent.change(screen.getByLabelText("Short text message"), {
+      target: { value: "   " },
+    });
+    expect(send).toBeDisabled();
+
+    fireEvent.click(send);
+    expect(onTrigger).not.toHaveBeenCalled();
+  });
+
   it("passes the selected fixed message and exposes Edit and Cancel", () => {
     const onTrigger = vi.fn();
     const onClose = vi.fn();

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -239,7 +239,10 @@ export type LocationHubViewModel = {
   sosEmergency: EmergencyInfo | null;
   sosEmergencyStatus: EmergencyNumberLookupStatus;
   onResolveSosLocation: () => void;
-  onTriggerSos: (message?: string | null) => void;
+  // Promise-returning on purpose: SosPanel awaits it to tell a real send from
+  // an early bail-out, so narrowing it back to `void` here would strip the
+  // signal the panel needs to release its fired latch.
+  onTriggerSos: (message?: string | null) => void | Promise<void>;
   onStopSos: () => void;
   onAddSmsContact: (recipientUserId: string) => void;
   onRemoveSmsContact: (recipientUserId: string) => Promise<boolean>;

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -9,7 +9,7 @@ import {
   type KeyboardEvent,
   type PointerEvent,
 } from "react";
-import { ChevronLeft, Loader2, Phone } from "lucide-react";
+import { ChevronLeft, Loader2, Phone, SendHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
@@ -48,7 +48,14 @@ export type SosPanelProps = {
   recipients: OneLocationRecipient[];
   active: boolean;
   busy: boolean;
-  onTrigger: (message?: string | null) => void;
+  /**
+   * Returning the handler's promise is load-bearing: the panel awaits it to
+   * learn whether the trigger actually started work. `handleTriggerSos` bails
+   * out early (no SMS contacts, blocked permission, an incident already live)
+   * without ever entering its busy phase, and the panel needs to know so it can
+   * release the fired latch instead of sitting on a dead progress ring.
+   */
+  onTrigger: (message?: string | null) => void | Promise<void>;
   /**
    * Stop a live SMS/SOS session: revokes the location grants created by the
    * alert AND clears the incident, so "SENT · Live now" resets. Kept separate
@@ -156,13 +163,33 @@ export function SosPanel({
     if (resetProgress && !firedRef.current) setProgress(0);
   }, []);
 
-  const completeHold = useCallback(() => {
+  /**
+   * Single path into `onTrigger`, shared by the press-and-hold ring and the
+   * send button in the message box.
+   *
+   * The `finally` is the fix for a panel that could latch permanently: when
+   * `onTrigger` returned early it never set `busy`, so the reset effect below
+   * (which only runs on a busy true -> false edge) never fired, `firedRef`
+   * stayed true, and `progress` stayed at 1. The ring then showed a frozen
+   * "0.0 s" with the radar pulse running forever and refused every later press.
+   * If the trigger never entered its busy phase there is nothing to wait for,
+   * so release the latch here.
+   */
+  const fireTrigger = useCallback(() => {
     if (firedRef.current || disabled) return;
     firedRef.current = true;
     clearHold(false);
     setProgress(1);
-    onTrigger(selectedMessage);
+    void Promise.resolve(onTrigger(selectedMessage)).finally(() => {
+      if (observedBusyRef.current) return;
+      firedRef.current = false;
+      setProgress(0);
+    });
   }, [clearHold, disabled, onTrigger, selectedMessage]);
+
+  const completeHold = useCallback(() => {
+    fireTrigger();
+  }, [fireTrigger]);
 
   const updateProgress = useCallback(function tickProgress() {
     if (!holdStartedAtRef.current || firedRef.current) return;
@@ -188,6 +215,23 @@ export function SosPanel({
   }, [completeHold, hardDisabled, noReadyRecipients, updateProgress]);
 
   const cancelHold = useCallback(() => clearHold(true), [clearHold]);
+
+  /**
+   * Send button inside the message box. A typed message is already a deliberate
+   * act, so this sends immediately rather than asking for a second two-second
+   * hold. Enter deliberately still inserts a newline: an emergency alert must
+   * not be one stray keystroke away.
+   */
+  const handleSendCustomMessage = useCallback(() => {
+    if (hardDisabled) return;
+    if (noReadyRecipients) {
+      toast.error(
+        "Please add at least one contact in your SMS emergency contact list.",
+      );
+      return;
+    }
+    fireTrigger();
+  }, [fireTrigger, hardDisabled, noReadyRecipients]);
 
   useEffect(() => {
     const onWindowBlur = () => cancelHold();
@@ -447,25 +491,51 @@ export function SosPanel({
               <label htmlFor="sos-short-message" className="sr-only">
                 Short text message
               </label>
-              <textarea
-                id="sos-short-message"
-                aria-describedby={
-                  customMessageLimitExceeded
-                    ? "sos-short-message-count sos-short-message-error"
-                    : "sos-short-message-count"
-                }
-                aria-invalid={customMessageLimitExceeded}
-                value={customMessage}
-                onChange={(event) => setCustomMessage(event.target.value)}
-                placeholder="Type a short message"
-                rows={2}
-                className={cn(
-                  "min-h-[72px] w-full resize-none rounded-2xl border bg-[#1c1c1e] px-3.5 py-3 text-[14px] leading-relaxed text-white outline-none placeholder:text-white/40 focus:border-white/55",
-                  customMessageLimitExceeded
-                    ? "border-[#ff453a]"
-                    : "border-white/10",
-                )}
-              />
+              <div className="relative">
+                <textarea
+                  id="sos-short-message"
+                  aria-describedby={
+                    customMessageLimitExceeded
+                      ? "sos-short-message-count sos-short-message-error"
+                      : "sos-short-message-count"
+                  }
+                  aria-invalid={customMessageLimitExceeded}
+                  value={customMessage}
+                  onChange={(event) => setCustomMessage(event.target.value)}
+                  placeholder="Type a short message"
+                  rows={2}
+                  className={cn(
+                    // pr-14 reserves the send button's column so typed text
+                    // never runs underneath it.
+                    "min-h-[72px] w-full resize-none rounded-2xl border bg-[#1c1c1e] py-3 pl-3.5 pr-14 text-[14px] leading-relaxed text-white outline-none placeholder:text-white/40 focus:border-white/55",
+                    customMessageLimitExceeded
+                      ? "border-[#ff453a]"
+                      : "border-white/10",
+                  )}
+                />
+                {/* Without this the only way to send a typed message was to go
+                    back up and hold the ring for two seconds, with nothing in
+                    the message box confirming the text had been taken. */}
+                <button
+                  type="button"
+                  data-testid="sos-send-custom-message"
+                  onClick={handleSendCustomMessage}
+                  disabled={hardDisabled || !selectedMessage}
+                  aria-label="Send this SMS alert"
+                  className={cn(
+                    "press-scale absolute bottom-2.5 right-2.5 flex h-10 w-10 items-center justify-center rounded-full transition-colors",
+                    hardDisabled || !selectedMessage
+                      ? "bg-white/10 text-white/35"
+                      : "bg-[#ff3b30] text-white",
+                  )}
+                >
+                  {busy ? (
+                    <Loader2 className="h-[18px] w-[18px] animate-spin" />
+                  ) : (
+                    <SendHorizontal className="h-[18px] w-[18px]" strokeWidth={2} />
+                  )}
+                </button>
+              </div>
               <div
                 id="sos-short-message-count"
                 className={cn(


### PR DESCRIPTION
# Description

Two problems in Save my Soul, both reported from the UAT Android build.

**1. A typed message had no way to send it.** The message box offered no send
control, and Enter inserted a newline like any textarea, so after typing there
was no signal the text had been taken. The only way through was to scroll back
up and hold the ring for two seconds — which reads as *"did that send or not?"*.

There is now a send button inside the box. A typed message is already a
deliberate act, so it sends immediately rather than demanding a second
two-second hold. It stays inert until the box holds more than whitespace, and
shows a spinner while the alert is in flight. Enter still inserts a newline on
purpose: an emergency alert must not be one stray keystroke away.

**2. The ring could latch and refuse every later press.** `handleTriggerSos`
returns early on a blocked location permission, an empty SMS contact list, or an
incident that is already live — all *before* it sets `busy`. `completeHold` had
already set `firedRef` and driven `progress` to 1, and the reset effect only runs
on a `busy` true → false edge, so with `busy` never going true nothing released
the latch. The ring sat at a frozen `0.0 s` with the radar pulse still running
— the "sending forever, never triggers" report — and `completeHold`'s `firedRef`
guard swallowed every later press until the screen was remounted.

Both entry points now route through one `fireTrigger`, which awaits the handler
and releases the latch when the trigger never entered its busy phase.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (component-level; `/one/location` SOS panel renders inside the
    existing route)

- API / schema / type changes:
  - [x] Listed below:
    - `SosPanelProps.onTrigger` widened `=> void` → `=> void | Promise<void>`
    - `LocationRedesignHubProps.onTriggerSos` widened identically — it had been
      narrowing the promise away, which is what hid the signal the panel needs

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] Listed below: the send button is a web-layer control inside the existing
    Capacitor webview. No native plugin change; the fix reaches iOS and Android
    through the same bundle. Reported on Android, fixed for all three.

- Docs updated (exact files):
  - [x] None — no documented contract changes; the widened prop types are
    internal component props.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None — no auth/consent/vault/PKM path changes. The alert still runs
    through the unchanged `runSosPanic` → `createGrant` → encrypted-publish path.

- Caller / proxy / backend pairing:
  - [x] Not applicable — no backend call shape changed.

- Rollback or safe-failure behavior:
  - [x] Listed below: this PR *is* the safe-failure fix. A trigger that bails out
    early now releases the fired latch instead of leaving the control dead.
    Covered by `stays pressable when the trigger bails out without ever going busy`.

- UI browser or Playwright proof:
  - [x] Listed below: no browser run — see Screenshots section for why.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` — clean
  - [ ] `cd hushh-webapp && npm test` — targeted suites only, see Testing
  - [x] `cd hushh-webapp && npm run build` — `✓ Compiled successfully in 39.8s`
  - [ ] `cd hushh-webapp && npm run ios:cold:audit`
  - [ ] `python scripts/ops/kai-system-audit.py ...`

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: no other open PR touches `sos-panel.tsx`.
- [x] This PR changes a current reachable app surface (`/one/location` → SMS · Save my Soul screen).
- [x] Reachable production attach point: `LocationRedesignHub` renders `SosPanel`; `page.tsx` supplies `onTriggerSos: handleTriggerSos`.
- [x] New tests import and exercise production code — they render the real `SosPanel` and assert against the real `fireTrigger` latch behaviour.
- [x] New helpers/components/services are wired to an existing route: `fireTrigger` is internal to the already-rendered `SosPanel`.
- [x] Production surface proved: `npm run build` compiles; the send button is `data-testid="sos-send-custom-message"` in the shipped panel.
- [x] Required checks are current on this head, commits are signed off, and the branch is cut from current `origin/main` (`62b0cc93e`).
- [x] Maintainer edits are enabled.
- [ ] If this is one PR in a stack, the predecessor PR is linked here: not a stack.
- [ ] If this responds to requested changes: first submission.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: `components/one-location/redesign/sos-panel.tsx` — send button + latch release
- [x] **iOS**: not applicable — no Swift plugin change; the panel is webview UI shared by all platforms
- [x] **Android**: not applicable — same; reported on Android, fixed in the shared web layer

## 🧪 Testing

- [ ] Tested on Web (Chrome/Safari) — no manual browser pass, see below
- [ ] Tested on iOS Simulator/Device
- [ ] Tested on Android Emulator/Device
- [x] Commits are signed off (`git commit -s`)
- [x] If generated files changed, they were regenerated by the canonical command — no generated files changed

Automated:

- `sos-panel.test.tsx` — **19 passed** (3 added)
  - `stays pressable when the trigger bails out without ever going busy` — the
    regression test for problem 2; asserts the ring returns to `Hold 2 s` and a
    second hold fires again
  - `sends a typed message straight from the send button in the message box`
  - `keeps the send button inert until the message box has text` (incl. whitespace-only)
- `sos-panel.test.tsx` + `sos-trigger.test.ts` — **46 passed**
- `tsc --noEmit` — clean
- `eslint --max-warnings=0` on all three changed files — clean
- `npm run build` — compiled successfully

## 📸 Screenshots / Video

No browser or device proof attached. Driving this screen for real needs a
signed-in, phone-verified account with an unlocked vault and at least one
share-ready SMS contact, plus reviewer credentials from Secret Manager that are
not available to me. Flagging that as a genuine gap rather than claiming a pass:
the latch fix and the send button are proven at the DOM level against the real
component, not on a device.

The original report is an Android screenshot of the SMS · Save my Soul screen
with a typed message and no send affordance.

## 🛡️ Privacy & Consent

- [ ] Does this change access user data? No.
- [ ] If yes, have you implemented `checkConsentToken()`? Not applicable.
- [x] Sensitive surface touched: **none** — the alert path (`runSosPanic`,
  grant creation, envelope encryption) is untouched; this changes only when the
  panel's local fired-latch is released and adds a second way to invoke the
  existing trigger.
- [x] Error path, rollback, or safe-failure behavior proved: yes — the added
  bail-out test is exactly that path.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no
  dependency changes; `SendHorizontal` comes from the already-vendored
  `lucide-react`.
