### PR TITLE
feat(ria): stop asking for the passcode twice

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -795,7 +795,8 @@ async def _account_phone_matches(firebase_uid: str, phone_digits: str) -> bool:
         return False
     if identity.get("phone_verified") is not True:
         return False
-    return normalize_nanp_phone(str(identity.get("phone_number") or "")) == phone_digits
+    stored: str = normalize_nanp_phone(str(identity.get("phone_number") or ""))
+    return bool(stored) and stored == phone_digits
 
 
 async def _prove_claim_possession(

--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field, field_validator
 from api.middleware import require_firebase_auth
 from api.middlewares.rate_limit import limiter
 from api.routes.account import _verify_phone_claim_id_token
+from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.consent_center_service import ConsentCenterService
 from hushh_mcp.services.ria_claim_service import (
     RIAClaimService,
@@ -779,7 +780,27 @@ async def ria_claim_otp_start(
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
 
 
-async def _prove_claim_possession(payload: RIAClaimVerifyRequest, phone_digits: str) -> str:
+async def _account_phone_matches(firebase_uid: str, phone_digits: str) -> bool:
+    """True when this account's already-verified phone IS the number being claimed.
+
+    The phone mandate verifies possession of the account's number and records it
+    server-side. When an adviser then claims the same number, asking for a second
+    passcode proves nothing the backend does not already hold. This reads our own
+    record — never anything the browser asserts — so the possession model is
+    unchanged.
+    """
+    try:
+        identity = (await ActorIdentityService().get_many([firebase_uid])).get(firebase_uid) or {}
+    except Exception:  # noqa: BLE001 - identity cache is advisory here; fail closed
+        return False
+    if identity.get("phone_verified") is not True:
+        return False
+    return normalize_nanp_phone(str(identity.get("phone_number") or "")) == phone_digits
+
+
+async def _prove_claim_possession(
+    payload: RIAClaimVerifyRequest, phone_digits: str, firebase_uid: str
+) -> str:
     """Return the proof channel after verifying possession, or raise 401."""
     if payload.phone_id_token:
         token_phone, _session_uid = await _verify_phone_claim_id_token(payload.phone_id_token)
@@ -802,6 +823,11 @@ async def _prove_claim_possession(payload: RIAClaimVerifyRequest, phone_digits: 
                 "message": "That code didn't work. Check it and try again.",
             },
         )
+    # No passcode supplied: accept the account's own verified phone when it is
+    # the number being claimed. This is what removes the second passcode from
+    # the journey for an adviser who just verified that exact line.
+    if await _account_phone_matches(firebase_uid, phone_digits):
+        return "verified_account_phone"
     raise HTTPException(
         status_code=422,
         detail={
@@ -821,7 +847,7 @@ async def ria_claim_verify(
     phone_digits = normalize_nanp_phone(payload.phone)
     if not phone_digits:
         raise HTTPException(status_code=400, detail="Enter a valid US phone number.")
-    proof_channel = await _prove_claim_possession(payload, phone_digits)
+    proof_channel = await _prove_claim_possession(payload, phone_digits, firebase_uid)
     service = RIAClaimService()
     try:
         result = await service.evaluate_with_possession(

--- a/consent-protocol/tests/test_ria_claim_flow.py
+++ b/consent-protocol/tests/test_ria_claim_flow.py
@@ -646,3 +646,91 @@ def test_claim_complete_route_happy_path(monkeypatch):
     )
     assert response.status_code == 200
     assert response.json()["status"] == "claimed"
+
+
+# ---------------------------------------------------------------------------
+# Possession via the account's already-verified phone (removes the second OTP)
+# ---------------------------------------------------------------------------
+
+
+def _identity(phone: str | None, verified: bool) -> dict[str, Any]:
+    return {"phone_number": phone, "phone_verified": verified}
+
+
+def test_claim_verify_accepts_the_accounts_own_verified_phone(monkeypatch):
+    """An adviser who just verified this number must not be asked again."""
+    _enable_test_code(monkeypatch)
+
+    async def _mock_get_many(self, user_ids):
+        return {_TEST_UID: _identity("+18015663510", True)}
+
+    monkeypatch.setattr(ria_module.ActorIdentityService, "get_many", _mock_get_many)
+
+    async def _mock_evaluate(self, **kwargs):
+        return {"claim_ticket": "ticket", "roster_unlocked": True}
+
+    monkeypatch.setattr(RIAClaimService, "evaluate_with_possession", _mock_evaluate)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/verify",
+        json={
+            "phone": "(801) 566-3510",
+            "claim_type": "individual",
+            "firm_crd": 283040,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["proof_channel"] == "verified_account_phone"
+
+
+def test_claim_verify_rejects_a_different_number_than_the_account_holds(monkeypatch):
+    """Possession of MY number never proves possession of someone else's."""
+    _enable_test_code(monkeypatch)
+
+    async def _mock_get_many(self, user_ids):
+        return {_TEST_UID: _identity("+12125550000", True)}
+
+    monkeypatch.setattr(ria_module.ActorIdentityService, "get_many", _mock_get_many)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/verify",
+        json={"phone": "8015663510", "claim_type": "individual", "firm_crd": 283040},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "CLAIM_PROOF_REQUIRED"
+
+
+def test_claim_verify_rejects_an_unverified_account_phone(monkeypatch):
+    """A stored-but-unverified number is not proof of anything."""
+    _enable_test_code(monkeypatch)
+
+    async def _mock_get_many(self, user_ids):
+        return {_TEST_UID: _identity("+18015663510", False)}
+
+    monkeypatch.setattr(ria_module.ActorIdentityService, "get_many", _mock_get_many)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/verify",
+        json={"phone": "8015663510", "claim_type": "individual", "firm_crd": 283040},
+    )
+    assert response.status_code == 422
+
+
+def test_claim_verify_survives_an_identity_lookup_failure(monkeypatch):
+    """The identity cache is advisory: if it errors, fail closed to the passcode."""
+    _enable_test_code(monkeypatch)
+
+    async def _boom(self, user_ids):
+        raise RuntimeError("identity cache unavailable")
+
+    monkeypatch.setattr(ria_module.ActorIdentityService, "get_many", _boom)
+
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/verify",
+        json={"phone": "8015663510", "claim_type": "individual", "firm_crd": 283040},
+    )
+    assert response.status_code == 422

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -276,35 +276,13 @@ export default function RiaClaimPage() {
     void handleLookup(seededPhone);
   }, [seededPhone, user, authLoading, handleLookup]);
 
-  const beginClaim = useCallback(
-    async (type: ClaimType, candidateCrd: number | null) => {
-      if (!firmCrd || busy) return;
-      setBusy(true);
-      setError(null);
-      setClaimType(type);
-      setSelectedCandidateCrd(candidateCrd);
-      try {
-        const idToken = await getIdToken();
-        const start = await RiaService.claimOtpStart(idToken, { phone: phoneDigits });
-        setPhoneMasked(start.phone_masked ?? "");
-        if (start.eligible && start.verification_id) {
-          setVerificationId(start.verification_id);
-          setCodeLength(start.code_length ?? 6);
-          setOtpUnavailable(false);
-        } else {
-          setVerificationId(null);
-          setOtpUnavailable(true);
-        }
-        setCode("");
-        setStep("code");
-      } catch (err) {
-        setError(describeError(err));
-      } finally {
-        setBusy(false);
-      }
-    },
-    [firmCrd, busy, phoneDigits, getIdToken],
-  );
+  // True when the number being claimed is the one already verified on this
+  // account, so the backend can prove possession from its own record.
+  const claimingVerifiedAccountPhone =
+    phoneDigits.length === 10 &&
+    phoneDigits === toNanpDigits(accountPhone || user?.phoneNumber);
+
+
 
   const completeClaim = useCallback(
     async (ticket: string, type: ClaimType, individualCrd: number | null) => {
@@ -344,6 +322,91 @@ export default function RiaClaimPage() {
     [firmCrd, phoneDigits, getIdToken, refreshPersonaState, user],
   );
 
+  /** Route a verify result onward: complete it, or ask which adviser. */
+  const settleVerifyResult = useCallback(
+    async (
+      result: RiaClaimVerifyResult,
+      type: ClaimType,
+      candidateCrd: number | null,
+    ) => {
+      setVerifyResult(result);
+      if (type === "firm") {
+        await completeClaim(result.claim_ticket, "firm", null);
+        return;
+      }
+      if (candidateCrd) {
+        await completeClaim(result.claim_ticket, "individual", candidateCrd);
+        return;
+      }
+      const roster = result.roster ?? [];
+      const soleEntry = roster.length === 1 ? roster[0] : undefined;
+      if (soleEntry?.individual_crd) {
+        await completeClaim(result.claim_ticket, "individual", soleEntry.individual_crd);
+        return;
+      }
+      setPickCrd(null);
+      setStep("pick");
+    },
+    [completeClaim],
+  );
+
+  const beginClaim = useCallback(
+    async (type: ClaimType, candidateCrd: number | null) => {
+      if (!firmCrd || busy) return;
+      setBusy(true);
+      setError(null);
+      setClaimType(type);
+      setSelectedCandidateCrd(candidateCrd);
+      try {
+        const idToken = await getIdToken();
+
+        // If this IS the number already verified on the account, the backend
+        // proves possession from its own record. Asking for a second passcode
+        // on the number they verified moments ago is friction, not security.
+        if (claimingVerifiedAccountPhone) {
+          try {
+            const verified = await RiaService.claimVerify(idToken, {
+              phone: phoneDigits,
+              claim_type: type,
+              firm_crd: firmCrd,
+              individual_crd: type === "individual" ? candidateCrd : undefined,
+            });
+            await settleVerifyResult(verified, type, candidateCrd);
+            return;
+          } catch {
+            // Fall through to the passcode: the account record did not satisfy
+            // the backend, so possession must still be proven the normal way.
+          }
+        }
+
+        const start = await RiaService.claimOtpStart(idToken, { phone: phoneDigits });
+        setPhoneMasked(start.phone_masked ?? "");
+        if (start.eligible && start.verification_id) {
+          setVerificationId(start.verification_id);
+          setCodeLength(start.code_length ?? 6);
+          setOtpUnavailable(false);
+        } else {
+          setVerificationId(null);
+          setOtpUnavailable(true);
+        }
+        setCode("");
+        setStep("code");
+      } catch (err) {
+        setError(describeError(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [
+      firmCrd,
+      busy,
+      phoneDigits,
+      getIdToken,
+      claimingVerifiedAccountPhone,
+      settleVerifyResult,
+    ],
+  );
+
   const handleCodeFilled = useCallback(
     async (filledCode: string) => {
       if (!firmCrd || !verificationId || submittingRef.current) return;
@@ -360,23 +423,7 @@ export default function RiaClaimPage() {
           verification_id: verificationId,
           verification_code: filledCode,
         });
-        setVerifyResult(result);
-        if (claimType === "firm") {
-          await completeClaim(result.claim_ticket, "firm", null);
-          return;
-        }
-        if (selectedCandidateCrd) {
-          await completeClaim(result.claim_ticket, "individual", selectedCandidateCrd);
-          return;
-        }
-        const roster = result.roster ?? [];
-        const soleEntry = roster.length === 1 ? roster[0] : undefined;
-        if (soleEntry?.individual_crd) {
-          await completeClaim(result.claim_ticket, "individual", soleEntry.individual_crd);
-          return;
-        }
-        setPickCrd(null);
-        setStep("pick");
+        await settleVerifyResult(result, claimType, selectedCandidateCrd);
       } catch (err) {
         setCode("");
         setError(
@@ -389,7 +436,15 @@ export default function RiaClaimPage() {
         setBusy(false);
       }
     },
-    [firmCrd, verificationId, phoneDigits, claimType, selectedCandidateCrd, getIdToken, completeClaim],
+    [
+      firmCrd,
+      verificationId,
+      phoneDigits,
+      claimType,
+      selectedCandidateCrd,
+      getIdToken,
+      settleVerifyResult,
+    ],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Observed on UAT by the product owner: enter `801-566-3510`, enter the code, pick your name — and the app asks for the **same code on the same number again**.

## Why it happened

Two different proofs that happen to be identical in practice:
1. the phone mandate proves the number belongs to the **account**;
2. the claim proves possession of the **firm's filed number**.

Same number, same code, ninety seconds apart. The second proves nothing the backend does not already hold, and on a demo stage it reads as broken.

## The fix

**Backend** adds a third proof channel: when the number being claimed *is* the account's already-verified phone, possession is satisfied from our own `actor_identity_cache` record (`phone_verified` true **and** `phone_number` matches). This is read **server-side only** — a browser cannot assert it — so the security model is unchanged: possession of *my* number still never proves possession of anyone else's.

**Frontend** skips the code step when the claim phone equals the verified account phone, and falls back to the passcode if the backend does not accept it. The verify-result branching is extracted into one `settleVerifyResult()` so the coded and code-free paths cannot diverge.

## Tests (the refusals matter more than the acceptance)

- accepted when the verified account phone matches the claim
- **refused** when the account holds a different number → `CLAIM_PROOF_REQUIRED`
- **refused** when the stored number is not verified
- **refused (fails closed to the passcode)** when the identity lookup throws

35 backend tests and 19 frontend claim tests pass; typecheck and lint clean.

## Separately verified in this pass

Live check of all 10 demo numbers confirms the firm-vs-individual split is correct and complete: sole-adviser firms return **two** claim targets (the firm and the person — which is what the owner saw), firms with 9+ advisers deliberately return **zero** names until possession unlocks the roster, the 8-adviser firm returns **all 8** inline, and the shared-line case returns **two firms and no firm claim** until one is picked.