### PR TITLE
feat(ria): claim completes setup instead of escaping it, and fills the profile from the regulator

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_claim_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_service.py
@@ -194,7 +194,104 @@ def _shape_firm(raw: dict[str, Any] | None) -> dict[str, Any] | None:
         "advisory_employees": raw.get("advisoryEmployees"),
         "aum": raw.get("aum"),
         "num_accounts": raw.get("numAccounts"),
+        "total_employees": raw.get("totalEmployees"),
+        "street1": address.get("street1"),
+        "street2": address.get("street2"),
+        "zip": address.get("zip"),
+        "registration_type": raw.get("registrationType"),
         "report_url": raw.get("reportUrl"),
+        "form_adv_pdf_url": raw.get("formAdvPdfUrl"),
+        "form_crs_url": raw.get("formCrsUrl"),
+        # States the firm has notice-filed in: the public "licensed in" list.
+        "notice_filed_states": [
+            str(item.get("jurisdiction"))
+            for item in (raw.get("noticeFilings") or [])
+            if isinstance(item, dict) and item.get("jurisdiction")
+        ],
+        "registrations": [
+            {
+                "jurisdiction": item.get("secJurisdiction"),
+                "status": item.get("status"),
+                "effective_date": item.get("effectiveDate"),
+            }
+            for item in (raw.get("registrations") or [])
+            if isinstance(item, dict)
+        ],
+        "brochures": [
+            {
+                "name": item.get("name"),
+                "date_submitted": item.get("dateSubmitted"),
+                "url": item.get("url"),
+            }
+            for item in (raw.get("brochures") or [])
+            if isinstance(item, dict) and item.get("url")
+        ],
+    }
+
+
+def _shape_advisor_record(raw: dict[str, Any] | None) -> dict[str, Any]:
+    """The public regulatory record we can put on a claimed profile.
+
+    Every field here is published on adviserinfo.sec.gov. Disclosure *events*
+    are deliberately reduced to a flag and a count rather than parsed detail:
+    the element shape is unverified, and a profile should link to the SEC record
+    rather than restate someone's disciplinary history from a guessed schema.
+    """
+    individual: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    employments = individual.get("currentEmployments")
+    current = employments[0] if isinstance(employments, list) and employments else {}
+    if not isinstance(current, dict):
+        current = {}
+    branches = current.get("branches")
+    branch = branches[0] if isinstance(branches, list) and branches else {}
+    if not isinstance(branch, dict):
+        branch = {}
+    disclosures = individual.get("disclosures")
+    return {
+        "crd": individual.get("crd"),
+        "other_names": [str(n) for n in (individual.get("otherNames") or []) if n],
+        "registered_since": current.get("registrationBeginDate"),
+        "exams": [
+            {
+                "code": item.get("code"),
+                "name": item.get("name"),
+                "date": item.get("date"),
+            }
+            for item in (individual.get("exams") or [])
+            if isinstance(item, dict) and item.get("code")
+        ],
+        "registered_states": [
+            {
+                "state": item.get("state"),
+                "scope": item.get("regScope"),
+                "status": item.get("status"),
+                "date": item.get("regDate"),
+            }
+            for item in (individual.get("registeredStates") or [])
+            if isinstance(item, dict) and item.get("state")
+        ],
+        "previous_firms": [
+            {
+                "firm_name": item.get("firmName"),
+                "firm_crd": item.get("firmCrd"),
+                "from": item.get("from"),
+                "to": item.get("to"),
+            }
+            for item in (individual.get("previousEmployments") or [])
+            if isinstance(item, dict) and item.get("firmName")
+        ],
+        "branch": {
+            "city": branch.get("city"),
+            "state": branch.get("state"),
+            "street1": branch.get("street1"),
+            "zip": branch.get("zip"),
+            "private_residence": branch.get("privateResidence"),
+        }
+        if branch
+        else None,
+        "has_disclosures": bool(individual.get("hasDisclosures")),
+        "disclosure_count": len(disclosures) if isinstance(disclosures, list) else 0,
+        "report_url": individual.get("reportUrl"),
     }
 
 
@@ -426,6 +523,20 @@ class RIAClaimService:
                 status_code=502,
             )
 
+        # Pull the adviser's full public record so the profile is built from the
+        # regulator's own data instead of asking the person to type it. Best
+        # effort: a claim must never fail because enrichment did.
+        advisor_record: dict[str, Any] = {}
+        if claim_type == "individual" and individual_crd is not None:
+            try:
+                fetched = await self._client.advisor_record(individual_crd)
+                advisor_record = _shape_advisor_record(fetched.get("individual"))
+            except Exception as exc:  # noqa: BLE001 - enrichment is best-effort
+                # A claim must never fail because the profile could not be
+                # enriched. Any upstream fault, timeout, or shape change leaves
+                # the person claimed with a thinner profile rather than blocked.
+                logger.info("ria.claim_enrichment_skipped error=%s", type(exc).__name__)
+
         reference_metadata = {
             "provider": CLAIM_PROVIDER_LABEL,
             "claim_type": claim_type,
@@ -437,6 +548,9 @@ class RIAClaimService:
             "missing": payload.get("missing") or [],
             "evidence_ledger": payload.get("evidenceLedger") or [],
             "scope_note": payload.get("scopeNote"),
+            # The snapshot the profile was built from, kept for provenance.
+            "firm_record": firm,
+            "advisor_record": advisor_record,
         }
 
         profile = await self._iam_service.claim_ria_profile_from_identity(
@@ -452,6 +566,15 @@ class RIAClaimService:
             firm_website=firm.get("website"),
             firm_sec_number=firm.get("sec_number"),
             reference_metadata=reference_metadata,
+            # Regulator facts, straight from the public record.
+            regulator="SEC" if firm.get("registration_type") == "sec" else "State",
+            regulator_status=firm.get("registration_status"),
+            disclosures_url=(advisor_record.get("report_url") or firm.get("report_url")),
+            certifications=[
+                str(exam.get("code"))
+                for exam in advisor_record.get("exams", [])
+                if exam.get("code")
+            ],
         )
         logger.info(
             json.dumps(
@@ -463,6 +586,7 @@ class RIAClaimService:
                 }
             )
         )
+        branch = advisor_record.get("branch") or {}
         return {
             "status": "claimed",
             "claim_type": claim_type,
@@ -470,4 +594,23 @@ class RIAClaimService:
             "profile_verified": profile_verified,
             "provisional": provisional,
             "profile": profile,
+            # What the regulator publishes, so the screen can show the person
+            # what was filled in for them rather than an empty profile.
+            "facts": {
+                "crd_number": crd_number,
+                "regulator": "SEC" if firm.get("registration_type") == "sec" else "State",
+                "regulator_status": firm.get("registration_status"),
+                "registered_since": advisor_record.get("registered_since"),
+                "branch_city": branch.get("city"),
+                "branch_state": branch.get("state"),
+                "exams": advisor_record.get("exams", []),
+                "registered_states": advisor_record.get("registered_states", []),
+                "previous_firms": advisor_record.get("previous_firms", []),
+                "notice_filed_states": firm.get("notice_filed_states", []),
+                "aum": firm.get("aum"),
+                "num_accounts": firm.get("num_accounts"),
+                "firm_website": firm.get("website"),
+                "report_url": advisor_record.get("report_url") or firm.get("report_url"),
+                "has_disclosures": advisor_record.get("has_disclosures"),
+            },
         }

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4302,6 +4302,10 @@ class RIAIAMService:
         firm_website: str | None = None,
         firm_sec_number: str | None = None,
         reference_metadata: dict[str, Any] | None = None,
+        regulator: str | None = None,
+        regulator_status: str | None = None,
+        disclosures_url: str | None = None,
+        certifications: list[str] | None = None,
     ) -> dict[str, Any]:
         """Auto-build an RIA profile from a possession-proven SEC claim.
 
@@ -4434,6 +4438,42 @@ class RIAIAMService:
                             firm_row["id"],
                             "Advisor" if claim_type == "individual" else "Firm representative",
                         )
+
+                # Regulator facts from the public record: written best-effort so
+                # a profile is populated without asking, and a missing column on
+                # an older schema never fails the claim.
+                try:
+                    await conn.execute(
+                        """
+                        UPDATE ria_profiles
+                        SET
+                          license_number = NULLIF($2, ''),
+                          regulator = NULLIF($3, ''),
+                          regulator_status = NULLIF($4, ''),
+                          certifications = $5::text[],
+                          onboarding_type = $6,
+                          updated_at = NOW()
+                        WHERE id = $1
+                        """,
+                        ria["id"],
+                        crd_number or "",
+                        regulator or "",
+                        regulator_status or "",
+                        list(certifications or []),
+                        claim_type,
+                    )
+                except asyncpg.exceptions.UndefinedColumnError:
+                    logger.warning("ria_profiles regulator columns unavailable during claim write")
+
+                if disclosures_url:
+                    try:
+                        await conn.execute(
+                            "UPDATE ria_profiles SET disclosures_url = $2, updated_at = NOW() WHERE id = $1",
+                            ria["id"],
+                            disclosures_url,
+                        )
+                    except asyncpg.exceptions.UndefinedColumnError:
+                        pass
 
                 try:
                     await conn.execute(

--- a/consent-protocol/hushh_mcp/services/ria_identity_client.py
+++ b/consent-protocol/hushh_mcp/services/ria_identity_client.py
@@ -111,13 +111,27 @@ class RIAIdentityClient:
         *,
         mode: str = "auto",
         limit: int = 10,
+        detail: bool = False,
     ) -> dict[str, Any]:
-        """Resolve a phone number to firm + adviser claim targets (buffered)."""
-        return await self._request(
-            "GET",
-            "/v1/claim/lookup",
-            params={"phone": phone, "mode": mode, "limit": limit, "stream": "off"},
-        )
+        """Resolve a phone number to firm + adviser claim targets (buffered).
+
+        ``detail=True`` hydrates each candidate with its full public record
+        (exams, state registrations, employment history, branch offices), which
+        is what lets a claimed profile be built without asking any questions.
+        """
+        params: dict[str, Any] = {
+            "phone": phone,
+            "mode": mode,
+            "limit": limit,
+            "stream": "off",
+        }
+        if detail:
+            params["detail"] = 1
+        return await self._request("GET", "/v1/claim/lookup", params=params)
+
+    async def advisor_record(self, individual_crd: int) -> dict[str, Any]:
+        """One adviser's full public regulatory record."""
+        return await self._request("GET", f"/v1/advisors/{individual_crd}")
 
     async def claim_evaluate(
         self,

--- a/consent-protocol/tests/test_ria_claim_flow.py
+++ b/consent-protocol/tests/test_ria_claim_flow.py
@@ -281,10 +281,12 @@ async def test_identity_client_error_mapping(monkeypatch):
 
 
 class _FakeIdentityClient:
-    def __init__(self, *, lookup_payload=None, evaluate_payload=None):
+    def __init__(self, *, lookup_payload=None, evaluate_payload=None, advisor_payload=None):
         self.lookup_payload = lookup_payload or {}
         self.evaluate_payload = evaluate_payload or {}
         self.evaluate_calls: list[dict[str, Any]] = []
+        self.advisor_calls: list[int] = []
+        self.advisor_payload: dict[str, Any] | None = advisor_payload
 
     async def claim_lookup(self, phone, **_kwargs):
         return self.lookup_payload
@@ -292,6 +294,12 @@ class _FakeIdentityClient:
     async def claim_evaluate(self, **kwargs):
         self.evaluate_calls.append(kwargs)
         return self.evaluate_payload
+
+    async def advisor_record(self, individual_crd):
+        self.advisor_calls.append(individual_crd)
+        if self.advisor_payload is None:
+            raise RIAIdentityUnavailableError("no record")
+        return self.advisor_payload
 
 
 class _FakeIamService:
@@ -734,3 +742,123 @@ def test_claim_verify_survives_an_identity_lookup_failure(monkeypatch):
         json={"phone": "8015663510", "claim_type": "individual", "firm_crd": 283040},
     )
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Agentic enrichment: the profile is built from the regulator's record
+# ---------------------------------------------------------------------------
+
+_ADVISOR_RECORD = {
+    "ok": True,
+    "individual": {
+        "crd": 5308823,
+        "otherNames": ["REGINALD MAXFIELD"],
+        "currentEmployments": [
+            {
+                "firmCrd": 283040,
+                "firmName": "OLYMPUS PEAKS FINANCIAL, LLC",
+                "registrationBeginDate": "5/20/2016",
+                "branches": [
+                    {
+                        "city": "SANDY",
+                        "state": "UT",
+                        "street1": "9035 S 1300 E STE 120",
+                        "zip": "84094",
+                        "privateResidence": False,
+                    }
+                ],
+            }
+        ],
+        "previousEmployments": [
+            {
+                "firmCrd": 6413,
+                "firmName": "LPL FINANCIAL LLC",
+                "from": "5/1/2007",
+                "to": "6/2/2016",
+            }
+        ],
+        "exams": [
+            {"code": "Series 66", "name": "Uniform Combined State Law", "date": "4/28/2007"},
+            {"code": "SIE", "name": "Securities Industry Essentials", "date": "6/2/2016"},
+        ],
+        "registeredStates": [
+            {"state": "Utah", "regScope": "IA", "status": "APPROVED", "regDate": "5/20/2016"}
+        ],
+        "hasDisclosures": False,
+        "disclosures": [],
+        "reportUrl": "https://adviserinfo.sec.gov/individual/summary/5308823",
+    },
+}
+
+
+async def test_claim_enriches_the_profile_from_the_public_record(monkeypatch):
+    """Nothing is asked: exams, regulator and the SEC link come from the record."""
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    iam = _FakeIamService()
+    payload = dict(_EVALUATE_VERIFIED)
+    payload["firm"] = dict(_EVALUATE_VERIFIED["firm"])
+    fake = _FakeIdentityClient(evaluate_payload=payload, advisor_payload=_ADVISOR_RECORD)
+    service = RIAClaimService(client=fake, iam_service=iam)
+
+    await service.complete(
+        user_id=_TEST_UID,
+        phone_digits="8015663510",
+        claim_type="individual",
+        firm_crd=283040,
+        individual_crd=5308823,
+    )
+
+    assert fake.advisor_calls == [5308823]
+    call = iam.calls[0]
+    # Exam codes become certifications — real credentials, not invented ones.
+    assert call["certifications"] == ["Series 66", "SIE"]
+    # The profile links to the regulator's own page rather than nothing.
+    assert "adviserinfo.sec.gov" in (call["disclosures_url"] or "")
+    # The full snapshot is kept for provenance.
+    record = call["reference_metadata"]["advisor_record"]
+    assert record["registered_states"][0]["state"] == "Utah"
+    assert record["previous_firms"][0]["firm_name"] == "LPL FINANCIAL LLC"
+    assert record["branch"]["city"] == "SANDY"
+    assert record["has_disclosures"] is False
+
+
+async def test_claim_still_succeeds_when_enrichment_fails(monkeypatch):
+    """Enrichment is a bonus, never a gate: a claim must not depend on it."""
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    iam = _FakeIamService()
+    # advisor_payload=None makes the fake raise, as a dead upstream would.
+    service = RIAClaimService(
+        client=_FakeIdentityClient(evaluate_payload=_EVALUATE_VERIFIED),
+        iam_service=iam,
+    )
+
+    result = await service.complete(
+        user_id=_TEST_UID,
+        phone_digits="8015663510",
+        claim_type="individual",
+        firm_crd=283040,
+        individual_crd=5308823,
+    )
+
+    assert result["status"] == "claimed"
+    assert iam.calls[0]["certifications"] == []
+
+
+async def test_firm_claim_does_not_fetch_an_advisor_record(monkeypatch):
+    """A firm claim has no individual to enrich; no wasted upstream call."""
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    payload = dict(_EVALUATE_VERIFIED)
+    payload.update(
+        {"claimType": "firm", "verificationLevel": "provisional", "profileVerified": False}
+    )
+    fake = _FakeIdentityClient(evaluate_payload=payload, advisor_payload=_ADVISOR_RECORD)
+    service = RIAClaimService(client=fake, iam_service=_FakeIamService())
+
+    await service.complete(
+        user_id=_TEST_UID,
+        phone_digits="8015663510",
+        claim_type="firm",
+        firm_crd=283040,
+    )
+
+    assert fake.advisor_calls == []

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -15,6 +15,7 @@ import {
   Building2,
   CheckCircle2,
   ChevronLeft,
+  ExternalLink,
   Loader2,
   ShieldCheck,
   UserRound,
@@ -29,7 +30,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { toNanpDigits } from "@/lib/ria/ria-claim-entry";
 import { Button } from "@/lib/morphy-ux/button";
-import { ROUTES } from "@/lib/navigation/routes";
+import { normalizeInternalRouteHref, ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
 import {
@@ -39,6 +40,7 @@ import {
   type RiaClaimCompleteResult,
   type RiaClaimFirm,
   type RiaClaimLookupResult,
+  type RiaClaimProfileFacts,
   type RiaClaimVerifyResult,
 } from "@/lib/services/ria-service";
 
@@ -173,6 +175,78 @@ function CodeCells({
   );
 }
 
+/** One labelled fact row, matching the review-card grammar. */
+function FactRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-h-[44px] items-center justify-between gap-4 border-t border-[color:var(--border)] px-4 py-2.5 first:border-t-0">
+      <span className="text-[13px] text-muted-foreground">{label}</span>
+      <span className="text-right text-[15px] font-medium">{value}</span>
+    </div>
+  );
+}
+
+/** What the regulator publishes, filled in without asking the adviser. */
+function ClaimedFacts({ facts }: { facts: RiaClaimProfileFacts }) {
+  const rows: { label: string; value: string }[] = [];
+  if (facts.crd_number) rows.push({ label: "CRD", value: facts.crd_number });
+  if (facts.regulator) {
+    rows.push({
+      label: "Regulator",
+      value: [facts.regulator, facts.regulator_status].filter(Boolean).join(" · "),
+    });
+  }
+  if (facts.registered_since) {
+    rows.push({ label: "Registered since", value: facts.registered_since });
+  }
+  const office = [titleCase(facts.branch_city), facts.branch_state].filter(Boolean).join(", ");
+  if (office) rows.push({ label: "Office", value: office });
+  const aum = formatAum(facts.aum);
+  if (aum) rows.push({ label: "Firm assets", value: aum.replace(" AUM", "") });
+  if (facts.num_accounts) {
+    rows.push({ label: "Accounts", value: facts.num_accounts.toLocaleString() });
+  }
+  const exams = (facts.exams ?? []).map((e) => e.code).filter(Boolean);
+  if (exams.length) rows.push({ label: "Exams", value: exams.join(", ") });
+  const states = (facts.registered_states ?? []).map((s) => s.state).filter(Boolean);
+  if (states.length) {
+    rows.push({
+      label: states.length === 1 ? "Registered in" : `Registered in ${states.length}`,
+      value: states.slice(0, 3).join(", ") + (states.length > 3 ? "…" : ""),
+    });
+  }
+  const filed = facts.notice_filed_states ?? [];
+  if (filed.length) {
+    rows.push({ label: `Notice filed in ${filed.length}`, value: filed.slice(0, 3).join(", ") + (filed.length > 3 ? "…" : "") });
+  }
+  const prior = facts.previous_firms ?? [];
+  if (prior.length) {
+    rows.push({ label: "Previously", value: titleCase(prior[0]?.firm_name) });
+  }
+  if (!rows.length) return null;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[13px] text-muted-foreground">From your SEC record.</p>
+      <div className="overflow-hidden rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] shadow-[0_8px_24px_rgba(62,48,30,0.05)]">
+        {rows.map((row) => (
+          <FactRow key={row.label} label={row.label} value={row.value} />
+        ))}
+      </div>
+      {facts.report_url ? (
+        <a
+          href={facts.report_url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-[13px] font-medium text-[color:var(--app-accent)]"
+        >
+          View on adviserinfo.sec.gov
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
 export default function RiaClaimPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -185,6 +259,9 @@ export default function RiaClaimPage() {
   const seededPhone =
     toNanpDigits(searchParams.get("phone")) ||
     toNanpDigits(accountPhone || user?.phoneNumber);
+  // Where the person was before recognition pulled them here, so claiming
+  // hands them back rather than stranding them in the RIA workspace.
+  const returnTo = normalizeInternalRouteHref(searchParams.get("return_to"));
 
   const [step, setStep] = useState<ClaimStep>("phone");
   const [phoneDigits, setPhoneDigits] = useState("");
@@ -212,6 +289,9 @@ export default function RiaClaimPage() {
   const [verifyResult, setVerifyResult] = useState<RiaClaimVerifyResult | null>(null);
   const [pickCrd, setPickCrd] = useState<number | null>(null);
   const [completeResult, setCompleteResult] = useState<RiaClaimCompleteResult | null>(null);
+  // True when first-run setup still has steps left, so the done screen returns
+  // the person to the hub instead of ending their setup early.
+  const [rootSetupUnresolved, setRootSetupUnresolved] = useState(false);
 
   const submittingRef = useRef(false);
 
@@ -306,13 +386,20 @@ export default function RiaClaimPage() {
         // hub must stop listing it as remaining. syncSetupCapabilities REPLACES
         // the stored set, so pass the union.
         try {
-          const current = await PreVaultUserStateService.bootstrapState(user.uid);
+          const current = await PreVaultUserStateService.bootstrapState(user.uid, {
+            force: true,
+          });
           if (!current.setupCapabilityIds.includes("ria")) {
             await PreVaultUserStateService.syncSetupCapabilities(
               user.uid,
               Array.from(new Set([...current.setupCapabilityIds, "ria"])).sort(),
             );
           }
+          // Claiming is one capability inside first-run setup, not an exit from
+          // it. While the root setup is unresolved the person still has other
+          // steps to finish, so the done screen must hand them back to the hub
+          // rather than drop them into the RIA workspace.
+          setRootSetupUnresolved(!PreVaultUserStateService.isSetupResolved(current));
         } catch {
           // best-effort; the dashboard reconciles the count on next load.
         }
@@ -865,23 +952,44 @@ export default function RiaClaimPage() {
                   </div>
                 </div>
               </div>
+              {completeResult.facts ? (
+                <ClaimedFacts facts={completeResult.facts} />
+              ) : null}
               {!verified ? (
                 <p className="text-[13px] leading-relaxed text-muted-foreground">
                   Finish verification anytime from your profile.
                 </p>
               ) : null}
-              <div className="mx-auto w-full sm:max-w-[22rem]">
+              <div className="mx-auto w-full space-y-3 sm:max-w-[22rem]">
                 <Button
                   variant="blue-gradient"
                   effect="fill"
                   size="lg"
                   fullWidth
                   className="h-12 text-base"
-                  onClick={() => router.replace(ROUTES.RIA_PROFILE)}
+                  onClick={() =>
+                    router.replace(
+                      rootSetupUnresolved || returnTo
+                        ? returnTo || ROUTES.ONE_SETUP
+                        : ROUTES.RIA_PROFILE,
+                    )
+                  }
                   data-voice-control-id="ria-claim-open-profile"
                 >
-                  Open your profile
+                  {rootSetupUnresolved || returnTo ? "Continue setup" : "Open your profile"}
                 </Button>
+                {rootSetupUnresolved || returnTo ? (
+                  <Button
+                    variant="none"
+                    effect="fade"
+                    size="lg"
+                    fullWidth
+                    className="h-12 text-base"
+                    onClick={() => router.replace(ROUTES.RIA_PROFILE)}
+                  >
+                    View profile
+                  </Button>
+                ) : null}
               </div>
             </div>
           ) : null}

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -293,6 +293,25 @@ export interface RiaClaimProfileSummary {
   firm_id?: string | null;
 }
 
+/** The public regulatory facts a claim pulled in, for display. */
+export interface RiaClaimProfileFacts {
+  crd_number?: string | null;
+  regulator?: string | null;
+  regulator_status?: string | null;
+  registered_since?: string | null;
+  branch_city?: string | null;
+  branch_state?: string | null;
+  exams?: { code?: string | null; name?: string | null; date?: string | null }[];
+  registered_states?: { state?: string | null; status?: string | null }[];
+  previous_firms?: { firm_name?: string | null; from?: string | null; to?: string | null }[];
+  notice_filed_states?: string[];
+  aum?: number | null;
+  num_accounts?: number | null;
+  firm_website?: string | null;
+  report_url?: string | null;
+  has_disclosures?: boolean | null;
+}
+
 export interface RiaClaimCompleteResult {
   status: string;
   claim_type: string;
@@ -300,6 +319,7 @@ export interface RiaClaimCompleteResult {
   profile_verified: boolean;
   provisional: boolean;
   profile: RiaClaimProfileSummary;
+  facts?: RiaClaimProfileFacts | null;
 }
 
 export interface RiaLicenseVerificationResult {


### PR DESCRIPTION
Two defects the product owner found by walking the real flow on UAT.

## 1. Claiming bypassed "Finish setting up One"

The done screen sent the adviser straight to `/ria/profile`, jumping **out** of first-run setup — while the same function had just marked RIA complete. Those two behaviours contradict each other: we ticked a box on a screen we then refused to show.

The done screen now returns the person to the setup hub (or to the route recognition pulled them from via `return_to`) with RIA ticked, and offers the profile as a quieter second action. Once root setup **is** resolved, it behaves as before and opens the profile directly.

## 2. The profile was nearly empty

The identity service publishes far more than a name and a registration number, and we were discarding all of it. A claim now fetches the adviser's full public record and fills in what the regulator already states:

- exam codes → `certifications` (Series 66, SIE, Series 7 …)
- the adviser's SEC page → `disclosures_url`
- `regulator` / `regulator_status` from the firm's registration
- firm notice-filed states, assets under management, account count, street address, Form ADV and Form CRS links, brochures
- prior firms, branch office, registered states, registration date

**Nothing is invented.** Disclosure *events* are deliberately reduced to a boolean and a link rather than restating someone's disciplinary history from a shape we have not verified.

The done screen renders these in the existing review-card grammar, so the adviser sees what was filled in for them rather than a bare name.

## Safety

Enrichment is strictly best-effort — any upstream fault, timeout, or shape change leaves the person **claimed with a thinner profile, never blocked**. A firm claim skips the per-person fetch entirely. Regulator columns are written inside a tolerant block so an older schema cannot fail a claim.

## Tests

- enrichment reaches the profile (exams, states, prior firms, branch)
- a dead upstream still completes the claim
- a firm claim makes no wasted per-person call

38 backend tests and 24 frontend tests pass; ruff, ruff format, mypy over 95 files, and the 537-test CI manifest all green locally before pushing.