### PR TITLE
fix(server): stop requiring runtime tables migration 129 retired

### DIFF
--- a/consent-protocol/server.py
+++ b/consent-protocol/server.py
@@ -55,6 +55,11 @@ def _require_database_on_startup() -> bool:
     return _is_production()
 
 
+# Tables the process refuses to start without. Every entry must still exist once
+# all migrations have run; a stale entry here is not a failing check but a
+# backend that cannot boot. test_server_startup_guards.py enforces that, because
+# the predeploy schema gate only knows about tables named in the DB contract and
+# so cannot catch a guard entry that no longer has a table behind it.
 REQUIRED_RUNTIME_TABLES = (
     "vault_keys",
     "vault_key_wrappers",
@@ -62,8 +67,6 @@ REQUIRED_RUNTIME_TABLES = (
     "user_push_tokens",
     "internal_access_events",
     "runtime_persona_state",
-    "ria_pick_uploads",
-    "ria_pick_upload_rows",
     "one_location_circles",
     "one_location_circle_memberships",
     "one_location_circle_invite_codes",

--- a/consent-protocol/tests/test_server_startup_guards.py
+++ b/consent-protocol/tests/test_server_startup_guards.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import pathlib
+import re
 
 import pytest
 
@@ -114,6 +116,70 @@ def test_named_circle_tables_are_required_runtime_dependencies():
         "connection_origins",
         "one_location_circle_member_invites",
     } <= set(server.REQUIRED_RUNTIME_TABLES)
+
+
+def test_required_runtime_tables_are_live_in_migrations():
+    """Every guarded table must still exist after the last migration runs.
+
+    Regression: a long-lived branch merge resurrected `ria_pick_uploads` and
+    `ria_pick_upload_rows` here after migration 129 had dropped them. Nothing
+    caught it -- both tables are absent from the DB contract, so the predeploy
+    schema gate had no opinion -- and the guard raises on startup, so the
+    deployed revision never became ready. UAT answered 503 on /health, every
+    downstream check failed, and the release rolled itself back.
+
+    A guarded table that no migration creates, or that a later migration drops,
+    is not a failing check: it is a backend that cannot boot at all.
+    """
+
+    db_dir = pathlib.Path(server.__file__).resolve().parent / "db"
+    # Base schema files seed tables that predate the numbered series, so they
+    # count as version 0 -- `consent_audit` is created there, not by a migration.
+    sources = [
+        (0, path.read_text(encoding="utf-8", errors="ignore"))
+        for path in (db_dir / "offline_schema.sql", db_dir / "legacy" / "init_legacy_schema.sql")
+        if path.exists()
+    ]
+    migrations = [
+        (int(path.name[:3]), path.read_text(encoding="utf-8", errors="ignore"))
+        for path in sorted((db_dir / "migrations").glob("[0-9][0-9][0-9]_*.sql"))
+    ]
+    assert migrations, "no migrations found; this test cannot verify the guard"
+
+    problems: list[str] = []
+    for table in server.REQUIRED_RUNTIME_TABLES:
+        created = [
+            version
+            for version, sql in sources + migrations
+            if re.search(
+                rf"CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(?:public\.)?{table}\b",
+                sql,
+                re.IGNORECASE,
+            )
+        ]
+        # Only numbered migrations can retire a table; a drop in a base schema
+        # file is part of that file rebuilding itself, not a retirement.
+        dropped = [
+            version
+            for version, sql in migrations
+            if re.search(
+                rf"DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+(?:public\.)?{table}\b",
+                sql,
+                re.IGNORECASE,
+            )
+        ]
+        if not created:
+            problems.append(f"{table}: nothing under db/ creates it")
+        elif dropped and max(dropped) > max(created):
+            problems.append(
+                f"{table}: dropped by migration {max(dropped):03d} after being "
+                f"created by migration {max(created):03d}"
+            )
+
+    assert not problems, (
+        "REQUIRED_RUNTIME_TABLES names tables the schema no longer has, so the "
+        "server will refuse to start:\n  " + "\n  ".join(problems)
+    )
 
 
 def test_market_cache_table_startup_warns_and_continues_in_development(


### PR DESCRIPTION
## Why UAT is failing

The last two `deploy-uat` runs ([31198924713](https://github.com/hushh-labs/hushh-research/actions/runs/31198924713), [31200095339](https://github.com/hushh-labs/hushh-research/actions/runs/31200095339)) both finished `rolled_back`.

The backend never started. `/health` returned **503**, which cascaded into `smoke_auth`, `gmail_status`, `voice_relay_session` and `ria_stage1_query_only`, classified as `runtime_behavior_failed` + `smoke_overlay_dependency_leak`, and the workflow rolled the backend revision back.

## Root cause

Merging #4660 re-added two entries to `REQUIRED_RUNTIME_TABLES`:

```
"ria_pick_uploads",
"ria_pick_upload_rows",
```

`1c2f5104a` had removed them when `129_ria_pick_legacy_retirement.sql` dropped both tables. The long-lived branch resurrected them on merge.

`startup_required_schema_guard` raises `RuntimeError` when any required table is missing, so the container never became ready.

## Why nothing caught it

- Both tables are **absent from `uat_integrated_schema.json`**, so the predeploy schema gate had no opinion — it reported `status: ok` while the runtime guard was about to fail on the same database.
- The new test added in #4660 only asserted the *Circle* tables were present, not that every guarded table still exists.
- No `.py` source references either table any more; only stale `.pyc` caches do.

## The fix

Remove the two entries, and add `test_required_runtime_tables_are_live_in_migrations`: every guarded table must be created somewhere under `db/` and not dropped by a later numbered migration.

Verified both directions — the test fails on the unfixed guard with:

```
ria_pick_uploads: dropped by migration 129 after being created by migration 025
ria_pick_upload_rows: dropped by migration 129 after being created by migration 025
```

and passes once removed. I also audited the remaining 13 guarded entries against the migrations and against the table set the failed run's own artifact recorded in UAT — none are stale.

`consent_audit` is created by the base schema rather than a numbered migration, so the test treats `db/offline_schema.sql` and `db/legacy/init_legacy_schema.sql` as version 0.

## Verification

- `pytest tests/test_server_startup_guards.py tests/test_one_location_named_circles_migration.py` → 18 passed
- `ruff check server.py tests/test_server_startup_guards.py` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)