### PR TITLE
fix(server): drop retired ria_pick tables from the startup guard

### DIFF
--- a/consent-protocol/tests/test_server_startup_guards.py
+++ b/consent-protocol/tests/test_server_startup_guards.py
@@ -108,6 +108,13 @@ def test_schema_guard_still_fails_when_required_tables_are_missing(
         asyncio.run(server.startup_required_schema_guard())
 
 
+def test_retired_ria_pick_tables_are_not_required_at_startup():
+    # Migration 129_ria_pick_legacy_retirement.sql drops these tables, so a
+    # guard entry for them crash-loops every deploy against a migrated database.
+    assert "ria_pick_uploads" not in server.REQUIRED_RUNTIME_TABLES
+    assert "ria_pick_upload_rows" not in server.REQUIRED_RUNTIME_TABLES
+
+
 def test_named_circle_tables_are_required_runtime_dependencies():
     assert {
         "one_location_circles",


### PR DESCRIPTION
## Why every UAT deploy is rolling back

- `129_ria_pick_legacy_retirement.sql` (merged 7/31 in 1c2f5104a) **drops** `ria_pick_uploads` / `ria_pick_upload_rows` and that same commit removed them from `REQUIRED_RUNTIME_TABLES`.
- PR #4660 (one-location-circles, forked before that commit) merged at 17:44 UTC and its conflict resolution **restored both names** into the guard (`server.py:65-66`).
- Since then every backend revision boots, hits `RuntimeError: Required runtime tables are missing: ria_pick_uploads, ria_pick_upload_rows`, serves 503 on `/health`, and the deploy pipeline rolls it back. Three consecutive deploy runs (31198924713, 31200095339, 31203889211) failed exactly this way; UAT is currently a half-release (new frontend, backend rolled back to consent-protocol-00379-dfh).

## Change

- Remove the two retired table names from `REQUIRED_RUNTIME_TABLES`.
- Regression test: retired tables must never reappear in the guard.

## Proof

- Revision log: `RuntimeError: Required runtime tables are missing: ria_pick_uploads, ria_pick_upload_rows` on consent-protocol-00382-7w6.
- No non-test code references these tables anymore (only server.py did).
- Local gate: ruff, mypy (CI invocation), bandit, **540 backend tests passed**.