### PR TITLE
feat(ria): stage claimed regulator facts in the PKM and finish setup server-side

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_claim_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_service.py
@@ -587,6 +587,26 @@ class RIAClaimService:
             )
         )
         branch = advisor_record.get("branch") or {}
+        # What the regulator publishes, so the screen can show the person what
+        # was filled in for them rather than an empty profile.
+        facts = {
+            "crd_number": crd_number,
+            "regulator": "SEC" if firm.get("registration_type") == "sec" else "State",
+            "regulator_status": firm.get("registration_status"),
+            "registered_since": advisor_record.get("registered_since"),
+            "branch_city": branch.get("city"),
+            "branch_state": branch.get("state"),
+            "exams": advisor_record.get("exams", []),
+            "registered_states": advisor_record.get("registered_states", []),
+            "previous_firms": advisor_record.get("previous_firms", []),
+            "notice_filed_states": firm.get("notice_filed_states", []),
+            "aum": firm.get("aum"),
+            "num_accounts": firm.get("num_accounts"),
+            "firm_website": firm.get("website"),
+            "report_url": advisor_record.get("report_url") or firm.get("report_url"),
+            "has_disclosures": advisor_record.get("has_disclosures"),
+        }
+        await self._record_claim_enrichment(user_id, facts)
         return {
             "status": "claimed",
             "claim_type": claim_type,
@@ -594,23 +614,54 @@ class RIAClaimService:
             "profile_verified": profile_verified,
             "provisional": provisional,
             "profile": profile,
-            # What the regulator publishes, so the screen can show the person
-            # what was filled in for them rather than an empty profile.
-            "facts": {
-                "crd_number": crd_number,
-                "regulator": "SEC" if firm.get("registration_type") == "sec" else "State",
-                "regulator_status": firm.get("registration_status"),
-                "registered_since": advisor_record.get("registered_since"),
-                "branch_city": branch.get("city"),
-                "branch_state": branch.get("state"),
-                "exams": advisor_record.get("exams", []),
-                "registered_states": advisor_record.get("registered_states", []),
-                "previous_firms": advisor_record.get("previous_firms", []),
-                "notice_filed_states": firm.get("notice_filed_states", []),
-                "aum": firm.get("aum"),
-                "num_accounts": firm.get("num_accounts"),
-                "firm_website": firm.get("website"),
-                "report_url": advisor_record.get("report_url") or firm.get("report_url"),
-                "has_disclosures": advisor_record.get("has_disclosures"),
-            },
+            "facts": facts,
         }
+
+    async def _record_claim_enrichment(self, user_id: str, facts: dict[str, Any]) -> None:
+        """Stage the claim's regulator facts in the user's knowledge planes.
+
+        The encrypted PKM blob is BYOK — only the owner's unlocked vault can
+        write it, so the client does that from the done screen. Here the server
+        writes the planes it legitimately owns: the append-only audit event
+        (the staged facts a vault session can materialize), the sanitized
+        discovery flag, and the durable setup mirror that marks the RIA
+        capability finished. Each block is best-effort in isolation: a claim
+        must never fail, and one plane must never block another.
+        """
+        try:
+            from hushh_mcp.services.personal_knowledge_model_service import get_pkm_service
+
+            await get_pkm_service().record_mutation_event(
+                user_id=user_id,
+                domain="ria",
+                operation_type="attribute_inference",
+                path_set=["regulator_profile"],
+                source_agent=CLAIM_PROVIDER_LABEL,
+                confidence=1.0,
+                metadata={"regulator_profile": facts},
+            )
+        except Exception as exc:  # noqa: BLE001 - enrichment is best-effort
+            logger.info("ria.claim_pkm_event_skipped error=%s", type(exc).__name__)
+
+        try:
+            from hushh_mcp.services.personal_knowledge_model_service import get_pkm_service
+
+            await get_pkm_service().update_domain_summary(
+                user_id, "ria", {"has_regulator_profile": True}
+            )
+        except Exception as exc:  # noqa: BLE001 - enrichment is best-effort
+            logger.info("ria.claim_pkm_summary_skipped error=%s", type(exc).__name__)
+
+        try:
+            from hushh_mcp.services.vault_keys_service import VaultKeysService
+
+            vault_keys = VaultKeysService()
+            state = await vault_keys.get_pre_vault_state(user_id)
+            capability_ids = [str(v) for v in (state.get("setupCapabilityIds") or [])]
+            if "ria" not in capability_ids:
+                await vault_keys.update_pre_vault_state(
+                    user_id=user_id,
+                    setup_capability_ids=sorted({*capability_ids, "ria"}),
+                )
+        except Exception as exc:  # noqa: BLE001 - enrichment is best-effort
+            logger.info("ria.claim_setup_mirror_skipped error=%s", type(exc).__name__)

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4487,6 +4487,7 @@ class RIAIAMService:
                           advisory_firm_iapd_number = NULLIF($6, ''),
                           advisory_status = $7,
                           advisory_provider = $8,
+                          brokerage_status = 'draft',
                           updated_at = NOW()
                         WHERE id = $1
                         """,

--- a/consent-protocol/tests/test_ria_claim_pkm_enrichment.py
+++ b/consent-protocol/tests/test_ria_claim_pkm_enrichment.py
@@ -1,0 +1,148 @@
+"""Claim completion stages regulator facts in the server-writable PKM planes.
+
+The encrypted PKM blob is BYOK, so the server never writes it. What the server
+does write after a claim — the audit event, the discovery flag, and the durable
+setup mirror — must be best-effort in isolation: no plane may fail the claim,
+and one plane failing may not block another.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import hushh_mcp.services.personal_knowledge_model_service as pkm_module
+import hushh_mcp.services.vault_keys_service as vault_keys_module
+from hushh_mcp.services.ria_claim_service import RIAClaimService
+from tests.test_ria_claim_flow import (
+    _EVALUATE_VERIFIED,
+    _TEST_UID,
+    _FakeIamService,
+    _FakeIdentityClient,
+)
+
+
+class _FakePkmService:
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.mutation_events: list[dict[str, Any]] = []
+        self.summaries: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def record_mutation_event(self, **kwargs: Any) -> bool:
+        if self.fail:
+            raise RuntimeError("pkm plane down")
+        self.mutation_events.append(kwargs)
+        return True
+
+    async def update_domain_summary(self, user_id: str, domain: str, summary: dict) -> bool:
+        if self.fail:
+            raise RuntimeError("pkm plane down")
+        self.summaries.append((user_id, domain, summary))
+        return True
+
+
+class _FakeVaultKeysService:
+    existing_ids: list[str] = []
+    fail = False
+    get_calls: list[str] = []
+    update_calls: list[dict[str, Any]] = []
+
+    async def get_pre_vault_state(self, user_id: str) -> dict[str, Any]:
+        if type(self).fail:
+            raise RuntimeError("vault keys down")
+        type(self).get_calls.append(user_id)
+        return {"setupCapabilityIds": list(type(self).existing_ids)}
+
+    async def update_pre_vault_state(self, *, user_id: str, **kwargs: Any) -> dict[str, Any]:
+        type(self).update_calls.append({"user_id": user_id, **kwargs})
+        return {}
+
+
+def _wire_fakes(monkeypatch, *, pkm_fail=False, vault_fail=False, existing_ids=None):
+    pkm = _FakePkmService(fail=pkm_fail)
+    monkeypatch.setattr(pkm_module, "get_pkm_service", lambda: pkm)
+    _FakeVaultKeysService.existing_ids = list(existing_ids or [])
+    _FakeVaultKeysService.fail = vault_fail
+    _FakeVaultKeysService.get_calls = []
+    _FakeVaultKeysService.update_calls = []
+    monkeypatch.setattr(vault_keys_module, "VaultKeysService", _FakeVaultKeysService)
+    return pkm
+
+
+def _service() -> RIAClaimService:
+    return RIAClaimService(
+        client=_FakeIdentityClient(evaluate_payload=_EVALUATE_VERIFIED),
+        iam_service=_FakeIamService(),
+    )
+
+
+async def _complete(service: RIAClaimService) -> dict[str, Any]:
+    return await service.complete(
+        user_id=_TEST_UID,
+        phone_digits="8015663510",
+        claim_type="individual",
+        firm_crd=283040,
+        individual_crd=5308823,
+    )
+
+
+async def test_complete_stages_facts_and_mirrors_setup(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    pkm = _wire_fakes(monkeypatch)
+
+    result = await _complete(_service())
+
+    assert result["status"] == "claimed"
+    event = pkm.mutation_events[0]
+    assert event["user_id"] == _TEST_UID
+    assert event["domain"] == "ria"
+    assert event["operation_type"] == "attribute_inference"
+    assert event["source_agent"] == "ria_identity_claim"
+    assert event["path_set"] == ["regulator_profile"]
+    # The staged facts are the same object the response shows the person.
+    assert event["metadata"]["regulator_profile"] == result["facts"]
+
+    assert pkm.summaries == [(_TEST_UID, "ria", {"has_regulator_profile": True})]
+
+    assert _FakeVaultKeysService.get_calls == [_TEST_UID]
+    update = _FakeVaultKeysService.update_calls[0]
+    assert update["user_id"] == _TEST_UID
+    assert "ria" in update["setup_capability_ids"]
+
+
+async def test_setup_mirror_preserves_other_capabilities(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    _wire_fakes(monkeypatch, existing_ids=["mail", "wallet"])
+
+    await _complete(_service())
+
+    update = _FakeVaultKeysService.update_calls[0]
+    assert update["setup_capability_ids"] == ["mail", "ria", "wallet"]
+
+
+async def test_setup_mirror_is_a_noop_on_reclaim(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    _wire_fakes(monkeypatch, existing_ids=["ria"])
+
+    await _complete(_service())
+
+    assert _FakeVaultKeysService.update_calls == []
+
+
+async def test_claim_succeeds_when_every_enrichment_plane_fails(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    _wire_fakes(monkeypatch, pkm_fail=True, vault_fail=True)
+
+    result = await _complete(_service())
+
+    assert result["status"] == "claimed"
+    assert result["facts"]["crd_number"] == "5308823"
+
+
+async def test_pkm_plane_failure_does_not_block_setup_mirror(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    _wire_fakes(monkeypatch, pkm_fail=True)
+
+    await _complete(_service())
+
+    update = _FakeVaultKeysService.update_calls[0]
+    assert "ria" in update["setup_capability_ids"]

--- a/hushh-webapp/__tests__/services/ria-service-regulator-profile.test.ts
+++ b/hushh-webapp/__tests__/services/ria-service-regulator-profile.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetchMock = vi.fn();
+const loadDomainDataMock = vi.fn();
+const saveMergedDomainMock = vi.fn();
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  },
+}));
+
+vi.mock("@/lib/cache/request-audit-log", () => ({
+  logRequestAudit: vi.fn(),
+}));
+
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    read: vi.fn(),
+    write: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {
+    loadDomainData: (...args: unknown[]) => loadDomainDataMock(...args),
+  },
+  PkmScopeExposureError: class PkmScopeExposureError extends Error {},
+}));
+
+vi.mock("@/lib/services/pkm-write-coordinator", () => ({
+  PkmWriteCoordinator: {
+    saveMergedDomain: (...args: unknown[]) => saveMergedDomainMock(...args),
+  },
+}));
+
+vi.mock("@/lib/observability/client", () => ({
+  trackEvent: vi.fn(),
+  toEventResult: vi.fn((value) => value),
+  toStatusBucket: vi.fn((value) => value),
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  resolveGrowthWorkspaceSource: vi.fn(() => "test"),
+  trackGrowthFunnelStepCompleted: vi.fn(),
+}));
+
+const FACTS = {
+  crd_number: "5308823",
+  regulator: "SEC",
+  regulator_status: "active",
+  exams: [{ code: "S65" }],
+};
+
+const PICKS_PAYLOAD = {
+  top_picks: [],
+  avoid_rows: [],
+  screening_sections: [],
+  package_note: null,
+  revision: 3,
+  updated_at: "2026-08-01T00:00:00.000Z",
+};
+
+async function capturePlan(): Promise<{
+  params: Record<string, any>;
+  plan: { domainData: Record<string, unknown>; summary: Record<string, unknown> };
+}> {
+  const params = saveMergedDomainMock.mock.calls[0][0];
+  const plan = await params.build({});
+  return { params, plan };
+}
+
+describe("RiaService.saveRegulatorProfile", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+    loadDomainDataMock.mockReset();
+    saveMergedDomainMock.mockReset();
+    saveMergedDomainMock.mockResolvedValue({ success: true, dataVersion: 2 });
+  });
+
+  it("writes regulator_profile with an owner confirmation from the claim", async () => {
+    loadDomainDataMock.mockResolvedValue(null);
+    const { RiaService } = await import("@/lib/services/ria-service");
+
+    const ok = await RiaService.saveRegulatorProfile({
+      userId: "u1",
+      vaultKey: "key",
+      vaultOwnerToken: "token",
+      facts: FACTS,
+    });
+
+    expect(ok).toBe(true);
+    const { params, plan } = await capturePlan();
+    expect(params.domain).toBe("ria");
+    expect(params.confirmation).toMatchObject({
+      confirmedByUser: true,
+      source: "ria_identity_claim_regulator_facts",
+    });
+    expect(plan.domainData.regulator_profile).toMatchObject(FACTS);
+    expect(plan.summary).toMatchObject({ has_regulator_profile: true });
+  });
+
+  it("keeps an existing picks package beside the new regulator_profile", async () => {
+    loadDomainDataMock.mockResolvedValue({
+      schema_version: 1,
+      advisor_package: PICKS_PAYLOAD,
+    });
+    const { RiaService } = await import("@/lib/services/ria-service");
+
+    await RiaService.saveRegulatorProfile({
+      userId: "u1",
+      vaultKey: "key",
+      vaultOwnerToken: "token",
+      facts: FACTS,
+    });
+
+    const { plan } = await capturePlan();
+    expect(plan.domainData.advisor_package).toMatchObject({ revision: 3 });
+    expect(plan.domainData.regulator_profile).toMatchObject(FACTS);
+    expect(plan.summary).toMatchObject({
+      has_regulator_profile: true,
+      package_revision: 3,
+    });
+  });
+
+  it("reports a blocked save without throwing", async () => {
+    loadDomainDataMock.mockRejectedValue(new Error("vault locked"));
+    saveMergedDomainMock.mockResolvedValue({ success: false });
+    const { RiaService } = await import("@/lib/services/ria-service");
+
+    const ok = await RiaService.saveRegulatorProfile({
+      userId: "u1",
+      vaultKey: null,
+      vaultOwnerToken: null,
+      facts: FACTS,
+    });
+
+    expect(ok).toBe(false);
+  });
+});
+
+describe("RiaService.savePickPackage sibling preservation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+    loadDomainDataMock.mockReset();
+    saveMergedDomainMock.mockReset();
+    saveMergedDomainMock.mockResolvedValue({ success: true, dataVersion: 4 });
+    apiFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ metadata: {} }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+
+  it("carries regulator_profile forward when saving picks", async () => {
+    loadDomainDataMock.mockResolvedValue({
+      schema_version: 1,
+      advisor_package: PICKS_PAYLOAD,
+      regulator_profile: { ...FACTS, updated_at: "2026-08-07T00:00:00.000Z" },
+    });
+    const { RiaService } = await import("@/lib/services/ria-service");
+
+    await RiaService.savePickPackage({
+      idToken: "id-token",
+      userId: "u1",
+      vaultKey: "key",
+      vaultOwnerToken: "token",
+      top_picks: [],
+      avoid_rows: [],
+      screening_sections: [],
+    });
+
+    const { plan } = await capturePlan();
+    expect(plan.domainData.regulator_profile).toMatchObject(FACTS);
+    expect(plan.domainData.advisor_package).toBeTruthy();
+    expect(plan.summary).toMatchObject({ has_regulator_profile: true });
+  });
+});

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -33,6 +33,7 @@ import { Button } from "@/lib/morphy-ux/button";
 import { normalizeInternalRouteHref, ROUTES } from "@/lib/navigation/routes";
 import { usePersonaState } from "@/lib/persona/persona-context";
 import { PreVaultUserStateService } from "@/lib/services/pre-vault-user-state-service";
+import { useVault } from "@/lib/vault/vault-context";
 import {
   RiaApiError,
   RiaService,
@@ -251,6 +252,7 @@ export default function RiaClaimPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, phoneNumber: accountPhone, loading: authLoading } = useAuth();
+  const { vaultKey, vaultOwnerToken } = useVault();
   const { refresh: refreshPersonaState } = usePersonaState();
   // Arrives pre-filled when the sign-up phone screen recognised this number.
   // Someone who verified their phone on an earlier visit never sees that
@@ -408,6 +410,26 @@ export default function RiaClaimPage() {
     },
     [firmCrd, phoneDigits, getIdToken, refreshPersonaState, user],
   );
+
+  // The regulator facts shown on the done screen also belong to the person's
+  // own encrypted knowledge store. That write needs the unlocked vault, which
+  // only this session has — fired when they act on the done screen, so the
+  // owner confirmation covers exactly the data they just looked at. Locked
+  // vault or any failure is silently fine: the server keeps a staged copy.
+  const factsPersistedRef = useRef(false);
+  const persistFactsToPkm = useCallback(() => {
+    const facts = completeResult?.facts;
+    if (factsPersistedRef.current || !facts || !user) return;
+    factsPersistedRef.current = true;
+    void RiaService.saveRegulatorProfile({
+      userId: user.uid,
+      vaultKey,
+      vaultOwnerToken,
+      facts,
+    }).catch(() => {
+      // Best-effort by design; the claim itself is already recorded.
+    });
+  }, [completeResult, user, vaultKey, vaultOwnerToken]);
 
   /** Route a verify result onward: complete it, or ask which adviser. */
   const settleVerifyResult = useCallback(
@@ -967,13 +989,14 @@ export default function RiaClaimPage() {
                   size="lg"
                   fullWidth
                   className="h-12 text-base"
-                  onClick={() =>
+                  onClick={() => {
+                    persistFactsToPkm();
                     router.replace(
                       rootSetupUnresolved || returnTo
                         ? returnTo || ROUTES.ONE_SETUP
                         : ROUTES.RIA_PROFILE,
-                    )
-                  }
+                    );
+                  }}
                   data-voice-control-id="ria-claim-open-profile"
                 >
                   {rootSetupUnresolved || returnTo ? "Continue setup" : "Open your profile"}
@@ -985,7 +1008,10 @@ export default function RiaClaimPage() {
                     size="lg"
                     fullWidth
                     className="h-12 text-base"
-                    onClick={() => router.replace(ROUTES.RIA_PROFILE)}
+                    onClick={() => {
+                      persistFactsToPkm();
+                      router.replace(ROUTES.RIA_PROFILE);
+                    }}
                   >
                     View profile
                   </Button>

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -803,6 +803,7 @@ interface ErrorPayload {
 
 const RIA_PICKS_DOMAIN = "ria";
 const RIA_PICKS_PATH = "advisor_package";
+const RIA_REGULATOR_PROFILE_PATH = "regulator_profile";
 const RIA_PICKS_DOMAIN_SCHEMA_VERSION = 1;
 
 function emptyRiaPickPackage(): RiaPickPackage {
@@ -2303,6 +2304,82 @@ export class RiaService {
     );
   }
 
+  /**
+   * Store the regulator facts from a completed claim in the owner's encrypted
+   * "ria" domain, under a `regulator_profile` key beside the picks package.
+   *
+   * Called from the claim done screen after the facts have been shown, so the
+   * confirmation reflects a real owner action on visible data. When the vault
+   * is locked the coordinator returns `blocked_pending_unlock` without
+   * throwing — the server-side staged audit event remains the durable record.
+   */
+  static async saveRegulatorProfile(params: {
+    userId: string;
+    vaultKey?: string | null;
+    vaultOwnerToken?: string | null;
+    facts: RiaClaimProfileFacts;
+  }): Promise<boolean> {
+    if (!params.vaultKey || !params.vaultOwnerToken) {
+      // Locked vault: nothing to do here — the server-side staged audit
+      // event is the durable record until an unlocked session confirms.
+      return false;
+    }
+    const nextUpdatedAt = new Date().toISOString();
+    const currentDomain = await PersonalKnowledgeModelService.loadDomainData({
+      userId: params.userId,
+      domain: RIA_PICKS_DOMAIN,
+      vaultKey: params.vaultKey,
+      vaultOwnerToken: params.vaultOwnerToken,
+    }).catch(() => null);
+    const currentSiblings =
+      currentDomain &&
+      typeof currentDomain === "object" &&
+      !Array.isArray(currentDomain)
+        ? (currentDomain as Record<string, unknown>)
+        : {};
+    const currentPicks = parseRiaPicksDomain(currentSiblings);
+    const result = await PkmWriteCoordinator.saveMergedDomain({
+      userId: params.userId,
+      domain: RIA_PICKS_DOMAIN,
+      vaultKey: params.vaultKey,
+      vaultOwnerToken: params.vaultOwnerToken,
+      confirmation: {
+        confirmedByUser: true,
+        surface: "web",
+        source: "ria_identity_claim_regulator_facts",
+      },
+      build: () => ({
+        domainData: {
+          schema_version: RIA_PICKS_DOMAIN_SCHEMA_VERSION,
+          ...currentSiblings,
+          [RIA_REGULATOR_PROFILE_PATH]: {
+            ...params.facts,
+            updated_at: nextUpdatedAt,
+          },
+          updated_at: nextUpdatedAt,
+        },
+        summary: {
+          domain_contract_version: 1,
+          has_regulator_profile: true,
+          last_updated: nextUpdatedAt,
+          // Keep the picks discovery fields intact when picks exist, since a
+          // domain summary write replaces the whole summary.
+          ...(currentPicks
+            ? {
+                package_revision: currentPicks.revision,
+                top_pick_count: currentPicks.package.top_picks.length,
+                avoid_count: currentPicks.package.avoid_rows.length,
+                screening_row_count: countScreeningRows(
+                  currentPicks.package.screening_sections,
+                ),
+              }
+            : {}),
+        },
+      }),
+    });
+    return result.success;
+  }
+
   static async savePickPackage(params: {
     idToken: string;
     userId: string;
@@ -2339,6 +2416,15 @@ export class RiaService {
         : null,
     );
     const nextRevision = Math.max(1, Number(currentParsed?.revision || 0) + 1);
+    // The "ria" domain holds more than picks (e.g. regulator_profile from a
+    // claim). Carry every current key forward so a picks save can never erase
+    // a sibling written by another flow.
+    const currentSiblings =
+      currentDomain &&
+      typeof currentDomain === "object" &&
+      !Array.isArray(currentDomain)
+        ? (currentDomain as Record<string, unknown>)
+        : {};
     const result = await PkmWriteCoordinator.saveMergedDomain({
       userId: params.userId,
       domain: RIA_PICKS_DOMAIN,
@@ -2350,11 +2436,14 @@ export class RiaService {
         source: "ria_picks_package_owner_save",
       },
       build: () => ({
-        domainData: buildRiaPicksDomainData({
-          pkg: nextPackage,
-          revision: nextRevision,
-          updatedAt: nextUpdatedAt,
-        }),
+        domainData: {
+          ...currentSiblings,
+          ...buildRiaPicksDomainData({
+            pkg: nextPackage,
+            revision: nextRevision,
+            updatedAt: nextUpdatedAt,
+          }),
+        },
         summary: {
           domain_contract_version: 1,
           package_revision: nextRevision,
@@ -2364,6 +2453,9 @@ export class RiaService {
             nextPackage.screening_sections,
           ),
           last_updated: nextUpdatedAt,
+          ...(currentSiblings[RIA_REGULATOR_PROFILE_PATH]
+            ? { has_regulator_profile: true }
+            : {}),
         },
       }),
     });


### PR DESCRIPTION
Completes the claim story: the regulator record now reaches the person's PKM (Personal Knowledge Model) and the RIA capability finishes durably server-side — with nothing asked of the user, and without touching the "Finish setting up One" flow.

## Why the split (consent architecture)

The encrypted PKM blob is BYOK — the server never holds the vault key, and `store_domain_data` refuses writes without an owner-confirmed mutation plan. So:

- **Server writes only the planes it legitimately owns** (`RIAClaimService._record_claim_enrichment`, three independent best-effort blocks):
  1. `pkm_events` append-only audit entry staging the full regulator facts (`source_agent=ria_identity_claim`, `path_set=[regulator_profile]`)
  2. sanitized `has_regulator_profile` discovery flag via `update_domain_summary`
  3. durable setup mirror: `vault_keys.setup_capability_ids ∪ {'ria'}` — previously client-only best-effort, now guaranteed even if the client sync never runs
- **Client writes the encrypted plane with real owner confirmation**: the done screen's CTA (after the facts are displayed) writes them into the encrypted `ria` domain under `regulator_profile` via `RiaService.saveRegulatorProfile`. Locked vault skips silently — the staged server copy remains the durable record.

## Data-integrity fix riding along

`savePickPackage` rebuilt the whole `ria` domain from picks keys only, so any sibling key would have been erased on the next picks save. It now carries unknown siblings forward (and `saveRegulatorProfile` symmetrically preserves the picks package + its summary fields).

## Also

- Claim capability write gains `brokerage_status='draft'` parity with the wizard.
- Never blocks a claim: every enrichment failure is caught per-plane and logged.
- Idempotent under re-claim: set-union mirror (no-op when 'ria' present), same-key merge for the encrypted write, append-only audit by design.

## Proof

- Backend gate (CI script): ruff, mypy, bandit, **540 passed** — includes 5 new tests in `test_ria_claim_pkm_enrichment.py` (facts staged + mirrored, other capabilities preserved, re-claim no-op, all-planes-fail still claims, one plane failing doesn't block another).
- Frontend: tsc 0 errors, eslint clean, 4 new tests in `ria-service-regulator-profile.test.ts` (owner confirmation shape, picks preserved beside regulator_profile and vice versa, locked vault returns false without throwing).
- Full vitest suite branch-vs-base: branch fails a strict SUBSET of origin/main's failing set (16/65 vs 17/65) — zero new failures.