### PR TITLE
fix(one-location): preserve request reason

### DIFF
--- a/hushh-webapp/__tests__/lib/one-location/request-message.test.ts
+++ b/hushh-webapp/__tests__/lib/one-location/request-message.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOneLocationRequestMessage } from "@/lib/one-location/request-message";
+
+describe("buildOneLocationRequestMessage", () => {
+  it("preserves the selected reason when the optional message is blank", () => {
+    expect(buildOneLocationRequestMessage("Safety check-in", "")).toBe(
+      "Safety check-in",
+    );
+  });
+
+  it("composes the selected reason with the optional message", () => {
+    expect(
+      buildOneLocationRequestMessage(
+        "Meeting nearby",
+        "I'm near the entrance",
+      ),
+    ).toBe("Meeting nearby — I'm near the entrance");
+  });
+
+  it("trims both fields without inventing content", () => {
+    expect(
+      buildOneLocationRequestMessage(
+        "  Pick-up  ",
+        "  Outside gate  ",
+      ),
+    ).toBe("Pick-up — Outside gate");
+  });
+
+  it("preserves legacy message-only callers and fails empty input closed", () => {
+    expect(buildOneLocationRequestMessage(null, "Please share")).toBe(
+      "Please share",
+    );
+    expect(buildOneLocationRequestMessage(null, "   ")).toBeUndefined();
+  });
+});

--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -165,6 +165,7 @@ import {
 import { LocationImmersiveMap } from "@/components/one-location/location-immersive-map";
 import { buildOneLocationActivityFallback } from "@/lib/one-location/activity";
 import { ONE_LOCATION_SHARE_NOTE_MAX_LENGTH } from "@/lib/one-location/message-limits";
+import { buildOneLocationRequestMessage } from "@/lib/one-location/request-message";
 import {
   clearLocationWorkspaceMemory,
   readLocationWorkspaceMemory,
@@ -4410,7 +4411,7 @@ export function OneLocationAgentPageContent({
     }
   }, [auth.user, contactSignal]);
 
-  const handleRequestAccess = useCallback(async () => {
+  const handleRequestAccess = useCallback(async (reason?: string | null) => {
     if (!vaultOwnerToken || !selectedRequestOwners.length) return;
     if (!auth.user || !auth.userId) {
       toast.error("Refresh your session before sending a location request.");
@@ -4450,7 +4451,7 @@ export function OneLocationAgentPageContent({
         await OneLocationService.requestAccess({
           vaultOwnerToken: activeVaultOwnerToken,
           ownerUserId: owner.userId,
-          message: requestMessage.trim() || undefined,
+          message: buildOneLocationRequestMessage(reason, requestMessage),
         });
         successCount += 1;
       }
@@ -7424,7 +7425,7 @@ export function OneLocationAgentPageContent({
     onShareToContacts: () => void handleShareContactInvite(),
     onOpenShareReview: () => void handleOpenShareReview(),
     onConfirmShare: () => void handleShare(),
-    onSendRequest: () => void handleRequestAccess(),
+    onSendRequest: (reason) => void handleRequestAccess(reason),
     onApprove: (request) => void handleApprove(request),
     onDeny: (requestId) => void handleDeny(requestId),
     onViewGrant: (grant) => void handleView(grant),

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -239,7 +239,7 @@ export type LocationHubViewModel = {
   onShareToContacts: () => void;
   onOpenShareReview: () => void;
   onConfirmShare: () => void;
-  onSendRequest: () => void;
+  onSendRequest: (reason?: string | null) => void;
   onApprove: (request: OneLocationAccessRequest) => void;
   onDeny: (requestId: string) => void;
   onViewGrant: (grant: OneLocationGrant) => void;
@@ -2327,7 +2327,7 @@ function AskFlow({
 
       <Button
         onClick={() => {
-          vm.onSendRequest();
+          vm.onSendRequest(reason);
           onClose();
         }}
         disabled={!vm.selectedRequestOwnerIds.length}

--- a/hushh-webapp/lib/one-location/request-message.ts
+++ b/hushh-webapp/lib/one-location/request-message.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the single request.message value stored by One Location.
+ *
+ * The Ask flow exposes "Reason" and "Message" as separate UI fields, while the
+ * existing request API persists one optional message string. Keep that storage
+ * contract stable and compose the two fields deterministically.
+ */
+export function buildOneLocationRequestMessage(
+  reason?: string | null,
+  message?: string | null,
+): string | undefined {
+  const normalizedReason = String(reason ?? "").trim();
+  const normalizedMessage = String(message ?? "").trim();
+
+  if (normalizedReason && normalizedMessage) {
+    return `${normalizedReason} — ${normalizedMessage}`;
+  }
+
+  return normalizedReason || normalizedMessage || undefined;
+}


### PR DESCRIPTION
## Problem

The One Location Ask flow captures a reason such as 'Safety check-in', but the selected reason was dropped before the access request was stored.

## Fix

Carry the selected reason through the Ask flow contract and compose it with the optional request message.

Examples:
- Safety check-in + blank message → Safety check-in
- Meeting nearby + I'm near the entrance → Meeting nearby — I'm near the entrance

## Validation

- Focused regression test: 4/4 passed
- TypeScript typecheck: passed

## Scope

Limited to the One Location Ask flow, request handler, request-message composition, and regression coverage.