### PR TITLE
fix(web): turn the full suite green — align stale tests with shipped intent (unwedges the merge queue)

### DIFF
--- a/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
+++ b/hushh-webapp/__tests__/components/capability-cinematic-intro.test.tsx
@@ -150,7 +150,7 @@ describe("CapabilityCinematicIntroGate", () => {
     );
 
     expect(gateSource).toContain(
-      "min-h-[calc(100dvh-var(--top-shell-reserved-height)-var(--app-scroll-bottom-pad,0px))]",
+      "min-h-[calc(100dvh-var(--top-shell-reserved-height,4rem)-var(--app-scroll-bottom-pad,2rem))]",
     );
     expect(gateSource).not.toContain("overflow-hidden");
   });

--- a/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
+++ b/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
@@ -17,23 +17,6 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ user: { uid: "user_1" } }),
 }));
 
-vi.mock("@/lib/vault/vault-context", () => ({
-  useVault: () => ({
-    vaultKey: "vault-key",
-    vaultOwnerToken: "owner-token",
-  }),
-}));
-
-vi.mock("@/components/vault/vault-unlock-dialog", () => ({
-  VaultUnlockDialog: () => null,
-}));
-
-vi.mock("@/components/app-ui/onboarding-stepper", () => ({
-  OnboardingStepper: ({ currentIndex }: { currentIndex: number }) => (
-    <div data-testid="onboarding-stepper">Step {currentIndex + 1}</div>
-  ),
-}));
-
 vi.mock("@/lib/services/kyc-identity-profile-pkm-service", () => ({
   KycIdentityProfilePkmService: {
     saveProfile: mocks.saveProfile,
@@ -41,7 +24,6 @@ vi.mock("@/lib/services/kyc-identity-profile-pkm-service", () => ({
   KycIdentityProfileDraftService: {
     stage: mocks.stageProfile,
   },
-  isValidDateOfBirth: (value: string) => value === "1994-04-15",
 }));
 
 vi.mock("sonner", () => ({
@@ -58,80 +40,35 @@ describe("KycIdentityPreface", () => {
     mocks.saveProfile.mockResolvedValue({ success: true });
   });
 
-  it("stages four identity answers in memory without opening the vault", async () => {
+  it("stages the about-me summary in memory without opening the vault", () => {
     const onComplete = vi.fn();
     render(<KycIdentityPreface onComplete={onComplete} />);
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
 
-    fireEvent.change(screen.getByLabelText("Legal name"), {
-      target: { value: "Avery Example" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(
+      screen.getByRole("button", { name: "Save & Continue" }),
+    ).toBeDisabled();
 
-    expect(screen.getByLabelText("Date of birth")).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText("Date of birth"), {
-      target: { value: "1994-04-15" },
+    fireEvent.change(screen.getByLabelText("Tell us about yourself"), {
+      target: { value: "  Product designer in Pune, settling estate matters. " },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
-
-    fireEvent.change(screen.getByLabelText("Country of citizenship"), {
-      target: { value: "IN" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
-
-    fireEvent.change(screen.getByLabelText("Employment status"), {
-      target: { value: "employed" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save & Continue" }));
 
     expect(onComplete).toHaveBeenCalledTimes(1);
-
     expect(KycIdentityProfileDraftService.stage).toHaveBeenCalledWith(
       "user_1",
       {
-        legalName: "Avery Example",
-        dateOfBirth: "1994-04-15",
-        citizenshipCountryCode: "IN",
-        citizenshipCountryName: "India",
-        employmentStatus: "employed",
+        aboutMe: "Product designer in Pune, settling estate matters.",
       },
     );
     expect(KycIdentityProfilePkmService.saveProfile).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("does not let a future date advance KYC setup", () => {
-    render(<KycIdentityPreface onComplete={vi.fn()} />);
-    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-    fireEvent.change(screen.getByLabelText("Legal name"), {
-      target: { value: "Avery Example" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Next" }));
-
-    fireEvent.change(screen.getByLabelText("Date of birth"), {
-      target: { value: "2099-01-01" },
-    });
-
-    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
-    expect(screen.getByLabelText("Date of birth")).toBeInTheDocument();
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Enter a real date of birth in the past.",
-    );
-  });
-
-  it("lets a user skip questions without writing a partial identity profile", () => {
+  it("lets a user skip KYC setup without writing a partial identity profile", () => {
     const onComplete = vi.fn();
     render(<KycIdentityPreface onComplete={onComplete} />);
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-
-    fireEvent.click(screen.getByRole("button", { name: "Skip this question" }));
-    expect(screen.getByLabelText("Date of birth")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Skip this question" }));
-    expect(screen.getByLabelText("Country of citizenship")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Skip this question" }));
-    expect(screen.getByLabelText("Employment status")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Skip KYC setup" }));
 

--- a/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-agent-page.test.tsx
@@ -279,6 +279,44 @@ vi.mock("@/lib/one-location/service", () => ({
     createCircleInvite: mockCreateCircleInvite,
     revokePublicInvite: vi.fn(),
     revokeCircleInvite: vi.fn(),
+    // Named-circle surface: the mandatory onboarding invite screen
+    // find-or-creates the user's first owned Circle and issues its
+    // member-visible invite code before the people step opens.
+    listCircles: vi.fn().mockResolvedValue([]),
+    getCircle: vi.fn(),
+    createNamedCircle: vi.fn().mockResolvedValue({
+      id: "circle_onboarding",
+      name: "Test's Circle",
+      kind: "family",
+      role: "owner",
+      memberCount: 1,
+      memberLimit: 8,
+      members: [],
+      activeInviteCode: null,
+    }),
+    updateNamedCircle: vi.fn(),
+    deleteNamedCircle: vi.fn(),
+    createNamedCircleInviteCode: vi.fn().mockResolvedValue({
+      id: "invite_code_1",
+      circleId: "circle_onboarding",
+      code: "HUSHH123",
+      expiresAt: "2026-05-23T07:30:00.000Z",
+    }),
+    revokeNamedCircleInviteCode: vi.fn(),
+    resolveNamedCircleCode: vi.fn(),
+    joinNamedCircle: vi.fn(),
+    leaveNamedCircle: vi.fn(),
+    removeNamedCircleMember: vi.fn(),
+    listNamedCircleEligibleConnections: vi.fn(),
+    createNamedCircleMemberInvites: vi.fn(),
+    listNamedCircleMemberInvites: vi.fn().mockResolvedValue([]),
+    acceptNamedCircleMemberInvite: vi.fn(),
+    declineNamedCircleMemberInvite: vi.fn(),
+    cancelNamedCircleMemberInvite: vi.fn(),
+    addSmsContact: vi.fn(),
+    removeSmsContact: vi.fn(),
+    routeEta: vi.fn(),
+    createGrantWithEnvelope: vi.fn(),
   },
 }));
 
@@ -528,6 +566,18 @@ async function openLocationFeatureStep() {
   ).toBeTruthy();
 }
 
+// The features step now always advances into the mandatory invite screen
+// (the page provides onPrepareOnboardingCircleInvite). Wait for the code to
+// finish provisioning — the footer button reads "Next" only once the invite
+// is ready — then continue to the people step.
+async function passLocationInviteStep() {
+  expect(
+    await screen.findByRole("heading", { name: "Share your circle code" }),
+  ).toBeTruthy();
+  const nextButton = await screen.findByRole("button", { name: "Next" });
+  fireEvent.click(nextButton);
+}
+
 async function openLocationPeopleStep() {
   await openLocationFeatureStep();
   await waitFor(() => {
@@ -548,6 +598,7 @@ async function openLocationPeopleStep() {
   });
   await waitFor(() => expect(continueButton).toBeEnabled());
   fireEvent.click(continueButton);
+  await passLocationInviteStep();
   expect(
     await screen.findByRole("heading", { name: "Add people" }),
   ).toBeTruthy();
@@ -2016,6 +2067,7 @@ describe("OneLocationAgentPage", () => {
     expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
+    await passLocationInviteStep();
     expect(
       await screen.findByRole("heading", { name: "Add people" }),
     ).toBeTruthy();
@@ -2118,6 +2170,7 @@ describe("OneLocationAgentPage", () => {
     ).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
+    await passLocationInviteStep();
     expect(
       await screen.findByRole("heading", { name: "Add people" }),
     ).toBeTruthy();
@@ -2196,6 +2249,7 @@ describe("OneLocationAgentPage", () => {
     expect(await screen.findByTestId("save-location-modal")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
+    await passLocationInviteStep();
     expect(
       await screen.findByRole("heading", { name: "Add people" }),
     ).toBeTruthy();

--- a/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
+++ b/hushh-webapp/__tests__/components/one-location-onboarding-flow.test.tsx
@@ -155,7 +155,7 @@ describe("OneLocationOnboardingFlow", () => {
     expect(featureSurface?.className).toContain("bg-white");
     expect(featureSurface?.className).toContain("px-6");
     expect(featureSurface?.className).toContain(
-      "pt-[max(env(safe-area-inset-top,0px),12px)]",
+      "pt-[max(var(--app-safe-area-top-effective,0px),12px)]",
     );
 
     const featureScroll = document.querySelector("[data-one-feature-scroll]");
@@ -813,7 +813,7 @@ describe("OneLocationOnboardingFlow", () => {
       // welcome -> features
       fireEvent.click(screen.getByRole("button", { name: "Get started" }));
       // features -> invite (NOT people, because the invite screen is enabled)
-      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+      fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
 
       expect(
         screen.getByTestId("one-location-onboarding-invite"),
@@ -849,7 +849,7 @@ describe("OneLocationOnboardingFlow", () => {
       renderFlow({ onPrepareOnboardingCircleInvite });
 
       fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+      fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
 
       await waitFor(() =>
         expect(screen.getByText("temporary")).toBeTruthy(),
@@ -870,7 +870,7 @@ describe("OneLocationOnboardingFlow", () => {
     it("skips the invite screen entirely when no prepare handler is provided", () => {
       renderFlow();
       fireEvent.click(screen.getByRole("button", { name: "Get started" }));
-      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+      fireEvent.click(screen.getByRole("button", { name: "Add my people" }));
       // With no onPrepareOnboardingCircleInvite, Continue goes straight to the
       // contact list — the invite screen never appears.
       expect(screen.getByTestId("one-location-onboarding-people")).toBeTruthy();

--- a/hushh-webapp/__tests__/lib/vault/vault-context-resume.test.tsx
+++ b/hushh-webapp/__tests__/lib/vault/vault-context-resume.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@capacitor/core", () => ({
     getPlatform: () => (mocks.nativePlatform ? "android" : "web"),
     isNativePlatform: () => mocks.nativePlatform,
   },
+  registerPlugin: vi.fn(() => ({})),
 }));
 
 vi.mock("@/lib/firebase/auth-context", () => ({

--- a/hushh-webapp/__tests__/onboarding/setup-warm-transition.contract.test.ts
+++ b/hushh-webapp/__tests__/onboarding/setup-warm-transition.contract.test.ts
@@ -14,11 +14,11 @@ describe("setup warm-transition contract", () => {
     );
     const admission = coordinator.slice(0, coordinator.indexOf("const settle"));
 
-    expect(admission).toContain("getCachedBootstrapState?.(user.uid)");
+    expect(admission).toContain("getCachedBootstrapState?.(userId)");
     expect(admission).toContain(
-      "cachedJourney ??\n          (await PreVaultUserStateService.bootstrapState(user.uid))",
+      "cachedJourney ??\n          (await PreVaultUserStateService.bootstrapState(userId))",
     );
-    expect(admission).toContain("await PreVaultUserStateService.bootstrapState(user.uid)");
+    expect(admission).toContain("await PreVaultUserStateService.bootstrapState(userId)");
   });
 
   it("does not block every route change on a forced onboarding admission check", () => {

--- a/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
+++ b/hushh-webapp/__tests__/services/one-kyc-client-zk-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { formatLocalDateTime } from "@/lib/utils/local-date-time";
 
 vi.mock("@/lib/pkm/pkm-domain-resource", () => ({
   PkmDomainResourceService: {
@@ -647,7 +648,12 @@ describe("OneKycClientZkService", () => {
     expect(draft.body).toContain("Risk profile: Balanced");
     expect(draft.body).toContain("Investment horizon: Medium term");
     expect(draft.body).toContain("Drawdown response: Buy more");
-    expect(draft.body).toContain("Last updated: Mar 1, 2026");
+    expect(draft.body).toContain(
+      `Last updated: ${formatLocalDateTime("2026-03-01T18:49:42.147Z", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })}`,
+    );
     expect(draft.body).not.toContain("Financial profile\n\nFinancial profile");
     expect(draft.body).not.toContain("2026-03-01T18:49:42.147Z");
     expect(draft.body).not.toContain("onboarding");

--- a/hushh-webapp/__tests__/voice/setup-catalog-action-parity.test.ts
+++ b/hushh-webapp/__tests__/voice/setup-catalog-action-parity.test.ts
@@ -43,7 +43,7 @@ describe("setup catalog voice parity", () => {
         .filter((action) => action.action_id.startsWith("setup.open_"))
         .map((action) => action.label),
     ).toEqual([
-      "Set up Connections",
+      "Set up AI access",
       ...CAPABILITY_SETUP_COPY.map((capability) => capability.setupTitle),
     ]);
     expect(actions.get("setup.open_connections")?.execution_target).toMatchObject({

--- a/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
+++ b/hushh-webapp/components/one-location/__tests__/saved-locations-section.test.tsx
@@ -72,6 +72,42 @@ vi.mock("@/lib/one-location/service", () => ({
   },
 }));
 
+vi.mock("@/components/one-location/onboarding/location-picker-map", () => ({
+  LocationPickerMap: ({
+    onConfirm,
+    onCancel,
+    confirmLabel,
+    cancelLabel,
+  }: {
+    onConfirm: (picked: {
+      latitude: number;
+      longitude: number;
+      address: string;
+    }) => void;
+    onCancel: () => void;
+    confirmLabel: string;
+    cancelLabel: string;
+  }) => (
+    <div aria-label="Mock location picker">
+      <button
+        type="button"
+        onClick={() =>
+          onConfirm({
+            latitude: 28.6139,
+            longitude: 77.209,
+            address: "Kartavya Path, New Delhi, Delhi 110001, India",
+          })
+        }
+      >
+        {confirmLabel}
+      </button>
+      <button type="button" onClick={onCancel}>
+        {cancelLabel}
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -94,6 +130,16 @@ const HOME = {
   longitude: 77.5929,
   address: "Kasturba Road, Bengaluru",
   savedAt: "2026-07-26T00:00:00.000Z",
+};
+
+// The coordinate + address the mocked LocationPickerMap confirms with, so
+// duplicate-gate tests can seed a saved place at the exact pinned entrance.
+const PICKED_ENTRANCE_ADDRESS = "Kartavya Path, New Delhi, Delhi 110001, India";
+const HOME_AT_PICKED_PIN = {
+  ...HOME,
+  latitude: 28.6139,
+  longitude: 77.209,
+  address: PICKED_ENTRANCE_ADDRESS,
 };
 
 describe("SavedLocationsSection", () => {
@@ -218,7 +264,7 @@ describe("SavedLocationsSection", () => {
     });
 
     expect(
-      screen.queryByRole("dialog", { name: /save this place/i }),
+      screen.queryByTestId("save-location-modal"),
     ).not.toBeInTheDocument();
     expect(mocks.reverseGeocode).not.toHaveBeenCalled();
   });
@@ -255,7 +301,9 @@ describe("SavedLocationsSection", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /add place/i }));
     expect(
-      await screen.findByRole("dialog", { name: /save this place/i }),
+      await screen.findByRole("dialog", {
+        name: /pin your entrance|before google maps opens/i,
+      }),
     ).toBeInTheDocument();
     await waitFor(() =>
       expect(mocks.reverseGeocode).toHaveBeenCalledWith({
@@ -265,6 +313,14 @@ describe("SavedLocationsSection", () => {
       }),
     );
 
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    expect(
+      await screen.findByRole("heading", { name: "Add your address details" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Flat 4B, Tower 2" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Home" }));
     fireEvent.click(screen.getByRole("button", { name: /save location/i }));
 
@@ -278,22 +334,33 @@ describe("SavedLocationsSection", () => {
         input: {
           category: "home",
           label: "",
-          latitude: 12.9763,
-          longitude: 77.5929,
-          address: "Kasturba Road, Bengaluru",
+          latitude: 28.6139,
+          longitude: 77.209,
+          // buildSavedLocationAddress folds the entrance details into the
+          // pinned map address (postal code already present, so not repeated).
+          address: `Flat 4B, Tower 2, ${PICKED_ENTRANCE_ADDRESS}`,
         },
       }),
     );
   });
 
   it("reminds the owner and blocks a duplicate category before persistence", async () => {
+    mocks.loadSavedLocations.mockResolvedValueOnce([HOME_AT_PICKED_PIN]);
     render(<SavedLocationsSection />);
-    await screen.findByText("Kasturba Road, Bengaluru");
+    await screen.findByText(PICKED_ENTRANCE_ADDRESS);
 
     fireEvent.click(screen.getByRole("button", { name: /add place/i }));
     expect(
-      await screen.findByRole("dialog", { name: /save this place/i }),
+      await screen.findByRole("dialog", {
+        name: /pin your entrance|before google maps opens/i,
+      }),
     ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    await screen.findByRole("heading", { name: "Add your address details" });
+
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Flat 4B" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
     fireEvent.click(screen.getByRole("button", { name: /save location/i }));
 
@@ -302,7 +369,7 @@ describe("SavedLocationsSection", () => {
       "This place is already saved as Home. Choose a different place or remove it first.",
     );
     expect(
-      screen.getByRole("dialog", { name: /save this place/i }),
+      screen.getByRole("dialog", { name: "Add your address details" }),
     ).toBeInTheDocument();
   });
 
@@ -317,7 +384,15 @@ describe("SavedLocationsSection", () => {
     await screen.findByText(/no saved places yet/i);
 
     fireEvent.click(screen.getByRole("button", { name: /add place/i }));
-    await screen.findByRole("dialog", { name: /save this place/i });
+    await screen.findByRole("dialog", {
+      name: /pin your entrance|before google maps opens/i,
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm pin" }));
+    await screen.findByRole("heading", { name: "Add your address details" });
+
+    fireEvent.change(screen.getByLabelText("House, flat, floor or block"), {
+      target: { value: "Flat 4B" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Work" }));
     fireEvent.click(screen.getByRole("button", { name: /save location/i }));
 
@@ -327,7 +402,7 @@ describe("SavedLocationsSection", () => {
       ),
     );
     expect(
-      screen.getByRole("dialog", { name: /save this place/i }),
+      screen.getByRole("dialog", { name: "Add your address details" }),
     ).toBeInTheDocument();
   });
 

--- a/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/check-in-flow.test.tsx
@@ -38,6 +38,7 @@ function viewModel(
   ];
   return {
     busy: null,
+    circles: [],
     sosRecipients: recipients,
     myLocationPoint: point,
     myLocationError: null,

--- a/hushh-webapp/lib/services/__tests__/post-unlock-sync-service.sos.test.ts
+++ b/hushh-webapp/lib/services/__tests__/post-unlock-sync-service.sos.test.ts
@@ -44,12 +44,11 @@ describe("PostUnlockSyncService", () => {
     expect(kycDraftMocks.flushIdentityDraft).toHaveBeenCalledWith(params);
   });
 
-  it("onboardingSynced is false when vault sync fails", async () => {
+  it("propagates a vault sync failure instead of swallowing it", async () => {
     const { KaiProfileSyncService } = await import("@/lib/services/kai-profile-sync-service");
     (
       KaiProfileSyncService.syncPendingToVault as unknown as ReturnType<typeof vi.fn>
     ).mockRejectedValueOnce(new Error("vault boom"));
-    const result = await PostUnlockSyncService.run(params);
-    expect(result.onboardingSynced).toBe(false);
+    await expect(PostUnlockSyncService.run(params)).rejects.toThrow("vault boom");
   });
 });

--- a/hushh-webapp/lib/services/connections-service.ts
+++ b/hushh-webapp/lib/services/connections-service.ts
@@ -80,6 +80,21 @@ export interface ConnectionInformationScopeCatalog {
   items: ConnectionInformationScope[];
 }
 
+export interface ConnectionCircleSummary {
+  id: string;
+  name: string;
+}
+
+export interface ConnectionRemovalResult {
+  removed: number;
+  stillConnected?: boolean;
+  connectionKind?: string;
+  circles?: ConnectionCircleSummary[];
+  circleIds?: string[];
+  circleNames?: string[];
+  canRemoveDirect?: boolean;
+}
+
 function authHeaders(idToken: string): HeadersInit {
   return {
     "Content-Type": "application/json",
@@ -273,12 +288,31 @@ export class ConnectionsService {
   static async removeConnection(opts: {
     idToken: string;
     connectionId: string;
-  }): Promise<void> {
+  }): Promise<ConnectionRemovalResult> {
     const response = await ApiService.apiFetch(
       `/api/one/connections/${encodeURIComponent(opts.connectionId)}`,
       { method: "DELETE", headers: authHeaders(opts.idToken) },
     );
-    await jsonOrThrow<unknown>(response);
+    const payload = await jsonOrThrow<{ result?: ConnectionRemovalResult }>(
+      response,
+    );
+    const result = payload.result ?? { removed: 0 };
+    // Prefer canonical Circle objects; synthesize them from the legacy
+    // parallel arrays for old servers that predate `circles`, then derive
+    // both arrays back from the canonical list so callers see one truth.
+    const circles =
+      result.circles ??
+      result.circleIds?.map((id, index) => ({
+        id,
+        name: result.circleNames?.[index] ?? id,
+      }));
+    if (!circles) return result;
+    return {
+      ...result,
+      circles,
+      circleIds: circles.map((circle) => circle.id),
+      circleNames: circles.map((circle) => circle.name),
+    };
   }
 
   static async linkCircleInvite(opts: {

--- a/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
+++ b/hushh-webapp/scripts/testing/signed-in-ui-flows.mjs
@@ -78,8 +78,10 @@ export const UI_FLOWS = [
       { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[1] },
       { type: "click_button", name: "Add my people" },
       { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[2] },
-      { type: "click_button", name: "Continue" },
+      { type: "click_button", name: "Next" },
       { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[3] },
+      { type: "click_button", name: "Continue" },
+      { type: "assert_visible_testid", testId: LOCATION_ONBOARDING_CHECKPOINTS[4] },
     ],
   },
   {


### PR DESCRIPTION
## Why every merge is blocked

The merge queue's **Queue Validation → Web Full (Next.js)** re-runs the full vitest suite, which is red on main itself (59 failures in CI, run 31208147239) since the one-location-circles merge (PR #4660). Every queued PR fails validation on main's own breakage — the queue is wedged repo-wide.

## What the diagnosis found

A parallel 7-agent root-cause pass over all 12 failing files: **zero user-facing bugs shipped.** Every component matches its intended, documented contract; the failures are tests that were not updated when intent changed (circles invite screen, KYC preface rewrite, safe-area token switch, CTA renames, throw-propagation, two-step save-place flow).

## Changes

**11 test files** updated to the shipped contracts (no UI component touched), plus **2 shipped-artifact fixes**:
- `connections-service.removeConnection` now parses and returns the removal result that PR #4660's own tests pin (was `Promise<void>` discarding the JSON). Safe: the sole caller (`app/connect/page-client.tsx`) ignores the return; all new fields optional.
- `scripts/testing/signed-in-ui-flows.mjs` walks the five-screen onboarding contract including the invite screen.

## For the one-location authors (non-blocking)

The removal-result contract pins fields (`stillConnected`, `circles[]`) the backend doesn't return yet (`connections_service.py` returns `{removed: N}` only). The frontend normalization satisfies the pinned contract and tolerates the legacy shape — if a backend change was meant to land alongside #4660, it still can, without touching this.

## Proof

- Full suite under Node 24 (CI's runtime): **2990 passed, 0 failed** (main: 59 failed in CI).
- `tsc --noEmit`: 0 errors; eslint clean on all changed files.
- Each cluster independently verified green by its fixing agent before the combined run.