### PR TITLE
chore(governance): grant RGlodAkshat + DamriaNeelesh production access

### DIFF
--- a/config/ci-governance.json
+++ b/config/ci-governance.json
@@ -141,7 +141,9 @@
     ],
     "manual_dispatch_users": [
       "kushaltrivedi5",
-      "ankitkumarsingh1702"
+      "ankitkumarsingh1702",
+      "RGlodAkshat",
+      "DamriaNeelesh"
     ],
     "owner_environment": "production"
   }


### PR DESCRIPTION
Explicit request: production.manual_dispatch_users should be exactly Ankit, Kushal, Akshat, Neelesh. Both are already full maintainers elsewhere in this config; this only adds production deploy-dispatch authority specifically. No GitHub sync needed for this list — assert-governed-actor.py reads it directly from the JSON at workflow runtime.