### PR TITLE
feat(one-location): admit nearby check-in to production behind a cohort and a travel-continuity guard

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -298,29 +298,67 @@ def _retention_auth_enabled() -> bool:
     return True
 
 
-def _nearby_presence_simulation_enabled() -> bool:
-    """Expose the spoofable radius simulation only in non-production lanes."""
+def _nearby_presence_cohort() -> set[str] | None:
+    """Production allowlist. `None` means "no cohort configured"."""
+
+    raw = str(os.getenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT") or "").strip()
+    if not raw:
+        return None
+    if raw.lower() == "all":
+        return set()
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def _nearby_presence_enabled(user_id: str | None = None) -> bool:
+    """Whether nearby check-in is reachable for this caller.
+
+    Non-production lanes are unchanged: the flow is on unless
+    `ONE_LOCATION_NEARBY_PRESENCE_MODE` names something other than the UAT
+    simulation.
+
+    Production is off unless deliberately opted into, because the reported
+    point is client-supplied and unattestable -- see the continuity guard in
+    `one_location_nearby_presence_service`, which bounds a roaming attack but
+    cannot prove any single check-in. Opting in therefore takes two steps, not
+    one: `ONE_LOCATION_NEARBY_PRESENCE_MODE=production` *and* a cohort. A
+    production rollout with no cohort configured stays closed, so forgetting
+    the second variable fails safe rather than opening the flow to everyone.
+    """
 
     environment = (
         str(os.getenv("ENVIRONMENT") or os.getenv("HUSHH_DEPLOY_ENV") or "").strip().lower()
     )
     safe_environments = {"development", "dev", "local", "test", "uat", "staging"}
-    if environment not in safe_environments:
-        return False
     mode = str(os.getenv("ONE_LOCATION_NEARBY_PRESENCE_MODE") or "").strip().lower()
-    if mode:
-        return mode == "uat_simulation" and environment in safe_environments
-    return True
+
+    if environment in safe_environments:
+        if mode:
+            return mode in {"uat_simulation", "production"}
+        return True
+
+    if mode != "production":
+        return False
+    cohort = _nearby_presence_cohort()
+    if cohort is None:
+        return False
+    if not cohort:
+        return True
+    return bool(user_id) and str(user_id) in cohort
 
 
-def _require_nearby_presence_simulation() -> None:
-    if _nearby_presence_simulation_enabled():
+# Retained under the old name because the surface map and existing tests
+# reference it; production admission is what it now decides.
+_nearby_presence_simulation_enabled = _nearby_presence_enabled
+
+
+def _require_nearby_presence_simulation(user_id: str | None = None) -> None:
+    if _nearby_presence_enabled(user_id):
         return
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail={
             "code": "NEARBY_PRESENCE_UNAVAILABLE",
-            "message": "Nearby check-in simulation is not available in this environment.",
+            "message": "Nearby check-in is not available on this account yet.",
         },
     )
 
@@ -986,8 +1024,7 @@ async def maps_nearby_places(
     payload: MapsNearbyPlacesRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    _require_nearby_presence_simulation()
-    _user_id(token_data)
+    _require_nearby_presence_simulation(_user_id(token_data))
     _set_private_no_store(response)
     try:
         suggestions = await _maps_service().nearby_places(
@@ -1013,7 +1050,7 @@ async def check_in_nearby(
 ):
     """Publish a short-lived presence after verifying a fresh nearby-place fix."""
 
-    _require_nearby_presence_simulation()
+    _require_nearby_presence_simulation(_user_id(token_data))
     _set_private_no_store(response)
     try:
         place = await _maps_service().place_details(
@@ -1061,7 +1098,7 @@ def get_nearby_presence(
     response: Response,
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    _require_nearby_presence_simulation()
+    _require_nearby_presence_simulation(_user_id(token_data))
     _set_private_no_store(response)
     try:
         return _nearby_presence_service().get_state(user_id=_user_id(token_data))
@@ -1091,7 +1128,7 @@ def request_nearby_connection(
     payload: NearbyConnectionRequest,
     token_data: dict = Depends(require_vault_owner_token),
 ):
-    _require_nearby_presence_simulation()
+    _require_nearby_presence_simulation(_user_id(token_data))
     _set_private_no_store(response)
     try:
         return _nearby_presence_service().request_connection(

--- a/consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_nearby_presence_service.py
@@ -25,6 +25,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import math
 import os
 import re
@@ -40,6 +41,8 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from db.db_client import get_db
 from hushh_mcp.config import VAULT_DATA_KEY
 from hushh_mcp.services.connections_service import ConnectionsService
+
+logger = logging.getLogger(__name__)
 
 NEARBY_PRESENCE_CONSENT_VERSION = "one-location-nearby-presence-v3"
 NEARBY_PRESENCE_DURATION_MINUTES = frozenset({30, 60, 120})
@@ -59,6 +62,32 @@ NEARBY_PRESENCE_MAX_POINT_AGE_SECONDS = 300.0
 NEARBY_PRESENCE_FUTURE_TOLERANCE_SECONDS = 60.0
 NEARBY_PRESENCE_ROSTER_LIMIT = 20
 NEARBY_PRESENCE_CANDIDATE_LIMIT = 240
+
+# The reported point is client-supplied and cannot be attested, so nothing above
+# stops an account from claiming a place on the other side of the world. What
+# *can* be checked is continuity: consecutive check-ins have to be reachable
+# from one another at a speed a person could actually travel. This does not make
+# a single check-in honest -- it makes a roaming attack cost real time, which is
+# the difference between "appear anywhere instantly" and "move like a human".
+# Faster than a commercial jet is treated as impossible.
+NEARBY_PRESENCE_MAX_TRAVEL_SPEED_KMH = 900.0
+# Re-checking in at the same venue, or one next door, must never trip the guard:
+# below this the elapsed time is meaningless and the speed term explodes.
+NEARBY_PRESENCE_TELEPORT_GRACE_METERS = 750.0
+#
+# Still missing before this should reach a general production audience:
+#
+#   * Device attestation (Play Integrity / App Attest) on the check-in write.
+#     This is the only control that makes a *single* check-in trustworthy; the
+#     continuity guard above only makes a *sequence* of them expensive. Needs
+#     native plumbing on both platforms, so it is not a server-side change.
+#   * A daily distinct-place cap. The guard forces an attacker to move at
+#     human speed, but says nothing about how many places they visit over a
+#     day. Enforcing that needs check-in history, and the table keeps one row
+#     per owner -- so it needs a migration, deliberately deferred here.
+#   * Report/block, so a blocked pair can never match into the same roster.
+#
+# Until those exist, production admission is cohort-gated in the route layer.
 
 _CELL_EPOCH_SECONDS = 6 * 60 * 60
 _CELL_TILE_ZOOM = 16
@@ -140,6 +169,8 @@ class NearbyPresenceStore(Protocol):
     ) -> dict[str, Any]: ...
 
     def get_active_presence(self, user_id: str) -> dict[str, Any] | None: ...
+
+    def get_last_presence(self, user_id: str) -> dict[str, Any] | None: ...
 
     def read_active_candidates(
         self,
@@ -329,6 +360,26 @@ class PostgresNearbyPresenceStore:
             WHERE p.owner_user_id = :user_id
               AND p.status = 'active'
               AND p.expires_at > NOW()
+            LIMIT 1
+            """,
+            {"user_id": user_id},
+        )
+
+    def get_last_presence(self, user_id: str) -> dict[str, Any] | None:
+        """The owner's most recent check-in, whatever state it ended in.
+
+        Deliberately not `get_active_presence`: the continuity guard has to see
+        a check-in the owner has already checked out of or let expire, which
+        that query filters away. The table keeps one row per owner, so this is
+        the previous check-in until it is overwritten or `purge_terminal`
+        removes it.
+        """
+
+        return self._execute_one(
+            """
+            SELECT p.*
+            FROM one_location_nearby_presences p
+            WHERE p.owner_user_id = :user_id
             LIMIT 1
             """,
             {"user_id": user_id},
@@ -528,6 +579,21 @@ def _normalize_captured_at(value: datetime) -> datetime:
         if value.tzinfo is None
         else value.astimezone(timezone.utc)
     )
+
+
+def _normalize_optional_timestamp(value: Any) -> datetime | None:
+    """UTC-normalize a stored timestamp, tolerating a driver that returns text."""
+
+    if isinstance(value, datetime):
+        return _normalize_captured_at(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return _normalize_captured_at(
+                datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+            )
+        except ValueError:
+            return None
+    return None
 
 
 def _distance_meters(
@@ -827,6 +893,83 @@ class OneLocationNearbyPresenceService:
                 status_code=403,
             )
 
+    def _require_reachable_from_last_check_in(
+        self,
+        *,
+        owner_user_id: str,
+        place_lat: float,
+        place_lng: float,
+        now: datetime,
+    ) -> None:
+        """Reject a check-in the owner could not physically have travelled to.
+
+        Everything else in this flow trusts a client-supplied point, so an
+        account can claim any single place. Consecutive claims, though, have to
+        be consistent with each other -- and that is checkable server-side with
+        no attestation. An account that checked in in London ten minutes ago is
+        not in Sydney now.
+
+        Fails open on our own data problems (no previous row, unreadable
+        anchor, unusable timestamp). A decryption bug must not lock people out
+        of a feature they are using honestly; the roaming attack this closes is
+        the deliberate one, and it needs a *readable* previous anchor to be
+        detected at all.
+        """
+
+        try:
+            previous = self._store.get_last_presence(owner_user_id)
+        except Exception:  # noqa: BLE001 - continuity is a guard, not a gate
+            return
+        if not previous:
+            return
+        try:
+            anchor = _decrypt_anchor(previous)
+        except Exception:  # noqa: BLE001 - see docstring
+            return
+
+        previous_lat = anchor.get("latitude")
+        previous_lng = anchor.get("longitude")
+        if not isinstance(previous_lat, (int, float)) or not isinstance(previous_lng, (int, float)):
+            return
+
+        previous_at = _normalize_optional_timestamp(previous.get("checked_in_at"))
+        if previous_at is None:
+            return
+
+        distance_meters = _distance_meters(
+            origin_lat=float(previous_lat),
+            origin_lng=float(previous_lng),
+            destination_lat=place_lat,
+            destination_lng=place_lng,
+        )
+        if (
+            not math.isfinite(distance_meters)
+            or distance_meters <= NEARBY_PRESENCE_TELEPORT_GRACE_METERS
+        ):
+            return
+
+        elapsed_seconds = (now - previous_at).total_seconds()
+        # A non-positive gap with real distance is itself impossible, so clamp
+        # rather than divide by zero -- the speed below then trips the guard.
+        elapsed_hours = max(elapsed_seconds, 1.0) / 3600.0
+        speed_kmh = (distance_meters / 1000.0) / elapsed_hours
+        if speed_kmh <= NEARBY_PRESENCE_MAX_TRAVEL_SPEED_KMH:
+            return
+
+        logger.warning(
+            "nearby_presence.teleport_rejected owner=%s distance_km=%.1f elapsed_s=%.0f speed_kmh=%.0f",
+            owner_user_id,
+            distance_meters / 1000.0,
+            elapsed_seconds,
+            speed_kmh,
+        )
+        raise NearbyPresenceError(
+            "NEARBY_PRESENCE_IMPLAUSIBLE_TRAVEL",
+            "That place is too far from your last check-in to be reachable yet. "
+            "Check in again once you have actually arrived.",
+            status_code=422,
+        )
+
     def check_in(
         self,
         *,
@@ -940,6 +1083,13 @@ class OneLocationNearbyPresenceService:
                 "Choose a place closer to your current location.",
                 status_code=422,
             )
+
+        self._require_reachable_from_last_check_in(
+            owner_user_id=owner_user_id,
+            place_lat=normalized_place_lat,
+            place_lng=normalized_place_lng,
+            now=now,
+        )
 
         # Anchor on the selected place, never the captured point: it makes the
         # roster exact regardless of receiver quality and keeps the owner's real

--- a/consent-protocol/tests/services/test_one_location_nearby_presence_service.py
+++ b/consent-protocol/tests/services/test_one_location_nearby_presence_service.py
@@ -70,6 +70,7 @@ class FakeStore:
     def __init__(self) -> None:
         self.profile = {"user_id": "viewer", "phone_verified": True}
         self.presence: dict | None = None
+        self.last_presence: dict | None = None
         self.candidates: list[dict] = []
         self.connection_rows: list[dict] = []
         self.upsert_args: dict | None = None
@@ -105,6 +106,11 @@ class FakeStore:
 
     def get_active_presence(self, user_id):
         return self.presence
+
+    def get_last_presence(self, user_id):
+        # The continuity guard must see a checked-out or expired check-in too,
+        # which is exactly what `get_active_presence` filters away.
+        return self.last_presence if self.last_presence is not None else self.presence
 
     def read_active_candidates(self, **kwargs):
         self.candidate_args = kwargs
@@ -161,6 +167,99 @@ def _check_in(service, **overrides):
     }
     values.update(overrides)
     return service.check_in(**values)
+
+
+def _previous_check_in(*, lat: float, lng: float, minutes_ago: float, status="checked_out"):
+    """A prior check-in row for this owner, as the store would return it."""
+
+    row = _anchor_row(
+        user_id="viewer",
+        alias="viewer-alias",
+        place_id="previous-place",
+        label="Previous place",
+        lat=lat,
+        lng=lng,
+    )
+    row["status"] = status
+    row["checked_in_at"] = NOW - timedelta(minutes=minutes_ago)
+    return row
+
+
+def test_check_in_rejects_a_place_the_owner_could_not_have_reached():
+    """The point is client-supplied, so continuity is what can be checked.
+
+    Nothing else here stops an account claiming a venue anywhere on earth: the
+    coordinates come from the browser and cannot be attested. Consecutive
+    claims, though, must be consistent with each other -- someone checked in
+    near Stanford four minutes ago is not in London now.
+    """
+
+    store = FakeStore()
+    # ~8,600 km away, four minutes earlier: roughly 129,000 km/h.
+    store.last_presence = _previous_check_in(lat=51.5074, lng=-0.1278, minutes_ago=4)
+    service, _ = _service(store)
+
+    with pytest.raises(NearbyPresenceError) as exc:
+        _check_in(service)
+
+    assert exc.value.code == "NEARBY_PRESENCE_IMPLAUSIBLE_TRAVEL"
+    assert exc.value.status_code == 422
+    assert store.upsert_args is None, "an implausible check-in must not be persisted"
+
+
+def test_check_in_allows_a_place_reachable_at_human_speed():
+    store = FakeStore()
+    # Same ~8,600 km, but a day later: well under the ceiling.
+    store.last_presence = _previous_check_in(lat=51.5074, lng=-0.1278, minutes_ago=24 * 60)
+    service, _ = _service(store)
+
+    state = _check_in(service)
+
+    assert state["presence"]["placeLabel"] == "Spot A"
+
+
+def test_check_in_allows_returning_to_the_same_venue_immediately():
+    """Re-checking in where you already are is the most ordinary case there is."""
+
+    store = FakeStore()
+    store.last_presence = _previous_check_in(lat=37.4276, lng=-122.1698, minutes_ago=0.0)
+    service, _ = _service(store)
+
+    state = _check_in(service)
+
+    assert state["presence"]["placeLabel"] == "Spot A"
+
+
+def test_continuity_guard_fails_open_when_the_previous_anchor_is_unreadable():
+    """A decryption problem of ours must not lock an honest owner out.
+
+    The attack this guard closes needs a *readable* previous anchor to be
+    detected at all, so failing open costs nothing an attacker could use.
+    """
+
+    store = FakeStore()
+    row = _previous_check_in(lat=51.5074, lng=-0.1278, minutes_ago=4)
+    row["anchor_ciphertext"] = "not-decryptable"
+    store.last_presence = row
+    service, _ = _service(store)
+
+    state = _check_in(service)
+
+    assert state["presence"]["placeLabel"] == "Spot A"
+
+
+def test_continuity_guard_fails_open_when_the_store_cannot_be_read():
+    store = FakeStore()
+
+    def _boom(user_id):
+        raise RuntimeError("store unavailable")
+
+    store.get_last_presence = _boom  # type: ignore[method-assign]
+    service, _ = _service(store)
+
+    state = _check_in(service)
+
+    assert state["presence"]["placeLabel"] == "Spot A"
 
 
 def test_check_in_encrypts_selected_place_and_never_stores_the_captured_point():

--- a/consent-protocol/tests/test_one_location_nearby_presence_routes.py
+++ b/consent-protocol/tests/test_one_location_nearby_presence_routes.py
@@ -17,6 +17,7 @@ from hushh_mcp.services.one_location_nearby_presence_service import (
 def client(monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "test")
     monkeypatch.delenv("ONE_LOCATION_NEARBY_PRESENCE_MODE", raising=False)
+    monkeypatch.delenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT", raising=False)
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[require_vault_owner_token] = lambda: {"user_id": "u1"}
@@ -240,6 +241,75 @@ def test_simulation_fails_closed_without_environment_identity(client, monkeypatc
 
     assert response.status_code == 404
     assert response.json()["detail"]["code"] == "NEARBY_PRESENCE_UNAVAILABLE"
+
+
+def _stub_presence_state(monkeypatch):
+    class FakePresenceService:
+        def get_state(self, *, user_id):
+            assert user_id == "u1"
+            return {"presence": None, "attendees": []}
+
+    monkeypatch.setattr(
+        location_routes,
+        "_nearby_presence_service",
+        lambda: FakePresenceService(),
+    )
+
+
+def test_production_stays_closed_without_an_explicit_mode(client, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("ONE_LOCATION_NEARBY_PRESENCE_MODE", raising=False)
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT", "all")
+
+    response = client.get("/api/one/location/nearby-presence")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "NEARBY_PRESENCE_UNAVAILABLE"
+
+
+def test_production_stays_closed_when_the_cohort_is_missing(client, monkeypatch):
+    """Forgetting the cohort must fail safe, not open the flow to everyone.
+
+    Production admission deliberately needs two variables. If setting the mode
+    alone were enough, a half-finished rollout would silently expose a
+    stranger-discovery surface to the whole user base.
+    """
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_MODE", "production")
+    monkeypatch.delenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT", raising=False)
+
+    response = client.get("/api/one/location/nearby-presence")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "NEARBY_PRESENCE_UNAVAILABLE"
+
+
+def test_production_admits_only_the_named_cohort(client, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_MODE", "production")
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT", "someone-else,u2")
+
+    assert client.get("/api/one/location/nearby-presence").status_code == 404
+
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT", "u1,u2")
+    _stub_presence_state(monkeypatch)
+
+    response = client.get("/api/one/location/nearby-presence")
+
+    assert response.status_code == 200
+    assert response.json()["presence"] is None
+
+
+def test_production_cohort_all_admits_everyone(client, monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_MODE", "production")
+    monkeypatch.setenv("ONE_LOCATION_NEARBY_PRESENCE_COHORT", "all")
+    _stub_presence_state(monkeypatch)
+
+    response = client.get("/api/one/location/nearby-presence")
+
+    assert response.status_code == 200
 
 
 def test_checkout_remains_available_when_simulation_is_disabled(client, monkeypatch):

--- a/hushh-webapp/lib/one-location/__tests__/nearby-check-in-availability.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/nearby-check-in-availability.test.ts
@@ -19,4 +19,28 @@ describe("nearby check-in availability", () => {
     vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
     expect(isOneLocationNearbyCheckInAvailable()).toBe(false);
   });
+
+  it("stays closed in production for anything but an explicit opt-in", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
+    for (const value of ["", "false", "0", "yes", "on", "1", "TRUE "]) {
+      vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", value);
+      expect(isOneLocationNearbyCheckInAvailable()).toBe(
+        value.trim().toLowerCase() === "true",
+      );
+    }
+  });
+
+  it("opens in production only when the build opts in", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", "true");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
+  });
+
+  it("ignores the flag outside production", () => {
+    // The backend admits by cohort regardless, so a non-production build has
+    // nothing to gain from being able to switch this off here.
+    vi.stubEnv("NEXT_PUBLIC_APP_ENV", "uat");
+    vi.stubEnv("NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN", "false");
+    expect(isOneLocationNearbyCheckInAvailable()).toBe(true);
+  });
 });

--- a/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
+++ b/hushh-webapp/lib/one-location/nearby-check-in-availability.ts
@@ -22,11 +22,23 @@ export const ONE_LOCATION_NEARBY_MAX_ACCURACY_METERS = 5_000;
 export const ONE_LOCATION_NEARBY_COARSE_ACCURACY_METERS = 200;
 
 /**
- * Radius-based nearby discovery is a local/UAT simulation until production
- * admission and abuse-prevention controls are available. The backend remains
- * authoritative; this frontend gate prevents collecting a location for a flow
- * that production will reject.
+ * Whether to offer nearby check-in in this build.
+ *
+ * Outside production the flow is always on. Production is off unless the build
+ * opts in, because the check-in point is client-supplied and cannot be
+ * attested: the backend bounds a roaming attack through its continuity guard
+ * but cannot prove any single check-in is honest.
+ *
+ * The backend remains authoritative and admits production callers by cohort.
+ * This gate only avoids collecting a location for a flow that would then be
+ * refused, so it is deliberately the looser of the two — a build with the flag
+ * on still gets a 404 from the backend unless that account is admitted.
  */
 export function isOneLocationNearbyCheckInAvailable(): boolean {
-  return resolveAppEnvironment() !== "production";
+  if (resolveAppEnvironment() !== "production") return true;
+  return (
+    String(process.env.NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN ?? "")
+      .trim()
+      .toLowerCase() === "true"
+  );
 }


### PR DESCRIPTION
# Description

Nearby check-in is closed in production today, and the reason is in the code's own words — `_nearby_presence_simulation_enabled` is documented as exposing *"the spoofable radius simulation only in non-production lanes"*.

"Spoofable" is the substance. `current_lat` / `current_lng` come from the client. The backend does check plausibility — accuracy ≤ 5 km, point age ≤ 5 min, distance from the chosen place — but every one of those inputs is also client-supplied. Nothing proves the device is where it claims. With the gate off, an account with a verified phone could claim any venue on earth, appear in the nearby-people roster of real users standing there, and send them connection requests.

So this does not simply flip the two booleans. It adds the missing property first.

## The continuity guard

Consecutive check-ins must be reachable from one another at under 900 km/h, measured place-to-place against the previous anchor.

It cannot prove a single check-in is honest — nothing server-side can, without attestation. What it does is convert *"appear anywhere instantly"* into *"move at human speed"*, which is the property the roster actually depends on. Scanning distant cities now costs real hours rather than one HTTP request.

Deliberately **fails open** on our own data problems — no previous row, unreadable anchor, unusable timestamp. The attack it detects requires a *readable* previous anchor to be detected at all, so failing open costs an attacker nothing while a decryption bug on our side never locks an honest owner out of a feature they are using correctly.

No migration. The presence table already keeps one row per owner, and terminal rows survive ~12 h until `purge_terminal`, which is ample lookback. Given the migration-driven prod incident yesterday (#4960), adding another migration here was not worth the risk for the marginal coverage.

## Admission takes two variables, not one

`ONE_LOCATION_NEARBY_PRESENCE_MODE=production` **and** `ONE_LOCATION_NEARBY_PRESENCE_COHORT`.

Setting the mode alone leaves the flow closed. That asymmetry is intentional: if one variable were enough, a half-finished rollout would silently expose a stranger-discovery surface to the entire user base. Forgetting the second one now fails safe. `COHORT=all` opens it to everyone; a comma-separated list opens it to those accounts only.

The frontend gate becomes a build flag (`NEXT_PUBLIC_ONE_LOCATION_NEARBY_CHECK_IN`) instead of a hardcoded environment check, and stays the looser of the two on purpose — a build with the flag on still gets a 404 for any account outside the cohort. It only avoids collecting a location for a flow that would then be refused.

## What is still missing

Recorded in the source beside the thresholds they would join, not just here:

- **Device attestation** (Play Integrity / App Attest) — the only control that makes a *single* check-in trustworthy. Needs native work on both platforms.
- **Daily distinct-place cap** — the guard bounds speed, not how many places an account visits in a day. Needs check-in history, and the table holds one row per owner, so it needs a migration.
- **Report / block** — a blocked pair must never match into the same roster.

**I would not open `COHORT=all` until at least attestation exists.** A named cohort of internal accounts is what this PR is built for.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below:
  - `POST /api/one/location/maps/nearby-places`, `POST /api/one/location/nearby-presence/check-in`, `GET /api/one/location/nearby-presence`, `POST /api/one/location/nearby-presence/connection-request` — all four now resolve the caller identity before the gate so the cohort can apply. No new routes.

- API / schema / type changes:
  - [x] Listed below:
  - New error `NEARBY_PRESENCE_IMPLAUSIBLE_TRAVEL` (422) on check-in.
  - `NEARBY_PRESENCE_UNAVAILABLE` message reworded (account-scoped, not environment-scoped).
  - New store port method `get_last_presence`. No DB schema change, no migration.

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None — one additional read of an existing row per check-in.

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — no plugin change. The frontend flag is read the same way on every platform.

- Docs updated (exact files):
  - [x] None — the outstanding controls are documented in `one_location_nearby_presence_service.py` next to the thresholds, where the next person changing them will actually read it.

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below:
  - **Consent / public ingress.** This is the change that decides whether an unattested, client-supplied location claim can place a real user in a stranger's roster in production. Default remains closed; opening it requires two explicit variables and a named cohort.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof:
  - `isOneLocationNearbyCheckInAvailable()` ↔ `_nearby_presence_enabled()` — the frontend is intentionally looser; the backend is authoritative. Proof: `test_production_admits_only_the_named_cohort` and `nearby-check-in-availability.test.ts`.

- Rollback or safe-failure behavior:
  - [x] Listed below:
  - Rollback is removing an env var — no deploy needed, no data migration to unwind.
  - Every new failure mode fails safe: missing cohort → closed; unknown mode → closed; no environment identity → closed.
  - The guard fails **open** by design, and only on our own data faults; that is argued in the docstring and covered by two tests.

- UI browser or Playwright proof:
  - [x] Not applicable — no UI change. The frontend edit is a single availability predicate, unit-tested.

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck`
  - [x] `cd hushh-webapp && npm run lint` (changed files clean)
  - [x] `bash scripts/ci/check-dco-signoff.sh`
  - [x] `ruff check` + `ruff format --check` + `pytest` on the changed protocol modules
  - [ ] `./bin/hushh codex pre-pr` — cannot complete on this Windows host (`/bin/bash` resolution under the WSL relay). Constituent checks run directly.

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate anything open.
- [x] This PR changes a current reachable app/backend surface.
- [x] Reachable production attach point: the four `/api/one/location/nearby-*` routes and `LocationImmersiveMap`'s availability check.
- [x] New tests import and exercise production code, not only mock components/helpers defined inside the test file.
- [x] New helpers are wired to existing routes.
- [x] Production surface proved: cohort admission asserted end-to-end through `TestClient`; the guard asserted through the service with a real encrypted anchor.
- [x] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`.
- [x] Maintainer edits are enabled.
- [x] Predecessor: #4966 (merged).

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: backend gate + availability predicate.
- [x] **iOS**: not applicable — no plugin change; the flag is read identically.
- [x] **Android**: not applicable — same reason.

## 🧪 Testing

- [x] Tested on Web
- [ ] iOS / Android not run — no platform-specific behaviour in this change.
- [x] Commits are signed off (`git commit -s`)
- [x] No generated files changed.

- `consent-protocol`: 92 passed across the presence service, presence routes, location routes and startup guards.
- `hushh-webapp`: 214 passed across the one-location suites.
- The rejection test was verified to **fail without the guard** — important here, because the guard fails open, so a test that passes either way would prove nothing. The four fail-open tests correctly stay green in both states.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? It reads the owner's own previous check-in anchor, server-side only.
- [x] Consent unchanged — explicit check-in consent still gates publication; the vault-owner token still gates every route.
- [x] Sensitive surface touched: consent / public ingress.
- [x] Error path and safe-failure proved: see rollback section; covered by the closed-by-default tests.

Nothing new is exposed to other participants. The roster payload is untouched and still returns a display name only — no coordinates, no distances. The previous anchor is decrypted in memory for a comparison and never returned.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
