### PR TITLE
fix(ui): re-init SwipeViews when the container width changes

### DIFF
--- a/hushh-webapp/__tests__/components/swipe-views.test.tsx
+++ b/hushh-webapp/__tests__/components/swipe-views.test.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EmblaCarouselType } from "embla-carousel";
 
@@ -269,5 +269,96 @@ describe("SwipeViews", () => {
     expect(
       watchDrag({ rootNode: () => nestedRoot }, { target: nestedTarget } as Event),
     ).toBe(true);
+  });
+
+  describe("viewport resize", () => {
+    // The engine measures width once. When the container narrows without the
+    // window changing — a vertical scrollbar appearing as pane content streams
+    // in — a window-only listener never fires, Embla keeps a stale width, and
+    // it translates by the wrong distance, leaving the previous pane clipped
+    // beside the selected one (the Memory /one/pkm report).
+    let observerCallback: ResizeObserverCallback | null = null;
+    let observed: Element | null = null;
+    let disconnected = false;
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const originalRaf = globalThis.requestAnimationFrame;
+
+    beforeEach(() => {
+      observerCallback = null;
+      observed = null;
+      disconnected = false;
+      globalThis.ResizeObserver = class {
+        constructor(callback: ResizeObserverCallback) {
+          observerCallback = callback;
+        }
+        observe(element: Element) {
+          observed = element;
+        }
+        disconnect() {
+          disconnected = true;
+        }
+        unobserve() {}
+      } as unknown as typeof ResizeObserver;
+      // Run rAF work synchronously so the debounce is deterministic.
+      globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }) as typeof globalThis.requestAnimationFrame;
+    });
+
+    afterEach(() => {
+      globalThis.ResizeObserver = originalResizeObserver;
+      globalThis.requestAnimationFrame = originalRaf;
+    });
+
+    const emitWidth = (width: number) => {
+      observerCallback?.(
+        [{ contentRect: { width } } as unknown as ResizeObserverEntry],
+        {} as ResizeObserver,
+      );
+    };
+
+    const renderPager = () =>
+      render(
+        <SwipeViews tabSetId="resize" activeValue="first" options={OPTIONS}>
+          <div>first panel content</div>
+          <div>second panel content</div>
+        </SwipeViews>,
+      );
+
+    it("observes the viewport element, not just the window", () => {
+      renderPager();
+      expect(observed).toBe(embla.rootNode);
+    });
+
+    it("re-initialises when the container width changes with no window resize", () => {
+      vi.spyOn(embla.rootNode!, "getBoundingClientRect").mockReturnValue({
+        width: 800,
+      } as DOMRect);
+      renderPager();
+      embla.reInit.mockClear();
+
+      emitWidth(785); // scrollbar appears; window.innerWidth never changes
+
+      expect(embla.reInit).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores height-only changes so streaming content does not re-init", () => {
+      vi.spyOn(embla.rootNode!, "getBoundingClientRect").mockReturnValue({
+        width: 800,
+      } as DOMRect);
+      renderPager();
+      embla.reInit.mockClear();
+
+      emitWidth(800); // taller content, identical width
+
+      expect(embla.reInit).not.toHaveBeenCalled();
+    });
+
+    it("disconnects the observer on unmount", () => {
+      const view = renderPager();
+      view.unmount();
+      expect(disconnected).toBe(true);
+    });
   });
 });

--- a/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
+++ b/hushh-webapp/lib/morphy-ux/ui/swipe-views.tsx
@@ -179,23 +179,54 @@ export function SwipeViews({
 
   useEffect(() => {
     if (!emblaApi) return;
-    let lastWidth = window.innerWidth;
-    const onResize = () => {
+    const root = emblaApi.rootNode();
+    const measure = () =>
+      root ? root.getBoundingClientRect().width : window.innerWidth;
+    let lastWidth = measure();
+
+    const scheduleReInit = (nextWidth: number) => {
       if (resizeFrameRef.current !== null) {
         window.cancelAnimationFrame(resizeFrameRef.current);
       }
       resizeFrameRef.current = window.requestAnimationFrame(() => {
         resizeFrameRef.current = null;
-        const nextWidth = window.innerWidth;
+        // Width is the only dimension the horizontal engine measures. Ignoring
+        // height is what keeps streaming pane content from re-initialising the
+        // engine — the Finance hitch `watchResize: false` was set to avoid.
         if (Math.abs(nextWidth - lastWidth) < 1) return;
         lastWidth = nextWidth;
         emblaApi.reInit();
         syncTabIndicator(false);
       });
     };
-    window.addEventListener("resize", onResize, { passive: true });
+
+    // Observe the viewport, not the window. The container can narrow while
+    // `window.innerWidth` never changes — a vertical scrollbar appearing as
+    // pane content streams in, or a parent transform settling. Embla then
+    // keeps a stale width and translates by the wrong distance, leaving the
+    // previous pane clipped beside the selected one (Memory /one/pkm).
+    const observer =
+      root && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver((entries) => {
+            const entry = entries[0];
+            if (!entry) return;
+            scheduleReInit(entry.contentRect?.width ?? measure());
+          })
+        : null;
+    observer?.observe(root as Element);
+
+    // Only needed where ResizeObserver is unavailable; the observer already
+    // catches window resizes, since they resize the container too.
+    const onWindowResize = observer ? null : () => scheduleReInit(measure());
+    if (onWindowResize) {
+      window.addEventListener("resize", onWindowResize, { passive: true });
+    }
+
     return () => {
-      window.removeEventListener("resize", onResize);
+      observer?.disconnect();
+      if (onWindowResize) {
+        window.removeEventListener("resize", onWindowResize);
+      }
       if (resizeFrameRef.current !== null) {
         window.cancelAnimationFrame(resizeFrameRef.current);
         resizeFrameRef.current = null;


### PR DESCRIPTION
## Problem

`SwipeViews` sets `watchResize: false` so streaming pane content cannot re-initialise the horizontal engine on vertical-only changes (a deliberate fix for a Finance hitch). The replacement handler watched **`window.innerWidth` only**:

```js
window.addEventListener("resize", onResize, { passive: true });
...
if (Math.abs(nextWidth - lastWidth) < 1) return;   // window width only
```

When the **container** narrows but the **window** does not, `reInit()` is never called. Embla keeps a stale width and translates the rail by the wrong distance, so it lands between panes — the previous pane stays visible, clipped, beside the selected one.

## Reproduction

Reported on Memory (`/one/pkm`): with **Add** selected, the Saved pane remained on screen to its left, cut off mid-sentence (`"iew and sharing."` — the tail of *"…appear here for review and sharing."*).

The container narrows there without a window resize when a vertical scrollbar appears as memory content streams in, and while `PkmSettingsShell` runs its GSAP enter transform on the panel.

Dragging the browser window does **not** reproduce it — that path always worked, which is part of why this went unnoticed.

## Fix

Observe the viewport element with a `ResizeObserver` instead of the window, keeping:

- the rAF debounce, and
- the **width-only guard**, so the original `watchResize: false` intent still holds — height changes from streaming content are still ignored.

Falls back to the window listener where `ResizeObserver` is unavailable.

## Tests

The resize path had **no coverage** — `reInit` was mocked but never asserted. Adds four tests; **three fail without this change**.

| Check | Result |
|---|---|
| `swipe-views.test.tsx` | 11 passed (7 existing + 4 new) |
| Same tests, fix reverted | **3 failed** |
| Consumer tests (pkm, consent, public-knowledge) | 52 passed |
| `tsc --noEmit` | exit 0 |
| `eslint --max-warnings=0` | exit 0 |
| `verify:design-system` | exit 0 |

## Blast radius

`SwipeViews` is shared, so this fixes the same class of bug on every surface using it: Consent Center, Kai market hub, Location hub, marketplace, PKM agent lab, and the public knowledge workspace.

## Local check

Loaded `/one/pkm` on this branch against a local dev server, signed in: the Memory workspace renders correctly — one pane at a time, no previous pane clipped beside the selected tab.

**This is not a clean A/B.** With the fix reverted, the broken state could not be reproduced on demand — the original trigger (container narrowing as memory content streams in and a scrollbar appears) depends on timing that did not reappear by hand. So the correct reading is:

- **Proven:** the defect is real. The resize handler never saw container-width changes, and three of the tests below fail without this change.
- **Inference:** that this defect caused the reported screenshot. The mechanism matches it precisely — including why the *tail* of the previous pane is visible rather than its start — but the causal link was not demonstrated by reproduction.

A reviewer who can reproduce the original clipping on `main` and then confirm it is gone here would close that gap.
