### PR TITLE
feat(connect): for 10 miles and 25 miles, open office details when clicked 

### DIFF
--- a/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
+++ b/hushh-webapp/components/connect/__tests__/advisors-nearby.test.tsx
@@ -227,6 +227,49 @@ describe("AdvisorsNearby", () => {
     expect(screen.getByText("74 advisors · New York")).toBeTruthy();
   });
 
+  it("opens an office surface for a branch instead of an adviser profile", async () => {
+    // Grouped results are what dense metros and wider radii return, so an
+    // office row is the only thing a reader can act on there. Leaving it inert
+    // made 10 mi and 25 mi look broken next to 5 mi.
+    mocks.locationState = {
+      status: "ready",
+      permission: "granted",
+      snapshot: { latitude: 41.88, longitude: -87.63 },
+      error: null,
+    };
+    mocks.searchNearby.mockResolvedValue(
+      result({
+        items: [
+          {
+            kind: "branch",
+            id: "408168",
+            name: "J.P. MORGAN SECURITIES LLC",
+            firmName: null,
+            advisorCount: 74,
+            advisorNames: ["A ADVISOR", "B ADVISOR"],
+            distanceMiles: 0.7,
+            city: "CHICAGO",
+            state: "IL",
+            phone: "312-555-0100",
+          },
+        ],
+        meta: { ...result().meta, grouped: true },
+      }),
+    );
+
+    render(<AdvisorsNearby getIdToken={getIdToken} />);
+
+    fireEvent.click(await screen.findByText("J.P. MORGAN SECURITIES LLC"));
+
+    // The office's own facts, not a person's credentials.
+    expect(await screen.findByText("Advisors at this office")).toBeTruthy();
+    expect(screen.getByText("A ADVISOR")).toBeTruthy();
+    expect(screen.getByText("and 72 more")).toBeTruthy();
+
+    // A branch carries no CRD, so no profile fetch may be attempted.
+    expect(mocks.getProfile).not.toHaveBeenCalled();
+  });
+
   it("surfaces the narrowed radius the server actually used", async () => {
     mocks.locationState = {
       status: "ready",

--- a/hushh-webapp/components/connect/advisors-nearby.tsx
+++ b/hushh-webapp/components/connect/advisors-nearby.tsx
@@ -11,6 +11,7 @@ import {
   PostalCodeForm,
   QuietBlock,
 } from "@/components/connect/nearby-directory-ui";
+import { OfficeDetailSurface } from "@/components/connect/office-detail-surface";
 import { Button } from "@/lib/morphy-ux/button";
 import { SegmentedTabs } from "@/lib/morphy-ux/ui";
 import { useCurrentLocation } from "@/lib/one-location/use-current-location";
@@ -240,12 +241,8 @@ export function AdvisorsNearby({
                   }
                   description={formatAdvisorSubtitle(card) ?? undefined}
                   density="compact"
-                  chevron={card.kind === "advisor"}
-                  onClick={
-                    card.kind === "advisor"
-                      ? () => setSelected(card)
-                      : undefined
-                  }
+                  chevron
+                  onClick={() => setSelected(card)}
                   trailing={
                     distance ? (
                       <span className="type-footnote shrink-0 tabular-nums text-muted-foreground">
@@ -292,13 +289,24 @@ export function AdvisorsNearby({
         />
       ) : null}
 
+      {/* An office and an adviser open different surfaces on purpose: a branch
+          row has no CRD, so there is no profile to fetch and nothing that would
+          justify showing it as a person. */}
       <AdvisorDetailSurface
-        card={selected}
-        open={selected !== null}
+        card={selected?.kind === "advisor" ? selected : null}
+        open={selected?.kind === "advisor"}
         onOpenChange={(open) => {
           if (!open) setSelected(null);
         }}
         getIdToken={getIdToken}
+      />
+
+      <OfficeDetailSurface
+        card={selected?.kind === "branch" ? selected : null}
+        open={selected?.kind === "branch"}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null);
+        }}
       />
     </div>
   );

--- a/hushh-webapp/components/connect/office-detail-surface.tsx
+++ b/hushh-webapp/components/connect/office-detail-surface.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { AdaptiveDetailSurface } from "@/components/app-ui/settings-ui";
+import { Button } from "@/lib/morphy-ux/button";
+import {
+  formatDistance,
+  type AdvisorCard,
+} from "@/lib/services/advisor-directory-service";
+import { usTelHref } from "@/lib/services/us-tel-href";
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="type-title2 text-foreground">{value}</p>
+      <p className="type-footnote text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+/**
+ * One office, opened from the nearby list when the server groups dense results
+ * into branches instead of people.
+ *
+ * Deliberately not the adviser surface. A branch row carries no CRD, so there
+ * is no BrokerCheck profile to fetch and no tenure or disclosure record to
+ * show — presenting one would put a person's credentials on an address. This
+ * shows only what the office itself is: how many advisers register there, where
+ * it is, and how to call it.
+ */
+export function OfficeDetailSurface({
+  card,
+  open,
+  onOpenChange,
+}: {
+  card: AdvisorCard | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  if (!card) return null;
+
+  const location = [card.city, card.state].filter(Boolean).join(", ");
+  const distance = formatDistance(card.distanceMiles);
+  const names = card.advisorNames ?? [];
+  // The directory returns at most three names per office, so the list is a
+  // sample and must never read as the full roster.
+  const undisclosed =
+    typeof card.advisorCount === "number"
+      ? card.advisorCount - names.length
+      : 0;
+
+  return (
+    <AdaptiveDetailSurface
+      open={open}
+      onOpenChange={onOpenChange}
+      eyebrow={location || undefined}
+      title={card.name ?? "Office"}
+      mobilePresentation="sheet"
+      footer={
+        card.phone ? (
+          <Button
+            type="button"
+            variant="blue-gradient"
+            effect="fill"
+            size="lg"
+            fullWidth
+            asChild
+          >
+            <a href={usTelHref(card.phone)}>Call</a>
+          </Button>
+        ) : undefined
+      }
+    >
+      <div className="space-y-7">
+        <div className="grid grid-cols-3 gap-4">
+          <Stat
+            label={card.advisorCount === 1 ? "Advisor" : "Advisors"}
+            value={String(card.advisorCount ?? "—")}
+          />
+          <Stat label="Distance" value={distance ?? "—"} />
+          <Stat label="State" value={card.state ?? "—"} />
+        </div>
+
+        {names.length ? (
+          <div className="space-y-2">
+            <p className="type-footnote text-muted-foreground">
+              Advisors at this office
+            </p>
+            <ul className="space-y-1">
+              {names.map((name) => (
+                <li key={name} className="type-callout text-foreground">
+                  {name}
+                </li>
+              ))}
+            </ul>
+            {undisclosed > 0 ? (
+              <p className="type-footnote text-muted-foreground">
+                and {undisclosed} more
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        {location ? (
+          <p className="type-callout text-muted-foreground">{location}</p>
+        ) : null}
+      </div>
+    </AdaptiveDetailSurface>
+  );
+}


### PR DESCRIPTION
## Problem

On Connect → **Around you**, office rows were tappable at 5 mi but inert at 10 mi and 25 mi.

The radius isn't the cause. Wider radii return more results, so the directory **groups** them into branch offices instead of people. At 5 mi you get few enough results to stay ungrouped as individual advisers — which *are* tappable. Grouped rows simply never had a destination:

```tsx
chevron={card.kind === "advisor"}
onClick={card.kind === "advisor" ? () => setSelected(card) : undefined}
```

So the list looked broken at exactly the radii that return the most results.

## Why offices don't reuse the adviser surface

A branch row carries **no CRD** — the backend sets `crd` only on adviser rows. `AdvisorDetailSurface` fetches a BrokerCheck profile by CRD and bails without one, so wiring offices to it would open an empty panel. Beyond that, tenure, firm count and disclosures describe a *person*; showing them for an office would attach someone's credentials to an address.

There is also an existing test named **"renders branch results without pretending they are people"** — the inert behaviour was deliberate, not an oversight.

## Change

A separate `OfficeDetailSurface`, built only from what a branch row already carries: adviser count, distance, state, phone, and the sample of adviser names the directory returns.

| Adviser sheet | Office sheet |
|---|---|
| Experience · Firms · States | **Advisors · Distance · State** |
| Street address (from profile) | City, State |
| BrokerCheck report link | **Advisors at this office** + "and N more" |
| Call | Call |

It keeps the adviser sheet's shape so the list feels consistent, while still presenting an office *as an office*. **No new endpoint, no profile fetch, no upstream change** — and the "without pretending they are people" test still passes unmodified.

### Honest limit

The directory caps `advisorNames` at three regardless of office size (`[:3]` server-side). The list is therefore labelled and followed by an explicit **"and N more"** so it cannot read as a full roster. A complete roster would need a new backend endpoint returning advisers for a `branchOfficeId`; that does not exist today.

## Tests

| Check | Result |
|---|---|
| Connect tests | 35 passed (34 existing + 1 new) |
| New test, wiring reverted | **fails** |
| `tsc --noEmit` | exit 0 |
| `eslint --max-warnings=0` | exit 0 |
| `verify:design-system` | exit 0 |

The new test also asserts `getProfile` is **never called** for a branch, locking in that offices cannot trigger an adviser profile fetch.

## Reviewer note

This **reverses a deliberate product decision** that offices are inert — it was reported as a bug (offices expected to be tappable at every radius), and the fix honours the original constraint rather than discarding it. Worth a second opinion on whether the office sheet shows the right facts.

Rendered locally and confirmed visually; the full A/B against the reported screenshot was not run.