### PR TITLE
fix(one-location): a Circle member is a connection — restore location sharing and Circle invites

### DIFF
--- a/consent-protocol/api/routes/one/location.py
+++ b/consent-protocol/api/routes/one/location.py
@@ -1218,6 +1218,9 @@ def create_location_grant_with_envelope(
             envelope=payload.envelope,
             reason=payload.reason,
             share_kind=payload.share_kind,
+            source_circle_id=(
+                str(payload.source_circle_id) if payload.source_circle_id is not None else None
+            ),
             enforce_connection=True,
         )
     except Exception as exc:

--- a/consent-protocol/hushh_mcp/services/one_location_agent_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_agent_service.py
@@ -34,6 +34,18 @@ logger = logging.getLogger(__name__)
 # ciphertext envelopes, so the grant's signed token carries this scope.
 LOCATION_GRANT_CONSENT_SCOPE = "cap.location.live.view"
 
+# One sentence for one rule. Every location authority path — grant creation,
+# the atomic grant+envelope write, and SMS contact selection — admits the same
+# two relationships: a direct connection, or shared membership of an active
+# named Circle. Wording is shared so a rejected user is never told a different
+# story depending on which endpoint refused them.
+LOCATION_PEER_NOT_ELIGIBLE_MESSAGE = (
+    "You can only share your live location with a connection or an active Circle member."
+)
+LOCATION_SMS_CONTACT_NOT_ELIGIBLE_MESSAGE = (
+    "Only an active connection or Circle member can be added as an SMS contact."
+)
+
 _NOTIFICATION_EXECUTOR = ThreadPoolExecutor(
     max_workers=max(1, int(os.getenv("ONE_LOCATION_NOTIFICATION_WORKERS", "2"))),
     thread_name_prefix="one-location-notify",
@@ -2928,6 +2940,15 @@ class OneLocationAgentService:
         # connections graph or shared active named-Circle membership. Neither
         # relationship grants location access: the explicit encrypted grant
         # below remains the sole authority.
+        #
+        # This predicate must stay identical to the one the authority paths
+        # enforce (`_resolve_location_peer_eligibility`,
+        # `_lock_circle_share_eligibility`, and the atomic private-share SQL).
+        # Offering someone the mutation will refuse produces a dead end the
+        # user has no way to resolve, so the direct-connection branch requires
+        # a non-`named_circle` origin here too: a pair whose only provenance is
+        # a Circle qualifies through the Circle branch, and stops qualifying
+        # the moment that Circle membership ends.
         rows = self._execute_many(
             """
             SELECT
@@ -2947,6 +2968,10 @@ class OneLocationAgentService:
                 EXISTS (
                   SELECT 1
                   FROM connections c
+                  JOIN connection_origins origin
+                    ON origin.connection_id = c.id
+                   AND origin.status = 'active'
+                   AND origin.origin_kind <> 'named_circle'
                   WHERE c.status = 'active'
                     AND (
                       (c.user_a_id = :owner_user_id AND c.user_b_id = a.user_id)
@@ -3212,26 +3237,13 @@ class OneLocationAgentService:
                 status_code=403,
             )
 
-    def _is_active_connection(self, *, owner_user_id: str, other_user_id: str) -> bool:
-        row = self._execute_one(
-            """
-            SELECT 1
-            FROM connections connection
-            JOIN connection_origins origin
-              ON origin.connection_id = connection.id
-             AND origin.status = 'active'
-             AND origin.origin_kind <> 'named_circle'
-            WHERE connection.status = 'active'
-              AND (
-                (connection.user_a_id = :a AND connection.user_b_id = :b)
-                OR (connection.user_a_id = :b AND connection.user_b_id = :a)
-              )
-            LIMIT 1
-            """,
-            {"a": owner_user_id, "b": other_user_id},
-        )
-        return row is not None
-
+    # `_is_active_connection` used to live here and answered a narrower
+    # question than every caller needed: it recognized only a direct
+    # (non-`named_circle`) connection origin. Once named Circles shipped, the
+    # recipient picker legitimately offered Circle-only peers that this gate
+    # then refused, so a share the product intends failed with "you can only
+    # share with your connections". Location eligibility now has exactly one
+    # definition — `_resolve_location_peer_eligibility` — and callers use it.
     def _resolve_location_peer_eligibility(
         self,
         *,
@@ -3365,6 +3377,10 @@ class OneLocationAgentService:
                 SELECT 1 WHERE EXISTS (
                   SELECT 1
                   FROM connections c
+                  JOIN connection_origins origin
+                    ON origin.connection_id = c.id
+                   AND origin.status = 'active'
+                   AND origin.origin_kind <> 'named_circle'
                   WHERE c.status = 'active'
                     AND (
                       (c.user_a_id = :owner_user_id AND c.user_b_id = sms.contact_user_id)
@@ -3417,7 +3433,7 @@ class OneLocationAgentService:
                         raise
                     raise OneLocationAgentError(
                         "LOCATION_SMS_CONTACT_NOT_CONNECTED",
-                        "Only an active connection or Circle member can be added as an SMS contact.",
+                        LOCATION_SMS_CONTACT_NOT_ELIGIBLE_MESSAGE,
                         status_code=403,
                     ) from exc
                 conn.execute(
@@ -3659,7 +3675,7 @@ class OneLocationAgentService:
         if not cleaned_circle_id:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_NOT_CONNECTED",
-                "You can only share live location with a connection or active Circle member.",
+                LOCATION_PEER_NOT_ELIGIBLE_MESSAGE,
                 status_code=403,
             )
 
@@ -3682,7 +3698,7 @@ class OneLocationAgentService:
         if not circle_row:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_NOT_CONNECTED",
-                "You can only share live location with a connection or active Circle member.",
+                LOCATION_PEER_NOT_ELIGIBLE_MESSAGE,
                 status_code=403,
             )
 
@@ -3712,7 +3728,7 @@ class OneLocationAgentService:
         if locked_users != {owner_user_id, recipient_user_id}:
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_NOT_CONNECTED",
-                "You can only share live location with a connection or active Circle member.",
+                LOCATION_PEER_NOT_ELIGIBLE_MESSAGE,
                 status_code=403,
             )
         return cleaned_circle_id
@@ -3839,6 +3855,7 @@ class OneLocationAgentService:
                     duration_hours=duration_hours,
                     reason=reason,
                     share_kind=share_kind,
+                    source_circle_id=source_circle_id,
                     require_recipient_phone_verified=require_recipient_phone_verified,
                     enforce_connection=enforce_connection,
                     _key_writer_guarded=True,
@@ -3854,12 +3871,20 @@ class OneLocationAgentService:
                     resolved_kind=resolved_kind,
                 )
             return grant
-        if enforce_connection and not self._is_active_connection(
-            owner_user_id=owner_user_id, other_user_id=recipient_user_id
+        # The pre-check must use exactly the relationship the authoritative
+        # mutation below (`_create_enforced_grant_row`) will re-validate under
+        # lock: a direct connection OR shared active Circle membership. A
+        # narrower gate here rejects Circle-only peers that the recipient
+        # picker legitimately offers, which is a rejection the user cannot act
+        # on.
+        if enforce_connection and not self._is_location_peer_eligible(
+            owner_user_id=owner_user_id,
+            other_user_id=recipient_user_id,
+            source_circle_id=source_circle_id,
         ):
             raise OneLocationAgentError(
                 "LOCATION_RECIPIENT_NOT_CONNECTED",
-                "You can only share your live location with your connections.",
+                LOCATION_PEER_NOT_ELIGIBLE_MESSAGE,
                 status_code=403,
             )
         try:
@@ -3994,6 +4019,7 @@ class OneLocationAgentService:
         envelope: dict[str, Any],
         reason: str | None = None,
         share_kind: str | None = None,
+        source_circle_id: str | None = None,
         require_recipient_phone_verified: bool = True,
         enforce_connection: bool = False,
     ) -> dict[str, Any]:
@@ -4035,6 +4061,27 @@ class OneLocationAgentService:
                 status_code=422,
             ) from exc
         resolved_kind = share_kind or _classify_share_kind(reason)
+        # Record which relationship authorized this share. When the caller names
+        # a Circle it must be that Circle; otherwise a Circle-only peer still
+        # gets its source Circle stamped, so revoking the Circle later revokes
+        # the grant's provenance rather than leaving an unattributed share.
+        grant_source_circle_id: str | None = None
+        if enforce_connection:
+            eligible, relationship_circle_id = self._resolve_location_peer_eligibility(
+                owner_user_id=owner_user_id,
+                other_user_id=recipient_user_id,
+                source_circle_id=source_circle_id,
+            )
+            if not eligible:
+                raise OneLocationAgentError(
+                    "LOCATION_RECIPIENT_NOT_CONNECTED",
+                    LOCATION_PEER_NOT_ELIGIBLE_MESSAGE,
+                    status_code=403,
+                )
+            # On success this is the canonical UUID text of the Circle that
+            # authorized the share (equal to the requested one when given), or
+            # None when a direct connection authorized it.
+            grant_source_circle_id = relationship_circle_id
         # Check-In notes are recipient information, not audit metadata. The web
         # client encrypts the note with the point; this fixed marker is the only
         # Check-In reason persisted or sent through notification metadata.
@@ -4130,21 +4177,51 @@ class OneLocationAgentService:
                   <= INTERVAL '60 seconds'
                 AND NOW() - CAST(:confirmed_at AS TIMESTAMPTZ)
                   <= INTERVAL '10 minutes'
+                -- Same relationship rule as `_resolve_location_peer_eligibility`
+                -- and `_lock_circle_share_eligibility`: a direct (non-Circle)
+                -- connection origin, or shared membership of an active named
+                -- Circle. Re-evaluated inside this transaction so a membership
+                -- removed after the pre-check still fails closed. An explicitly
+                -- requested Circle narrows this to that Circle alone.
                 AND (
                   CAST(:enforce_connection AS BOOLEAN) IS FALSE
+                  OR (
+                    CAST(:source_circle_id AS UUID) IS NULL
+                    AND EXISTS (
+                      SELECT 1
+                      FROM connections c
+                      JOIN connection_origins origin
+                        ON origin.connection_id = c.id
+                       AND origin.status = 'active'
+                       AND origin.origin_kind <> 'named_circle'
+                      WHERE c.status = 'active'
+                        AND (
+                          (
+                            c.user_a_id = :owner_user_id
+                            AND c.user_b_id = :recipient_user_id
+                          )
+                          OR (
+                            c.user_a_id = :recipient_user_id
+                            AND c.user_b_id = :owner_user_id
+                          )
+                        )
+                    )
+                  )
                   OR EXISTS (
                     SELECT 1
-                    FROM connections c
-                    WHERE c.status = 'active'
+                    FROM one_location_circle_memberships mine
+                    JOIN one_location_circle_memberships theirs
+                      ON theirs.circle_id = mine.circle_id
+                     AND theirs.user_id = :recipient_user_id
+                     AND theirs.status = 'active'
+                    JOIN one_location_circles circle
+                      ON circle.id = mine.circle_id
+                     AND circle.status = 'active'
+                    WHERE mine.user_id = :owner_user_id
+                      AND mine.status = 'active'
                       AND (
-                        (
-                          c.user_a_id = :owner_user_id
-                          AND c.user_b_id = :recipient_user_id
-                        )
-                        OR (
-                          c.user_a_id = :recipient_user_id
-                          AND c.user_b_id = :owner_user_id
-                        )
+                        CAST(:source_circle_id AS UUID) IS NULL
+                        OR mine.circle_id = CAST(:source_circle_id AS UUID)
                       )
                   )
                 )
@@ -4173,13 +4250,14 @@ class OneLocationAgentService:
               INSERT INTO one_location_share_grants (
                 id, owner_user_id, recipient_user_id, recipient_key_id,
                 status, consent_scope, capability_scopes, duration_hours,
-                expires_at, created_at, updated_at, metadata
+                expires_at, source_circle_id, created_at, updated_at, metadata
               )
               SELECT
                 CAST(:grant_id AS UUID),
                 :owner_user_id, :recipient_user_id, :recipient_key_id, 'active',
                 'cap.location.live.view', CAST(:capability_scopes AS JSONB),
-                :duration_hours, :expires_at, NOW(), NOW(),
+                :duration_hours, :expires_at,
+                CAST(:source_circle_id AS UUID), NOW(), NOW(),
                 CAST(:metadata_json AS JSONB)
               FROM eligible_recipient
               CROSS JOIN (SELECT COUNT(*) FROM revoked_grants) revoke_barrier
@@ -4287,6 +4365,7 @@ class OneLocationAgentService:
                 "confirmed_at": confirmed_at_value,
                 "require_phone_verified": require_recipient_phone_verified,
                 "enforce_connection": enforce_connection,
+                "source_circle_id": grant_source_circle_id,
                 "require_sms_contact": resolved_kind == "sos",
                 "envelope_metadata_json": envelope_fields["metadata_json"],
                 **{key: value for key, value in envelope_fields.items() if key != "metadata_json"},
@@ -4299,13 +4378,14 @@ class OneLocationAgentService:
             )
             if freshness_error is not None:
                 raise freshness_error
-            if enforce_connection and not self._is_active_connection(
+            if enforce_connection and not self._is_location_peer_eligible(
                 owner_user_id=owner_user_id,
                 other_user_id=recipient_user_id,
+                source_circle_id=source_circle_id,
             ):
                 raise OneLocationAgentError(
                     "LOCATION_RECIPIENT_NOT_CONNECTED",
-                    "You can only share your live location with your connections.",
+                    LOCATION_PEER_NOT_ELIGIBLE_MESSAGE,
                     status_code=403,
                 )
             if resolved_kind == "sos" and not self._is_sms_contact(

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -1189,7 +1189,14 @@ class OneLocationCircleService:
         actor_user_id: str,
         circle_id: str,
     ) -> list[dict[str, Any]]:
-        """List an active member's own direct connections eligible to invite."""
+        """List an active member's own connections eligible to invite.
+
+        "Eligible" means an active connection of any provenance. Someone the
+        member met through a Circle is a connection — they already appear in
+        the connections list and can receive a location share — so excluding
+        them here left the member unable to invite the very people a Circle
+        introduced them to.
+        """
 
         cleaned_circle_id = _clean_circle_id(circle_id)
         try:
@@ -1238,9 +1245,12 @@ class OneLocationCircleService:
                    connection.user_a_id = :actor_user_id
                    OR connection.user_b_id = :actor_user_id
                   )
+                -- Any live provenance makes someone invitable. A Circle
+                -- co-member is a connection — they already appear in the
+                -- connections list — so requiring `direct_request` here hid
+                -- exactly the people a Circle was meant to introduce.
                 JOIN connection_origins origin
                   ON origin.connection_id = connection.id
-                 AND origin.origin_kind = 'direct_request'
                  AND origin.status = 'active'
                 LEFT JOIN actor_identity_cache identity
                   ON identity.user_id = CASE
@@ -1694,11 +1704,15 @@ class OneLocationCircleService:
                 if missing_connection:
                     raise OneLocationCircleError(
                         "LOCATION_CIRCLE_DIRECT_CONNECTION_REQUIRED",
-                        "Every selected person must still be a direct connection.",
+                        "Every selected person must still be a connection.",
                         status_code=409,
                     )
                 connection_ids = [str(row.get("connection_id") or "") for row in connection_rows]
-                direct_origin_rows = _all(
+                # Lock whatever provenance keeps each connection alive, of any
+                # kind, so a concurrent revoke or Circle-leave cannot slip
+                # between this check and the invite write. The kind no longer
+                # matters: an active connection is an invitable connection.
+                live_origin_rows = _all(
                     conn.execute(
                         text(
                             """
@@ -1706,7 +1720,6 @@ class OneLocationCircleService:
                             FROM connection_origins
                             WHERE connection_id =
                                   ANY(CAST(:connection_ids AS UUID[]))
-                              AND origin_kind = 'direct_request'
                               AND status = 'active'
                             ORDER BY connection_id
                             FOR UPDATE
@@ -1715,16 +1728,16 @@ class OneLocationCircleService:
                         {"connection_ids": connection_ids},
                     )
                 )
-                direct_origin_connection_ids = {
-                    str(row.get("connection_id") or "") for row in direct_origin_rows
+                live_origin_connection_ids = {
+                    str(row.get("connection_id") or "") for row in live_origin_rows
                 }
                 if any(
-                    connection_id not in direct_origin_connection_ids
+                    connection_id not in live_origin_connection_ids
                     for connection_id in connection_ids
                 ):
                     raise OneLocationCircleError(
                         "LOCATION_CIRCLE_DIRECT_CONNECTION_REQUIRED",
-                        "Every selected person must still be a direct connection.",
+                        "Every selected person must still be a connection.",
                         status_code=409,
                     )
                 existing_rows = _all(
@@ -2153,10 +2166,13 @@ class OneLocationCircleService:
                             status_code=409,
                         )
                     # Transaction lock order is Circle/invite (above), exact
-                    # canonical connection, direct origin, then membership.
+                    # canonical connection, its live origin, then membership.
                     # The origin check runs after the connection lock in a new
-                    # statement/snapshot so a concurrent direct removal cannot
-                    # be masked by another active Circle origin.
+                    # statement/snapshot so a relationship revoked concurrently
+                    # is observed rather than masked. Any active origin counts:
+                    # a Circle co-member is a connection, so a Circle-sourced
+                    # provenance is as valid an invitation basis as a direct
+                    # request.
                     connection_row = _first(
                         conn.execute(
                             text(
@@ -2189,7 +2205,7 @@ class OneLocationCircleService:
                             "Reconnect before accepting this Circle invitation.",
                             status_code=409,
                         )
-                    direct_origin = _first(
+                    live_origin = _first(
                         conn.execute(
                             text(
                                 """
@@ -2197,7 +2213,6 @@ class OneLocationCircleService:
                                 FROM connection_origins
                                 WHERE connection_id =
                                       CAST(:connection_id AS UUID)
-                                  AND origin_kind = 'direct_request'
                                   AND status = 'active'
                                 FOR UPDATE
                                 """
@@ -2205,7 +2220,7 @@ class OneLocationCircleService:
                             {"connection_id": str(connection_row.get("id") or "")},
                         )
                     )
-                    if not direct_origin:
+                    if not live_origin:
                         raise OneLocationCircleError(
                             "LOCATION_CIRCLE_DIRECT_CONNECTION_REQUIRED",
                             "Reconnect before accepting this Circle invitation.",

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -25,6 +25,7 @@ tests/test_pkm_upgrade_routes.py
 tests/test_pkm_upgrade_service.py
 tests/test_vault_keys_metadata.py
 tests/test_one_location_routes.py
+tests/services/test_one_location_agent_service.py
 tests/test_adk_a2a_compliance_script.py
 tests/test_ria_claim_flow.py
 tests/test_ria_iam_service_architecture.py

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -1224,8 +1224,13 @@ class FourUserMemoryService(OneLocationAgentService):
             ][:100]
         if (
             "FROM advisor_investor_relationships rel" in sql
-            and "LEFT JOIN relationship_share_grants share" in sql
+            and "rel.investor_user_id = :owner_user_id" in sql
         ):
+            # The owner-scoped professional-network query. Keyed on its WHERE
+            # clause rather than its join keyword: the production query changed
+            # from LEFT JOIN to JOIN, and matching the keyword let this fall
+            # through to the graph-wide branch below, handing the owner other
+            # people's relationships unfiltered.
             owner = params["owner_user_id"]
             return [
                 row
@@ -1233,7 +1238,13 @@ class FourUserMemoryService(OneLocationAgentService):
                 if row.get("investor_user_id") == owner or row.get("ria_user_id") == owner
             ][:100]
         if "FROM advisor_investor_relationships rel" in sql:
-            return self.professional_relationships[:500]
+            # The graph-wide mutual-KAI query, which selects approved
+            # relationships only.
+            return [
+                row
+                for row in self.professional_relationships
+                if str(row.get("status") or "").lower() == "approved"
+            ][:500]
         if "FROM ria_profiles owner_rp" in sql:
             owner = params["owner_user_id"]
             return [
@@ -2117,6 +2128,28 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
             "relationship_share_granted_at": now - timedelta(days=1),
         }
     )
+    # A shared, approved advisor both the owner and User G work with. Mutual-KAI
+    # adjacency is built from approved relationships only, so the owner needs one
+    # of its own to have any neighbour in common with User G. This advisor is not
+    # a connection of the owner, so it never enters the recipient directory and
+    # cannot shift anyone else's category.
+    shared_advisor = "user_shared_advisor"
+    for investor in (user_a, user_g):
+        service.professional_relationships.append(
+            {
+                "investor_user_id": investor,
+                "ria_user_id": shared_advisor,
+                "status": "approved",
+                "granted_scope": "attr.financial.*",
+                "consent_granted_at": now - timedelta(days=2),
+                "created_at": now - timedelta(days=3),
+                "updated_at": now - timedelta(days=1),
+                "ria_display_name": "Shared Advisor",
+                "ria_verification_status": "verified",
+                "relationship_share_status": "active",
+                "relationship_share_granted_at": now - timedelta(days=1),
+            }
+        )
     service.organization_memberships.append(
         {
             "owner_user_id": user_a,
@@ -2190,7 +2223,17 @@ def test_kai_circle_recipient_directory_uses_safe_recommendation_signals() -> No
         for reason in by_id[user_c]["recommendationReasons"]
     )
     assert by_id[user_d]["recommendationCategory"] == "professional_network"
-    assert by_id[user_d]["relationshipType"] == "Advisor relationship"
+    # The owner's advisor relationship with User D is only `discovered`, with no
+    # active relationship share, so the service fail-closes and declines to call
+    # it an advisor relationship — it falls back to what User D published. This
+    # is also the only reachable state for a `professional_network` label: an
+    # approved relationship marks the signal trusted, which outranks
+    # professional and would read as Trusted Circle instead.
+    assert by_id[user_d]["relationshipType"] == "Marketplace profile"
+    assert not any(
+        reason["code"] == "approved_professional_relationship"
+        for reason in by_id[user_d]["recommendationReasons"]
+    )
     assert by_id[user_d]["profileHeadline"] == "Retirement planning specialist"
     assert by_id[user_f]["recommendationCategory"] == "professional_network"
     assert any(

--- a/consent-protocol/tests/services/test_one_location_agent_service.py
+++ b/consent-protocol/tests/services/test_one_location_agent_service.py
@@ -148,8 +148,13 @@ class AtomicPrivateShareProbe(OneLocationAgentService):
         self.notifications: list[dict] = []
         self.expiry_normalizations: list[str | None] = []
 
-    def _is_active_connection(self, **_kwargs) -> bool:
-        return True
+    # This probe exercises the atomic private-share SQL, not the relationship
+    # graph, so eligibility is stubbed open. It stubs the single canonical
+    # predicate: stubbing a narrower helper here is what previously let the
+    # production connection gate drift away from what the picker offered
+    # without a single test noticing.
+    def _resolve_location_peer_eligibility(self, **_kwargs) -> tuple[bool, str | None]:
+        return True, None
 
     def _recipient_key_row(self, **_kwargs) -> dict:
         return {
@@ -3502,6 +3507,111 @@ def test_create_grant_rejects_an_unshared_explicit_circle() -> None:
         )
 
     assert error.value.code == "LOCATION_RECIPIENT_NOT_CONNECTED"
+
+
+def test_recipient_picker_offers_exactly_what_a_share_will_accept() -> None:
+    """Every offered recipient must be shareable, and vice versa.
+
+    The UAT regression this guards: the picker listed Circle-only peers while
+    the share gate accepted direct connections only, so people were shown an
+    "Add"/"Share" button that always answered "you can only share with your
+    connections" — a dead end with nothing the user could do about it.
+    """
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    service = FourUserMemoryService()
+    for user_id in ("user_b", "user_c", "user_d"):
+        service.register_recipient_key(
+            user_id=user_id,
+            key_id=f"key-{user_id}",
+            public_key_jwk={"kty": "EC", "crv": "P-256", "x": user_id, "y": user_id},
+        )
+    # user_b: direct connection only. user_c: Circle co-member only.
+    # user_d: neither, and must stay out of both sets.
+    service._seed_connection("user_a", "user_b")
+    service._seed_named_circle(circle_id, "user_a", "user_c")
+
+    offered = {
+        recipient["userId"]
+        for recipient in service.list_verified_recipients(owner_user_id="user_a")
+    }
+    assert offered == {"user_b", "user_c"}
+
+    for user_id in sorted(offered):
+        grant = service.create_grant(
+            owner_user_id="user_a",
+            recipient_user_id=user_id,
+            recipient_key_id=f"key-{user_id}",
+            duration_hours=1,
+            enforce_connection=True,
+        )
+        assert grant["status"] == "active"
+        service.add_sms_contact(owner_user_id="user_a", contact_user_id=user_id)
+
+    assert service.list_sms_contact_ids(owner_user_id="user_a") == ["user_b", "user_c"]
+
+    with pytest.raises(OneLocationAgentError) as error:
+        service.create_grant(
+            owner_user_id="user_a",
+            recipient_user_id="user_d",
+            recipient_key_id="key-user_d",
+            duration_hours=1,
+            enforce_connection=True,
+        )
+    assert error.value.code == "LOCATION_RECIPIENT_NOT_CONNECTED"
+
+
+def test_create_grant_forwards_the_requested_circle_through_the_writer_guard() -> None:
+    """An explicitly requested Circle must survive the outer create_grant call.
+
+    `create_grant` re-enters itself once to take the key-writer guard. That
+    inner call used to drop `source_circle_id`, so a caller naming a Circle it
+    did not share had the constraint silently discarded and the share was
+    authorized as a plain connection instead of being refused.
+    """
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+    service._seed_connection("user_a", "user_b")
+
+    with pytest.raises(OneLocationAgentError) as error:
+        service.create_grant(
+            owner_user_id="user_a",
+            recipient_user_id="user_b",
+            recipient_key_id="key-user_b",
+            duration_hours=1,
+            source_circle_id="550e8400-e29b-41d4-a716-446655440000",
+            enforce_connection=True,
+            _key_writer_guarded=False,
+        )
+
+    assert error.value.code == "LOCATION_RECIPIENT_NOT_CONNECTED"
+    assert not service.grants
+
+
+def test_create_grant_stamps_the_circle_that_authorized_a_circle_only_share() -> None:
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    service = FourUserMemoryService()
+    service.register_recipient_key(
+        user_id="user_b",
+        key_id="key-user_b",
+        public_key_jwk={"kty": "EC", "crv": "P-256", "x": "user_b", "y": "user_b"},
+    )
+    service._seed_named_circle(circle_id, "user_a", "user_b")
+
+    grant = service.create_grant(
+        owner_user_id="user_a",
+        recipient_user_id="user_b",
+        recipient_key_id="key-user_b",
+        duration_hours=1,
+        enforce_connection=True,
+        _key_writer_guarded=False,
+    )
+
+    # Provenance is what makes the grant revocable with the Circle later.
+    assert grant["sourceCircleId"] == circle_id
 
 
 def test_enforced_circle_grant_locks_relationship_before_mutation(monkeypatch) -> None:

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -723,8 +723,12 @@ def test_targeted_invite_accept_rechecks_direct_connection_and_creates_origins(
     origin_lock_index = next(
         index
         for index, sql in enumerate(conn.sql)
-        if "FROM connection_origins" in sql and "origin_kind = 'direct_request'" in sql
+        if "FROM connection_origins" in sql and "FOR UPDATE" in sql
     )
+    # The lock must not narrow to one provenance: a Circle co-member is a
+    # connection, so the origin that keeps them connected is lockable whatever
+    # kind it is.
+    assert "origin_kind" not in conn.sql[origin_lock_index]
     membership_insert_index = next(
         index
         for index, sql in enumerate(conn.sql)
@@ -1521,3 +1525,55 @@ def test_targeted_circle_invite_push_is_metadata_only_and_deep_links_to_people(
         "inviter_user_id": "owner-user",
     }
     assert captured["body"] == "You have a new Circle invitation."
+
+
+class _RecordingDb:
+    """Capture the SQL a read path emits and replay canned rows in order."""
+
+    def __init__(self, *results: list[dict]) -> None:
+        self.results = list(results)
+        self.sql: list[str] = []
+        self.params: list[dict] = []
+
+    def execute_raw(self, sql: str, params: dict | None = None):
+        self.sql.append(str(sql))
+        self.params.append(dict(params or {}))
+        rows = self.results.pop(0) if self.results else []
+        return SimpleNamespace(data=rows)
+
+
+def test_invitable_connections_are_not_narrowed_to_directly_requested_ones() -> None:
+    """A Circle co-member is a connection, so they can be invited elsewhere.
+
+    Requiring `origin_kind = 'direct_request'` here meant someone you met
+    through a Circle — already in your connections list, already able to
+    receive your location — could never be invited into another Circle.
+    """
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+    db = _RecordingDb(
+        [{"user_id": "actor-user"}],
+        [
+            {
+                "connection_id": "conn-1",
+                "user_id": "circle-only-peer",
+                "connected_at": datetime.now(timezone.utc),
+                "display_name": "Circle Only Peer",
+                "photo_url": None,
+                "custom_photo_url": None,
+            }
+        ],
+    )
+    service = OneLocationCircleService(db=db, hmac_key="a" * 32)  # type: ignore[arg-type]
+
+    eligible = service.list_eligible_direct_connections(
+        actor_user_id="actor-user",
+        circle_id=circle_id,
+    )
+
+    assert [row["userId"] for row in eligible] == ["circle-only-peer"]
+    listing_sql = next(
+        sql for sql in db.sql if "FROM connection_origins" in sql or "connection_origins" in sql
+    )
+    assert "origin.status = 'active'" in listing_sql
+    # The guard: provenance must not be filtered down to direct requests.
+    assert "origin_kind = 'direct_request'" not in listing_sql

--- a/hushh-webapp/lib/capacitor/plugins/__tests__/location-web-position.test.ts
+++ b/hushh-webapp/lib/capacitor/plugins/__tests__/location-web-position.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HushhLocationWeb } from "@/lib/capacitor/plugins/location-web";
+
+const PERMISSION_DENIED = 1;
+const POSITION_UNAVAILABLE = 2;
+
+type PositionOptions = { maximumAge?: number };
+
+function position(latitude: number) {
+  return {
+    coords: { latitude, longitude: 12.34, accuracy: 20 },
+    timestamp: Date.parse("2026-08-08T00:00:00.000Z"),
+  };
+}
+
+/**
+ * Install a geolocation stub whose fresh readers (`maximumAge: 0`) always fail,
+ * while a cached fix remains available. This is the reported UAT shape: the
+ * browser has Location on and a recent position in hand, but its provider
+ * cannot produce a NEW fix right now.
+ */
+function stubGeolocation(options: {
+  freshErrorCode: number;
+  cachedLatitude: number | null;
+}) {
+  const getCurrentPosition = vi.fn(
+    (
+      onSuccess: (value: unknown) => void,
+      onError: (error: unknown) => void,
+      positionOptions?: PositionOptions,
+    ) => {
+      const wantsCached = (positionOptions?.maximumAge ?? 0) > 0;
+      if (wantsCached && options.cachedLatitude !== null) {
+        onSuccess(position(options.cachedLatitude));
+        return;
+      }
+      onError({ code: options.freshErrorCode });
+    },
+  );
+  const watchPosition = vi.fn(
+    (_onSuccess: unknown, onError: (error: unknown) => void) => {
+      // A watch only aborts sampling on a hard denial; anything else is left to
+      // the sampling budget, so mirror that here.
+      if (options.freshErrorCode === PERMISSION_DENIED) {
+        onError({ code: PERMISSION_DENIED });
+      }
+      return 1;
+    },
+  );
+
+  vi.stubGlobal("navigator", {
+    geolocation: {
+      getCurrentPosition,
+      watchPosition,
+      clearWatch: vi.fn(),
+    },
+  });
+
+  return { getCurrentPosition };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("HushhLocationWeb.getCurrentPosition", () => {
+  it("falls back to a recent cached fix when no fresh fix is available", async () => {
+    const { getCurrentPosition } = stubGeolocation({
+      freshErrorCode: POSITION_UNAVAILABLE,
+      cachedLatitude: 47.6769,
+    });
+
+    const web = new HushhLocationWeb();
+    // Attach the assertion before advancing timers so the promise is never
+    // momentarily unhandled.
+    const settled = expect(
+      web.getCurrentPosition({ timeoutMs: 5_000 }),
+    ).resolves.toMatchObject({ latitude: 47.6769 });
+    await vi.runAllTimersAsync();
+    await settled;
+
+    // The cached read is a last resort: fresh reads are attempted first, and the
+    // accepted fix must be recent enough to still pass the backend's freshness
+    // window between capture and confirmation.
+    const maxAges = getCurrentPosition.mock.calls.map(
+      (call) => (call[2] as PositionOptions | undefined)?.maximumAge ?? 0,
+    );
+    expect(maxAges).toContain(0);
+    expect(Math.max(...maxAges)).toBeLessThanOrEqual(30_000);
+  });
+
+  it("still fails when neither a fresh nor a cached fix exists", async () => {
+    stubGeolocation({
+      freshErrorCode: POSITION_UNAVAILABLE,
+      cachedLatitude: null,
+    });
+
+    const web = new HushhLocationWeb();
+    const settled = expect(
+      web.getCurrentPosition({ timeoutMs: 5_000 }),
+    ).rejects.toThrow(/Could not get your location/i);
+    await vi.runAllTimersAsync();
+    await settled;
+  });
+
+  it("reports a blocked permission rather than a cached fix", async () => {
+    stubGeolocation({
+      freshErrorCode: PERMISSION_DENIED,
+      cachedLatitude: 47.6769,
+    });
+
+    const web = new HushhLocationWeb();
+    const settled = expect(
+      web.getCurrentPosition({ timeoutMs: 5_000 }),
+    ).rejects.toMatchObject({ name: "LocationPermissionDeniedError" });
+    await vi.runAllTimersAsync();
+    await settled;
+  });
+});

--- a/hushh-webapp/lib/capacitor/plugins/location-web.ts
+++ b/hushh-webapp/lib/capacitor/plugins/location-web.ts
@@ -118,15 +118,21 @@ export class HushhLocationWeb implements HushhLocationPlugin {
       return candidate.accuracyM < current.accuracyM;
     };
 
-    // Single-shot reader (used for the low-accuracy desktop fallback). Always
-    // requests a FRESH fix (maximumAge: 0) so a stale cached position from a
-    // previous place is never returned as "current location".
-    const readOnce = (enableHighAccuracy: boolean) =>
+    // How old a cached fix may be before the last-resort reader refuses it.
+    // Deliberately far below the 60s the backend allows between capture and
+    // confirmation, so a fix accepted here still passes the server's freshness
+    // check and still describes where the user actually is.
+    const LAST_RESORT_MAX_AGE_MS = 30_000;
+
+    // Single-shot reader (used for the low-accuracy desktop fallback). Defaults
+    // to a FRESH fix (maximumAge: 0) so a stale cached position from a previous
+    // place is never returned as "current location".
+    const readOnce = (enableHighAccuracy: boolean, maximumAge = 0) =>
       new Promise<WebFix>((resolve, reject) => {
         navigator.geolocation.getCurrentPosition(
           (position) => resolve(toFix(position)),
           (error) => reject(error),
-          { enableHighAccuracy, timeout: timeoutMs, maximumAge: 0 },
+          { enableHighAccuracy, timeout: timeoutMs, maximumAge },
         );
       });
 
@@ -202,6 +208,32 @@ export class HushhLocationWeb implements HushhLocationPlugin {
     };
 
 
+    // Last resort before telling a user with working Location that we could not
+    // find them. Both fresh readers demand `maximumAge: 0`, so a browser whose
+    // provider is momentarily unable to produce a NEW fix fails even though it
+    // is holding a perfectly good one from seconds ago — the exact shape of the
+    // "location is on but sharing says it is off" reports. Accept that cached
+    // fix when it is recent enough to still be true, and only then give up.
+    const lastResortCachedFix = async (): Promise<WebFix> => {
+      try {
+        return await readOnce(false, LAST_RESORT_MAX_AGE_MS);
+      } catch (cachedRaw) {
+        const cachedError = cachedRaw as
+          | Partial<GeolocationPositionError>
+          | undefined;
+        if (cachedError?.code === 1) {
+          const denied = new Error(
+            "Location permission is blocked for this site. Allow location access in your browser's site settings, then try again.",
+          );
+          denied.name = "LocationPermissionDeniedError";
+          throw denied;
+        }
+        throw new Error(
+          "Could not get your location. Turn on Location for your device/browser and try again.",
+        );
+      }
+    };
+
     // The browser GeolocationPositionError codes: 1 = PERMISSION_DENIED,
     // 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT. Many desktops have no GPS, so a
     // high-accuracy request can fail with POSITION_UNAVAILABLE/TIMEOUT even when
@@ -243,14 +275,10 @@ export class HushhLocationWeb implements HushhLocationPlugin {
               denied.name = "LocationPermissionDeniedError";
               throw denied;
             }
-            throw new Error(
-              "Could not get your location. Turn on Location for your device/browser and try again.",
-            );
+            return await lastResortCachedFix();
           }
         }
-        throw new Error(
-          "Could not get your location. Turn on Location for your device/browser and try again.",
-        );
+        return await lastResortCachedFix();
       }
 
       throw new Error(

--- a/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/location-bus.test.ts
@@ -197,5 +197,26 @@ describe("LocationBus.watch", () => {
 
     expect(LocationBus.getState().status).toBe("ready");
     expect(LocationBus.getState().snapshot).not.toBeNull();
+    // A watch reports unavailable/timeout routinely between fixes. Publishing
+    // that message alongside a healthy snapshot is what put "Could not get your
+    // location" on screen while location was working.
+    expect(LocationBus.getState().error).toBeNull();
+  });
+
+  it("reports a permission denial even while a fix is still held", async () => {
+    let emit: ((point: unknown, error: unknown) => void) | null = null;
+    mockLocation.watchPosition.mockImplementation(
+      async (_options: unknown, callback: (p: unknown, e: unknown) => void) => {
+        emit = callback;
+        return "watch-1";
+      },
+    );
+
+    await LocationBus.watch();
+    emit?.(POINT, null);
+    emit?.(null, { message: "blocked for this site", code: 1 });
+
+    expect(LocationBus.getState().status).toBe("denied");
+    expect(LocationBus.getState().error).toBe("blocked for this site");
   });
 });

--- a/hushh-webapp/lib/one-location/location-bus.ts
+++ b/hushh-webapp/lib/one-location/location-bus.ts
@@ -233,8 +233,15 @@ export const LocationBus = {
           }
           if (!error) return;
           const denied = error.code === 1;
+          if (!denied && state.snapshot) {
+            // A live watch reports POSITION_UNAVAILABLE/TIMEOUT routinely
+            // between fixes. We already hold a position, so this is noise, not
+            // a failure — surfacing its message here previously left "Could not
+            // get your location" on screen while location was working fine.
+            return;
+          }
           emit({
-            status: denied ? "denied" : state.snapshot ? "ready" : "error",
+            status: denied ? "denied" : "error",
             permission: denied ? "denied" : state.permission,
             error: error.message,
           });


### PR DESCRIPTION
## What broke

On UAT, sharing live location and adding an SMS contact both failed for people the app had *just offered* as valid recipients:

- `Only an active connection or Circle member can be added as an SMS contact.`
- `You can only share your live location with your connections.`

The recipient picker and the code that authorizes a share disagreed about what "connected" means.

Joining a Circle creates a real mutual connection — written to `connections` with `named_circle` provenance — and it shows up in the connections list like any other. `list_verified_recipients` accepted it. The grant gate did not: `_is_active_connection` required a `connection_origins` row that is **not** `named_circle`. So a Circle-only peer was listed with an **Add** / **Share** button that could never succeed, with nothing the user could do to resolve it.

The transactional writer underneath (`_lock_circle_share_eligibility`) *already* accepted Circles. The gate was refusing shares its own mutation would have allowed, one call later.

**Why tests didn't catch it:** the service test double stubbed `_is_active_connection` to return `True`, so the production gate never executed in any test. Two tests on `main` describing the intended behaviour were already red — `test_create_grant_circle_only_connection_derives_revocable_provenance` and `test_create_grant_rejects_an_unshared_explicit_circle`.

## Reproduced on the live UAT database

Owner = the account from the bug report. Every member of her Circle except one has a direct connection *and* Circle membership; the reporter has Circle membership only:

| sender | before (`main`) | after |
|---|---|---|
| Abdul Rashid | share OK | share OK |
| Parth Mawai | share OK | share OK |
| Smirthika Dharmalingam | share OK | share OK |
| lpF4mm6…IK1BCfoOTn2 | share OK | share OK |
| **Neelesh Meena** | **HTTP 403 rejected** | **share OK** (via Circle) |

## The fix

Location eligibility now has **one** definition. `_is_active_connection` is deleted; grant creation, the atomic grant+envelope write, and SMS contact selection all ask `_resolve_location_peer_eligibility`, and the picker and SMS-list queries use the same predicate — so the offered set equals the acceptable set.

Two more defects on the same path:

- **`create_grant` dropped `source_circle_id`.** It re-enters itself once to take the key-writer guard and lost the parameter. A caller naming a Circle it did not share had that constraint *silently discarded* and the share was authorized as a plain connection instead of being refused.
- **The atomic private-share statement gated on a bare `connections` row** — neither the origin rule nor the Circle rule — disagreeing with the Python check wrapping it. It now enforces the same rule inside the transaction (so a membership removed after the pre-check still fails closed), carries the requested Circle, and stamps the authorizing Circle on the grant so revoking the Circle revokes the share's provenance. `/location/grants/with-envelope` forwards `sourceCircleId`.

### Circle invites — the same split, one place further on

`list_eligible_direct_connections` and both invite write paths required an active `direct_request` origin, so someone you met through a Circle could never be invited into another Circle: listed as a connection everywhere, refused at the point of use with *"must still be a direct connection"*. All three sites now accept **any active origin**. Which route created a connection is provenance, not permission. Lock order and scope are unchanged — a concurrent revoke or Circle-leave is still observed, only the kind filter is gone.

### Web geolocation — `Could not get your location. Turn on Location…` with Location on

- Every reader demanded `maximumAge: 0`, so a browser momentarily unable to produce a **new** fix failed while holding a good one from seconds ago. A last resort now accepts a cached fix up to **30s** old — inside the backend's 60s capture-to-confirmation window — and only then gives up. A permission denial is still reported as a denial.
- `LocationBus.watch` published routine between-fix `POSITION_UNAVAILABLE`/`TIMEOUT` messages alongside a healthy snapshot, leaving failure text on screen while location worked. Transient errors are now ignored while a fix is held.

### Test harness

`test_kai_circle_recipient_directory_uses_safe_recommendation_signals` was red on `main`. The double keyed the owner-scoped advisor query on `LEFT JOIN`; production had changed to `JOIN`, so it fell through to the graph-wide branch and handed the owner *other people's* relationships unfiltered. Keyed on the WHERE clause instead, the graph-wide branch now filters to `approved` like production, and the assertion states what the fail-closed rule actually produces. Green here.

The location agent suite is also added to the CI manifest so this class of drift cannot recur silently.

## Verification

Against the live UAT database, using SQL captured from the patched service (not hand-copied):

- picker's offered set **==** the set a share accepts
- **0** offered-but-unshareable active connections, database-wide (was: 12 whose only provenance is a Circle)
- rewritten atomic statement parses and plans against the live schema
- `one_location_share_grants.source_circle_id` confirmed present

Tests, on this branch vs. true `origin/main`:

| | `main` | this branch |
|---|---|---|
| `test_one_location_agent_service.py` | 3 failed, 59 passed | **65 passed** |
| `test_one_location_circle_service.py` | 34 passed | **35 passed** |
| backend `-k "location or circle or connection"` | — | **514 passed** |
| webapp one-location + capacitor suites | — | **144 passed** |

`ruff check` / `ruff format --check` clean; `eslint --max-warnings=0` and `tsc --noEmit` clean.

**No schema migration and no data repair needed** — UAT has zero affected rows once the predicate is aligned.

### Pre-existing failures, untouched by this PR

Confirmed failing identically on true `origin/main`, in files and code this PR does not modify:

- `test_connection_graph_service.py::test_migration_backfills_existing_active_circle_member_pairs`
- `test_one_location_maps_routes.py::test_autocomplete_route`
- `test_one_location_maps_routes.py::test_maps_unconfigured_returns_503`

### Follow-up (not in this PR)

Making a Circle-derived connection **survive leaving the Circle** needs a `circle_member` origin kind, a backfill migration, and a guard in `_reconcile_circle_sourced_grants` — which today preserves a live location grant whenever any non-`named_circle` origin exists. Without that guard, permanent connections would mean removing someone from your Circle no longer stops their live location share. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)