### PR TITLE
fix(test): mock useVault in kyc-identity-preface tests

### DIFF
--- a/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
+++ b/hushh-webapp/__tests__/components/kyc-identity-preface.test.tsx
@@ -17,6 +17,18 @@ vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ user: { uid: "user_1" } }),
 }));
 
+// Both tests below exercise the vault-locked path deliberately ("without
+// opening the vault") -- the component stages the draft in memory instead of
+// saving to the PKM vault whenever isVaultUnlocked/vaultKey/vaultOwnerToken
+// aren't all present.
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({
+    isVaultUnlocked: false,
+    vaultKey: null,
+    vaultOwnerToken: null,
+  }),
+}));
+
 vi.mock("@/lib/services/kyc-identity-profile-pkm-service", () => ({
   KycIdentityProfilePkmService: {
     saveProfile: mocks.saveProfile,


### PR DESCRIPTION
## Summary
- The merge queue's \"Web Full\" validation lane (the only lane that runs the *complete* test suite; PR-level checks only run core/targeted subsets) has been failing for every PR, unrelated to whatever each PR actually changes.
- Root cause: \`kyc-identity-preface.test.tsx\`'s two tests never mocked \`useVault\`, so \`render()\` threw \`useVault must be used within a VaultProvider\` before either assertion ran. The component started reading vault state through \`useVault()\` at some point; the test was never updated to match.
- Fix: mock \`@/lib/vault/vault-context\` the same way every other vault-aware component test in this suite already does, returning the locked-vault shape both tests already assume (they're deliberately testing the \"without opening the vault\" staging path).

## Test plan
- [x] Full suite: 3006/3012 passed, 6 skipped, **0 failed** (was 2 failed before this fix)
- [x] typecheck clean
- [x] lint clean
- [x] verify:design-system, verify:docs, verify:voice-gateway, verify:surface-map, verify:capacitor:static all clean — the complete set of checks the \"Web Full\" queue lane runs