### PR TITLE
feat(one-location): show street address in "Shared with me" tile

### DIFF
--- a/hushh-webapp/app/one/location/page.tsx
+++ b/hushh-webapp/app/one/location/page.tsx
@@ -7483,6 +7483,8 @@ export function OneLocationAgentPageContent({
     ),
     mapLocationHref: googleMapsLocationUrl,
     decryptedPoints,
+    reverseGeocodePoint: (point) =>
+      reverseGeocodeForSavedLocation(point.latitude, point.longitude),
     sosRecipients: sosActionRecipients,
     smsRecipients: smsActionRecipients,
     smsContactCandidates: sosActionRecipients,

--- a/hushh-webapp/components/one-location/redesign/cards.tsx
+++ b/hushh-webapp/components/one-location/redesign/cards.tsx
@@ -257,6 +257,9 @@ export function SharedWithMeCard({
   previewExpanded,
   children,
   message,
+  address,
+  addressLoading,
+  coordinatesFallback,
 }: {
   name: string;
   statusLine: string;
@@ -268,6 +271,12 @@ export function SharedWithMeCard({
   previewExpanded?: boolean;
   children?: ReactNode;
   message?: string;
+  /** Reverse-geocoded street address for the shared location, if resolved. */
+  address?: string | null;
+  /** True while the street address is being reverse-geocoded. */
+  addressLoading?: boolean;
+  /** "lat, lng" shown when no street address is available. */
+  coordinatesFallback?: string;
 }) {
   const canOpenMap = Boolean(previewExpanded && mapHref);
   const previewRegionId = useId();
@@ -334,6 +343,24 @@ export function SharedWithMeCard({
           ) : null}
         </div>
       </div>
+      {address || addressLoading || coordinatesFallback ? (
+        <div className="flex items-start gap-1.5">
+          <MapPin
+            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          {addressLoading && !address ? (
+            <span
+              className="mt-0.5 h-3.5 w-40 max-w-full animate-pulse rounded bg-muted"
+              aria-hidden="true"
+            />
+          ) : (
+            <p className={cn(MUTED_TEXT, "min-w-0 break-words text-sm")}>
+              {address ?? coordinatesFallback}
+            </p>
+          )}
+        </div>
+      ) : null}
       <div id={previewRegionId} hidden={!isPreviewExpanded}>
         {children}
       </div>

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -349,6 +349,12 @@ export type LocationHubViewModel = {
   ) => ReactNode;
   mapLocationHref: (point: PlainLocationPoint) => string;
   decryptedPoints: Record<string, PlainLocationPoint>;
+  /**
+   * Reverse-geocode a decrypted shared point to a street address. Returns null
+   * when unavailable (no vault token, provider error, or no match). Optional so
+   * a view model without it degrades to the lat/lng fallback.
+   */
+  reverseGeocodePoint?: (point: PlainLocationPoint) => Promise<string | null>;
 };
 
 type FlowKind =
@@ -1146,6 +1152,41 @@ function LocationDetailFlow({
       [grantId]: (current[grantId] ?? 0) + 1,
     }));
   }, []);
+
+  // Reverse-geocode each received share's decrypted point to a street address,
+  // keyed by grant id + coordinates so a moved point re-resolves. The ref
+  // dedupes in-flight/resolved coordinate pairs without re-triggering the effect.
+  const [addressByGrant, setAddressByGrant] = useState<
+    Record<string, { key: string; status: "loading" | "done"; text: string | null }>
+  >({});
+  const resolvedAddressKeyRef = useRef<Record<string, string>>({});
+  const reverseGeocodePoint = vm.reverseGeocodePoint;
+  useEffect(() => {
+    if (kind !== "shared-with-me" || !reverseGeocodePoint) return;
+    let cancelled = false;
+    for (const grant of vm.receivedGrants) {
+      const point = vm.decryptedPoints[grant.id];
+      if (!point) continue;
+      const key = `${point.latitude},${point.longitude}`;
+      if (resolvedAddressKeyRef.current[grant.id] === key) continue;
+      resolvedAddressKeyRef.current[grant.id] = key;
+      setAddressByGrant((current) => ({
+        ...current,
+        [grant.id]: { key, status: "loading", text: null },
+      }));
+      void reverseGeocodePoint(point).then((text) => {
+        if (cancelled) return;
+        setAddressByGrant((current) => {
+          const entry = current[grant.id];
+          if (!entry || entry.key !== key) return current;
+          return { ...current, [grant.id]: { key, status: "done", text } };
+        });
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, reverseGeocodePoint, vm.receivedGrants, vm.decryptedPoints]);
   const copy = {
     "active-shares": {
       title: "Active shares",
@@ -1200,6 +1241,7 @@ function LocationDetailFlow({
           <div className="space-y-3">
             {vm.receivedGrants.map((grant) => {
               const point = vm.decryptedPoints[grant.id];
+              const addressEntry = addressByGrant[grant.id];
               const expanded =
                 Boolean(point) && !collapsedGrantIds.has(grant.id);
               return (
@@ -1219,6 +1261,17 @@ function LocationDetailFlow({
                     point?.checkIn?.message ??
                     grant.shareMessage ??
                     undefined
+                  }
+                  address={
+                    addressEntry?.status === "done" ? addressEntry.text : null
+                  }
+                  addressLoading={
+                    Boolean(point) && addressEntry?.status === "loading"
+                  }
+                  coordinatesFallback={
+                    point
+                      ? `${point.latitude.toFixed(5)}, ${point.longitude.toFixed(5)}`
+                      : undefined
                   }
                 >
                   {expanded && point


### PR DESCRIPTION
# Description

Show the **street address** on each "Shared with me" location tile under Location.

The `SharedWithMeCard` previously showed only the sharer's name, expiry, a Live pill, and an expandable lat/lng map — no human-readable address. This reverse-geocodes each received share's decrypted point and renders the street address inline, using the card's existing muted-text pattern. It falls back to `lat, lng` when no address resolves and shows a skeleton while the lookup is in flight.

No existing "Receiving an SOS" address tile exists to copy (the SOS "Save my Soul" panel shows an emergency number, not an address), so the address line follows the card's own `MUTED_TEXT` typography for consistency.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] None (UI-only change inside the existing `/one/location` "Shared with me" tab; no route handler added or changed)

- API / schema / type changes:
  - [x] Listed below:
    - `SharedWithMeCard` gains three **optional** props: `address?: string | null`, `addressLoading?: boolean`, `coordinatesFallback?: string`.
    - `LocationHubViewModel` gains one **optional** method: `reverseGeocodePoint?: (point: PlainLocationPoint) => Promise<string | null>`.
    - No backend/DB schema changes.

- Cache keys touched:
  - [x] None (address resolution is deduped in-component by grant id + coordinates; no shared cache key)

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None (web-only redesign component; reuses the existing `/api/one/location/maps/reverse-geocode` contract that native already has access to)

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] Listed below:
    - **Location data.** Received share coordinates are end-to-end encrypted (the backend never sees plaintext). To render a human-readable address, the decrypted point is sent to the Maps provider via the existing authenticated `reverse-geocode` endpoint (vault-owner token required). This is the same call already used by the save-location picker. No new plaintext persistence, logging, or metadata is introduced.

- Caller / proxy / backend pairing:
  - [x] Listed below with contract proof:
    - Reuses `OneLocationService.reverseGeocode({ vaultOwnerToken, lat, lng })` → `POST /api/one/location/maps/reverse-geocode` → `{ name, formattedAddress, countryCode }`. Existing contract; no new endpoint.

- Rollback or safe-failure behavior:
  - [x] Listed below:
    - `reverseGeocodePoint` returns `null` on any failure (no vault token, provider error, no match) → the tile falls back to `lat, lng`.
    - The vm method is optional; a view model without it degrades silently to the coordinate fallback.
    - The effect only runs for the `shared-with-me` tab and is cancel-guarded on unmount.
    - Reverting the three files fully removes the feature with no residual state.

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below:
    - Route: `/one/location` → "Shared with me" tab, expand a received share.
    - Automated: `SharedWithMeCard` unit test passes (see below). No Playwright spec added; browser screenshot not captured in this environment — see Screenshots section.

- Verification commands executed:
  - [ ] `./bin/hushh codex pre-pr`
  - [x] `cd hushh-webapp && npm run typecheck` — clean
  - [x] `cd hushh-webapp && npm run lint` — clean (`--max-warnings=0`)
  - [~] `cd hushh-webapp && npm test` — targeted + neighboring suites green: `shared-with-me-card.test.tsx` and the `one-location/redesign/__tests__` suite pass. Two failures in `one-location-agent-page.test.tsx` (`resolves a fresh local emergency number…`, `resolves the local emergency number on a direct SOS link…`) reproduce on a clean `main` with this diff stashed, so they are **pre-existing and unrelated** (SOS emergency-number resolution, environment-dependent).
  - [x] `cd hushh-webapp && npm run build` — succeeds

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate: no existing address rendering on received-share tiles.
- [x] This PR changes a current reachable app surface: `/one/location` "Shared with me" tile.
- [x] Reachable production attach point: `LocationRedesignHub` (rendered by `app/one/location/page.tsx`) → `SharedWithMeCard`.
- [x] New tests import and exercise production code: existing `SharedWithMeCard` test exercises the real component (new props are backward-compatible and optional).
- [x] New helpers/components/services are wired to an existing route/caller: `reverseGeocodePoint` is provided by the live `locationHubVm` and consumed by the hub.
- [x] Production surface proved: build + typecheck + lint green; component test green.
- [ ] Required checks are current on this head, commits are signed off, and GitHub shows this branch is mergeable with `main`. — commits signed off; awaiting CI on this head.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js implementation — this change.
- [x] **iOS**: N/A — web redesign component only; no native surface touched.
- [x] **Android**: N/A — web redesign component only; no native surface touched.

## 🧪 Testing

- [x] Tested on Web (unit test + typecheck + build); manual browser walkthrough recommended by reviewer (see Screenshots).
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)
- [ ] If generated files changed, they were regenerated — no generated files changed.

## 📸 Screenshots / Video

Browser screenshot not captured in this environment. To verify: open `/one/location`, go to "Shared with me", and expand a received share — the street address renders under the sharer's name/expiry (skeleton while resolving, `lat, lng` if no address is returned).

## 🛡️ Privacy & Consent

- [x] Does this change access user data? Yes — the sharer's decrypted location coordinates.
- [x] If yes, have you implemented `checkConsentToken()`? Access is gated by the existing vault-owner token already required to decrypt and to call `reverse-geocode`; no new access path is introduced.
- [x] Sensitive surface touched: **location data** (reverse-geocoding sends E2E-encrypted coordinates to the Maps provider).
- [x] Error path, rollback, or safe-failure behavior proved: geocode failure → `lat, lng` fallback; optional vm method → silent degrade.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] Third-party notice impact reviewed when dependencies changed — no dependencies changed.
