### PR TITLE
fix(one-location): route approved-request toast to Shared with me

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/resolve-location-deep-link-focus.test.ts
+++ b/hushh-webapp/components/one-location/redesign/__tests__/resolve-location-deep-link-focus.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveLocationDeepLinkFocus } from "@/components/one-location/redesign/location-redesign-hub";
+
+/**
+ * Deep-link focus resolution for One-Location notification "Open" actions.
+ *
+ * Regression guard: an approval notification ("location_access_approved")
+ * carries BOTH the newly created grantId and the originating requestId, plus an
+ * explicit section=shared. The recipient must land on "Shared with me", not
+ * "Needs my review". The explicit section must win over the requestId heuristic.
+ */
+describe("resolveLocationDeepLinkFocus", () => {
+  it("routes an approved request (section=shared with a requestId + grantId) to Shared with me", () => {
+    expect(
+      resolveLocationDeepLinkFocus({
+        section: "shared",
+        hasRequest: true,
+        hasGrant: true,
+        hasSubmission: false,
+      }),
+    ).toEqual({ detailAction: "shared-with-me", nextTab: null });
+  });
+
+  it("routes an access request (section=approvals) to Needs my review", () => {
+    expect(
+      resolveLocationDeepLinkFocus({
+        section: "approvals",
+        hasRequest: true,
+        hasGrant: false,
+        hasSubmission: false,
+      }),
+    ).toEqual({ detailAction: "needs-review", nextTab: null });
+  });
+
+  it("routes section=my_requests to Needs my review", () => {
+    expect(
+      resolveLocationDeepLinkFocus({
+        section: "my_requests",
+        hasRequest: false,
+        hasGrant: false,
+        hasSubmission: false,
+      }),
+    ).toEqual({ detailAction: "needs-review", nextTab: null });
+  });
+
+  it("routes section=public_responses to the Links tab", () => {
+    expect(
+      resolveLocationDeepLinkFocus({
+        section: "public_responses",
+        hasRequest: false,
+        hasGrant: false,
+        hasSubmission: true,
+      }),
+    ).toEqual({ detailAction: null, nextTab: "links" });
+  });
+
+  it("routes section=people to the People tab", () => {
+    expect(
+      resolveLocationDeepLinkFocus({
+        section: "people",
+        hasRequest: false,
+        hasGrant: false,
+        hasSubmission: false,
+      }),
+    ).toEqual({ detailAction: null, nextTab: "people" });
+  });
+
+  describe("fallbacks when no explicit section is present", () => {
+    it("falls back to Needs my review when only a requestId is present", () => {
+      expect(
+        resolveLocationDeepLinkFocus({
+          section: "",
+          hasRequest: true,
+          hasGrant: false,
+          hasSubmission: false,
+        }),
+      ).toEqual({ detailAction: "needs-review", nextTab: null });
+    });
+
+    it("falls back to Shared with me when only a grantId is present", () => {
+      expect(
+        resolveLocationDeepLinkFocus({
+          section: "",
+          hasRequest: false,
+          hasGrant: true,
+          hasSubmission: false,
+        }),
+      ).toEqual({ detailAction: "shared-with-me", nextTab: null });
+    });
+
+    it("falls back to the Links tab when only a submissionId is present", () => {
+      expect(
+        resolveLocationDeepLinkFocus({
+          section: "",
+          hasRequest: false,
+          hasGrant: false,
+          hasSubmission: true,
+        }),
+      ).toEqual({ detailAction: null, nextTab: "links" });
+    });
+
+    it("prefers the requestId fallback over the grantId fallback", () => {
+      expect(
+        resolveLocationDeepLinkFocus({
+          section: "",
+          hasRequest: true,
+          hasGrant: true,
+          hasSubmission: false,
+        }),
+      ).toEqual({ detailAction: "needs-review", nextTab: null });
+    });
+  });
+
+  it("resolves to nothing when neither a section nor any id is present", () => {
+    expect(
+      resolveLocationDeepLinkFocus({
+        section: "",
+        hasRequest: false,
+        hasGrant: false,
+        hasSubmission: false,
+      }),
+    ).toEqual({ detailAction: null, nextTab: null });
+  });
+});

--- a/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
+++ b/hushh-webapp/components/one-location/redesign/location-redesign-hub.tsx
@@ -414,6 +414,57 @@ const LEGACY_ACTION_TO_FLOW: Readonly<Partial<Record<string, FlowKind>>> = {
   privacy: "settings",
 };
 
+/**
+ * Focus a One-Location notification "Open" deep link resolves to. `detailAction`
+ * opens a focused flow (e.g. Shared with me / Needs my review); `nextTab`
+ * selects a hub tab.
+ */
+export type LocationDeepLinkFocus = {
+  detailAction: Extract<FlowKind, "needs-review" | "shared-with-me"> | null;
+  nextTab: LocationHubTab | null;
+};
+
+/**
+ * Resolve where a location deep link should land. An explicit `section` (set by
+ * the notification "Open" action) ALWAYS wins over the id-presence heuristics:
+ * an approval notification carries BOTH the newly created grantId and the
+ * originating requestId, so only the section separates "Shared with me"
+ * (section=shared) from "Needs my review" (section=approvals). Checking
+ * `hasRequest` before the section — as the previous inline logic did — stranded
+ * an approved requester on "Needs my review". The id checks remain as fallbacks
+ * for legacy links that omit the section.
+ */
+export function resolveLocationDeepLinkFocus(input: {
+  section: string;
+  hasRequest: boolean;
+  hasGrant: boolean;
+  hasSubmission: boolean;
+}): LocationDeepLinkFocus {
+  const { section, hasRequest, hasGrant, hasSubmission } = input;
+  if (section === "approvals" || section === "my_requests") {
+    return { detailAction: "needs-review", nextTab: null };
+  }
+  if (section === "shared") {
+    return { detailAction: "shared-with-me", nextTab: null };
+  }
+  if (section === "public_responses") {
+    return { detailAction: null, nextTab: "links" };
+  }
+  if (section === "people") {
+    return { detailAction: null, nextTab: "people" };
+  }
+  if (hasRequest) {
+    return { detailAction: "needs-review", nextTab: null };
+  }
+  if (hasGrant) {
+    return { detailAction: "shared-with-me", nextTab: null };
+  }
+  if (hasSubmission) {
+    return { detailAction: null, nextTab: "links" };
+  }
+  return { detailAction: null, nextTab: null };
+}
+
 const BUSY = (vm: LocationHubViewModel, key: string) => vm.busy === key;
 
 function LocationHeaderActions({ vm }: { vm: LocationHubViewModel }) {
@@ -541,17 +592,12 @@ export function LocationRedesignHub({ vm }: { vm: LocationHubViewModel }) {
     const hasSubmission = Boolean(
       String(searchParams.get("submissionId") || "").trim(),
     );
-    let nextTab: LocationHubTab | null = null;
-    let detailAction: FlowKind | null = null;
-    if (section === "approvals" || section === "my_requests" || hasRequest) {
-      detailAction = "needs-review";
-    } else if (section === "shared" || hasGrant) {
-      detailAction = "shared-with-me";
-    } else if (section === "public_responses" || hasSubmission) {
-      nextTab = "links";
-    } else if (section === "people") {
-      nextTab = "people";
-    }
+    const { detailAction, nextTab } = resolveLocationDeepLinkFocus({
+      section,
+      hasRequest,
+      hasGrant,
+      hasSubmission,
+    });
     const legacyInbox = searchParams.get(LOCATION_HUB_TAB_PARAM) === "inbox";
     if (detailAction || nextTab || legacyInbox) {
       setFlow("none");


### PR DESCRIPTION
# Description

When a location access **request is approved**, the recipient receives an
"Open" toast. Clicking it landed them on **"Needs my review"** instead of
**"Shared with me"**.

Root cause: the approval deep link carries the new `grantId`, the originating
`requestId`, **and** an explicit `section=shared`. The redesign hub's deep-link
resolver (`location-redesign-hub.tsx`) evaluated `hasRequest` **before**
`section === "shared"`, so the stray `requestId` won and forced the
`needs-review` detail flow.

Fix: an explicit `section` now always wins over the id-presence heuristics,
which remain only as fallbacks for legacy links that omit the section. The
precedence is extracted into a pure, exported `resolveLocationDeepLinkFocus`
helper so it is unit-testable without mounting the hub. This mirrors the
precedence the legacy page focus resolver (`app/one/location/page.tsx`) already
uses correctly.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: client-side deep-link focus for `/one/location` (no API route changed)

- API / schema / type changes:
  - [x] Listed below: new exported `resolveLocationDeepLinkFocus` helper + `LocationDeepLinkFocus` type (internal to the one-location redesign module)

- Cache keys touched:
  - [x] None

- Runtime DB data-plane changes:
  - [x] None

- World-model domain summary effects:
  - [x] None

- Mobile parity impacts:
  - [x] None — shared web component; no Capacitor plugin surface changed

- Docs updated (exact files):
  - [x] None

- Top-level / devex / config / generated / ignore files touched:
  - [x] None

- Trust boundary touched:
  - [x] None — routing only; no auth/consent/vault/decryption path changed

- Caller / proxy / backend pairing:
  - [x] Not applicable — frontend-only navigation fix

- Rollback or safe-failure behavior:
  - [x] Listed below: pure resolver returns `{ detailAction: null, nextTab: null }` for unknown input, so an unrecognized link is a no-op (same as before)

- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: covered by `resolve-location-deep-link-focus.test.ts` (pure resolver); manual browser proof not run locally

- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm test` (targeted: one-location + notification + redesign suites, 447 pass; 2 pre-existing SOS/emergency-number failures reproduce on clean `main` and are environmental) — pass for the changed surface
  - [x] `cd hushh-webapp && npm run build` — pass
  - [ ] `./bin/hushh codex pre-pr` — not run
  - [ ] `npm run ios:cold:audit` / kai-system-audit — not applicable to this frontend routing change

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (the active One-Location redesign hub).
- [x] Reachable production attach point: `LocationRedesignHub` deep-link `useEffect` calls `resolveLocationDeepLinkFocus`.
- [x] New tests import and exercise production code (`resolveLocationDeepLinkFocus` from the hub module), not test-local mocks.
- [x] New helper is wired to the existing `/one/location` deep-link effect.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client component (`components/one-location/redesign/location-redesign-hub.tsx`)
- [x] **iOS**: N/A — no native plugin surface touched
- [x] **Android**: N/A — no native plugin surface touched

## 🧪 Testing

- [x] Tested on Web (unit): `resolve-location-deep-link-focus.test.ts` — 10 cases
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No UI pixels change; only the destination tab of the approval toast's "Open"
action. Behavior is proven by the unit test asserting the approval payload
(`section=shared` + `requestId` + `grantId`) resolves to `shared-with-me`.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — navigation only.
- [x] Sensitive surface touched: none
- [x] Error path / safe-failure proved: unknown links resolve to a no-op focus

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


