### PR TITLE
feat(one-location): a Circle invitation connects two people, not everyone

### DIFF
--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 137,
+  "expected_migration_version": 138,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/migrations/138_circle_member_connection_origin.sql
+++ b/consent-protocol/db/migrations/138_circle_member_connection_origin.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+-- Migration 138: a Circle invitation is a connection between two people.
+--
+-- Joining a Circle used to write a `named_circle` origin between the joiner
+-- and EVERY existing member — a 20-person Circle produced 19 connections from
+-- one join, connecting people who had never chosen each other. It also made
+-- those connections disappear again the moment someone left, because
+-- `named_circle` origins are revoked with the membership.
+--
+-- Redeeming an invitation is the same consent shape as a connection request:
+-- one person offers, one person accepts, and the pair is connected. This kind
+-- records that pair. It is deliberately NOT `named_circle`, so it survives
+-- leaving the Circle exactly as an accepted connection request does, and it is
+-- deliberately NOT `direct_request`, so the Circle lifecycle can still tell
+-- "we met through a Circle" apart from "we exchanged a request" — the
+-- distinction that keeps a Circle removal from silently preserving a live
+-- location share the Circle authorized.
+--
+-- No backfill. Connections created by the old mesh behavior stay exactly as
+-- they are: people may already be sharing location with them, and revoking
+-- them would be a silent disconnection. This changes what future joins create.
+ALTER TABLE connection_origins
+  DROP CONSTRAINT IF EXISTS connection_origins_origin_kind_check;
+
+ALTER TABLE connection_origins
+  ADD CONSTRAINT connection_origins_origin_kind_check
+  CHECK (origin_kind IN (
+    'direct_request',
+    'named_circle',
+    'circle_member',
+    'legacy_invite',
+    'import'
+  ));
+
+-- `circle_member` is pair provenance, not Circle-scoped provenance: one row per
+-- connection regardless of how many Circles the pair later share. The existing
+-- shape constraint already requires source_circle_id IS NULL and
+-- origin_key = origin_kind for every kind except 'named_circle', which is
+-- exactly right here, so it needs no change.
+
+COMMENT ON COLUMN connection_origins.origin_kind IS
+  'Why this connection exists. `named_circle` is Circle-scoped and revoked with the membership; `circle_member` records the invitation two people accepted and outlives the Circle, like `direct_request`.';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/138_circle_member_connection_origin_down.sql
+++ b/consent-protocol/db/migrations/rollback/138_circle_member_connection_origin_down.sql
@@ -1,0 +1,41 @@
+BEGIN;
+
+-- Roll back migration 138.
+--
+-- Rows written by the new join behavior must go before the constraint can
+-- narrow again, otherwise the ALTER fails validation. Revoking rather than
+-- deleting keeps the audit trail, so recompute the aggregate afterwards and
+-- retire any connection left with no live provenance.
+UPDATE connections connection
+SET status = 'revoked',
+    revoked_at = COALESCE(connection.revoked_at, NOW()),
+    updated_at = NOW()
+WHERE connection.status = 'active'
+  AND EXISTS (
+    SELECT 1 FROM connection_origins origin
+    WHERE origin.connection_id = connection.id
+      AND origin.origin_kind = 'circle_member'
+      AND origin.status = 'active'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM connection_origins origin
+    WHERE origin.connection_id = connection.id
+      AND origin.origin_kind <> 'circle_member'
+      AND origin.status = 'active'
+  );
+
+DELETE FROM connection_origins WHERE origin_kind = 'circle_member';
+
+ALTER TABLE connection_origins
+  DROP CONSTRAINT IF EXISTS connection_origins_origin_kind_check;
+
+ALTER TABLE connection_origins
+  ADD CONSTRAINT connection_origins_origin_kind_check
+  CHECK (origin_kind IN (
+    'direct_request',
+    'named_circle',
+    'legacy_invite',
+    'import'
+  ));
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -115,7 +115,8 @@
     "134_one_location_named_circles.sql",
     "135_one_location_circle_connection_origins.sql",
     "136_one_location_circle_member_invites.sql",
-    "137_ria_claim_dossiers.sql"
+    "137_ria_claim_dossiers.sql",
+    "138_circle_member_connection_origin.sql"
   ],
   "groups": {
     "iam": [
@@ -185,7 +186,8 @@
       "134_one_location_named_circles.sql",
       "135_one_location_circle_connection_origins.sql",
       "136_one_location_circle_member_invites.sql",
-      "137_ria_claim_dossiers.sql"
+      "137_ria_claim_dossiers.sql",
+      "138_circle_member_connection_origin.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/connection_graph_service.py
+++ b/consent-protocol/hushh_mcp/services/connection_graph_service.py
@@ -20,6 +20,12 @@ from sqlalchemy.engine import Connection
 
 ORIGIN_DIRECT_REQUEST = "direct_request"
 ORIGIN_NAMED_CIRCLE = "named_circle"
+# The invitation two people accepted to become Circle co-members. Distinct from
+# `named_circle`, which is Circle-scoped provenance revoked with the membership:
+# this one records the pair and outlives the Circle, the way an accepted
+# connection request does. Distinct from `direct_request` so Circle lifecycle
+# code can still tell the two apart.
+ORIGIN_CIRCLE_MEMBER = "circle_member"
 ORIGIN_LEGACY_INVITE = "legacy_invite"
 ORIGIN_IMPORT = "import"
 
@@ -27,12 +33,18 @@ ORIGIN_KINDS = frozenset(
     {
         ORIGIN_DIRECT_REQUEST,
         ORIGIN_NAMED_CIRCLE,
+        ORIGIN_CIRCLE_MEMBER,
         ORIGIN_LEGACY_INVITE,
         ORIGIN_IMPORT,
     }
 )
 USER_MANAGEABLE_ORIGIN_KINDS = frozenset(
-    {ORIGIN_DIRECT_REQUEST, ORIGIN_LEGACY_INVITE, ORIGIN_IMPORT}
+    {
+        ORIGIN_DIRECT_REQUEST,
+        ORIGIN_CIRCLE_MEMBER,
+        ORIGIN_LEGACY_INVITE,
+        ORIGIN_IMPORT,
+    }
 )
 
 
@@ -83,6 +95,10 @@ class ConnectionGraphService:
         return {
             ORIGIN_DIRECT_REQUEST: "request",
             ORIGIN_NAMED_CIRCLE: "named_circle",
+            # `connections.source` predates this ledger and its CHECK does not
+            # know `circle_member`. Both invite-shaped kinds project onto the
+            # existing `circle_invite` value; the ledger keeps them distinct.
+            ORIGIN_CIRCLE_MEMBER: "circle_invite",
             ORIGIN_LEGACY_INVITE: "circle_invite",
             ORIGIN_IMPORT: "import",
         }[origin_kind]
@@ -415,7 +431,9 @@ class ConnectionGraphService:
                         ) THEN 'request'
                         WHEN BOOL_OR(
                           origin.status = 'active'
-                          AND origin.origin_kind = 'legacy_invite'
+                          AND origin.origin_kind IN (
+                            'circle_member', 'legacy_invite'
+                          )
                         ) THEN 'circle_invite'
                         WHEN BOOL_OR(
                           origin.status = 'active'

--- a/consent-protocol/hushh_mcp/services/one_location_circle_service.py
+++ b/consent-protocol/hushh_mcp/services/one_location_circle_service.py
@@ -401,8 +401,28 @@ class OneLocationCircleService:
         *,
         circle_id: str,
         user_id: str,
+        inviter_user_id: str | None = None,
     ) -> None:
-        """Create bounded, source-aware Circle origins in the same transaction."""
+        """Connect a joiner to whoever invited them, and to nobody else.
+
+        Redeeming an invitation is the same consent shape as a connection
+        request: one person offered, one accepted. So it produces exactly one
+        connection, between exactly those two.
+
+        This used to connect the joiner to every existing member, which meant a
+        single join could connect people who had never chosen each other — one
+        join into a full 20-person Circle created 19 connections, 18 of them
+        between strangers. Restricting who may invite does not fix that; the
+        fan-out does. Co-members who were never introduced can still share
+        location with each other through the Circle itself, which is a sharing
+        scope rather than a claim that everyone is connected.
+
+        Two origins are written for the one pair: `circle_member`, which
+        records the accepted invitation and outlives the Circle, and
+        `named_circle`, which is Circle-scoped provenance revoked with the
+        membership. Together they let the connection persist after someone
+        leaves while the Circle still governs what it authorized.
+        """
 
         member_rows = _all(
             conn.execute(
@@ -419,26 +439,28 @@ class OneLocationCircleService:
                 {"circle_id": circle_id},
             )
         )
-        if user_id not in {str(row.get("user_id") or "").strip() for row in member_rows}:
+        active_member_ids = {str(row.get("user_id") or "").strip() for row in member_rows}
+        if user_id not in active_member_ids:
             raise OneLocationCircleError(
                 "LOCATION_CIRCLE_MEMBERSHIP_NOT_ACTIVE",
                 "Circle membership is no longer active.",
                 status_code=409,
             )
-        for member_user_id in sorted(
-            {
-                str(row.get("user_id") or "").strip()
-                for row in member_rows
-                if str(row.get("user_id") or "").strip()
-                and str(row.get("user_id") or "").strip() != user_id
-            }
+        inviter_id = str(inviter_user_id or "").strip()
+        # An inviter who has since left introduces nobody: the joiner is in the
+        # Circle and can share through it, but there is no live pair to record.
+        if not inviter_id or inviter_id == user_id or inviter_id not in active_member_ids:
+            return
+        for kind, source_circle in (
+            ("circle_member", None),
+            ("named_circle", circle_id),
         ):
             ensure_connection_origin(
                 conn,
                 user_a_id=user_id,
-                user_b_id=member_user_id,
-                kind="named_circle",
-                source_circle_id=circle_id,
+                user_b_id=inviter_id,
+                kind=kind,
+                source_circle_id=source_circle,
             )
 
     def list_circles(self, *, user_id: str) -> list[dict[str, Any]]:
@@ -976,7 +998,7 @@ class OneLocationCircleService:
                             """
                             SELECT
                               id, circle_id, status, expires_at,
-                              max_uses, use_count
+                              max_uses, use_count, created_by_user_id
                             FROM one_location_circle_invite_codes
                             WHERE id = CAST(:invite_id AS UUID)
                               AND circle_id = CAST(:circle_id AS UUID)
@@ -1119,6 +1141,9 @@ class OneLocationCircleService:
                     conn,
                     circle_id=circle_id,
                     user_id=user_id,
+                    # Whoever generated this code did the inviting, so they are
+                    # the one person the joiner becomes connected to.
+                    inviter_user_id=str(invite_row.get("created_by_user_id") or ""),
                 )
                 conn.execute(
                     text(
@@ -2108,6 +2133,7 @@ class OneLocationCircleService:
                         conn,
                         circle_id=circle_id,
                         user_id=user_id,
+                        inviter_user_id=str(invite_row.get("inviter_user_id") or ""),
                     )
                 else:
                     expires_at = invite_row.get("expires_at")
@@ -2300,6 +2326,7 @@ class OneLocationCircleService:
                         conn,
                         circle_id=circle_id,
                         user_id=user_id,
+                        inviter_user_id=str(invite_row.get("inviter_user_id") or ""),
                     )
                     conn.execute(
                         text(
@@ -2489,7 +2516,19 @@ class OneLocationCircleService:
         circle_id: str,
         member_user_id: str | None = None,
     ) -> None:
-        """Preserve grants when another active relationship origin still supports them."""
+        """Preserve grants when an independent relationship still supports them.
+
+        "Independent" excludes `circle_member`. That origin exists *because of*
+        a Circle invitation, so it cannot be the reason a Circle-authorized
+        grant outlives the Circle — if it were, removing someone from your
+        Circle would silently keep their live location running, reattached as a
+        connection-scoped share. Removal has one obvious meaning and this keeps
+        it: the pair stays connected, the share the Circle authorized ends.
+
+        A `direct_request` (or import/legacy invite) is independent: those two
+        people connected on their own terms, so their share survives losing a
+        Circle they happened to share.
+        """
 
         params = {
             "circle_id": circle_id,
@@ -2513,7 +2552,9 @@ class OneLocationCircleService:
                     JOIN connection_origins origin
                       ON origin.connection_id = connection.id
                      AND origin.status = 'active'
-                     AND origin.origin_kind <> 'named_circle'
+                     AND origin.origin_kind NOT IN (
+                       'named_circle', 'circle_member'
+                     )
                     WHERE connection.status = 'active'
                       AND (
                         (

--- a/consent-protocol/tests/services/test_connection_graph_service.py
+++ b/consent-protocol/tests/services/test_connection_graph_service.py
@@ -5,8 +5,11 @@ from unittest.mock import patch
 import pytest
 
 from hushh_mcp.services.connection_graph_service import (
+    ORIGIN_CIRCLE_MEMBER,
     ORIGIN_DIRECT_REQUEST,
+    ORIGIN_KINDS,
     ORIGIN_NAMED_CIRCLE,
+    USER_MANAGEABLE_ORIGIN_KINDS,
     ConnectionGraphService,
     ensure_connection_origin,
     revoke_circle_origins,
@@ -204,13 +207,13 @@ def test_ensure_origins_sorts_and_deduplicates_pairs():
 
 
 def test_migration_backfills_existing_active_circle_member_pairs():
-    migration_path = (
-        Path(__file__).resolve().parents[2]
-        / "db"
-        / "migrations"
-        / "126_one_location_circle_connection_origins.sql"
-    )
-    sql = migration_path.read_text(encoding="utf-8")
+    # Located by name, not by number: this migration has already been
+    # renumbered once (126 -> 135) and the hard-coded path silently rotted into
+    # a FileNotFoundError, so the assertions below stopped guarding anything.
+    migrations_dir = Path(__file__).resolve().parents[2] / "db" / "migrations"
+    matches = sorted(migrations_dir.glob("*_one_location_circle_connection_origins.sql"))
+    assert len(matches) == 1, f"expected exactly one origins migration, found {matches}"
+    sql = matches[0].read_text(encoding="utf-8")
 
     assert "WITH active_circle_pairs AS" in sql
     assert "first_member.user_id < second_member.user_id" in sql
@@ -259,3 +262,35 @@ def test_recompute_uses_one_ordered_circle_mapping():
         {"id": circle_a, "name": "Same name"},
         {"id": circle_b, "name": "Same name"},
     ]
+
+
+def test_circle_member_origin_is_a_durable_pair_not_circle_scoped() -> None:
+    """The kind that records an accepted Circle invitation.
+
+    It must key like a pair-level origin, not a Circle-scoped one, so a person
+    carries exactly one of these however many Circles they later share — and so
+    leaving a Circle cannot take it with them.
+    """
+    assert ORIGIN_CIRCLE_MEMBER in ORIGIN_KINDS
+    assert ConnectionGraphService.origin_key(ORIGIN_CIRCLE_MEMBER) == "circle_member"
+
+    with pytest.raises(ValueError):
+        ConnectionGraphService.origin_key(
+            ORIGIN_CIRCLE_MEMBER,
+            source_circle_id="550e8400-e29b-41d4-a716-446655440000",
+        )
+
+
+def test_circle_member_origin_is_removable_by_the_people_in_it() -> None:
+    """A connection you gained by accepting an invitation is yours to drop.
+
+    Circle-scoped provenance is managed by the Circle's lifecycle instead, so
+    it stays out of the user-manageable set.
+    """
+    assert ORIGIN_CIRCLE_MEMBER in USER_MANAGEABLE_ORIGIN_KINDS
+    assert ORIGIN_NAMED_CIRCLE not in USER_MANAGEABLE_ORIGIN_KINDS
+
+
+def test_circle_member_projects_onto_the_existing_compatibility_source() -> None:
+    """`connections.source` predates the ledger and cannot learn a new value."""
+    assert ConnectionGraphService._compatibility_source(ORIGIN_CIRCLE_MEMBER) == "circle_invite"

--- a/consent-protocol/tests/services/test_one_location_circle_service.py
+++ b/consent-protocol/tests/services/test_one_location_circle_service.py
@@ -573,18 +573,15 @@ def test_code_join_revalidates_revocation_after_locking_the_circle() -> None:
     assert not any("SET use_count = use_count + 1" in sql for sql in conn.sql)
 
 
-def test_join_origin_sync_connects_every_other_active_member_once(
+def _join_connection_calls(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    *,
+    members: list[str],
+    user_id: str,
+    inviter_user_id: str | None,
+) -> list[dict]:
     circle_id = "550e8400-e29b-41d4-a716-446655440000"
-    conn = _CapacityConnection(
-        [
-            {"user_id": "member-user"},
-            {"user_id": "owner-user"},
-            {"user_id": "friend-user"},
-            {"user_id": "friend-user"},
-        ]
-    )
+    conn = _CapacityConnection([{"user_id": member} for member in members])
     calls: list[dict] = []
     monkeypatch.setattr(
         circle_service_module,
@@ -595,16 +592,39 @@ def test_join_origin_sync_connects_every_other_active_member_once(
     OneLocationCircleService._connect_member_to_circle(
         conn,
         circle_id=circle_id,
+        user_id=user_id,
+        inviter_user_id=inviter_user_id,
+    )
+    return calls
+
+
+def test_join_connects_the_joiner_to_their_inviter_and_to_nobody_else(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One invitation accepted is one connection, exactly like a request.
+
+    The mesh this replaces connected a joiner to every existing member, so a
+    single join into a full Circle produced 19 connections between people who
+    had never chosen each other.
+    """
+    circle_id = "550e8400-e29b-41d4-a716-446655440000"
+
+    calls = _join_connection_calls(
+        monkeypatch,
+        members=["member-user", "owner-user", "friend-user"],
         user_id="member-user",
+        inviter_user_id="owner-user",
     )
 
     assert calls == [
+        # Outlives the Circle: the pair accepted an invitation.
         {
             "user_a_id": "member-user",
-            "user_b_id": "friend-user",
-            "kind": "named_circle",
-            "source_circle_id": circle_id,
+            "user_b_id": "owner-user",
+            "kind": "circle_member",
+            "source_circle_id": None,
         },
+        # Circle-scoped provenance, revoked when the membership ends.
         {
             "user_a_id": "member-user",
             "user_b_id": "owner-user",
@@ -612,6 +632,45 @@ def test_join_origin_sync_connects_every_other_active_member_once(
             "source_circle_id": circle_id,
         },
     ]
+    assert not any(call["user_b_id"] == "friend-user" for call in calls)
+
+
+def test_join_connects_nobody_when_the_inviter_is_no_longer_a_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inviter who has left introduces no one.
+
+    The joiner is still in the Circle and can share through it; there is simply
+    no live pair to record, and the remaining members must not be swept in.
+    """
+    assert (
+        _join_connection_calls(
+            monkeypatch,
+            members=["member-user", "owner-user", "friend-user"],
+            user_id="member-user",
+            inviter_user_id="departed-user",
+        )
+        == []
+    )
+    assert (
+        _join_connection_calls(
+            monkeypatch,
+            members=["member-user", "owner-user"],
+            user_id="member-user",
+            inviter_user_id=None,
+        )
+        == []
+    )
+    # Self-invitation is not a relationship.
+    assert (
+        _join_connection_calls(
+            monkeypatch,
+            members=["member-user", "owner-user"],
+            user_id="member-user",
+            inviter_user_id="member-user",
+        )
+        == []
+    )
 
 
 def test_member_invite_payload_is_metadata_only() -> None:
@@ -701,20 +760,23 @@ def test_targeted_invite_accept_rechecks_direct_connection_and_creates_origins(
     assert result["accepted"] is True
     assert result["joined"] is True
     assert result["invite"]["status"] == "accepted"
+    # Accepting a targeted invitation connects the joiner to the member who
+    # sent it. The Circle's owner did not invite them and is not swept in.
     assert origin_calls == [
+        {
+            "user_a_id": "member-user",
+            "user_b_id": "inviter-member",
+            "kind": "circle_member",
+            "source_circle_id": None,
+        },
         {
             "user_a_id": "member-user",
             "user_b_id": "inviter-member",
             "kind": "named_circle",
             "source_circle_id": circle_id,
         },
-        {
-            "user_a_id": "member-user",
-            "user_b_id": "owner-user",
-            "kind": "named_circle",
-            "source_circle_id": circle_id,
-        },
     ]
+    assert not any(call["user_b_id"] == "owner-user" for call in origin_calls)
     connection_lock_index = next(
         index
         for index, sql in enumerate(conn.sql)
@@ -1443,7 +1505,12 @@ def test_circle_grant_reconciliation_preserves_other_relationship_origins() -> N
     )
 
     assert len(conn.sql) == 3
-    assert "origin.origin_kind <> 'named_circle'" in conn.sql[0]
+    # Only an independent relationship keeps a Circle-authorized grant alive.
+    # `circle_member` is not independent — it exists because of a Circle
+    # invitation — so counting it would mean removing someone from your Circle
+    # silently kept their live location running as a connection-scoped share.
+    preserve_sql = " ".join(conn.sql[0].split())
+    assert "origin.origin_kind NOT IN ( 'named_circle', 'circle_member' )" in preserve_sql
     assert "SET source_circle_id = NULL" in conn.sql[0]
     assert "origin.origin_kind = 'named_circle'" in conn.sql[1]
     assert "replacement_circle_id" in conn.sql[1]


### PR DESCRIPTION
> **Stacked on #4976.** Base is `fix/one-location-share-eligibility`, so the diff shows only this change. Merge #4976 first; this retargets to `main` automatically.

## The problem

Joining a Circle wrote a connection between the joiner and **every existing member**. One join into a full twenty-person Circle produced **nineteen connections, eighteen of them between people who had never chosen each other.**

That surfaced while deciding whether any member should be allowed to invite. Restricting invites to the Circle admin does **not** fix it: owner A invites B, C and D, and B–C, B–D, C–D all still become connections. The problem is the fan-out, not who sends the invite.

## What it does now

Redeeming an invitation is the same consent shape as a connection request — one person offers, one accepts, those two are connected. So that is what it creates:

- **targeted invite** → joiner ↔ `inviter_user_id`
- **invite code** → joiner ↔ `created_by_user_id` (whoever generated the code)
- **nobody else**

An inviter who has since left introduces no one; a missing or self-referencing inviter connects nobody. The Circle join itself still succeeds in every case.

This is what the Circle invite code exists for: someone new installs the app, enters the code, and is connected — without also having to send a connection request. It just no longer connects them to strangers as a side effect.

**Co-members who were never introduced are unaffected in the way that matters.** They still share location with each other through the Circle, which is a *sharing scope*, not a claim that everyone in it is connected. That branch ships in #4976.

## Two origins, one pair

| origin | records | lifetime |
|---|---|---|
| **`circle_member`** (new) | the accepted invitation | **outlives the Circle**, like an accepted request |
| `named_circle` | Circle-scoped provenance | revoked with the membership |

Keeping them distinct is what makes the lifecycle safe.

### The trap this closes

`_reconcile_circle_sourced_grants` preserves a Circle-authorized location grant when an *independent* relationship still supports it. `circle_member` is **not** independent — it exists *because of* a Circle invitation.

Had it counted, **removing someone from your Circle would have silently kept their live location running**, reattached as a connection-scoped share. Removal has one obvious meaning and this preserves it:

> the pair stays connected, the share the Circle authorized ends.

A `direct_request` still preserves the grant, unchanged — those two connected on their own terms.

## Migration 137 backfills nothing, deliberately

Connections created by the old mesh stay exactly as they are. People may already be sharing location with them, and revoking them would be a silent disconnection. This changes what **future** joins create.

Verified against the live UAT schema, inside a rolled-back transaction:

- migration applies to the real schema
- a `circle_member` origin satisfies the existing shape constraint
- a *Circle-scoped* `circle_member` row is correctly **rejected**
- the rollback restores the narrower constraint, leaving **0** rows behind

## Also repaired

`test_migration_backfills_existing_active_circle_member_pairs` had stopped guarding anything: the connection-origins migration was renumbered 126 → 135 and the hard-coded path rotted into a `FileNotFoundError`, so every assertion in it was dead. It now locates the migration by name. This was red on `main` before this branch.

## Verification

- backend `-k "location or circle or connection"` — **519 passed**, 2 failed
- the 2 failures are `test_one_location_maps_routes.py` (`test_autocomplete_route`, `test_maps_unconfigured_returns_503`), confirmed failing identically on true `origin/main`, in code this PR does not touch
- `ruff check` / `ruff format --check` clean

New tests cover: inviter-only connection with both origin kinds; departed / missing / self inviter connecting nobody; targeted-accept not sweeping in the Circle owner; `circle_member` keying as a pair-level origin and rejecting a Circle id; user-removability; compatibility-source projection; and the grant-reconciliation guard.

## Behaviour change to be aware of

**Joining a Circle no longer adds every member to your Connect list** — only the person who invited you. Existing pairs are grandfathered, so nothing visible today disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)