### PR TITLE
fix(ui): add vertical rhythm between AI access panel groups

### DIFF
--- a/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
+++ b/hushh-webapp/components/connections/gemini-runtime-configuration-page.tsx
@@ -196,7 +196,10 @@ export function GeminiRuntimeConfigurationPage({
           accent="neutral"
         />
       </AppPageHeaderRegion>
-      <AppPageContentRegion>
+      {/* space-y-6 gives the Gemini and "Coming soon" groups the standard
+          surface rhythm; without it the two SettingsGroups render flush and the
+          "Coming soon" heading looks cramped against the Gemini card (#1940). */}
+      <AppPageContentRegion className="space-y-6">
         <GeminiRuntimeSettingsCard
           userId={user?.uid}
           vaultKey={vaultKey}


### PR DESCRIPTION
# Description

Fixes the cramped spacing on the **AI access** / **Gemini settings** panel
reported in `hushh-labs/hushh_Tech_website#1940` ("proper padding on AI access;
set up"). The component actually lives here in `hushh-webapp`, so the fix lands
in this repo.

**Root cause:** `gemini-runtime-configuration-page.tsx` renders the "Gemini"
and "Coming soon" `SettingsGroup`s as a bare fragment inside
`AppPageContentRegion`, and that region has no inter-child spacing
(`.app-page-content-region` is only `width:100%`). With zero gap between the two
sections, the "Coming soon" heading sat flush against the Gemini card and read
as cramped.

**Fix:** set `space-y-6` on the content region — the same standard surface
rhythm peer pages already use (e.g. `app/one/location/page.tsx`). One line,
scoped to this page. The shared `SettingsGroup`/`SettingsRow`/`Badge` primitives
are untouched, and the card's other mount (profile workspace, which supplies its
own stack spacing) is unaffected.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/setup/connections` and `/one/connect/settings` (visual spacing only; no routing/logic change)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — Tailwind `space-y-6` is responsive-safe; no native surface changed
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — presentation only; no auth/consent/vault/credential path changed
- Caller / proxy / backend pairing:
  - [x] Not applicable — frontend spacing only
- Rollback or safe-failure behavior:
  - [x] Listed below: purely additive CSS class; reverting the one line restores prior layout
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: manual browser proof not run (authenticated, vault-gated setup page); change is a single well-scoped Tailwind class validated by build + existing card tests
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed file, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`gemini-runtime-settings-card.test.tsx`, 8 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (AI access / Gemini settings page).
- [x] Reachable production attach point: `AppPageContentRegion` in `gemini-runtime-configuration-page.tsx`.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js page (`components/connections/gemini-runtime-configuration-page.tsx`)
- [x] **iOS**: N/A — no native plugin surface touched
- [x] **Android**: N/A — no native plugin surface touched

## 🧪 Testing

- [x] Tested on Web (typecheck + lint + build + existing card unit tests)
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Before (from `hushh_Tech_website#1940`): the "Coming soon" section is cramped
against the Gemini card. After: `space-y-6` gives the two groups the standard
24px vertical rhythm. No other pixels change.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — layout spacing only.
- [x] Sensitive surface touched: none

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


