### PR TITLE
fix(journey): end the post-claim profile redirect loop, and unbreak account deletion

### DIFF
--- a/consent-protocol/hushh_mcp/services/account_service.py
+++ b/consent-protocol/hushh_mcp/services/account_service.py
@@ -217,6 +217,38 @@ class AccountService:
             "one_location_circle_memberships": text(
                 "DELETE FROM one_location_circle_memberships WHERE user_id = :user_id"
             ),
+            # Scope proposals hold plain (no ON DELETE) foreign keys into
+            # connection_requests, so they must be cleared first — including
+            # rows owned by OTHER users that reference this user's requests,
+            # or the request delete below fails the whole account deletion.
+            "connection_scope_proposal_events": text(
+                """
+                DELETE FROM connection_scope_proposal_events
+                WHERE actor_user_id = :user_id
+                   OR connection_scope_proposal_id IN (
+                        SELECT id FROM connection_scope_proposals
+                        WHERE owner_user_id = :user_id
+                           OR receiver_user_id = :user_id
+                           OR connection_request_id IN (
+                                SELECT id FROM connection_requests
+                                WHERE requester_user_id = :user_id
+                                   OR addressee_user_id = :user_id
+                           )
+                   )
+                """
+            ),
+            "connection_scope_proposals": text(
+                """
+                DELETE FROM connection_scope_proposals
+                WHERE owner_user_id = :user_id
+                   OR receiver_user_id = :user_id
+                   OR connection_request_id IN (
+                        SELECT id FROM connection_requests
+                        WHERE requester_user_id = :user_id
+                           OR addressee_user_id = :user_id
+                   )
+                """
+            ),
             "connection_requests": text(
                 """
                 DELETE FROM connection_requests
@@ -975,6 +1007,8 @@ class AccountService:
             "one_location_circle_invites",
             "one_location_circle_member_invites",
             "one_location_circle_memberships",
+            "connection_scope_proposal_events",
+            "connection_scope_proposals",
             "connection_requests",
             "connections",
             "trusted_connections",
@@ -1370,6 +1404,8 @@ class AccountService:
                     "one_location_circle_invites",
                     "one_location_circle_member_invites",
                     "one_location_circle_memberships",
+                    "connection_scope_proposal_events",
+                    "connection_scope_proposals",
                     "connection_requests",
                     "connections",
                     "trusted_connections",

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -44,3 +44,4 @@ tests/test_advisors_coordinate_privacy.py
 tests/test_ria_claim_email_evidence.py
 tests/test_ria_claim_email_routes.py
 tests/test_ria_onboarding_status_claim_event.py
+tests/test_account_delete_scope_proposals.py

--- a/consent-protocol/tests/test_account_delete_scope_proposals.py
+++ b/consent-protocol/tests/test_account_delete_scope_proposals.py
@@ -1,0 +1,50 @@
+"""Account deletion must clear scope proposals before connection requests.
+
+connection_scope_proposals holds a plain (no ON DELETE) foreign key into
+connection_requests, and proposal events hold one into proposals. Deleting the
+requests first raises ForeignKeyViolation and fails the WHOLE account deletion
+with a 500 — which is exactly what happened on UAT on 2026-08-08.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from hushh_mcp.services.account_service import AccountService
+
+
+def _full_account_source() -> str:
+    return inspect.getsource(AccountService._delete_full_account)
+
+
+def test_scope_proposal_tables_have_registered_delete_queries() -> None:
+    service = AccountService.__new__(AccountService)
+    AccountService.__init__(service)
+    for table in ("connection_scope_proposal_events", "connection_scope_proposals"):
+        assert table in service._delete_by_user_queries, table
+
+
+def test_scope_proposals_are_deleted_before_connection_requests() -> None:
+    source = _full_account_source()
+    # Find the deletion tuple (not the results-bookkeeping dict, which also
+    # names these tables) and assert order inside it.
+    loop_start = source.index("for table_name in (")
+    loop = source[loop_start : source.index("):", loop_start)]
+    assert '"connection_scope_proposal_events"' in loop
+    events_at = loop.index('"connection_scope_proposal_events"')
+    proposals_at = loop.index('"connection_scope_proposals"')
+    requests_at = loop.index('"connection_requests"')
+    assert events_at < proposals_at < requests_at, (
+        "proposal events -> proposals -> requests is the only order the foreign keys allow"
+    )
+
+
+def test_proposal_cleanup_reaches_rows_owned_by_other_users() -> None:
+    # The FK blocks deleting MY request while ANYONE's proposal references it,
+    # so the cleanup must delete by referenced request, not only by ownership.
+    service = AccountService.__new__(AccountService)
+    AccountService.__init__(service)
+    proposals_sql = str(service._delete_by_user_queries["connection_scope_proposals"])
+    assert "connection_request_id IN" in proposals_sql
+    events_sql = str(service._delete_by_user_queries["connection_scope_proposal_events"])
+    assert "connection_scope_proposal_id IN" in events_sql

--- a/hushh-webapp/__tests__/services/ria-claim-admission.test.ts
+++ b/hushh-webapp/__tests__/services/ria-claim-admission.test.ts
@@ -29,12 +29,20 @@ describe("the journey guard must admit the claim screen", () => {
     expect(isOnboardingAdmissionExemptRoute(ROUTES.RIA_CLAIM)).toBe(true);
   });
 
+  it("admits the claimed profile while the ria capability is being set up", () => {
+    // The claim done screen offers "View profile", and the RIA onboarding page
+    // redirects established advisers to it. Bouncing either one creates a
+    // profile -> onboarding -> profile loop that never settles.
+    expect(isCapabilityOnboardingRoute("ria", ROUTES.RIA_PROFILE)).toBe(true);
+  });
+
   it("does not widen admission to the rest of the RIA workspace", () => {
-    // Only the claim screen is reachable mid-setup; clients/picks/profile must
-    // still be gated behind completed onboarding.
+    // Only the claim screen and the claimed profile are reachable mid-setup;
+    // clients/picks must still be gated behind completed onboarding.
     expect(isOnboardingAdmissionExemptRoute(ROUTES.RIA_CLIENTS)).toBe(false);
     expect(isOnboardingAdmissionExemptRoute(ROUTES.RIA_PICKS)).toBe(false);
     expect(isCapabilityOnboardingRoute("ria", ROUTES.RIA_CLIENTS)).toBe(false);
+    expect(isCapabilityOnboardingRoute("ria", ROUTES.RIA_PICKS)).toBe(false);
   });
 
   it("does not admit the claim screen under an unrelated capability", () => {

--- a/hushh-webapp/lib/navigation/routes.ts
+++ b/hushh-webapp/lib/navigation/routes.ts
@@ -346,7 +346,11 @@ export const CAPABILITY_ONBOARDING_ROUTE_PREFIXES: Readonly<
   // RIA_CLAIM belongs to the ria capability: recognising an adviser from their
   // filed number routes here from setup, and the journey guard must admit it
   // or the redirect is bounced straight back to the hub.
-  ria: [ROUTES.ONE_SETUP_RIA, ROUTES.RIA_CLAIM],
+  // RIA_PROFILE too: the claim done screen offers "View profile", and the RIA
+  // onboarding page redirects established advisers there. Without admission the
+  // guard bounces that redirect to the onboarding page, which redirects back to
+  // the profile — an infinite loop while setup is unresolved.
+  ria: [ROUTES.ONE_SETUP_RIA, ROUTES.RIA_CLAIM, ROUTES.RIA_PROFILE],
   "connected-systems": [ROUTES.ONE_SETUP_CONNECTED_SYSTEMS],
 };
 


### PR DESCRIPTION
Two user-visible breakages hit while walking the claim journey on UAT today. Both reproduced, both root-caused.

## 1. View profile → infinite loop

From the claim done screen, **Continue setup** works but **View profile** never loads: `/ria/profile` sticks on "Checking vault…", `/ria/onboarding` on "Checking setup…", and `/api/one/adk/relay-session` floods 429s.

Cycle: `View profile` → journey guard holds the `ria` capability and does not admit `/ria/profile` → bounce to RIA onboarding → it recognises an established adviser → replace back to `/ria/profile` → forever. Each cycle remounts `VaultLockGuard`, resetting `hasVault` to null before its check settles.

**Fix:** admit `ROUTES.RIA_PROFILE` under the `ria` capability, mirroring the existing `RIA_CLAIM` admission. Clients/picks stay gated. Admission test extended (6/6).

## 2. Account deletion 500 (breaks re-testing the journey)

`DELETE /api/account/delete` fails: `ForeignKeyViolation — connection_scope_proposals_connection_request_id_fkey` (UAT logs, 2026-08-08 08:47Z). Migration 127 added `connection_scope_proposals` → `connection_requests` with a plain FK (and proposal events → proposals), but account deletion never learned to clear them, and the FK blocks deleting a user's requests while ANY user's proposal references them.

**Fix:** explicit delete queries for both tables (reaching rows owned by other users via the referenced request), ordered events → proposals → requests in both deletion paths. Contract test pins registration, order, and cross-owner reach.

## Proof
- Backend gate: ruff, mypy, bandit, **605 passed** (3 new).
- Frontend: admission tests 6/6, tsc clean.
- Previous head's CI: 14/14 green; re-running on this head.