### PR TITLE
fix(feed): prevent self-consent request card on outgoing location requests

### DIFF
--- a/hushh-webapp/__tests__/lib/feed/use-feed-actionables.test.ts
+++ b/hushh-webapp/__tests__/lib/feed/use-feed-actionables.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { isIncomingLocationRequestActionable } from "@/lib/feed/use-feed-actionables";
+import type { OneLocationAccessRequest } from "@/lib/one-location/types";
+
+const ME = "user-me";
+const CONTACT = "user-contact";
+
+function request(
+  overrides: Partial<OneLocationAccessRequest>,
+): OneLocationAccessRequest {
+  return {
+    id: "req-1",
+    ownerUserId: CONTACT,
+    requesterUserId: ME,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("isIncomingLocationRequestActionable", () => {
+  it("does NOT surface a request the viewer sent (outgoing) — the reported self-card bug", () => {
+    // Viewer asked to see CONTACT's location: owner=contact, requester=me.
+    expect(
+      isIncomingLocationRequestActionable(
+        request({ ownerUserId: CONTACT, requesterUserId: ME }),
+        ME,
+      ),
+    ).toBe(false);
+  });
+
+  it("surfaces a genuine incoming request the viewer owns", () => {
+    expect(
+      isIncomingLocationRequestActionable(
+        request({ ownerUserId: ME, requesterUserId: CONTACT }),
+        ME,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT surface a self-request where sender equals recipient", () => {
+    expect(
+      isIncomingLocationRequestActionable(
+        request({ ownerUserId: ME, requesterUserId: ME }),
+        ME,
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT surface a non-pending incoming request", () => {
+    expect(
+      isIncomingLocationRequestActionable(
+        request({
+          ownerUserId: ME,
+          requesterUserId: CONTACT,
+          status: "approved",
+        }),
+        ME,
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT surface a pending request owned by someone else", () => {
+    expect(
+      isIncomingLocationRequestActionable(
+        request({ ownerUserId: "user-other", requesterUserId: CONTACT }),
+        ME,
+      ),
+    ).toBe(false);
+  });
+});

--- a/hushh-webapp/lib/feed/use-feed-actionables.ts
+++ b/hushh-webapp/lib/feed/use-feed-actionables.ts
@@ -113,6 +113,26 @@ function consentSummary(entry: ConsentCenterEntry): string {
   );
 }
 
+/**
+ * A pending location access request is actionable in the viewer's "Needs you"
+ * feed only when the viewer OWNS the request (their location is being asked for)
+ * and did NOT send it themselves. `state.requests` carries BOTH directions, so
+ * without this guard a user's own OUTGOING request leaks back onto their feed as
+ * an incoming "wants to see your location" card labelled with their own name.
+ * Mirrors the `pendingOwnerRequests` predicate in the Location page, plus an
+ * explicit sender-≠-recipient check so a self-request never becomes actionable.
+ */
+export function isIncomingLocationRequestActionable(
+  request: OneLocationAccessRequest,
+  userId: string,
+): boolean {
+  return (
+    request.status === "pending" &&
+    request.ownerUserId === userId &&
+    request.requesterUserId !== userId
+  );
+}
+
 export function useFeedActionables(): UseFeedActionablesResult {
   const router = useRouter();
   const { user } = useAuth();
@@ -287,9 +307,12 @@ export function useFeedActionables(): UseFeedActionablesResult {
       }
     }
 
-    // Location access requests — inline Approve (1h) / Deny.
+    // Location access requests — inline Approve (1h) / Deny. Only requests the
+    // viewer owns (and did not send) are actionable; outgoing requests must not
+    // surface here as a self-addressed "wants to see your location" card.
     const pendingLocation = (locationRequests ?? []).filter(
-      (request: OneLocationAccessRequest) => request.status === "pending",
+      (request: OneLocationAccessRequest) =>
+        isIncomingLocationRequestActionable(request, userId),
     );
     for (const request of pendingLocation) {
       const label = request.requesterDisplayName?.trim() || "Someone";


### PR DESCRIPTION
# Description

**Bug:** When a user requests to see a contact's location, an incoming consent
card ("… wants to see your location", Approve/Deny) appeared on the **sender's
own** Feed under "Needs you", labelled with the sender's own name — as if they
had requested consent from themselves.

**Root cause:** One-Location state's `requests` list carries access requests in
**both** directions (ones the viewer owns and ones the viewer sent). The Feed's
"Needs you" actionables (`lib/feed/use-feed-actionables.ts`) filtered only by
`status === "pending"`, so a request the viewer **sent** leaked back onto their
own feed as an incoming card (rendered with `requesterDisplayName`, i.e. the
sender's own name). The Location page already filters correctly via
`pendingOwnerRequests` (`ownerUserId === userId`); the feed hook did not.

**Fix:** only surface requests the viewer actually owns and did not send —
`status === "pending" && ownerUserId === userId && requesterUserId !== userId`.
The explicit `requesterUserId !== userId` guard also blocks any self-request
(sender === recipient) from ever becoming an actionable card. Extracted as a
pure `isIncomingLocationRequestActionable(request, userId)` helper so the
direction logic is unit-testable in isolation.

No backend change: the backend already stores `ownerUserId = contact`,
`requesterUserId = sender` correctly; this was purely a missing frontend
direction filter.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: `/one/feed` "Needs you" actionables (client hook only; no route/API changed)
- API / schema / type changes:
  - [x] Listed below: new exported pure helper `isIncomingLocationRequestActionable` (no type/schema change)
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — shared web hook; no native surface changed
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] Consent — this narrows what surfaces as an actionable consent card; it only ever REMOVES the viewer's own outgoing/self requests from their feed (never grants or hides an incoming request)
- Caller / proxy / backend pairing:
  - [x] Not applicable — frontend filter only; backend request direction already correct
- Rollback or safe-failure behavior:
  - [x] Listed below: reverting the filter restores prior behavior; a stricter filter cannot approve/deny anything on its own
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: covered by `use-feed-actionables.test.ts` (pure direction predicate); manual browser proof not run (auth + vault-gated feed)
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed files, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`use-feed-actionables.test.ts`, 5 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (the Feed "Needs you" zone).
- [x] Reachable production attach point: `useFeedActionables` location-request filter.
- [x] New tests import and exercise production code (`isIncomingLocationRequestActionable`), not test-local mocks.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client hook (`lib/feed/use-feed-actionables.ts`)
- [x] **iOS**: N/A — no native plugin surface touched
- [x] **Android**: N/A — no native plugin surface touched

## 🧪 Testing

- [x] Tested on Web (unit): `use-feed-actionables.test.ts` — 5 cases (outgoing, incoming, self, non-pending, someone-else-owned)
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

No new UI; the fix removes an incorrectly-shown card. Proven by the unit test
asserting an outgoing request (`owner=contact`, `requester=viewer`) resolves to
`false` (not actionable) while a genuine incoming request resolves to `true`.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — it filters which consent
  actionables render; it never reads location data or mutates consent state.
- [x] Sensitive surface touched: consent (feed actionable visibility only)
- [x] Error path / safe-failure proved: the filter only narrows the list; it
  cannot approve/deny or expose an incoming request.

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed


