### PR TITLE
feat(ria): verified-status nudge, the full SEC record on the profile, and one OTP total

### DIFF
--- a/consent-protocol/api/routes/ria.py
+++ b/consent-protocol/api/routes/ria.py
@@ -11,9 +11,14 @@ from pydantic import BaseModel, Field, field_validator
 from api.middleware import require_firebase_auth
 from api.middlewares.rate_limit import limiter
 from api.routes.account import _verify_phone_claim_id_token
-from hushh_mcp.services.actor_identity_service import ActorIdentityService
+from hushh_mcp.services.actor_identity_service import (
+    ActorIdentityAliasError,
+    ActorIdentityService,
+)
 from hushh_mcp.services.consent_center_service import ConsentCenterService
+from hushh_mcp.services.ria_claim_email_service import queue_claim_verification_email
 from hushh_mcp.services.ria_claim_service import (
+    RIAClaimEmailError,
     RIAClaimService,
     normalize_nanp_phone,
     validate_claim_ticket,
@@ -895,3 +900,110 @@ async def ria_claim_complete(
         return _iam_schema_not_ready_response()
     except RIAIAMPolicyError as exc:
         raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Claim email upgrade: verify a work-email alias on the claimed firm's own
+# domain, then re-run the upstream evaluation with the extra evidence. The
+# plaintext code travels only from the identity service to the mail queue —
+# it never appears in any HTTP response.
+# ---------------------------------------------------------------------------
+
+
+class RIAClaimEmailStartRequest(BaseModel):
+    email: str = Field(min_length=3, max_length=320)
+
+
+class RIAClaimEmailConfirmRequest(BaseModel):
+    email: str = Field(min_length=3, max_length=320)
+    code: str = Field(min_length=1, max_length=16)
+
+
+@router.post("/claim/email/start")
+@limiter.limit("20/minute")
+async def ria_claim_email_start(
+    payload: RIAClaimEmailStartRequest,
+    request: Request,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    service = RIAClaimService()
+    try:
+        prepared = await service.prepare_email_verification(firebase_uid, payload.email)
+    except RIAClaimEmailError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except RIAIAMPolicyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+    try:
+        alias_result = await ActorIdentityService().request_email_alias_verification(
+            user_id=firebase_uid,
+            email=prepared["email"],
+            verification_source="user_verified",
+            source_ref="ria_claim_email",
+            include_plaintext_code=True,
+        )
+    except ActorIdentityAliasError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+
+    # Route-internal handoff: pop the plaintext so it cannot leak into the
+    # response, and give it only to the mail sender.
+    code_plaintext = alias_result.pop("verification_code_plaintext", None)
+    if alias_result.get("already_verified"):
+        return {"status": "already_verified", "email_masked": prepared["email_masked"]}
+
+    delivery = await queue_claim_verification_email(
+        target_email=prepared["email"],
+        verification_code=str(code_plaintext or ""),
+        firm_name=prepared.get("firm_name"),
+    )
+    if delivery.get("delivery_status") != "queued":
+        # Best-effort mail: the alias ceremony stands, the client may retry.
+        return JSONResponse(
+            status_code=502,
+            content={"status": "send_failed", "email_masked": prepared["email_masked"]},
+        )
+    return {"status": "sent", "email_masked": prepared["email_masked"]}
+
+
+@router.post("/claim/email/confirm")
+@limiter.limit("20/minute")
+async def ria_claim_email_confirm(
+    payload: RIAClaimEmailConfirmRequest,
+    request: Request,
+    firebase_uid: str = Depends(require_firebase_auth),
+):
+    try:
+        await ActorIdentityService().confirm_email_alias_verification(
+            user_id=firebase_uid,
+            email=payload.email,
+            verification_code=payload.code,
+        )
+    except ActorIdentityAliasError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+
+    service = RIAClaimService()
+    try:
+        result = await service.upgrade_with_email_evidence(firebase_uid, email=payload.email)
+    except RIAClaimEmailError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"code": exc.code, "message": str(exc)},
+        ) from exc
+    except IAMSchemaNotReadyError:
+        return _iam_schema_not_ready_response()
+    except RIAIAMPolicyError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    return {
+        "verified": bool(result.get("verified")),
+        "verification_status": str(result.get("verification_status") or ""),
+        "verification_level": result.get("verification_level"),
+    }

--- a/consent-protocol/hushh_mcp/services/actor_identity_service.py
+++ b/consent-protocol/hushh_mcp/services/actor_identity_service.py
@@ -757,7 +757,16 @@ class ActorIdentityService:
         email: str,
         verification_source: str = "user_verified",
         source_ref: str | None = None,
+        include_plaintext_code: bool = False,
     ) -> dict[str, Any]:
+        """Start (or restart) the alias ceremony for one account-owned email.
+
+        ``include_plaintext_code=True`` adds a route-internal
+        ``verification_code_plaintext`` key so the caller can hand the code to
+        a mail sender. It stays opt-in because at least one existing route
+        serializes this result verbatim; the plaintext must never be added to
+        any HTTP response.
+        """
         normalized_user_id = str(user_id or "").strip()
         if not normalized_user_id:
             raise ActorIdentityAliasError(
@@ -820,11 +829,15 @@ class ActorIdentityService:
                 and existing["verification_status"] == "verified"
                 and existing["revoked_at"] is None
             ):
-                return {
+                already_verified: dict[str, Any] = {
                     "alias": self._normalize_alias_row(existing),
                     "already_verified": True,
                     "review_verification_code": None,
                 }
+                if include_plaintext_code:
+                    # Already verified, so there is no code to send.
+                    already_verified["verification_code_plaintext"] = None
+                return already_verified
 
             verification_code = f"{secrets.randbelow(1_000_000):06d}"
             code_hash = self._hash_alias_verification_code(
@@ -895,13 +908,18 @@ class ActorIdentityService:
                 code_hash,
             )
 
-        return {
+        result: dict[str, Any] = {
             "alias": self._normalize_alias_row(row),
             "already_verified": False,
             "review_verification_code": (
                 verification_code if self._may_return_review_alias_code() else None
             ),
         }
+        if include_plaintext_code:
+            # Route-internal only: the caller pops this and hands it to the
+            # mail sender. It must never be serialized into an HTTP response.
+            result["verification_code_plaintext"] = verification_code
+        return result
 
     async def confirm_email_alias_verification(
         self,

--- a/consent-protocol/hushh_mcp/services/ria_claim_email_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_email_service.py
@@ -1,0 +1,277 @@
+"""Work-email verification code delivery for RIA claim upgrades.
+
+Modeled on ``kai_invite_email_service``: Gmail API via Workspace delegation
+from ``one@hushh.ai`` (``SupportEmailConfig``), test/live recipient
+redirection, serialized through ``EmailDeliveryQueueService``. Delivery is
+best-effort by contract — ``queue_claim_verification_email`` never raises, so
+a mail fault can never fail the claim endpoint that triggered it.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+import logging
+from dataclasses import dataclass
+from email.message import EmailMessage
+
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
+
+from hushh_mcp.services.email_delivery_queue_service import (
+    get_email_delivery_queue_service,
+)
+from hushh_mcp.services.support_email_service import (
+    SupportEmailConfig,
+    SupportEmailNotConfiguredError,
+    SupportEmailSendError,
+)
+
+logger = logging.getLogger(__name__)
+
+_GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
+_GMAIL_SEND_ENDPOINT = "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+
+
+def _clean_text(value: str | None) -> str:
+    return (value or "").strip()
+
+
+@dataclass(frozen=True)
+class RIAClaimEmailDelivery:
+    accepted: bool
+    message_id: str | None
+    recipient: str
+    intended_recipient: str
+    delivery_mode: str
+    from_email: str
+
+
+class RIAClaimEmailService:
+    """Send the work-email verification code from the ``one@hushh.ai`` mailbox."""
+
+    def __init__(self) -> None:
+        self._config: SupportEmailConfig | None = None
+        self._session: AuthorizedSession | None = None
+
+    @property
+    def config(self) -> SupportEmailConfig:
+        if self._config is None:
+            self._config = SupportEmailConfig.from_env()
+        return self._config
+
+    def _build_authorized_session(self) -> AuthorizedSession:
+        cfg = self.config
+        if not cfg.configured:
+            raise SupportEmailNotConfiguredError(
+                "Claim verification email is not configured. Provide SUPPORT_EMAIL_* settings "
+                "or a service account JSON that can send Gmail through Workspace delegation."
+            )
+        if self._session is None:
+            credentials = service_account.Credentials.from_service_account_info(
+                cfg.service_account_info,
+                scopes=[_GMAIL_SEND_SCOPE],
+                subject=cfg.delegated_user,
+            )
+            self._session = AuthorizedSession(credentials)
+        return self._session
+
+    def _effective_recipient(self, target_email: str) -> str:
+        cfg = self.config
+        if cfg.delivery_mode == "test" and cfg.test_to_email:
+            return str(cfg.test_to_email)
+        return target_email
+
+    def _build_subject(self) -> str:
+        prefix = "[TEST] " if self.config.delivery_mode == "test" else ""
+        return f"{prefix}Your Hushh verification code"
+
+    def _build_plain_text(
+        self,
+        *,
+        verification_code: str,
+        firm_name: str | None,
+        recipient: str,
+        intended_recipient: str,
+    ) -> str:
+        lines = [
+            f"Your verification code: {verification_code}",
+            "",
+            "Enter it on your Hushh profile to verify your work email"
+            + (f" at {firm_name}." if firm_name else "."),
+            "",
+            "If you didn't request this, ignore this email.",
+        ]
+        if recipient != intended_recipient:
+            lines.extend(
+                [
+                    "",
+                    f"Delivery mode: {self.config.delivery_mode}",
+                    f"Actual recipient: {recipient}",
+                    f"Intended recipient: {intended_recipient}",
+                ]
+            )
+        return "\n".join(lines)
+
+    def _build_html(self, *, verification_code: str, firm_name: str | None) -> str:
+        code = html.escape(verification_code)
+        firm_line = (
+            f'<p style="margin:14px 0 0;font-size:15px;line-height:1.7;color:#475569;">'
+            f"Enter it on your Hushh profile to verify your work email at "
+            f"{html.escape(firm_name)}.</p>"
+            if firm_name
+            else (
+                '<p style="margin:14px 0 0;font-size:15px;line-height:1.7;color:#475569;">'
+                "Enter it on your Hushh profile to verify your work email.</p>"
+            )
+        )
+        return f"""
+<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#f4f7fb;font-family:-apple-system,BlinkMacSystemFont,'SF Pro Text','Helvetica Neue',sans-serif;color:#0f172a;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f7fb;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background:#ffffff;border-radius:28px;overflow:hidden;border:1px solid rgba(15,23,42,0.06);box-shadow:0 24px 80px rgba(15,23,42,0.08);">
+            <tr>
+              <td style="padding:36px;">
+                <p style="margin:0 0 14px;font-size:12px;letter-spacing:0.24em;text-transform:uppercase;color:#2563eb;font-weight:700;">Hussh</p>
+                <h1 style="margin:0;font-size:24px;line-height:1.2;font-weight:700;letter-spacing:-0.02em;color:#020617;">Your verification code</h1>
+                {firm_line}
+                <div style="margin-top:24px;padding:18px 22px;border-radius:18px;background:#f8fafc;border:1px solid rgba(15,23,42,0.06);">
+                  <p style="margin:0;font-size:32px;letter-spacing:0.35em;font-weight:700;color:#0f172a;">{code}</p>
+                </div>
+                <p style="margin:24px 0 0;font-size:13px;line-height:1.7;color:#64748b;">If you didn't request this, ignore this email.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+        """.strip()
+
+    def send_verification_code(
+        self,
+        *,
+        target_email: str,
+        verification_code: str,
+        firm_name: str | None = None,
+    ) -> RIAClaimEmailDelivery:
+        if not _clean_text(target_email):
+            raise SupportEmailSendError("Verification email requires a target email address.")
+        if not _clean_text(verification_code):
+            raise SupportEmailSendError("Verification email requires a code.")
+
+        cfg = self.config
+        intended_recipient = target_email.strip().lower()
+        recipient = self._effective_recipient(intended_recipient)
+
+        message = EmailMessage()
+        message["To"] = recipient
+        message["From"] = f"Hussh <{cfg.from_email}>"
+        message["Subject"] = self._build_subject()
+        if cfg.from_email:
+            message["Reply-To"] = cfg.from_email
+
+        message.set_content(
+            self._build_plain_text(
+                verification_code=verification_code,
+                firm_name=firm_name,
+                recipient=recipient,
+                intended_recipient=intended_recipient,
+            )
+        )
+        message.add_alternative(
+            self._build_html(verification_code=verification_code, firm_name=firm_name),
+            subtype="html",
+        )
+
+        encoded = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
+        try:
+            session = self._build_authorized_session()
+            response = session.post(_GMAIL_SEND_ENDPOINT, json={"raw": encoded}, timeout=20)
+        except SupportEmailNotConfiguredError:
+            raise
+        except Exception as exc:
+            # Never log the code itself; the recipient is enough to triage.
+            logger.exception("ria_claim_email.transport_failed recipient=%s", recipient)
+            raise SupportEmailSendError(
+                "Claim verification email authorization failed. Verify Workspace Gmail "
+                f"delegation for `{cfg.delegated_user}` and the service account client."
+            ) from exc
+
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+
+        if response.status_code >= 400:
+            logger.error(
+                "ria_claim_email.send_failed status=%s recipient=%s payload=%s",
+                response.status_code,
+                recipient,
+                payload,
+            )
+            detail_message = (
+                payload.get("error", {}).get("message")
+                if isinstance(payload, dict)
+                and isinstance(payload.get("error"), dict)
+                and isinstance(payload.get("error", {}).get("message"), str)
+                else None
+            )
+            raise SupportEmailSendError(
+                detail_message
+                or f"Claim verification email failed with status {response.status_code}"
+            )
+
+        message_id = payload.get("id") if isinstance(payload, dict) else None
+        return RIAClaimEmailDelivery(
+            accepted=True,
+            message_id=message_id if isinstance(message_id, str) else None,
+            recipient=recipient,
+            intended_recipient=intended_recipient,
+            delivery_mode=cfg.delivery_mode,
+            from_email=cfg.from_email,
+        )
+
+
+_ria_claim_email_service: RIAClaimEmailService | None = None
+
+
+def get_ria_claim_email_service() -> RIAClaimEmailService:
+    global _ria_claim_email_service
+    if _ria_claim_email_service is None:
+        _ria_claim_email_service = RIAClaimEmailService()
+    return _ria_claim_email_service
+
+
+async def queue_claim_verification_email(
+    *,
+    target_email: str,
+    verification_code: str,
+    firm_name: str | None = None,
+) -> dict[str, str]:
+    """Enqueue the code email. Best-effort: returns a status dict, never raises."""
+    email_service = get_ria_claim_email_service()
+    if not email_service.config.configured:
+        logger.warning("ria_claim_email.not_configured")
+        return {"delivery_status": "failed", "reason": "not_configured"}
+    if not _clean_text(verification_code):
+        logger.warning("ria_claim_email.missing_code")
+        return {"delivery_status": "failed", "reason": "missing_code"}
+    try:
+        await get_email_delivery_queue_service().enqueue(
+            kind="invite_email",
+            send_callable=lambda: email_service.send_verification_code(
+                target_email=target_email,
+                verification_code=verification_code,
+                firm_name=firm_name,
+            ),
+            context={"purpose": "ria_claim_email_code"},
+        )
+    except Exception as exc:  # noqa: BLE001 - delivery must never fail the request
+        logger.warning("ria_claim_email.enqueue_failed error=%s", type(exc).__name__)
+        return {"delivery_status": "failed", "reason": "enqueue_failed"}
+    return {"delivery_status": "queued"}

--- a/consent-protocol/hushh_mcp/services/ria_claim_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_service.py
@@ -25,7 +25,12 @@ import re
 import secrets
 import time
 from typing import Any
+from urllib.parse import urlsplit
 
+import asyncpg
+
+from db.connection import get_pool
+from hushh_mcp.services.actor_identity_service import ActorIdentityService
 from hushh_mcp.services.ria_iam_service import RIAIAMPolicyError, RIAIAMService
 from hushh_mcp.services.ria_identity_client import (
     RIAIdentityClient,
@@ -68,6 +73,121 @@ def mask_phone_digits(digits10: str) -> str:
     if len(digits10) != 10:
         return "•••"
     return f"••• ••• {digits10[-4:]}"
+
+
+class RIAClaimEmailError(RIAIAMPolicyError):
+    """A claim email-verification precondition failed; carries a stable code."""
+
+    def __init__(self, message: str, *, code: str, status_code: int = 409) -> None:
+        super().__init__(message, status_code=status_code)
+        self.code = code
+
+
+# Consumer mailbox providers can never prove firm affiliation.
+FREE_MAIL_DOMAINS = frozenset(
+    {
+        "gmail.com",
+        "googlemail.com",
+        "outlook.com",
+        "hotmail.com",
+        "live.com",
+        "msn.com",
+        "yahoo.com",
+        "ymail.com",
+        "icloud.com",
+        "me.com",
+        "mac.com",
+        "proton.me",
+        "protonmail.com",
+        "pm.me",
+        "aol.com",
+        "zoho.com",
+        "gmx.com",
+        "mail.com",
+    }
+)
+
+# Common two-label public suffixes so "firm.co.uk" is not reduced to "co.uk".
+_MULTI_PART_SUFFIXES = frozenset(
+    {
+        "co.uk",
+        "org.uk",
+        "ac.uk",
+        "gov.uk",
+        "com.au",
+        "net.au",
+        "org.au",
+        "co.nz",
+        "co.in",
+        "com.sg",
+        "com.hk",
+        "co.jp",
+        "com.br",
+        "com.mx",
+        "co.za",
+    }
+)
+
+
+def registrable_domain(host: str) -> str:
+    """Reduce a hostname to its registrable domain (small-suffix heuristic)."""
+    labels = [label for label in str(host or "").strip().lower().strip(".").split(".") if label]
+    if len(labels) < 2:
+        return ".".join(labels)
+    if len(labels) >= 3 and ".".join(labels[-2:]) in _MULTI_PART_SUFFIXES:
+        return ".".join(labels[-3:])
+    return ".".join(labels[-2:])
+
+
+def firm_website_host(website: str | None) -> str:
+    """Extract the bare host from a Form ADV website value ('' when unusable)."""
+    value = str(website or "").strip().lower()
+    if not value:
+        return ""
+    if "://" not in value:
+        value = f"https://{value}"
+    try:
+        host = urlsplit(value).hostname or ""
+    except ValueError:
+        return ""
+    if host.startswith("www."):
+        host = host[len("www.") :]
+    return host
+
+
+def email_domain(email: str) -> str:
+    value = str(email or "").strip().lower()
+    if "@" not in value:
+        return ""
+    return value.rsplit("@", 1)[1]
+
+
+def is_free_mail_domain(domain: str) -> bool:
+    return registrable_domain(domain) in FREE_MAIL_DOMAINS
+
+
+def email_matches_firm_domain(email: str, website: str | None) -> bool:
+    """True when the address's registrable domain is the firm website's.
+
+    Server-side gate that must pass BEFORE any email evidence is asserted
+    upstream, even though the evaluator also checks the domain itself.
+    """
+    alias_domain = email_domain(email)
+    host = firm_website_host(website)
+    if not alias_domain or not host:
+        return False
+    if is_free_mail_domain(alias_domain):
+        return False
+    return registrable_domain(alias_domain) == registrable_domain(host)
+
+
+def mask_email(email: str) -> str:
+    value = str(email or "").strip().lower()
+    if "@" not in value:
+        return "•••"
+    local, domain = value.rsplit("@", 1)
+    lead = local[0] if local else "•"
+    return f"{lead}•••@{domain}"
 
 
 def claim_test_numbers() -> set[str]:
@@ -330,9 +450,11 @@ class RIAClaimService:
         *,
         client: RIAIdentityClient | None = None,
         iam_service: RIAIAMService | None = None,
+        identity_service: ActorIdentityService | None = None,
     ) -> None:
         self._client = client or RIAIdentityClient()
         self._iam_service = iam_service or RIAIAMService()
+        self._identity_service = identity_service or ActorIdentityService()
 
     @staticmethod
     def _map_upstream_error(exc: Exception) -> RIAIAMPolicyError:
@@ -615,6 +737,259 @@ class RIAClaimService:
             "provisional": provisional,
             "profile": profile,
             "facts": facts,
+        }
+
+    async def _load_claim_context(self, user_id: str) -> dict[str, Any] | None:
+        """Latest persisted claim snapshot plus the profile row it belongs to."""
+        normalized_user_id = str(user_id or "").strip()
+        if not normalized_user_id:
+            return None
+        pool = await get_pool()
+        try:
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                      p.id AS ria_profile_id,
+                      p.display_name,
+                      p.legal_name,
+                      p.finra_crd,
+                      p.verification_status,
+                      e.reference_metadata
+                    FROM ria_verification_events e
+                    JOIN ria_profiles p ON p.id = e.ria_profile_id
+                    WHERE p.user_id = $1
+                      AND e.provider = $2
+                    ORDER BY e.checked_at DESC
+                    LIMIT 1
+                    """,
+                    normalized_user_id,
+                    CLAIM_PROVIDER_LABEL,
+                )
+        except asyncpg.UndefinedTableError:
+            return None
+        if row is None:
+            return None
+        metadata_raw = row["reference_metadata"]
+        metadata: dict[str, Any] = {}
+        if isinstance(metadata_raw, dict):
+            metadata = metadata_raw
+        elif isinstance(metadata_raw, str):
+            try:
+                parsed = json.loads(metadata_raw)
+                metadata = parsed if isinstance(parsed, dict) else {}
+            except ValueError:
+                metadata = {}
+        return {
+            "ria_profile_id": str(row["ria_profile_id"]),
+            "display_name": str(row["display_name"] or ""),
+            "legal_name": str(row["legal_name"] or ""),
+            "crd_number": str(row["finra_crd"] or ""),
+            "verification_status": str(row["verification_status"] or ""),
+            "metadata": metadata,
+        }
+
+    @staticmethod
+    def _check_claim_email_domain(email: str, firm_record: dict[str, Any]) -> None:
+        """Fail closed unless the address sits on the claimed firm's own domain."""
+        domain = email_domain(email)
+        if not domain:
+            raise RIAClaimEmailError(
+                "Enter a valid work email.",
+                code="EMAIL_INVALID",
+                status_code=422,
+            )
+        if is_free_mail_domain(domain):
+            raise RIAClaimEmailError(
+                "Use your work email at the firm.",
+                code="EMAIL_DOMAIN_MISMATCH",
+            )
+        if not email_matches_firm_domain(email, firm_record.get("website")):
+            raise RIAClaimEmailError(
+                "This email doesn't match your firm's website domain.",
+                code="EMAIL_DOMAIN_MISMATCH",
+            )
+
+    async def prepare_email_verification(self, user_id: str, email: str) -> dict[str, Any]:
+        """Server-side domain gate for /claim/email/start.
+
+        Validates the address against the *persisted* firm record before any
+        alias ceremony begins; nothing the browser asserts is trusted.
+        """
+        context = await self._load_claim_context(user_id)
+        if context is None or not context["metadata"]:
+            raise RIAClaimEmailError(
+                "Claim your profile before verifying a work email.",
+                code="CLAIM_CONTEXT_MISSING",
+            )
+        email_normalized = str(email or "").strip().lower()
+        firm_record_raw = context["metadata"].get("firm_record")
+        firm_record: dict[str, Any] = firm_record_raw if isinstance(firm_record_raw, dict) else {}
+        self._check_claim_email_domain(email_normalized, firm_record)
+        return {
+            "email": email_normalized,
+            "email_masked": mask_email(email_normalized),
+            "firm_name": title_case_name(firm_record.get("name")) or None,
+        }
+
+    async def upgrade_with_email_evidence(self, user_id: str, *, email: str) -> dict[str, Any]:
+        """Re-evaluate the persisted claim with a verified work-email alias.
+
+        The profile is only ever upgraded through
+        ``claim_ria_profile_from_identity`` (same-identity re-claim, which
+        never downgrades), and only when the evaluator itself answers
+        ``verificationLevel == "verified"``. On any other outcome nothing is
+        written and the stored status stays exactly as it was.
+        """
+        context = await self._load_claim_context(user_id)
+        if context is None or not context["metadata"]:
+            raise RIAClaimEmailError(
+                "Claim your profile before verifying a work email.",
+                code="CLAIM_CONTEXT_MISSING",
+            )
+        metadata = context["metadata"]
+        firm_record_raw = metadata.get("firm_record")
+        firm_record: dict[str, Any] = firm_record_raw if isinstance(firm_record_raw, dict) else {}
+        email_normalized = str(email or "").strip().lower()
+        self._check_claim_email_domain(email_normalized, firm_record)
+
+        verified_alias: str | None = None
+        for alias in await self._identity_service.list_verified_email_aliases(user_id):
+            if str(alias.get("verification_status") or "").strip().lower() != "verified":
+                continue
+            if alias.get("revoked_at") is not None:
+                continue
+            alias_email = str(alias.get("email_normalized") or alias.get("email") or "").lower()
+            if alias_email == email_normalized:
+                verified_alias = alias_email
+                break
+        if not verified_alias:
+            raise RIAClaimEmailError(
+                "Verify this email before it can be used as claim evidence.",
+                code="EMAIL_ALIAS_NOT_VERIFIED",
+            )
+
+        phone_digits = normalize_nanp_phone(str(metadata.get("phone") or ""))
+        claim_type = str(metadata.get("claim_type") or "")
+        try:
+            firm_crd = int(metadata.get("firm_crd") or 0)
+        except (TypeError, ValueError):
+            firm_crd = 0
+        individual_crd_raw = metadata.get("individual_crd")
+        try:
+            individual_crd = int(individual_crd_raw) if individual_crd_raw is not None else None
+        except (TypeError, ValueError):
+            individual_crd = None
+        display_name = context["display_name"] or title_case_name(context["legal_name"])
+        if not phone_digits or claim_type not in {"individual", "firm"} or firm_crd <= 0:
+            raise RIAClaimEmailError(
+                "The stored claim snapshot is incomplete. Re-claim your profile first.",
+                code="CLAIM_CONTEXT_MISSING",
+            )
+        if not display_name:
+            raise RIAClaimEmailError(
+                "The stored claim snapshot is incomplete. Re-claim your profile first.",
+                code="CLAIM_CONTEXT_MISSING",
+            )
+
+        try:
+            payload = await self._client.claim_evaluate(
+                phone=phone_digits,
+                claim_type=claim_type,
+                firm_crd=firm_crd,
+                individual_crd=individual_crd,
+                # Possession of the filed number was proven at original claim
+                # time and lives in the persisted evidence ledger.
+                assert_phone_otp=True,
+                extra_evidence=[{"signal": "domain_email", "email": verified_alias}],
+            )
+        except (
+            RIAIdentityNotConfiguredError,
+            RIAIdentityUnavailableError,
+            RIAIdentityRequestError,
+        ) as exc:
+            raise self._map_upstream_error(exc) from exc
+
+        verification_level = str(payload.get("verificationLevel") or "none")
+        current_status = context["verification_status"]
+        if verification_level != "verified":
+            # No status write without the evaluator's verified answer.
+            return {
+                "verified": current_status in {"verified", "active", "finra_verified"},
+                "verification_status": current_status,
+                "verification_level": verification_level,
+                "satisfied": payload.get("satisfied") or [],
+                "missing": payload.get("missing") or [],
+            }
+
+        fresh_firm = _shape_firm(payload.get("firm")) or {}
+        firm = {
+            **firm_record,
+            **{key: value for key, value in fresh_firm.items() if value not in (None, "", [])},
+        }
+        advisor_record_raw = metadata.get("advisor_record")
+        advisor_record: dict[str, Any] = (
+            advisor_record_raw if isinstance(advisor_record_raw, dict) else {}
+        )
+        reference_metadata = {
+            "provider": CLAIM_PROVIDER_LABEL,
+            "claim_type": claim_type,
+            "phone": phone_digits,
+            "firm_crd": firm_crd,
+            "individual_crd": individual_crd,
+            "verification_level": verification_level,
+            "satisfied": payload.get("satisfied") or [],
+            "missing": payload.get("missing") or [],
+            "evidence_ledger": payload.get("evidenceLedger") or [],
+            "scope_note": payload.get("scopeNote"),
+            "evidence_upgrade": "domain_email",
+            "firm_record": firm,
+            "advisor_record": advisor_record,
+        }
+
+        legal_name = context["legal_name"] or display_name
+        crd_number = context["crd_number"] or (
+            str(individual_crd) if claim_type == "individual" and individual_crd else str(firm_crd)
+        )
+        firm_name = str(firm.get("name") or "").strip() or None
+
+        profile = await self._iam_service.claim_ria_profile_from_identity(
+            user_id,
+            claim_type=claim_type,
+            verification_level=verification_level,
+            phone_e164=f"+1{phone_digits}",
+            display_name=display_name,
+            legal_name=legal_name,
+            crd_number=crd_number,
+            firm_name=firm_name,
+            firm_crd=str(firm_crd),
+            firm_website=firm.get("website"),
+            firm_sec_number=firm.get("sec_number"),
+            reference_metadata=reference_metadata,
+            regulator="SEC" if firm.get("registration_type") == "sec" else "State",
+            regulator_status=firm.get("registration_status"),
+            disclosures_url=(advisor_record.get("report_url") or firm.get("report_url")),
+            certifications=[
+                str(exam.get("code"))
+                for exam in advisor_record.get("exams", [])
+                if isinstance(exam, dict) and exam.get("code")
+            ],
+        )
+        logger.info(
+            json.dumps(
+                {
+                    "event": "ria.claim_email_upgrade",
+                    "claim_type": claim_type,
+                    "verification_level": verification_level,
+                    "firm_crd": firm_crd,
+                }
+            )
+        )
+        return {
+            "verified": True,
+            "verification_status": str(profile.get("verification_status") or "verified"),
+            "verification_level": verification_level,
+            "profile": profile,
         }
 
     async def _record_claim_enrichment(self, user_id: str, facts: dict[str, Any]) -> None:

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4680,6 +4680,23 @@ class RIAIAMService:
             if event and "reference_metadata" in event:
                 event["reference_metadata"] = self._parse_metadata(event["reference_metadata"])
 
+            latest_claim = await conn.fetchrow(
+                """
+                SELECT outcome, checked_at, expires_at, reference_metadata
+                FROM ria_verification_events
+                WHERE ria_profile_id = $1
+                  AND provider = 'ria_identity_claim'
+                ORDER BY checked_at DESC
+                LIMIT 1
+                """,
+                ria["id"],
+            )
+            claim_event = dict(latest_claim) if latest_claim else None
+            if claim_event and "reference_metadata" in claim_event:
+                claim_event["reference_metadata"] = self._parse_metadata(
+                    claim_event["reference_metadata"]
+                )
+
             v2_profile: dict[str, Any] = {}
             try:
                 v2_row = await conn.fetchrow(
@@ -4806,6 +4823,7 @@ class RIAIAMService:
                 "strategy": v2_profile.get("strategy"),
                 "disclosures_url": v2_profile.get("disclosures_url"),
                 "latest_verification_event": event,
+                "latest_claim_event": claim_event,
             }
         except asyncpg.exceptions.UndefinedTableError as exc:
             raise IAMSchemaNotReadyError() from exc

--- a/consent-protocol/hushh_mcp/services/ria_identity_client.py
+++ b/consent-protocol/hushh_mcp/services/ria_identity_client.py
@@ -141,9 +141,13 @@ class RIAIdentityClient:
         firm_crd: int,
         individual_crd: int | None = None,
         assert_phone_otp: bool = False,
+        extra_evidence: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Score a claim. ``assert_phone_otp`` must only ever be set after this
-        backend has itself verified possession of the filed number."""
+        backend has itself verified possession of the filed number, and every
+        entry in ``extra_evidence`` only after this backend has itself verified
+        the signal it asserts (e.g. a ``domain_email`` alias the user proved
+        they control)."""
         body: dict[str, Any] = {
             "phone": phone,
             "claimType": claim_type,
@@ -153,4 +157,6 @@ class RIAIdentityClient:
             body["individualCrd"] = individual_crd
         if assert_phone_otp:
             body["evidence"] = [{"signal": "phone_otp"}]
+        if extra_evidence:
+            body.setdefault("evidence", []).extend(extra_evidence)
         return await self._request("POST", "/v1/claim/evaluate", json_body=body)

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -41,3 +41,6 @@ tests/test_deploy_sha_gate_payload_size.py
 tests/services/test_advisor_directory_service.py
 tests/test_advisors_runtime_config_wiring.py
 tests/test_advisors_coordinate_privacy.py
+tests/test_ria_claim_email_evidence.py
+tests/test_ria_claim_email_routes.py
+tests/test_ria_onboarding_status_claim_event.py

--- a/consent-protocol/tests/test_ria_claim_email_evidence.py
+++ b/consent-protocol/tests/test_ria_claim_email_evidence.py
@@ -1,0 +1,383 @@
+"""RIA claim email upgrade: domain matcher, evidence assertion, and upgrade path."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from hushh_mcp.services.ria_claim_service import (
+    RIAClaimEmailError,
+    RIAClaimService,
+    email_matches_firm_domain,
+    firm_website_host,
+    is_free_mail_domain,
+    mask_email,
+    registrable_domain,
+)
+from hushh_mcp.services.ria_identity_client import RIAIdentityClient
+
+_TEST_UID = "user_claim_123"
+
+
+# ---------------------------------------------------------------------------
+# Registrable-domain matcher (server-side gate, must never be skipped)
+# ---------------------------------------------------------------------------
+
+
+def test_registrable_domain_reduces_hosts():
+    assert registrable_domain("olympuspeaks.com") == "olympuspeaks.com"
+    assert registrable_domain("mail.olympuspeaks.com") == "olympuspeaks.com"
+    assert registrable_domain("advisors.firm.co.uk") == "firm.co.uk"
+    assert registrable_domain("FIRM.CO.UK.") == "firm.co.uk"
+    assert registrable_domain("localhost") == "localhost"
+
+
+def test_firm_website_host_normalizes_form_adv_values():
+    assert firm_website_host("HTTPS://WWW.OLYMPUSPEAKS.COM") == "olympuspeaks.com"
+    assert firm_website_host("olympuspeaks.com/about") == "olympuspeaks.com"
+    assert firm_website_host("http://www.firm.co.uk") == "firm.co.uk"
+    assert firm_website_host(None) == ""
+    assert firm_website_host("   ") == ""
+
+
+def test_email_matches_firm_domain_exact_host():
+    assert email_matches_firm_domain("reg@olympuspeaks.com", "https://www.olympuspeaks.com")
+
+
+def test_email_matches_firm_domain_subdomain():
+    assert email_matches_firm_domain("reg@mail.olympuspeaks.com", "https://olympuspeaks.com")
+    assert email_matches_firm_domain("reg@firm.co.uk", "https://advisors.firm.co.uk")
+
+
+def test_email_matches_firm_domain_rejects_free_mail():
+    assert is_free_mail_domain("gmail.com") is True
+    assert is_free_mail_domain("olympuspeaks.com") is False
+    # Even a firm whose "website" is a free-mail host cannot be matched by one.
+    assert not email_matches_firm_domain("reg@gmail.com", "https://gmail.com")
+    assert not email_matches_firm_domain("reg@outlook.com", "https://www.olympuspeaks.com")
+
+
+def test_email_matches_firm_domain_rejects_missing_website():
+    assert not email_matches_firm_domain("reg@olympuspeaks.com", None)
+    assert not email_matches_firm_domain("reg@olympuspeaks.com", "")
+
+
+def test_email_matches_firm_domain_rejects_other_firms():
+    assert not email_matches_firm_domain("reg@lpl.com", "https://www.olympuspeaks.com")
+    # Lookalike suffix is not a subdomain of the firm's registrable domain.
+    assert not email_matches_firm_domain("reg@notolympuspeaks.com", "https://olympuspeaks.com")
+
+
+def test_mask_email_keeps_first_letter_and_domain():
+    assert mask_email("reginald@olympuspeaks.com") == "r•••@olympuspeaks.com"
+    assert "eginald" not in mask_email("reginald@olympuspeaks.com")
+    assert mask_email("nonsense") == "•••"
+
+
+# ---------------------------------------------------------------------------
+# Identity client: extra evidence rides alongside phone_otp
+# ---------------------------------------------------------------------------
+
+
+async def test_client_appends_extra_evidence_after_phone_otp(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setenv("RIA_IDENTITY_BASE_URL", "https://identity.test")
+    monkeypatch.setenv("RIA_IDENTITY_API_KEY", "test-key")
+    client = RIAIdentityClient(transport=httpx.MockTransport(handler))
+    await client.claim_evaluate(
+        phone="8015663510",
+        claim_type="individual",
+        firm_crd=283040,
+        individual_crd=5308823,
+        assert_phone_otp=True,
+        extra_evidence=[{"signal": "domain_email", "email": "reg@olympuspeaks.com"}],
+    )
+    assert captured["evidence"] == [
+        {"signal": "phone_otp"},
+        {"signal": "domain_email", "email": "reg@olympuspeaks.com"},
+    ]
+
+
+async def test_client_extra_evidence_without_phone_otp(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.update(json.loads(request.content))
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setenv("RIA_IDENTITY_BASE_URL", "https://identity.test")
+    monkeypatch.setenv("RIA_IDENTITY_API_KEY", "test-key")
+    client = RIAIdentityClient(transport=httpx.MockTransport(handler))
+    await client.claim_evaluate(
+        phone="8015663510",
+        claim_type="individual",
+        firm_crd=283040,
+        extra_evidence=[{"signal": "domain_email", "email": "reg@olympuspeaks.com"}],
+    )
+    assert captured["evidence"] == [{"signal": "domain_email", "email": "reg@olympuspeaks.com"}]
+
+
+# ---------------------------------------------------------------------------
+# upgrade_with_email_evidence
+# ---------------------------------------------------------------------------
+
+
+class _FakeIdentityClient:
+    def __init__(self, *, evaluate_payload=None):
+        self.evaluate_payload = evaluate_payload or {}
+        self.evaluate_calls: list[dict[str, Any]] = []
+
+    async def claim_evaluate(self, **kwargs):
+        self.evaluate_calls.append(kwargs)
+        return self.evaluate_payload
+
+
+class _FakeIamService:
+    def __init__(self):
+        self.calls: list[dict[str, Any]] = []
+
+    async def claim_ria_profile_from_identity(self, user_id, **kwargs):
+        self.calls.append({"user_id": user_id, **kwargs})
+        return {
+            "ria_profile_id": "profile-1",
+            "user_id": user_id,
+            "display_name": kwargs["display_name"],
+            "verification_status": (
+                "verified" if kwargs["verification_level"] == "verified" else "submitted"
+            ),
+        }
+
+
+class _FakeActorIdentityService:
+    def __init__(self, aliases: list[dict[str, Any]] | None = None):
+        self.aliases = aliases or []
+
+    async def list_verified_email_aliases(self, user_id):
+        return self.aliases
+
+
+def _verified_alias(email: str) -> dict[str, Any]:
+    return {
+        "email": email,
+        "email_normalized": email,
+        "verification_status": "verified",
+        "revoked_at": None,
+    }
+
+
+def _claim_context(*, verification_status: str = "submitted") -> dict[str, Any]:
+    return {
+        "ria_profile_id": "profile-1",
+        "display_name": "Reginald Troy Maxfield",
+        "legal_name": "REGINALD TROY MAXFIELD",
+        "crd_number": "5308823",
+        "verification_status": verification_status,
+        "metadata": {
+            "provider": "ria_identity_claim",
+            "claim_type": "individual",
+            "phone": "8015663510",
+            "firm_crd": 283040,
+            "individual_crd": 5308823,
+            "verification_level": "provisional",
+            "satisfied": ["phone_otp"],
+            "missing": ["domain_email"],
+            "evidence_ledger": [{"signal": "phone_otp", "accepted": True}],
+            "firm_record": {
+                "crd": 283040,
+                "name": "OLYMPUS PEAKS FINANCIAL, LLC",
+                "sec_number": "801-134885",
+                "website": "HTTPS://WWW.OLYMPUSPEAKS.COM",
+                "registration_type": "sec",
+                "registration_status": "ACTIVE",
+                "report_url": "https://adviserinfo.sec.gov/firm/summary/283040",
+            },
+            "advisor_record": {
+                "crd": 5308823,
+                "exams": [{"code": "Series 66"}],
+                "report_url": "https://adviserinfo.sec.gov/individual/summary/5308823",
+            },
+        },
+    }
+
+
+_EVALUATE_EMAIL_VERIFIED = {
+    "ok": True,
+    "claimType": "individual",
+    "provisional": False,
+    "profileVerified": True,
+    "verificationLevel": "verified",
+    "satisfied": ["phone_otp", "domain_email", "email_name_match"],
+    "missing": [],
+    "evidenceLedger": [
+        {"signal": "phone_otp", "accepted": True},
+        {"signal": "domain_email", "accepted": True},
+    ],
+    "firm": {
+        "crd": 283040,
+        "name": "OLYMPUS PEAKS FINANCIAL, LLC",
+        "secNumber": "801-134885",
+        "website": "HTTPS://WWW.OLYMPUSPEAKS.COM",
+        "registrationType": "sec",
+    },
+}
+
+
+def _service_with(
+    monkeypatch,
+    *,
+    context: dict[str, Any] | None,
+    evaluate_payload: dict[str, Any] | None = None,
+    aliases: list[dict[str, Any]] | None = None,
+) -> tuple[RIAClaimService, _FakeIdentityClient, _FakeIamService]:
+    client = _FakeIdentityClient(evaluate_payload=evaluate_payload)
+    iam = _FakeIamService()
+    service = RIAClaimService(
+        client=client,
+        iam_service=iam,
+        identity_service=_FakeActorIdentityService(aliases),
+    )
+
+    async def _mock_load(self, user_id):
+        return context
+
+    monkeypatch.setattr(RIAClaimService, "_load_claim_context", _mock_load)
+    return service, client, iam
+
+
+async def test_upgrade_happy_path_reclaims_as_verified(monkeypatch):
+    service, client, iam = _service_with(
+        monkeypatch,
+        context=_claim_context(),
+        evaluate_payload=_EVALUATE_EMAIL_VERIFIED,
+        aliases=[_verified_alias("reg@olympuspeaks.com")],
+    )
+    result = await service.upgrade_with_email_evidence(_TEST_UID, email="reg@olympuspeaks.com")
+
+    assert result["verified"] is True
+    assert result["verification_status"] == "verified"
+    call = client.evaluate_calls[0]
+    assert call["assert_phone_otp"] is True
+    assert call["extra_evidence"] == [{"signal": "domain_email", "email": "reg@olympuspeaks.com"}]
+    # Upgrade goes through the same-identity re-claim writer, never a raw UPDATE.
+    upgrade = iam.calls[0]
+    assert upgrade["verification_level"] == "verified"
+    assert upgrade["crd_number"] == "5308823"
+    assert upgrade["display_name"] == "Reginald Troy Maxfield"
+    metadata = upgrade["reference_metadata"]
+    assert metadata["provider"] == "ria_identity_claim"
+    assert metadata["evidence_upgrade"] == "domain_email"
+    assert metadata["satisfied"] == ["phone_otp", "domain_email", "email_name_match"]
+
+
+async def test_upgrade_non_verified_answer_writes_nothing(monkeypatch):
+    payload = dict(_EVALUATE_EMAIL_VERIFIED)
+    payload.update({"verificationLevel": "provisional", "profileVerified": False})
+    service, _client, iam = _service_with(
+        monkeypatch,
+        context=_claim_context(),
+        evaluate_payload=payload,
+        aliases=[_verified_alias("reg@olympuspeaks.com")],
+    )
+    result = await service.upgrade_with_email_evidence(_TEST_UID, email="reg@olympuspeaks.com")
+
+    assert result["verified"] is False
+    assert result["verification_status"] == "submitted"
+    assert result["verification_level"] == "provisional"
+    assert iam.calls == []
+
+
+async def test_upgrade_never_downgrades_an_already_verified_profile(monkeypatch):
+    payload = dict(_EVALUATE_EMAIL_VERIFIED)
+    payload.update({"verificationLevel": "provisional", "profileVerified": False})
+    service, _client, iam = _service_with(
+        monkeypatch,
+        context=_claim_context(verification_status="verified"),
+        evaluate_payload=payload,
+        aliases=[_verified_alias("reg@olympuspeaks.com")],
+    )
+    result = await service.upgrade_with_email_evidence(_TEST_UID, email="reg@olympuspeaks.com")
+
+    assert result["verified"] is True
+    assert result["verification_status"] == "verified"
+    assert iam.calls == []
+
+
+async def test_upgrade_requires_a_claim_context(monkeypatch):
+    service, client, _iam = _service_with(monkeypatch, context=None)
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.upgrade_with_email_evidence(_TEST_UID, email="reg@olympuspeaks.com")
+    assert excinfo.value.code == "CLAIM_CONTEXT_MISSING"
+    assert excinfo.value.status_code == 409
+    assert client.evaluate_calls == []
+
+
+async def test_upgrade_rejects_a_domain_mismatch_before_asserting_evidence(monkeypatch):
+    service, client, _iam = _service_with(
+        monkeypatch,
+        context=_claim_context(),
+        aliases=[_verified_alias("reg@lpl.com")],
+    )
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.upgrade_with_email_evidence(_TEST_UID, email="reg@lpl.com")
+    assert excinfo.value.code == "EMAIL_DOMAIN_MISMATCH"
+    assert client.evaluate_calls == []
+
+
+async def test_upgrade_rejects_free_mail_domains(monkeypatch):
+    service, client, _iam = _service_with(
+        monkeypatch,
+        context=_claim_context(),
+        aliases=[_verified_alias("reg@gmail.com")],
+    )
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.upgrade_with_email_evidence(_TEST_UID, email="reg@gmail.com")
+    assert excinfo.value.code == "EMAIL_DOMAIN_MISMATCH"
+    assert client.evaluate_calls == []
+
+
+async def test_upgrade_requires_the_alias_to_be_verified(monkeypatch):
+    service, client, _iam = _service_with(
+        monkeypatch,
+        context=_claim_context(),
+        aliases=[],
+    )
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.upgrade_with_email_evidence(_TEST_UID, email="reg@olympuspeaks.com")
+    assert excinfo.value.code == "EMAIL_ALIAS_NOT_VERIFIED"
+    assert client.evaluate_calls == []
+
+
+async def test_prepare_email_verification_masks_and_validates(monkeypatch):
+    service, _client, _iam = _service_with(monkeypatch, context=_claim_context())
+    prepared = await service.prepare_email_verification(_TEST_UID, "Reg@OlympusPeaks.com")
+    assert prepared["email"] == "reg@olympuspeaks.com"
+    assert prepared["email_masked"] == "r•••@olympuspeaks.com"
+    assert prepared["firm_name"] == "Olympus Peaks Financial, LLC"
+
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.prepare_email_verification(_TEST_UID, "reg@gmail.com")
+    assert excinfo.value.code == "EMAIL_DOMAIN_MISMATCH"
+
+
+async def test_prepare_email_verification_without_context(monkeypatch):
+    service, _client, _iam = _service_with(monkeypatch, context=None)
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.prepare_email_verification(_TEST_UID, "reg@olympuspeaks.com")
+    assert excinfo.value.code == "CLAIM_CONTEXT_MISSING"
+
+
+async def test_prepare_email_verification_missing_firm_website(monkeypatch):
+    context = _claim_context()
+    context["metadata"]["firm_record"]["website"] = None
+    service, _client, _iam = _service_with(monkeypatch, context=context)
+    with pytest.raises(RIAClaimEmailError) as excinfo:
+        await service.prepare_email_verification(_TEST_UID, "reg@olympuspeaks.com")
+    assert excinfo.value.code == "EMAIL_DOMAIN_MISMATCH"

--- a/consent-protocol/tests/test_ria_claim_email_routes.py
+++ b/consent-protocol/tests/test_ria_claim_email_routes.py
@@ -1,0 +1,378 @@
+"""Routes for the claim email upgrade: /claim/email/start and /claim/email/confirm.
+
+The plaintext verification code must never appear in any HTTP response — the
+happy-path tests assert its absence from the serialized body, not just its
+absence from a named field.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Stub the rate-limit middleware *before* importing the route module so the
+# decorator is a no-op during tests (same pattern as test_ria_claim_flow).
+rate_limit_module = types.ModuleType("api.middlewares.rate_limit")
+
+
+class _NoopLimiter:
+    def limit(self, *_args, **_kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+rate_limit_module.limiter = _NoopLimiter()
+sys.modules.setdefault("api.middlewares.rate_limit", rate_limit_module)
+
+import hushh_mcp.services.ria_claim_email_service as email_module  # noqa: E402
+from api.middleware import require_firebase_auth  # noqa: E402
+from api.routes import ria as ria_module  # noqa: E402
+from hushh_mcp.services.actor_identity_service import ActorIdentityAliasError  # noqa: E402
+from hushh_mcp.services.ria_claim_email_service import (  # noqa: E402
+    queue_claim_verification_email,
+)
+from hushh_mcp.services.ria_claim_service import (  # noqa: E402
+    RIAClaimEmailError,
+    RIAClaimService,
+)
+
+_TEST_UID = "user_claim_123"
+_PLAINTEXT_CODE = "483920"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(ria_module.router)
+    app.dependency_overrides[require_firebase_auth] = lambda: _TEST_UID
+    return app
+
+
+def _prepared() -> dict[str, Any]:
+    return {
+        "email": "reg@olympuspeaks.com",
+        "email_masked": "r•••@olympuspeaks.com",
+        "firm_name": "Olympus Peaks Financial, LLC",
+    }
+
+
+def _alias_result(*, already_verified: bool = False) -> dict[str, Any]:
+    return {
+        "alias": {
+            "alias_id": "alias-1",
+            "email": "reg@olympuspeaks.com",
+            "email_normalized": "reg@olympuspeaks.com",
+            "verification_status": "verified" if already_verified else "pending",
+            "revoked_at": None,
+        },
+        "already_verified": already_verified,
+        "review_verification_code": None,
+        "verification_code_plaintext": None if already_verified else _PLAINTEXT_CODE,
+    }
+
+
+def _mock_start_dependencies(
+    monkeypatch,
+    *,
+    alias_result: dict[str, Any] | None = None,
+    delivery: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    async def _mock_prepare(self, user_id, email):
+        captured["prepare"] = {"user_id": user_id, "email": email}
+        return _prepared()
+
+    monkeypatch.setattr(RIAClaimService, "prepare_email_verification", _mock_prepare)
+
+    async def _mock_request(
+        self, *, user_id, email, verification_source, source_ref, include_plaintext_code=False
+    ):
+        captured["request"] = {
+            "user_id": user_id,
+            "email": email,
+            "source_ref": source_ref,
+            "include_plaintext_code": include_plaintext_code,
+        }
+        return dict(alias_result if alias_result is not None else _alias_result())
+
+    monkeypatch.setattr(
+        ria_module.ActorIdentityService, "request_email_alias_verification", _mock_request
+    )
+
+    async def _mock_queue(*, target_email, verification_code, firm_name=None):
+        captured["queue"] = {
+            "target_email": target_email,
+            "verification_code": verification_code,
+            "firm_name": firm_name,
+        }
+        return dict(delivery if delivery is not None else {"delivery_status": "queued"})
+
+    monkeypatch.setattr(ria_module, "queue_claim_verification_email", _mock_queue)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# /claim/email/start
+# ---------------------------------------------------------------------------
+
+
+def test_email_start_sends_and_never_leaks_the_code(monkeypatch):
+    captured = _mock_start_dependencies(monkeypatch)
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/claim/email/start", json={"email": "Reg@OlympusPeaks.com"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "sent", "email_masked": "r•••@olympuspeaks.com"}
+    # The plaintext travels only through the route-internal opt-in handoff.
+    assert captured["request"]["include_plaintext_code"] is True
+    # The plaintext code reached the mail queue and ONLY the mail queue.
+    assert captured["queue"]["verification_code"] == _PLAINTEXT_CODE
+    assert _PLAINTEXT_CODE not in response.text
+
+
+def test_email_start_queue_failure_returns_send_failed_without_raising(monkeypatch):
+    _mock_start_dependencies(
+        monkeypatch, delivery={"delivery_status": "failed", "reason": "not_configured"}
+    )
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/claim/email/start", json={"email": "reg@olympuspeaks.com"})
+    assert response.status_code == 502
+    assert response.json()["status"] == "send_failed"
+    assert _PLAINTEXT_CODE not in response.text
+
+
+def test_email_start_already_verified_short_circuits(monkeypatch):
+    captured = _mock_start_dependencies(
+        monkeypatch, alias_result=_alias_result(already_verified=True)
+    )
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/claim/email/start", json={"email": "reg@olympuspeaks.com"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "already_verified"
+    assert "queue" not in captured
+
+
+def test_email_start_domain_mismatch(monkeypatch):
+    async def _mock_prepare(self, user_id, email):
+        raise RIAClaimEmailError(
+            "This email doesn't match your firm's website domain.",
+            code="EMAIL_DOMAIN_MISMATCH",
+        )
+
+    monkeypatch.setattr(RIAClaimService, "prepare_email_verification", _mock_prepare)
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/claim/email/start", json={"email": "reg@gmail.com"})
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "EMAIL_DOMAIN_MISMATCH"
+
+
+def test_email_start_missing_claim_context(monkeypatch):
+    async def _mock_prepare(self, user_id, email):
+        raise RIAClaimEmailError(
+            "Claim your profile before verifying a work email.",
+            code="CLAIM_CONTEXT_MISSING",
+        )
+
+    monkeypatch.setattr(RIAClaimService, "prepare_email_verification", _mock_prepare)
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/claim/email/start", json={"email": "reg@olympuspeaks.com"})
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "CLAIM_CONTEXT_MISSING"
+
+
+def test_email_start_alias_owned_elsewhere(monkeypatch):
+    async def _mock_prepare(self, user_id, email):
+        return _prepared()
+
+    monkeypatch.setattr(RIAClaimService, "prepare_email_verification", _mock_prepare)
+
+    async def _mock_request(
+        self, *, user_id, email, verification_source, source_ref, include_plaintext_code=False
+    ):
+        raise ActorIdentityAliasError(
+            "This email alias is already verified for another account.",
+            code="EMAIL_ALIAS_ALREADY_VERIFIED",
+            status_code=409,
+        )
+
+    monkeypatch.setattr(
+        ria_module.ActorIdentityService, "request_email_alias_verification", _mock_request
+    )
+    client = TestClient(_build_app())
+    response = client.post("/api/ria/claim/email/start", json={"email": "reg@olympuspeaks.com"})
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "EMAIL_ALIAS_ALREADY_VERIFIED"
+
+
+# ---------------------------------------------------------------------------
+# /claim/email/confirm
+# ---------------------------------------------------------------------------
+
+
+def test_email_confirm_upgrades_when_evaluator_verifies(monkeypatch):
+    async def _mock_confirm(self, *, user_id, email, verification_code):
+        assert user_id == _TEST_UID
+        assert verification_code == _PLAINTEXT_CODE
+        return {"email_normalized": email, "verification_status": "verified"}
+
+    monkeypatch.setattr(
+        ria_module.ActorIdentityService, "confirm_email_alias_verification", _mock_confirm
+    )
+
+    async def _mock_upgrade(self, user_id, *, email):
+        return {
+            "verified": True,
+            "verification_status": "verified",
+            "verification_level": "verified",
+        }
+
+    monkeypatch.setattr(RIAClaimService, "upgrade_with_email_evidence", _mock_upgrade)
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/email/confirm",
+        json={"email": "reg@olympuspeaks.com", "code": _PLAINTEXT_CODE},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["verified"] is True
+    assert body["verification_status"] == "verified"
+
+
+def test_email_confirm_reports_unverified_without_writing(monkeypatch):
+    async def _mock_confirm(self, *, user_id, email, verification_code):
+        return {"email_normalized": email, "verification_status": "verified"}
+
+    monkeypatch.setattr(
+        ria_module.ActorIdentityService, "confirm_email_alias_verification", _mock_confirm
+    )
+
+    async def _mock_upgrade(self, user_id, *, email):
+        return {
+            "verified": False,
+            "verification_status": "submitted",
+            "verification_level": "provisional",
+        }
+
+    monkeypatch.setattr(RIAClaimService, "upgrade_with_email_evidence", _mock_upgrade)
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/email/confirm",
+        json={"email": "reg@olympuspeaks.com", "code": _PLAINTEXT_CODE},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["verified"] is False
+    assert body["verification_status"] == "submitted"
+
+
+def test_email_confirm_rejects_a_bad_code(monkeypatch):
+    async def _mock_confirm(self, *, user_id, email, verification_code):
+        raise ActorIdentityAliasError(
+            "Email alias verification code is invalid.",
+            code="EMAIL_ALIAS_CODE_INVALID",
+            status_code=400,
+        )
+
+    monkeypatch.setattr(
+        ria_module.ActorIdentityService, "confirm_email_alias_verification", _mock_confirm
+    )
+    client = TestClient(_build_app())
+    response = client.post(
+        "/api/ria/claim/email/confirm",
+        json={"email": "reg@olympuspeaks.com", "code": "000000"},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "EMAIL_ALIAS_CODE_INVALID"
+
+
+# ---------------------------------------------------------------------------
+# Plaintext code contract
+# ---------------------------------------------------------------------------
+
+
+def test_plaintext_code_is_opt_in_only():
+    """`/api/account/email-aliases/verification/start` serializes the service
+    result verbatim, so the plaintext key must never appear unless a route
+    explicitly opts in and pops it before responding."""
+    import inspect
+
+    from hushh_mcp.services.actor_identity_service import ActorIdentityService
+
+    signature = inspect.signature(ActorIdentityService.request_email_alias_verification)
+    assert signature.parameters["include_plaintext_code"].default is False
+
+
+# ---------------------------------------------------------------------------
+# Best-effort mail: the queue helper never raises
+# ---------------------------------------------------------------------------
+
+
+class _StubEmailService:
+    def __init__(self, *, configured: bool):
+        self.config = types.SimpleNamespace(configured=configured)
+
+    def send_verification_code(self, **_kwargs):  # pragma: no cover - queued only
+        raise AssertionError("send should only run inside the queue worker")
+
+
+async def test_queue_helper_reports_failed_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(
+        email_module, "get_ria_claim_email_service", lambda: _StubEmailService(configured=False)
+    )
+    result = await queue_claim_verification_email(
+        target_email="reg@olympuspeaks.com", verification_code=_PLAINTEXT_CODE
+    )
+    assert result == {"delivery_status": "failed", "reason": "not_configured"}
+
+
+async def test_queue_helper_reports_failed_when_enqueue_raises(monkeypatch):
+    monkeypatch.setattr(
+        email_module, "get_ria_claim_email_service", lambda: _StubEmailService(configured=True)
+    )
+
+    class _BrokenQueue:
+        async def enqueue(self, **_kwargs):
+            raise RuntimeError("queue unavailable")
+
+    monkeypatch.setattr(email_module, "get_email_delivery_queue_service", lambda: _BrokenQueue())
+    result = await queue_claim_verification_email(
+        target_email="reg@olympuspeaks.com", verification_code=_PLAINTEXT_CODE
+    )
+    assert result == {"delivery_status": "failed", "reason": "enqueue_failed"}
+
+
+async def test_queue_helper_refuses_an_empty_code(monkeypatch):
+    monkeypatch.setattr(
+        email_module, "get_ria_claim_email_service", lambda: _StubEmailService(configured=True)
+    )
+    result = await queue_claim_verification_email(
+        target_email="reg@olympuspeaks.com", verification_code=""
+    )
+    assert result == {"delivery_status": "failed", "reason": "missing_code"}
+
+
+async def test_queue_helper_queues_when_configured(monkeypatch):
+    monkeypatch.setattr(
+        email_module, "get_ria_claim_email_service", lambda: _StubEmailService(configured=True)
+    )
+    enqueued: dict[str, Any] = {}
+
+    class _Queue:
+        async def enqueue(self, **kwargs):
+            enqueued.update(kwargs)
+            return {"accepted": True, "delivery_status": "queued"}
+
+    monkeypatch.setattr(email_module, "get_email_delivery_queue_service", lambda: _Queue())
+    result = await queue_claim_verification_email(
+        target_email="reg@olympuspeaks.com",
+        verification_code=_PLAINTEXT_CODE,
+        firm_name="Olympus Peaks Financial, LLC",
+    )
+    assert result == {"delivery_status": "queued"}
+    assert enqueued["context"] == {"purpose": "ria_claim_email_code"}
+    assert callable(enqueued["send_callable"])

--- a/consent-protocol/tests/test_ria_onboarding_status_claim_event.py
+++ b/consent-protocol/tests/test_ria_onboarding_status_claim_event.py
@@ -1,0 +1,173 @@
+"""get_ria_onboarding_status must surface the latest ria_identity_claim event.
+
+The claim snapshot (firm_record / advisor_record) is persisted in
+ria_verification_events with provider 'ria_identity_claim'. Later
+refresh-license or onboarding events shadow it in the unfiltered
+latest_verification_event fetch, so the status payload carries a dedicated
+latest_claim_event resolved with a provider filter.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+_NOW = datetime(2026, 8, 8, 12, 0, 0, tzinfo=UTC)
+
+_CLAIM_METADATA = {
+    "provider": "ria_identity_claim",
+    "claim_type": "individual",
+    "firm_record": {"firm_crd": "801-12345", "website": "https://advisoralpha.com"},
+    "advisor_record": {"individual_crd": "12345", "name": "Advisor Alpha"},
+    "verification_level": "provisional",
+}
+
+_REFRESH_METADATA = {
+    "provider": "profile_refresh",
+    "matched_name": "Advisor Alpha",
+}
+
+
+def _claim_event_row() -> dict:
+    return {
+        "provider": "ria_identity_claim",
+        "outcome": "provisional",
+        "checked_at": _NOW - timedelta(hours=2),
+        "expires_at": None,
+        "reference_metadata": json.dumps(_CLAIM_METADATA),
+    }
+
+
+def _refresh_event_row() -> dict:
+    return {
+        "provider": "profile_refresh",
+        "outcome": "verified",
+        "checked_at": _NOW - timedelta(minutes=5),
+        "expires_at": None,
+        "reference_metadata": json.dumps(_REFRESH_METADATA),
+    }
+
+
+class _FakeConn:
+    def __init__(self, events: list[dict]):
+        self._events = events
+
+    def _latest(self, events: list[dict]) -> dict | None:
+        if not events:
+            return None
+        row = max(events, key=lambda item: item["checked_at"])
+        return {
+            "outcome": row["outcome"],
+            "checked_at": row["checked_at"],
+            "expires_at": row["expires_at"],
+            "reference_metadata": row["reference_metadata"],
+        }
+
+    async def fetchrow(self, query: str, *_args):
+        if "FROM ria_verification_events" in query:
+            if "ria_identity_claim" in query:
+                return self._latest(
+                    [row for row in self._events if row["provider"] == "ria_identity_claim"]
+                )
+            return self._latest(self._events)
+        if "FROM ria_profiles" in query and "requested_capabilities" in query:
+            return {
+                "id": "ria-profile-1",
+                "user_id": "user-1",
+                "display_name": "Advisor Alpha",
+                "requested_capabilities": ["advisory"],
+                "individual_legal_name": "Advisor Alpha",
+                "individual_crd": "12345",
+                "advisory_firm_legal_name": "Advisor Alpha LLC",
+                "advisory_firm_iapd_number": "801-12345",
+                "broker_firm_legal_name": None,
+                "broker_firm_crd": None,
+                "advisory_status": "verified",
+                "brokerage_status": None,
+                "advisory_provider": "ria_identity_claim",
+                "brokerage_provider": None,
+                "advisory_verification_expires_at": None,
+                "brokerage_verification_expires_at": None,
+                "legal_name": "Advisor Alpha",
+                "finra_crd": "12345",
+                "sec_iard": None,
+                "verification_status": "provisional",
+                "verification_provider": "ria_identity_claim",
+                "verification_expires_at": None,
+                "created_at": _NOW - timedelta(days=1),
+                "updated_at": _NOW,
+            }
+        return None
+
+    async def close(self):
+        return None
+
+
+def _service_with_events(monkeypatch, events: list[dict]) -> RIAIAMService:
+    service = RIAIAMService()
+
+    async def _fake_conn():
+        return _FakeConn(events)
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _noop)
+    monkeypatch.setattr(service, "_ensure_vault_user_row", _noop)
+    monkeypatch.setattr(service, "_ensure_actor_profile_row", _noop)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_status_returns_latest_claim_event_when_claim_exists(monkeypatch):
+    service = _service_with_events(monkeypatch, [_claim_event_row()])
+
+    result = await service.get_ria_onboarding_status("user-1")
+
+    claim_event = result["latest_claim_event"]
+    assert claim_event is not None
+    assert claim_event["outcome"] == "provisional"
+    assert claim_event["reference_metadata"]["provider"] == "ria_identity_claim"
+    assert claim_event["reference_metadata"]["firm_record"]["firm_crd"] == "801-12345"
+    assert claim_event["reference_metadata"]["advisor_record"]["individual_crd"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_claim_event_survives_newer_profile_refresh_event(monkeypatch):
+    service = _service_with_events(monkeypatch, [_claim_event_row(), _refresh_event_row()])
+
+    result = await service.get_ria_onboarding_status("user-1")
+
+    # The unfiltered latest event is the newer refresh event...
+    latest = result["latest_verification_event"]
+    assert latest is not None
+    assert latest["reference_metadata"]["provider"] == "profile_refresh"
+
+    # ...but the claim snapshot is still reachable, not shadowed.
+    claim_event = result["latest_claim_event"]
+    assert claim_event is not None
+    assert claim_event["reference_metadata"]["provider"] == "ria_identity_claim"
+    assert claim_event["reference_metadata"]["firm_record"]["firm_crd"] == "801-12345"
+
+
+@pytest.mark.asyncio
+async def test_latest_claim_event_is_null_without_claim_event(monkeypatch):
+    service = _service_with_events(monkeypatch, [_refresh_event_row()])
+
+    result = await service.get_ria_onboarding_status("user-1")
+
+    assert result["latest_claim_event"] is None
+    assert result["latest_verification_event"] is not None
+
+
+@pytest.mark.asyncio
+async def test_latest_claim_event_is_null_with_no_events_at_all(monkeypatch):
+    service = _service_with_events(monkeypatch, [])
+
+    result = await service.get_ria_onboarding_status("user-1")
+
+    assert result["latest_claim_event"] is None
+    assert result["latest_verification_event"] is None

--- a/hushh-webapp/__tests__/app/ria-claim-single-otp.test.tsx
+++ b/hushh-webapp/__tests__/app/ria-claim-single-otp.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RiaClaimPage from "@/app/ria/claim/page";
+
+const {
+  replace,
+  claimLookupMock,
+  claimVerifyMock,
+  claimOtpStartMock,
+  claimCompleteMock,
+  refreshPersonaMock,
+} = vi.hoisted(() => ({
+  replace: vi.fn(),
+  claimLookupMock: vi.fn(),
+  claimVerifyMock: vi.fn(),
+  claimOtpStartMock: vi.fn(),
+  claimCompleteMock: vi.fn(),
+  refreshPersonaMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+// The number arrives via ?phone= from register-phone; the account record in
+// useAuth is deliberately null — the exact state where the old client-side
+// gate produced a second OTP. The server alone decides.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => new URLSearchParams("phone=8015551234"),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: {
+      uid: "claimant",
+      phoneNumber: null,
+      getIdToken: vi.fn().mockResolvedValue("token"),
+    },
+    phoneNumber: null,
+    loading: false,
+  }),
+}));
+
+vi.mock("@/lib/vault/vault-context", () => ({
+  useVault: () => ({ vaultKey: null, vaultOwnerToken: null }),
+}));
+
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: () => ({ refresh: refreshPersonaMock }),
+}));
+
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: { onPersonaStateChanged: vi.fn() },
+}));
+
+vi.mock("@/lib/services/pre-vault-user-state-service", () => ({
+  PreVaultUserStateService: {
+    bootstrapState: vi.fn().mockResolvedValue({ setupCapabilityIds: ["ria"] }),
+    syncSetupCapabilities: vi.fn().mockResolvedValue(undefined),
+    isSetupResolved: vi.fn().mockReturnValue(true),
+  },
+}));
+
+vi.mock("@/components/app-ui/fullscreen-flow-shell", () => ({
+  FullscreenFlowShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/app-ui/native-test-beacon", () => ({
+  NativeTestBeacon: () => null,
+}));
+
+vi.mock("@/lib/services/ria-service", () => {
+  class RiaApiError extends Error {
+    status: number;
+    code?: string;
+    constructor(message: string, status: number, code?: string) {
+      super(message);
+      this.name = "RiaApiError";
+      this.status = status;
+      this.code = code;
+    }
+  }
+  return {
+    RiaApiError,
+    RiaService: {
+      claimLookup: claimLookupMock,
+      claimVerify: claimVerifyMock,
+      claimOtpStart: claimOtpStartMock,
+      claimComplete: claimCompleteMock,
+      saveRegulatorProfile: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+import { RiaApiError } from "@/lib/services/ria-service";
+
+const lookupResult = {
+  outcome: "single_person",
+  firm: {
+    crd: 800001,
+    name: "EXAMPLE ADVISORS LLC",
+    city: "AUSTIN",
+    state: "TX",
+    phone: null,
+    aum: null,
+  },
+  firms: [],
+  candidates: [
+    { individual_crd: 123, name: "JANE DOE", branch_city: "AUSTIN", branch_state: "TX" },
+  ],
+  current_adviser_count: 1,
+};
+
+const verifyResult = {
+  claim_ticket: "ticket-1",
+  provisional: false,
+  profile_verified: true,
+  roster_unlocked: true,
+  roster: null,
+};
+
+const completeResult = {
+  status: "claimed",
+  claim_type: "individual",
+  verification_level: "verified",
+  profile_verified: true,
+  provisional: false,
+  profile: {
+    ria_profile_id: "rp-1",
+    user_id: "claimant",
+    display_name: "Jane Doe",
+    verification_status: "verified",
+    firm_name: "EXAMPLE ADVISORS LLC",
+  },
+  facts: null,
+};
+
+async function renderToFoundStep() {
+  render(<RiaClaimPage />);
+  const continueButton = await screen.findByRole("button", { name: "Continue" });
+  return continueButton;
+}
+
+describe("RiaClaimPage beginClaim — single OTP", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    claimLookupMock.mockResolvedValue(lookupResult);
+    claimCompleteMock.mockResolvedValue(completeResult);
+    claimOtpStartMock.mockResolvedValue({
+      eligible: true,
+      verification_id: "v-1",
+      code_length: 5,
+      phone_masked: "(•••) •••-1234",
+    });
+  });
+
+  it("attempts the tokenless verify first and skips the code step on success", async () => {
+    claimVerifyMock.mockResolvedValue(verifyResult);
+    const continueButton = await renderToFoundStep();
+
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(screen.getByText("Profile claimed")).toBeInTheDocument());
+    expect(claimVerifyMock).toHaveBeenCalledTimes(1);
+    expect(claimVerifyMock).toHaveBeenCalledWith("token", {
+      phone: "8015551234",
+      claim_type: "individual",
+      firm_crd: 800001,
+      individual_crd: 123,
+    });
+    expect(claimOtpStartMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("Verify the number")).not.toBeInTheDocument();
+  });
+
+  it("falls through to the passcode when the server answers 422 CLAIM_PROOF_REQUIRED", async () => {
+    claimVerifyMock.mockRejectedValue(
+      new RiaApiError("Proof required", 422, "CLAIM_PROOF_REQUIRED"),
+    );
+    const continueButton = await renderToFoundStep();
+
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(screen.getByText("Verify the number")).toBeInTheDocument());
+    expect(claimVerifyMock).toHaveBeenCalledTimes(1);
+    expect(claimOtpStartMock).toHaveBeenCalledTimes(1);
+    expect(claimCompleteMock).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the passcode on a network error instead of dead-ending", async () => {
+    claimVerifyMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    const continueButton = await renderToFoundStep();
+
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(screen.getByText("Verify the number")).toBeInTheDocument());
+    expect(claimOtpStartMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
@@ -27,11 +27,14 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("lucide-react", () => ({
   ArrowRight: () => <span />,
+  CheckCircle2: () => <span />,
   ClipboardCheck: () => <span />,
+  ExternalLink: () => <span />,
   Loader2: () => <span />,
   MessageCircle: () => <span />,
   Pencil: () => <span />,
   RotateCcw: () => <span />,
+  ShieldCheck: () => <span />,
   Trash2: () => <span />,
 }));
 
@@ -40,6 +43,10 @@ vi.mock("@/components/ria/ria-page-shell", () => ({
     <div data-testid="ria-page-shell">{children}</div>
   ),
   RiaCompatibilityState: () => <div data-testid="ria-compat" />,
+  isRiaVerified: (status?: string | null) =>
+    ["active", "verified", "finra_verified"].includes(
+      String(status || "").toLowerCase(),
+    ),
 }));
 
 vi.mock("@/components/ria/onboarding/onboarding-step-review", () => ({

--- a/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
@@ -1,0 +1,415 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  useAuth: vi.fn(),
+  usePersonaState: vi.fn(),
+  refresh: vi.fn(),
+  switchPersona: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  riaService: {
+    deleteProfile: vi.fn(),
+    updateProfile: vi.fn(),
+    refreshLicenseProfile: vi.fn(),
+    claimEmailStart: vi.fn(),
+    claimEmailConfirm: vi.fn(),
+  },
+  openKaiCommandBar: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush, replace: mocks.routerReplace }),
+}));
+
+vi.mock("lucide-react", () => ({
+  ArrowRight: () => <span />,
+  CheckCircle2: () => <span />,
+  ClipboardCheck: () => <span />,
+  ExternalLink: () => <span />,
+  Loader2: () => <span />,
+  MessageCircle: () => <span />,
+  Pencil: () => <span />,
+  RotateCcw: () => <span />,
+  ShieldCheck: () => <span />,
+  Trash2: () => <span />,
+}));
+
+vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
+  OnboardingStepServices: () => <div data-testid="step-services" />,
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaCompatibilityState: () => <div data-testid="ria-compat" />,
+  isRiaVerified: (status?: string | null) =>
+    ["active", "verified", "finra_verified"].includes(
+      String(status || "").toLowerCase(),
+    ),
+}));
+
+vi.mock("@/components/app-ui/settings-ui", () => ({
+  SettingsDetailPanel: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="edit-panel">{children}</div> : null),
+  SettingsGroup: ({
+    children,
+    testId = "manage-group",
+  }: {
+    children: React.ReactNode;
+    testId?: string;
+  }) => <div data-testid={testId}>{children}</div>,
+  SettingsRow: ({
+    title,
+    onClick,
+    disabled,
+    testId,
+  }: {
+    title: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    testId?: string;
+  }) => (
+    <button data-testid={testId} onClick={onClick} disabled={disabled}>
+      {title}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="license-dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="delete-dialog">{children}</div> : null),
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+  AlertDialogAction: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: mocks.useAuth }));
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: mocks.usePersonaState,
+}));
+vi.mock("@/lib/services/ria-service", () => ({ RiaService: mocks.riaService }));
+vi.mock("@/lib/services/ria-onboarding-draft-local-service", () => ({
+  RiaOnboardingDraftLocalService: { clear: () => Promise.resolve() },
+}));
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: { onPersonaStateChanged: vi.fn() },
+}));
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    invalidateResourcePrefix: () => Promise.resolve(),
+  },
+}));
+vi.mock("@/lib/morphy-ux/morphy", () => ({ morphyToast: mocks.toast }));
+vi.mock("@/lib/navigation/routes", () => ({
+  ROUTES: { RIA_ONBOARDING: "/ria/onboarding", ONE_HOME: "/one" },
+}));
+vi.mock("@/lib/navigation/kai-command-bar-events", () => ({
+  openKaiCommandBar: mocks.openKaiCommandBar,
+}));
+
+import { RiaProfileSection } from "@/components/ria/profile/ria-profile-section";
+
+const PHONE_DIGITS = "8015663510";
+
+const CLAIM_EVENT = {
+  outcome: "verified",
+  checked_at: "2026-08-01T00:00:00Z",
+  expires_at: null,
+  reference_metadata: {
+    provider: "ria_identity_claim",
+    claim_type: "individual",
+    phone: PHONE_DIGITS,
+    verification_level: "provisional",
+    satisfied: ["phone_otp"],
+    missing: ["domain_email"],
+    firm_record: {
+      crd: 800001,
+      name: "EXAMPLE ADVISORS LLC",
+      registration_status: "Active",
+      registration_type: "sec",
+      aum: 2_500_000_000,
+      phone: PHONE_DIGITS,
+    },
+    advisor_record: {
+      crd: 1234567,
+      registered_since: "2004-01-12",
+    },
+  },
+};
+
+const BASE_STATUS = {
+  exists: true,
+  advisory_status: "submitted",
+  verification_status: "submitted",
+  display_name: "Andrew Kirkland",
+  individual_crd: "7413463",
+  services_offered: ["Portfolio Management"],
+  fee_structure: ["Hourly"],
+};
+
+function renderSection(status: unknown, onRefresh = vi.fn()) {
+  return render(
+    <RiaProfileSection
+      status={status as never}
+      loading={false}
+      onRefresh={onRefresh}
+    />,
+  );
+}
+
+describe("RiaProfileSection verification chip + email nudge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({
+      user: { uid: "u1", getIdToken: vi.fn().mockResolvedValue("tok") },
+    });
+    mocks.usePersonaState.mockReturnValue({
+      riaCapability: "switch",
+      loading: false,
+      refreshing: false,
+      refresh: mocks.refresh,
+      switchPersona: mocks.switchPersona,
+    });
+    mocks.refresh.mockResolvedValue(undefined);
+  });
+
+  it("renders the Not verified chip and the email nudge when unverified", async () => {
+    renderSection({ ...BASE_STATUS, latest_claim_event: CLAIM_EVENT });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ria-profile-verification-chip")).toBeTruthy(),
+    );
+    expect(
+      screen.getByTestId("ria-profile-verification-chip").textContent,
+    ).toContain("Not verified");
+    expect(screen.getByTestId("ria-email-verify-card")).toBeTruthy();
+    expect(screen.getByText("Verify with your work email")).toBeTruthy();
+  });
+
+  it("renders the Verified chip and no nudge when verified", async () => {
+    renderSection({
+      ...BASE_STATUS,
+      verification_status: "verified",
+      advisory_status: "verified",
+      latest_claim_event: CLAIM_EVENT,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ria-profile-verification-chip")).toBeTruthy(),
+    );
+    expect(
+      screen.getByTestId("ria-profile-verification-chip").textContent,
+    ).toContain("Verified");
+    expect(
+      screen.getByTestId("ria-profile-verification-chip").textContent,
+    ).not.toContain("Not verified");
+    expect(screen.queryByTestId("ria-email-verify-card")).toBeNull();
+  });
+
+  it("hides the nudge without a claim snapshot and for firm claims", () => {
+    // Onboarded-but-never-claimed: no claim event → no email card.
+    renderSection({ ...BASE_STATUS }).unmount();
+    expect(screen.queryByTestId("ria-email-verify-card")).toBeNull();
+
+    // Firm claims are gated out in v1 (no adviser name for email_name_match).
+    renderSection({
+      ...BASE_STATUS,
+      latest_claim_event: {
+        ...CLAIM_EVENT,
+        reference_metadata: {
+          ...CLAIM_EVENT.reference_metadata,
+          claim_type: "firm",
+        },
+      },
+    });
+    expect(screen.queryByTestId("ria-email-verify-card")).toBeNull();
+  });
+
+  it("renders the SEC record from the claim event, ahead of the verification event", async () => {
+    renderSection({
+      ...BASE_STATUS,
+      latest_claim_event: CLAIM_EVENT,
+      latest_verification_event: {
+        outcome: "verified",
+        checked_at: "2026-08-05T00:00:00Z",
+        reference_metadata: {
+          provider: "sec_iapd",
+          advisor_record: { crd: 999 },
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("From your SEC record.")).toBeTruthy(),
+    );
+    expect(screen.getByText("1234567")).toBeTruthy();
+    expect(screen.queryByText("999")).toBeNull();
+    expect(screen.getByText("$2.5B")).toBeTruthy();
+  });
+
+  it("falls back to the verification event only when it carries records", async () => {
+    renderSection({
+      ...BASE_STATUS,
+      latest_verification_event: {
+        outcome: "verified",
+        checked_at: "2026-08-05T00:00:00Z",
+        reference_metadata: {
+          provider: "sec_iapd",
+          advisor_record: { crd: 424242, registered_since: "2010-05-01" },
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("From your SEC record.")).toBeTruthy(),
+    );
+    expect(screen.getByText("424242")).toBeTruthy();
+  });
+
+  it("omits the section when neither event carries records", () => {
+    renderSection({
+      ...BASE_STATUS,
+      latest_verification_event: {
+        outcome: "verified",
+        checked_at: "2026-08-05T00:00:00Z",
+        reference_metadata: { provider: "sec_iapd" },
+      },
+    });
+
+    expect(screen.queryByText("From your SEC record.")).toBeNull();
+    expect(screen.queryByTestId("ria-profile-verification-chip")).toBeNull();
+  });
+
+  it("never renders the raw phone digits persisted in the claim metadata", async () => {
+    const { container } = renderSection({
+      ...BASE_STATUS,
+      latest_claim_event: CLAIM_EVENT,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("From your SEC record.")).toBeTruthy(),
+    );
+    expect(container.textContent).not.toContain(PHONE_DIGITS);
+  });
+
+  it("sends the code, confirms it, and refreshes on verified", async () => {
+    mocks.riaService.claimEmailStart.mockResolvedValue({
+      status: "sent",
+      email_masked: "r•••@examplefirm.com",
+    });
+    mocks.riaService.claimEmailConfirm.mockResolvedValue({
+      verified: true,
+      verification_status: "verified",
+      verification_level: "verified",
+    });
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    renderSection({ ...BASE_STATUS, latest_claim_event: CLAIM_EVENT }, onRefresh);
+
+    fireEvent.change(screen.getByTestId("ria-email-verify-input"), {
+      target: { value: "reggie@examplefirm.com" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ria-email-verify-send"));
+    });
+    expect(mocks.riaService.claimEmailStart).toHaveBeenCalledWith("tok", {
+      email: "reggie@examplefirm.com",
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("ria-email-verify-code")).toBeTruthy(),
+    );
+    fireEvent.change(screen.getByTestId("ria-email-verify-code"), {
+      target: { value: "123456" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ria-email-verify-confirm"));
+    });
+
+    expect(mocks.riaService.claimEmailConfirm).toHaveBeenCalledWith("tok", {
+      email: "reggie@examplefirm.com",
+      code: "123456",
+    });
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledWith(true);
+      expect(mocks.refresh).toHaveBeenCalledWith({ force: true });
+    });
+  });
+
+  it("offers Retry when the mail queue fails, without losing the card", async () => {
+    mocks.riaService.claimEmailStart.mockResolvedValue({
+      status: "send_failed",
+      email_masked: "r•••@examplefirm.com",
+    });
+    renderSection({ ...BASE_STATUS, latest_claim_event: CLAIM_EVENT });
+
+    fireEvent.change(screen.getByTestId("ria-email-verify-input"), {
+      target: { value: "reggie@examplefirm.com" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ria-email-verify-send"));
+    });
+
+    expect(screen.getByText("Couldn't send.")).toBeTruthy();
+    expect(screen.getByTestId("ria-email-verify-send").textContent).toContain(
+      "Retry",
+    );
+    // Still on the email phase — no code input yet.
+    expect(screen.queryByTestId("ria-email-verify-code")).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/components/ria/ria-sec-record-section.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-sec-record-section.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  RiaSecRecordSection,
+  type RiaSecAdvisorRecord,
+  type RiaSecFirmRecord,
+} from "@/components/ria/profile/ria-sec-record-section";
+import type { RiaClaimProfileFacts } from "@/lib/services/ria-service";
+
+const fullAdvisor: RiaSecAdvisorRecord = {
+  crd: 1234567,
+  registered_since: "2004-01-12",
+  exams: [
+    { code: "Series 65", name: "Uniform Investment Adviser Law", date: "2004-01-05" },
+    { code: "Series 7", name: "General Securities Representative", date: "2001-06-02" },
+  ],
+  registered_states: [
+    { state: "CA", status: "APPROVED", date: "2004-01-12" },
+    { state: "NY", status: "APPROVED", date: "2006-03-01" },
+  ],
+  previous_firms: [{ firm_name: "OLD CAPITAL LLC", firm_crd: 99, from: "2001", to: "2004" }],
+  branch: { city: "SAN FRANCISCO", state: "CA", street1: "1 Market St", zip: "94105" },
+  has_disclosures: true,
+  disclosure_count: 2,
+  report_url: "https://adviserinfo.sec.gov/individual/summary/1234567",
+};
+
+const fullFirm: RiaSecFirmRecord = {
+  crd: 800001,
+  name: "EXAMPLE ADVISORS LLC",
+  registration_status: "Active",
+  registration_type: "sec",
+  aum: 2_500_000_000,
+  num_accounts: 1400,
+  total_employees: 52,
+  registrations: [{ jurisdiction: "SEC", status: "APPROVED", effective_date: "1998-04-20" }],
+  notice_filed_states: ["CA", "NY", "TX", "WA"],
+  form_adv_pdf_url: "https://reports.adviserinfo.sec.gov/reports/ADV/800001/adv.pdf",
+  form_crs_url: "https://reports.adviserinfo.sec.gov/crs/crs_800001.pdf",
+  brochures: [{ name: "WRAP FEE BROCHURE", date_submitted: "2025-03-01", url: "https://example.com/brochure.pdf" }],
+  website: "https://exampleadvisors.com",
+  report_url: "https://adviserinfo.sec.gov/firm/summary/800001",
+};
+
+describe("RiaSecRecordSection", () => {
+  it("renders the full record from persisted firm and adviser snapshots", () => {
+    render(<RiaSecRecordSection advisorRecord={fullAdvisor} firmRecord={fullFirm} />);
+
+    expect(screen.getByText("From your SEC record.")).toBeInTheDocument();
+    // Adviser rows.
+    expect(screen.getByText("CRD")).toBeInTheDocument();
+    expect(screen.getByText("1234567")).toBeInTheDocument();
+    expect(screen.getByText("Registered since")).toBeInTheDocument();
+    expect(screen.getByText("2004-01-12")).toBeInTheDocument();
+    expect(screen.getByText("Office")).toBeInTheDocument();
+    expect(screen.getByText("San Francisco, CA")).toBeInTheDocument();
+    expect(screen.getByText("Exams")).toBeInTheDocument();
+    expect(screen.getByText("Series 65, Series 7")).toBeInTheDocument();
+    expect(screen.getByText("Registered in 2")).toBeInTheDocument();
+    expect(screen.getByText("CA, NY · Approved")).toBeInTheDocument();
+    expect(screen.getByText("Previously")).toBeInTheDocument();
+    expect(screen.getByText("Old Capital LLC · 2001–2004")).toBeInTheDocument();
+    expect(screen.getByText("Disclosures")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    // Firm rows.
+    expect(screen.getByText("Regulator")).toBeInTheDocument();
+    expect(screen.getByText("SEC · Active")).toBeInTheDocument();
+    expect(screen.getByText("Firm assets")).toBeInTheDocument();
+    expect(screen.getByText("$2.5B")).toBeInTheDocument();
+    expect(screen.getByText("Accounts")).toBeInTheDocument();
+    expect(screen.getByText("1,400")).toBeInTheDocument();
+    expect(screen.getByText("Employees")).toBeInTheDocument();
+    expect(screen.getByText("52")).toBeInTheDocument();
+    expect(screen.getByText("Notice filed in 4")).toBeInTheDocument();
+    expect(screen.getByText("CA, NY, TX…")).toBeInTheDocument();
+    expect(screen.getByText("SEC")).toBeInTheDocument();
+    expect(screen.getByText("Approved · 1998-04-20")).toBeInTheDocument();
+    // Links.
+    expect(
+      screen.getByRole("link", { name: /View on adviserinfo\.sec\.gov/ }),
+    ).toHaveAttribute("href", fullAdvisor.report_url);
+    expect(screen.getByRole("link", { name: /Form ADV/ })).toHaveAttribute(
+      "href",
+      fullFirm.form_adv_pdf_url,
+    );
+    expect(screen.getByRole("link", { name: /Form CRS/ })).toHaveAttribute(
+      "href",
+      fullFirm.form_crs_url,
+    );
+    expect(screen.getByRole("link", { name: /Wrap Fee Brochure/ })).toHaveAttribute(
+      "href",
+      "https://example.com/brochure.pdf",
+    );
+    expect(screen.getByRole("link", { name: /Website/ })).toHaveAttribute(
+      "href",
+      fullFirm.website,
+    );
+  });
+
+  it("renders from the claim-page facts shape", () => {
+    const facts: RiaClaimProfileFacts = {
+      crd_number: "7654321",
+      regulator: "SEC",
+      regulator_status: "Active",
+      registered_since: "2010-05-01",
+      branch_city: "AUSTIN",
+      branch_state: "TX",
+      exams: [{ code: "Series 66" }],
+      registered_states: [{ state: "TX", status: "APPROVED" }],
+      previous_firms: [{ firm_name: "PRIOR LLC" }],
+      notice_filed_states: ["TX"],
+      aum: 120_000_000,
+      num_accounts: 300,
+      firm_website: "https://factsfirm.com",
+      report_url: "https://adviserinfo.sec.gov/individual/summary/7654321",
+      has_disclosures: false,
+    };
+    render(<RiaSecRecordSection facts={facts} />);
+
+    expect(screen.getByText("7654321")).toBeInTheDocument();
+    expect(screen.getByText("SEC · Active")).toBeInTheDocument();
+    expect(screen.getByText("Austin, TX")).toBeInTheDocument();
+    expect(screen.getByText("$120M")).toBeInTheDocument();
+    expect(screen.getByText("Registered in")).toBeInTheDocument();
+    expect(screen.getByText("TX · Approved")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Website/ })).toHaveAttribute(
+      "href",
+      "https://factsfirm.com",
+    );
+    // No disclosures flag → no row.
+    expect(screen.queryByText("Disclosures")).not.toBeInTheDocument();
+  });
+
+  it("prefers the fuller snapshot over facts where both exist", () => {
+    const facts: RiaClaimProfileFacts = { crd_number: "1", aum: 1_000_000 };
+    render(
+      <RiaSecRecordSection
+        facts={facts}
+        advisorRecord={{ crd: 999 }}
+        firmRecord={{ aum: 2_000_000_000 }}
+      />,
+    );
+    expect(screen.getByText("999")).toBeInTheDocument();
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+    expect(screen.getByText("$2.0B")).toBeInTheDocument();
+  });
+
+  it("omits absent rows entirely instead of rendering placeholders", () => {
+    render(<RiaSecRecordSection advisorRecord={{ crd: 42 }} firmRecord={{}} />);
+    expect(screen.getByText("CRD")).toBeInTheDocument();
+    expect(screen.queryByText(/N\/A/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Office")).not.toBeInTheDocument();
+    expect(screen.queryByText("Exams")).not.toBeInTheDocument();
+    expect(screen.queryByText("Regulator")).not.toBeInTheDocument();
+    expect(screen.queryByText("Employees")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when no record exists", () => {
+    const { container } = render(<RiaSecRecordSection />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("never renders phone digits from the raw metadata snapshot", () => {
+    // The persisted firm_record carries the claimant's phone; the section must
+    // render selected keys only and drop it even when present at runtime.
+    const leakyFirm = { ...fullFirm, phone: "2125550123" } as RiaSecFirmRecord;
+    const { container } = render(
+      <RiaSecRecordSection advisorRecord={fullAdvisor} firmRecord={leakyFirm} />,
+    );
+    expect(container.textContent).not.toContain("2125550123");
+    expect(container.textContent).not.toContain("(212) 555-0123");
+  });
+
+  it("mounts the header accessory beside the caption", () => {
+    render(
+      <RiaSecRecordSection
+        advisorRecord={{ crd: 42 }}
+        headerAccessory={<span data-testid="chip">Verified</span>}
+      />,
+    );
+    expect(screen.getByTestId("chip")).toBeInTheDocument();
+  });
+});

--- a/hushh-webapp/__tests__/services/ria-service-claim-email.test.ts
+++ b/hushh-webapp/__tests__/services/ria-service-claim-email.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiFetchMock = vi.fn();
+
+vi.mock("@/lib/services/api-service", () => ({
+  ApiService: {
+    apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  },
+}));
+
+vi.mock("@/lib/cache/request-audit-log", () => ({
+  logRequestAudit: vi.fn(),
+}));
+
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    read: vi.fn(),
+    write: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/personal-knowledge-model-service", () => ({
+  PersonalKnowledgeModelService: {},
+  PkmScopeExposureError: class PkmScopeExposureError extends Error {},
+}));
+
+vi.mock("@/lib/services/pkm-write-coordinator", () => ({
+  PkmWriteCoordinator: {},
+}));
+
+vi.mock("@/lib/observability/client", () => ({
+  trackEvent: vi.fn(),
+  toEventResult: vi.fn((value) => value),
+  toStatusBucket: vi.fn((value) => value),
+}));
+
+vi.mock("@/lib/observability/growth", () => ({
+  resolveGrowthWorkspaceSource: vi.fn(() => "test"),
+  trackGrowthFunnelStepCompleted: vi.fn(),
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("RiaService claim email verification methods", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    apiFetchMock.mockReset();
+  });
+
+  it("posts the work email to claim/email/start and returns the masked receipt", async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse({ status: "sent", email_masked: "r•••@examplefirm.com" }),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    const result = await RiaService.claimEmailStart("id-token", {
+      email: "reggie@examplefirm.com",
+    });
+
+    expect(result.status).toBe("sent");
+    expect(result.email_masked).toBe("r•••@examplefirm.com");
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/ria/claim/email/start",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ email: "reggie@examplefirm.com" }),
+        headers: expect.objectContaining({
+          Authorization: "Bearer id-token",
+        }),
+      }),
+    );
+  });
+
+  it("returns send_failed as a result on 502 so the UI can offer Retry", async () => {
+    // Best-effort mail: the alias ceremony stood, only the send failed.
+    apiFetchMock.mockResolvedValue(
+      jsonResponse(
+        { status: "send_failed", email_masked: "r•••@examplefirm.com" },
+        502,
+      ),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    const result = await RiaService.claimEmailStart("id-token", {
+      email: "reggie@examplefirm.com",
+    });
+
+    expect(result.status).toBe("send_failed");
+  });
+
+  it("surfaces the typed domain-mismatch rejection", async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          detail: {
+            code: "EMAIL_DOMAIN_MISMATCH",
+            message: "Use an email at your firm's domain.",
+          },
+        },
+        409,
+      ),
+    );
+
+    const { RiaService, RiaApiError } = await import(
+      "@/lib/services/ria-service"
+    );
+    const err = await RiaService.claimEmailStart("id-token", {
+      email: "reggie@gmail.com",
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(RiaApiError);
+    expect(err.code).toBe("EMAIL_DOMAIN_MISMATCH");
+    expect(err.message).toBe("Use an email at your firm's domain.");
+  });
+
+  it("confirms the code and returns the upgraded status", async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse({
+        verified: true,
+        verification_status: "verified",
+        verification_level: "verified",
+      }),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    const result = await RiaService.claimEmailConfirm("id-token", {
+      email: "reggie@examplefirm.com",
+      code: "123456",
+    });
+
+    expect(result.verified).toBe(true);
+    expect(result.verification_status).toBe("verified");
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      "/api/ria/claim/email/confirm",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          email: "reggie@examplefirm.com",
+          code: "123456",
+        }),
+      }),
+    );
+  });
+
+  it("returns verified:false untouched when the evaluator declines", async () => {
+    // Non-verified evaluator answer is a 200 with no local status write.
+    apiFetchMock.mockResolvedValue(
+      jsonResponse({ verified: false, verification_status: "submitted" }),
+    );
+
+    const { RiaService } = await import("@/lib/services/ria-service");
+    const result = await RiaService.claimEmailConfirm("id-token", {
+      email: "reggie@examplefirm.com",
+      code: "123456",
+    });
+
+    expect(result.verified).toBe(false);
+    expect(result.verification_status).toBe("submitted");
+  });
+
+  it("surfaces the typed wrong-code rejection", async () => {
+    apiFetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          detail: {
+            code: "EMAIL_ALIAS_CODE_INVALID",
+            message: "That code didn't work.",
+          },
+        },
+        400,
+      ),
+    );
+
+    const { RiaService, RiaApiError } = await import(
+      "@/lib/services/ria-service"
+    );
+    const err = await RiaService.claimEmailConfirm("id-token", {
+      email: "reggie@examplefirm.com",
+      code: "000000",
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(RiaApiError);
+    expect(err.code).toBe("EMAIL_ALIAS_CODE_INVALID");
+  });
+});

--- a/hushh-webapp/app/api/ria/[...path]/route.ts
+++ b/hushh-webapp/app/api/ria/[...path]/route.ts
@@ -161,7 +161,14 @@ async function proxyRequest(
 
     const result = await load;
 
-    if (method === "POST" && path === "profile/refresh-license" && authHeader) {
+    // Mutations that change onboarding/status upstream must drop the hot GET
+    // cache so the next status read reflects them (license refresh updates the
+    // official fields; claim email verify can flip verification_status).
+    if (
+      method === "POST" &&
+      authHeader &&
+      (path === "profile/refresh-license" || path.startsWith("claim/email/"))
+    ) {
       hotGetCache.delete(`onboarding/status:${authHeader}`);
     }
 

--- a/hushh-webapp/app/ria/claim/page.tsx
+++ b/hushh-webapp/app/ria/claim/page.tsx
@@ -15,7 +15,6 @@ import {
   Building2,
   CheckCircle2,
   ChevronLeft,
-  ExternalLink,
   Loader2,
   ShieldCheck,
   UserRound,
@@ -26,6 +25,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FullscreenFlowShell } from "@/components/app-ui/fullscreen-flow-shell";
 import { NativeTestBeacon } from "@/components/app-ui/native-test-beacon";
 import { SettingsGroup, SettingsRow } from "@/components/app-ui/settings-ui";
+import {
+  formatAum,
+  RiaSecRecordSection,
+  titleCase,
+} from "@/components/ria/profile/ria-sec-record-section";
 import { useAuth } from "@/hooks/use-auth";
 import { CacheSyncService } from "@/lib/cache/cache-sync-service";
 import { toNanpDigits } from "@/lib/ria/ria-claim-entry";
@@ -41,7 +45,6 @@ import {
   type RiaClaimCompleteResult,
   type RiaClaimFirm,
   type RiaClaimLookupResult,
-  type RiaClaimProfileFacts,
   type RiaClaimVerifyResult,
 } from "@/lib/services/ria-service";
 
@@ -55,27 +58,6 @@ function formatUsPhone(digits: string): string {
   if (digits.length <= 3) return digits;
   if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
   return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6, 10)}`;
-}
-
-function formatAum(aum: number | null | undefined): string | null {
-  if (!aum || aum <= 0) return null;
-  if (aum >= 1_000_000_000) return `$${(aum / 1_000_000_000).toFixed(1)}B AUM`;
-  if (aum >= 1_000_000) return `$${Math.round(aum / 1_000_000)}M AUM`;
-  return `$${Math.round(aum / 1_000)}K AUM`;
-}
-
-function titleCase(value: string | null | undefined): string {
-  const text = String(value ?? "").trim();
-  if (!text) return "";
-  const keepUpper = new Set(["llc", "lp", "llp", "pc", "pa", "ltd", "inc"]);
-  return text
-    .split(/\s+/)
-    .map((word) => {
-      const cleaned = word.replace(/[.,]+$/, "").toLowerCase();
-      if (keepUpper.has(cleaned)) return word.toLowerCase().replace(cleaned, cleaned.toUpperCase());
-      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-    })
-    .join(" ");
 }
 
 function FirmCard({ firm, adviserCount }: { firm: RiaClaimFirm; adviserCount?: number | null }) {
@@ -172,78 +154,6 @@ function CodeCells({
         className="absolute inset-0 h-full w-full cursor-default opacity-0"
         data-voice-control-id="ria-claim-code-input"
       />
-    </div>
-  );
-}
-
-/** One labelled fact row, matching the review-card grammar. */
-function FactRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="flex min-h-[44px] items-center justify-between gap-4 border-t border-[color:var(--border)] px-4 py-2.5 first:border-t-0">
-      <span className="text-[13px] text-muted-foreground">{label}</span>
-      <span className="text-right text-[15px] font-medium">{value}</span>
-    </div>
-  );
-}
-
-/** What the regulator publishes, filled in without asking the adviser. */
-function ClaimedFacts({ facts }: { facts: RiaClaimProfileFacts }) {
-  const rows: { label: string; value: string }[] = [];
-  if (facts.crd_number) rows.push({ label: "CRD", value: facts.crd_number });
-  if (facts.regulator) {
-    rows.push({
-      label: "Regulator",
-      value: [facts.regulator, facts.regulator_status].filter(Boolean).join(" · "),
-    });
-  }
-  if (facts.registered_since) {
-    rows.push({ label: "Registered since", value: facts.registered_since });
-  }
-  const office = [titleCase(facts.branch_city), facts.branch_state].filter(Boolean).join(", ");
-  if (office) rows.push({ label: "Office", value: office });
-  const aum = formatAum(facts.aum);
-  if (aum) rows.push({ label: "Firm assets", value: aum.replace(" AUM", "") });
-  if (facts.num_accounts) {
-    rows.push({ label: "Accounts", value: facts.num_accounts.toLocaleString() });
-  }
-  const exams = (facts.exams ?? []).map((e) => e.code).filter(Boolean);
-  if (exams.length) rows.push({ label: "Exams", value: exams.join(", ") });
-  const states = (facts.registered_states ?? []).map((s) => s.state).filter(Boolean);
-  if (states.length) {
-    rows.push({
-      label: states.length === 1 ? "Registered in" : `Registered in ${states.length}`,
-      value: states.slice(0, 3).join(", ") + (states.length > 3 ? "…" : ""),
-    });
-  }
-  const filed = facts.notice_filed_states ?? [];
-  if (filed.length) {
-    rows.push({ label: `Notice filed in ${filed.length}`, value: filed.slice(0, 3).join(", ") + (filed.length > 3 ? "…" : "") });
-  }
-  const prior = facts.previous_firms ?? [];
-  if (prior.length) {
-    rows.push({ label: "Previously", value: titleCase(prior[0]?.firm_name) });
-  }
-  if (!rows.length) return null;
-
-  return (
-    <div className="space-y-3">
-      <p className="text-[13px] text-muted-foreground">From your SEC record.</p>
-      <div className="overflow-hidden rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] shadow-[0_8px_24px_rgba(62,48,30,0.05)]">
-        {rows.map((row) => (
-          <FactRow key={row.label} label={row.label} value={row.value} />
-        ))}
-      </div>
-      {facts.report_url ? (
-        <a
-          href={facts.report_url}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1.5 text-[13px] font-medium text-[color:var(--app-accent)]"
-        >
-          View on adviserinfo.sec.gov
-          <ExternalLink className="h-3.5 w-3.5" />
-        </a>
-      ) : null}
     </div>
   );
 }
@@ -358,14 +268,6 @@ export default function RiaClaimPage() {
     void handleLookup(seededPhone);
   }, [seededPhone, user, authLoading, handleLookup]);
 
-  // True when the number being claimed is the one already verified on this
-  // account, so the backend can prove possession from its own record.
-  const claimingVerifiedAccountPhone =
-    phoneDigits.length === 10 &&
-    phoneDigits === toNanpDigits(accountPhone || user?.phoneNumber);
-
-
-
   const completeClaim = useCallback(
     async (ticket: string, type: ClaimType, individualCrd: number | null) => {
       if (!firmCrd) return;
@@ -469,23 +371,25 @@ export default function RiaClaimPage() {
       try {
         const idToken = await getIdToken();
 
-        // If this IS the number already verified on the account, the backend
-        // proves possession from its own record. Asking for a second passcode
-        // on the number they verified moments ago is friction, not security.
-        if (claimingVerifiedAccountPhone) {
-          try {
-            const verified = await RiaService.claimVerify(idToken, {
-              phone: phoneDigits,
-              claim_type: type,
-              firm_crd: firmCrd,
-              individual_crd: type === "individual" ? candidateCrd : undefined,
-            });
-            await settleVerifyResult(verified, type, candidateCrd);
-            return;
-          } catch {
-            // Fall through to the passcode: the account record did not satisfy
-            // the backend, so possession must still be proven the normal way.
-          }
+        // Always try the tokenless verify first: the server checks the number
+        // against its own record of the account phone and answers 422
+        // CLAIM_PROOF_REQUIRED when possession still needs proving. The client
+        // must not pre-gate this — useAuth().phoneNumber is stale right after
+        // sign-up verification, and a wrong guess forces a second passcode on
+        // a number proven moments ago. Cost: one extra round-trip, mismatch
+        // case only.
+        try {
+          const verified = await RiaService.claimVerify(idToken, {
+            phone: phoneDigits,
+            claim_type: type,
+            firm_crd: firmCrd,
+            individual_crd: type === "individual" ? candidateCrd : undefined,
+          });
+          await settleVerifyResult(verified, type, candidateCrd);
+          return;
+        } catch {
+          // Server said CLAIM_PROOF_REQUIRED (or was unreachable): possession
+          // must still be proven the normal way — fall through to the passcode.
         }
 
         const start = await RiaService.claimOtpStart(idToken, { phone: phoneDigits });
@@ -506,14 +410,7 @@ export default function RiaClaimPage() {
         setBusy(false);
       }
     },
-    [
-      firmCrd,
-      busy,
-      phoneDigits,
-      getIdToken,
-      claimingVerifiedAccountPhone,
-      settleVerifyResult,
-    ],
+    [firmCrd, busy, phoneDigits, getIdToken, settleVerifyResult],
   );
 
   const handleCodeFilled = useCallback(
@@ -975,7 +872,7 @@ export default function RiaClaimPage() {
                 </div>
               </div>
               {completeResult.facts ? (
-                <ClaimedFacts facts={completeResult.facts} />
+                <RiaSecRecordSection facts={completeResult.facts} />
               ) : null}
               {!verified ? (
                 <p className="text-[13px] leading-relaxed text-muted-foreground">

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -4,15 +4,25 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowRight,
+  CheckCircle2,
   ClipboardCheck,
   Loader2,
   MessageCircle,
   Pencil,
   RotateCcw,
+  ShieldCheck,
   Trash2,
 } from "lucide-react";
 
-import { RiaCompatibilityState } from "@/components/ria/ria-page-shell";
+import {
+  RiaCompatibilityState,
+  isRiaVerified,
+} from "@/components/ria/ria-page-shell";
+import {
+  RiaSecRecordSection,
+  type RiaSecAdvisorRecord,
+  type RiaSecFirmRecord,
+} from "@/components/ria/profile/ria-sec-record-section";
 import { OnboardingStepServices } from "@/components/ria/onboarding/onboarding-step-services";
 import {
   SettingsDetailPanel,
@@ -260,6 +270,190 @@ function RiaRegulatoryProfileSummary({
   );
 }
 
+function asRecord<T>(value: unknown): T | null {
+  return value && typeof value === "object" ? (value as T) : null;
+}
+
+function hasSecRecords(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return Boolean(metadata && (metadata.firm_record || metadata.advisor_record));
+}
+
+/**
+ * The metadata snapshot the SEC record section renders from. The durable claim
+ * event wins; the generic verification event only qualifies when it actually
+ * carries the firm/adviser records (older rows can be a bare license check).
+ */
+function resolveSecRecordMetadata(
+  status: RiaOnboardingStatus | null,
+): Record<string, unknown> | null {
+  const claimMetadata = status?.latest_claim_event?.reference_metadata;
+  if (hasSecRecords(claimMetadata)) return claimMetadata ?? null;
+  const verificationMetadata =
+    status?.latest_verification_event?.reference_metadata;
+  if (hasSecRecords(verificationMetadata)) return verificationMetadata ?? null;
+  return null;
+}
+
+function RiaVerificationChip({ verified }: { verified: boolean }) {
+  return (
+    <span
+      data-testid="ria-profile-verification-chip"
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded-full border px-2.5 py-0.5 text-[12px] font-medium",
+        verified
+          ? "border-[rgba(18,161,80,0.35)] bg-[rgba(18,161,80,0.08)] text-[#12A150]"
+          : "border-[rgba(201,139,46,0.3)] bg-[rgba(201,139,46,0.08)] text-[color:var(--ria-gold,#C8923A)]",
+      )}
+    >
+      {verified ? (
+        <CheckCircle2 className="h-3.5 w-3.5" />
+      ) : (
+        <ShieldCheck className="h-3.5 w-3.5" />
+      )}
+      {verified ? "Verified" : "Not verified"}
+    </span>
+  );
+}
+
+/**
+ * The "finish verification" nudge: type the work email once, get a code, type
+ * the code. Success flips the chip via the host refresh; a mail-queue failure
+ * is retryable (best-effort transport never blocks); a profile without a claim
+ * snapshot (409 CLAIM_CONTEXT_MISSING) hides the card entirely.
+ */
+function RiaEmailVerifyCard({ onVerified }: { onVerified: () => Promise<void> }) {
+  const { user } = useAuth();
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [phase, setPhase] = useState<"email" | "code">("email");
+  const [busy, setBusy] = useState(false);
+  const [sendFailed, setSendFailed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  const handleSend = useCallback(async () => {
+    if (!user || busy) return;
+    const address = email.trim();
+    if (!address) return;
+    setBusy(true);
+    setError(null);
+    setSendFailed(false);
+    try {
+      const idToken = await user.getIdToken();
+      const result = await RiaService.claimEmailStart(idToken, {
+        email: address,
+      });
+      if (result.status === "send_failed") {
+        setSendFailed(true);
+        return;
+      }
+      setPhase("code");
+    } catch (err) {
+      if ((err as { code?: unknown })?.code === "CLAIM_CONTEXT_MISSING") {
+        setHidden(true);
+        return;
+      }
+      setError(err instanceof Error ? err.message : "Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, email, user]);
+
+  const handleVerify = useCallback(async () => {
+    if (!user || busy) return;
+    const trimmed = code.trim();
+    if (trimmed.length !== 6) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const idToken = await user.getIdToken();
+      const result = await RiaService.claimEmailConfirm(idToken, {
+        email: email.trim(),
+        code: trimmed,
+      });
+      if (result.verified) {
+        toast.success("Email verified");
+        await onVerified();
+        return;
+      }
+      setError("Not verified yet.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, code, email, onVerified, user]);
+
+  if (hidden) return null;
+
+  return (
+    <div
+      data-testid="ria-email-verify-card"
+      className="space-y-3 rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] p-4 shadow-[0_8px_24px_rgba(62,48,30,0.05)]"
+    >
+      <div>
+        <p className="text-[15px] font-semibold">Verify with your work email</p>
+        <p className="mt-0.5 text-[13px] text-muted-foreground">
+          We&apos;ll send a code.
+        </p>
+      </div>
+      {phase === "email" ? (
+        <div className="flex items-center gap-2">
+          <Input
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            placeholder="you@yourfirm.com"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            data-testid="ria-email-verify-input"
+          />
+          <Button
+            disabled={busy || !email.trim()}
+            onClick={() => void handleSend()}
+            data-testid="ria-email-verify-send"
+          >
+            {busy ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : sendFailed ? (
+              "Retry"
+            ) : (
+              "Send code"
+            )}
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          <Input
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={6}
+            placeholder="6-digit code"
+            value={code}
+            onChange={(event) =>
+              setCode(event.target.value.replace(/\D/g, "").slice(0, 6))
+            }
+            data-testid="ria-email-verify-code"
+          />
+          <Button
+            disabled={busy || code.trim().length !== 6}
+            onClick={() => void handleVerify()}
+            data-testid="ria-email-verify-confirm"
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : "Verify"}
+          </Button>
+        </div>
+      )}
+      {sendFailed ? (
+        <p className="text-[13px] text-destructive">Couldn&apos;t send.</p>
+      ) : null}
+      {error ? <p className="text-[13px] text-destructive">{error}</p> : null}
+    </div>
+  );
+}
+
 /**
  * The unified RIA profile management section. Re-homed verbatim from the former
  * `/ria/profile` page so the SAME view / edit / re-initiate / delete / license
@@ -476,6 +670,20 @@ export function RiaProfileSection({
   }, [licenseNumber, licenseRegulator, onRefresh, refresh, refreshingLicense, user]);
 
   const currentLicenseNumber = getProfileRiaRefreshLicenseNumber(status);
+  const verified = isRiaVerified(status?.verification_status);
+  const secRecordMetadata = useMemo(
+    () => resolveSecRecordMetadata(status),
+    [status],
+  );
+  const claimMetadata = status?.latest_claim_event?.reference_metadata;
+  // Email upgrade needs a claim snapshot; v1 gates firm claims out (no adviser
+  // name to match an email against).
+  const showEmailVerify =
+    !verified && Boolean(claimMetadata) && claimMetadata?.claim_type !== "firm";
+  const handleEmailVerified = useCallback(async () => {
+    await onRefresh(true);
+    await refresh({ force: true });
+  }, [onRefresh, refresh]);
   const verificationProvider =
     status?.latest_verification_event?.reference_metadata?.provider;
   const currentRegulator =
@@ -557,6 +765,20 @@ export function RiaProfileSection({
         onEditSection={handleEditSection}
         onAskKaiUpdateAnything={handleAskKai}
       />
+
+      {secRecordMetadata ? (
+        <RiaSecRecordSection
+          advisorRecord={asRecord<RiaSecAdvisorRecord>(
+            secRecordMetadata.advisor_record,
+          )}
+          firmRecord={asRecord<RiaSecFirmRecord>(secRecordMetadata.firm_record)}
+          headerAccessory={<RiaVerificationChip verified={verified} />}
+        />
+      ) : null}
+
+      {showEmailVerify ? (
+        <RiaEmailVerifyCard onVerified={handleEmailVerified} />
+      ) : null}
 
       <SettingsGroup eyebrow="Manage" title="RIA profile" testId="ria-profile-manage">
         <SettingsRow

--- a/hushh-webapp/components/ria/profile/ria-sec-record-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-sec-record-section.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+/**
+ * "From your SEC record." — the public regulatory facts behind a claimed
+ * profile, rendered identically on the claim done-screen and the profile tab
+ * so the two surfaces cannot drift.
+ *
+ * Accepts either the condensed claim facts (`RiaClaimProfileFacts`, what
+ * /claim/complete returns) or the fuller persisted snapshot from
+ * `ria_verification_events.reference_metadata` (`firm_record` /
+ * `advisor_record`). Selected keys only: raw metadata is never dumped —
+ * it carries the claimant's phone digits — and absent values omit their row
+ * entirely rather than rendering "N/A".
+ */
+
+import { ExternalLink } from "lucide-react";
+import type { ReactNode } from "react";
+
+import type { RiaClaimProfileFacts } from "@/lib/services/ria-service";
+
+/** The adviser snapshot persisted at claim time (`advisor_record`). */
+export interface RiaSecAdvisorRecord {
+  crd?: number | string | null;
+  registered_since?: string | null;
+  exams?: { code?: string | null; name?: string | null; date?: string | null }[] | null;
+  registered_states?: {
+    state?: string | null;
+    scope?: string | null;
+    status?: string | null;
+    date?: string | null;
+  }[] | null;
+  previous_firms?: {
+    firm_name?: string | null;
+    firm_crd?: number | null;
+    from?: string | null;
+    to?: string | null;
+  }[] | null;
+  branch?: {
+    city?: string | null;
+    state?: string | null;
+    street1?: string | null;
+    zip?: string | null;
+  } | null;
+  has_disclosures?: boolean | null;
+  disclosure_count?: number | null;
+  report_url?: string | null;
+}
+
+/** The firm snapshot persisted at claim time (`firm_record`). */
+export interface RiaSecFirmRecord {
+  crd?: number | string | null;
+  name?: string | null;
+  registration_status?: string | null;
+  registration_type?: string | null;
+  aum?: number | null;
+  num_accounts?: number | null;
+  total_employees?: number | null;
+  advisory_employees?: number | null;
+  registrations?: {
+    jurisdiction?: string | null;
+    status?: string | null;
+    effective_date?: string | null;
+  }[] | null;
+  notice_filed_states?: string[] | null;
+  form_adv_pdf_url?: string | null;
+  form_crs_url?: string | null;
+  brochures?: {
+    name?: string | null;
+    date_submitted?: string | null;
+    url?: string | null;
+  }[] | null;
+  website?: string | null;
+  report_url?: string | null;
+}
+
+export interface RiaSecRecordSectionProps {
+  /** The condensed facts shape the claim done-screen already has. */
+  facts?: RiaClaimProfileFacts | null;
+  /** The fuller persisted snapshots; they win over `facts` where both exist. */
+  advisorRecord?: RiaSecAdvisorRecord | null;
+  firmRecord?: RiaSecFirmRecord | null;
+  /** Rendered right of the caption — the verification chip lives here. */
+  headerAccessory?: ReactNode;
+}
+
+export function formatAum(aum: number | null | undefined): string | null {
+  if (!aum || aum <= 0) return null;
+  if (aum >= 1_000_000_000) return `$${(aum / 1_000_000_000).toFixed(1)}B AUM`;
+  if (aum >= 1_000_000) return `$${Math.round(aum / 1_000_000)}M AUM`;
+  return `$${Math.round(aum / 1_000)}K AUM`;
+}
+
+export function titleCase(value: string | null | undefined): string {
+  const text = String(value ?? "").trim();
+  if (!text) return "";
+  const keepUpper = new Set(["llc", "lp", "llp", "pc", "pa", "ltd", "inc"]);
+  return text
+    .split(/\s+/)
+    .map((word) => {
+      const cleaned = word.replace(/[.,]+$/, "").toLowerCase();
+      if (keepUpper.has(cleaned)) return word.toLowerCase().replace(cleaned, cleaned.toUpperCase());
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    })
+    .join(" ");
+}
+
+/** One labelled fact row, matching the review-card grammar. */
+export function FactRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-h-[44px] items-center justify-between gap-4 border-t border-[color:var(--border)] px-4 py-2.5 first:border-t-0">
+      <span className="text-[13px] text-muted-foreground">{label}</span>
+      <span className="text-right text-[15px] font-medium">{value}</span>
+    </div>
+  );
+}
+
+/** Regulator label from the firm's registration type ("sec" → SEC). */
+function regulatorLabel(registrationType: string | null | undefined): string | null {
+  if (!registrationType) return null;
+  return registrationType === "sec" ? "SEC" : "State";
+}
+
+function advisorFromFacts(facts: RiaClaimProfileFacts): RiaSecAdvisorRecord {
+  return {
+    crd: facts.crd_number,
+    registered_since: facts.registered_since,
+    exams: facts.exams,
+    registered_states: facts.registered_states,
+    previous_firms: facts.previous_firms,
+    branch:
+      facts.branch_city || facts.branch_state
+        ? { city: facts.branch_city, state: facts.branch_state }
+        : null,
+    has_disclosures: facts.has_disclosures,
+    report_url: facts.report_url,
+  };
+}
+
+function firmFromFacts(facts: RiaClaimProfileFacts): RiaSecFirmRecord {
+  return {
+    registration_status: facts.regulator_status,
+    registration_type: facts.regulator === "SEC" ? "sec" : null,
+    aum: facts.aum,
+    num_accounts: facts.num_accounts,
+    notice_filed_states: facts.notice_filed_states,
+    website: facts.firm_website,
+  };
+}
+
+/** Later sources fill only what earlier ones left empty. */
+function mergeRecords<T extends object>(primary: T | null | undefined, fallback: T): T {
+  const merged: Record<string, unknown> = { ...(fallback as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(primary ?? {})) {
+    if (value !== null && value !== undefined) merged[key] = value;
+  }
+  return merged as T;
+}
+
+type Row = { label: string; value: string };
+type LinkItem = { label: string; href: string };
+
+function truncatedList(values: string[], max = 3): string {
+  return values.slice(0, max).join(", ") + (values.length > max ? "…" : "");
+}
+
+function buildRows(advisor: RiaSecAdvisorRecord, firmRecord: RiaSecFirmRecord): Row[] {
+  const rows: Row[] = [];
+
+  const crd = advisor.crd ?? firmRecord.crd;
+  if (crd) rows.push({ label: "CRD", value: String(crd) });
+
+  const regulator = regulatorLabel(firmRecord.registration_type);
+  if (regulator || firmRecord.registration_status) {
+    rows.push({
+      label: "Regulator",
+      value: [regulator, firmRecord.registration_status].filter(Boolean).join(" · "),
+    });
+  }
+  if (advisor.registered_since) {
+    rows.push({ label: "Registered since", value: advisor.registered_since });
+  }
+
+  const branch = advisor.branch ?? null;
+  const office = [titleCase(branch?.city), branch?.state].filter(Boolean).join(", ");
+  if (office) rows.push({ label: "Office", value: office });
+
+  const aum = formatAum(firmRecord.aum);
+  if (aum) rows.push({ label: "Firm assets", value: aum.replace(" AUM", "") });
+  if (firmRecord.num_accounts) {
+    rows.push({ label: "Accounts", value: firmRecord.num_accounts.toLocaleString() });
+  }
+  const employees = firmRecord.total_employees ?? firmRecord.advisory_employees;
+  if (employees) rows.push({ label: "Employees", value: employees.toLocaleString() });
+
+  const exams = (advisor.exams ?? []).map((e) => e.code).filter(Boolean) as string[];
+  if (exams.length) rows.push({ label: "Exams", value: exams.join(", ") });
+
+  const stateEntries = (advisor.registered_states ?? []).filter((s) => s.state);
+  if (stateEntries.length) {
+    const states = stateEntries.map((s) => String(s.state));
+    const statuses = new Set(
+      stateEntries.map((s) => String(s.status ?? "").trim()).filter(Boolean),
+    );
+    const uniformStatus = statuses.size === 1 ? titleCase([...statuses][0]) : null;
+    rows.push({
+      label: stateEntries.length === 1 ? "Registered in" : `Registered in ${stateEntries.length}`,
+      value: [truncatedList(states), uniformStatus].filter(Boolean).join(" · "),
+    });
+  }
+
+  const filed = firmRecord.notice_filed_states ?? [];
+  if (filed.length) {
+    rows.push({ label: `Notice filed in ${filed.length}`, value: truncatedList(filed) });
+  }
+
+  for (const registration of (firmRecord.registrations ?? []).slice(0, 3)) {
+    if (!registration.jurisdiction) continue;
+    const value = [titleCase(registration.status), registration.effective_date]
+      .filter(Boolean)
+      .join(" · ");
+    if (!value) continue;
+    rows.push({ label: String(registration.jurisdiction), value });
+  }
+
+  for (const prior of (advisor.previous_firms ?? []).slice(0, 3)) {
+    if (!prior.firm_name) continue;
+    const dates = [prior.from, prior.to].filter(Boolean).join("–");
+    rows.push({
+      label: "Previously",
+      value: [titleCase(prior.firm_name), dates].filter(Boolean).join(" · "),
+    });
+  }
+
+  if (advisor.has_disclosures) {
+    rows.push({
+      label: "Disclosures",
+      value: advisor.disclosure_count ? String(advisor.disclosure_count) : "On record",
+    });
+  }
+
+  return rows;
+}
+
+function buildLinks(advisor: RiaSecAdvisorRecord, firmRecord: RiaSecFirmRecord): LinkItem[] {
+  const links: LinkItem[] = [];
+  const reportUrl = advisor.report_url ?? firmRecord.report_url;
+  if (reportUrl) links.push({ label: "View on adviserinfo.sec.gov", href: reportUrl });
+  if (firmRecord.form_adv_pdf_url) links.push({ label: "Form ADV", href: firmRecord.form_adv_pdf_url });
+  if (firmRecord.form_crs_url) links.push({ label: "Form CRS", href: firmRecord.form_crs_url });
+  for (const brochure of (firmRecord.brochures ?? []).slice(0, 3)) {
+    if (!brochure.url) continue;
+    links.push({ label: titleCase(brochure.name) || "Brochure", href: brochure.url });
+  }
+  if (firmRecord.website) links.push({ label: "Website", href: firmRecord.website });
+  return links;
+}
+
+/** What the regulator publishes, filled in without asking the adviser. */
+export function RiaSecRecordSection({
+  facts,
+  advisorRecord,
+  firmRecord,
+  headerAccessory,
+}: RiaSecRecordSectionProps) {
+  const advisor = mergeRecords(advisorRecord, facts ? advisorFromFacts(facts) : {});
+  const firm = mergeRecords(firmRecord, facts ? firmFromFacts(facts) : {});
+  const rows = buildRows(advisor, firm);
+  const links = buildLinks(advisor, firm);
+  if (!rows.length) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[13px] text-muted-foreground">From your SEC record.</p>
+        {headerAccessory ?? null}
+      </div>
+      <div className="overflow-hidden rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] shadow-[0_8px_24px_rgba(62,48,30,0.05)]">
+        {rows.map((row, index) => (
+          <FactRow key={`${row.label}-${index}`} label={row.label} value={row.value} />
+        ))}
+      </div>
+      {links.length ? (
+        <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+          {links.map((link, index) => (
+            <a
+              key={`${link.label}-${index}`}
+              href={link.href}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-[13px] font-medium text-[color:var(--app-accent)]"
+            >
+              {link.label}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -124,6 +124,19 @@ export interface MarketplaceContactMatch {
   profile: MarketplaceRia | MarketplaceInvestor;
 }
 
+/** Parsed claim snapshot persisted in `ria_verification_events.reference_metadata`. */
+export interface RiaClaimEventMetadata {
+  provider?: string;
+  claim_type?: string;
+  firm_record?: Record<string, unknown> | null;
+  advisor_record?: Record<string, unknown> | null;
+  satisfied?: string[];
+  missing?: string[];
+  evidence_ledger?: unknown;
+  verification_level?: string | null;
+  [key: string]: unknown;
+}
+
 export interface RiaOnboardingStatus {
   exists: boolean;
   ria_profile_id?: string;
@@ -168,6 +181,18 @@ export interface RiaOnboardingStatus {
     checked_at: string;
     expires_at?: string | null;
     reference_metadata?: Record<string, unknown>;
+  } | null;
+  /**
+   * The durable `ria_identity_claim` snapshot (provider-filtered server-side so
+   * later refresh-license / onboarding events can't shadow it). Null when the
+   * profile was never claimed by phone. `reference_metadata` also carries raw
+   * phone digits — render selected keys only, never the whole object.
+   */
+  latest_claim_event?: {
+    outcome: string;
+    checked_at: string;
+    expires_at?: string | null;
+    reference_metadata?: RiaClaimEventMetadata;
   } | null;
   latest_advisory_event?: {
     outcome: string;
@@ -320,6 +345,17 @@ export interface RiaClaimCompleteResult {
   provisional: boolean;
   profile: RiaClaimProfileSummary;
   facts?: RiaClaimProfileFacts | null;
+}
+
+export interface RiaClaimEmailStartResult {
+  status: "sent" | "already_verified" | "send_failed" | (string & {});
+  email_masked?: string | null;
+}
+
+export interface RiaClaimEmailConfirmResult {
+  verified: boolean;
+  verification_status: string;
+  verification_level?: string | null;
 }
 
 export interface RiaLicenseVerificationResult {
@@ -1684,6 +1720,40 @@ export class RiaService {
       body: payload,
     });
     return toJsonOrThrow<RiaClaimCompleteResult>(response);
+  }
+
+  static async claimEmailStart(
+    idToken: string,
+    payload: { email: string },
+  ): Promise<RiaClaimEmailStartResult> {
+    const response = await authFetch("/api/ria/claim/email/start", {
+      method: "POST",
+      idToken,
+      body: payload,
+    });
+    // Mail is best-effort upstream: a queue failure comes back as a 502 with
+    // {status:"send_failed"} and the alias ceremony still stands. Surface it as
+    // a result so the UI can offer Retry instead of a thrown error.
+    if (response.status === 502) {
+      const body = (await response
+        .json()
+        .catch(() => null)) as RiaClaimEmailStartResult | null;
+      if (body?.status === "send_failed") return body;
+      throw new RiaApiError("Couldn't send the code.", 502);
+    }
+    return toJsonOrThrow<RiaClaimEmailStartResult>(response);
+  }
+
+  static async claimEmailConfirm(
+    idToken: string,
+    payload: { email: string; code: string },
+  ): Promise<RiaClaimEmailConfirmResult> {
+    const response = await authFetch("/api/ria/claim/email/confirm", {
+      method: "POST",
+      idToken,
+      body: payload,
+    });
+    return toJsonOrThrow<RiaClaimEmailConfirmResult>(response);
   }
 
   static async verifyOnboardingLicense(


### PR DESCRIPTION
The three journey asks from live UAT testing, built per an evidence-backed spec (every anchor verified in-repo; the one external unknown — the evaluator's email-evidence shape — resolved by probing the live RIA Identity API).

## One OTP, ever
The claim screen always attempts the tokenless verify first; the server grants possession from the account's verified phone (`actor_identity_cache`) and 422s only genuine mismatches into the passcode step. Root cause was a stale in-session `useAuth().phoneNumber` gating the skip branch — on production (where the test passcode is disabled by design) that stale gate was the only working path, so this also unbreaks prod claims.

## Not verified → Verified, by work email
- Profile chip: **Verified / Not verified**; unverified advisers get one card: *Verify with your work email* → **Send code** → 6-digit **Verify**.
- Real mail from `one@hushh.ai` via the existing Gmail-delegated delivery queue; the alias ceremony (migration 052) stores the verified address (hashed code, one-verified-owner).
- Backend asserts `[{signal: phone_otp}, {signal: domain_email, email}]` to `/v1/claim/evaluate`; the evaluator checks the domain against the firm's own Form ADV filing and derives `email_name_match` from the local part (probed live — see PR discussion).
- Upgrade happens ONLY on the evaluator's `verificationLevel == verified`, through the never-downgrade re-claim path. Server-side registrable-domain + free-mail checks run before any assertion. The plaintext code is opt-in at the service layer and asserted absent from every HTTP response.

## The full SEC record on the profile
Shared `RiaSecRecordSection` (claim done screen + RIA profile, one component): registrations with dates, notice-filed states, Form ADV PDF, Form CRS, brochures, AUM, accounts, employees, exams, registered states, prior firms, disclosures flag, SEC links. Sourced from `latest_claim_event` (new on onboarding status, provider-filtered so refresh-license events can't shadow it). Selected keys only; raw phone digits never rendered; no Google-Places fields (none are persisted).

## Proof
- Backend gate: ruff, mypy, bandit, **643 passed** (38 new — and the CI manifest now includes them; new test files silently don't run unless listed).
- Frontend: tsc clean, eslint clean, full vitest **3034 passed / 1 failed** — the failure is `one-location-agent-page` (not in this diff), passes 54/54 in isolation; ordering flake in the parallel run.
- Live-API probe evidence for the domain_email handshake in the session log.

## Follow-up (flagged, not blocking)
Live deliverability of `one@hushh.ai` mail to arbitrary firm domains needs a UAT smoke send (SPF/DKIM history on hushh.ai).