### PR TITLE
fix(runtime): PKM upgrade loop on blob-less domains, 500 on deleted-account tokens, relay-session flood

### DIFF
--- a/consent-protocol/api/middlewares/observability.py
+++ b/consent-protocol/api/middlewares/observability.py
@@ -165,6 +165,35 @@ def _extract_bearer_user_id(request: Request) -> str | None:
     valid, _reason, payload = validate_token(consent_token)
     if valid and payload and payload.user_id:
         return str(payload.user_id)
+    firebase_uid = _unverified_jwt_subject(consent_token)
+    if firebase_uid:
+        return f"firebase:{firebase_uid}"
+    return None
+
+
+def _unverified_jwt_subject(token: str) -> str | None:
+    """Best-effort ``sub`` claim from a JWT, WITHOUT signature verification.
+
+    Used ONLY to pick a rate-limit bucket, never for authorization — the route
+    itself still verifies the token properly. Without this, every Firebase-
+    authenticated request through the Next.js proxy keys to the proxy's IP,
+    collapsing all users into one shared bucket: one noisy client then
+    rate-limits everyone (observed on /api/one/adk/relay-session).
+    """
+    import base64
+    import json
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        payload_raw = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_raw))
+    except Exception:  # noqa: BLE001 - malformed tokens just fall to the IP bucket
+        return None
+    subject = claims.get("sub") or claims.get("user_id")
+    if isinstance(subject, str) and 0 < len(subject) <= 128:
+        return subject
     return None
 
 

--- a/consent-protocol/api/utils/firebase_auth.py
+++ b/consent-protocol/api/utils/firebase_auth.py
@@ -84,6 +84,9 @@ def verify_firebase_bearer(authorization: Optional[str]) -> str:
         firebase_auth.ExpiredIdTokenError,
         firebase_auth.RevokedIdTokenError,
         firebase_auth.UserDisabledError,
+        # check_revoked=True looks the user up, so a just-deleted account's
+        # replayed token raises this. It is a 401 (sign in again), not a 500.
+        firebase_auth.UserNotFoundError,
     ):
         raise HTTPException(status_code=401, detail="Invalid Firebase ID token") from None
     except firebase_auth.CertificateFetchError as exc:

--- a/consent-protocol/hushh_mcp/services/pkm_upgrade_service.py
+++ b/consent-protocol/hushh_mcp/services/pkm_upgrade_service.py
@@ -457,6 +457,15 @@ class PkmUpgradeService:
                 < self._semantic_version(CURRENT_READABLE_PROJECTION_VERSION)
             ) and not future_reasons
             blocked_reasons = self._domain_blockers(manifest)
+            if needs_upgrade and "missing_manifest" in blocked_reasons:
+                # Discovery-only domains: a server-side summary flag (e.g. a
+                # claim's has_regulator_profile) can list a domain in the index
+                # before any encrypted blob exists. There is nothing to
+                # upgrade, and marking it upgradable sends every app entry
+                # into a run that fails on the missing blob.
+                snapshot = await self.pkm_service.get_domain_snapshot(user_id, domain)
+                if snapshot is None:
+                    needs_upgrade = False
             if future_reasons:
                 blocked_reasons = [*blocked_reasons, "client_update_required", *future_reasons]
             domain_states.append(

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -45,3 +45,4 @@ tests/test_ria_claim_email_evidence.py
 tests/test_ria_claim_email_routes.py
 tests/test_ria_onboarding_status_claim_event.py
 tests/test_account_delete_scope_proposals.py
+tests/test_console_triage_regressions.py

--- a/consent-protocol/tests/test_console_triage_regressions.py
+++ b/consent-protocol/tests/test_console_triage_regressions.py
@@ -1,0 +1,90 @@
+"""Regressions from the 2026-08-08 UAT console triage.
+
+Three failure modes seen live: a just-deleted account's replayed token turned
+into a 500, discovery-only PKM domains sent every app entry into a doomed
+upgrade run, and all Firebase-authenticated users shared one rate-limit
+bucket through the Next.js proxy IP.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from api.middlewares.observability import _unverified_jwt_subject
+from api.utils.firebase_auth import verify_firebase_bearer
+from hushh_mcp.services.pkm_upgrade_service import PkmUpgradeService
+from tests.test_pkm_upgrade_service import _FakePkmService
+
+
+def test_deleted_account_token_is_401_not_500(monkeypatch):
+    import firebase_admin.auth as firebase_auth
+
+    monkeypatch.setattr(
+        "api.utils.firebase_auth.ensure_firebase_auth_admin",
+        lambda: (True, "hushh-pda"),
+    )
+    monkeypatch.setattr("api.utils.firebase_auth.get_firebase_auth_app", lambda: object())
+
+    def fake_verify(token: str, app=None, check_revoked: bool = False):
+        raise firebase_auth.UserNotFoundError("No user record found")
+
+    monkeypatch.setattr(firebase_auth, "verify_id_token", fake_verify)
+
+    with pytest.raises(HTTPException) as excinfo:
+        verify_firebase_bearer("Bearer replayed-after-deletion")
+    assert excinfo.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_discovery_only_domain_is_not_upgradable():
+    # A server-side summary flag (e.g. a claim's has_regulator_profile) lists
+    # the domain in the index before any encrypted blob exists. There is
+    # nothing to upgrade — a run would fail on the missing blob forever.
+    service = PkmUpgradeService()
+    service._pkm_service = _FakePkmService(has_blob=False)
+
+    async def _no_runs(_user_id: str):
+        return None
+
+    service._get_latest_run = _no_runs  # type: ignore[method-assign]
+
+    status = await service.build_status("user_123")
+
+    assert status["upgradable_domains"] == []
+
+
+@pytest.mark.asyncio
+async def test_missing_manifest_with_blob_still_bootstraps():
+    # The inverse must keep working: legacy data (blob, no manifest) upgrades.
+    service = PkmUpgradeService()
+    service._pkm_service = _FakePkmService(has_blob=True)
+
+    async def _no_runs(_user_id: str):
+        return None
+
+    service._get_latest_run = _no_runs  # type: ignore[method-assign]
+
+    status = await service.build_status("user_123")
+
+    assert [d["domain"] for d in status["upgradable_domains"]] == ["financial"]
+
+
+def _jwt_with_claims(claims: dict) -> str:
+    body = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"header.{body}.signature"
+
+
+def test_firebase_bearer_gets_its_own_rate_limit_bucket():
+    assert _unverified_jwt_subject(_jwt_with_claims({"sub": "uid_abc"})) == "uid_abc"
+    assert _unverified_jwt_subject(_jwt_with_claims({"user_id": "uid_xyz"})) == "uid_xyz"
+
+
+def test_malformed_tokens_fall_back_to_ip_bucket():
+    assert _unverified_jwt_subject("not-a-jwt") is None
+    assert _unverified_jwt_subject("a.b") is None
+    assert _unverified_jwt_subject(_jwt_with_claims({"sub": "x" * 200})) is None
+    assert _unverified_jwt_subject("h." + "!!notbase64!!" + ".s") is None

--- a/consent-protocol/tests/test_pkm_upgrade_service.py
+++ b/consent-protocol/tests/test_pkm_upgrade_service.py
@@ -22,9 +22,11 @@ class _FakePkmService:
         manifest: dict | None = None,
         model_version: int = 2,
         last_upgraded_at: datetime | None = None,
+        has_blob: bool = True,
     ):
         self._domain_summaries = domain_summaries or {}
         self._manifest = manifest
+        self._has_blob = has_blob
         self._index = type(
             "_Index",
             (),
@@ -43,6 +45,9 @@ class _FakePkmService:
 
     async def get_domain_manifest(self, user_id: str, domain: str):
         return self._manifest
+
+    async def get_domain_snapshot(self, user_id: str, domain: str):
+        return {"ciphertext": "blob"} if self._has_blob else None
 
     async def upsert_index_v2(self, index):
         self._index = index

--- a/hushh-webapp/components/agent/agent-bar.tsx
+++ b/hushh-webapp/components/agent/agent-bar.tsx
@@ -284,6 +284,9 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
   const activeRuntimeModeRef = useRef<"hushh_managed_vertex" | "byok" | null>(null);
   const lastTranscriptRef = useRef<{ text: string; atMs: number } | null>(null);
   const prewarmedRelayRef = useRef<PrewarmedGeminiRelay | null>(null);
+  const relayMintInFlightRef = useRef(false);
+  const relayMintCooldownUntilRef = useRef(0);
+  const relayMintBackoffMsRef = useRef(5_000);
   // Idle-close precaution: any live-session activity (speech, thinking, tool
   // results, navigation) reschedules this timer; if it ever fires, the
   // session has been silent for AGENT_BAR_VOICE_IDLE_TIMEOUT_MS and is closed
@@ -1221,10 +1224,26 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
 
     const controller = new AbortController();
     const timer = window.setTimeout(() => {
-      // Context (screen, consent token) rides in post-connect app_context
-      // frames, so the prewarmed URL only carries the opaque relay ticket.
+      // The snapshot identity churns on every navigation and cache event, so
+      // this effect re-fires constantly. The ticket is context-free (context
+      // rides in post-connect app_context frames) — reuse an unexpired one,
+      // never mint concurrently, and back off after a rate limit instead of
+      // hammering the relay endpoint on every snapshot change.
+      const existing = prewarmedRelayRef.current;
+      if (
+        existing &&
+        existing.accessTier === accessTier &&
+        existing.expiresAtMs > Date.now()
+      ) {
+        return;
+      }
+      if (relayMintInFlightRef.current) return;
+      if (Date.now() < relayMintCooldownUntilRef.current) return;
+      relayMintInFlightRef.current = true;
       void ApiService.getOneAdkLiveRelayUrl({ signal: controller.signal })
         .then((relayUrl) => {
+          relayMintInFlightRef.current = false;
+          relayMintBackoffMsRef.current = 5_000;
           if (controller.signal.aborted) return;
           prewarmedRelayRef.current = {
             relayUrl,
@@ -1233,7 +1252,20 @@ export function AgentBar({ layout = "fixed" }: { layout?: "fixed" | "slot" }) {
             accessTier,
           };
         })
-        .catch(() => {
+        .catch((error: unknown) => {
+          relayMintInFlightRef.current = false;
+          const status =
+            typeof error === "object" && error !== null
+              ? Number((error as { status?: unknown }).status)
+              : NaN;
+          if (status === 429) {
+            relayMintCooldownUntilRef.current =
+              Date.now() + relayMintBackoffMsRef.current;
+            relayMintBackoffMsRef.current = Math.min(
+              relayMintBackoffMsRef.current * 2,
+              60_000,
+            );
+          }
           if (!controller.signal.aborted) {
             prewarmedRelayRef.current = null;
           }

--- a/hushh-webapp/lib/services/api-service.ts
+++ b/hushh-webapp/lib/services/api-service.ts
@@ -3199,7 +3199,11 @@ export class ApiService {
       signal: data?.signal,
     });
     if (!response.ok) {
-      throw new Error(`One voice relay session failed: ${response.status}`);
+      const error = new Error(
+        `One voice relay session failed: ${response.status}`,
+      ) as Error & { status: number };
+      error.status = response.status;
+      throw error;
     }
     return response.json();
   }

--- a/hushh-webapp/lib/services/pkm-upgrade-orchestrator.ts
+++ b/hushh-webapp/lib/services/pkm-upgrade-orchestrator.ts
@@ -760,7 +760,7 @@ export class PkmUpgradeOrchestrator {
     stepPlan: PkmUpgradeStepPlan;
     mode: PkmUpgradeMode;
     runId: string | null;
-  }): Promise<{
+  }): Promise<{ skippedMissingBlob: true } | {
     domainBlobDataVersion: number | undefined;
     domainManifestRevision: number;
     upgradedDomainData: Record<string, unknown>;
@@ -792,7 +792,11 @@ export class PkmUpgradeOrchestrator {
     });
     const domainSnapshot = loadedSnapshot.snapshot;
     if (!domainSnapshot) {
-      throw new Error(`No encrypted PKM domain blob found for ${params.stepDomain}.`);
+      // A domain can be listed by discovery flags alone (a server-side
+      // summary written before any encrypted blob exists). Nothing to
+      // upgrade — skip the step instead of failing the run on every
+      // app entry against a stale server status.
+      return { skippedMissingBlob: true } as const;
     }
     const domainData = loadedSnapshot.data;
     if (!domainData) {
@@ -1129,6 +1133,20 @@ export class PkmUpgradeOrchestrator {
         mode: run.mode || "real",
         runId: run.runId,
       });
+      if ("skippedMissingBlob" in prepared) {
+        return await PkmUpgradeService.updateStep({
+          runId: run.runId,
+          domain: params.stepDomain,
+          userId: params.userId,
+          status: "completed",
+          checkpointPayload: {
+            stage: "skipped_missing_blob",
+            current_domain: params.stepDomain,
+          },
+          attemptCount: attempt,
+          vaultOwnerToken: params.vaultOwnerToken,
+        });
+      }
       const upgradeClaim = await PkmUpgradeService.issueClaim({
         runId: run.runId,
         domain: params.stepDomain,
@@ -1282,6 +1300,16 @@ export class PkmUpgradeOrchestrator {
       mode: params.mode,
       runId: null,
     });
+    if ("skippedMissingBlob" in prepared) {
+      return {
+        manifestReadMs: 0,
+        decryptLoadMs: 0,
+        transformMs: 0,
+        structureRebuildMs: 0,
+        validationMs: 0,
+        totalMs: 0,
+      };
+    }
 
     AppBackgroundTaskService.updateTask(params.taskId, {
       metadata: {


### PR DESCRIPTION
Root-caused from live UAT console + Cloud Logging (screenshots in session). Three independent fixes:

## 1. Doomed PKM upgrade loop (regression from #4963 + pre-existing class)
`update_domain_summary` registers a domain in `pkm_index.available_domains` even when no encrypted blob exists (claim's discovery flag for `ria`; same pre-existing pattern for `financial` via `kai_chat_service` and `kyc_connector`). `build_status` marked such domains upgradable; the client orchestrator then hard-threw `No encrypted PKM domain blob found for ria` on every app entry, recreating the failed run forever.
**Fix (both sides):** `build_status` skips manifest-less domains whose snapshot is null; the orchestrator turns a missing blob into a completed `skipped_missing_blob` step so a stale server can never brick app entry. Bootstrap of legacy blob-with-no-manifest domains still works (pinned by test).

## 2. `/api/vault/bootstrap-state` 500 after account deletion (pre-existing since July)
`verify_id_token(check_revoked=True)` performs a user lookup; a just-deleted account's replayed token raises `UserNotFoundError`, which was missing from the 401 tuple (added by 699e4ed45's hardening, which assumed the except block covered it). UAT logs show the exact sequence: deletion completes 08:50:12.498Z, the 500 lands 08:50:12.895Z.
**Fix:** one line — `UserNotFoundError` → 401, so the client signs out instead of erroring.

## 3. Relay-session 429 flood (pre-existing, exposed by the redirect loop #4983 fixed)
The voice prewarm effect re-fires on every runtime snapshot churn (~14 dep inputs) with no ticket reuse, no single-flight, no backoff — swallowed 429s re-mint forever. Worse, the backend rate-limit key only understands consent tokens, so **every Firebase-authenticated user through the Next proxy shares one IP bucket** — one noisy client rate-limits everyone on UAT.
**Fix:** reuse unexpired tickets + single-flight + exponential 429 backoff (5s→60s cap) client-side; bucket by Firebase uid server-side (unverified `sub` decode used ONLY for bucketing — the route still verifies properly; malformed tokens fall back to the IP bucket).

## Proof
- Backend gate: ruff, mypy, bandit, **651 passed** (5 new in `test_console_triage_regressions.py`, incl. the inverse bootstrap case).
- Frontend: tsc 0 errors, eslint clean, orchestrator + agent suites 44 passed.
- All three anchored to Cloud Logging evidence with timestamps and request ids.