### PR TITLE
fix(deploy): default the nearby check-in audience to all so a routine deploy cannot disable it

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,9 +33,9 @@ on:
           - "false"
           - "true"
       nearby_check_in_cohort:
-        description: "Nearby check-in audience: blank leaves it off, 'all' opens it to everyone, or a comma-separated list of user ids. Blank falls back to the ONE_LOCATION_NEARBY_PRESENCE_COHORT repository variable, so a routine deploy cannot silently switch the feature off."
+        description: "Nearby check-in audience. Leave this as 'all' for a normal deploy. Clearing it turns nearby check-in OFF in production, which is the kill switch; a comma-separated list of user ids restricts it to those accounts."
         required: false
-        default: ""
+        default: "all"
         type: string
 
 permissions:
@@ -242,8 +242,8 @@ jobs:
             --plaid-redirect-path "/kai/plaid/oauth/return" \
             --plaid-tx-history-days "730" \
             --hushh-trusted-device-enabled "false" \
-            --one-location-nearby-presence-mode "${{ (github.event.inputs.nearby_check_in_cohort || vars.ONE_LOCATION_NEARBY_PRESENCE_COHORT) && 'production' || '' }}" \
-            --one-location-nearby-presence-cohort "${{ github.event.inputs.nearby_check_in_cohort || vars.ONE_LOCATION_NEARBY_PRESENCE_COHORT || '' }}" \
+            --one-location-nearby-presence-mode "${{ github.event.inputs.nearby_check_in_cohort && 'production' || '' }}" \
+            --one-location-nearby-presence-cohort "${{ github.event.inputs.nearby_check_in_cohort }}" \
             > /tmp/prod-runtime-secret-sync.json
 
           "${{ env.PROTOCOL_PYTHON }}" scripts/ops/sync_frontend_runtime_secrets.py \
@@ -431,7 +431,7 @@ jobs:
           gcloud builds submit \
             --project="${{ env.GCP_PROJECT_ID }}" \
             --config=deploy/frontend.cloudbuild.yaml \
-            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_ONE_LOCATION_NEARBY_CHECK_IN=${{ (github.event.inputs.nearby_check_in_cohort || vars.ONE_LOCATION_NEARBY_PRESENCE_COHORT) && 'true' || 'false' }},_APP_ENV=production,_ONE_WALLET_CARD_ENABLED=true,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
+            "--substitutions=_FRONTEND_SERVICE=${{ env.FRONTEND_SERVICE }},_REGION=${{ env.GCP_REGION }},_ONE_LOCATION_NEARBY_CHECK_IN=${{ github.event.inputs.nearby_check_in_cohort && 'true' || 'false' }},_APP_ENV=production,_ONE_WALLET_CARD_ENABLED=true,_CLOUD_RUN_NO_TRAFFIC=true,_IMAGE_TAG=prod-${{ github.event.inputs.sha }},_DEPLOY_ENV=production,_DEPLOY_SOURCE=deploy-production,_DEPLOY_SHA=${{ github.event.inputs.sha }},_GITHUB_RUN_ID=${{ github.run_id }}"
 
       - name: Get frontend URL
         if: steps.scope.outputs.deploy_frontend == 'true'


### PR DESCRIPTION
# Description

The `nearby_check_in_cohort` field added in #4977 defaulted to **blank**, and blank means off.

That put the burden the wrong way round: **every future production deploy had to remember to retype `all`**, or nearby check-in would switch off in production — with no error, no warning, and nothing in the release summary to notice. Including deploys by people who have never heard of the feature and are shipping something unrelated.

## The fallback I added did not actually protect anything

#4977 paired the field with a fallback to `ONE_LOCATION_NEARBY_PRESENCE_COHORT`, precisely to stop a blank field disabling the feature. But that repository variable was **never set** — the production rollout passed `all` as a dispatch input instead. So there was nothing behind the field, and the next blank deploy would have taken check-in down.

I got the default backwards, and the safety net I reached for was not connected.

## The fix

Default the field to `all`.

- A normal deploy preserves current production behaviour without anyone thinking about it
- **Clearing the field is now the deliberate kill switch** — one field, one meaning
- `gh workflow run` without the flag also inherits `all`, so CLI deploys are covered too

With the default carrying that weight, the repository-variable fallback is redundant and actively harmful: it would have made "clear the field to disable" conditional on a variable nobody can see from the dispatch form. Removed, so the field is the single source of truth for all three flags.

## Behaviour change

Production keeps exactly what it has now (`mode=production`, `cohort=all`, web flag on) instead of losing it on the next deploy. No other lane is touched — UAT does not use this input.

## 📌 Impact Map (Required)

- Routes touched: [x] None
- API / schema / type changes: [x] None
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None
- Docs updated: [x] None — the semantics live in the input `description`, which is what the operator reads at dispatch time.
- Top-level / devex / config / generated / ignore files touched: [x] Listed below: `.github/workflows/deploy-production.yml` only.
- Trust boundary touched: [x] Listed below: **deploy / consent.** This controls the production nearby check-in audience. It now defaults to the audience production is already serving rather than silently reverting it.
- Caller / proxy / backend pairing: [x] Listed below: dispatch input → `sync_backend_runtime_secrets.py` → `BACKEND_RUNTIME_CONFIG_JSON` → `_nearby_presence_enabled()`. Unchanged by this PR; only the default and the removal of the redundant fallback differ.
- Rollback or safe-failure behavior: [x] Listed below: clear the field and deploy. That is now the documented, unambiguous kill switch.
- UI browser or Playwright proof: [x] Not applicable — no application code changed.
- Verification commands executed:
  - [x] YAML parse; asserted `default: 'all'`, `required: false`, `type: string`
  - [x] Confirmed all three consuming expressions now read the input only
  - [x] Confirmed zero remaining `ONE_LOCATION_NEARBY_PRESENCE_COHORT` references
  - [x] `bash scripts/ci/check-dco-signoff.sh`

## ✅ Review-Ready Contract

- [x] Title, body, and changed file describe the same contract.
- [x] Does not duplicate anything open.
- [x] Changes a current reachable deploy surface.
- [x] Reachable production attach point: the governed `deploy-production` workflow.
- [x] No new helpers or components.
- [x] Production surface proved: the rendered expressions were inspected after editing.
- [x] Required checks current, commit signed off, mergeable with `main`.
- [x] Maintainer edits enabled.
- [x] Predecessor: #4977 (merged).

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: deploy input default.
- [x] **iOS** / **Android**: not applicable — no plugin or native change.

## 🧪 Testing

- [x] Commit is signed off (`git commit -s`)
- [x] No generated files changed.

No new unit tests: this changes a workflow input default, verified by parsing the YAML and inspecting the three rendered expressions. The behaviour it feeds is covered by #4969's gate tests and #4972's hydration test.

## 🛡️ Privacy & Consent

- [x] Accesses no user data.
- [x] Consent unchanged.
- [x] Sensitive surface: deploy / consent.
- [x] Safe-failure proved: clearing the field disables the feature on the next deploy.

## 📜 Licensing

- [x] Apache-2.0 compatible; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)