### PR TITLE
fix(ui): adapt SMS interface layout to wide screen viewports

### DIFF
--- a/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
+++ b/hushh-webapp/components/one-location/redesign/__tests__/sos-panel.test.tsx
@@ -454,4 +454,16 @@ describe("SosPanel", () => {
     expect(screen.queryByText("Live now")).toBeNull();
     expect(screen.queryByTestId("sos-cancel-alert")).toBeNull();
   });
+
+  it("keeps the mobile strip but widens into a two-column layout on large screens", () => {
+    const { container } = render(<SosPanel {...baseProps} />);
+    const screenEl = screen.getByTestId("sms-safety-screen");
+    // Mobile behavior preserved: still the full-screen black overlay.
+    expect(screenEl).toHaveClass("fixed", "inset-0", "bg-black");
+    // The inner container keeps the mobile 407px strip and widens on lg.
+    const inner = screenEl.firstElementChild as HTMLElement;
+    expect(inner).toHaveClass("max-w-[407px]", "lg:max-w-5xl");
+    // The press ring + controls become side-by-side columns on lg.
+    expect(container.querySelector('[class*="lg:flex-row"]')).not.toBeNull();
+  });
 });

--- a/hushh-webapp/components/one-location/redesign/sos-panel.tsx
+++ b/hushh-webapp/components/one-location/redesign/sos-panel.tsx
@@ -303,7 +303,7 @@ export function SosPanel({
       data-ambient-chrome-ignore
       data-testid="sms-safety-screen"
     >
-      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))]">
+      <div className="mx-auto flex min-h-[100dvh] w-full max-w-[407px] flex-col px-6 pb-[max(21px,env(safe-area-inset-bottom))] pt-[max(52px,env(safe-area-inset-top))] lg:max-w-5xl lg:px-8">
         <button
           type="button"
           onClick={onClose}
@@ -323,7 +323,13 @@ export function SosPanel({
           </p>
         </header>
 
-        <div className="flex min-h-[310px] flex-1 items-center justify-center py-6">
+        {/* On wide viewports (lg+) the primary press ring and the
+            message/controls column sit side by side so the safety screen fills
+            the space instead of a single narrow strip. Below lg it stays the
+            original stacked column, untouched. The <style> block inside is
+            display:none and never participates in the flex row. */}
+        <div className="flex flex-1 flex-col lg:flex-row lg:items-center lg:justify-center lg:gap-12 xl:gap-16">
+          <div className="flex min-h-[310px] flex-1 items-center justify-center py-6">
           <div className="relative flex h-[252px] w-[252px] items-center justify-center">
             <span className="absolute inset-0 rounded-full border border-white/10" />
             <span className="absolute inset-[24px] rounded-full border border-white/15" />
@@ -414,7 +420,7 @@ export function SosPanel({
         `}</style>
 
 
-        <div className="mt-auto">
+        <div className="mt-auto w-full lg:mt-0 lg:max-w-md lg:flex-shrink-0">
           {/* While an SMS/SOS session is live, the primary action becomes
               stopping it. Cancelling here revokes the location grants created by
               the alert AND clears the incident, so "SENT · Live now" resets and
@@ -654,6 +660,7 @@ export function SosPanel({
               Cancel
             </button>
           </div>
+        </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
# Description

**Bug:** The Save My Soul (SMS) safety screen locked its inner container to
`max-w-[407px]`, so on desktop/tablet it rendered as a thin centred strip
against a mostly-empty black screen — it never used the wider viewport.

**Fix** (`components/one-location/redesign/sos-panel.tsx`), responsive-only, no
behavior change:
- Widen the inner container on `lg+` (`lg:max-w-5xl lg:px-8`) so it uses the
  available width.
- Below `lg` the press ring and the message/controls block **stack exactly as
  before**; on `lg+` they split into two columns (ring left, controls right,
  bounded to `max-w-md`) via a `lg:flex-row` wrapper — a balanced two-pane
  layout instead of one stretched column.

**Mobile (< lg) is untouched:** the container keeps `max-w-[407px]`, the stacked
order is preserved (`mt-auto` still pins the controls to the bottom), and the
full-screen black overlay, press-and-hold trigger, message composer, and
emergency dialer are unchanged. The `<style>` block inside the new wrapper is
`display:none` and never participates in the flex row.

## 📌 Impact Map (Required)

- Routes touched:
  - [x] Listed below: the Save My Soul overlay rendered from `/one/location` (presentation only)
- API / schema / type changes:
  - [x] None
- Cache keys touched:
  - [x] None
- Runtime DB data-plane changes:
  - [x] None
- World-model domain summary effects:
  - [x] None
- Mobile parity impacts:
  - [x] None — mobile (< lg) markup/classes are unchanged; only lg+ adds columns
- Docs updated (exact files):
  - [x] None
- Top-level / devex / config / generated / ignore files touched:
  - [x] None
- Trust boundary touched:
  - [x] None — layout only; no auth/consent/vault/SOS-trigger logic changed
- Caller / proxy / backend pairing:
  - [x] Not applicable — presentational component
- Rollback or safe-failure behavior:
  - [x] Listed below: additive responsive classes + one wrapper div; reverting restores the prior single-column layout
- UI browser or Playwright proof:
  - [x] Route/spec/command listed below: `sos-panel.test.tsx` asserts the preserved mobile strip + the lg two-column classes; live browser capture not run (auth + vault + SOS-gated overlay)
- Verification commands executed:
  - [x] `cd hushh-webapp && npm run typecheck` — pass
  - [x] `cd hushh-webapp && npm run lint` (changed files, `--max-warnings=0`) — pass
  - [x] `cd hushh-webapp && npm test` (`sos-panel.test.tsx` 20 + `one-location-sos-emergency.contract.test.tsx` 3 = 23 pass) — pass
  - [x] `cd hushh-webapp && npm run build` — pass

## ✅ Review-Ready Contract

- [x] Title, body, changed files, and tests describe the same contract.
- [x] Existing implementation and related open PRs were checked; this PR does not duplicate.
- [x] This PR changes a current reachable app surface (Save My Soul overlay).
- [x] Reachable production attach point: `SosPanel` (rendered by `location-redesign-hub`).
- [x] New test asserts on production component markup, not test-local mocks.
- [x] Commits are signed off; branch is mergeable with `main`.
- [x] Maintainer edits are enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web**: Next.js client component (`components/one-location/redesign/sos-panel.tsx`)
- [x] **iOS**: N/A — shared web component; no native plugin changed
- [x] **Android**: N/A — shared web component; no native plugin changed

## 🧪 Testing

- [x] Tested on Web (unit): `sos-panel.test.tsx` — existing 19 behavior tests still pass + 1 new responsive-layout test; contract test green
- [ ] Tested on iOS Simulator/Device — N/A
- [ ] Tested on Android Emulator/Device — N/A
- [x] Commits are signed off (`git commit -s`)

## 📸 Screenshots / Video

Below `lg`: identical to today (single stacked column, `max-w-[407px]`). At
`lg+`: the press ring and the controls sit as two columns filling the width
(`max-w-5xl`). Guarded by the new unit test asserting both the preserved mobile
strip and the `lg:flex-row` / `lg:max-w-5xl` classes. Live browser capture not
run — the overlay is auth + vault + SOS-gated.

## 🛡️ Privacy & Consent

- [x] Does this change access user data? No — layout only.
- [x] Sensitive surface touched: none (SOS trigger/dialer logic unchanged)

## 📜 Licensing

- [x] First-party changes remain Apache-2.0 compatible
- [x] No dependencies changed

