### PR TITLE
fix(db): declare migration 138 in the production schema contract

### DIFF
--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 137,
+  "expected_migration_version": 138,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",


### PR DESCRIPTION
# Description

The production deploy ([run 31266082351](https://github.com/hushh-labs/hushh-research/actions/runs/31266082351)) failed its drift gate:

```
contract_version_mismatch:policy=exact:highest_local=138:expected=137
```

Commit `965529707` (*"make a Circle invitation connect two people, not everyone"*) added `138_circle_member_connection_origin.sql` and bumped the **UAT** contract to 138, but left the **production** contract at 137. Both use the `exact` policy.

That is why UAT went green and production could not — **on the identical commit**. It is exactly the divergence a UAT-green signal is supposed to rule out, and it is invisible until a production deploy is attempted.

| Contract | expected | policy | outcome |
|---|---|---|---|
| `uat_integrated_schema.json` | 138 | exact | passed |
| `prod_core_schema.json` | **137** | exact | **failed** |
| `dev_minimum_schema.json` | 137 | minimum | passed (lenient) |

## The database is not the stale side

`138_circle_member_connection_origin.sql` is in the canonical release manifest, and the deploy's "Apply production release migrations" step **applied it to production successfully**. The gate that runs immediately afterwards then disagreed with the contract file.

So the production database is genuinely at 138; the contract was the artefact left behind. This bumps it to match.

## Why no other contract change is needed

Migration 138 only drops and re-adds a CHECK constraint on the existing `connection_origins` table — no new tables, no new columns. The two contracts already carry **identical 82-table sets** and differed solely in this version number.

Verified after the edit:

```
prod contract now expects: 138 | policy: exact
uat contract expects:      138
highest local migration:   138
PROD GATE WOULD NOW PASS: True
UAT  GATE STILL PASSES:   True
```

## Production impact

**None yet, and nothing was broken.** The gate blocked before any deploy step ran — backend build, frontend build and traffic promotion were all skipped. Production is still serving the previous good revision and nearby check-in remains live.

## 📌 Impact Map (Required)

- Routes touched: [x] None
- API / schema / type changes: [x] Listed below: no schema change. This declares a schema state the production database already has.
- Cache keys touched: [x] None
- Runtime DB data-plane changes: [x] None — no migration added or altered.
- World-model domain summary effects: [x] None
- Mobile parity impacts: [x] None
- Docs updated: [x] None
- Top-level / devex / config / generated / ignore files touched: [x] Listed below: `consent-protocol/db/contracts/prod_core_schema.json`, which attaches to the existing production deploy drift gate.
- Trust boundary touched: [x] Listed below: **schema / deploy.** This is the gate that decides whether production's schema matches its contract. It is being corrected to match reality, not relaxed — the policy stays `exact`.
- Caller / proxy / backend pairing: [x] Not applicable.
- Rollback or safe-failure behavior: [x] Listed below: revert the one-line change. The gate would then block production deploys again, which is the current state.
- UI browser or Playwright proof: [x] Not applicable.
- Verification commands executed:
  - [x] Asserted `expected_migration_version == highest local migration` for both prod and UAT contracts
  - [x] `json.tool` parse check on the edited contract
  - [x] Inspected 138's SQL to confirm it adds no tables or columns
  - [x] Diffed prod vs UAT contract table sets — identical, 82 each
  - [x] `ruff check` + `ruff format --check` on `consent-protocol` — clean
  - [x] `bash scripts/ci/check-dco-signoff.sh`

## ✅ Review-Ready Contract

- [x] Title, body, changed file and evidence describe the same contract.
- [x] Does not duplicate anything open.
- [x] Changes a current reachable deploy gate.
- [x] Reachable production attach point: "Migration governance and DB drift gate" in `deploy-production`.
- [x] No new helpers or components.
- [x] Production surface proved: the failing run's own violation string names this exact field and value.
- [x] Required checks current, commit signed off, mergeable with `main`.
- [x] Maintainer edits enabled.

## 🛑 Tri-Flow Architecture Check

- [x] **Web** / **iOS** / **Android**: not applicable — a deploy-time schema contract, no application code.

## 🧪 Testing

- [x] Commit is signed off (`git commit -s`)
- [x] No generated files changed.

The real test is the production deploy's own drift gate, which is what reported the mismatch. The assertions above reproduce its comparison locally.

## 🛡️ Privacy & Consent

- [x] Accesses no user data.
- [x] Consent unchanged.
- [x] Sensitive surface: schema / deploy.
- [x] Safe-failure proved: the gate still uses the `exact` policy, so any future drift in either direction still blocks the deploy.

## 📜 Licensing

- [x] Apache-2.0 compatible; no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)