### PR TITLE
fix(ria): unbreak the profile screen — stale status cache and an unbounded redirect

### DIFF
--- a/hushh-webapp/__tests__/api/ria-status-cache-invalidation.test.ts
+++ b/hushh-webapp/__tests__/api/ria-status-cache-invalidation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Regression (UAT, 2026-08-08): claiming an RIA profile left the profile screen
+ * hanging forever.
+ *
+ * The claim screen reads `onboarding/status` BEFORE the claim (answer:
+ * exists=false); the proxy caches that for 30s. `POST claim/complete` was not on
+ * the invalidation list, so the post-claim force-refresh was served the stale
+ * exists=false with a 200 and persisted client-side for 30 minutes. The profile
+ * screen then believed the adviser had no profile.
+ *
+ * Source-level assertions: these proxies are Next route handlers whose caches
+ * are module-local, so the cheapest honest guard is that the invalidation and
+ * the force-bypass stay in the code.
+ */
+
+const WEBAPP_ROOT = join(__dirname, "..", "..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(WEBAPP_ROOT, relativePath), "utf8");
+}
+
+describe("RIA proxy invalidates the onboarding status cache on claim mutations", () => {
+  const source = readSource("app/api/ria/[...path]/route.ts");
+
+  it("busts the status cache for every claim step, not only claim/email", () => {
+    expect(source).toContain('path.startsWith("claim/")');
+    expect(source).toContain("hotGetCache.delete(`onboarding/status:${authHeader}`)");
+  });
+
+  it("still busts it for a licence refresh", () => {
+    expect(source).toContain('path === "profile/refresh-license"');
+  });
+});
+
+describe("IAM proxy honours a forced persona read", () => {
+  const source = readSource("app/api/iam/[...path]/route.ts");
+
+  it("skips the cache hit when force=1 is requested", () => {
+    // The key omitted the query string, so ?force=1 — sent specifically to
+    // bypass caching — was answered from this cache.
+    expect(source).toContain('searchParams.get("force") === "1"');
+    expect(source).toContain("const hotCacheKey = forceRefresh ? null : personaCacheKey;");
+  });
+
+  it("still writes the fresh answer and can still fall back to stale", () => {
+    expect(source).toContain("writeHotGetCache(personaCacheKey, result)");
+    expect(source).toContain("readHotGetCache(personaCacheKey, { allowStale: true })");
+  });
+});

--- a/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression: /ria/profile hung forever on "Loading profile..." (UAT, 2026-08-08).
+ *
+ * The section redirected to /ria/onboarding whenever it believed no profile
+ * existed, and the onboarding page redirected an established adviser straight
+ * back. With a stale cached status against a correct persona the two bounced
+ * ~1.3 times a second, silently, with no network traffic and no console error —
+ * and the profile rendered its spinner under the same predicate that fired the
+ * redirect, so the user saw an eternal spinner.
+ *
+ * The redirect must therefore be attempted at most once, and the screen must
+ * end up on something actionable.
+ */
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  useAuth: vi.fn(),
+  usePersonaState: vi.fn(),
+  refresh: vi.fn(),
+  switchPersona: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+  riaService: {
+    deleteProfile: vi.fn(),
+    updateProfile: vi.fn(),
+    refreshLicenseProfile: vi.fn(),
+    claimEmailStart: vi.fn(),
+    claimEmailConfirm: vi.fn(),
+    getDossier: vi.fn().mockResolvedValue(null),
+    retryDossier: vi.fn(),
+  },
+  openKaiCommandBar: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush, replace: mocks.routerReplace }),
+}));
+
+vi.mock("lucide-react", () => ({
+  ArrowRight: () => <span />,
+  CheckCircle2: () => <span />,
+  ClipboardCheck: () => <span />,
+  ExternalLink: () => <span />,
+  Loader2: () => <span />,
+  MessageCircle: () => <span />,
+  Pencil: () => <span />,
+  RotateCcw: () => <span />,
+  ShieldCheck: () => <span />,
+  Trash2: () => <span />,
+}));
+
+vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
+  OnboardingStepServices: () => <div data-testid="step-services" />,
+}));
+
+vi.mock("@/components/ria/ria-page-shell", () => ({
+  RiaCompatibilityState: () => <div data-testid="ria-compat" />,
+  isRiaVerified: (status?: string | null) =>
+    ["active", "verified", "finra_verified"].includes(
+      String(status || "").toLowerCase(),
+    ),
+}));
+
+vi.mock("@/components/app-ui/settings-ui", () => ({
+  SettingsDetailPanel: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="edit-panel">{children}</div> : null),
+  SettingsGroup: ({
+    children,
+    testId = "manage-group",
+  }: {
+    children: React.ReactNode;
+    testId?: string;
+  }) => <div data-testid={testId}>{children}</div>,
+  SettingsRow: ({
+    title,
+    onClick,
+    testId,
+  }: {
+    title: React.ReactNode;
+    onClick?: () => void;
+    testId?: string;
+  }) => (
+    <button data-testid={testId} onClick={onClick}>
+      {title}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  AlertDialogAction: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: mocks.useAuth }));
+vi.mock("@/lib/persona/persona-context", () => ({
+  usePersonaState: mocks.usePersonaState,
+}));
+vi.mock("@/lib/services/ria-service", () => ({ RiaService: mocks.riaService }));
+vi.mock("@/lib/services/ria-onboarding-draft-local-service", () => ({
+  RiaOnboardingDraftLocalService: { clear: () => Promise.resolve() },
+}));
+vi.mock("@/lib/cache/cache-sync-service", () => ({
+  CacheSyncService: { onPersonaStateChanged: vi.fn() },
+}));
+vi.mock("@/lib/services/device-resource-cache-service", () => ({
+  DeviceResourceCacheService: {
+    invalidateResourcePrefix: () => Promise.resolve(),
+  },
+}));
+vi.mock("@/lib/morphy-ux/morphy", () => ({ morphyToast: mocks.toast }));
+vi.mock("@/lib/navigation/routes", () => ({
+  ROUTES: { RIA_ONBOARDING: "/ria/onboarding", ONE_HOME: "/one" },
+}));
+vi.mock("@/lib/navigation/kai-command-bar-events", () => ({
+  openKaiCommandBar: mocks.openKaiCommandBar,
+}));
+
+import { RiaProfileSection } from "@/components/ria/profile/ria-profile-section";
+
+// The split brain: the persona says this adviser is established ("switch"),
+// the (stale) status says the profile does not exist.
+const SPLIT_BRAIN_STATUS = { exists: false };
+
+function renderSection(status: unknown) {
+  return render(
+    <RiaProfileSection
+      status={status as never}
+      loading={false}
+      onRefresh={vi.fn()}
+    />,
+  );
+}
+
+describe("RiaProfileSection redirect loop breaker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.useAuth.mockReturnValue({
+      user: { uid: "u1", getIdToken: vi.fn().mockResolvedValue("tok") },
+    });
+    mocks.usePersonaState.mockReturnValue({
+      riaCapability: "switch",
+      loading: false,
+      refreshing: false,
+      refresh: mocks.refresh,
+      switchPersona: mocks.switchPersona,
+    });
+    mocks.refresh.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("redirects to onboarding at most once, even across re-renders", () => {
+    const { rerender } = renderSection(SPLIT_BRAIN_STATUS);
+
+    for (let i = 0; i < 5; i += 1) {
+      rerender(
+        <RiaProfileSection
+          status={SPLIT_BRAIN_STATUS as never}
+          loading={false}
+          onRefresh={vi.fn()}
+        />,
+      );
+    }
+
+    expect(mocks.routerReplace).toHaveBeenCalledTimes(1);
+    expect(mocks.routerReplace).toHaveBeenCalledWith("/ria/onboarding");
+  });
+
+  it("stops spinning and offers a way out when the redirect never lands", async () => {
+    renderSection(SPLIT_BRAIN_STATUS);
+
+    // Before the bound elapses the neutral skeleton is correct.
+    expect(screen.queryByText("Loading profile...")).toBeTruthy();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await waitFor(() =>
+      expect(screen.queryByText("Loading profile...")).toBeNull(),
+    );
+    expect(screen.getByTestId("ria-profile-missing-retry")).toBeTruthy();
+    expect(screen.getByTestId("ria-profile-missing-setup")).toBeTruthy();
+  });
+
+  it("never redirects when the profile exists", () => {
+    renderSection({ exists: true, verification_status: "submitted" });
+    expect(mocks.routerReplace).not.toHaveBeenCalled();
+  });
+});

--- a/hushh-webapp/app/api/iam/[...path]/route.ts
+++ b/hushh-webapp/app/api/iam/[...path]/route.ts
@@ -51,10 +51,18 @@ async function proxyRequest(
   const path = params.path.join("/");
   const targetUrl = `${getPythonApiUrl()}/api/iam/${path}${query}`;
   const authHeader = request.headers.get("authorization") || "";
-  const hotCacheKey =
+  // A caller that asks to bypass caching must not be answered from this cache.
+  // The key omitted the query string, so `GET /api/iam/persona?force=1` — sent
+  // specifically to bypass the backend's own cache — was served a stale persona
+  // from here, which is one half of the profile/onboarding redirect loop.
+  // The fresh answer still populates the cache, and stale-on-upstream-failure
+  // still applies; only the cache HIT is skipped for a forced read.
+  const forceRefresh = request.nextUrl.searchParams.get("force") === "1";
+  const personaCacheKey =
     method === "GET" && path === "persona" && authHeader
       ? `${path}:${authHeader}`
       : null;
+  const hotCacheKey = forceRefresh ? null : personaCacheKey;
 
   const headers = createUpstreamHeaders(requestId, {
     ...(authHeader ? { Authorization: authHeader } : {}),
@@ -104,12 +112,12 @@ async function proxyRequest(
 
     const result = await load;
 
-    if (hotCacheKey && result.status < 500) {
-      writeHotGetCache(hotCacheKey, result);
+    if (personaCacheKey && result.status < 500) {
+      writeHotGetCache(personaCacheKey, result);
     }
 
-    if (hotCacheKey && result.status >= 500) {
-      const stale = readHotGetCache(hotCacheKey, { allowStale: true });
+    if (personaCacheKey && result.status >= 500) {
+      const stale = readHotGetCache(personaCacheKey, { allowStale: true });
       if (stale) {
         console.warn(
           `[IAM API] request_id=${requestId} serving stale persona cache after upstream ${result.status}`
@@ -125,8 +133,8 @@ async function proxyRequest(
     });
   } catch (error) {
     console.error(`[IAM API] request_id=${requestId} proxy_error`, error);
-    if (hotCacheKey) {
-      const stale = readHotGetCache(hotCacheKey, { allowStale: true });
+    if (personaCacheKey) {
+      const stale = readHotGetCache(personaCacheKey, { allowStale: true });
       if (stale) {
         console.warn(
           `[IAM API] request_id=${requestId} serving stale persona cache after proxy failure`

--- a/hushh-webapp/app/api/ria/[...path]/route.ts
+++ b/hushh-webapp/app/api/ria/[...path]/route.ts
@@ -163,11 +163,19 @@ async function proxyRequest(
 
     // Mutations that change onboarding/status upstream must drop the hot GET
     // cache so the next status read reflects them (license refresh updates the
-    // official fields; claim email verify can flip verification_status).
+    // official fields; every claim step can create the profile or flip
+    // verification_status).
+    //
+    // claim/complete is the load-bearing one: the claim screen reads
+    // onboarding/status BEFORE the claim (answer: exists=false), that answer is
+    // cached here for 30s, and the post-claim force-refresh was then served the
+    // stale exists=false with a 200 and persisted client-side for 30 minutes.
+    // The profile screen believed the adviser had no profile and bounced to
+    // onboarding forever.
     if (
       method === "POST" &&
       authHeader &&
-      (path === "profile/refresh-license" || path.startsWith("claim/email/"))
+      (path === "profile/refresh-license" || path.startsWith("claim/"))
     ) {
       hotGetCache.delete(`onboarding/status:${authHeader}`);
     }

--- a/hushh-webapp/app/ria/profile/page.tsx
+++ b/hushh-webapp/app/ria/profile/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import { InlineLoadingState } from "@/components/app-ui/inline-loading-state";
 import { RiaProfileSection } from "@/components/ria/profile/ria-profile-section";
 import { RiaPageShell } from "@/components/ria/ria-page-shell";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import { RiaService, type RiaOnboardingStatus } from "@/lib/services/ria-service";
 
@@ -16,6 +17,7 @@ export default function RiaProfilePage() {
   const { user, loading: authLoading } = useAuth();
   const [status, setStatus] = useState<RiaOnboardingStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   const refreshStatus = useCallback(
     async (force = false) => {
@@ -33,7 +35,13 @@ export default function RiaProfilePage() {
           force,
         });
         setStatus(nextStatus);
+        setLoadError(false);
         return nextStatus;
+      } catch {
+        // A failed status read left `status` null with no error surface and an
+        // unhandled rejection. Say it failed and offer the retry instead.
+        setLoadError(true);
+        return null;
       } finally {
         setLoading(false);
       }
@@ -60,8 +68,27 @@ export default function RiaProfilePage() {
     >
       {authLoading || loading ? (
         <InlineLoadingState label="Loading profile…" />
+      ) : loadError && !status ? (
+        <div className="space-y-4 rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] p-5">
+          <div>
+            <p className="text-[16px] font-semibold">We couldn&apos;t load your profile</p>
+            <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
+              Check your connection and try again.
+            </p>
+          </div>
+          <Button
+            onClick={() => void refreshStatus(true)}
+            data-testid="ria-profile-load-retry"
+          >
+            Try again
+          </Button>
+        </div>
       ) : (
-        <RiaProfileSection status={status} onRefresh={refreshStatus} />
+        <RiaProfileSection
+          status={status}
+          loading={loading}
+          onRefresh={refreshStatus}
+        />
       )}
     </RiaPageShell>
   );

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowRight,
@@ -611,11 +611,24 @@ export function RiaProfileSection({
   // Covers "setup" (never onboarded) AND the split-brain case where the persona
   // still reports 'ria' but the profile row is gone (exists:false). Skipped while
   // a delete is in flight (that navigates to One home itself) and while loading.
+  //
+  // ONE attempt only. The onboarding page redirects an established adviser
+  // straight back here, so when the two disagree — a stale cached status against
+  // a correct persona — an unbounded redirect becomes an infinite bounce that
+  // renders as a permanent "Loading profile..." with no network traffic and no
+  // console error. After one try we stop redirecting and show the real screen.
+  const onboardingRedirectAttemptedRef = useRef(false);
+  const [redirectSettled, setRedirectSettled] = useState(false);
   useEffect(() => {
     if (personaLoading || personaRefreshing || deleting || loading) return;
-    if (riaCapability === "setup" || status?.exists === false) {
-      router.replace(ROUTES.RIA_ONBOARDING);
-    }
+    if (riaCapability !== "setup" && status?.exists !== false) return;
+    if (onboardingRedirectAttemptedRef.current) return;
+    onboardingRedirectAttemptedRef.current = true;
+    router.replace(ROUTES.RIA_ONBOARDING);
+    // If the navigation lands, this component unmounts and the timer dies with
+    // it. If it bounces back, this fires and the screen stops waiting.
+    const timer = window.setTimeout(() => setRedirectSettled(true), 1500);
+    return () => window.clearTimeout(timer);
   }, [
     personaLoading,
     personaRefreshing,
@@ -852,8 +865,11 @@ export function RiaProfileSection({
   // When the profile resolves to "setup / no profile", the effect above redirects
   // to onboarding. Render the neutral skeleton (not the empty profile body) until
   // that navigation lands, so the profile never flashes empty before redirecting.
+  // `redirectSettled` ends the wait when the navigation never lands, so this is a
+  // brief skeleton rather than a dead end.
   const pendingOnboardingRedirect =
     !deleting &&
+    !redirectSettled &&
     riaCapability !== "disabled" &&
     (riaCapability === "setup" || status?.exists === false);
 
@@ -872,6 +888,40 @@ export function RiaProfileSection({
         title="RIA profile is waiting on the IAM rollout"
         description="This environment needs the IAM schema before your advisor profile can load."
       />
+    );
+  }
+
+  // The redirect to onboarding did not land (the two screens disagree about
+  // whether this adviser exists). Say so and offer the way out, instead of
+  // spinning forever or rendering an empty profile body.
+  if (riaCapability === "setup" || status?.exists === false) {
+    return (
+      <div className="space-y-4 rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)] p-5">
+        <div>
+          <p className="text-[16px] font-semibold">We couldn&apos;t load your profile</p>
+          <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
+            Your adviser profile didn&apos;t come back. Try again, or set it up.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            onClick={() => {
+              void onRefresh(true);
+              void refresh({ force: true });
+            }}
+            data-testid="ria-profile-missing-retry"
+          >
+            Try again
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => router.push(ROUTES.RIA_ONBOARDING)}
+            data-testid="ria-profile-missing-setup"
+          >
+            Set up profile
+          </Button>
+        </div>
+      </div>
     );
   }
 


### PR DESCRIPTION
`/ria/profile` hangs forever on **"Loading profile..."** after claiming (reproduced on UAT). Root-caused from live logs: the page is in a **redirect ping-pong with `/ria/onboarding` at ~1.3 navigations per second** — 2,000+ captured in a 14-minute window — entirely client-side, so there is no failed request and no console error to point at.

## Why the two screens disagree

1. **`claim/complete` never invalidated the status cache.** The claim screen reads `onboarding/status` *before* the claim (answer `exists:false`), and `app/api/ria/[...path]/route.ts` caches that for 30s. The bust list covered only `profile/refresh-license` and `claim/email/` — so the post-claim force-refresh was handed the stale `exists:false` with a **200**, and `ria-service.ts` then persisted it on the device for **30 minutes**. Widened to `claim/*`.
2. **`?force=1` was answered from cache.** `app/api/iam/[...path]/route.ts` built its hot-cache key without the query string, so `GET /api/iam/persona?force=1` — sent specifically to bypass caching — got a cached persona. The cache HIT is now skipped on a forced read; the fresh answer still populates the cache and stale-on-upstream-failure is unchanged.

With those two disagreeing, the profile redirected to onboarding, onboarding recognised an established adviser and redirected back, forever — and the profile rendered its spinner under the *same* predicate that fired the redirect.

## Making this class of bug non-fatal

- The onboarding redirect is attempted **once per mount** (ref-guarded). If it doesn't land within a short bound, the screen stops waiting and renders **Try again / Set up profile** instead of an eternal spinner.
- A failed status read now surfaces a retry instead of being swallowed into a null status plus an unhandled rejection (`app/ria/profile/page.tsx` had `try/finally` with no `catch`).
- The host passes its `loading` flag down so the page gate and the section gate stop disagreeing.

## Proof
- New `ria-profile-redirect-loop.test.tsx`: redirect fires exactly once across re-renders; spinner resolves to an actionable state; no redirect when the profile exists.
- New `ria-status-cache-invalidation.test.ts` pins both proxy fixes.
- `tsc --noEmit` 0 errors, eslint 0, **full suite 3085 passed / 0 failed** (Node 24).

Backend untouched — live logs show it healthy throughout (zero tracebacks, zero 5xx on RIA routes).