### PR TITLE
fix(ria): show the claimed adviser's office, and put it on a map with the route

### DIFF
--- a/consent-protocol/hushh_mcp/services/ria_claim_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_service.py
@@ -440,6 +440,85 @@ def _shape_advisor_record(raw: dict[str, Any] | None) -> dict[str, Any]:
     }
 
 
+def _clean_text(value: Any) -> str:
+    """Trim any scalar to text; None and blanks collapse to ''."""
+    return str(value or "").strip()
+
+
+def _location_from_address(
+    *,
+    street1: Any,
+    street2: Any = None,
+    city: Any,
+    zip_code: Any,
+) -> dict[str, str]:
+    """One filed address rendered in the shape ria_business_contacts stores."""
+    line1 = _clean_text(street1)
+    line2 = _clean_text(street2)
+    address = ", ".join(part for part in (line1, line2) if part)
+    return {
+        "city": _clean_text(city),
+        # The SEC feed has no locality/neighbourhood concept. Inventing one
+        # would put words on a profile no regulator filed; the row honestly
+        # reads "Not provided" instead.
+        "area": "",
+        "address": address,
+        "pin_zip": _clean_text(zip_code),
+    }
+
+
+def derive_business_location(reference_metadata: dict[str, Any]) -> dict[str, str]:
+    """Business address from the claim's SEC snapshot: {city, area, address, pin_zip}.
+
+    A claimed adviser never typed an address, so the only honest source is the
+    record they claimed against. Order of preference:
+
+    1. The adviser's branch office — but ONLY when the SEC did not flag it as a
+       private residence. A private-residence branch is somebody's home; no
+       part of it (not the street, not the city, not the zip) is ever returned.
+    2. The firm's filed address.
+
+    A source is taken whole — never a branch street beside a firm zip, which
+    would publish an address that appears on no filing. Every key is always a
+    trimmed string; missing values are '' rather than None.
+    """
+    metadata = reference_metadata if isinstance(reference_metadata, dict) else {}
+    firm_raw = metadata.get("firm_record")
+    firm = firm_raw if isinstance(firm_raw, dict) else {}
+    advisor_raw = metadata.get("advisor_record")
+    advisor = advisor_raw if isinstance(advisor_raw, dict) else {}
+    branch_raw = advisor.get("branch")
+    branch = branch_raw if isinstance(branch_raw, dict) else {}
+
+    candidates: list[dict[str, str]] = []
+    if branch and not branch.get("private_residence"):
+        candidates.append(
+            _location_from_address(
+                street1=branch.get("street1"),
+                city=branch.get("city"),
+                zip_code=branch.get("zip"),
+            )
+        )
+    candidates.append(
+        _location_from_address(
+            street1=firm.get("street1"),
+            street2=firm.get("street2"),
+            city=firm.get("city"),
+            zip_code=firm.get("zip"),
+        )
+    )
+
+    # A street line is what the profile's map needs, so a source that has one
+    # wins; otherwise the first source carrying anything at all stands in.
+    for candidate in candidates:
+        if candidate["address"]:
+            return candidate
+    for candidate in candidates:
+        if any(candidate.values()):
+            return candidate
+    return _location_from_address(street1="", city="", zip_code="")
+
+
 def _shape_candidate(raw: dict[str, Any]) -> dict[str, Any]:
     return {
         "individual_crd": raw.get("individualCrd"),
@@ -713,6 +792,9 @@ class RIAClaimService:
             firm_website=firm.get("website"),
             firm_sec_number=firm.get("sec_number"),
             reference_metadata=reference_metadata,
+            # The claimed profile's LOCATION section, filled from the same
+            # snapshot rather than left blank for the adviser to retype.
+            business_location=derive_business_location(reference_metadata),
             # Regulator facts, straight from the public record.
             regulator="SEC" if firm.get("registration_type") == "sec" else "State",
             regulator_status=firm.get("registration_status"),
@@ -1028,6 +1110,7 @@ class RIAClaimService:
             firm_website=firm.get("website"),
             firm_sec_number=firm.get("sec_number"),
             reference_metadata=reference_metadata,
+            business_location=derive_business_location(reference_metadata),
             regulator="SEC" if firm.get("registration_type") == "sec" else "State",
             regulator_status=firm.get("registration_status"),
             disclosures_url=(advisor_record.get("report_url") or firm.get("report_url")),

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4302,6 +4302,7 @@ class RIAIAMService:
         firm_website: str | None = None,
         firm_sec_number: str | None = None,
         reference_metadata: dict[str, Any] | None = None,
+        business_location: dict[str, str] | None = None,
         regulator: str | None = None,
         regulator_status: str | None = None,
         disclosures_url: str | None = None,
@@ -4313,6 +4314,11 @@ class RIAIAMService:
         service, so the claim is CRD-backed by construction. A claim that only
         reached ``provisional`` is stored as ``submitted`` — it opens the RIA
         surface but no verified-only gate.
+
+        ``business_location`` is the caller's already-derived
+        ``{city, area, address, pin_zip}`` (see
+        ``ria_claim_service.derive_business_location``) — the claim snapshot is
+        parsed there, not here, and every value only ever fills a blank.
         """
         normalized_user_id = str(user_id or "").strip()
         if not normalized_user_id:
@@ -4550,20 +4556,41 @@ class RIAIAMService:
                     "verified" if verified else "pending",
                 )
 
+                # The claimed profile's contact block. The phone is the number
+                # possession was proven on; the address comes from the same SEC
+                # snapshot the rest of the profile was built from. Every address
+                # column only ever fills a blank — a value the adviser typed
+                # themselves always survives a re-claim.
+                location = business_location or {}
                 try:
                     await conn.execute(
                         """
-                        INSERT INTO ria_business_contacts (user_id, phone)
-                        VALUES ($1, NULLIF($2, ''))
+                        INSERT INTO ria_business_contacts (
+                          user_id, phone, city, area_locality, full_street_address, pin_zip
+                        )
+                        VALUES (
+                          $1, NULLIF($2, ''), NULLIF($3, ''),
+                          NULLIF($4, ''), NULLIF($5, ''), NULLIF($6, '')
+                        )
                         ON CONFLICT (user_id) DO UPDATE
-                        SET phone = EXCLUDED.phone, updated_at = NOW()
+                        SET
+                          phone = EXCLUDED.phone,
+                          city = COALESCE(NULLIF(EXCLUDED.city, ''), ria_business_contacts.city),
+                          area_locality = COALESCE(NULLIF(EXCLUDED.area_locality, ''), ria_business_contacts.area_locality),
+                          full_street_address = COALESCE(NULLIF(EXCLUDED.full_street_address, ''), ria_business_contacts.full_street_address),
+                          pin_zip = COALESCE(NULLIF(EXCLUDED.pin_zip, ''), ria_business_contacts.pin_zip),
+                          updated_at = NOW()
                         """,
                         normalized_user_id,
                         phone_e164 or "",
+                        str(location.get("city") or "").strip(),
+                        str(location.get("area") or "").strip(),
+                        str(location.get("address") or "").strip(),
+                        str(location.get("pin_zip") or "").strip(),
                     )
                 except asyncpg.exceptions.UndefinedTableError:
                     logger.warning(
-                        "ria_business_contacts unavailable during claim write; skipping phone persistence"
+                        "ria_business_contacts unavailable during claim write; skipping contact persistence"
                     )
 
                 self._invalidate_cached_persona_state(normalized_user_id)
@@ -4593,6 +4620,55 @@ class RIAIAMService:
             "Dev bypass onboarding is no longer available. All RIAs must complete CRD-backed verification.",
             status_code=410,
         )
+
+    @staticmethod
+    def _resolve_business_location(
+        business_contact: dict[str, Any],
+        claim_event: dict[str, Any] | None,
+    ) -> tuple[dict[str, Any], str | None]:
+        """The LOCATION block, with the claim's SEC address filling any blank.
+
+        Advisers who claimed their profile by phone never typed an address, so
+        an empty contact row would read "Not provided" forever even though the
+        claim snapshot carries the filed address. This is a pure read — nothing
+        is written on a GET — and a value the adviser stored always wins.
+
+        Returns ``(values, source)`` where source is ``"sec_record"`` when any
+        shown value came from the claim snapshot, ``"profile"`` when everything
+        shown was stored, and ``None`` when there is nothing to show.
+        """
+        # Imported here, not at module scope: ria_claim_service imports this
+        # module, so a top-level import would be circular.
+        from hushh_mcp.services.ria_claim_service import derive_business_location
+
+        columns = {
+            "city": "city",
+            "area": "area_locality",
+            "address": "full_street_address",
+            "pin_zip": "pin_zip",
+        }
+        metadata = (claim_event or {}).get("reference_metadata")
+        derived = derive_business_location(metadata if isinstance(metadata, dict) else {})
+
+        resolved: dict[str, Any] = {}
+        used_stored = False
+        used_derived = False
+        for key, column in columns.items():
+            stored = business_contact.get(column)
+            if str(stored or "").strip():
+                resolved[key] = stored
+                used_stored = True
+                continue
+            if derived.get(key, ""):
+                resolved[key] = derived[key]
+                used_derived = True
+                continue
+            # Nothing either way: keep whatever the row held (NULL stays NULL)
+            # so the payload's shape does not change for empty profiles.
+            resolved[key] = stored
+        if used_derived:
+            return resolved, "sec_record"
+        return resolved, ("profile" if used_stored else None)
 
     async def get_ria_onboarding_status(self, user_id: str) -> dict[str, Any]:
         conn = await self._conn()
@@ -4749,6 +4825,10 @@ class RIAIAMService:
             ):
                 logger.warning("ria_business_contacts unavailable during onboarding status")
 
+            business_location, business_location_source = self._resolve_business_location(
+                business_contact, claim_event
+            )
+
             if used_legacy_capabilities_fallback:
                 requested_capabilities = ["advisory"]
                 individual_legal_name = ria["legal_name"]
@@ -4811,10 +4891,11 @@ class RIAIAMService:
                 "fee_structure": list(v2_profile.get("fee_structure") or []),
                 "min_engagement_amount": v2_profile.get("min_engagement_amount"),
                 "min_engagement_currency": v2_profile.get("min_engagement_currency"),
-                "business_city": business_contact.get("city"),
-                "business_area": business_contact.get("area_locality"),
-                "business_address": business_contact.get("full_street_address"),
-                "business_pin_zip": business_contact.get("pin_zip"),
+                "business_city": business_location["city"],
+                "business_area": business_location["area"],
+                "business_address": business_location["address"],
+                "business_pin_zip": business_location["pin_zip"],
+                "business_location_source": business_location_source,
                 "business_latitude": business_contact.get("latitude"),
                 "business_longitude": business_contact.get("longitude"),
                 "contact_email": business_contact.get("email"),

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -52,3 +52,4 @@ tests/test_ria_dossier_email_service.py
 tests/test_ria_dossier_routes.py
 tests/test_ria_claim_email_test_path.py
 tests/test_ria_dossier_mail_contract.py
+tests/test_ria_claim_location.py

--- a/consent-protocol/tests/test_ria_claim_location.py
+++ b/consent-protocol/tests/test_ria_claim_location.py
@@ -1,0 +1,561 @@
+"""A claimed profile's LOCATION section comes from the SEC record it claimed.
+
+The onboarding wizard asks for city / area / address / PIN-ZIP and writes them
+to ``ria_business_contacts``. Claim-by-phone never asks — so before this, every
+adviser who claimed their profile read "Not provided" on all four rows even
+though the filed address was already sitting in the claim snapshot
+(``ria_verification_events.reference_metadata``).
+
+Three seams are covered here:
+
+1. ``derive_business_location`` — the pure read of the snapshot, including the
+   privacy rule that a branch flagged as a private residence is never published.
+2. The claim write — the ``ria_business_contacts`` upsert carries the derived
+   address and only ever fills a blank.
+3. ``get_ria_onboarding_status`` — a pure read-time fallback so advisers who
+   claimed *before* this shipped see their address without re-claiming.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import asyncpg
+import pytest
+
+from hushh_mcp.services.ria_claim_service import derive_business_location
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+_NOW = datetime(2026, 8, 8, 12, 0, 0, tzinfo=UTC)
+_USER_ID = "user_claim_location_1"
+
+_FIRM_RECORD = {
+    "crd": 283040,
+    "name": "OLYMPUS PEAKS FINANCIAL, LLC",
+    "street1": "9539 S PROSPERITY RD",
+    "street2": "SUITE 200",
+    "city": "SANDY",
+    "state": "UT",
+    "zip": "84070",
+}
+
+_BRANCH_OFFICE = {
+    "city": "PARK CITY",
+    "state": "UT",
+    "street1": "1441 W UTE BLVD",
+    "zip": "84098",
+    "private_residence": False,
+}
+
+# Somebody's home. Nothing here may ever reach a published profile.
+_BRANCH_HOME = {
+    "city": "HEBER CITY",
+    "state": "UT",
+    "street1": "742 EVERGREEN TERRACE",
+    "zip": "84032",
+    "private_residence": True,
+}
+
+
+def _metadata(*, firm: dict | None = None, branch: dict | None = None) -> dict[str, Any]:
+    return {
+        "provider": "ria_identity_claim",
+        "claim_type": "individual",
+        "firm_record": dict(firm) if firm is not None else dict(_FIRM_RECORD),
+        "advisor_record": {"crd": 5308823, "branch": dict(branch) if branch else None},
+    }
+
+
+# ---------------------------------------------------------------------------
+# derive_business_location
+# ---------------------------------------------------------------------------
+
+
+def test_firm_only_snapshot_uses_the_firm_address():
+    result = derive_business_location(_metadata(branch=None))
+
+    assert result == {
+        "city": "SANDY",
+        "area": "",
+        "address": "9539 S PROSPERITY RD, SUITE 200",
+        "pin_zip": "84070",
+    }
+
+
+def test_branch_office_is_preferred_over_the_firm_address():
+    result = derive_business_location(_metadata(branch=_BRANCH_OFFICE))
+
+    assert result["city"] == "PARK CITY"
+    assert result["address"] == "1441 W UTE BLVD"
+    assert result["pin_zip"] == "84098"
+    # The firm HQ is not mixed in beside the branch street.
+    assert "SANDY" not in result.values()
+    assert result["pin_zip"] != "84070"
+
+
+def test_private_residence_branch_falls_back_to_the_firm_and_leaks_nothing():
+    result = derive_business_location(_metadata(branch=_BRANCH_HOME))
+
+    assert result["city"] == "SANDY"
+    assert result["address"] == "9539 S PROSPERITY RD, SUITE 200"
+    assert result["pin_zip"] == "84070"
+    # No fragment of the home address appears under ANY key.
+    published = " | ".join(result.values())
+    for secret in ("HEBER CITY", "742 EVERGREEN TERRACE", "84032"):
+        assert secret not in published
+
+
+def test_private_residence_with_no_firm_address_publishes_nothing():
+    result = derive_business_location(_metadata(firm={}, branch=_BRANCH_HOME))
+
+    assert result == {"city": "", "area": "", "address": "", "pin_zip": ""}
+
+
+def test_street2_is_joined_onto_street1():
+    single = derive_business_location(_metadata(firm={**_FIRM_RECORD, "street2": None}))
+    assert single["address"] == "9539 S PROSPERITY RD"
+
+    joined = derive_business_location(_metadata())
+    assert joined["address"] == "9539 S PROSPERITY RD, SUITE 200"
+
+
+def test_values_are_trimmed():
+    result = derive_business_location(
+        _metadata(
+            firm={
+                "street1": "  9539 S PROSPERITY RD  ",
+                "street2": "  SUITE 200 ",
+                "city": "  SANDY ",
+                "zip": " 84070  ",
+            }
+        )
+    )
+
+    assert result == {
+        "city": "SANDY",
+        "area": "",
+        "address": "9539 S PROSPERITY RD, SUITE 200",
+        "pin_zip": "84070",
+    }
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"firm_record": None, "advisor_record": None},
+        {"firm_record": {}, "advisor_record": {"branch": {}}},
+        {"firm_record": "not-a-dict", "advisor_record": ["not-a-dict"]},
+        None,
+    ],
+)
+def test_missing_or_malformed_metadata_returns_empty_strings(metadata):
+    result = derive_business_location(metadata)
+
+    assert result == {"city": "", "area": "", "address": "", "pin_zip": ""}
+    assert all(isinstance(value, str) for value in result.values())
+
+
+def test_area_is_never_invented():
+    # The SEC feed has no locality concept; the row must honestly read blank.
+    assert derive_business_location(_metadata(branch=_BRANCH_OFFICE))["area"] == ""
+    assert derive_business_location(_metadata())["area"] == ""
+
+
+def test_branch_without_a_street_defers_to_the_firms_full_address():
+    branch = {"city": "PARK CITY", "state": "UT", "street1": None, "zip": None}
+    result = derive_business_location(_metadata(branch=branch))
+
+    # A city-only branch cannot fill the street the map needs, and half a branch
+    # beside half a firm address would be an address on no filing.
+    assert result["address"] == "9539 S PROSPERITY RD, SUITE 200"
+    assert result["city"] == "SANDY"
+    assert result["pin_zip"] == "84070"
+
+
+# ---------------------------------------------------------------------------
+# The claim write
+# ---------------------------------------------------------------------------
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeClaimConn:
+    """Enough of asyncpg for claim_ria_profile_from_identity to run through."""
+
+    def __init__(self, *, contacts_table_missing: bool = False):
+        self.contacts_table_missing = contacts_table_missing
+        self.executes: list[tuple[str, tuple[Any, ...]]] = []
+
+    def transaction(self):
+        return _FakeTransaction()
+
+    async def fetchrow(self, query: str, *_args: Any):
+        if "INSERT INTO ria_profiles" in query:
+            return {
+                "id": "ria-profile-1",
+                "user_id": _USER_ID,
+                "display_name": "Reginald Troy Maxfield",
+                "legal_name": "REGINALD TROY MAXFIELD",
+                "finra_crd": "5308823",
+                "verification_status": "verified",
+            }
+        if "INSERT INTO ria_firms" in query:
+            return {"id": "firm-1"}
+        # No pre-existing profile row.
+        return None
+
+    async def execute(self, query: str, *args: Any) -> str:
+        if "ria_business_contacts" in query and self.contacts_table_missing:
+            raise asyncpg.exceptions.UndefinedTableError("relation does not exist")
+        self.executes.append((query, args))
+        return "OK"
+
+    async def close(self) -> None:
+        return None
+
+    def contacts_write(self) -> tuple[str, tuple[Any, ...]]:
+        for query, args in self.executes:
+            if "INSERT INTO ria_business_contacts" in query:
+                return query, args
+        raise AssertionError("no ria_business_contacts write was issued")
+
+
+def _claim_service(monkeypatch, conn: _FakeClaimConn) -> RIAIAMService:
+    service = RIAIAMService()
+
+    async def _fake_conn():
+        return conn
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _noop)
+    monkeypatch.setattr(service, "_ensure_vault_user_row", _noop)
+    monkeypatch.setattr(service, "_set_runtime_last_persona", _noop)
+    return service
+
+
+async def _claim(service: RIAIAMService, **overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "claim_type": "individual",
+        "verification_level": "verified",
+        "phone_e164": "+18015663510",
+        "display_name": "Reginald Troy Maxfield",
+        "legal_name": "REGINALD TROY MAXFIELD",
+        "crd_number": "5308823",
+        "firm_name": "OLYMPUS PEAKS FINANCIAL, LLC",
+        "firm_crd": "283040",
+        "reference_metadata": _metadata(),
+        "business_location": derive_business_location(_metadata()),
+    }
+    kwargs.update(overrides)
+    return await service.claim_ria_profile_from_identity(_USER_ID, **kwargs)
+
+
+async def test_claim_write_persists_the_derived_location(monkeypatch):
+    conn = _FakeClaimConn()
+    service = _claim_service(monkeypatch, conn)
+
+    await _claim(service)
+
+    _, args = conn.contacts_write()
+    assert args[0] == _USER_ID
+    assert args[1] == "+18015663510"
+    assert args[2] == "SANDY"
+    assert args[3] == ""  # area: never invented
+    assert args[4] == "9539 S PROSPERITY RD, SUITE 200"
+    assert args[5] == "84070"
+
+
+async def test_claim_write_without_a_location_still_writes_the_phone(monkeypatch):
+    conn = _FakeClaimConn()
+    service = _claim_service(monkeypatch, conn)
+
+    await _claim(service, business_location=None)
+
+    _, args = conn.contacts_write()
+    assert args[1] == "+18015663510"
+    assert args[2:6] == ("", "", "", "")
+
+
+async def test_claim_write_only_fills_blanks_and_never_typed_values(monkeypatch):
+    conn = _FakeClaimConn()
+    service = _claim_service(monkeypatch, conn)
+
+    await _claim(service)
+
+    query, _ = conn.contacts_write()
+    normalized = " ".join(query.split())
+    for column in ("city", "area_locality", "full_street_address", "pin_zip"):
+        guard = (
+            f"{column} = COALESCE(NULLIF(EXCLUDED.{column}, ''), ria_business_contacts.{column})"
+        )
+        assert guard in normalized, f"{column} may overwrite an adviser-typed value"
+    # The SEC feed carries no coordinates; the claim must not touch them.
+    assert "latitude" not in normalized
+    assert "longitude" not in normalized
+
+
+async def test_claim_survives_a_missing_business_contacts_table(monkeypatch):
+    conn = _FakeClaimConn(contacts_table_missing=True)
+    service = _claim_service(monkeypatch, conn)
+
+    profile = await _claim(service)
+
+    assert profile["ria_profile_id"] == "ria-profile-1"
+    assert profile["verification_status"] == "verified"
+
+
+async def test_completing_a_claim_hands_the_derived_location_to_the_iam_service(monkeypatch):
+    """The parsing lives in the claim service; the IAM service is only told."""
+    from hushh_mcp.services.ria_claim_service import RIAClaimService
+
+    calls: list[dict[str, Any]] = []
+
+    class _FakeIdentityClient:
+        async def claim_evaluate(self, **_kwargs):
+            return {
+                "ok": True,
+                "claimType": "firm",
+                "provisional": True,
+                "profileVerified": True,
+                "verificationLevel": "verified",
+                "firm": {
+                    "crd": 283040,
+                    "name": "OLYMPUS PEAKS FINANCIAL, LLC",
+                    "address": {
+                        "street1": "9539 S PROSPERITY RD",
+                        "street2": "SUITE 200",
+                        "city": "SANDY",
+                        "state": "UT",
+                        "zip": "84070",
+                    },
+                },
+                "roster": [],
+            }
+
+    class _FakeIamService:
+        async def claim_ria_profile_from_identity(self, user_id, **kwargs):
+            calls.append({"user_id": user_id, **kwargs})
+            return {"ria_profile_id": "ria-profile-1", "verification_status": "verified"}
+
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+
+    async def _no_dossier(**_kwargs):
+        return None
+
+    async def _no_enrichment(*_args, **_kwargs):
+        return None
+
+    service = RIAClaimService(client=_FakeIdentityClient(), iam_service=_FakeIamService())
+    monkeypatch.setattr(service, "_dispatch_dossier", _no_dossier)
+    monkeypatch.setattr(service, "_record_claim_enrichment", _no_enrichment)
+
+    await service.complete(
+        user_id=_USER_ID,
+        phone_digits="8015663510",
+        claim_type="firm",
+        firm_crd=283040,
+    )
+
+    assert calls[0]["business_location"] == {
+        "city": "SANDY",
+        "area": "",
+        "address": "9539 S PROSPERITY RD, SUITE 200",
+        "pin_zip": "84070",
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_ria_onboarding_status: the read-time fallback
+# ---------------------------------------------------------------------------
+
+
+class _FakeStatusConn:
+    def __init__(self, *, contact: dict | None, claim_metadata: dict | None):
+        self.contact = contact
+        self.claim_metadata = claim_metadata
+        self.executes: list[str] = []
+
+    async def fetchrow(self, query: str, *_args: Any):
+        if "FROM ria_verification_events" in query:
+            if self.claim_metadata is None:
+                return None
+            return {
+                "outcome": "verified",
+                "checked_at": _NOW - timedelta(hours=1),
+                "expires_at": None,
+                "reference_metadata": json.dumps(self.claim_metadata),
+            }
+        if "FROM ria_business_contacts" in query:
+            return dict(self.contact) if self.contact is not None else None
+        if "FROM ria_profiles" in query and "requested_capabilities" in query:
+            return {
+                "id": "ria-profile-1",
+                "user_id": _USER_ID,
+                "display_name": "Reginald Troy Maxfield",
+                "requested_capabilities": ["advisory"],
+                "individual_legal_name": "REGINALD TROY MAXFIELD",
+                "individual_crd": "5308823",
+                "advisory_firm_legal_name": "OLYMPUS PEAKS FINANCIAL, LLC",
+                "advisory_firm_iapd_number": "801-134885",
+                "broker_firm_legal_name": None,
+                "broker_firm_crd": None,
+                "advisory_status": "verified",
+                "brokerage_status": None,
+                "advisory_provider": "ria_identity_claim",
+                "brokerage_provider": None,
+                "advisory_verification_expires_at": None,
+                "brokerage_verification_expires_at": None,
+                "legal_name": "REGINALD TROY MAXFIELD",
+                "finra_crd": "5308823",
+                "sec_iard": None,
+                "verification_status": "verified",
+                "verification_provider": "ria_identity_claim",
+                "verification_expires_at": None,
+                "created_at": _NOW - timedelta(days=1),
+                "updated_at": _NOW,
+            }
+        if "FROM ria_profiles" in query and "license_number" in query:
+            return {}
+        return None
+
+    async def execute(self, query: str, *_args: Any) -> str:
+        self.executes.append(query)
+        return "OK"
+
+    async def close(self) -> None:
+        return None
+
+
+def _empty_contact_row() -> dict[str, Any]:
+    return {
+        "city": None,
+        "area_locality": None,
+        "full_street_address": None,
+        "pin_zip": None,
+        "latitude": None,
+        "longitude": None,
+        "email": "adviser@olympuspeaks.com",
+        "phone": "+18015663510",
+    }
+
+
+def _status_service(monkeypatch, conn: _FakeStatusConn) -> RIAIAMService:
+    service = RIAIAMService()
+
+    async def _fake_conn():
+        return conn
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    monkeypatch.setattr(service, "_ensure_iam_schema_ready", _noop)
+    monkeypatch.setattr(service, "_ensure_vault_user_row", _noop)
+    monkeypatch.setattr(service, "_ensure_actor_profile_row", _noop)
+    return service
+
+
+async def test_status_fills_an_empty_contact_row_from_the_claim_snapshot(monkeypatch):
+    conn = _FakeStatusConn(contact=_empty_contact_row(), claim_metadata=_metadata())
+    service = _status_service(monkeypatch, conn)
+
+    result = await service.get_ria_onboarding_status(_USER_ID)
+
+    assert result["business_city"] == "SANDY"
+    assert result["business_address"] == "9539 S PROSPERITY RD, SUITE 200"
+    assert result["business_pin_zip"] == "84070"
+    assert result["business_area"] is None  # honestly "Not provided"
+    assert result["business_location_source"] == "sec_record"
+    # A GET writes nothing.
+    assert conn.executes == []
+
+
+async def test_status_never_publishes_a_private_residence_branch(monkeypatch):
+    conn = _FakeStatusConn(
+        contact=_empty_contact_row(), claim_metadata=_metadata(branch=_BRANCH_HOME)
+    )
+    service = _status_service(monkeypatch, conn)
+
+    result = await service.get_ria_onboarding_status(_USER_ID)
+
+    assert result["business_city"] == "SANDY"
+    assert result["business_address"] == "9539 S PROSPERITY RD, SUITE 200"
+    shown = " | ".join(
+        str(result[key] or "")
+        for key in ("business_city", "business_area", "business_address", "business_pin_zip")
+    )
+    for secret in ("HEBER CITY", "742 EVERGREEN TERRACE", "84032"):
+        assert secret not in shown
+
+
+async def test_stored_values_win_over_the_claim_snapshot(monkeypatch):
+    contact = _empty_contact_row()
+    contact.update(
+        {
+            "city": "Draper",
+            "area_locality": "Corner Canyon",
+            "full_street_address": "12 S Main St",
+            "pin_zip": "84020",
+        }
+    )
+    conn = _FakeStatusConn(contact=contact, claim_metadata=_metadata())
+    service = _status_service(monkeypatch, conn)
+
+    result = await service.get_ria_onboarding_status(_USER_ID)
+
+    assert result["business_city"] == "Draper"
+    assert result["business_area"] == "Corner Canyon"
+    assert result["business_address"] == "12 S Main St"
+    assert result["business_pin_zip"] == "84020"
+    assert result["business_location_source"] == "profile"
+
+
+async def test_a_typed_city_survives_while_a_blank_address_is_filled(monkeypatch):
+    contact = _empty_contact_row()
+    contact["city"] = "Draper"
+    conn = _FakeStatusConn(contact=contact, claim_metadata=_metadata())
+    service = _status_service(monkeypatch, conn)
+
+    result = await service.get_ria_onboarding_status(_USER_ID)
+
+    assert result["business_city"] == "Draper"
+    assert result["business_address"] == "9539 S PROSPERITY RD, SUITE 200"
+    assert result["business_location_source"] == "sec_record"
+
+
+async def test_status_without_a_claim_or_contact_row_reports_no_source(monkeypatch):
+    conn = _FakeStatusConn(contact=None, claim_metadata=None)
+    service = _status_service(monkeypatch, conn)
+
+    result = await service.get_ria_onboarding_status(_USER_ID)
+
+    assert result["business_city"] is None
+    assert result["business_area"] is None
+    assert result["business_address"] is None
+    assert result["business_pin_zip"] is None
+    assert result["business_location_source"] is None
+
+
+async def test_wizard_profile_without_a_claim_keeps_reporting_profile(monkeypatch):
+    contact = _empty_contact_row()
+    contact.update({"city": "Draper", "full_street_address": "12 S Main St"})
+    conn = _FakeStatusConn(contact=contact, claim_metadata=None)
+    service = _status_service(monkeypatch, conn)
+
+    result = await service.get_ria_onboarding_status(_USER_ID)
+
+    assert result["business_city"] == "Draper"
+    assert result["business_location_source"] == "profile"
+    assert result["business_latitude"] is None

--- a/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
+++ b/hushh-webapp/__tests__/app/ria/profile-page.test.tsx
@@ -53,6 +53,10 @@ vi.mock("@/components/ria/onboarding/onboarding-step-review", () => ({
   OnboardingStepReview: () => <div data-testid="step-review" />,
 }));
 
+vi.mock("@/components/ria/profile/ria-location-map", () => ({
+  RiaLocationMap: () => <div data-testid="ria-location-map" />,
+}));
+
 vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
   OnboardingStepServices: () => <div data-testid="step-services" />,
 }));

--- a/hushh-webapp/__tests__/components/ria/ria-dossier-card.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-dossier-card.test.tsx
@@ -39,6 +39,10 @@ vi.mock("lucide-react", () => ({
   Trash2: () => <span />,
 }));
 
+vi.mock("@/components/ria/profile/ria-location-map", () => ({
+  RiaLocationMap: () => <div data-testid="ria-location-map" />,
+}));
+
 vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
   OnboardingStepServices: () => <div data-testid="step-services" />,
 }));

--- a/hushh-webapp/__tests__/components/ria/ria-location-map.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-location-map.test.tsx
@@ -1,0 +1,194 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useCurrentLocation: vi.fn(),
+  request: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("lucide-react", () => ({
+  MapPin: () => <span data-testid="map-pin-icon" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/lib/one-location/use-current-location", () => ({
+  useCurrentLocation: mocks.useCurrentLocation,
+}));
+
+import { RiaLocationMap } from "@/components/ria/profile/ria-location-map";
+
+const ADDRESS = {
+  fullStreetAddress: "4050 E. Cotton Center Blvd.",
+  areaLocality: "Cotton Center",
+  city: "Phoenix",
+  pinZip: "85040",
+};
+
+const DESTINATION =
+  "4050 E. Cotton Center Blvd., Cotton Center, Phoenix, 85040";
+
+function setLocation(
+  state: Partial<{
+    status: string;
+    permission: string | null;
+    snapshot: {
+      latitude: number;
+      longitude: number;
+      accuracyM: number | null;
+      capturedAt: string;
+    } | null;
+    error: string | null;
+  }> = {},
+) {
+  mocks.useCurrentLocation.mockReturnValue({
+    status: "idle",
+    permission: null,
+    snapshot: null,
+    error: null,
+    request: mocks.request,
+    refresh: mocks.refresh,
+    ...state,
+  });
+}
+
+describe("RiaLocationMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setLocation();
+  });
+
+  it("renders the office-only embed while no position is held", () => {
+    render(<RiaLocationMap {...ADDRESS} />);
+
+    const office = screen.getByTestId("ria-location-map-office");
+    expect(office.getAttribute("src")).toContain("output=embed");
+    expect(office.getAttribute("src")).toContain(
+      encodeURIComponent(DESTINATION),
+    );
+    expect(screen.queryByTestId("ria-location-map-route")).toBeNull();
+    expect(screen.getByTestId("ria-location-map-show-route")).toBeTruthy();
+  });
+
+  it("never asks for location on mount — only from the button", () => {
+    render(<RiaLocationMap {...ADDRESS} />);
+    expect(mocks.request).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("ria-location-map-show-route"));
+    expect(mocks.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a busy button while locating", () => {
+    setLocation({ status: "locating", permission: "granted" });
+    render(<RiaLocationMap {...ADDRESS} />);
+
+    const button = screen.getByTestId(
+      "ria-location-map-show-route",
+    ) as HTMLButtonElement;
+    expect(button.textContent).toContain("Locating");
+    expect(button.disabled).toBe(true);
+  });
+
+  it("renders the directions embed with both endpoints once a position exists", () => {
+    setLocation({
+      status: "ready",
+      permission: "granted",
+      snapshot: {
+        latitude: 12.9716,
+        longitude: 77.5946,
+        accuracyM: 12,
+        capturedAt: "2026-08-08T00:00:00.000Z",
+      },
+    });
+    render(<RiaLocationMap {...ADDRESS} />);
+
+    const route = screen.getByTestId("ria-location-map-route");
+    const src = route.getAttribute("src") ?? "";
+    expect(src).toContain("output=embed");
+    expect(src).toContain(`saddr=${encodeURIComponent("12.971600,77.594600")}`);
+    expect(src).toContain(`daddr=${encodeURIComponent(DESTINATION)}`);
+    // The route replaces the office-only view, and the prompt is spent.
+    expect(screen.queryByTestId("ria-location-map-office")).toBeNull();
+    expect(screen.queryByTestId("ria-location-map-show-route")).toBeNull();
+  });
+
+  it("keeps the office map and drops the dead button when permission is denied", () => {
+    setLocation({
+      status: "denied",
+      permission: "denied",
+      error: "Location is off for Hussh.",
+    });
+    render(<RiaLocationMap {...ADDRESS} />);
+
+    expect(screen.getByTestId("ria-location-map-office")).toBeTruthy();
+    expect(screen.getByTestId("ria-location-map-denied").textContent).toContain(
+      "Location is off — showing the office only.",
+    );
+    expect(screen.queryByTestId("ria-location-map-show-route")).toBeNull();
+  });
+
+  it("treats an unavailable device the same as denied", () => {
+    setLocation({ status: "unavailable", permission: "unavailable" });
+    render(<RiaLocationMap {...ADDRESS} />);
+
+    expect(screen.getByTestId("ria-location-map-office")).toBeTruthy();
+    expect(screen.queryByTestId("ria-location-map-show-route")).toBeNull();
+  });
+
+  it("names every missing field instead of hiding the map", () => {
+    render(
+      <RiaLocationMap
+        fullStreetAddress=""
+        areaLocality=""
+        city=""
+        pinZip="   "
+      />,
+    );
+
+    expect(screen.getByTestId("ria-location-map-missing").textContent).toContain(
+      "Location unavailable — missing: street address, area, city, PIN / ZIP",
+    );
+    expect(screen.queryByTestId("ria-location-map-office")).toBeNull();
+    expect(screen.queryByTestId("ria-location-map-route")).toBeNull();
+    // Nothing to route to, so no control is offered.
+    expect(screen.queryByTestId("ria-location-map-show-route")).toBeNull();
+  });
+
+  it("names only the fields actually missing", () => {
+    render(
+      <RiaLocationMap
+        fullStreetAddress=""
+        areaLocality=""
+        city="Phoenix"
+        pinZip="85040"
+      />,
+    );
+
+    const office = screen.getByTestId("ria-location-map-office");
+    expect(office.getAttribute("src")).toContain(
+      encodeURIComponent("Phoenix, 85040"),
+    );
+    expect(screen.queryByTestId("ria-location-map-missing")).toBeNull();
+  });
+
+  it("keeps a retryable button when a fix fails but permission is intact", () => {
+    setLocation({
+      status: "error",
+      permission: "granted",
+      error: "Could not get your location.",
+    });
+    render(<RiaLocationMap {...ADDRESS} />);
+
+    expect(screen.getByTestId("ria-location-map-show-route")).toBeTruthy();
+    expect(screen.queryByTestId("ria-location-map-denied")).toBeNull();
+  });
+});

--- a/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-redirect-loop.test.tsx
@@ -53,6 +53,10 @@ vi.mock("lucide-react", () => ({
   Trash2: () => <span />,
 }));
 
+vi.mock("@/components/ria/profile/ria-location-map", () => ({
+  RiaLocationMap: () => <div data-testid="ria-location-map" />,
+}));
+
 vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
   OnboardingStepServices: () => <div data-testid="step-services" />,
 }));

--- a/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
@@ -37,6 +37,10 @@ vi.mock("lucide-react", () => ({
   Trash2: () => <span />,
 }));
 
+vi.mock("@/components/ria/profile/ria-location-map", () => ({
+  RiaLocationMap: () => <div data-testid="ria-location-map" />,
+}));
+
 vi.mock("@/components/ria/onboarding/onboarding-step-services", () => ({
   OnboardingStepServices: () => <div data-testid="step-services" />,
 }));
@@ -240,6 +244,15 @@ describe("RiaProfileSection verification chip + email nudge", () => {
     ).toContain("Not verified");
     expect(screen.getByTestId("ria-email-verify-card")).toBeTruthy();
     expect(screen.getByText("Verify with your work email")).toBeTruthy();
+  });
+
+  it("mounts the location map inside the Location group", () => {
+    renderSection({ ...BASE_STATUS });
+
+    const locationGroup = screen.getByTestId("ria-profile-location-summary");
+    expect(
+      locationGroup.querySelector('[data-testid="ria-location-map"]'),
+    ).toBeTruthy();
   });
 
   it("renders the Verified chip and no nudge when verified", async () => {

--- a/hushh-webapp/__tests__/lib/ria/ria-profile-view-model.test.ts
+++ b/hushh-webapp/__tests__/lib/ria/ria-profile-view-model.test.ts
@@ -103,4 +103,28 @@ describe("ria-profile-view-model", () => {
     // Verified advisor is seeded as licence-found so the draft is coherent.
     expect(draft.licenseVerificationStatus).toBe("found");
   });
+
+  it("seeds stored coordinates so saving the profile cannot wipe them", () => {
+    const draft = seedRiaDraftFromStatus(
+      baseStatus({ business_latitude: 33.4084, business_longitude: -111.9797 }),
+    );
+    expect(draft.latitude).toBe(33.4084);
+    expect(draft.longitude).toBe(-111.9797);
+
+    // Mirrors the payload ria-profile-section builds in handleSaveProfile:
+    // before the seeding fix these resolved to undefined on every save, which
+    // erased the adviser's geocoded office.
+    const savePayload = {
+      business_latitude: draft.latitude ?? undefined,
+      business_longitude: draft.longitude ?? undefined,
+    };
+    expect(savePayload.business_latitude).toBe(33.4084);
+    expect(savePayload.business_longitude).toBe(-111.9797);
+  });
+
+  it("leaves coordinates null when the record has none", () => {
+    const draft = seedRiaDraftFromStatus(baseStatus());
+    expect(draft.latitude).toBeNull();
+    expect(draft.longitude).toBeNull();
+  });
 });

--- a/hushh-webapp/components/ria/profile/ria-location-map.tsx
+++ b/hushh-webapp/components/ria/profile/ria-location-map.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+/**
+ * RIA profile — the adviser's registered office, and the route to it.
+ *
+ * The office is known only as words (four address fields off the SEC record),
+ * so both embeds are the keyless Google Maps iframes, which geocode the text
+ * themselves. With a position for the viewer the directions embed draws the
+ * route, both markers, and fits the viewport to them natively.
+ *
+ * Location is never requested on mount. iOS grants exactly one system prompt,
+ * and spending it on a screen the user opened to read their profile would burn
+ * it before they know why — so the prompt hangs off an explicit "Show route".
+ * A viewer who already granted permission gets the route with no tap, because
+ * useCurrentLocation()'s auto pass reads an existing grant without prompting.
+ */
+
+import { MapPin } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  googleMapsDirectionsEmbedUrl,
+  googleMapsLocationEmbedUrl,
+} from "@/lib/one-location/maps-urls";
+import { useCurrentLocation } from "@/lib/one-location/use-current-location";
+
+/** Address parts in composition order, paired with how we name a gap. */
+const ADDRESS_FIELD_LABELS = [
+  "street address",
+  "area",
+  "city",
+  "PIN / ZIP",
+] as const;
+
+const MAP_FRAME_CLASS = "h-[180px] w-full border-0";
+
+export interface RiaLocationMapProps {
+  city: string;
+  areaLocality: string;
+  fullStreetAddress: string;
+  pinZip: string;
+}
+
+export function RiaLocationMap({
+  city,
+  areaLocality,
+  fullStreetAddress,
+  pinZip,
+}: RiaLocationMapProps) {
+  const { status, permission, snapshot, request } = useCurrentLocation();
+
+  // Same composition as the onboarding location step, so the pin the adviser
+  // previewed while editing is the pin the reader sees here.
+  const parts = [fullStreetAddress, areaLocality, city, pinZip].map((part) =>
+    (part ?? "").trim(),
+  );
+  const destination = parts.filter(Boolean).join(", ");
+  const missing = ADDRESS_FIELD_LABELS.filter((_, index) => !parts[index]);
+
+  const origin = snapshot
+    ? { lat: snapshot.latitude, lng: snapshot.longitude }
+    : null;
+
+  // Denied and unavailable are terminal for this screen: the OS will not
+  // re-prompt, so offering a button that cannot work would be a dead control.
+  const blocked =
+    status === "denied" ||
+    status === "unavailable" ||
+    permission === "denied" ||
+    permission === "restricted" ||
+    permission === "unavailable";
+  const locating = status === "locating";
+
+  const routeSrc =
+    destination && origin
+      ? googleMapsDirectionsEmbedUrl(origin, destination)
+      : "";
+  const officeSrc = destination ? googleMapsLocationEmbedUrl(destination) : "";
+
+  return (
+    <div className="p-3" data-testid="ria-location-map">
+      <div className="overflow-hidden rounded-[22px] border border-[color:var(--border)] bg-[color:var(--card)]">
+        {routeSrc ? (
+          <iframe
+            title="Route from your location to the advisor's office"
+            src={routeSrc}
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+            className={MAP_FRAME_CLASS}
+            data-testid="ria-location-map-route"
+          />
+        ) : officeSrc ? (
+          <iframe
+            title="Advisor office location"
+            src={officeSrc}
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+            className={MAP_FRAME_CLASS}
+            data-testid="ria-location-map-office"
+          />
+        ) : (
+          <div
+            className="flex h-[180px] flex-col items-center justify-center gap-2 px-4 text-center"
+            data-testid="ria-location-map-missing"
+          >
+            <MapPin className="h-4 w-4 text-muted-foreground" />
+            <p className="text-[13px] leading-[1.4] text-muted-foreground">
+              {`Location unavailable — missing: ${missing.join(", ")}`}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {destination && !origin ? (
+        <div className="mt-3 flex items-center justify-between gap-3">
+          {blocked ? (
+            <p
+              className="text-[13px] text-muted-foreground"
+              data-testid="ria-location-map-denied"
+            >
+              Location is off — showing the office only.
+            </p>
+          ) : (
+            <>
+              <p className="text-[13px] text-muted-foreground">
+                {status === "error"
+                  ? "Couldn't get your location."
+                  : "See how far the office is from you."}
+              </p>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={locating}
+                onClick={() => {
+                  void request();
+                }}
+                data-testid="ria-location-map-show-route"
+              >
+                {locating ? "Locating…" : "Show route"}
+              </Button>
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -23,6 +23,7 @@ import {
   type RiaSecAdvisorRecord,
   type RiaSecFirmRecord,
 } from "@/components/ria/profile/ria-sec-record-section";
+import { RiaLocationMap } from "@/components/ria/profile/ria-location-map";
 import { OnboardingStepServices } from "@/components/ria/onboarding/onboarding-step-services";
 import {
   SettingsDetailPanel,
@@ -261,6 +262,12 @@ function RiaRegulatoryProfileSummary({
           title="PIN / ZIP"
           value={reviewProps.pinZip}
           testId="ria-profile-summary-pin-zip"
+        />
+        <RiaLocationMap
+          city={reviewProps.city}
+          areaLocality={reviewProps.areaLocality}
+          fullStreetAddress={reviewProps.fullStreetAddress}
+          pinZip={reviewProps.pinZip}
         />
         <SettingsRow
           icon={Pencil}

--- a/hushh-webapp/lib/one-location/__tests__/maps-urls.test.ts
+++ b/hushh-webapp/lib/one-location/__tests__/maps-urls.test.ts
@@ -47,4 +47,21 @@ describe("googleMapsDirectionsEmbedUrl", () => {
     expect(url).toContain(`saddr=${encodeURIComponent("12.971600,77.594600")}`);
     expect(url).toContain(`daddr=${encodeURIComponent("28.556200,77.100000")}`);
   });
+
+  it("accepts a text address as a destination", () => {
+    const url = googleMapsDirectionsEmbedUrl(
+      { lat: 12.9716, lng: 77.5946 },
+      "4050 E. Cotton Center Blvd., Phoenix, 85040",
+    );
+    expect(url).toContain(`saddr=${encodeURIComponent("12.971600,77.594600")}`);
+    expect(url).toContain(
+      `daddr=${encodeURIComponent("4050 E. Cotton Center Blvd., Phoenix, 85040")}`,
+    );
+  });
+
+  it("accepts a text address for the single-location embed", () => {
+    const url = googleMapsLocationEmbedUrl("Phoenix, 85040");
+    expect(url).toContain("output=embed");
+    expect(url).toContain(`q=${encodeURIComponent("Phoenix, 85040")}`);
+  });
 });

--- a/hushh-webapp/lib/one-location/maps-urls.ts
+++ b/hushh-webapp/lib/one-location/maps-urls.ts
@@ -16,8 +16,25 @@ export function locationCoordinateQuery(point: PlainLocationPoint): string {
   ].join(",");
 }
 
-export function googleMapsLocationEmbedUrl(point: PlainLocationPoint): string {
-  const query = encodeURIComponent(locationCoordinateQuery(point));
+/**
+ * Anything the keyless Google Maps embeds accept as a place: a coordinate we
+ * hold, or a free-text address we only know as words. Surfaces that read an
+ * address out of a record (an adviser's registered office, a saved place) never
+ * have a lat/lng, and the embed geocodes the text for them — so the helpers
+ * take either rather than forcing a caller to geocode first.
+ */
+export type MapsPlace = LatLngLiteral | PlainLocationPoint | string;
+
+function placeQuery(place: MapsPlace): string {
+  if (typeof place === "string") return place.trim();
+  if ("lat" in place) {
+    return `${formatCoordinate(place.lat)},${formatCoordinate(place.lng)}`;
+  }
+  return locationCoordinateQuery(place);
+}
+
+export function googleMapsLocationEmbedUrl(place: MapsPlace): string {
+  const query = encodeURIComponent(placeQuery(place));
   return `https://www.google.com/maps?q=${query}&z=16&output=embed`;
 }
 
@@ -26,15 +43,15 @@ export function googleMapsDirectionsUrl(point: PlainLocationPoint): string {
   return `https://www.google.com/maps/dir/?api=1&destination=${destination}&travelmode=driving`;
 }
 
+/**
+ * A keyless directions embed. Google draws the route, both markers and fits the
+ * viewport to them itself, so callers do not compute bounds.
+ */
 export function googleMapsDirectionsEmbedUrl(
-  origin: LatLngLiteral,
-  destination: LatLngLiteral,
+  origin: MapsPlace,
+  destination: MapsPlace,
 ): string {
-  const saddr = encodeURIComponent(
-    `${formatCoordinate(origin.lat)},${formatCoordinate(origin.lng)}`,
-  );
-  const daddr = encodeURIComponent(
-    `${formatCoordinate(destination.lat)},${formatCoordinate(destination.lng)}`,
-  );
+  const saddr = encodeURIComponent(placeQuery(origin));
+  const daddr = encodeURIComponent(placeQuery(destination));
   return `https://www.google.com/maps?saddr=${saddr}&daddr=${daddr}&output=embed`;
 }

--- a/hushh-webapp/lib/ria/ria-profile-view-model.ts
+++ b/hushh-webapp/lib/ria/ria-profile-view-model.ts
@@ -8,6 +8,10 @@ function text(value: string | null | undefined): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function number(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 function stringArray(value: string[] | null | undefined): string[] {
   return Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
 }
@@ -101,6 +105,12 @@ export function seedRiaDraftFromStatus(
     pinZip: props.pinZip,
     areaLocality: props.areaLocality,
     fullStreetAddress: props.fullStreetAddress,
+    // The profile save sends `draft.latitude/longitude` verbatim. Leaving them
+    // unseeded meant every save wrote undefined over whatever coordinates the
+    // record already held, so opening the edit panel and saving silently
+    // dropped the adviser's geocoded office.
+    latitude: number(status?.business_latitude),
+    longitude: number(status?.business_longitude),
     contactEmail: text(status?.contact_email),
     contactPhone: text(status?.contact_phone),
     licenseVerificationStatus: isRiaAdvisoryAccessReady(status)

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -171,6 +171,12 @@ export interface RiaOnboardingStatus {
   business_pin_zip?: string | null;
   business_latitude?: number | null;
   business_longitude?: number | null;
+  /**
+   * Where the shown address came from: "profile" when the adviser entered it,
+   * "sec_record" when any shown value was derived from their claimed SEC
+   * filing, null when there is no address at all.
+   */
+  business_location_source?: "profile" | "sec_record" | null;
   bio?: string | null;
   strategy?: string | null;
   disclosures_url?: string | null;


### PR DESCRIPTION
## What you reported
The LOCATION rows on `/ria/profile` all read **"Not provided"**, and the map that used to be there is gone.

## What I found (before changing anything)

**The rows are working.** "Not provided" is the formatter's honest output for an empty value — this is a **backend-data problem**, not a mapping or rendering fault.

**Where the data comes from:** `GET /api/ria/onboarding/status` → `get_ria_onboarding_status`, which reads `business_city / business_area / business_address / business_pin_zip / business_latitude / business_longitude` from the **`ria_business_contacts`** table (the RIA profile table has no address columns at all).

**Why it's empty:** the onboarding *wizard* writes that table because the adviser types the address. The **claim** path (`claim_ria_profile_from_identity`) wrote **only the phone number** — so every phone-claimed adviser has a permanently empty address. Meanwhile the SEC firm address *and* the adviser's branch address were already fetched and persisted in the same transaction's `reference_metadata`, and the screen was already printing the branch city in the "From your SEC record" section directly below the empty rows.

**About the map — an honest correction:** no commit in this repository's history, on any branch, has ever rendered a map under `app/ria/**` or `components/ria/**`. Nothing was removed from this screen. Two real things were being remembered:
1. `DriveRouteMap` — a genuine Directions-API route map with markers, `fitBounds` and a polyline fallback — shipped 2026-07-13 (PR #4433) and **silently deleted 2026-07-22 by `754acc277`** (PR #4625) as collateral in a 3,567-line One Location sweep, with no stated reason. It lived on One Location → Drive to; its destination was a place, never an adviser. Its orphaned helper `googleMapsDirectionsEmbedUrl` has had zero callers ever since.
2. PR #4799, titled *"put advisers on the map in Connect"* — live on main, but it renders a **list** with distances. The title is figurative.

So this is a **first build**, and it revives that orphaned helper for its intended purpose.

## The fix

**Backend**
- `derive_business_location(reference_metadata)` — pure, no I/O. Prefers the adviser's branch address, **never when the SEC flags it a private residence** (then the firm's filed address is used, whole — half a branch beside half a firm address is an address on no filing). `area` stays empty: the feed has no locality concept.
- The claim writes it **filling blanks only** (`COALESCE(NULLIF(EXCLUDED.x,''), existing)`), so nothing self-entered is ever overwritten. The email-upgrade re-claim passes it too.
- `get_ria_onboarding_status` derives the same values at read time when stored ones are empty, so **advisers who already claimed see their office immediately, without re-claiming**. Pure read; stored wins. New key `business_location_source: "profile" | "sec_record" | null` so the two are never blurred.

**Frontend**
- `RiaLocationMap` inside the existing Location group (no layout moved): office-only by default; the full **route with both markers, auto-fitted** once the viewer shares position.
- **Permission is never requested on mount** — iOS grants exactly one prompt, so it is spent on an explicit "Show route" tap. Already-granted viewers get the route with no tap.
- Denied/unavailable → keeps the office map, removes the button (no dead control). No address → **names the exact missing fields** rather than hiding the map.
- `googleMapsDirectionsEmbedUrl`/`googleMapsLocationEmbedUrl` were typed for coordinates only and would have rendered a text address at `0.000000,0.000000`; both now accept coordinates **or** an address behind one normalizer, backward compatible with the existing caller.
- **Data-loss bug fixed:** `seedRiaDraftFromStatus` never read `latitude`/`longitude` back, so saving the profile silently erased stored coordinates.

No geocoder was added: the embed takes the address string, and coordinates stay null for claimed advisers by design (the SEC feed has none).

## Proof
- Backend gate (ruff, mypy, bandit, manifest): **733 passed**, 24 new — private-residence leak, branch-vs-firm selection, blanks-only upsert, read-time fallback, source reporting.
- Frontend: **3100 passed**, 14 new; `tsc` 0 errors; eslint clean.
- Pre-existing mypy findings verified identical against a clean `origin/main` extract — zero new.

Known edge, deliberately accepted: an adviser who *clears* their address sees the SEC-filed one return (a cleared value is indistinguishable from never-set at the DB level). Typing a different address wins permanently.