### PR TITLE
feat(ria): fill services, fees and bio from the adviser's Form ADV brochure

### DIFF
--- a/consent-protocol/db/contracts/dev_minimum_schema.json
+++ b/consent-protocol/db/contracts/dev_minimum_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 137,
+  "expected_migration_version": 139,
   "migration_version_policy": "minimum",
   "required_functions": [
     "merge_domain_summary",

--- a/consent-protocol/db/contracts/prod_core_schema.json
+++ b/consent-protocol/db/contracts/prod_core_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "prod_core_schema",
-  "expected_migration_version": 138,
+  "expected_migration_version": 139,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -101,6 +101,9 @@
       "fee_structure",
       "min_engagement_amount",
       "min_engagement_currency",
+      "profile_source",
+      "profile_source_url",
+      "profile_source_filed_on",
       "created_at",
       "updated_at"
     ],

--- a/consent-protocol/db/contracts/uat_integrated_schema.json
+++ b/consent-protocol/db/contracts/uat_integrated_schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "uat_integrated_schema",
-  "expected_migration_version": 138,
+  "expected_migration_version": 139,
   "migration_version_policy": "exact",
   "required_functions": [
     "merge_domain_summary",
@@ -101,6 +101,9 @@
       "fee_structure",
       "min_engagement_amount",
       "min_engagement_currency",
+      "profile_source",
+      "profile_source_url",
+      "profile_source_filed_on",
       "created_at",
       "updated_at"
     ],

--- a/consent-protocol/db/migrations/139_ria_profile_brochure_provenance.sql
+++ b/consent-protocol/db/migrations/139_ria_profile_brochure_provenance.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+-- Migration 139: say where a claimed adviser's profile words came from.
+--
+-- Services, fees and the engagement minimum are not published by the SEC
+-- identity API. They exist only as narrative prose inside the firm's own Form
+-- ADV Part 2A brochure, which the post-claim worker reads and writes into the
+-- blank fields on ria_profiles.
+--
+-- Those three sentences then sit on the profile looking exactly like something
+-- the adviser wrote. They are not. These columns record the filing they were
+-- taken from — which brochure, at which URL, filed on which date — so the UI
+-- can label them and the adviser can see, correct, or overwrite them against
+-- the actual source. Without provenance the profile would assert a filing's
+-- words as the adviser's own, which is the one thing this feature must not do.
+--
+-- All three are nullable and carry no default: a profile the adviser typed
+-- themselves has no source to name, and must keep saying nothing.
+ALTER TABLE ria_profiles
+  ADD COLUMN IF NOT EXISTS profile_source TEXT,
+  ADD COLUMN IF NOT EXISTS profile_source_url TEXT,
+  ADD COLUMN IF NOT EXISTS profile_source_filed_on TEXT;
+
+COMMENT ON COLUMN ria_profiles.profile_source IS
+  'Where the narrative profile fields came from, e.g. `form_adv_part2`. NULL means the adviser authored them.';
+
+COMMENT ON COLUMN ria_profiles.profile_source_url IS
+  'URL of the exact filing the narrative fields were read from, so a reader can check the words against the source.';
+
+COMMENT ON COLUMN ria_profiles.profile_source_filed_on IS
+  'Filing date of that source document, as the regulator published it (free text: the feed is not a date type).';
+
+COMMIT;

--- a/consent-protocol/db/migrations/rollback/139_ria_profile_brochure_provenance_down.sql
+++ b/consent-protocol/db/migrations/rollback/139_ria_profile_brochure_provenance_down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+-- Roll back migration 139.
+--
+-- Drops only the three provenance labels. The narrative fields they describe
+-- (services_offered, fee_structure, min_engagement_amount, bio) stay exactly
+-- as they are: those are values on a live profile, and dropping the label is
+-- not a reason to delete what it labelled.
+ALTER TABLE ria_profiles
+  DROP COLUMN IF EXISTS profile_source,
+  DROP COLUMN IF EXISTS profile_source_url,
+  DROP COLUMN IF EXISTS profile_source_filed_on;
+
+COMMIT;

--- a/consent-protocol/db/release_migration_manifest.json
+++ b/consent-protocol/db/release_migration_manifest.json
@@ -116,7 +116,8 @@
     "135_one_location_circle_connection_origins.sql",
     "136_one_location_circle_member_invites.sql",
     "137_ria_claim_dossiers.sql",
-    "138_circle_member_connection_origin.sql"
+    "138_circle_member_connection_origin.sql",
+    "139_ria_profile_brochure_provenance.sql"
   ],
   "groups": {
     "iam": [
@@ -187,7 +188,8 @@
       "135_one_location_circle_connection_origins.sql",
       "136_one_location_circle_member_invites.sql",
       "137_ria_claim_dossiers.sql",
-      "138_circle_member_connection_origin.sql"
+      "138_circle_member_connection_origin.sql",
+      "139_ria_profile_brochure_provenance.sql"
     ],
     "pkm": [
       "030_pkm_cutover.sql",

--- a/consent-protocol/hushh_mcp/services/ria_brochure_profile_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_brochure_profile_service.py
@@ -1,0 +1,639 @@
+"""Read a claimed adviser's Form ADV Part 2A brochure into profile fields.
+
+Services, fees, and the engagement minimum are NOT in the SEC identity API.
+They exist only as narrative prose inside the adviser's Form ADV Part 2
+brochure PDFs, whose URLs the claim snapshot already carries in
+``firm_record.brochures``. This module fetches that filing, reads a bounded
+slice of it, and asks the repo's existing Gemini runtime to return the few
+structured facts the profile shows.
+
+Three rules keep this honest rather than merely convenient:
+
+1. **Category, never rate.** A Part 2A fee schedule is typically tiered *and*
+   negotiable ("$0-$250,000 1.25% ... Fees for portfolio management services
+   are negotiable"). Publishing "1.25%" as *the* fee would misstate a
+   negotiable schedule, so ``fee_structure`` stays at the category level
+   ("Percentage of assets under management") and any entry carrying a rate is
+   dropped on the way out.
+2. **A stated absence is not a value.** Olympus Peaks' brochure says "There is
+   no account minimum for any of OPFL's services" — the only time the word
+   appears in 23 pages. A keyword grab near "minimum" would publish a number
+   the filing explicitly denies, so the prompt and the validator both treat a
+   stated absence as ``None``.
+3. **Never raise.** This is best-effort enrichment behind a claim that must
+   always stand. Every fault — fetch, size, parse, model, JSON — returns the
+   empty shape with an ``"error"`` key.
+
+Nothing from the PDF body is ever logged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import re
+from typing import Any
+
+import httpx
+
+from hushh_mcp.constants import GEMINI_MODEL
+from hushh_mcp.services.ria_claim_service import title_case_name
+
+logger = logging.getLogger(__name__)
+
+# Hard bounds. A Form ADV Part 2A is a ~20-30 page narrative; anything past
+# these limits is a filing we should decline rather than pay to read.
+FETCH_TIMEOUT_SECONDS = 20.0
+MAX_PDF_BYTES = 10 * 1024 * 1024
+MAX_PAGES = 15
+MAX_TEXT_CHARS = 40_000
+
+# Shape guards for what we are willing to publish onto a profile.
+MAX_LIST_ITEMS = 12
+MAX_ITEM_CHARS = 120
+# A plausible engagement minimum. Anything larger is a parse artefact
+# (an AUM figure, a fee table cell) rather than a stated minimum.
+MAX_MIN_ENGAGEMENT = 1_000_000_000.0
+
+_HTTP_HEADERS = {
+    "User-Agent": "hushh-consent-protocol/1.0 (+https://hushh.ai) Form ADV reader",
+    "Accept": "application/pdf,*/*",
+}
+
+# Table-of-contents debris: the section headers appear twice in a Part 2A,
+# once with dotted leaders and a page number, once as real content. Feeding
+# the leader lines to the model teaches it that "Item 5 Fees ... 7" is the
+# fee section, so they are stripped before the slice is taken.
+_TOC_LEADER_LINE = re.compile(r"\.{2,}\s*\d{1,3}\s*$")
+_TOC_HEADING_LINE = re.compile(r"^\s*table of contents\s*$", re.IGNORECASE)
+_TOC_ITEM_LINE = re.compile(r"^\s*item\s+\d+\b.*\s{2,}\d{1,3}\s*$", re.IGNORECASE)
+
+# A fee entry carrying a number is a rate, not a category.
+_RATE_LIKE = re.compile(
+    r"(\d\s*%|%\s*\d|\$\s*[\d,]|\b\d+(?:\.\d+)?\s*(?:bps|basis points)\b)", re.I
+)
+
+_EXTRACTION_PROMPT = """You are reading an investment adviser's Form ADV Part 2A brochure for {firm_name}.
+
+Extract ONLY what this brochure states. You are not summarising, advertising, or inferring.
+
+RULES — these override any instinct to be helpful:
+1. If the brochure does not state something, return an empty list or null. Never guess, never
+   generalise from what advisers usually offer, never carry a fact over from another firm.
+2. "services_offered" is a short list of the advisory services this brochure says the firm
+   provides (Item 4 / Item 7 territory). Use plain service names, e.g. "Portfolio management",
+   "Financial planning", "Retirement plan consulting". Do not include client types
+   ("Individuals", "High-net-worth individuals", "Pension plans") — those are who, not what.
+3. "fee_structure" is a list of fee CATEGORIES only, e.g. "Percentage of assets under
+   management", "Hourly", "Fixed fees", "Performance-based". NEVER return a rate, a
+   percentage, a dollar amount, a tier, or a basis-point figure. Fee schedules are commonly
+   tiered and negotiable, so a single number would misstate them.
+4. "min_engagement_amount" is the minimum account size or minimum engagement the brochure
+   REQUIRES, as a plain number. If the brochure says there is NO minimum (for example
+   "there is no account minimum"), return null. If it is silent, return null. A stated
+   absence is null, never zero and never a guessed figure.
+
+Return STRICT JSON, nothing else, in exactly this shape:
+{{"services_offered": ["..."], "fee_structure": ["..."], "min_engagement_amount": null}}
+
+BROCHURE TEXT:
+{brochure_text}
+"""
+
+# Every word this module is allowed to add to a factual bio beyond the facts
+# themselves. The bio must read as a restatement of the profile, not as copy.
+BIO_CONNECTIVE_TOKENS = frozenset(
+    {
+        "is",
+        "an",
+        "a",
+        "at",
+        "in",
+        "investment",
+        "adviser",
+        "firm",
+        "registered",
+        "since",
+        "crd",
+        "sec",
+        "state",
+    }
+)
+
+
+# Strong references keep fire-and-forget workers alive until they finish
+# (asyncio holds tasks weakly); mirrors the dossier lane's tracked-task set.
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
+# The label persisted as ria_profiles.profile_source so the UI can say where
+# these words came from rather than presenting them as the adviser's own.
+PROFILE_SOURCE_LABEL = "form_adv_part2"
+
+
+def _track_background_task(task: asyncio.Task[Any]) -> None:
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _empty_result(
+    *,
+    error: str = "",
+    source_url: str = "",
+    source_name: str = "",
+    source_filed_on: str = "",
+) -> dict[str, Any]:
+    """The published shape with nothing in it. Errors always land here."""
+    result: dict[str, Any] = {
+        "services_offered": [],
+        "fee_structure": [],
+        "min_engagement_amount": None,
+        "min_engagement_currency": "USD",
+        "source_url": source_url,
+        "source_name": source_name,
+        "source_filed_on": source_filed_on,
+    }
+    if error:
+        result["error"] = error
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Brochure selection
+# ---------------------------------------------------------------------------
+
+
+def select_brochure(brochures: Any) -> dict[str, str]:
+    """Pick the firm brochure to read: Part 2A first, then anything filed.
+
+    Part 2B is a *supplement* about one individual — education, exams, other
+    business activities. It says nothing authoritative about what the firm
+    offers or charges, so it is only ever a fallback.
+
+    Accepts both the shaped claim snapshot (``date_submitted``) and the raw
+    identity-API payload (``dateSubmitted``); returns ``{}`` when nothing
+    usable is on file.
+    """
+    entries: list[dict[str, str]] = []
+    for item in brochures if isinstance(brochures, list) else []:
+        if not isinstance(item, dict):
+            continue
+        url = _clean_text(item.get("url"))
+        if not url:
+            continue
+        entries.append(
+            {
+                "url": url,
+                "name": _clean_text(item.get("name")),
+                "filed_on": _clean_text(item.get("date_submitted") or item.get("dateSubmitted")),
+            }
+        )
+    if not entries:
+        return {}
+    for entry in entries:
+        if "2a" in entry["name"].lower():
+            return entry
+    return entries[0]
+
+
+# ---------------------------------------------------------------------------
+# Fetch (bounded) and text extraction (bounded)
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_pdf_bytes(url: str) -> tuple[bytes, str]:
+    """Download the filing under a hard timeout and a hard size cap.
+
+    The SEC URLs are ``.aspx`` redirectors in front of the PDF, so redirects
+    are followed. The cap is enforced on the streamed body, not just on
+    Content-Length, so a server that lies about the length still cannot make
+    us hold 200 MB.
+    """
+    try:
+        async with httpx.AsyncClient(
+            timeout=FETCH_TIMEOUT_SECONDS,
+            follow_redirects=True,
+            headers=_HTTP_HEADERS,
+        ) as client:
+            async with client.stream("GET", url) as response:
+                if response.status_code != 200:
+                    return b"", f"fetch_status_{response.status_code}"
+                declared = response.headers.get("content-length")
+                if declared and declared.isdigit() and int(declared) > MAX_PDF_BYTES:
+                    return b"", "brochure_too_large"
+                buffer = bytearray()
+                async for chunk in response.aiter_bytes():
+                    buffer.extend(chunk)
+                    if len(buffer) > MAX_PDF_BYTES:
+                        return b"", "brochure_too_large"
+                return bytes(buffer), ""
+    except httpx.HTTPError as exc:
+        logger.info("ria.brochure_fetch_failed error=%s", type(exc).__name__)
+        return b"", f"fetch_failed:{type(exc).__name__}"
+    except Exception as exc:  # noqa: BLE001 - enrichment never raises
+        logger.info("ria.brochure_fetch_error error=%s", type(exc).__name__)
+        return b"", f"fetch_error:{type(exc).__name__}"
+
+
+def strip_table_of_contents(text: str) -> str:
+    """Drop the dotted-leader contents block so headers are read once.
+
+    A Part 2A lists every Item twice: page 1-3 as a contents table with dotted
+    leaders and page numbers, then again as the body. Searching the raw text
+    for "Advisory Business" matches the contents entry first and yields a page
+    number where the content should be.
+    """
+    kept: list[str] = []
+    for line in str(text or "").splitlines():
+        if _TOC_HEADING_LINE.match(line):
+            continue
+        if _TOC_LEADER_LINE.search(line):
+            continue
+        if _TOC_ITEM_LINE.match(line):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def _extract_pdf_text(data: bytes) -> str:
+    """Read at most MAX_PAGES pages of text. Blocking; call in a thread."""
+    import pdfplumber
+
+    pages: list[str] = []
+    with pdfplumber.open(io.BytesIO(data)) as pdf:
+        for page in pdf.pages[:MAX_PAGES]:
+            try:
+                pages.append(page.extract_text() or "")
+            except Exception:  # noqa: BLE001 - one bad page is not a failed read
+                continue
+    return "\n".join(pages)
+
+
+async def _brochure_text(data: bytes) -> tuple[str, str]:
+    try:
+        raw = await asyncio.to_thread(_extract_pdf_text, data)
+    except Exception as exc:  # noqa: BLE001 - a corrupt filing is an empty result
+        logger.info("ria.brochure_parse_failed error=%s", type(exc).__name__)
+        return "", f"parse_failed:{type(exc).__name__}"
+    text = strip_table_of_contents(raw).strip()
+    if not text:
+        return "", "no_text_extracted"
+    return text[:MAX_TEXT_CHARS], ""
+
+
+# ---------------------------------------------------------------------------
+# Model call + defensive validation
+# ---------------------------------------------------------------------------
+
+
+async def _run_model(prompt: str) -> tuple[dict[str, Any], str]:
+    """Ask the managed Gemini runtime for strict JSON. Never raises."""
+    try:
+        from google.genai import types as genai_types
+
+        from hushh_mcp.runtime_providers import (
+            build_generate_content_config,
+            build_managed_runtime_client,
+        )
+
+        client = build_managed_runtime_client("gemini")
+    except Exception as exc:  # noqa: BLE001 - no brain is an empty result
+        logger.info("ria.brochure_model_unavailable error=%s", type(exc).__name__)
+        return {}, f"model_unavailable:{type(exc).__name__}"
+    if client is None:
+        return {}, "model_unavailable"
+
+    try:
+        config = build_generate_content_config(
+            genai_types,
+            GEMINI_MODEL,
+            response_mime_type="application/json",
+            temperature=0.1,
+        )
+        response = await client.aio.models.generate_content(
+            model=GEMINI_MODEL,
+            contents=prompt,
+            config=config,
+        )
+    except Exception as exc:  # noqa: BLE001 - enrichment never raises
+        logger.info("ria.brochure_model_failed error=%s", type(exc).__name__)
+        return {}, f"model_failed:{type(exc).__name__}"
+
+    try:
+        parsed = json.loads(_clean_text(getattr(response, "text", "")))
+    except (TypeError, ValueError):
+        # Never log the body: it is the filing's text, not ours to emit.
+        logger.info("ria.brochure_model_json_invalid")
+        return {}, "model_json_invalid"
+    if not isinstance(parsed, dict):
+        return {}, "model_json_not_an_object"
+    return parsed, ""
+
+
+def _coerce_str_list(value: Any, *, drop_rates: bool = False) -> list[str]:
+    """Strings only, trimmed, deduped, bounded. Wrong types collapse to []."""
+    if not isinstance(value, list):
+        return []
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        entry = " ".join(item.split())
+        if not entry or len(entry) > MAX_ITEM_CHARS:
+            continue
+        if not any(char.isalpha() for char in entry):
+            continue
+        if drop_rates and _RATE_LIKE.search(entry):
+            # A tiered, negotiable schedule cannot be published as one number.
+            continue
+        key = entry.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(entry)
+        if len(cleaned) >= MAX_LIST_ITEMS:
+            break
+    return cleaned
+
+
+def _coerce_minimum(value: Any) -> float | None:
+    """A stated minimum, or None. Zero means 'no minimum', which is None."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        amount = float(value)
+    elif isinstance(value, str):
+        digits = re.sub(r"[^0-9.]", "", value)
+        if digits.count(".") > 1 or not digits.strip("."):
+            return None
+        try:
+            amount = float(digits)
+        except ValueError:
+            return None
+    else:
+        return None
+    if amount <= 0 or amount > MAX_MIN_ENGAGEMENT or amount != amount:
+        return None
+    return amount
+
+
+def validate_model_payload(payload: Any) -> dict[str, Any]:
+    """Reduce whatever the model returned to values we are willing to publish."""
+    body = payload if isinstance(payload, dict) else {}
+    return {
+        "services_offered": _coerce_str_list(body.get("services_offered")),
+        "fee_structure": _coerce_str_list(body.get("fee_structure"), drop_rates=True),
+        "min_engagement_amount": _coerce_minimum(body.get("min_engagement_amount")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def extract_profile_from_brochure(brochures: list[dict], *, firm_name: str) -> dict[str, Any]:
+    """Read the firm's Form ADV Part 2A into the profile's narrative fields.
+
+    Best-effort by contract: every failure returns the empty shape with an
+    ``"error"`` key, and nothing here ever raises into the claim.
+    """
+    selected = select_brochure(brochures)
+    if not selected:
+        return _empty_result(error="no_brochure_on_file")
+
+    url = selected["url"]
+    source = {
+        "source_url": url,
+        "source_name": selected["name"],
+        "source_filed_on": selected["filed_on"],
+    }
+    logger.info(
+        "ria.brochure_extract_started brochure=%s",
+        selected["name"] or "unnamed",
+    )
+
+    data, fetch_error = await _fetch_pdf_bytes(url)
+    if fetch_error:
+        return _empty_result(error=fetch_error, **source)
+
+    text, parse_error = await _brochure_text(data)
+    if parse_error:
+        return _empty_result(error=parse_error, **source)
+
+    prompt = _EXTRACTION_PROMPT.format(
+        firm_name=_clean_text(firm_name) or "this firm",
+        brochure_text=text,
+    )
+    payload, model_error = await _run_model(prompt)
+    if model_error:
+        return _empty_result(error=model_error, **source)
+
+    fields = validate_model_payload(payload)
+    logger.info(
+        "ria.brochure_extract_done services=%d fees=%d minimum=%s",
+        len(fields["services_offered"]),
+        len(fields["fee_structure"]),
+        fields["min_engagement_amount"] is not None,
+    )
+    return {
+        **fields,
+        "min_engagement_currency": "USD",
+        **source,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Post-claim dispatch: background, best-effort, blanks-only
+# ---------------------------------------------------------------------------
+
+
+async def enrich_claimed_profile(
+    *,
+    ria_profile_id: str,
+    reference_metadata: dict[str, Any],
+    iam_service: Any = None,
+) -> dict[str, Any]:
+    """Read the brochure, build the bio, and fill only what is still blank.
+
+    Returns a small status dict for tests and logs. Never raises: the claim
+    that dispatched this has already succeeded and must stay succeeded.
+    """
+    profile_id = _clean_text(ria_profile_id)
+    metadata = reference_metadata if isinstance(reference_metadata, dict) else {}
+    if not profile_id:
+        return {"status": "skipped", "reason": "missing_profile_id"}
+
+    firm_raw = metadata.get("firm_record")
+    firm = firm_raw if isinstance(firm_raw, dict) else {}
+
+    extracted = _empty_result(error="not_attempted")
+    try:
+        extracted = await extract_profile_from_brochure(
+            firm.get("brochures") or [],
+            firm_name=_clean_text(firm.get("name")),
+        )
+    except Exception:  # noqa: BLE001 - extraction is contractually non-raising
+        logger.warning("ria.brochure_extract_unexpected_error", exc_info=True)
+
+    try:
+        bio = build_factual_bio(metadata)
+    except Exception:  # noqa: BLE001 - a missing bio is not a failed claim
+        logger.warning("ria.brochure_bio_failed", exc_info=True)
+        bio = ""
+
+    has_brochure_values = bool(
+        extracted.get("services_offered")
+        or extracted.get("fee_structure")
+        or extracted.get("min_engagement_amount") is not None
+    )
+    if not has_brochure_values and not bio:
+        return {"status": "nothing_to_write", "error": _clean_text(extracted.get("error"))}
+
+    try:
+        if iam_service is None:
+            from hushh_mcp.services.ria_iam_service import RIAIAMService
+
+            iam_service = RIAIAMService()
+        filled = await iam_service.apply_brochure_profile_fields(
+            profile_id,
+            services_offered=extracted.get("services_offered") or [],
+            fee_structure=extracted.get("fee_structure") or [],
+            min_engagement_amount=extracted.get("min_engagement_amount"),
+            min_engagement_currency=_clean_text(extracted.get("min_engagement_currency")) or "USD",
+            bio=bio,
+            # Provenance only means anything when a brochure supplied it; a
+            # bio-only write restates facts the profile already shows.
+            profile_source=PROFILE_SOURCE_LABEL if has_brochure_values else "",
+            profile_source_url=(
+                _clean_text(extracted.get("source_url")) if has_brochure_values else ""
+            ),
+            profile_source_filed_on=(
+                _clean_text(extracted.get("source_filed_on")) if has_brochure_values else ""
+            ),
+        )
+    except Exception:  # noqa: BLE001 - the profile write can never fail a claim
+        logger.warning("ria.brochure_profile_write_failed", exc_info=True)
+        return {"status": "write_failed"}
+
+    logger.info("ria.brochure_profile_written filled=%s", bool(filled))
+    return {"status": "written" if filled else "no_blanks_to_fill"}
+
+
+def dispatch_profile_enrichment(
+    *,
+    ria_profile_id: str,
+    reference_metadata: dict[str, Any],
+) -> bool:
+    """Fire the enrichment behind the claim. Returns whether a task started."""
+    try:
+        task = asyncio.create_task(
+            enrich_claimed_profile(
+                ria_profile_id=ria_profile_id,
+                reference_metadata=reference_metadata,
+            )
+        )
+    except RuntimeError:
+        # No running loop (sync call path): the profile simply stays blank.
+        logger.info("ria.brochure_dispatch_no_event_loop")
+        return False
+    _track_background_task(task)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# The factual bio — no model, no adjectives
+# ---------------------------------------------------------------------------
+
+
+def _bio_location(reference_metadata: dict[str, Any]) -> str:
+    """City, ST from the same source the profile's LOCATION block uses."""
+    firm_raw = reference_metadata.get("firm_record")
+    firm = firm_raw if isinstance(firm_raw, dict) else {}
+    advisor_raw = reference_metadata.get("advisor_record")
+    advisor = advisor_raw if isinstance(advisor_raw, dict) else {}
+    branch_raw = advisor.get("branch")
+    branch = branch_raw if isinstance(branch_raw, dict) else {}
+
+    # A private-residence branch is somebody's home; it never reaches a profile.
+    if branch and not branch.get("private_residence"):
+        city, state = _clean_text(branch.get("city")), _clean_text(branch.get("state"))
+        if city or state:
+            return ", ".join(part for part in (title_case_name(city), state.upper()) if part)
+    city, state = _clean_text(firm.get("city")), _clean_text(firm.get("state"))
+    if city or state:
+        return ", ".join(part for part in (title_case_name(city), state.upper()) if part)
+    return ""
+
+
+def build_factual_bio(reference_metadata: dict) -> str:
+    """One factual sentence built only from facts already shown on the profile.
+
+    Name, firm, city/state, CRD, registration status and year, exam codes —
+    every one of them already visible above the bio. No adjective, no claim
+    about quality, specialisation, or client outcome enters here, because
+    nothing in the SEC record supports one. Returns "" when the facts are too
+    thin to say anything true.
+    """
+    metadata = reference_metadata if isinstance(reference_metadata, dict) else {}
+    firm_raw = metadata.get("firm_record")
+    firm = firm_raw if isinstance(firm_raw, dict) else {}
+    advisor_raw = metadata.get("advisor_record")
+    advisor = advisor_raw if isinstance(advisor_raw, dict) else {}
+
+    claim_type = _clean_text(metadata.get("claim_type")).lower()
+    firm_name = title_case_name(_clean_text(firm.get("name")))
+    person_name = title_case_name(_clean_text(metadata.get("display_name")))
+    location = _bio_location(metadata)
+    regulator = "SEC" if _clean_text(firm.get("registration_type")).lower() == "sec" else "State"
+
+    if claim_type == "firm" or not person_name:
+        subject = firm_name
+        crd = _clean_text(metadata.get("firm_crd")) or _clean_text(firm.get("crd"))
+        opening = f"{subject} is an investment adviser firm"
+    else:
+        subject = person_name
+        crd = _clean_text(metadata.get("individual_crd")) or _clean_text(advisor.get("crd"))
+        opening = f"{subject} is an investment adviser"
+        if firm_name:
+            opening += f" at {firm_name}"
+    if not subject:
+        return ""
+
+    # Registration year only: a full filing date would be a fact the profile
+    # does not otherwise show.
+    since = ""
+    match = re.search(r"\b(19|20)\d{2}\b", _clean_text(advisor.get("registered_since")))
+    if match:
+        since = match.group(0)
+
+    exams = [
+        _clean_text(exam.get("code"))
+        for exam in (advisor.get("exams") or [])
+        if isinstance(exam, dict) and _clean_text(exam.get("code"))
+    ]
+
+    # A name on its own is not a bio; it must carry at least one hard fact.
+    if not (location or crd or since or exams or (claim_type != "firm" and firm_name)):
+        return ""
+
+    sentences: list[str] = [f"{opening} in {location}." if location else f"{opening}."]
+
+    registration = f"{regulator}-registered"
+    if since:
+        registration += f" since {since}"
+    if crd:
+        registration += f" (CRD {crd})"
+    if since or crd:
+        sentences.append(f"{registration}.")
+
+    if exams:
+        sentences.append(f"{', '.join(dict.fromkeys(exams))}.")
+
+    return " ".join(sentences)

--- a/consent-protocol/hushh_mcp/services/ria_claim_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_claim_service.py
@@ -774,6 +774,9 @@ class RIAClaimService:
             "missing": payload.get("missing") or [],
             "evidence_ledger": payload.get("evidenceLedger") or [],
             "scope_note": payload.get("scopeNote"),
+            # The name the profile was built from, so a later reader (the
+            # factual bio) never has to guess who this snapshot describes.
+            "display_name": display_name,
             # The snapshot the profile was built from, kept for provenance.
             "firm_record": firm,
             "advisor_record": advisor_record,
@@ -835,7 +838,12 @@ class RIAClaimService:
             "report_url": advisor_record.get("report_url") or firm.get("report_url"),
             "has_disclosures": advisor_record.get("has_disclosures"),
         }
-        await self._record_claim_enrichment(user_id, facts)
+        await self._record_claim_enrichment(
+            user_id,
+            facts,
+            ria_profile_id=str(profile.get("ria_profile_id") or ""),
+            reference_metadata=reference_metadata,
+        )
         dossier_status = await self._dispatch_dossier(
             user_id=user_id,
             ria_profile_id=str(profile.get("ria_profile_id") or ""),
@@ -1145,16 +1153,24 @@ class RIAClaimService:
             "profile": profile,
         }
 
-    async def _record_claim_enrichment(self, user_id: str, facts: dict[str, Any]) -> None:
+    async def _record_claim_enrichment(
+        self,
+        user_id: str,
+        facts: dict[str, Any],
+        *,
+        ria_profile_id: str = "",
+        reference_metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Stage the claim's regulator facts in the user's knowledge planes.
 
         The encrypted PKM blob is BYOK — only the owner's unlocked vault can
         write it, so the client does that from the done screen. Here the server
         writes the planes it legitimately owns: the append-only audit event
         (the staged facts a vault session can materialize), the sanitized
-        discovery flag, and the durable setup mirror that marks the RIA
-        capability finished. Each block is best-effort in isolation: a claim
-        must never fail, and one plane must never block another.
+        discovery flag, the durable setup mirror that marks the RIA capability
+        finished, and the background read of the firm's own Form ADV Part 2
+        brochure. Each block is best-effort in isolation: a claim must never
+        fail, and one plane must never block another.
         """
         try:
             from hushh_mcp.services.personal_knowledge_model_service import get_pkm_service
@@ -1193,3 +1209,19 @@ class RIAClaimService:
                 )
         except Exception as exc:  # noqa: BLE001 - enrichment is best-effort
             logger.info("ria.claim_setup_mirror_skipped error=%s", type(exc).__name__)
+
+        try:
+            # Services, fees, the engagement minimum and a factual bio are not
+            # in the identity API; they live in the firm's filed brochure. This
+            # is fire-and-forget for the same reason the dossier is: fetching
+            # and reading a 20-page PDF must never sit inside a claim response.
+            from hushh_mcp.services.ria_brochure_profile_service import (
+                dispatch_profile_enrichment,
+            )
+
+            dispatch_profile_enrichment(
+                ria_profile_id=ria_profile_id,
+                reference_metadata=reference_metadata or {},
+            )
+        except Exception as exc:  # noqa: BLE001 - enrichment is best-effort
+            logger.info("ria.claim_brochure_dispatch_skipped error=%s", type(exc).__name__)

--- a/consent-protocol/hushh_mcp/services/ria_iam_service.py
+++ b/consent-protocol/hushh_mcp/services/ria_iam_service.py
@@ -4610,6 +4610,124 @@ class RIAIAMService:
         finally:
             await conn.close()
 
+    # Blanks-only fill of the narrative profile fields from the firm's own
+    # Form ADV Part 2A brochure. Every assignment reads the OLD row, so a
+    # value the adviser typed always wins; this can only fill a hole.
+    _BROCHURE_PROFILE_SQL = """
+        WITH target AS (
+          SELECT
+            id,
+            COALESCE(array_length(services_offered, 1), 0) = 0 AS services_blank,
+            COALESCE(array_length(fee_structure, 1), 0) = 0 AS fees_blank,
+            min_engagement_amount IS NULL AS minimum_blank,
+            COALESCE(NULLIF(bio, ''), '') = '' AS bio_blank,
+            (
+              (COALESCE(array_length(services_offered, 1), 0) = 0
+                 AND COALESCE(array_length($2::text[], 1), 0) > 0)
+              OR (COALESCE(array_length(fee_structure, 1), 0) = 0
+                 AND COALESCE(array_length($3::text[], 1), 0) > 0)
+              OR (min_engagement_amount IS NULL AND $4::numeric IS NOT NULL)
+              OR (COALESCE(NULLIF(bio, ''), '') = '' AND NULLIF($6, '') IS NOT NULL)
+            ) AS fills_blank
+          FROM ria_profiles
+          WHERE id = $1
+        )
+        UPDATE ria_profiles p
+        SET
+          services_offered = CASE WHEN t.services_blank
+            THEN COALESCE(NULLIF($2::text[], '{{}}'::text[]), p.services_offered)
+            ELSE p.services_offered END,
+          fee_structure = CASE WHEN t.fees_blank
+            THEN COALESCE(NULLIF($3::text[], '{{}}'::text[]), p.fee_structure)
+            ELSE p.fee_structure END,
+          min_engagement_amount = CASE WHEN t.minimum_blank
+            THEN COALESCE($4::numeric, p.min_engagement_amount)
+            ELSE p.min_engagement_amount END,
+          min_engagement_currency = COALESCE(
+            NULLIF(p.min_engagement_currency, ''), NULLIF($5, ''), p.min_engagement_currency),
+          bio = CASE WHEN t.bio_blank
+            THEN COALESCE(NULLIF($6, ''), p.bio)
+            ELSE p.bio END,
+          {provenance}
+          updated_at = NOW()
+        FROM target t
+        WHERE p.id = t.id
+        RETURNING t.fills_blank AS filled
+    """
+
+    # Provenance is only stamped when something was actually filled: labelling
+    # an adviser's own typed profile "from the SEC filing" would be a lie.
+    _BROCHURE_PROVENANCE_SQL = """
+          profile_source = CASE WHEN t.fills_blank
+            THEN COALESCE(NULLIF(p.profile_source, ''), NULLIF($7, ''))
+            ELSE p.profile_source END,
+          profile_source_url = CASE WHEN t.fills_blank
+            THEN COALESCE(NULLIF(p.profile_source_url, ''), NULLIF($8, ''))
+            ELSE p.profile_source_url END,
+          profile_source_filed_on = CASE WHEN t.fills_blank
+            THEN COALESCE(NULLIF(p.profile_source_filed_on, ''), NULLIF($9, ''))
+            ELSE p.profile_source_filed_on END,
+    """
+
+    async def apply_brochure_profile_fields(
+        self,
+        ria_profile_id: str,
+        *,
+        services_offered: list[str] | None = None,
+        fee_structure: list[str] | None = None,
+        min_engagement_amount: float | None = None,
+        min_engagement_currency: str = "USD",
+        bio: str = "",
+        profile_source: str = "",
+        profile_source_url: str = "",
+        profile_source_filed_on: str = "",
+    ) -> bool:
+        """Fill only the blank narrative fields on a claimed RIA profile.
+
+        Written by the post-claim brochure worker, never by a person. The
+        adviser is the author of their own profile: anything they typed is
+        left exactly as it is, and this returns ``True`` only when at least
+        one genuinely empty field was filled.
+        """
+        profile_id = str(ria_profile_id or "").strip()
+        if not profile_id:
+            return False
+        params: list[Any] = [
+            profile_id,
+            [str(item) for item in (services_offered or []) if str(item).strip()],
+            [str(item) for item in (fee_structure or []) if str(item).strip()],
+            min_engagement_amount,
+            str(min_engagement_currency or ""),
+            str(bio or "").strip(),
+            str(profile_source or "").strip(),
+            str(profile_source_url or "").strip(),
+            str(profile_source_filed_on or "").strip(),
+        ]
+        conn = await self._conn()
+        try:
+            try:
+                row = await conn.fetchrow(
+                    self._BROCHURE_PROFILE_SQL.format(
+                        provenance=self._BROCHURE_PROVENANCE_SQL.strip() + "\n"
+                    ),
+                    *params,
+                )
+            except asyncpg.exceptions.UndefinedColumnError:
+                # A deploy can land ahead of its migration; the values still
+                # belong on the profile, only their label has to wait.
+                logger.warning(
+                    "ria_profiles provenance columns unavailable; "
+                    "writing brochure fields without provenance"
+                )
+                row = await conn.fetchrow(
+                    self._BROCHURE_PROFILE_SQL.format(provenance=""), *params[:6]
+                )
+            return bool(row and row["filled"])
+        except asyncpg.exceptions.UndefinedTableError as exc:
+            raise IAMSchemaNotReadyError() from exc
+        finally:
+            await conn.close()
+
     async def _removed_activate_ria_dev_onboarding(self) -> None:
         """Dev bypass onboarding has been permanently removed.
 
@@ -4800,6 +4918,27 @@ class RIAIAMService:
             except asyncpg.exceptions.UndefinedColumnError:
                 logger.warning("ria_profiles v2 columns unavailable during onboarding status")
 
+            # Read in its own statement, not folded into the v2 SELECT above:
+            # on an environment where the provenance migration has not landed
+            # yet, a combined query would take the whole v2 block down with it
+            # and the profile would lose services/fees it already had.
+            profile_provenance: dict[str, Any] = {}
+            try:
+                provenance_row = await conn.fetchrow(
+                    """
+                    SELECT
+                      profile_source,
+                      profile_source_url,
+                      profile_source_filed_on
+                    FROM ria_profiles
+                    WHERE id = $1
+                    """,
+                    ria["id"],
+                )
+                profile_provenance = dict(provenance_row) if provenance_row else {}
+            except asyncpg.exceptions.UndefinedColumnError:
+                logger.warning("ria_profiles provenance columns unavailable during status")
+
             business_contact: dict[str, Any] = {}
             try:
                 contact_row = await conn.fetchrow(
@@ -4903,6 +5042,11 @@ class RIAIAMService:
                 "bio": v2_profile.get("bio"),
                 "strategy": v2_profile.get("strategy"),
                 "disclosures_url": v2_profile.get("disclosures_url"),
+                # Where the narrative fields came from, so the UI can say so
+                # instead of presenting a filing's words as the adviser's.
+                "profile_source": profile_provenance.get("profile_source"),
+                "profile_source_url": profile_provenance.get("profile_source_url"),
+                "profile_source_filed_on": profile_provenance.get("profile_source_filed_on"),
                 "latest_verification_event": event,
                 "latest_claim_event": claim_event,
             }

--- a/consent-protocol/scripts/test-ci.manifest.txt
+++ b/consent-protocol/scripts/test-ci.manifest.txt
@@ -53,3 +53,4 @@ tests/test_ria_dossier_routes.py
 tests/test_ria_claim_email_test_path.py
 tests/test_ria_dossier_mail_contract.py
 tests/test_ria_claim_location.py
+tests/test_ria_brochure_profile.py

--- a/consent-protocol/tests/test_ria_brochure_profile.py
+++ b/consent-protocol/tests/test_ria_brochure_profile.py
@@ -1,0 +1,1093 @@
+"""Reading a claimed adviser's Form ADV Part 2A into their profile.
+
+The fixtures below are trimmed from the real filing for Olympus Peaks
+Financial, LLC (CRD 283040, brochure version 953234, 23 pages) — including the
+two traps that filing sets:
+
+* the fee schedule is TIERED and NEGOTIABLE ("$0 - $250,000 1.25% ... Fees for
+  portfolio management services are negotiable"), so publishing "1.25%" as the
+  fee would misstate it; and
+* the word "minimum" appears exactly once in 23 pages, in the sentence "There
+  is no account minimum for any of OPFL's services" — a keyword grab would
+  publish a number the filing explicitly denies.
+
+Nothing here touches the network or a real model, and no PDF is committed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import httpx
+import pytest
+
+import hushh_mcp.runtime_providers as runtime_providers
+import hushh_mcp.services.ria_brochure_profile_service as brochure_module
+from hushh_mcp.services.ria_brochure_profile_service import (
+    BIO_CONNECTIVE_TOKENS,
+    build_factual_bio,
+    enrich_claimed_profile,
+    extract_profile_from_brochure,
+    select_brochure,
+    strip_table_of_contents,
+    validate_model_payload,
+)
+from hushh_mcp.services.ria_claim_service import RIAClaimService
+from hushh_mcp.services.ria_iam_service import RIAIAMService
+from tests.test_ria_claim_flow import (
+    _EVALUATE_VERIFIED,
+    _TEST_UID,
+    _FakeIamService,
+    _FakeIdentityClient,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+MANIFEST_PATH = REPO_ROOT / "db" / "release_migration_manifest.json"
+CONTRACTS_DIR = REPO_ROOT / "db" / "contracts"
+MIGRATION = "139_ria_profile_brochure_provenance.sql"
+ROLLBACK = "139_ria_profile_brochure_provenance_down.sql"
+PROVENANCE_COLUMNS = ("profile_source", "profile_source_url", "profile_source_filed_on")
+
+_PROFILE_ID = "11111111-2222-3333-4444-555555555555"
+_PART_2A_URL = (
+    "https://files.adviserinfo.sec.gov/IAPD/Content/Common/"
+    "crd_iapd_Brochure.aspx?BRCHR_VRSN_ID=953234"
+)
+_PART_2B_URL = (
+    "https://files.adviserinfo.sec.gov/IAPD/Content/Common/"
+    "crd_iapd_Brochure.aspx?BRCHR_VRSN_ID=910903"
+)
+
+# Exactly as the claim snapshot stores them (see _shape_firm).
+_BROCHURES = [
+    {"name": "ADV PART 2B-MAXFIELD", "date_submitted": "1/13/2026", "url": _PART_2B_URL},
+    {
+        "name": "ADV PART 2A-OLYMPUS PEAKS FINANCIAL, LLC",
+        "date_submitted": "1/13/2026",
+        "url": _PART_2A_URL,
+    },
+]
+
+# The contents table: dotted leaders, page numbers, and the same headers the
+# body uses. Searching the raw text for "Advisory Business" hits this first.
+_TOC_TEXT = """Item 1 Cover Page
+Table of Contents
+Item 4 Advisory Business .................................................. 4
+Item 5 Fees and Compensation .............................................. 5
+Item 7 Types of Clients ................................................... 7
+"""
+
+_BODY_TEXT = """Item 4 Advisory Business
+Olympus Peaks Financial, LLC ("OPFL") provides Portfolio Management services
+to its clients. A financial plan is included at no additional fee for clients
+who engage OPFL for ongoing Portfolio Management.
+Item 5 Fees and Compensation
+Portfolio Management Fees
+Total Assets Under Management Annual Fees
+$0 - $250,000 1.25%
+$250,001 - $1,000,000 1.00%
+$1,000,001 - And Up 0.50%
+Fees for portfolio management services are negotiable.
+There is no account minimum for any of OPFL's services.
+Item 7 Types of Clients
+Individuals
+High-Net-Worth Individuals
+Pension and Profit-Sharing Plans
+"""
+
+_BROCHURE_TEXT = _TOC_TEXT + _BODY_TEXT
+
+_FIRM_RECORD = {
+    "crd": 283040,
+    "name": "OLYMPUS PEAKS FINANCIAL, LLC",
+    "city": "SANDY",
+    "state": "UT",
+    "registration_type": "sec",
+    "registration_status": "APPROVED",
+    "brochures": _BROCHURES,
+}
+
+_ADVISOR_RECORD = {
+    "crd": 5308823,
+    "registered_since": "2016-05-13",
+    "exams": [
+        {"code": "Series 66", "name": "Uniform Combined State Law"},
+        {"code": "SIE", "name": "Securities Industry Essentials"},
+        {"code": "Series 7", "name": "General Securities Representative"},
+    ],
+    "branch": {"city": "SANDY", "state": "UT", "private_residence": False},
+}
+
+
+def _metadata(**overrides: Any) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "claim_type": "individual",
+        "display_name": "Reginald Troy Maxfield",
+        "firm_crd": 283040,
+        "individual_crd": 5308823,
+        "firm_record": dict(_FIRM_RECORD),
+        "advisor_record": dict(_ADVISOR_RECORD),
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# Fakes: HTTP, pdfplumber, the model
+# ---------------------------------------------------------------------------
+
+
+def _fake_http(monkeypatch, handler) -> list[str]:
+    """Route every AsyncClient in the module through a MockTransport."""
+    requested: list[str] = []
+    real_client = httpx.AsyncClient
+
+    def _factory(*args: Any, **kwargs: Any):
+        def _wrapped(request: httpx.Request) -> httpx.Response:
+            requested.append(str(request.url))
+            return handler(request)
+
+        kwargs["transport"] = httpx.MockTransport(_wrapped)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(brochure_module.httpx, "AsyncClient", _factory)
+    return requested
+
+
+def _pdf_response(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, content=b"%PDF-1.7 fake bytes", headers={"x-fake": "1"})
+
+
+class _FakePage:
+    def __init__(self, text: str, *, boom: bool = False) -> None:
+        self._text = text
+        self._boom = boom
+
+    def extract_text(self) -> str:
+        if self._boom:
+            raise RuntimeError("page is malformed")
+        return self._text
+
+
+class _FakePdf:
+    def __init__(self, pages: list[_FakePage]) -> None:
+        self.pages = pages
+
+    def __enter__(self) -> _FakePdf:
+        return self
+
+    def __exit__(self, *_exc: Any) -> bool:
+        return False
+
+
+def _fake_pdfplumber(monkeypatch, pages: list[_FakePage]) -> None:
+    module = types.ModuleType("pdfplumber")
+    module.open = lambda _stream: _FakePdf(pages)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pdfplumber", module)
+
+
+class _FakeModels:
+    def __init__(self, holder: _FakeModelClient) -> None:
+        self._holder = holder
+
+    async def generate_content(self, *, model: str, contents: str, config: Any) -> Any:
+        self._holder.prompts.append(contents)
+        self._holder.models.append(model)
+        if isinstance(self._holder.response, Exception):
+            raise self._holder.response
+        return types.SimpleNamespace(text=self._holder.response)
+
+
+class _FakeAio:
+    def __init__(self, holder: _FakeModelClient) -> None:
+        self.models = _FakeModels(holder)
+
+
+class _FakeModelClient:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.prompts: list[str] = []
+        self.models: list[str] = []
+        self.aio = _FakeAio(self)
+
+
+def _fake_model(monkeypatch, response: Any) -> _FakeModelClient:
+    client = _FakeModelClient(response)
+    monkeypatch.setattr(runtime_providers, "build_managed_runtime_client", lambda _p: client)
+    return client
+
+
+def _wire_happy_path(monkeypatch, *, model_json: str) -> _FakeModelClient:
+    _fake_http(monkeypatch, _pdf_response)
+    _fake_pdfplumber(monkeypatch, [_FakePage(_BROCHURE_TEXT)])
+    return _fake_model(monkeypatch, model_json)
+
+
+_GOOD_MODEL_JSON = json.dumps(
+    {
+        "services_offered": ["Portfolio management", "Financial planning"],
+        "fee_structure": ["Percentage of assets under management"],
+        "min_engagement_amount": None,
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Which brochure gets read
+# ---------------------------------------------------------------------------
+
+
+def test_part_2a_is_preferred_over_the_2b_supplement():
+    """2B is a supplement about one person; it cannot describe the firm."""
+    chosen = select_brochure(_BROCHURES)
+
+    assert chosen["url"] == _PART_2A_URL
+    assert chosen["name"] == "ADV PART 2A-OLYMPUS PEAKS FINANCIAL, LLC"
+    assert chosen["filed_on"] == "1/13/2026"
+
+
+def test_falls_back_to_any_brochure_when_no_2a_is_on_file():
+    chosen = select_brochure([_BROCHURES[0]])
+
+    assert chosen["url"] == _PART_2B_URL
+
+
+def test_raw_identity_api_key_casing_is_accepted():
+    """The snapshot stores date_submitted; the upstream API sends dateSubmitted."""
+    chosen = select_brochure(
+        [{"name": "ADV PART 2A-X", "dateSubmitted": "1/13/2026", "url": _PART_2A_URL}]
+    )
+
+    assert chosen["filed_on"] == "1/13/2026"
+
+
+@pytest.mark.parametrize(
+    "brochures",
+    [[], None, "not a list", [{"name": "ADV PART 2A"}], [{"url": ""}], [None]],
+)
+async def test_no_usable_brochure_is_an_empty_result_not_a_crash(brochures):
+    result = await extract_profile_from_brochure(brochures, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "no_brochure_on_file"
+    assert result["services_offered"] == []
+    assert result["fee_structure"] == []
+    assert result["min_engagement_amount"] is None
+
+
+# ---------------------------------------------------------------------------
+# Bounded fetch
+# ---------------------------------------------------------------------------
+
+
+async def test_oversized_brochure_is_refused_by_the_declared_length(monkeypatch):
+    monkeypatch.setattr(brochure_module, "MAX_PDF_BYTES", 64)
+
+    def _huge(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"z" * 4096)
+
+    _fake_http(monkeypatch, _huge)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "brochure_too_large"
+    assert result["services_offered"] == []
+    # Provenance still names the filing we declined, so the refusal is legible.
+    assert result["source_url"] == _PART_2A_URL
+
+
+async def test_oversized_brochure_is_refused_mid_stream_when_the_length_is_absent(monkeypatch):
+    """A server that sends no content-length still cannot make us hold it all."""
+    monkeypatch.setattr(brochure_module, "MAX_PDF_BYTES", 64)
+
+    def _streamed(_request: httpx.Request) -> httpx.Response:
+        async def _chunks():
+            for _ in range(16):
+                yield b"z" * 32
+
+        return httpx.Response(200, content=_chunks())
+
+    _fake_http(monkeypatch, _streamed)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "brochure_too_large"
+
+
+async def test_fetch_timeout_returns_an_empty_result_and_never_raises(monkeypatch):
+    def _timeout(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out")
+
+    _fake_http(monkeypatch, _timeout)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "fetch_failed:ReadTimeout"
+    assert result["services_offered"] == []
+    assert result["fee_structure"] == []
+    assert result["min_engagement_amount"] is None
+    assert result["min_engagement_currency"] == "USD"
+
+
+async def test_a_non_200_filing_is_an_empty_result(monkeypatch):
+    _fake_http(monkeypatch, lambda _r: httpx.Response(404))
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "fetch_status_404"
+
+
+async def test_the_aspx_redirector_is_followed(monkeypatch):
+    seen: list[str] = []
+
+    def _redirect(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith(".aspx"):
+            return httpx.Response(302, headers={"location": "https://files.example/real.pdf"})
+        return _pdf_response(request)
+
+    seen = _fake_http(monkeypatch, _redirect)
+    _fake_pdfplumber(monkeypatch, [_FakePage(_BROCHURE_TEXT)])
+    _fake_model(monkeypatch, _GOOD_MODEL_JSON)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert seen[-1] == "https://files.example/real.pdf"
+    assert result["services_offered"] == ["Portfolio management", "Financial planning"]
+
+
+# ---------------------------------------------------------------------------
+# Bounded text extraction, and the table-of-contents trap
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_first_pages_are_read(monkeypatch):
+    _fake_pdfplumber(monkeypatch, [_FakePage(f"page {i}") for i in range(40)])
+
+    text = brochure_module._extract_pdf_text(b"%PDF")
+
+    assert text.count("page ") == brochure_module.MAX_PAGES
+    assert "page 40" not in text
+
+
+def test_one_malformed_page_does_not_lose_the_filing(monkeypatch):
+    _fake_pdfplumber(
+        monkeypatch,
+        [_FakePage("first"), _FakePage("", boom=True), _FakePage("third")],
+    )
+
+    text = brochure_module._extract_pdf_text(b"%PDF")
+
+    assert "first" in text
+    assert "third" in text
+
+
+def test_the_contents_table_is_stripped_before_anything_reads_the_text():
+    """The headers appear twice; the dotted-leader copy is page numbers, not content."""
+    stripped = strip_table_of_contents(_BROCHURE_TEXT)
+
+    assert "Item 4 Advisory Business ....." not in stripped
+    assert "Table of Contents" not in stripped
+    # The body copies of the same headers survive.
+    assert "Item 5 Fees and Compensation\n" in stripped
+    assert "There is no account minimum for any of OPFL's services." in stripped
+    # No orphaned page numbers were left behind as if they were content.
+    assert not re.search(r"\.{3,}", stripped)
+
+
+async def test_the_text_handed_to_the_model_is_capped(monkeypatch):
+    monkeypatch.setattr(brochure_module, "MAX_TEXT_CHARS", 200)
+    _fake_http(monkeypatch, _pdf_response)
+    _fake_pdfplumber(monkeypatch, [_FakePage("word " * 5000)])
+    client = _fake_model(monkeypatch, _GOOD_MODEL_JSON)
+
+    await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    prompt = client.prompts[0]
+    brochure_slice = prompt.split("BROCHURE TEXT:\n", 1)[1]
+    assert len(brochure_slice.strip()) <= 200
+
+
+async def test_a_filing_with_no_extractable_text_is_an_empty_result(monkeypatch):
+    _fake_http(monkeypatch, _pdf_response)
+    _fake_pdfplumber(monkeypatch, [_FakePage("   ")])
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "no_text_extracted"
+
+
+async def test_an_unreadable_pdf_is_an_empty_result(monkeypatch):
+    _fake_http(monkeypatch, _pdf_response)
+    module = types.ModuleType("pdfplumber")
+
+    def _boom(_stream):
+        raise ValueError("not a PDF")
+
+    module.open = _boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pdfplumber", module)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "parse_failed:ValueError"
+
+
+# ---------------------------------------------------------------------------
+# The prompt, and what we refuse to publish
+# ---------------------------------------------------------------------------
+
+
+async def test_the_prompt_forbids_invention_and_names_the_absence_rule(monkeypatch):
+    client = _wire_happy_path(monkeypatch, model_json=_GOOD_MODEL_JSON)
+
+    await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS FINANCIAL, LLC")
+
+    prompt = client.prompts[0]
+    rules = " ".join(prompt.split())
+    assert "Extract ONLY what this brochure states" in rules
+    assert "Never guess" in rules
+    assert "A stated absence is null, never zero and never a guessed figure." in rules
+    assert "NEVER return a rate, a percentage, a dollar amount, a tier" in rules
+    # The trap sentence itself reaches the model, so the null is a reading and
+    # not an accident of the text being cut off.
+    assert "There is no account minimum for any of OPFL's services." in prompt
+
+
+async def test_a_tiered_negotiable_schedule_never_becomes_a_published_rate(monkeypatch):
+    """1.25% is the top tier of a negotiable schedule, not "the fee"."""
+    _wire_happy_path(
+        monkeypatch,
+        model_json=json.dumps(
+            {
+                "services_offered": ["Portfolio management"],
+                "fee_structure": [
+                    "1.25%",
+                    "1.25% of assets under management",
+                    "$5,000",
+                    "25 bps",
+                    "Percentage of assets under management",
+                ],
+                "min_engagement_amount": None,
+            }
+        ),
+    )
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["fee_structure"] == ["Percentage of assets under management"]
+    for entry in result["fee_structure"]:
+        assert "%" not in entry
+        assert not any(char.isdigit() for char in entry)
+
+
+async def test_a_brochure_that_denies_a_minimum_publishes_no_minimum(monkeypatch):
+    """ "There is no account minimum" must never become a number."""
+    _wire_happy_path(monkeypatch, model_json=_GOOD_MODEL_JSON)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["min_engagement_amount"] is None
+    assert result["min_engagement_currency"] == "USD"
+    assert result["services_offered"] == ["Portfolio management", "Financial planning"]
+    assert "error" not in result
+    assert result["source_url"] == _PART_2A_URL
+    assert result["source_name"] == "ADV PART 2A-OLYMPUS PEAKS FINANCIAL, LLC"
+    assert result["source_filed_on"] == "1/13/2026"
+
+
+@pytest.mark.parametrize("stated", [0, 0.0, -5, "none", "no minimum", None, True, {"a": 1}])
+def test_a_stated_absence_or_nonsense_minimum_is_null(stated):
+    assert (
+        validate_model_payload({"min_engagement_amount": stated})["min_engagement_amount"] is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("stated", "expected"),
+    [(250000, 250000.0), (250000.0, 250000.0), ("$250,000", 250000.0)],
+)
+def test_a_minimum_the_brochure_actually_states_is_kept(stated, expected):
+    parsed = validate_model_payload({"min_engagement_amount": stated})
+    assert parsed["min_engagement_amount"] == expected
+
+
+def test_an_absurd_minimum_is_treated_as_a_parse_artefact():
+    """An AUM figure caught by mistake is not an engagement minimum."""
+    assert (
+        validate_model_payload({"min_engagement_amount": 9_000_000_000_000})[
+            "min_engagement_amount"
+        ]
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"services_offered": "Portfolio management"},
+        {"services_offered": {"a": "b"}},
+        {"services_offered": [1, 2, 3]},
+        {"services_offered": [None, "", "   "]},
+        {"fee_structure": 42},
+        "not a dict",
+        None,
+        [],
+    ],
+)
+def test_wrong_types_collapse_to_empty_rather_than_publishing_garbage(payload):
+    parsed = validate_model_payload(payload)
+
+    assert parsed["services_offered"] == []
+    assert parsed["fee_structure"] == []
+    assert parsed["min_engagement_amount"] is None
+
+
+def test_duplicate_and_overlong_entries_are_dropped():
+    parsed = validate_model_payload(
+        {
+            "services_offered": [
+                "Portfolio management",
+                "portfolio MANAGEMENT",
+                "x" * 400,
+                *[f"Service {i}" for i in range(30)],
+            ]
+        }
+    )
+
+    assert parsed["services_offered"][0] == "Portfolio management"
+    assert "portfolio MANAGEMENT" not in parsed["services_offered"]
+    assert len(parsed["services_offered"]) <= brochure_module.MAX_LIST_ITEMS
+    assert all(len(entry) <= brochure_module.MAX_ITEM_CHARS for entry in parsed["services_offered"])
+
+
+# ---------------------------------------------------------------------------
+# Model faults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("body", ["not json at all", "", "{unclosed", "null"])
+async def test_malformed_model_json_is_an_empty_result_and_never_raises(monkeypatch, body):
+    _wire_happy_path(monkeypatch, model_json=body)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] in {"model_json_invalid", "model_json_not_an_object"}
+    assert result["services_offered"] == []
+    assert result["fee_structure"] == []
+    assert result["min_engagement_amount"] is None
+
+
+async def test_a_model_returning_a_json_array_is_an_empty_result(monkeypatch):
+    _wire_happy_path(monkeypatch, model_json='["Portfolio management"]')
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "model_json_not_an_object"
+
+
+async def test_a_model_that_raises_is_an_empty_result(monkeypatch):
+    _fake_http(monkeypatch, _pdf_response)
+    _fake_pdfplumber(monkeypatch, [_FakePage(_BROCHURE_TEXT)])
+    _fake_model(monkeypatch, RuntimeError("quota exhausted"))
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "model_failed:RuntimeError"
+
+
+async def test_an_unavailable_model_client_is_an_empty_result(monkeypatch):
+    _fake_http(monkeypatch, _pdf_response)
+    _fake_pdfplumber(monkeypatch, [_FakePage(_BROCHURE_TEXT)])
+
+    def _boom(_provider):
+        raise RuntimeError("no managed runtime configured")
+
+    monkeypatch.setattr(runtime_providers, "build_managed_runtime_client", _boom)
+
+    result = await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    assert result["error"] == "model_unavailable:RuntimeError"
+
+
+async def test_no_brochure_text_is_ever_logged(monkeypatch, caplog):
+    _wire_happy_path(monkeypatch, model_json="not json")
+    caplog.set_level("DEBUG")
+
+    await extract_profile_from_brochure(_BROCHURES, firm_name="OLYMPUS PEAKS")
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "no account minimum" not in logged
+    assert "1.25%" not in logged
+
+
+# ---------------------------------------------------------------------------
+# The factual bio
+# ---------------------------------------------------------------------------
+
+
+def test_a_full_record_produces_a_factual_sentence():
+    bio = build_factual_bio(_metadata())
+
+    assert bio == (
+        "Reginald Troy Maxfield is an investment adviser at Olympus Peaks Financial, LLC "
+        "in Sandy, UT. SEC-registered since 2016 (CRD 5308823). Series 66, SIE, Series 7."
+    )
+
+
+def test_a_firm_claim_describes_the_firm():
+    bio = build_factual_bio(_metadata(claim_type="firm", display_name="", advisor_record={}))
+
+    assert (
+        bio
+        == "Olympus Peaks Financial, LLC is an investment adviser firm in Sandy, UT. SEC-registered (CRD 283040)."
+    )
+
+
+def test_a_state_registered_firm_is_not_called_sec_registered():
+    firm = dict(_FIRM_RECORD, registration_type="state")
+    bio = build_factual_bio(_metadata(firm_record=firm))
+
+    assert "State-registered" in bio
+    assert "SEC-registered" not in bio
+
+
+def test_a_private_residence_branch_never_reaches_the_bio():
+    advisor = dict(
+        _ADVISOR_RECORD,
+        branch={"city": "DRAPER", "state": "UT", "private_residence": True},
+    )
+    firm = dict(_FIRM_RECORD, city="SANDY", state="UT")
+    bio = build_factual_bio(_metadata(advisor_record=advisor, firm_record=firm))
+
+    assert "Draper" not in bio
+    assert "Sandy, UT" in bio
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        None,
+        "not a dict",
+        {"claim_type": "individual"},
+        {"claim_type": "firm", "firm_record": {}},
+        # A name and nothing else is not a bio.
+        {"claim_type": "individual", "display_name": "Reginald Troy Maxfield"},
+    ],
+)
+def test_thin_facts_produce_no_bio(metadata):
+    assert build_factual_bio(metadata) == ""
+
+
+def test_the_bio_invents_no_word_that_was_not_supplied():
+    """Every word is either a supplied fact or a listed connective. No adjectives."""
+    metadata = _metadata()
+    supplied = " ".join(
+        [
+            metadata["display_name"],
+            str(metadata["firm_record"]["name"]),
+            str(metadata["firm_record"]["city"]),
+            str(metadata["firm_record"]["state"]),
+            str(metadata["firm_crd"]),
+            str(metadata["individual_crd"]),
+            str(metadata["advisor_record"]["registered_since"]),
+            " ".join(exam["code"] for exam in metadata["advisor_record"]["exams"]),
+        ]
+    ).lower()
+    supplied_tokens = set(re.findall(r"[a-z0-9]+", supplied))
+
+    bio = build_factual_bio(metadata)
+
+    for token in re.findall(r"[a-z0-9]+", bio.lower()):
+        assert token in supplied_tokens or token in BIO_CONNECTIVE_TOKENS, (
+            f"the bio invented {token!r}"
+        )
+
+
+def test_the_bio_makes_no_claim_about_quality_or_specialisation():
+    bio = build_factual_bio(_metadata()).lower()
+
+    for word in (
+        "experienced",
+        "trusted",
+        "leading",
+        "expert",
+        "specialis",
+        "specializ",
+        "passionate",
+        "dedicated",
+        "helps",
+        "clients",
+        "wealth",
+    ):
+        assert word not in bio
+
+
+# ---------------------------------------------------------------------------
+# The write: blanks only, never an adviser's own words
+# ---------------------------------------------------------------------------
+
+
+class _FakeProfileConn:
+    """Captures the UPDATE so its blanks-only guards can be read back."""
+
+    def __init__(self, *, provenance_missing: bool = False, filled: bool = True) -> None:
+        self.provenance_missing = provenance_missing
+        self.filled = filled
+        self.queries: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetchrow(self, query: str, *args: Any):
+        if self.provenance_missing and "profile_source" in query:
+            raise asyncpg.exceptions.UndefinedColumnError("column does not exist")
+        self.queries.append((query, args))
+        return {"filled": self.filled}
+
+    async def close(self) -> None:
+        return None
+
+
+def _iam(monkeypatch, conn: _FakeProfileConn) -> RIAIAMService:
+    service = RIAIAMService()
+
+    async def _fake_conn():
+        return conn
+
+    monkeypatch.setattr(service, "_conn", _fake_conn)
+    return service
+
+
+async def _write(service: RIAIAMService, **overrides: Any) -> bool:
+    kwargs: dict[str, Any] = {
+        "services_offered": ["Portfolio management"],
+        "fee_structure": ["Percentage of assets under management"],
+        "min_engagement_amount": None,
+        "min_engagement_currency": "USD",
+        "bio": "Reginald Troy Maxfield is an investment adviser at Olympus Peaks Financial, LLC.",
+        "profile_source": "form_adv_part2",
+        "profile_source_url": _PART_2A_URL,
+        "profile_source_filed_on": "1/13/2026",
+    }
+    kwargs.update(overrides)
+    return await service.apply_brochure_profile_fields(_PROFILE_ID, **kwargs)
+
+
+async def test_the_write_can_only_fill_blanks_and_never_overwrites_typed_values(monkeypatch):
+    conn = _FakeProfileConn()
+    await _write(_iam(monkeypatch, conn))
+
+    query = " ".join(conn.queries[0][0].split())
+
+    # Each field is guarded by whether the STORED value is blank, so anything
+    # the adviser typed survives untouched.
+    assert "COALESCE(array_length(services_offered, 1), 0) = 0 AS services_blank" in query
+    assert "COALESCE(array_length(fee_structure, 1), 0) = 0 AS fees_blank" in query
+    assert "min_engagement_amount IS NULL AS minimum_blank" in query
+    assert "COALESCE(NULLIF(bio, ''), '') = '' AS bio_blank" in query
+    for guard in (
+        "services_offered = CASE WHEN t.services_blank",
+        "fee_structure = CASE WHEN t.fees_blank",
+        "min_engagement_amount = CASE WHEN t.minimum_blank",
+        "bio = CASE WHEN t.bio_blank",
+    ):
+        assert guard in query, f"missing blanks-only guard: {guard}"
+    # No unguarded assignment of an incoming value anywhere in the statement.
+    for column in ("services_offered", "fee_structure", "min_engagement_amount", "bio"):
+        assert f"{column} = $" not in query
+    # The brochure lane touches nothing outside the narrative block.
+    for untouched in (
+        "display_name",
+        "legal_name",
+        "finra_crd",
+        "verification_status",
+        "certifications",
+        "strategy",
+    ):
+        assert untouched not in query
+
+
+async def test_provenance_is_stamped_only_when_a_blank_was_actually_filled(monkeypatch):
+    conn = _FakeProfileConn()
+    await _write(_iam(monkeypatch, conn))
+
+    query = " ".join(conn.queries[0][0].split())
+
+    for column in PROVENANCE_COLUMNS:
+        assert f"{column} = CASE WHEN t.fills_blank" in query
+
+
+async def test_the_write_reports_whether_anything_was_filled(monkeypatch):
+    assert await _write(_iam(monkeypatch, _FakeProfileConn(filled=True))) is True
+    assert await _write(_iam(monkeypatch, _FakeProfileConn(filled=False))) is False
+
+
+async def test_an_empty_profile_id_writes_nothing(monkeypatch):
+    conn = _FakeProfileConn()
+    service = _iam(monkeypatch, conn)
+
+    assert await service.apply_brochure_profile_fields("  ") is False
+    assert conn.queries == []
+
+
+async def test_the_values_still_land_when_the_provenance_migration_has_not_run(monkeypatch):
+    """A deploy can precede its migration; only the label waits, not the data."""
+    conn = _FakeProfileConn(provenance_missing=True)
+
+    assert await _write(_iam(monkeypatch, conn)) is True
+
+    query, args = conn.queries[0]
+    assert "profile_source" not in query
+    assert len(args) == 6
+    assert args[1] == ["Portfolio management"]
+
+
+async def test_blank_incoming_values_are_passed_through_as_empty_not_null(monkeypatch):
+    conn = _FakeProfileConn()
+    await _write(_iam(monkeypatch, conn), services_offered=None, fee_structure=[], bio="")
+
+    _, args = conn.queries[0]
+    assert args[1] == []
+    assert args[2] == []
+    assert args[5] == ""
+
+
+# ---------------------------------------------------------------------------
+# Post-claim dispatch
+# ---------------------------------------------------------------------------
+
+
+class _RecordingIam:
+    def __init__(self, *, boom: bool = False, filled: bool = True) -> None:
+        self.boom = boom
+        self.filled = filled
+        self.calls: list[dict[str, Any]] = []
+
+    async def apply_brochure_profile_fields(self, profile_id: str, **kwargs: Any) -> bool:
+        if self.boom:
+            raise RuntimeError("profile write failed")
+        self.calls.append({"profile_id": profile_id, **kwargs})
+        return self.filled
+
+
+async def test_enrichment_writes_the_brochure_fields_and_the_bio(monkeypatch):
+    _wire_happy_path(monkeypatch, model_json=_GOOD_MODEL_JSON)
+    iam = _RecordingIam()
+
+    status = await enrich_claimed_profile(
+        ria_profile_id=_PROFILE_ID,
+        reference_metadata=_metadata(),
+        iam_service=iam,
+    )
+
+    assert status == {"status": "written"}
+    call = iam.calls[0]
+    assert call["profile_id"] == _PROFILE_ID
+    assert call["services_offered"] == ["Portfolio management", "Financial planning"]
+    assert call["fee_structure"] == ["Percentage of assets under management"]
+    assert call["min_engagement_amount"] is None
+    assert call["profile_source"] == "form_adv_part2"
+    assert call["profile_source_url"] == _PART_2A_URL
+    assert call["profile_source_filed_on"] == "1/13/2026"
+    assert call["bio"].startswith("Reginald Troy Maxfield is an investment adviser")
+
+
+async def test_a_bio_only_write_claims_no_brochure_provenance(monkeypatch):
+    """Restating facts already on the profile is not "from the SEC filing"."""
+    _fake_http(monkeypatch, lambda _r: httpx.Response(404))
+    iam = _RecordingIam()
+
+    await enrich_claimed_profile(
+        ria_profile_id=_PROFILE_ID,
+        reference_metadata=_metadata(),
+        iam_service=iam,
+    )
+
+    call = iam.calls[0]
+    assert call["services_offered"] == []
+    assert call["profile_source"] == ""
+    assert call["profile_source_url"] == ""
+    assert call["bio"]
+
+
+async def test_nothing_is_written_when_there_is_nothing_to_say(monkeypatch):
+    _fake_http(monkeypatch, lambda _r: httpx.Response(404))
+    iam = _RecordingIam()
+
+    status = await enrich_claimed_profile(
+        ria_profile_id=_PROFILE_ID,
+        reference_metadata={"claim_type": "individual"},
+        iam_service=iam,
+    )
+
+    assert status["status"] == "nothing_to_write"
+    assert iam.calls == []
+
+
+async def test_a_failing_profile_write_is_swallowed(monkeypatch):
+    _wire_happy_path(monkeypatch, model_json=_GOOD_MODEL_JSON)
+
+    status = await enrich_claimed_profile(
+        ria_profile_id=_PROFILE_ID,
+        reference_metadata=_metadata(),
+        iam_service=_RecordingIam(boom=True),
+    )
+
+    assert status == {"status": "write_failed"}
+
+
+async def test_enrichment_survives_an_extractor_that_raises(monkeypatch):
+    async def _boom(*_args: Any, **_kwargs: Any):
+        raise RuntimeError("the extractor broke its own contract")
+
+    monkeypatch.setattr(brochure_module, "extract_profile_from_brochure", _boom)
+    iam = _RecordingIam()
+
+    status = await enrich_claimed_profile(
+        ria_profile_id=_PROFILE_ID,
+        reference_metadata=_metadata(),
+        iam_service=iam,
+    )
+
+    # The bio needs no model, so it still lands.
+    assert status == {"status": "written"}
+    assert iam.calls[0]["services_offered"] == []
+    assert iam.calls[0]["bio"]
+
+
+async def test_a_missing_profile_id_is_a_skip(monkeypatch):
+    status = await enrich_claimed_profile(ria_profile_id="", reference_metadata=_metadata())
+
+    assert status == {"status": "skipped", "reason": "missing_profile_id"}
+
+
+# ---------------------------------------------------------------------------
+# The claim can never be failed by any of this
+# ---------------------------------------------------------------------------
+
+
+async def _complete_claim(service: RIAClaimService) -> dict[str, Any]:
+    return await service.complete(
+        user_id=_TEST_UID,
+        phone_digits="8015663510",
+        claim_type="individual",
+        firm_crd=283040,
+        individual_crd=5308823,
+    )
+
+
+def _claim_service() -> RIAClaimService:
+    return RIAClaimService(
+        client=_FakeIdentityClient(evaluate_payload=_EVALUATE_VERIFIED),
+        iam_service=_FakeIamService(),
+    )
+
+
+async def test_claim_still_succeeds_when_the_whole_extraction_raises(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+
+    def _boom(**_kwargs: Any):
+        raise RuntimeError("brochure lane is down")
+
+    monkeypatch.setattr(brochure_module, "dispatch_profile_enrichment", _boom)
+
+    result = await _complete_claim(_claim_service())
+
+    assert result["status"] == "claimed"
+    assert result["facts"]["crd_number"] == "5308823"
+
+
+async def test_the_claim_hands_the_profile_and_snapshot_to_the_brochure_lane(monkeypatch):
+    monkeypatch.setenv("APP_SIGNING_KEY", "test_secret_key_for_ci_only_32chars_min")
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(brochure_module, "dispatch_profile_enrichment", _capture)
+
+    result = await _complete_claim(_claim_service())
+
+    assert result["status"] == "claimed"
+    assert captured["ria_profile_id"]
+    metadata = captured["reference_metadata"]
+    # The name the profile was built from travels with the snapshot, so the
+    # factual bio never has to guess who it describes.
+    assert metadata["display_name"] == "Reginald Troy Maxfield"
+    assert metadata["firm_record"]["name"] == "OLYMPUS PEAKS FINANCIAL, LLC"
+
+
+# ---------------------------------------------------------------------------
+# Migration 139
+# ---------------------------------------------------------------------------
+
+
+def test_brochure_provenance_migration_is_registered_in_the_release_lane() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    assert MIGRATION in manifest["ordered_migrations"]
+    assert MIGRATION in manifest["groups"]["iam"]
+    assert manifest["ordered_migrations"].index(MIGRATION) > manifest["ordered_migrations"].index(
+        "138_circle_member_connection_origin.sql"
+    )
+    assert len(manifest["ordered_migrations"]) == len(set(manifest["ordered_migrations"]))
+    assert (MIGRATIONS_DIR / MIGRATION).exists()
+    assert (MIGRATIONS_DIR / "rollback" / ROLLBACK).exists()
+
+
+def test_brochure_provenance_migration_adds_only_nullable_labels() -> None:
+    migration = (MIGRATIONS_DIR / MIGRATION).read_text(encoding="utf-8")
+
+    assert "ALTER TABLE ria_profiles" in migration
+    for column in PROVENANCE_COLUMNS:
+        assert f"ADD COLUMN IF NOT EXISTS {column} TEXT" in migration
+        # Nullable and undefaulted: a self-authored profile names no source.
+        assert f"{column} TEXT NOT NULL" not in migration
+        assert f"{column} TEXT DEFAULT" not in migration
+    # A label migration writes no data and touches no other table.
+    assert "INSERT INTO" not in migration
+    assert "UPDATE ria_profiles" not in migration
+    assert "DROP TABLE" not in migration
+
+
+def test_brochure_provenance_is_covered_by_the_schema_contracts() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    highest = max(
+        int(name.split("_", 1)[0]) for name in manifest["ordered_migrations"] if name[:3].isdigit()
+    )
+    assert highest == 139
+
+    for contract_name in ("uat_integrated_schema.json", "prod_core_schema.json"):
+        contract = json.loads((CONTRACTS_DIR / contract_name).read_text(encoding="utf-8"))
+        assert contract["expected_migration_version"] == highest
+        assert set(contract["required_tables"]["ria_profiles"]) >= set(PROVENANCE_COLUMNS)
+
+    dev_contract = json.loads(
+        (CONTRACTS_DIR / "dev_minimum_schema.json").read_text(encoding="utf-8")
+    )
+    assert dev_contract["expected_migration_version"] == highest
+
+
+def test_brochure_provenance_rollback_drops_only_the_labels() -> None:
+    rollback = (MIGRATIONS_DIR / "rollback" / ROLLBACK).read_text(encoding="utf-8")
+
+    for column in PROVENANCE_COLUMNS:
+        assert f"DROP COLUMN IF EXISTS {column}" in rollback
+    # The values those labels described are live profile content.
+    for kept in ("services_offered", "fee_structure", "min_engagement_amount", "bio"):
+        assert f"DROP COLUMN IF EXISTS {kept}" not in rollback
+    assert "DROP TABLE" not in rollback
+
+
+def test_onboarding_status_returns_the_provenance_keys() -> None:
+    """The UI can only label a filing's words if the status names the source."""
+    source = (REPO_ROOT / "hushh_mcp" / "services" / "ria_iam_service.py").read_text(
+        encoding="utf-8"
+    )
+
+    for column in PROVENANCE_COLUMNS:
+        assert f'"{column}": profile_provenance.get("{column}")' in source

--- a/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
+++ b/hushh-webapp/__tests__/components/ria/ria-profile-verification.test.tsx
@@ -431,3 +431,111 @@ describe("RiaProfileSection verification chip + email nudge", () => {
     expect(screen.queryByTestId("ria-email-verify-code")).toBeNull();
   });
 });
+
+const BROCHURE_URL =
+  "https://reports.adviserinfo.sec.gov/reports/ADV/800001/PDF/800001-Brochure.pdf";
+const BROCHURE_CAPTION = "From your Form ADV brochure, filed 1/13/2026.";
+
+describe("RiaProfileSection Form ADV brochure provenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({
+      user: { uid: "u1", getIdToken: vi.fn().mockResolvedValue("tok") },
+    });
+    mocks.usePersonaState.mockReturnValue({
+      riaCapability: "switch",
+      loading: false,
+      refreshing: false,
+      refresh: mocks.refresh,
+      switchPersona: mocks.switchPersona,
+    });
+    mocks.refresh.mockResolvedValue(undefined);
+  });
+
+  it("captions the Services group with the filing date the SEC states", () => {
+    renderSection({
+      ...BASE_STATUS,
+      profile_source: "form_adv_part2",
+      profile_source_url: BROCHURE_URL,
+      profile_source_filed_on: "1/13/2026",
+    });
+
+    const caption = screen.getByTestId("ria-profile-brochure-source");
+    // The SEC's own date string, rendered as filed — not reformatted.
+    expect(caption.textContent).toBe(BROCHURE_CAPTION);
+  });
+
+  it("links the caption to the brochure PDF when the url is present", () => {
+    renderSection({
+      ...BASE_STATUS,
+      profile_source: "form_adv_part2",
+      profile_source_url: BROCHURE_URL,
+      profile_source_filed_on: "1/13/2026",
+    });
+
+    const link = screen
+      .getByTestId("ria-profile-brochure-source")
+      .querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe(BROCHURE_URL);
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toBe("noreferrer");
+    expect(link?.textContent).toBe(BROCHURE_CAPTION);
+  });
+
+  it("renders plain text when the brochure url is absent", () => {
+    renderSection({
+      ...BASE_STATUS,
+      profile_source: "form_adv_part2",
+      profile_source_filed_on: "1/13/2026",
+    });
+
+    const caption = screen.getByTestId("ria-profile-brochure-source");
+    expect(caption.textContent).toBe(BROCHURE_CAPTION);
+    expect(caption.querySelector("a")).toBeNull();
+  });
+
+  it("renders nothing when no brochure supplied a value", () => {
+    // Absent source: the adviser wrote everything shown.
+    renderSection({ ...BASE_STATUS }).unmount();
+    expect(screen.queryByTestId("ria-profile-brochure-source")).toBeNull();
+
+    // Empty source with a stray url: still nothing — no caption, no placeholder.
+    renderSection({
+      ...BASE_STATUS,
+      profile_source: "",
+      profile_source_url: BROCHURE_URL,
+      profile_source_filed_on: "1/13/2026",
+    });
+    expect(screen.queryByTestId("ria-profile-brochure-source")).toBeNull();
+    expect(screen.queryByText(BROCHURE_CAPTION)).toBeNull();
+  });
+
+  it("belongs to the Services group and to no other group", () => {
+    renderSection({
+      ...BASE_STATUS,
+      profile_source: "form_adv_part2",
+      profile_source_url: BROCHURE_URL,
+      profile_source_filed_on: "1/13/2026",
+    });
+
+    expect(screen.getAllByTestId("ria-profile-brochure-source")).toHaveLength(1);
+    expect(
+      screen
+        .getByTestId("ria-profile-services-summary")
+        .querySelector('[data-testid="ria-profile-brochure-source"]'),
+    ).toBeTruthy();
+    for (const groupTestId of [
+      "ria-profile-assistant",
+      "ria-profile-licence-summary",
+      "ria-profile-location-summary",
+      "ria-profile-manage",
+    ]) {
+      expect(
+        screen
+          .getByTestId(groupTestId)
+          .querySelector('[data-testid="ria-profile-brochure-source"]'),
+      ).toBeNull();
+    }
+  });
+});

--- a/hushh-webapp/components/ria/profile/ria-profile-section.tsx
+++ b/hushh-webapp/components/ria/profile/ria-profile-section.tsx
@@ -142,12 +142,63 @@ function RiaProfileSummaryRow({
   );
 }
 
+/**
+ * Provenance for the Services group: the claim reads the adviser's Form ADV
+ * Part 2 brochure and fills only what they left blank, so the caption belongs
+ * to the group and claims no more than "these came from the brochure". The
+ * backend stamps a source ONLY when the brochure actually supplied a value, so
+ * an absent source renders nothing at all — no empty caption, no placeholder.
+ */
+function RiaBrochureSourceCaption({
+  source,
+  url,
+  filedOn,
+}: {
+  source?: string | null;
+  url?: string | null;
+  filedOn?: string | null;
+}) {
+  if (!String(source ?? "").trim()) return null;
+  // The SEC's own date string — shown as filed, never reformatted or reparsed.
+  const filedOnLabel = String(filedOn ?? "").trim();
+  const caption = filedOnLabel
+    ? `From your Form ADV brochure, filed ${filedOnLabel}.`
+    : "From your Form ADV brochure.";
+  const href = String(url ?? "").trim();
+
+  return (
+    <p
+      className="px-[var(--settings-row-px)] py-[var(--settings-row-py)] text-[13px] text-muted-foreground"
+      data-testid="ria-profile-brochure-source"
+    >
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-[color:var(--app-accent)]"
+        >
+          {caption}
+        </a>
+      ) : (
+        caption
+      )}
+    </p>
+  );
+}
+
 function RiaRegulatoryProfileSummary({
   reviewProps,
+  profileSource,
+  profileSourceUrl,
+  profileSourceFiledOn,
   onEditSection,
   onAskKaiUpdateAnything,
 }: {
   reviewProps: RiaProfileReviewSummary;
+  profileSource?: string | null;
+  profileSourceUrl?: string | null;
+  profileSourceFiledOn?: string | null;
   onEditSection: (section: "license" | "services") => void;
   onAskKaiUpdateAnything: () => void;
 }) {
@@ -239,6 +290,11 @@ function RiaRegulatoryProfileSummary({
           onClick={() => onEditSection("services")}
           chevron
           testId="ria-profile-edit-services"
+        />
+        <RiaBrochureSourceCaption
+          source={profileSource}
+          url={profileSourceUrl}
+          filedOn={profileSourceFiledOn}
         />
       </SettingsGroup>
 
@@ -953,6 +1009,9 @@ export function RiaProfileSection({
 
       <RiaRegulatoryProfileSummary
         reviewProps={reviewProps}
+        profileSource={status?.profile_source}
+        profileSourceUrl={status?.profile_source_url}
+        profileSourceFiledOn={status?.profile_source_filed_on}
         onEditSection={handleEditSection}
         onAskKaiUpdateAnything={handleAskKai}
       />

--- a/hushh-webapp/lib/services/ria-service.ts
+++ b/hushh-webapp/lib/services/ria-service.ts
@@ -177,6 +177,17 @@ export interface RiaOnboardingStatus {
    * filing, null when there is no address at all.
    */
   business_location_source?: "profile" | "sec_record" | null;
+  /**
+   * Where the narrative fields (services, fees, min engagement, bio) came from
+   * when the adviser left them blank: "form_adv_part2" when the claimed Form
+   * ADV Part 2 brochure supplied at least one of them, empty/absent when the
+   * adviser wrote everything shown.
+   */
+  profile_source?: string | null;
+  /** The exact brochure PDF the values were read from. */
+  profile_source_url?: string | null;
+  /** The filing date as the SEC states it (e.g. "1/13/2026") — never reparsed. */
+  profile_source_filed_on?: string | null;
   bio?: string | null;
   strategy?: string | null;
   disclosures_url?: string | null;


### PR DESCRIPTION
Services, Fees, Min engagement and Bio read **"Not provided"** for every claimed adviser.

## Why this one is different from the address fix

The address was in our hands and simply wasn't being written. This data genuinely **is not in the SEC identity service** — I probed `/v1/firms/{crd}`, the same with `detail=1`, and `/v1/advisors/{crd}`; none return services, fees, a minimum, or a bio. It exists only as narrative text inside the adviser's **Form ADV Part 2 brochure PDF**, whose URL we already capture at claim time.

## How it works

`ria_brochure_profile_service` picks the **Part 2A firm brochure** (never the 2B individual supplement when a 2A exists), fetches it under timeout and size caps, extracts text with `pdfplumber` (already a pinned dependency) under a page cap, and asks Gemini for strict JSON. **It never raises** — any fault returns the empty shape with a reason recorded, so a bad PDF cannot harm a claim. Writes are **blanks-only** and run in the background, exactly like the dossier lane.

## Three safeguards, each derived from the real filing

I fetched and read Olympus Peaks' actual Part 2A (23 pages) before writing the extractor:

1. **Fees stay category-level.** That firm's schedule is tiered *and* negotiable — 1.25% / 1.00% / 0.50% by band, plus *"Fees for portfolio management services are negotiable."* Publishing "1.25%" would misstate it. A `_RATE_LIKE` filter drops anything carrying `%`, `$` or bps.
2. **A stated absence means null.** The word "minimum" appears exactly **once** in 23 pages: *"There is no account minimum for any of OPFL's services."* A keyword grab near that word would invent a minimum the filing explicitly denies.
3. **The table of contents is stripped first** — its headings repeat the body's with dotted leaders, so a naive slice extracts page numbers as content.

## Verified against the real brochure, with a real model call

| Extracted | Line in the filing |
|---|---|
| Portfolio management | *"Portfolio Management Services — OPFL offers ongoing portfolio management services…"* |
| Pension consulting | *"Pension Consulting Services — OPFL offers ongoing consulting services to pension or other employee benefit plans"* |
| Financial planning | *"Financial plans and financial planning may include… investment planning; life insurance; tax concerns"* |
| Percentage of assets under management | the tiered AUM schedule |
| Hourly | *"The hourly fee for these services is up to $125."* |
| minimum = **null** | *"There is no account minimum…"* |

Nothing invented; every value traces to a quoted line.

**A bug this caught that 83 unit tests could not:** the first real run returned `model_failed:ClientError` — `gemini-3.6-flash` 404s in `us-central1`; the deployed backend runs Vertex at location `global`. The tests all pass against a fake model, so only a real call surfaces it. The best-effort contract also proved itself: empty result, reason recorded, claim untouched.

## Provenance
`From your Form ADV brochure, filed 1/13/2026.` — a quiet caption on the Services group, linking the exact PDF, stamped **only when the brochure actually supplied a value**. A bio-only write carries no source, because the bio restates facts already on the profile and labelling it "from the filing" would be false. The bio needs no model at all: name, firm, city, CRD, registration, exams — no adjectives, no quality claims.

## Proof
Migration **139** (three nullable provenance columns, registered in the manifest and all three contracts). Backend gate: **816 passed** (83 new). Frontend: **3105 passed** (5 new), `tsc` 0, eslint clean. Pre-existing mypy findings verified identical against a clean `origin/main` extract — zero new. Also incidentally fixes a red test on main: migration 138 left `dev_minimum_schema` at 137 while prod/uat moved to 138.